### PR TITLE
Fix LookupResponse to serialize enriched artwork fields

### DIFF
--- a/lookup/models.py
+++ b/lookup/models.py
@@ -34,7 +34,7 @@ class LookupResultItem(_GeneratedLookupResultItem):
 class LookupResponse(_GeneratedLookupResponse):
     """Override so results use our LookupResultItem with SerializeAsAny."""
 
-    results: list[LookupResultItem] | None = None
+    results: list[LookupResultItem] | None = None  # type: ignore[assignment]
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Follow-up to #64. The `SerializeAsAny` override on `LookupResultItem.artwork` was correct, but `LookupResponse.results` still referenced the generated `LookupResultItem` (without `SerializeAsAny`). Since FastAPI uses `response_model=LookupResponse` for serialization, the enriched fields were stripped.

Fix: Also override `LookupResponse` in `lookup/models.py` to reference our `LookupResultItem` subclass.