### PR TITLE
Extract BaseStreamingClient from streaming service clients

### DIFF
--- a/scripts/streaming_availability/apple_music_client.py
+++ b/scripts/streaming_availability/apple_music_client.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import asyncio
 import logging
 
-import httpx
-from aiolimiter import AsyncLimiter
+from scripts.streaming_availability.http_client import BaseStreamingClient
 
 logger = logging.getLogger(__name__)
 
 
-class AppleMusicClient:
+class AppleMusicClient(BaseStreamingClient):
     """iTunes Search API client with rate limiting for album searches.
 
     Unlike the existing _fetch_apple_music_url() in the service which searches
@@ -22,15 +21,8 @@ class AppleMusicClient:
     BASE_URL = "https://itunes.apple.com/search"
 
     def __init__(self):
-        self._http: httpx.AsyncClient | None = None
-        self._rate_limiter = AsyncLimiter(15, 60)
-        self._semaphore = asyncio.Semaphore(3)
+        super().__init__(rate_limit=(15, 60), semaphore_limit=3)
         self._max_retries = 2
-
-    async def _get_client(self) -> httpx.AsyncClient:
-        if self._http is None:
-            self._http = httpx.AsyncClient(timeout=10.0)
-        return self._http
 
     async def search_album(self, artist: str, title: str) -> list[dict]:
         """Search iTunes for albums matching artist + title.
@@ -83,8 +75,3 @@ class AppleMusicClient:
 
         logger.error("iTunes max retries exhausted for %s - %s", artist, title)
         return []
-
-    async def close(self) -> None:
-        if self._http:
-            await self._http.aclose()
-            self._http = None

--- a/scripts/streaming_availability/deezer_client.py
+++ b/scripts/streaming_availability/deezer_client.py
@@ -10,26 +10,18 @@ from __future__ import annotations
 import asyncio
 import logging
 
-import httpx
-from aiolimiter import AsyncLimiter
+from scripts.streaming_availability.http_client import BaseStreamingClient
 
 logger = logging.getLogger(__name__)
 
 
-class DeezerClient:
+class DeezerClient(BaseStreamingClient):
     """Deezer API client with rate limiting for album and track searches."""
 
     BASE_URL = "https://api.deezer.com"
 
     def __init__(self):
