### PR TITLE
Consolidate strip_discogs_suffix and normalize_artist_for_validation into core/matching.py

### DIFF
--- a/core/matching.py
+++ b/core/matching.py
@@ -74,6 +74,19 @@ def strip_discogs_suffix(name: str) -> str:
     return _DISCOGS_SUFFIX_RE.sub("", name)
 
 
+def normalize_artist_for_validation(name: str) -> str:
+    """Normalize an artist name for substring comparison during track validation.
+
+    Lowercases, strips quotes (Discogs uses quotes for nicknames, e.g.
+    '"Weird Al" Yankovic'), and removes disambiguation suffixes like '(2)'.
+    Safe for both user-provided and Discogs-sourced names.
+    """
+    if not name:
+        return ""
+    result = name.lower().replace('"', "").replace("'", "")
+    return strip_discogs_suffix(result).strip()
+
+
 # =============================================================================
 # Search Result Limiting
 # =============================================================================

--- a/core/matching.py
+++ b/core/matching.py
@@ -56,6 +56,25 @@ def normalize_for_track_comparison(text: str | None) -> str:
 
 
 # =============================================================================
+# Discogs Disambiguation Suffix
+# =============================================================================
+
+# Discogs disambiguation suffix: (2), (22), etc.
+_DISCOGS_SUFFIX_RE = re.compile(r"\s*\(\d+\)$")
+
+
+def strip_discogs_suffix(name: str) -> str:
+    """Remove Discogs numeric disambiguation suffixes like '(2)' or '(22)'.
+
+    Discogs appends these to artist and label names when multiple entities
+    share the same name. Safe to apply to names that have no suffix (no-op).
+    """
+    if not name:
+        return name
+    return _DISCOGS_SUFFIX_RE.sub("", name)
+
+
+# =============================================================================
 # Search Result Limiting
 # =============================================================================
 

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -12,7 +12,7 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 import asyncio
 import logging
 
