### PR TITLE
Update README and CLAUDE.md after script migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,3 +229,12 @@ Loads `DISCOGS_TOKEN` and `DATABASE_URL_DISCOGS` from `.env` or the Railway CLI 
 - **[request-parser](https://github.com/WXYC/request-parser)** -- The caller. Parses messages, calls this service, posts to Slack.
 - **[wxyc-shared](https://github.com/WXYC/wxyc-shared)** -- Shared API contract (`api.yaml`). Defines `LookupRequest`, `LookupResponse`, and related schemas with code generation for Python, TypeScript, Swift, Kotlin.
 - **[discogs-cache](https://github.com/WXYC/discogs-cache)** -- ETL pipeline that populates the PostgreSQL Discogs cache consumed by `discogs/cache_service.py`.
+
+## Example Music Data for Tests
+
+WXYC is a freeform station. When creating test fixtures or mock data, use representative artists instead of mainstream acts like Queen, Radiohead, or The Beatles. The canonical data source is `wxyc-shared/src/test-utils/wxyc-example-data.json`.
+
+Preferred defaults for fixtures:
+- `LibraryItem`: `artist="Stereolab", title="Aluminum Tunes", genre="Rock"`
+- `LOOKUP_BODY`: `{"artist": "Jessica Pratt", "album": "On Your Own Love Again", "raw_message": "Jessica Pratt - On Your Own Love Again"}`
+- Other good choices: Juana Molina / "DOGA" (Sonamos), Cat Power / "Moon Pix" (Matador), Chuquimamani-Condori / "Edits" (self-released), Duke Ellington & John Coltrane / "Duke Ellington & John Coltrane" (Impulse Records), Sessa / "Pequena Vertigem de Amor" (Mexican Summer), Large Professor / "1st Class" (Matador Records)

--- a/README.md
+++ b/README.md
@@ -131,12 +131,16 @@ library-metadata-lookup/
   routers/
     admin.py                   # POST /admin/upload-library-db
     health.py                  # GET /health
+  scripts/
+    sync-library.sh            # ETL: MySQL -> SQLite -> upload to Railway
+    export_to_sqlite.py        # CSV -> SQLite FTS5 conversion
+    benchmark_cache.py         # Discogs PG cache vs API benchmarks
   services/
     parser.py                  # Minimal ParsedRequest model (no Groq)
   tests/
     factories.py               # Shared test factories (make_library_item, make_discogs_result)
-    unit/                      # 399 mocked unit tests (97% source coverage)
-    integration/               # 45 integration tests with real SQLite/FTS5
+    unit/                      # 472 mocked unit tests (97% source coverage)
+    integration/               # 48 integration tests with real SQLite/FTS5
 ```
 
 ## Development
@@ -144,11 +148,7 @@ library-metadata-lookup/
 ### Prerequisites
 
 - Python 3.12+
-- Uses the shared venv from request-parser for now:
-
-```bash
-/Users/jake/Developer/request-parser/venv/bin/python
-```
+- [uv](https://docs.astral.sh/uv/) for dependency management
 
 ### Running locally
 
@@ -159,13 +159,13 @@ uvicorn main:app --reload
 ### Running tests
 
 ```bash
-# Unit tests only (default, fast -- 399 tests)
+# Unit tests only (default, fast -- 472 tests)
 uv run pytest tests/unit/ -v
 
-# Integration tests only (real SQLite/FTS5 -- 45 tests)
+# Integration tests only (real SQLite/FTS5 -- 48 tests)
 uv run pytest -m integration -v
 
-# All tests with coverage (444 tests, 97% source coverage)
+# All tests with coverage (520 tests, 97% source coverage)
 uv run pytest -m "" --cov=. --cov-report=term-missing -v
 ```
 
@@ -211,8 +211,8 @@ Hosted on Railway with CI-driven deploys (automatic deploys are disabled).
 ### Library Database
 
 The `library.db` file is uploaded to the Railway volume via `POST /admin/upload-library-db`,
-not committed to git. The request-o-matic ETL script (`scripts/sync-library.sh`) handles
-daily uploads to both staging and production environments.
+not committed to git. The ETL script (`scripts/sync-library.sh`) handles daily uploads to
+both staging and production environments.
 
 On first deploy, the volume is empty. The service starts healthy for non-database endpoints
 but the health check reports `unhealthy` (503) until `library.db` is uploaded.


### PR DESCRIPTION
## Summary

- Update test counts in README (472 unit, 48 integration, 520 total)
- Add `scripts/` directory to project structure listing
- Replace stale `request-parser` shared venv path with `uv` as dependency manager
- Fix ETL reference to point to local `scripts/sync-library.sh` instead of request-o-matic
- Add example music data section to CLAUDE.md

Follow-up to #6.