### PR TITLE
Fix false positive album matches in search pipeline

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -249,6 +249,16 @@ async def search_library_with_fallback(
             )
             return all_results, False
 
+        # Discogs found specific albums for this track but none matched in the
+        # library.  Don't fall through to generic artist search — that would
+        # return unrelated albums (e.g., "808 State" self-titled for a track
+        # on "The Best Of 808 State: Blueprint").  The compilation search
+        # strategy runs next and can still find the track.
+        logger.info(
+            f"Discogs found albums {albums} but none matched in library; skipping artist fallback"
+        )
+        return [], True
+
     if parsed.artist and parsed.song:
         query = f"{parsed.artist} {parsed.song}"
         results = await db.search(query=query, limit=MAX_SEARCH_RESULTS)
@@ -394,11 +404,34 @@ async def search_compilations_for_track(
     return limit_results(results), discogs_titles
 
 
+def _album_title_acceptable(query_lower: str, result_lower: str) -> bool:
+    """Check if a library album title is an acceptable match for a Discogs album title.
+
+    Uses prefix matching (handles parenthetical suffixes like edition names) and
+    length-sensitive fuzz.ratio to reject subset matches that token_set_ratio
+    would incorrectly accept.
+    """
+    from rapidfuzz import fuzz
+
+    if query_lower.startswith(result_lower) or result_lower.startswith(query_lower):
+        return True
+    return fuzz.ratio(query_lower, result_lower) >= 50
+
+
 async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryItem]:
     """Search for album with fuzzy keyword matching."""
     from rapidfuzz import fuzz
 
     results = await db.search(query=album_title, limit=MAX_SEARCH_RESULTS)
+
+    # Filter exact FTS5 results by title similarity to reject subset matches
+    # (e.g., FTS5 matches "808 State" for query "The Best Of 808 State: Blueprint"
+    # because it tokenizes and matches on shared terms "808" and "State")
+    if results:
+        album_lower = album_title.lower()
+        results = [
+            r for r in results if _album_title_acceptable(album_lower, (r.title or "").lower())
+        ]
 
     if not results:
         words = re.sub(r"[^\w\s]", " ", album_title.lower()).split()
@@ -419,8 +452,9 @@ async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryIte
                         1 for word in significant_words if word in result_title_lower
                     )
                     similarity = fuzz.token_set_ratio(album_lower, result_title_lower)
+                    title_ok = _album_title_acceptable(album_lower, result_title_lower)
 
