### PR TITLE
Support Discogs key/secret auth and add E2E tests

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -123,6 +123,28 @@ async def close_discogs_service() -> None:
         _discogs_pool = None
 
 
+async def get_discogs_cache_service(
+    settings: Settings = Depends(get_settings),
+) -> DiscogsCacheService | None:
+    """Get Discogs cache service instance for direct cache queries.
+
+    Returns the cache layer only (no Discogs API client). Used by endpoints
+    that query the PostgreSQL cache directly, like track autocomplete.
+
+    Returns:
+        DiscogsCacheService if the cache pool is available, None otherwise.
+    """
+    global _discogs_pool
+
+    if _discogs_pool is None:
+        await get_discogs_service(settings)
+
+    if _discogs_pool is None:
+        return None
+
+    return DiscogsCacheService(_discogs_pool)
+
+
 def get_posthog_client(settings: Settings = Depends(get_settings)) -> Posthog | None:
     """Get PostHog client instance.
 

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -135,6 +135,58 @@ class DiscogsCacheService:
             logger.error(f"Cache search failed: {e}")
             raise CacheUnavailableError(f"Cache search failed: {e}") from e
 
+    async def autocomplete_tracks(
+        self, artist: str, q: str, *, release: str | None = None, limit: int = 20
+    ) -> list[str]:
+        """Autocomplete track titles for an artist from the cache.
+
+        Searches the release_track table for track titles matching the prefix,
+        filtered by artist. Returns distinct, sorted titles.
+
+        Args:
+            artist: Artist name to filter by (required).
+            q: Track title prefix to search for.
+            release: Optional release title to filter by.
+            limit: Maximum number of results after deduplication.
+
+        Returns:
+            Sorted list of distinct track titles.
+
+        Raises:
+            CacheUnavailableError: If the database is unreachable.
+        """
+        try:
+            query = """
+                SELECT rt.title
+                FROM release_track rt
+                JOIN release_artist ra ON ra.release_id = rt.release_id AND ra.extra = 0
+                LEFT JOIN release r ON r.id = rt.release_id
+                WHERE lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($1))
+                  AND lower(f_unaccent(rt.title)) ILIKE f_unaccent($2) || '%'
+                  AND ($3::text IS NULL OR lower(f_unaccent(r.title)) % lower(f_unaccent($3)))
+                LIMIT $4
+            """
+
+            # Overfetch to allow for dedup
+            rows = await self.pool.fetch(query, artist, q, release, limit * 5)
+
+            # Case-insensitive dedup (first occurrence wins), then sort
+            seen: set[str] = set()
+            titles: list[str] = []
+            for row in rows:
+                title = row["title"]
+                key = title.lower()
+                if key not in seen:
+                    seen.add(key)
+                    titles.append(title)
+
+            titles.sort(key=str.lower)
+            return titles[:limit]
+
+        except Exception as e:
+            logger.error(f"Cache autocomplete_tracks failed: {e}")
+            raise CacheUnavailableError(f"Cache autocomplete_tracks failed: {e}") from e
+
     async def get_release(self, release_id: int) -> ReleaseMetadataResponse | None:
         """Get full release metadata by ID.
 

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -9,6 +9,15 @@ from pydantic import BaseModel
 from generated.api_models import DiscogsMatchResult as _GeneratedDiscogsMatchResult
 
 
