### PR TITLE
fix: return artist album alongside compilation when track appears on both

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -68,6 +68,15 @@ class SearchState:
     albums_for_search: list[str] = field(default_factory=list)
     """Album names resolved from Discogs track lookup (may contain multiple)."""
 
+    artist_fallback_results: list[LibraryItem] = field(default_factory=list)
+    """Artist-only fallback results saved before TRACK_ON_COMPILATION replaces them.
+
+    When compilation search replaces the previous artist-only results, the originals
+    are preserved here so perform_lookup can validate them against Discogs tracklists
+    and merge any confirmed matches (e.g., the artist's own album containing the track)
+    back into the final results.
+    """
+
 
 # Type aliases for strategy functions
 ConditionFunc = Callable[[ParsedRequest, SearchState, str], bool]
@@ -269,6 +278,11 @@ async def execute_search_pipeline(
         elif strategy.name == SearchStrategyType.TRACK_ON_COMPILATION:
             results, discogs_titles = await strategy.execute(db, parsed)
             if results:
+                # Save artist fallback results before replacing — perform_lookup
+                # will validate them against Discogs tracklists and merge any
+                # confirmed matches back into the final results.
+                if state.results and state.song_not_found:
+                    state.artist_fallback_results = list(state.results)
                 state.results = results
                 state.found_on_compilation = True
                 state.song_not_found = False

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -835,16 +835,32 @@ async def perform_lookup(
             telemetry.record_api_call("discogs")
 
     # Step 3b: Validate results against Discogs track data.
-    # Skip when results come from compilation search — those were already
-    # validated by search_compilations_for_track (deferred validation).
-    if library_results and parsed.song and parsed.artist and not found_on_compilation:
-        with telemetry.track_step("track_validation"):
-            validated = await filter_results_by_track_validation(
-                library_results, parsed.song, parsed.artist, discogs_service
-            )
-            if validated:
-                library_results = validated
-                song_not_found = False
+    if library_results and parsed.song and parsed.artist:
+        if not found_on_compilation:
+            # Normal case: validate all results against Discogs tracklists
+            with telemetry.track_step("track_validation"):
+                validated = await filter_results_by_track_validation(
+                    library_results, parsed.song, parsed.artist, discogs_service
+                )
+                if validated:
+                    library_results = validated
+                    song_not_found = False
+        elif search_state.artist_fallback_results:
+            # Compilation found, but the artist's own album may also contain the track.
+            # Validate the artist fallback results (saved before compilation search
+            # replaced them) and prepend any confirmed matches.
+            with telemetry.track_step("track_validation"):
+                validated = await filter_results_by_track_validation(
+                    search_state.artist_fallback_results,
+                    parsed.song,
+                    parsed.artist,
+                    discogs_service,
+                )
+                if validated:
+                    compilation_ids = {r.id for r in library_results}
+                    merged = [r for r in validated if r.id not in compilation_ids]
+                    merged.extend(library_results)
+                    library_results = merged
 
     # Step 4: Fetch artwork
     with telemetry.track_step("artwork_fetch"):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,6 +45,9 @@ SEED_ITEMS = [
     (23, "Weird Al Yankovic", "Weird Al Yankovic", "YA", 1, 1, "Rock", "Vinyl"),
     (24, "Dare to Be Stupid", "Weird Al Yankovic", "YA", 1, 2, "Rock", "Vinyl"),
     (25, "Even Worse", "Weird Al Yankovic", "YA", 1, 3, "Rock", "Vinyl"),
+    (26, "London Zoo", "The Bug", "B", 2, 1, "Electronic", "CD"),
+    (27, "Pressure", "The Bug", "B", 2, 2, "Electronic", "CD"),
+    (28, "The Sound of Dub", "Various Artists - Reggae", "V", 2, 1, "Reggae", "CD"),
 ]
 
 

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -367,3 +367,112 @@ class TestVACompilationTrackSearch:
         assert len(response.results) >= 1
         titles = [r.library_item.title for r in response.results]
         assert "Now That's What I Call Music 47" in titles
+
+
+class TestTrackOnArtistAlbumAndCompilation:
+    """Test that tracks on both an artist album and a compilation return both results.
+
+    Bug: "Poison Dart" by "The Bug" is on London Zoo (artist album) AND
+    The Sound of Dub (VA compilation). When ARTIST_PLUS_ALBUM falls back to
+    artist-only and then TRACK_ON_COMPILATION finds the compilation, the artist
+    fallback results should be validated and the artist's own album included.
+    """
+
+    @pytest.mark.asyncio
+    async def test_artist_album_and_compilation_both_returned(self, library_db):
+        """Both London Zoo and The Sound of Dub should appear in results.
+
+        Seed data includes:
+        - (26, "London Zoo", "The Bug") - artist's own album
+        - (27, "Pressure", "The Bug") - another Bug album (should be excluded)
+        - (28, "The Sound of Dub", "Various Artists - Reggae") - compilation
+        """
+        from core.telemetry import RequestTelemetry, init_cache_stats
+        from lookup.models import LookupRequest
+        from lookup.orchestrator import perform_lookup
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(
+            spec_set=[
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "search",
+                "get_release",
+                "cache_service",
+            ]
+        )
+        mock_service.cache_service = None
+
+        # Discogs search_releases_by_track returns The Sound of Dub (compilation)
+        mock_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Poison Dart",
+                artist="The Bug",
+                releases=[
+                    ReleaseInfo(
+                        album="The Sound of Dub",
+                        artist="Various Artists",
+                        release_id=2308471,
+                        release_url="https://www.discogs.com/release/2308471",
+                        is_compilation=True,
+                    ),
+                ],
+                total=1,
+                cached=False,
+            )
+        )
+
+        # Track validation:
+        # - "Poison Dart" IS on London Zoo (release 1395903)
+        # - "Poison Dart" IS on The Sound of Dub (release 2308471)
+        # - "Poison Dart" is NOT on Pressure (release 9999)
+        from tests.factories import make_discogs_result
+
+        london_zoo_discogs = make_discogs_result(
+            release_id=1395903, album="London Zoo", artist="The Bug"
+        )
+        pressure_discogs = make_discogs_result(release_id=9999, album="Pressure", artist="The Bug")
+
+        async def mock_search(request):
+            album = request.album if hasattr(request, "album") else ""
+            if album and "london" in album.lower():
+                return DiscogsSearchResponse(results=[london_zoo_discogs])
+            if album and "pressure" in album.lower():
+                return DiscogsSearchResponse(results=[pressure_discogs])
+            return DiscogsSearchResponse(results=[])
+
+        mock_service.search = AsyncMock(side_effect=mock_search)
+
+        async def mock_validate(release_id, track, artist):
+            return release_id in (1395903, 2308471)
+
+        mock_service.validate_track_on_release = AsyncMock(side_effect=mock_validate)
+        mock_service.get_release = AsyncMock(return_value=None)
+
+        request = LookupRequest(
+            artist="The Bug",
+            song="Poison Dart",
+            raw_message="poison dart, the bug",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(request, library_db, mock_service, RequestTelemetry())
+
+        titles = [r.library_item.title for r in response.results]
+        assert "London Zoo" in titles, (
+            f"Artist album 'London Zoo' should be in results, got: {titles}"
+        )
+        assert "The Sound of Dub" in titles, (
+            f"Compilation 'The Sound of Dub' should be in results, got: {titles}"
+        )
+        assert "Pressure" not in titles, (
+            f"'Pressure' (doesn't contain 'Poison Dart') should NOT be in results, got: {titles}"
+        )
+        assert response.found_on_compilation is True
+        # Artist's own album should come before the compilation
+        assert titles.index("London Zoo") < titles.index("The Sound of Dub")

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -742,10 +742,13 @@ class TestPerformLookupCompilations:
             )
 
         assert response.found_on_compilation is True
