### PR TITLE
Extract find_best_match to replace duplicate match-scoring functions

### DIFF
--- a/scripts/streaming_availability/__main__.py
+++ b/scripts/streaming_availability/__main__.py
@@ -28,8 +28,7 @@ from scripts.streaming_availability.discogs_enricher import (
     enrich_album,
 )
 from scripts.streaming_availability.matching import (
-    is_acceptable_match,
-    score_match,
+    find_best_match,
     strip_discogs_suffix,
     strip_format_suffix,
 )
@@ -419,116 +418,79 @@ async def _process_discogs_enrichment(
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Service-specific field extractors for find_best_match
+# ---------------------------------------------------------------------------
+
+_SPOTIFY_ARTIST = lambda r: r.get("artists", [{}])[0].get("name", "")  # noqa: E731
+_SPOTIFY_TITLE = lambda r: r.get("name", "")  # noqa: E731
+_SPOTIFY_URL = lambda r: r.get("external_urls", {}).get("spotify", "")  # noqa: E731
+_SPOTIFY_ID = lambda r: r.get("id", "")  # noqa: E731
+
+_APPLE_ARTIST = lambda r: r.get("artistName", "")  # noqa: E731
+_APPLE_TITLE = lambda r: r.get("collectionName", "")  # noqa: E731
+_APPLE_URL = lambda r: r.get("collectionViewUrl", "")  # noqa: E731
+
+_DEEZER_ARTIST = lambda r: r.get("artist", {}).get("name", "")  # noqa: E731
+_DEEZER_TITLE = lambda r: r.get("title", "")  # noqa: E731
+_DEEZER_URL = lambda r: r.get("link", "")  # noqa: E731
+
+
 def _find_best_spotify_match(artist: str, title: str, results: list[dict]) -> dict | None:
-    best: dict | None = None
-    best_score = 0.0
-    for album in results:
-        spotify_artist = album.get("artists", [{}])[0].get("name", "")
-        spotify_title = album.get("name", "")
-        artist_score = score_match(artist, spotify_artist)
-        title_score = score_match(title, spotify_title)
-        if not is_acceptable_match(artist_score, title_score):
-            continue
-        combined = (artist_score + title_score) / 2
-        if combined > best_score:
-            best_score = combined
-            best = {
-                "url": album.get("external_urls", {}).get("spotify", ""),
-                "id": album.get("id", ""),
-                "confidence": combined,
-                "matched_artist": spotify_artist,
-                "matched_title": spotify_title,
-            }
-    return best
+    return find_best_match(
+        results,
+        artist,
+        title,
+        artist_fn=_SPOTIFY_ARTIST,
+        title_fn=_SPOTIFY_TITLE,
+        url_fn=_SPOTIFY_URL,
+        id_fn=_SPOTIFY_ID,
+    )
 
 
 def _find_best_track_match(artist: str, title: str, results: list[dict]) -> dict | None:
-    best: dict | None = None
-    best_score = 0.0
-    for track in results:
-        spotify_artist = track.get("artists", [{}])[0].get("name", "")
-        spotify_title = track.get("name", "")
-        artist_score = score_match(artist, spotify_artist)
-        title_score = score_match(title, spotify_title)
-        if not is_acceptable_match(artist_score, title_score):
-            continue
-        combined = (artist_score + title_score) / 2
-        if combined > best_score:
-            best_score = combined
-            best = {
-                "url": track.get("external_urls", {}).get("spotify", ""),
-                "id": track.get("id", ""),
-                "confidence": combined,
-                "matched_artist": spotify_artist,
-                "matched_title": spotify_title,
-            }
-    return best
+    return find_best_match(
+        results,
+        artist,
+        title,
+        artist_fn=_SPOTIFY_ARTIST,
+        title_fn=_SPOTIFY_TITLE,
+        url_fn=_SPOTIFY_URL,
+        id_fn=_SPOTIFY_ID,
+    )
 
 
 def _find_best_apple_match(artist: str, title: str, results: list[dict]) -> dict | None:
-    best: dict | None = None
-    best_score = 0.0
-    for album in results:
-        apple_artist = album.get("artistName", "")
-        apple_title = album.get("collectionName", "")
-        artist_score = score_match(artist, apple_artist)
-        title_score = score_match(title, apple_title)
-        if not is_acceptable_match(artist_score, title_score):
-            continue
-        combined = (artist_score + title_score) / 2
-        if combined > best_score:
-            best_score = combined
-            best = {
-                "url": album.get("collectionViewUrl", ""),
-                "confidence": combined,
-                "matched_artist": apple_artist,
-                "matched_title": apple_title,
-            }
-    return best
+    return find_best_match(
+        results,
+        artist,
+        title,
+        artist_fn=_APPLE_ARTIST,
+        title_fn=_APPLE_TITLE,
+        url_fn=_APPLE_URL,
+    )
 
 
 def _find_best_deezer_match(artist: str, title: str, results: list[dict]) -> dict | None:
-    best: dict | None = None
-    best_score = 0.0
-    for album in results:
-        deezer_artist = album.get("artist", {}).get("name", "")
-        deezer_title = album.get("title", "")
-        artist_score = score_match(artist, deezer_artist)
-        title_score = score_match(title, deezer_title)
-        if not is_acceptable_match(artist_score, title_score):
-            continue
-        combined = (artist_score + title_score) / 2
-        if combined > best_score:
-            best_score = combined
-            best = {
-                "url": album.get("link", ""),
-                "confidence": combined,
-                "matched_artist": deezer_artist,
-                "matched_title": deezer_title,
-            }
-    return best
+    return find_best_match(
+        results,
+        artist,
+        title,
+        artist_fn=_DEEZER_ARTIST,
+        title_fn=_DEEZER_TITLE,
+        url_fn=_DEEZER_URL,
+    )
 
 
 def _find_best_deezer_track_match(artist: str, title: str, results: list[dict]) -> dict | None:
-    best: dict | None = None
-    best_score = 0.0
-    for track in results:
-        deezer_artist = track.get("artist", {}).get("name", "")
-        deezer_title = track.get("title", "")
-        artist_score = score_match(artist, deezer_artist)
-        title_score = score_match(title, deezer_title)
-        if not is_acceptable_match(artist_score, title_score):
-            continue
-        combined = (artist_score + title_score) / 2
-        if combined > best_score:
-            best_score = combined
-            best = {
-                "url": track.get("link", ""),
-                "confidence": combined,
-                "matched_artist": deezer_artist,
-                "matched_title": deezer_title,
-            }
-    return best
+    return find_best_match(
+        results,
+        artist,
+        title,
+        artist_fn=_DEEZER_ARTIST,
+        title_fn=_DEEZER_TITLE,
+        url_fn=_DEEZER_URL,
+    )
 
 
 async def _skip_compilations(results_db: ResultsDB) -> int:

--- a/scripts/streaming_availability/matching.py
+++ b/scripts/streaming_availability/matching.py
@@ -1,6 +1,9 @@
 """Title normalization, format stripping, and match scoring for streaming availability."""
 
+from __future__ import annotations
+
 import re
+from collections.abc import Callable
 
 from rapidfuzz import fuzz
 
@@ -86,3 +89,56 @@ def score_match(query: str, result: str) -> float:
 def is_acceptable_match(artist_score: float, title_score: float) -> bool:
     """Returns True if both artist and title scores meet the acceptance threshold (>= 80)."""
     return artist_score >= 80.0 and title_score >= 80.0
+
+
+def find_best_match(
+    results: list[dict],
+    query_artist: str,
+    query_title: str,
+    *,
+    artist_fn: Callable[[dict], str],
+    title_fn: Callable[[dict], str],
+    url_fn: Callable[[dict], str],
+    id_fn: Callable[[dict], str] | None = None,
+) -> dict | None:
+    """Find the best-scoring match from a list of service results.
+
+    Iterates results, extracts artist/title using the provided callables,
+    scores each with score_match/is_acceptable_match, and returns the
+    highest-scoring result as a dict with url, confidence, matched_artist,
+    matched_title, and optionally id.
+
+    Args:
+        results: Raw result dicts from a streaming service API.
+        query_artist: Artist name to match against.
+        query_title: Title to match against.
+        artist_fn: Extracts artist name from a result dict.
+        title_fn: Extracts title from a result dict.
+        url_fn: Extracts URL from a result dict.
+        id_fn: Extracts ID from a result dict (optional).
+
+    Returns:
+        Best match dict, or None if no acceptable match found.
+    """
+    best: dict | None = None
+    best_score = 0.0
+    for item in results:
+        result_artist = artist_fn(item)
+        result_title = title_fn(item)
+        artist_score = score_match(query_artist, result_artist)
+        title_score = score_match(query_title, result_title)
+        if not is_acceptable_match(artist_score, title_score):
+            continue
+        combined = (artist_score + title_score) / 2
+        if combined > best_score:
+            best_score = combined
+            match: dict = {
+                "url": url_fn(item),
+                "confidence": combined,
+                "matched_artist": result_artist,
+                "matched_title": result_title,
+            }
+            if id_fn is not None:
+                match["id"] = id_fn(item)
+            best = match
+    return best

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -142,6 +142,119 @@ class TestStripDiscogsSuffix:
         assert strip_discogs_suffix(name) == expected
 
 
+class TestFindBestMatch:
+    """Tests for the generic find_best_match function."""
+
+    def test_finds_best_by_combined_score(self):
+        from scripts.streaming_availability.matching import find_best_match
+
+        results = [
+            {"artist": "Stereolab", "album": "Dots and Loops", "url": "http://a"},
+            {"artist": "Stereolab", "album": "Aluminum Tunes", "url": "http://b"},
+        ]
+        best = find_best_match(
+            results,
+            "Stereolab",
+            "Aluminum Tunes",
+            artist_fn=lambda r: r["artist"],
+            title_fn=lambda r: r["album"],
+            url_fn=lambda r: r["url"],
+        )
+        assert best is not None
+        assert best["url"] == "http://b"
+        assert best["matched_title"] == "Aluminum Tunes"
+
+    def test_returns_none_when_no_acceptable_match(self):
+        from scripts.streaming_availability.matching import find_best_match
+
+        results = [
+            {"artist": "Cat Power", "album": "Moon Pix", "url": "http://x"},
+        ]
+        best = find_best_match(
+            results,
+            "Autechre",
+            "Confield",
+            artist_fn=lambda r: r["artist"],
+            title_fn=lambda r: r["album"],
+            url_fn=lambda r: r["url"],
+        )
+        assert best is None
+
+    def test_returns_none_for_empty_results(self):
+        from scripts.streaming_availability.matching import find_best_match
+
+        best = find_best_match(
+            [],
+            "Stereolab",
+            "Aluminum Tunes",
+            artist_fn=lambda r: r["artist"],
+            title_fn=lambda r: r["album"],
+            url_fn=lambda r: r["url"],
+        )
+        assert best is None
+
+    def test_includes_id_when_id_fn_provided(self):
+        from scripts.streaming_availability.matching import find_best_match
+
+        results = [
+            {"artist": "Stereolab", "album": "Aluminum Tunes", "url": "http://b", "id": "abc123"},
+        ]
+        best = find_best_match(
+            results,
+            "Stereolab",
+            "Aluminum Tunes",
+            artist_fn=lambda r: r["artist"],
+            title_fn=lambda r: r["album"],
+            url_fn=lambda r: r["url"],
+            id_fn=lambda r: r["id"],
+        )
+        assert best is not None
+        assert best["id"] == "abc123"
+
+    def test_no_id_key_when_id_fn_omitted(self):
+        from scripts.streaming_availability.matching import find_best_match
+
+        results = [
+            {"artist": "Stereolab", "album": "Aluminum Tunes", "url": "http://b"},
+        ]
+        best = find_best_match(
+            results,
+            "Stereolab",
+            "Aluminum Tunes",
+            artist_fn=lambda r: r["artist"],
+            title_fn=lambda r: r["album"],
+            url_fn=lambda r: r["url"],
+        )
+        assert best is not None
+        assert "id" not in best
+
+    def test_spotify_field_extraction(self):
+        """Verifies find_best_match works with Spotify's nested response format."""
+        from scripts.streaming_availability.matching import find_best_match
+
+        results = [
+            {
+                "name": "Aluminum Tunes",
+                "artists": [{"name": "Stereolab"}],
+                "external_urls": {"spotify": "https://open.spotify.com/album/xyz"},
+                "id": "xyz",
+            },
+        ]
+        best = find_best_match(
+            results,
+            "Stereolab",
+            "Aluminum Tunes",
+            artist_fn=lambda r: r.get("artists", [{}])[0].get("name", ""),
+            title_fn=lambda r: r.get("name", ""),
+            url_fn=lambda r: r.get("external_urls", {}).get("spotify", ""),
+            id_fn=lambda r: r.get("id", ""),
+        )
+        assert best is not None
+        assert best["url"] == "https://open.spotify.com/album/xyz"
+        assert best["id"] == "xyz"
+        assert best["confidence"] > 0
+
+
 class TestStripThePrefix:
     @pytest.mark.parametrize(
         "name, expected",


### PR DESCRIPTION
## Summary

- Adds `find_best_match()` to `scripts/streaming_availability/matching.py` — a generic scorer that takes field extractor callables for service-specific response formats
- Replaces five near-identical `_find_best_*_match` functions with thin wrappers using per-service extractors (Spotify, Apple Music, Deezer album/track)
- Eliminates ~80 lines of duplicated scoring logic

## Test plan

- [x] 6 new tests for `find_best_match` (best selection, rejection, empty results, optional id, Spotify format)
- [x] All 922 unit tests pass
- [x] ruff check/format clean, mypy clean