### PR TITLE
Fix enriched fields not serialized in lookup response

### DIFF
--- a/lookup/models.py
+++ b/lookup/models.py
@@ -3,16 +3,31 @@
 These are re-exports from the generated api.yaml models (wxyc-shared).
 Internal models (LibraryItem, DiscogsSearchResult) remain in their
 respective modules for domain logic.
+
+LookupResultItem is overridden here to use SerializeAsAny so that
+EnrichedDiscogsMatchResult (a subclass of DiscogsMatchResult) is
+serialized with all its fields, not just the base class fields.
 """
+
+from pydantic import SerializeAsAny
 
 from generated.api_models import (
     DiscogsMatchResult,
     LibraryCatalogItem,
     LookupRequest,
     LookupResponse,
-    LookupResultItem,
     SearchType,
 )
+from generated.api_models import (
+    LookupResultItem as _GeneratedLookupResultItem,
+)
+
+
+class LookupResultItem(_GeneratedLookupResultItem):
+    """Override to serialize artwork subclasses with all fields."""
+
+    artwork: SerializeAsAny[DiscogsMatchResult] | None = None
+
 
 __all__ = [
     "DiscogsMatchResult",


### PR DESCRIPTION
## Summary

The enriched metadata fields (release_year, artist_bio, wikipedia_url, streaming URLs) were not appearing in the JSON response because Pydantic v2 serializes using the declared type annotation (`DiscogsMatchResult`), stripping subclass fields from `EnrichedDiscogsMatchResult`.

Fix: Override `LookupResultItem.artwork` with `SerializeAsAny[DiscogsMatchResult]` so Pydantic serializes the actual runtime type including all enriched fields.

## Test plan

- [x] 565 unit tests pass
- [x] Verified enriched fields appear in JSON output