### PR TITLE
Normalize diacritics in validate_track_on_release

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -12,6 +12,7 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 import asyncio
 import logging
 
+from core.matching import normalize_for_comparison
 from discogs.models import (
     ArtistCredit,
     ArtistDetails,
@@ -694,11 +695,11 @@ class DiscogsCacheService:
 
             primary_artist = release_artist_row["artist_name"] if release_artist_row else ""
 
-            track_lower = track.lower()
+            track_lower = normalize_for_comparison(track)
             artist_lower = artist.lower().replace('"', "").replace("'", "")
 
             for row in track_rows:
-                item_title = row["title"].lower()
+                item_title = normalize_for_comparison(row["title"])
 
                 if track_lower not in item_title and item_title not in track_lower:
                     continue

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from config.settings import get_settings
-from core.matching import calculate_confidence, is_compilation_artist
+from core.matching import calculate_confidence, is_compilation_artist, normalize_for_comparison
 from core.telemetry import (
     record_api_time,
     record_discogs_api_call,
@@ -828,14 +828,14 @@ class DiscogsService:
         if release is None:
             return False
 
-        track_lower = track.lower()
+        track_lower = normalize_for_comparison(track)
         # Strip quotes from artist name — Discogs uses quotes for nicknames
         # (e.g. '"Weird Al" Yankovic') which breaks substring matching against
         # the user-supplied form ('Weird Al Yankovic').
         artist_lower = artist.lower().replace('"', "").replace("'", "")
 
         for item in release.tracklist:
-            item_title = item.title.lower()
+            item_title = normalize_for_comparison(item.title)
             # Check if track title matches
             if track_lower not in item_title and item_title not in track_lower:
                 continue

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -563,6 +563,20 @@ class TestValidateTrackOnRelease:
         assert result is False
 
     @pytest.mark.asyncio
+    async def test_diacritics_in_track_title(self, cache_service, mock_asyncpg_pool):
+        """Track title with diacritics should match the unaccented search query."""
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[{"track_sequence": 1, "artist_name": "Azul 29"}],
+                release_track=[{"sequence": 1, "title": "Ciências Sensuais"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "Various Artists"})
+        result = await cache_service.validate_track_on_release(1, "Ciencias Sensuais", "Azul 29")
+        assert result is True
+
+    @pytest.mark.asyncio
     async def test_error_raises(self, cache_service, mock_asyncpg_pool):
         mock_asyncpg_pool.fetchval = AsyncMock(side_effect=Exception("db error"))
         with pytest.raises(CacheUnavailableError):

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -706,6 +706,29 @@ class TestValidateTrackOnRelease:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_diacritics_in_track_title(self, service):
+        """Track title with diacritics should match the unaccented search query.
+
+        Discogs stores "Ciências Sensuais" but the user searches for "Ciencias Sensuais".
+        """
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Compilation",
+            artist="Various Artists",
+            release_url="https://discogs.com/release/1",
+            tracklist=[
+                TrackItem(
+                    position="5",
+                    title="Ciências Sensuais",
+                    artists=["Azul 29"],
+                ),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(1, "Ciencias Sensuais", "Azul 29")
+        assert result is True
+
+    @pytest.mark.asyncio
     async def test_cache_validated(self, service_with_cache):
         service_with_cache.cache_service.validate_track_on_release = AsyncMock(return_value=True)
 


### PR DESCRIPTION
## Summary

- Both `validate_track_on_release` implementations used `.lower()` for track title comparison, failing when diacritics differ ("Ciencias" vs "Ciências")
- Use `normalize_for_comparison()` which strips diacritics before comparing
- Third and final fix for the "Ciencias Sensuais by Azul 29" lookup (after #53 PG cache query and #55 keyword threshold)

Closes #58

## Test plan

- [ ] New diacritics tests in both `test_cache_service.py` and `test_discogs_service.py`
- [ ] All existing `TestValidateTrackOnRelease` tests pass
- [ ] Full suite: 588 passed, 0 failures
- [ ] After staging deploy, verify `lookup "Ciencias Sensuais by Azul 29"` finds the Nao Wave compilation