### PR TITLE
fix: retry compilation album search with Various prefix

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -402,6 +402,11 @@ async def search_compilations_for_track(
 
             matches = await search_album_fuzzy(db, release_album)
 
+            # If album-only search failed for a compilation, retry with "Various"
+            # to help FTS5 match entries stored as "Various Artists - ..."
+            if not matches and is_compilation_artist(release_artist):
+                matches = await search_album_fuzzy(db, f"Various {release_album}")
+
             if matches and parsed.artist:
                 filtered_matches = []
                 discogs_is_compilation = is_compilation_artist(release_artist)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -604,6 +604,76 @@ class TestPerformLookupCompilations:
         assert response.context_message is not None
         assert "Found" in response.context_message
 
+    @pytest.mark.asyncio
+    async def test_compilation_search_retries_with_various_prefix(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """When album-only FTS5 fails for a VA compilation, retry with 'Various' prefix.
+
+        On staging, db.search("Trax Records 20th Anniversary Collection") returns
+        nothing via FTS5, but db.search("Various Trax Records 20th Anniversary
+        Collection") succeeds because FTS5 matches "Various" against the artist
+        column "Various Artists - Electronic - T".
+        """
+        compilation_item = make_library_item(
+            id=46602,
+            artist="Various Artists - Electronic - T",
+            title="Trax Records 20th Anniversary Collection",
+            call_letters="V",
+        )
+
+        mock_library_db.find_similar_artist.return_value = None
+
+        # db.search call order:
+        # 1. search_library_with_fallback: "Adonis No Way Back" (artist+album) -> []
+        # 2. search_library_with_fallback: "Adonis No Way Back" (artist+song) -> []
+        # 3. search_library_with_fallback: "Adonis" (artist only) -> []
+        # 4. search_compilations_for_track: keyword "adonis back" -> []
+        # 5. search_album_fuzzy("No Way Back"): exact -> []
+        # 6. search_album_fuzzy("No Way Back"): fuzzy "back" -> []
+        # 7. search_album_fuzzy("Trax Records..."): exact -> [] (FTS5 FAILS!)
+        # 8. search_album_fuzzy("Trax Records..."): fuzzy -> [] (also fails)
+        # 9. search_album_fuzzy("Various Trax Records..."): exact -> found! (retry)
+        mock_library_db.search.side_effect = [
+            [],  # 1: artist + album
+            [],  # 2: artist + song
+            [],  # 3: artist only
+            [],  # 4: keyword search
+            [],  # 5: search_album_fuzzy("No Way Back") exact
+            [],  # 6: search_album_fuzzy("No Way Back") fuzzy "back"
+            [],  # 7: search_album_fuzzy("Trax Records...") exact (FTS5 failure)
+            [],  # 8: search_album_fuzzy("Trax Records...") fuzzy
+            [compilation_item],  # 9: search_album_fuzzy("Various Trax Records...") (retry!)
+        ]
+
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        request = LookupRequest(
+            artist="Adonis",
+            song="No Way Back",
+            raw_message="No Way Back by Adonis",
+        )
+
+        async def mock_track_lookup(track, artist=None, **kwargs):
+            if artist:
+                return [("Adonis", "No Way Back")]
+            return [
+                ("Adonis", "No Way Back"),
+                ("Various Artists", "Trax Records 20th Anniversary Collection"),
+            ]
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            side_effect=mock_track_lookup,
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        assert response.found_on_compilation is True
+        assert len(response.results) >= 1
+        assert response.results[0].library_item.title == "Trax Records 20th Anniversary Collection"
+
 
 # ---------------------------------------------------------------------------
 # Tests: perform_lookup - artwork


### PR DESCRIPTION
## Summary

- When `search_album_fuzzy` fails to find a VA compilation album by title alone, retry with "Various" prefixed to the query so FTS5 can match against the artist column (e.g., "Various Artists - Electronic - T")
- This fixes the "No Way Back by Adonis" case where the track exists on "Trax Records 20th Anniversary Collection" (library item 46602) but FTS5 couldn't find it by title alone

## Context

This is the fourth fix in the compilation search fallback chain. Previous fixes (#42, #43, #44) threaded `song_not_found` through the pipeline, set it correctly when all searches fail, and added artist-less Discogs retry. This fix addresses the final gap: FTS5 not matching album-only queries for compilation entries.

## Test plan

- [x] New unit test `test_compilation_search_retries_with_various_prefix` models the real staging failure (9 mocked `db.search` calls)
- [x] All 498 existing unit tests pass
- [ ] Verify on staging: `lookup -s "no way back by adonis"` returns the compilation