+class TracksAutocompleteResponse(BaseModel):
+    """Response for track title autocomplete from cache."""
+
+    results: list[str] = []
+    total: int = 0
+    artist: str
+    cached: bool = True
+
+
 class ArtistCredit(BaseModel):
     """An artist credit on a release."""
 

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -4,7 +4,8 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from core.dependencies import get_discogs_service
+from core.dependencies import get_discogs_cache_service, get_discogs_service
+from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 from discogs.models import (
     ArtistDetails,
     DiscogsSearchRequest,
@@ -13,6 +14,7 @@ from discogs.models import (
     EntityType,
     ReleaseMetadataResponse,
     TrackReleasesResponse,
+    TracksAutocompleteResponse,
 )
 from discogs.service import DiscogsService
 
@@ -169,3 +171,45 @@ async def resolve_entity(
         if master is None:
             raise HTTPException(status_code=404, detail=f"Master {entity_id} not found")
         return EntityResolveResponse(name=master.title, type=entity_type, id=entity_id)
+
+
+@router.get(
+    "/tracks/autocomplete",
+    response_model=TracksAutocompleteResponse,
+    summary="Autocomplete track titles for an artist",
+    responses={
+        200: {"description": "Track titles returned (may be empty on cache error)"},
+        422: {"description": "Missing required artist or q parameter"},
+        503: {"description": "Discogs cache not available"},
+    },
+)
+async def autocomplete_tracks(
+    artist: str = Query(..., description="Artist name (required)"),
+    q: str = Query(..., description="Track title prefix to search for"),
+    release: str | None = Query(None, description="Optional release title filter"),
+    limit: int = Query(20, ge=1, le=100, description="Maximum number of results"),
+    cache: DiscogsCacheService | None = Depends(get_discogs_cache_service),
+) -> TracksAutocompleteResponse:
+    """Autocomplete track titles from the Discogs cache for a given artist."""
+    if cache is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Discogs cache is not available. Set DATABASE_URL_DISCOGS.",
+        )
+
+    try:
+        results = await cache.autocomplete_tracks(artist, q, release=release, limit=limit)
+        return TracksAutocompleteResponse(
+            results=results,
+            total=len(results),
+            artist=artist,
+            cached=True,
+        )
+    except CacheUnavailableError:
+        logger.warning("Cache error during track autocomplete, returning empty results")
+        return TracksAutocompleteResponse(
+            results=[],
+            total=0,
+            artist=artist,
+            cached=True,
+        )

--- a/tests/unit/test_track_autocomplete.py
+++ b/tests/unit/test_track_autocomplete.py
@@ -1,0 +1,283 @@
+"""Unit tests for track autocomplete endpoint and cache service method."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from discogs.cache_service import DiscogsCacheService
+from tests.unit.conftest import override_deps
+
+
+# ---------------------------------------------------------------------------
+# Cache service: autocomplete_tracks
+# ---------------------------------------------------------------------------
+
+
+class TestAutocompleteTracksCache:
+    @pytest.mark.asyncio
+    async def test_returns_distinct_track_titles(self, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {"title": "Percolator"},
+                {"title": "Per Clansen"},
+            ]
+        )
+
+        svc = DiscogsCacheService(mock_asyncpg_pool)
+        result = await svc.autocomplete_tracks("Stereolab", "per", limit=20)
+
+        assert result == ["Per Clansen", "Percolator"]
+        mock_asyncpg_pool.fetch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_case_insensitive(self, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {"title": "Percolator"},
+                {"title": "percolator"},
+                {"title": "PERCOLATOR"},
+            ]
+        )
+
+        svc = DiscogsCacheService(mock_asyncpg_pool)
+        result = await svc.autocomplete_tracks("Stereolab", "per", limit=20)
+
+        assert len(result) == 1
+        assert result[0] == "Percolator"  # keeps first occurrence
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[{"title": f"Track {i}"} for i in range(10)]
+        )
+
+        svc = DiscogsCacheService(mock_asyncpg_pool)
+        result = await svc.autocomplete_tracks("Artist", "tr", limit=5)
+
+        assert len(result) == 5
+
+    @pytest.mark.asyncio
+    async def test_with_release_filter(self, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[{"title": "Song"}])
+
+        svc = DiscogsCacheService(mock_asyncpg_pool)
+        result = await svc.autocomplete_tracks("Artist", "so", release="Album", limit=20)
+
+        assert result == ["Song"]
+        # Verify the release parameter was passed: fetch(query, artist, q, release, limit)
+        call_args = mock_asyncpg_pool.fetch.call_args
+        assert call_args[0][3] == "Album"  # release param at index 3
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_cache_error(self, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=Exception("connection lost"))
+
+        svc = DiscogsCacheService(mock_asyncpg_pool)
+        from discogs.cache_service import CacheUnavailableError
+
+        with pytest.raises(CacheUnavailableError):
+            await svc.autocomplete_tracks("Artist", "per", limit=20)
+
+    @pytest.mark.asyncio
+    async def test_returns_sorted_titles(self, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {"title": "Zebra"},
+                {"title": "Alpha"},
+                {"title": "Mango"},
+            ]
+        )
+
+        svc = DiscogsCacheService(mock_asyncpg_pool)
+        result = await svc.autocomplete_tracks("Artist", "a", limit=20)
+
+        assert result == ["Alpha", "Mango", "Zebra"]
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+
+        svc = DiscogsCacheService(mock_asyncpg_pool)
+        result = await svc.autocomplete_tracks("Unknown", "xyz", limit=20)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Router: GET /api/v1/discogs/tracks/autocomplete
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_discogs():
+    from discogs.service import DiscogsService
+
+    svc = AsyncMock(spec=DiscogsService)
+    return svc
+
+
+@pytest.fixture
+def mock_cache():
+    svc = AsyncMock(spec=DiscogsCacheService)
+    return svc
+
+
+@pytest.fixture
+def app_with_cache(mock_discogs, mock_cache, mock_settings):
+    from config.settings import get_settings
+    from core.dependencies import (
+        get_discogs_cache_service,
+        get_discogs_service,
+        get_library_db,
+        get_posthog_client,
+    )
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: mock_discogs,
+            get_discogs_cache_service: mock_cache,
+            get_posthog_client: None,
+            get_settings: mock_settings,
+        },
+    ):
+        yield app
+
+
+@pytest.fixture
+def app_without_cache(mock_discogs, mock_settings):
+    from config.settings import get_settings
+    from core.dependencies import (
+        get_discogs_cache_service,
+        get_discogs_service,
+        get_library_db,
+        get_posthog_client,
+    )
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: mock_discogs,
+            get_discogs_cache_service: None,
+            get_posthog_client: None,
+            get_settings: mock_settings,
+        },
+    ):
+        yield app
+
+
+class TestTracksAutocompleteEndpoint:
+    @pytest.mark.asyncio
+    async def test_success(self, app_with_cache, mock_cache):
+        mock_cache.autocomplete_tracks = AsyncMock(return_value=["Percolator", "Per Clansen"])
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/tracks/autocomplete",
+                params={"artist": "Stereolab", "q": "per"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["results"] == ["Percolator", "Per Clansen"]
+        assert data["total"] == 2
+        assert data["artist"] == "Stereolab"
+        assert data["cached"] is True
+
+    @pytest.mark.asyncio
+    async def test_with_release_param(self, app_with_cache, mock_cache):
+        mock_cache.autocomplete_tracks = AsyncMock(return_value=["Song"])
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/tracks/autocomplete",
+                params={"artist": "Stereolab", "q": "so", "release": "Dots and Loops"},
+            )
+
+        assert resp.status_code == 200
+        mock_cache.autocomplete_tracks.assert_called_once_with(
+            "Stereolab", "so", release="Dots and Loops", limit=20
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_artist_returns_422(self, app_with_cache):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/tracks/autocomplete",
+                params={"q": "per"},
+            )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_missing_q_returns_422(self, app_with_cache):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/tracks/autocomplete",
+                params={"artist": "Stereolab"},
+            )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_no_cache_returns_503(self, app_without_cache):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_without_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/tracks/autocomplete",
+                params={"artist": "Stereolab", "q": "per"},
+            )
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_cache_error_returns_empty(self, app_with_cache, mock_cache):
+        from discogs.cache_service import CacheUnavailableError
+
+        mock_cache.autocomplete_tracks = AsyncMock(
+            side_effect=CacheUnavailableError("connection lost")
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/tracks/autocomplete",
+                params={"artist": "Stereolab", "q": "per"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["results"] == []
+        assert data["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_custom_limit(self, app_with_cache, mock_cache):
+        mock_cache.autocomplete_tracks = AsyncMock(return_value=["Track"])
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/tracks/autocomplete",
+                params={"artist": "Artist", "q": "tr", "limit": 5},
+            )
+
+        assert resp.status_code == 200
+        mock_cache.autocomplete_tracks.assert_called_once_with(
+            "Artist", "tr", release=None, limit=5
+        )


### PR DESCRIPTION
## Summary

- Support `DISCOGS_API_KEY` + `DISCOGS_API_SECRET` as alternative auth to `DISCOGS_TOKEN` in DiscogsService
- Add E2E test suite for Discogs API endpoints (search, release, artist, entity)
- Tests use real Discogs API, skipped when no credentials available

Closes #68

## Test plan

- [ ] Existing unit tests pass (`uv run pytest tests/unit/ -q`)
- [ ] E2E tests pass with key/secret: `DISCOGS_API_KEY=xxx DISCOGS_API_SECRET=yyy uv run pytest tests/e2e/ -v -m e2e`
- [ ] E2E tests skip gracefully when no credentials set
- [ ] Service starts with key/secret auth: `DISCOGS_API_KEY=xxx DISCOGS_API_SECRET=yyy uvicorn main:app`