### PR TITLE
fix: remove early return that blocks artist-only fallback

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -249,15 +249,14 @@ async def search_library_with_fallback(
             )
             return all_results, False
 
-        # Discogs found specific albums for this track but none matched in the
-        # library.  Don't fall through to generic artist search — that would
-        # return unrelated albums (e.g., "808 State" self-titled for a track
-        # on "The Best Of 808 State: Blueprint").  The compilation search
-        # strategy runs next and can still find the track.
+        # When Discogs found albums but none matched the library, fall through to
+        # artist+song and artist-only search.  filter_results_by_track_validation()
+        # (called by perform_lookup after the search pipeline) validates fallback
+        # results against Discogs tracklists to prevent false positives.
         logger.info(
-            f"Discogs found albums {albums} but none matched in library; skipping artist fallback"
+            f"Discogs found albums {albums} but none matched in library; "
+            "falling through to artist search"
         )
-        return [], True
 
     if parsed.artist and parsed.song:
         query = f"{parsed.artist} {parsed.song}"

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -186,15 +186,19 @@ class TestSearchLibraryWithFallbackSongPath:
         assert "Bohemian Rhapsody" in results[0].title
 
     @pytest.mark.asyncio
-    async def test_no_fallback_when_discogs_albums_provided(self):
-        """When Discogs found specific albums but none matched, don't fall back."""
+    async def test_falls_through_to_artist_search_when_discogs_albums_not_in_library(self):
+        """When Discogs found specific albums but none matched, fall through to artist search.
+
+        filter_results_by_track_validation() (called downstream by perform_lookup)
+        handles rejecting false positives from the fallback results.
+        """
         db = AsyncMock()
         item = _item(id=1, artist="Queen", title="Greatest Hits")
 
         db.search = AsyncMock(
             side_effect=[
                 [],  # album search: no match
-                [item],  # would be artist+song
+                [item],  # artist+song fallback
             ]
         )
 
@@ -206,7 +210,8 @@ class TestSearchLibraryWithFallbackSongPath:
             db, parsed, albums=["Nonexistent Album"]
         )
 
-        assert results == []
+        assert len(results) == 1
+        assert results[0].title == "Greatest Hits"
         assert song_not_found is True
 
 

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -364,13 +364,15 @@ class TestSearchLibraryWithFallback:
         assert fallback is True
 
     @pytest.mark.asyncio
-    async def test_no_fallback_when_discogs_found_albums(self, mock_library_db):
-        """When Discogs found specific albums but none are in the library, don't fall back.
+    async def test_artist_fallback_when_discogs_albums_not_in_library(self, mock_library_db):
+        """When Discogs found specific albums but none are in library, artist fallback runs.
 
-        Bug: searching "flow coma by 808 state" — Discogs finds the track on
-        "The Best Of 808 State: Blueprint" but the library doesn't have that album.
-        The old code fell back to artist+song/artist-only search, returning the
-        unrelated "808 State" (self-titled) album which does NOT contain "Flow Coma".
+        Scenario: "flow coma by 808 state" — Discogs finds the track on
+        "The Best Of 808 State: Blueprint" but the library doesn't have it.
+        The artist+song fallback returns the "808 State" self-titled album,
+        which is a false positive.  filter_results_by_track_validation()
+        (tested separately in TestFilterResultsByTrackValidation) rejects it
+        because "Flow Coma" isn't on the self-titled album.
         """
         false_positive = make_library_item(
             id=958,
@@ -379,9 +381,9 @@ class TestSearchLibraryWithFallback:
             call_letters="Ei",
         )
         mock_library_db.search.side_effect = [
-            [],  # album search: no match
-            [false_positive],  # artist+song: would match via fuzzy
-            [false_positive],  # artist-only: would match
+            [],  # album search: no match for "The Best Of 808 State: Blueprint"
+            [false_positive],  # artist+song: "808 State Flow Coma" matches via fuzzy
+            [false_positive],  # artist-only: "808 State" matches
         ]
 
         parsed = ParsedRequest(
@@ -395,11 +397,52 @@ class TestSearchLibraryWithFallback:
         results, fallback = await search_library_with_fallback(
             mock_library_db, parsed, ["The Best Of 808 State: Blueprint"]
         )
-        assert results == [], (
-            "Should not fall back to artist search when Discogs found specific albums"
+        # Artist+song fallback now returns the false positive; it's the job of
+        # filter_results_by_track_validation() to reject it downstream.
+        assert len(results) == 1
+        assert results[0].title == "808 State"
+        assert fallback is True
+        assert mock_library_db.search.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_artist_when_discogs_albums_not_in_library(self, mock_library_db):
+        """When Discogs found only singles/EPs not in library, fall through to artist search.
+
+        Bug: "6 underground by sneaker pimps" — Discogs only returns singles
+        (6 Underground (Rewired), 6 Underground) which aren't in the library.
+        The artist-only fallback should still run, returning all Sneaker Pimps
+        albums.  filter_results_by_track_validation() (called by perform_lookup)
+        then validates each against Discogs tracklists to keep only Becoming X.
+        """
+        becoming_x = make_library_item(id=1, artist="Sneaker Pimps", title="Becoming X")
+        kiss_swallow = make_library_item(
+            id=2, artist="Sneaker Pimps", title="Kiss & Swallow", release_call_number=2
+        )
+        mock_library_db.search.side_effect = [
+            [],  # album search for "6 Underground (Rewired)" → no match
+            [],  # album search for "6 Underground" → no match
+            [],  # artist+song "Sneaker Pimps 6 Underground" → no match
+            [becoming_x, kiss_swallow],  # artist-only "Sneaker Pimps" → both albums
+        ]
+
+        parsed = ParsedRequest(
+            song="6 Underground",
+            artist="Sneaker Pimps",
+            raw_message="6 underground by sneaker pimps",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(
+            mock_library_db,
+            parsed,
+            ["6 Underground (Rewired)", "6 Underground"],
+        )
+        assert len(results) == 2, (
+            "Artist-only fallback should return both Sneaker Pimps albums; "
+            "filter_results_by_track_validation handles false-positive filtering"
         )
         assert fallback is True
-        assert mock_library_db.search.call_count == 1
 
     @pytest.mark.asyncio
     async def test_filters_results_by_album_title(self, mock_library_db):


### PR DESCRIPTION
## Summary
- Remove early return in `search_library_with_fallback` that blocked artist+song and artist-only fallback searches when Discogs found albums not in the library
- `filter_results_by_track_validation()` (called downstream by `perform_lookup`) already validates fallback results against Discogs tracklists, making the early return redundant
- Fixes "6 underground by sneaker pimps" returning no results when Discogs only finds singles

Closes #20

## Test plan
- [x] New test: `test_falls_back_to_artist_when_discogs_albums_not_in_library` — Sneaker Pimps case
- [x] Updated: `test_artist_fallback_when_discogs_albums_not_in_library` — 808 State now expects fallback to run
- [x] Updated: `test_falls_through_to_artist_search_when_discogs_albums_not_in_library` — gap test
- [x] All 429 unit tests pass
- [ ] Integration test `test_6_underground_sneaker_pimps_returns_only_becoming_x` passes on staging after deploy
- [ ] Integration test `test_flow_coma_808_state_excludes_unrelated_album` still passes (808 State regression)