-from core.matching import normalize_for_track_comparison
+from core.matching import normalize_for_track_comparison, strip_discogs_suffix
 from discogs.models import (
     ArtistCredit,
     ArtistDetails,
@@ -814,12 +814,12 @@ class DiscogsCacheService:
                 if artists_for_track:
                     for track_artist in artists_for_track:
                         track_artist_lower = track_artist.lower().replace('"', "").replace("'", "")
-                        track_artist_lower = track_artist_lower.split("(")[0].strip()
+                        track_artist_lower = strip_discogs_suffix(track_artist_lower)
                         if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
                             return True
                 else:
                     release_artist_clean = primary_artist.lower().replace('"', "").replace("'", "")
-                    release_artist_clean = release_artist_clean.split("(")[0].strip()
+                    release_artist_clean = strip_discogs_suffix(release_artist_clean)
                     if artist_lower in release_artist_clean or release_artist_clean in artist_lower:
                         return True
 

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -12,7 +12,7 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 import asyncio
 import logging
 
-from core.matching import normalize_for_track_comparison, strip_discogs_suffix
+from core.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.models import (
     ArtistCredit,
     ArtistDetails,
@@ -801,7 +801,7 @@ class DiscogsCacheService:
             primary_artist = release_artist_row["artist_name"] if release_artist_row else ""
 
             track_lower = normalize_for_track_comparison(track)
-            artist_lower = artist.lower().replace('"', "").replace("'", "")
+            artist_lower = normalize_artist_for_validation(artist)
 
             for row in track_rows:
                 item_title = normalize_for_track_comparison(row["title"])
@@ -813,13 +813,11 @@ class DiscogsCacheService:
                 artists_for_track = track_artists.get(seq, [])
                 if artists_for_track:
                     for track_artist in artists_for_track:
-                        track_artist_lower = track_artist.lower().replace('"', "").replace("'", "")
-                        track_artist_lower = strip_discogs_suffix(track_artist_lower)
+                        track_artist_lower = normalize_artist_for_validation(track_artist)
                         if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
                             return True
                 else:
-                    release_artist_clean = primary_artist.lower().replace('"', "").replace("'", "")
-                    release_artist_clean = strip_discogs_suffix(release_artist_clean)
+                    release_artist_clean = normalize_artist_for_validation(primary_artist)
                     if artist_lower in release_artist_clean or release_artist_clean in artist_lower:
                         return True
 

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -13,8 +13,8 @@ from config.settings import get_settings
 from core.matching import (
     calculate_confidence,
     is_compilation_artist,
+    normalize_artist_for_validation,
     normalize_for_track_comparison,
-    strip_discogs_suffix,
 )
 from core.telemetry import (
     record_api_time,
@@ -891,10 +891,7 @@ class DiscogsService:
             return False
 
         track_lower = normalize_for_track_comparison(track)
-        # Strip quotes from artist name — Discogs uses quotes for nicknames
-        # (e.g. '"Weird Al" Yankovic') which breaks substring matching against
-        # the user-supplied form ('Weird Al Yankovic').
-        artist_lower = artist.lower().replace('"', "").replace("'", "")
+        artist_lower = normalize_artist_for_validation(artist)
 
         for item in release.tracklist:
             item_title = normalize_for_track_comparison(item.title)
@@ -905,8 +902,7 @@ class DiscogsService:
             # Check per-track artists first (for compilations)
             if item.artists:
                 for track_artist in item.artists:
-                    track_artist_lower = track_artist.lower().replace('"', "").replace("'", "")
-                    track_artist_lower = strip_discogs_suffix(track_artist_lower)
+                    track_artist_lower = normalize_artist_for_validation(track_artist)
                     if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
                         logger.info(
                             f"Validated: '{track}' by '{artist}' found on release {release_id}"
@@ -914,9 +910,7 @@ class DiscogsService:
                         return True
             else:
                 # For single-artist releases, check release artist
-                release_artist = release.artist.lower().replace('"', "").replace("'", "")
-                # Remove Discogs numbering like "(2)"
-                release_artist = strip_discogs_suffix(release_artist)
+                release_artist = normalize_artist_for_validation(release.artist)
 
                 if artist_lower in release_artist or release_artist in artist_lower:
                     logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -14,6 +14,7 @@ from core.matching import (
     calculate_confidence,
     is_compilation_artist,
     normalize_for_track_comparison,
+    strip_discogs_suffix,
 )
 from core.telemetry import (
     record_api_time,
@@ -905,7 +906,7 @@ class DiscogsService:
             if item.artists:
                 for track_artist in item.artists:
                     track_artist_lower = track_artist.lower().replace('"', "").replace("'", "")
-                    track_artist_lower = track_artist_lower.split("(")[0].strip()
+                    track_artist_lower = strip_discogs_suffix(track_artist_lower)
                     if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
                         logger.info(
                             f"Validated: '{track}' by '{artist}' found on release {release_id}"
@@ -915,7 +916,7 @@ class DiscogsService:
                 # For single-artist releases, check release artist
                 release_artist = release.artist.lower().replace('"', "").replace("'", "")
                 # Remove Discogs numbering like "(2)"
-                release_artist = release_artist.split("(")[0].strip()
+                release_artist = strip_discogs_suffix(release_artist)
 
                 if artist_lower in release_artist or release_artist in artist_lower:
                     logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")

--- a/scripts/streaming_availability/matching.py
+++ b/scripts/streaming_availability/matching.py
@@ -4,7 +4,7 @@ import re
 
 from rapidfuzz import fuzz
 
-from core.matching import normalize_for_comparison
+from core.matching import normalize_for_comparison, strip_discogs_suffix  # noqa: F401
 
 # Trailing format indicators: 12", 7", 10", LP, EP, CD, and multi-disc (x 2, x 3, ...)
 _FORMAT_SUFFIX_RE = re.compile(
@@ -29,9 +29,6 @@ _BRACKET_SUFFIX_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Discogs disambiguation suffix: (2), (22), etc.
-_DISCOGS_SUFFIX_RE = re.compile(r"\s+\(\d+\)$")
-
 # Leading "The " prefix
 _THE_PREFIX_RE = re.compile(r"^The\s+", re.IGNORECASE)
 
@@ -44,13 +41,6 @@ def strip_format_suffix(title: str) -> str:
     result = _BRACKET_SUFFIX_RE.sub("", result)
     result = _FORMAT_SUFFIX_RE.sub("", result)
     return result.strip()
-
-
-def strip_discogs_suffix(name: str) -> str:
-    """Remove Discogs disambiguation suffixes like (2), (22) from artist names."""
-    if not name:
-        return name
-    return _DISCOGS_SUFFIX_RE.sub("", name)
 
 
 def strip_the_prefix(name: str) -> str:

--- a/scripts/va_disambiguate/library_lookup.py
+++ b/scripts/va_disambiguate/library_lookup.py
@@ -6,12 +6,9 @@ resolved artist names to find the corresponding LIBRARY_CODE.ID.
 
 from __future__ import annotations
 
-import re
-
 from rapidfuzz import fuzz
 
-# Discogs numeric disambiguation suffix: "Artist Name (2)"
-_DISCOGS_SUFFIX_RE = re.compile(r"\s*\(\d+\)$")
+from core.matching import strip_discogs_suffix
 
 # Minimum fuzzy match score to accept
 _FUZZY_THRESHOLD = 85
@@ -63,7 +60,7 @@ def find_library_code_id(index: dict[str, int], artist: str) -> int | None:
         return index[lower]
 
     # Strip Discogs numeric suffix and try again
-    stripped = _DISCOGS_SUFFIX_RE.sub("", lower).strip()
+    stripped = strip_discogs_suffix(lower).strip()
     if stripped != lower and stripped in index:
         return index[stripped]
 

--- a/scripts/va_disambiguate/matching.py
+++ b/scripts/va_disambiguate/matching.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import re
 
+from core.matching import strip_discogs_suffix
+
 # Canonical VA names (exact match, case-insensitive)
 _VA_EXACT = frozenset(
     {
@@ -36,9 +38,6 @@ _EMBEDDED_PARENS_RE = re.compile(
     r"^(?:various\s+(?:artists?|performers?)|v/?a\.?)\s*\((.+)\)$",
     re.IGNORECASE,
 )
-
-# Discogs numeric disambiguation suffix: "Artist Name (2)"
-_DISCOGS_SUFFIX_RE = re.compile(r"\s*\(\d+\)$")
 
 # Discogs placeholder artist names that shouldn't be used as resolutions
 _PLACEHOLDER_ARTISTS = frozenset(
@@ -161,5 +160,5 @@ def select_primary_artist(artists: list[str]) -> str | None:
 
     primary = artists[0].strip()
     # Strip Discogs numeric disambiguation suffix
-    primary = _DISCOGS_SUFFIX_RE.sub("", primary).strip()
+    primary = strip_discogs_suffix(primary).strip()
     return primary

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from core.matching import strip_discogs_suffix
 from discogs.models import (
     DiscogsSearchResponse,
     ReleaseInfo,
@@ -299,7 +300,7 @@ class TestQuotedArtistNameValidation:
             for item in release.tracklist:
                 if track_lower in item.title.lower() or item.title.lower() in track_lower:
                     release_artist = release.artist.lower().replace('"', "").replace("'", "")
-                    release_artist = release_artist.split("(")[0].strip()
+                    release_artist = strip_discogs_suffix(release_artist)
                     if artist_lower in release_artist or release_artist in artist_lower:
                         return True
             return False

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from core.matching import strip_discogs_suffix
+from core.matching import normalize_artist_for_validation
 from discogs.models import (
     DiscogsSearchResponse,
     ReleaseInfo,
@@ -296,11 +296,10 @@ class TestQuotedArtistNameValidation:
             if release is None:
                 return False
             track_lower = track.lower()
-            artist_lower = artist.lower().replace('"', "").replace("'", "")
+            artist_lower = normalize_artist_for_validation(artist)
             for item in release.tracklist:
                 if track_lower in item.title.lower() or item.title.lower() in track_lower:
-                    release_artist = release.artist.lower().replace('"', "").replace("'", "")
-                    release_artist = strip_discogs_suffix(release_artist)
+                    release_artist = normalize_artist_for_validation(release.artist)
                     if artist_lower in release_artist or release_artist in artist_lower:
                         return True
             return False

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -11,6 +11,7 @@ from core.matching import (
     normalize_for_comparison,
     normalize_for_track_comparison,
     strip_diacritics,
+    strip_discogs_suffix,
 )
 
 # ---------------------------------------------------------------------------
@@ -48,6 +49,33 @@ class TestStripDiacritics:
     )
     def test_strip_diacritics(self, input_text, expected):
         assert strip_diacritics(input_text) == expected
+
+
+# ---------------------------------------------------------------------------
+# strip_discogs_suffix
+# ---------------------------------------------------------------------------
+
+
+class TestStripDiscogsSuffix:
+    """Tests for Discogs numeric disambiguation suffix removal."""
+
+    @pytest.mark.parametrize(
+        "input_text, expected",
+        [
+            pytest.param("DNA (22)", "DNA", id="numeric-suffix-22"),
+            pytest.param("Asia (2)", "Asia", id="numeric-suffix-2"),
+            pytest.param("Bjork", "Bjork", id="no-suffix-unchanged"),
+            pytest.param("", "", id="empty-string"),
+            pytest.param(
+                "Moon Pix (Deluxe Edition)",
+                "Moon Pix (Deluxe Edition)",
+                id="non-numeric-parens-preserved",
+            ),
+            pytest.param("Artist(2)", "Artist", id="no-space-before-parens"),
+        ],
+    )
+    def test_strip_discogs_suffix(self, input_text, expected):
+        assert strip_discogs_suffix(input_text) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -8,6 +8,7 @@ from core.matching import (
     is_compilation_artist,
     is_self_titled,
     map_library_format_to_discogs,
+    normalize_artist_for_validation,
     normalize_for_comparison,
     normalize_for_track_comparison,
     strip_diacritics,
@@ -76,6 +77,28 @@ class TestStripDiscogsSuffix:
     )
     def test_strip_discogs_suffix(self, input_text, expected):
         assert strip_discogs_suffix(input_text) == expected
+
+
+# ---------------------------------------------------------------------------
+# normalize_artist_for_validation
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeArtistForValidation:
+    """Tests for artist name normalization used in track validation."""
+
+    @pytest.mark.parametrize(
+        "input_name, expected",
+        [
+            pytest.param('"Weird Al" Yankovic', "weird al yankovic", id="quoted-nickname"),
+            pytest.param("Koo Nimo (2)", "koo nimo", id="discogs-suffix"),
+            pytest.param('"MF Doom" (3)', "mf doom", id="quotes-and-suffix"),
+            pytest.param("Stereolab", "stereolab", id="plain-name"),
+            pytest.param("", "", id="empty-string"),
+        ],
+    )
+    def test_normalize_artist_for_validation(self, input_name, expected):
+        assert normalize_artist_for_validation(input_name) == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Moves `strip_discogs_suffix()` from 3 separate definitions into `core/matching.py` with a single canonical regex
- Replaces `.split("(")[0].strip()` in `discogs/service.py` and `discogs/cache_service.py` with the more precise regex-based approach
- Adds `normalize_artist_for_validation()` to encapsulate the repeated lowercase + quote-strip + suffix-strip chain (8 inline occurrences replaced)

Closes #90 (part 1 of 3)

## Test plan

- [x] Parametrized tests for `strip_discogs_suffix` (6 cases)
- [x] Parametrized tests for `normalize_artist_for_validation` (5 cases)
- [x] All 905 unit tests pass
- [x] ruff check/format clean, mypy clean