### PR TITLE
Fix compilation search: retry Discogs without artist filter for VA releases

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -368,6 +368,25 @@ async def search_compilations_for_track(
         releases = await lookup_releases_by_track(
             song_search, parsed.artist, service=discogs_service
         )
+        # If artist-scoped search only found non-compilation releases,
+        # retry without artist to find VA compilations containing the track
+        has_compilation = any(is_compilation_artist(a) for a, _ in releases)
+        if not has_compilation:
+            va_releases = await lookup_releases_by_track(
+                song_search, artist=None, service=discogs_service
+            )
+            for release_artist, release_album in va_releases:
+                if (
+                    is_compilation_artist(release_artist)
+                    and (
+                        release_artist,
+                        release_album,
+                    )
+                    not in releases
+                ):
+                    releases.append((release_artist, release_album))
+            if va_releases and not releases:
+                releases = va_releases
         logger.info(f"Found {len(releases)} releases with '{song_search}' on Discogs")
         discogs_found_releases = len(releases) > 0
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -580,13 +580,19 @@ class TestPerformLookupCompilations:
             raw_message="No Way Back by Adonis",
         )
 
-        with patch(
-            "lookup.orchestrator.lookup_releases_by_track",
-            new_callable=AsyncMock,
-            return_value=[
+        # Discogs API with artist="Adonis" returns only the single;
+        # without artist filter, it also returns VA compilations
+        async def mock_track_lookup(track, artist=None, **kwargs):
+            if artist:
+                return [("Adonis", "No Way Back")]
+            return [
                 ("Adonis", "No Way Back"),
                 ("Various Artists", "Trax Records 20th Anniversary Collection"),
-            ],
+            ]
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            side_effect=mock_track_lookup,
         ):
             response = await perform_lookup(
                 request, mock_library_db, mock_discogs_service, telemetry


### PR DESCRIPTION
## Summary

- When `search_compilations_for_track` finds no compilation releases from artist-scoped Discogs search, retry without the artist filter to discover VA compilations containing the track
- This completes the fix for "No Way Back by Adonis" -- the Discogs API with `artist=Adonis` only returns the Adonis single, excluding the VA compilation "Trax Records 20th Anniversary Collection" where the track also appears

Follow-up to #43 and #42

## Test plan

- [x] Unit test: `test_finds_song_on_compilation_when_discogs_resolves_single` updated with realistic mock (artist-scoped returns single only, unscoped returns VA compilation)
- [x] Full unit suite (497 tests) passes
- [x] ruff + black clean