### PR TITLE
Fix stale request-parser references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Library Metadata Lookup is a FastAPI service for WXYC radio that searches the library catalog and cross-references results with Discogs metadata. It was extracted from [request-parser](https://github.com/WXYC/request-parser) to separate search/lookup concerns from message parsing and Slack posting.
+Library Metadata Lookup is a FastAPI service for WXYC radio that searches the library catalog and cross-references results with Discogs metadata. It was extracted from [request-o-matic](https://github.com/WXYC/request-o-matic) to separate search/lookup concerns from message parsing and Slack posting.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/WXYC/library-metadata-lookup/actions/workflows/ci.yml/badge.svg)](https://github.com/WXYC/library-metadata-lookup/actions/workflows/ci.yml)
 
-A FastAPI service for WXYC radio that searches the library catalog and cross-references results with Discogs metadata. Extracted from [request-o-matic](https://github.com/WXYC/request-o-matic) to separate search/lookup concerns from message parsing and Slack posting.
+A FastAPI service for WXYC radio that searches the library catalog and cross-references results with Discogs metadata.
 
 ## What it does
 
@@ -125,7 +125,7 @@ library-metadata-lookup/
     db.py                      # SQLite FTS5 + fuzzy fallback search
     models.py, router.py
   lookup/
-    orchestrator.py            # Core search pipeline (extracted from request-parser)
+    orchestrator.py            # Core search pipeline
     models.py                  # LookupRequest, LookupResponse
     router.py                  # POST /lookup endpoint
   routers/
@@ -214,12 +214,5 @@ daily uploads to both staging and production environments.
 
 On first deploy, the volume is empty. The service starts healthy for non-database endpoints
 but the health check reports `unhealthy` (503) until `library.db` is uploaded.
-
-## Relationship to request-parser
-
-This service extracts all search/lookup logic from `request-parser/routers/request.py`. After migration:
-
-- **request-parser**: parse message (Groq) -> call this service -> post to Slack
-- **library-metadata-lookup**: search library + Discogs -> return enriched results
 
 The API contract is defined in [`wxyc-shared/api.yaml`](https://github.com/WXYC/wxyc-shared) with generated models for Python, TypeScript, Swift, and Kotlin.

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1,4 +1,4 @@
-"""Lookup orchestrator: the core search logic extracted from request-parser.
+"""Lookup orchestrator: the core search logic extracted from request-o-matic.
 
 This module contains the perform_lookup() function that orchestrates the full
 search pipeline: artist correction -> album resolution -> search strategies ->

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -33,7 +33,7 @@ router = APIRouter(tags=["lookup"])
     5. Fetches album artwork from Discogs
     6. Returns enriched results with metadata
 
-    The caller (request-parser) handles parsing and Slack posting.
+    The caller (request-o-matic) handles parsing and Slack posting.
     """,
     responses={
         200: {"description": "Lookup completed successfully"},

--- a/services/parser.py
+++ b/services/parser.py
@@ -1,6 +1,6 @@
 """Minimal parser models for the lookup service.
 
-The lookup service receives pre-parsed requests from request-parser,
+The lookup service receives pre-parsed requests from request-o-matic,
 so it only needs the ParsedRequest model shape, not the Groq parsing logic.
 """
 


### PR DESCRIPTION
## Summary

- Replace `request-parser` with `request-o-matic` in CLAUDE.md and source file docstrings
- Remove extraction provenance text from README (no longer relevant to users)
- Remove the "Relationship to request-parser" README section

Closes #35