### PR TITLE
Fix PG cache to find tracks on VA compilations

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -77,7 +77,8 @@ class DiscogsCacheService:
         try:
             query = """
                 WITH matching_tracks AS (
-                    SELECT DISTINCT rt.release_id, rt.title as track_title,
+                    SELECT DISTINCT rt.release_id, rt.sequence,
+                           rt.title as track_title,
                            similarity(lower(f_unaccent(rt.title)), lower(f_unaccent($1))) as sim
                     FROM release_track rt
                     WHERE lower(f_unaccent(rt.title)) % lower(f_unaccent($1))
@@ -90,7 +91,14 @@ class DiscogsCacheService:
                 FROM matching_tracks mt
                 JOIN release r ON r.id = mt.release_id
                 JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
-                WHERE ($3::text IS NULL OR lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3)))
+                LEFT JOIN release_track_artist rta
+                    ON rta.release_id = mt.release_id
+                    AND rta.track_sequence = mt.sequence
+                WHERE (
+                    $3::text IS NULL
+                    OR lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3))
+                    OR lower(f_unaccent(rta.artist_name)) % lower(f_unaccent($3))
+                )
                 ORDER BY mt.sim DESC
             """
 

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -6,8 +6,10 @@ import pytest
 
 from discogs.models import (
     DiscogsSearchResponse,
+    ReleaseInfo,
     ReleaseMetadataResponse,
     TrackItem,
+    TrackReleasesResponse,
 )
 
 pytestmark = pytest.mark.integration
@@ -302,3 +304,66 @@ class TestQuotedArtistNameValidation:
         assert response.context_message and "not" in response.context_message.lower(), (
             f"Context should indicate song not found; got: {response.context_message}"
         )
+
+
+class TestVACompilationTrackSearch:
+    """Test that tracks on VA compilations are found via Discogs cross-reference."""
+
+    @pytest.mark.asyncio
+    async def test_finds_track_on_va_compilation(self, library_db):
+        """Track on a VA compilation should be found when Discogs identifies the release.
+
+        Seed data includes (10, "Now That's What I Call Music 47", "Various Artists").
+        When Discogs reports a track is on this compilation, the pipeline should find
+        the library entry and return found_on_compilation=True.
+        """
+        from core.telemetry import RequestTelemetry, init_cache_stats
+        from discogs.service import DiscogsService
+        from lookup.models import LookupRequest
+        from lookup.orchestrator import perform_lookup
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(spec=DiscogsService)
+        mock_service.cache_service = None
+
+        # Discogs finds the track on a VA compilation matching the library entry
+        mock_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Dancing Queen",
+                artist="Chuquimamani-Condori",
+                releases=[
+                    ReleaseInfo(
+                        album="Now That's What I Call Music 47",
+                        artist="Various Artists",
+                        release_id=9001,
+                        release_url="https://discogs.com/release/9001",
+                        is_compilation=True,
+                    ),
+                ],
+                total=1,
+                cached=False,
+            )
+        )
+
+        # Validate that the track is on the release
+        mock_service.validate_track_on_release = AsyncMock(return_value=True)
+
+        # No artwork
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        mock_service.get_release = AsyncMock(return_value=None)
+
+        request = LookupRequest(
+            artist="Chuquimamani-Condori",
+            song="Dancing Queen",
+            raw_message="Dancing Queen by Chuquimamani-Condori",
+        )
+
+        response = await perform_lookup(request, library_db, mock_service, RequestTelemetry())
+
+        assert response.found_on_compilation is True, (
+            "Track on VA compilation should set found_on_compilation=True"
+        )
+        assert len(response.results) >= 1
+        titles = [r.library_item.title for r in response.results]
+        assert "Now That's What I Call Music 47" in titles

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -124,6 +124,62 @@ class TestSearchReleasesByTrack:
         assert len(results) == 3
 
     @pytest.mark.asyncio
+    async def test_returns_va_compilation_via_track_artist(self, cache_service, mock_asyncpg_pool):
+        """VA compilation is returned when the track-level artist matches."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {
+                    "release_id": 99,
+                    "title": "Nao Wave- Brazilian Punk 82-88",
+                    "artist_name": "Various Artists",
+                    "track_title": "Ciencias Sensuais",
+                    "is_compilation": True,
+                }
+            ]
+        )
+
+        results = await cache_service.search_releases_by_track("Ciencias Sensuais", "Azul 29")
+        assert len(results) == 1
+        assert results[0].album == "Nao Wave- Brazilian Punk 82-88"
+        assert results[0].is_compilation is True
+
+    @pytest.mark.asyncio
+    async def test_query_includes_track_artist_join(self, cache_service, mock_asyncpg_pool):
+        """SQL query joins release_track_artist for track-level artist matching."""
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+
+        await cache_service.search_releases_by_track("Song", "Artist")
+
+        sql = mock_asyncpg_pool.fetch.call_args[0][0]
+        assert "release_track_artist" in sql
+        assert "rta.artist_name" in sql
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_multiple_track_artists(self, cache_service, mock_asyncpg_pool):
+        """Multiple rows from LEFT JOIN (different track artists) are deduplicated."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {
+                    "release_id": 99,
+                    "title": "Compilation",
+                    "artist_name": "Various Artists",
+                    "track_title": "Track",
+                    "is_compilation": True,
+                },
+                {
+                    "release_id": 99,
+                    "title": "Compilation",
+                    "artist_name": "Various Artists",
+                    "track_title": "Track",
+                    "is_compilation": True,
+                },
+            ]
+        )
+
+        results = await cache_service.search_releases_by_track("Track", "Artist A")
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
     async def test_error_raises_cache_unavailable(self, cache_service, mock_asyncpg_pool):
         mock_asyncpg_pool.fetch = AsyncMock(side_effect=Exception("db error"))
 


### PR DESCRIPTION
## Summary

- The PG cache's `search_releases_by_track` query filtered only by release-level artist, missing VA compilations where the artist is credited on individual tracks via `release_track_artist`
- Add a LEFT JOIN to `release_track_artist` and an OR condition in the WHERE clause so track-level artist credits also satisfy the artist filter
- The existing trigram GIN index on `release_track_artist.artist_name` keeps the query efficient

Closes #52

## Test plan

- [ ] Unit tests: 3 new tests in `TestSearchReleasesByTrack` (VA compilation via track artist, query structure assertion, deduplication)
- [ ] Integration test: full pipeline test verifying `found_on_compilation=True` for a VA compilation
- [ ] Verified against real Discogs cache data: old query returns 1 result, fixed query returns 5 including the target compilation
- [ ] All 589 existing tests pass with no regressions