### PR TITLE
Fix compilation search for track artists with zero library entries

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -217,6 +217,7 @@ async def execute_search_pipeline(
     raw_message: str,
     strategies: list[SearchStrategy],
     albums_for_search: list[str] | None = None,
+    song_not_found: bool = False,
 ) -> SearchState:
     """Execute strategies in array order until results found.
 
@@ -226,6 +227,7 @@ async def execute_search_pipeline(
         raw_message: Original request message (for ambiguous format detection)
         strategies: List of search strategies to try
         albums_for_search: Optional list of album names from Discogs lookup
+        song_not_found: Whether album resolution already determined the song wasn't found
 
     Returns:
         SearchState with results and metadata about the search
@@ -234,6 +236,7 @@ async def execute_search_pipeline(
         results=[],
         strategies_tried=[],
         albums_for_search=albums_for_search or [],
+        song_not_found=song_not_found,
     )
 
     for strategy in strategies:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -733,6 +733,7 @@ async def perform_lookup(
             raw_message=request.raw_message,
             strategies=strategies,
             albums_for_search=albums_for_search,
+            song_not_found=song_not_found,
         )
 
         library_results = limit_results(search_state.results)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -476,6 +476,62 @@ class TestPerformLookupCompilations:
         assert response.context_message is not None
         assert "Found" in response.context_message
 
+    @pytest.mark.asyncio
+    async def test_finds_song_on_compilation_when_artist_not_in_library(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """Compilation search runs when the track artist has zero library entries.
+
+        Scenario: "No Way Back by Adonis"
+        - resolve_albums_for_track finds only VA releases -> song_not_found=True
+        - search_library_with_fallback finds nothing for "Adonis" -> ([], False)
+        - song_not_found from album resolution must propagate so
+          TRACK_ON_COMPILATION still triggers
+        """
+        compilation_item = make_library_item(
+            id=46602,
+            artist="Various Artists - Electronic - T",
+            title="Trax Records 20th Anniversary Collection",
+            call_letters="V",
+        )
+
+        mock_library_db.find_similar_artist.return_value = None
+
+        # search_library_with_fallback: artist+song -> empty, artist-only -> empty
+        # search_compilations_for_track: keyword search -> compilation,
+        #   search_album_fuzzy -> compilation
+        mock_library_db.search.side_effect = [
+            [],  # search_library_with_fallback: artist + song
+            [],  # search_library_with_fallback: artist only (Adonis not in library)
+            [compilation_item],  # search_compilations_for_track: keyword search
+            [compilation_item],  # search_album_fuzzy: exact search for Discogs album
+        ]
+
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        request = LookupRequest(
+            artist="Adonis",
+            song="No Way Back",
+            raw_message="No Way Back by Adonis",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[
+                ("Various Artists", "Trax Records 20th Anniversary Collection"),
+            ],
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        assert response.found_on_compilation is True
+        assert len(response.results) >= 1
+        assert response.results[0].library_item.title == "Trax Records 20th Anniversary Collection"
+        assert response.context_message is not None
+        assert "Found" in response.context_message
+
 
 # ---------------------------------------------------------------------------
 # Tests: perform_lookup - artwork

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -245,3 +245,45 @@ class TestExecuteSearchPipeline:
 
         assert state.found_on_compilation is True
         assert state.discogs_titles == {1: "Rock Comp"}
+
+    @pytest.mark.asyncio
+    async def test_compilation_search_when_song_not_found_from_album_resolution(self):
+        """song_not_found from album resolution triggers compilation search.
+
+        When resolve_albums_for_track() sets song_not_found=True (Discogs found
+        only VA releases) but the artist has zero library entries so
+        ARTIST_PLUS_ALBUM returns ([], False), the song_not_found flag must
+        propagate into the pipeline so TRACK_ON_COMPILATION still runs.
+        """
+        compilation = _item(
+            id=46602,
+            artist="Various Artists - Electronic - T",
+            title="Trax Records 20th Anniversary Collection",
+        )
+
+        # ARTIST_PLUS_ALBUM: artist not in library at all -> ([], False)
+        search_lib = AsyncMock(return_value=([], False))
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(
+            return_value=([compilation], {46602: "Trax Records 20th Anniversary Collection"})
+        )
+
+        strategies = build_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Adonis",
+            song="No Way Back",
+            raw_message="No Way Back by Adonis",
+        )
+
+        state = await execute_search_pipeline(
+            parsed,
+            AsyncMock(),
+            "No Way Back by Adonis",
+            strategies,
+            song_not_found=True,
+        )
+
+        assert state.found_on_compilation is True
+        assert state.results == [compilation]
+        assert state.discogs_titles == {46602: "Trax Records 20th Anniversary Collection"}


### PR DESCRIPTION
## Summary

- Thread `song_not_found` from `resolve_albums_for_track()` through `execute_search_pipeline()` so the `TRACK_ON_COMPILATION` strategy triggers even when the track artist has zero library entries
- Add unit tests for both the pipeline level (`test_search.py`) and the full orchestrator path (`test_orchestrator.py`)

Closes #41

## Test plan

- [x] New unit test: `execute_search_pipeline` with `song_not_found=True` triggers compilation search when `ARTIST_PLUS_ALBUM` returns `([], False)`
- [x] New unit test: `perform_lookup` finds "No Way Back by Adonis" on VA compilation when Adonis has no library entries
- [x] Existing `test_finds_song_on_compilation` still passes (artist-only fallback path)
- [x] Full unit suite (470 tests) passes
- [x] ruff + black clean