### PR TITLE
fix: Railway deploy issues (PORT, volume, pool timeout)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,11 @@ RUN pip install --no-cache-dir .
 # Copy application
 COPY . .
 
-# Create logs directory
-RUN mkdir -p /app/logs && chown -R appuser:appuser /app/logs
-
-# Switch to non-root user
-USER appuser
+# Create logs and data directories
+RUN mkdir -p /app/logs /data && chown -R appuser:appuser /app/logs /data
 
 # Expose port
 EXPOSE 8000
 
-# Run the application
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Entrypoint fixes volume permissions then drops to non-root user
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -90,7 +90,10 @@ async def get_discogs_service(
         if settings.database_url_discogs and _discogs_pool is None:
             try:
                 _discogs_pool = await asyncpg.create_pool(
-                    settings.database_url_discogs, min_size=1, max_size=5
+                    settings.database_url_discogs,
+                    min_size=1,
+                    max_size=5,
+                    timeout=10,
                 )
                 logger.info("Discogs cache pool connected")
             except Exception as e:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Fix volume mount permissions (Railway mounts volumes as root)
+chown -R appuser:appuser /data 2>/dev/null || true
+
+# Drop to non-root user and start the application
+exec su -s /bin/sh appuser -c "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"

--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 60
+healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary
- Use `$PORT` env var instead of hardcoded 8000 (Railway sets `PORT`)
- Add `entrypoint.sh` to fix volume mount permissions before dropping to non-root user (Railway mounts volumes as root)
- Add 10s connection timeout to asyncpg pool creation so the first health check isn't blocked for 60s when Postgres is unreachable
- Increase `healthcheckTimeout` to 300s to accommodate first-request initialization

## Context
These issues were discovered during the first Railway deploy of library-metadata-lookup (staging). The service built successfully but:
1. Railway Edge returned 502 because the app listened on 8000 instead of the Railway-assigned `PORT`
2. `POST /admin/upload-library-db` returned 500 (permission denied) because the volume is mounted as root
3. Health check timed out because `asyncpg.create_pool()` blocks for 60s on unreachable Postgres

## Test plan
- [x] Verified service responds on correct port (health endpoint returns 200)
- [x] Verified library.db upload succeeds (64,578 rows)
- [x] Verified lookup endpoint returns results (Queen - The Game)
- [x] Verified health check passes within Railway's timeout window

Closes #11