-        # discogs_service.search should only be called for artwork fetch,
-        # NOT for track validation. With 1 result, artwork fetch calls search once.
-        # If track validation also ran, search would be called 2+ times.
-        assert mock_discogs_service.search.call_count <= 1
+        # Compilation results should NOT be re-validated (already validated in
+        # search_compilations_for_track). search calls come from:
+        # 1. Artist fallback validation: 1 call (for fallback_item → no Discogs match)
+        # 2. Artwork fetch: 1 call (for compilation_item)
+        # Without the artist fallback validation this would be 1 call.
+        # If compilation results were ALSO re-validated, count would be 3+.
+        assert mock_discogs_service.search.call_count <= 2
 
 
 # ---------------------------------------------------------------------------
@@ -825,3 +828,138 @@ class TestPerformLookupAmbiguousFormat:
 
         assert len(response.results) >= 1
         assert response.search_type == "alternative"
+
+
+# ---------------------------------------------------------------------------
+# Tests: perform_lookup - track on artist album + compilation
+# ---------------------------------------------------------------------------
+
+
+class TestArtistAlbumPlusCompilation:
+    """Test that tracks found on both an artist album and a compilation return both results.
+
+    Bug: "Poison Dart" by "The Bug" is on London Zoo (artist album, library ID 54324)
+    AND The Sound of Dub (VA compilation, library ID 47808). The pipeline should
+    return both, but currently only returns the compilation because TRACK_ON_COMPILATION
+    replaces artist fallback results and track validation is skipped.
+    """
+
+    @pytest.mark.asyncio
+    async def test_artist_album_included_when_compilation_also_found(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """Both London Zoo (artist album) and The Sound of Dub (compilation) should be returned.
+
+        Scenario:
+        1. resolve_albums_for_track returns nothing (Discogs track lookup fails/empty)
+        2. ARTIST_PLUS_ALBUM: artist+song empty, falls back to artist-only → Bug albums
+        3. TRACK_ON_COMPILATION: finds The Sound of Dub (compilation)
+        4. Track validation should confirm London Zoo contains "Poison Dart"
+        5. Both London Zoo and The Sound of Dub should appear in results
+        """
+        from discogs.models import ReleaseInfo, TrackReleasesResponse
+
+        london_zoo = make_library_item(
+            id=54324,
+            artist="The Bug",
+            title="London Zoo",
+            call_letters="B",
+            genre="Electronic",
+        )
+        pressure = make_library_item(
+            id=54325,
+            artist="The Bug",
+            title="Pressure",
+            call_letters="B",
+            genre="Electronic",
+            release_call_number=2,
+        )
+        sound_of_dub = make_library_item(
+            id=47808,
+            artist="various",
+            title="The Sound of Dub",
+            call_letters="V",
+            genre="Reggae",
+        )
+
+        mock_library_db.find_similar_artist.return_value = None
+
+        # db.search call order:
+        # 1. search_library_with_fallback: artist+song "The Bug Poison Dart" → []
+        # 2. search_library_with_fallback: artist only "The Bug" → [london_zoo, pressure]
+        # 3. search_compilations_for_track: keyword "poison dart" → []
+        # 4. search_album_fuzzy: "The Sound of Dub" → [sound_of_dub]
+        mock_library_db.search.side_effect = [
+            [],  # artist + song
+            [london_zoo, pressure],  # artist only fallback
+            [],  # keyword search (no library match for "poison dart")
+            [sound_of_dub],  # search_album_fuzzy for Discogs album title
+        ]
+
+        # Discogs: search_releases_by_track finds The Sound of Dub (compilation)
+        mock_discogs_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Poison Dart",
+                artist="The Bug",
+                releases=[
+                    ReleaseInfo(
+                        album="The Sound of Dub",
+                        artist="Various Artists",
+                        release_id=2308471,
+                        release_url="https://www.discogs.com/release/2308471",
+                        is_compilation=True,
+                    ),
+                ],
+                total=1,
+                cached=False,
+            )
+        )
+
+        # Track validation: "Poison Dart" IS on London Zoo, NOT on Pressure
+        london_zoo_discogs = make_discogs_result(
+            release_id=1395903, album="London Zoo", artist="The Bug"
+        )
+        pressure_discogs = make_discogs_result(release_id=9999, album="Pressure", artist="The Bug")
+
+        async def mock_discogs_search(request):
+            album = request.album if hasattr(request, "album") else ""
+            if album and "london" in album.lower():
+                return DiscogsSearchResponse(results=[london_zoo_discogs])
+            if album and "pressure" in album.lower():
+                return DiscogsSearchResponse(results=[pressure_discogs])
+            return DiscogsSearchResponse(results=[])
+
+        mock_discogs_service.search = AsyncMock(side_effect=mock_discogs_search)
+
+        async def mock_validate(release_id, track, artist):
+            # Poison Dart is on London Zoo (1395903) and The Sound of Dub (2308471)
+            return release_id in (1395903, 2308471)
+
+        mock_discogs_service.validate_track_on_release = AsyncMock(side_effect=mock_validate)
+        mock_discogs_service.get_release = AsyncMock(return_value=None)
+
+        request = LookupRequest(
+            artist="The Bug",
+            song="Poison Dart",
+            raw_message="poison dart, the bug",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],  # Discogs track lookup returns nothing
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        titles = [r.library_item.title for r in response.results]
+        assert "London Zoo" in titles, (
+            f"Artist album 'London Zoo' should be in results, got: {titles}"
+        )
+        assert "The Sound of Dub" in titles, (
+            f"Compilation 'The Sound of Dub' should be in results, got: {titles}"
+        )
+        assert response.found_on_compilation is True
+        # Artist's own album should come first
+        assert titles.index("London Zoo") < titles.index("The Sound of Dub")


### PR DESCRIPTION
## Summary

- When a track is on both an artist's own album and a compilation (e.g., "Poison Dart" by The Bug on London Zoo and The Sound of Dub), the pipeline previously returned only the compilation
- Preserves artist fallback results in `SearchState.artist_fallback_results` before `TRACK_ON_COMPILATION` replaces them
- After compilation search, validates saved artist fallback results against Discogs tracklists and merges confirmed matches back into results

Closes #56

## Test plan

- [x] Unit test: `TestArtistAlbumPlusCompilation::test_artist_album_included_when_compilation_also_found` — verifies both London Zoo and The Sound of Dub are returned with mocked data
- [x] Integration test: `TestTrackOnArtistAlbumAndCompilation::test_artist_album_and_compilation_both_returned` — verifies with real FTS5 SQLite and seed data
- [x] All 591 existing tests pass (535 unit + 56 integration)
- [x] Existing `test_compilation_results_skip_track_validation` updated to account for new artist fallback validation (compilation results themselves are still NOT re-validated)