### PR TITLE
Fix compilation search keyword fallback false positives

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -334,6 +334,8 @@ async def search_compilations_for_track(
         logger.warning(f"Keyword search failed: {e}")
         keyword_matches = []
 
+    discogs_found_releases = False
+
     try:
         raw_lower = parsed.raw_message.lower()
         song_search = parsed.song
@@ -347,6 +349,7 @@ async def search_compilations_for_track(
             song_search, parsed.artist, service=discogs_service
         )
         logger.info(f"Found {len(releases)} releases with '{song_search}' on Discogs")
+        discogs_found_releases = len(releases) > 0
 
         for release_artist, release_album in releases:
             if parsed.artist and release_album.lower().strip() == parsed.artist.lower().strip():
@@ -387,7 +390,7 @@ async def search_compilations_for_track(
     except Exception as e:
         logger.warning(f"Failed to search for track on other releases: {e}")
 
-    if not results and keyword_matches:
+    if not results and keyword_matches and not discogs_found_releases:
         logger.info("Discogs search found nothing, using keyword matches as fallback")
         for item in keyword_matches[:1]:
             if item.id not in seen_ids:

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -425,6 +425,41 @@ class TestSearchCompilationsForTrack:
         # Should fall back to keyword matches
         assert len(results) >= 1
 
+    @pytest.mark.asyncio
+    async def test_no_keyword_fallback_when_discogs_found_releases(self):
+        """When Discogs finds releases but none match in library, don't use keyword fallback.
+
+        Bug: "flow coma by 808 state" — keyword search finds "808 State" via
+        fuzzy matching, Discogs finds "The Best Of 808 State: Blueprint", but
+        search_album_fuzzy correctly rejects "808 State" for that album.
+        The keyword fallback then returns "808 State" anyway — a false positive.
+        """
+        db = AsyncMock()
+        false_positive = _item(id=958, artist="808 State", title="808 State")
+
+        # First call (keyword search): returns the false positive
+        # Second call (search_album_fuzzy for "The Best Of 808 State: Blueprint"): empty
+        db.search = AsyncMock(side_effect=[[false_positive], []])
+
+        parsed = ParsedRequest(
+            artist="808 State",
+            song="Flow Coma",
+            raw_message="flow coma by 808 state",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[("808 State", "The Best Of 808 State: Blueprint")],
+        ):
+            results, _ = await search_compilations_for_track(db, parsed)
+
+        # Should NOT fall back to keyword matches — Discogs found releases
+        assert results == [], (
+            "Should not return '808 State' as keyword fallback when Discogs found specific "
+            "releases that didn't match in library"
+        )
+
 
 # ---------------------------------------------------------------------------
 # search_album_fuzzy (lines 411-444)


### PR DESCRIPTION
## Summary

- Skip keyword fallback in `search_compilations_for_track` when Discogs found releases but none matched in the library
- Add `discogs_found_releases` flag to track whether Discogs returned any results
- Gate the keyword fallback on `not discogs_found_releases` to prevent unvalidated matches from leaking through

Closes #18

## Test plan

- [x] New unit test: `test_no_keyword_fallback_when_discogs_found_releases` verifies "808 State" is not returned when Discogs found "The Best Of 808 State: Blueprint" but it didn't match in library
- [x] Existing test `test_keyword_search_with_compilation_filter` still passes (keyword fallback works when Discogs returns empty)
- [x] Existing test `test_discogs_exception_falls_back_to_keyword` still passes (keyword fallback works when Discogs raises)
- [x] All 428 unit tests pass
- [ ] Integration test against staging after deploy