-                    if keyword_matches >= 2 and similarity >= 60:
+                    if keyword_matches >= 2 and similarity >= 60 and title_ok:
                         logger.debug(
                             f"Album match: '{result.title}' "
                             f"(keywords={keyword_matches}, similarity={similarity})"

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -165,14 +165,38 @@ class TestSearchSongAsArtist:
 
 class TestSearchLibraryWithFallbackSongPath:
     @pytest.mark.asyncio
-    async def test_artist_plus_song_fallback(self):
-        """When albums produce no results, tries artist+song and sorts by song match."""
+    async def test_artist_plus_song_fallback_when_no_discogs_albums(self):
+        """When Discogs found no albums (empty list), falls back to artist+song."""
         db = AsyncMock()
         item1 = _item(id=1, artist="Queen", title="Greatest Hits")
         item2 = _item(id=2, artist="Queen", title="Bohemian Rhapsody Single")
 
-        # No album results (first call), artist+song results (second call)
-        db.search = AsyncMock(side_effect=[[], [item1, item2]])
+        # artist+song results (first call)
+        db.search = AsyncMock(side_effect=[[item1, item2]])
+
+        parsed = ParsedRequest(
+            artist="Queen", song="Bohemian Rhapsody", raw_message="Queen - Bohemian Rhapsody"
+        )
+
+        results, song_not_found = await search_library_with_fallback(db, parsed, albums=[])
+
+        assert len(results) >= 1
+        assert song_not_found is True
+        # Item with song in title should be sorted first
+        assert "Bohemian Rhapsody" in results[0].title
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_discogs_albums_provided(self):
+        """When Discogs found specific albums but none matched, don't fall back."""
+        db = AsyncMock()
+        item = _item(id=1, artist="Queen", title="Greatest Hits")
+
+        db.search = AsyncMock(
+            side_effect=[
+                [],  # album search: no match
+                [item],  # would be artist+song
+            ]
+        )
 
         parsed = ParsedRequest(
             artist="Queen", song="Bohemian Rhapsody", raw_message="Queen - Bohemian Rhapsody"
@@ -182,10 +206,8 @@ class TestSearchLibraryWithFallbackSongPath:
             db, parsed, albums=["Nonexistent Album"]
         )
 
-        assert len(results) >= 1
+        assert results == []
         assert song_not_found is True
-        # Item with song in title should be sorted first
-        assert "Bohemian Rhapsody" in results[0].title
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -336,7 +336,8 @@ class TestSearchLibraryWithFallback:
         assert fallback is False
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_artist_only(self, mock_library_db):
+    async def test_falls_back_to_artist_only_when_no_discogs_albums(self, mock_library_db):
+        """Falls back to artist-only when Discogs found no albums (empty list)."""
         item = make_library_item(
             id=2,
             artist="Queen",
@@ -345,7 +346,6 @@ class TestSearchLibraryWithFallback:
             release_call_number=2,
         )
         mock_library_db.search.side_effect = [
-            [],  # artist + album
             [],  # artist + song
             [item],  # artist only
         ]
@@ -359,11 +359,47 @@ class TestSearchLibraryWithFallback:
             message_type=MessageType.REQUEST,
         )
 
-        results, fallback = await search_library_with_fallback(
-            mock_library_db, parsed, ["Unknown Album"]
-        )
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
         assert len(results) == 1
         assert fallback is True
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_discogs_found_albums(self, mock_library_db):
+        """When Discogs found specific albums but none are in the library, don't fall back.
+
+        Bug: searching "flow coma by 808 state" — Discogs finds the track on
+        "The Best Of 808 State: Blueprint" but the library doesn't have that album.
+        The old code fell back to artist+song/artist-only search, returning the
+        unrelated "808 State" (self-titled) album which does NOT contain "Flow Coma".
+        """
+        false_positive = make_library_item(
+            id=958,
+            artist="808 State",
+            title="808 State",
+            call_letters="Ei",
+        )
+        mock_library_db.search.side_effect = [
+            [],  # album search: no match
+            [false_positive],  # artist+song: would match via fuzzy
+            [false_positive],  # artist-only: would match
+        ]
+
+        parsed = ParsedRequest(
+            song="Flow Coma",
+            artist="808 State",
+            raw_message="flow coma by 808 state",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(
+            mock_library_db, parsed, ["The Best Of 808 State: Blueprint"]
+        )
+        assert results == [], (
+            "Should not fall back to artist search when Discogs found specific albums"
+        )
+        assert fallback is True
+        assert mock_library_db.search.call_count == 1
 
     @pytest.mark.asyncio
     async def test_filters_results_by_album_title(self, mock_library_db):


### PR DESCRIPTION
## Summary

- Skip artist+song/artist-only fallback when Discogs found specific albums that don't match in the library (prevents unrelated albums like "808 State" self-titled from being returned)
- Add `_album_title_acceptable()` helper using `fuzz.ratio` and prefix matching to reject FTS5/fuzzy subset matches
- Apply the helper to both exact FTS5 and fuzzy fallback paths in `search_album_fuzzy`

Closes #16

## Test plan

- [x] Unit test: `test_no_fallback_when_discogs_found_albums` — verifies early return when Discogs found albums
- [x] Unit test: `test_no_fallback_when_discogs_albums_provided` — verifies no artist+song fallback
- [x] Unit test: `test_falls_back_to_artist_only_when_no_discogs_albums` — verifies fallback still works when albums=[]
- [x] Full unit suite: 427 passed
- [ ] Integration test against staging: `test_flow_coma_808_state_excludes_unrelated_album`