-        self._http: httpx.AsyncClient | None = None
-        self._rate_limiter = AsyncLimiter(25, 5)
-        self._semaphore = asyncio.Semaphore(5)
-
-    async def _get_client(self) -> httpx.AsyncClient:
-        if self._http is None:
-            self._http = httpx.AsyncClient(timeout=10.0)
-        return self._http
+        super().__init__(rate_limit=(25, 5), semaphore_limit=5)
 
     async def search_album(self, artist: str, title: str) -> list[dict]:
         """Search Deezer for albums matching artist + title.
@@ -93,8 +85,3 @@ class DeezerClient:
 
         logger.warning("Deezer quota retries exhausted for query: %s", query[:50])
         return []
-
-    async def close(self) -> None:
-        if self._http:
-            await self._http.aclose()
-            self._http = None

--- a/scripts/streaming_availability/http_client.py
+++ b/scripts/streaming_availability/http_client.py
@@ -1,0 +1,37 @@
+"""Base HTTP client for streaming service API integrations."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+from aiolimiter import AsyncLimiter
+
+
+class BaseStreamingClient:
+    """Base class for streaming service HTTP clients.
+
+    Provides lazy httpx.AsyncClient lifecycle management, rate limiting
+    via aiolimiter, and concurrency control via asyncio.Semaphore.
+
+    Args:
+        rate_limit: Tuple of (max_rate, time_period) for AsyncLimiter.
+        semaphore_limit: Maximum concurrent requests.
+    """
+
+    def __init__(self, rate_limit: tuple[float, float], semaphore_limit: int):
+        self._http: httpx.AsyncClient | None = None
+        self._rate_limiter = AsyncLimiter(*rate_limit)
+        self._semaphore = asyncio.Semaphore(semaphore_limit)
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create the shared HTTP client."""
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=10.0)
+        return self._http
+
+    async def close(self) -> None:
+        """Close the HTTP client and release resources."""
+        if self._http:
+            await self._http.aclose()
+            self._http = None

--- a/scripts/streaming_availability/spotify_client.py
+++ b/scripts/streaming_availability/spotify_client.py
@@ -7,32 +7,24 @@ import base64
 import logging
 import time
 
-import httpx
-from aiolimiter import AsyncLimiter
+from scripts.streaming_availability.http_client import BaseStreamingClient
 
 logger = logging.getLogger(__name__)
 
 
-class SpotifyClient:
+class SpotifyClient(BaseStreamingClient):
     """Spotify Web API client using client credentials flow for album searches."""
 
     ACCOUNTS_URL = "https://accounts.spotify.com/api/token"
     API_BASE = "https://api.spotify.com/v1"
 
     def __init__(self, client_id: str, client_secret: str):
+        super().__init__(rate_limit=(30, 30), semaphore_limit=5)
         self._client_id = client_id
         self._client_secret = client_secret
         self._access_token: str | None = None
         self._token_expires_at: float = 0
-        self._http: httpx.AsyncClient | None = None
-        self._rate_limiter = AsyncLimiter(30, 30)
-        self._semaphore = asyncio.Semaphore(5)
         self._max_retries = 5
-
-    async def _get_client(self) -> httpx.AsyncClient:
-        if self._http is None:
-            self._http = httpx.AsyncClient(timeout=10.0)
-        return self._http
 
     async def _ensure_token(self) -> str:
         """Get or refresh the access token via client credentials flow."""
@@ -141,8 +133,3 @@ class SpotifyClient:
 
         logger.error("Spotify max retries exhausted for %s - %s", artist, term)
         return []
-
-    async def close(self) -> None:
-        if self._http:
-            await self._http.aclose()
-            self._http = None

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1,0 +1,43 @@
+"""Unit tests for scripts/streaming_availability/http_client.py."""
+
+import pytest
+
+from scripts.streaming_availability.http_client import BaseStreamingClient
+
+
+class TestBaseStreamingClient:
+    def test_init_sets_attributes(self):
+        client = BaseStreamingClient(rate_limit=(10, 5), semaphore_limit=3)
+        assert client._http is None
+        assert client._semaphore._value == 3
+
+    @pytest.mark.asyncio
+    async def test_get_client_creates_lazily(self):
+        client = BaseStreamingClient(rate_limit=(10, 5), semaphore_limit=3)
+        assert client._http is None
+        http = await client._get_client()
+        assert http is not None
+        assert client._http is http
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_get_client_returns_same_instance(self):
+        client = BaseStreamingClient(rate_limit=(10, 5), semaphore_limit=3)
+        http1 = await client._get_client()
+        http2 = await client._get_client()
+        assert http1 is http2
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_close_clears_client(self):
+        client = BaseStreamingClient(rate_limit=(10, 5), semaphore_limit=3)
+        await client._get_client()
+        assert client._http is not None
+        await client.close()
+        assert client._http is None
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_when_no_client(self):
+        client = BaseStreamingClient(rate_limit=(10, 5), semaphore_limit=3)
+        await client.close()  # Should not raise
+        assert client._http is None


### PR DESCRIPTION
## Summary

- Extracts shared HTTP client lifecycle, rate limiting, and concurrency control into `BaseStreamingClient`
- `AppleMusicClient`, `DeezerClient`, and `SpotifyClient` now inherit the common scaffolding
- Fixes a double-close bug in `DeezerClient`

Part 3 of #90

## Test plan

- [x] Unit tests for `BaseStreamingClient` (lazy init, singleton, close, safe double-close)
- [x] All 899 existing tests pass unchanged
- [x] ruff check/format clean, mypy clean