### PR TITLE
Entity store schema + reconciliation CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,9 @@ ignore_errors = true
 markers = [
     "integration: marks tests as integration tests",
     "slow: marks tests as slow",
+    "postgres: marks tests requiring PostgreSQL (docker-compose on port 5433)",
 ]
-addopts = "-m 'not integration'"
+addopts = "-m 'not integration and not postgres'"
 console_output_style = "progress"
 testpaths = ["tests"]
 pythonpath = ["."]

--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -118,7 +118,7 @@ async def run_wikidata_stage(
 
     qid_bridged = 0
     if need_qid:
-        discogs_ids = {i.discogs_artist_id for i in need_qid}
+        discogs_ids: set[int] = {i.discogs_artist_id for i in need_qid if i.discogs_artist_id}
         id_to_identity = {i.discogs_artist_id: i for i in need_qid}
         qid_map = await reconciler.resolve_qids_from_discogs_ids(discogs_ids)
 
@@ -141,17 +141,17 @@ async def run_wikidata_stage(
     no_match = await store.get_identities_by_status("no_match")
     name_searched = 0
     for identity in no_match:
-        qid = await reconciler.search_musician_by_name(identity.library_name)
-        if qid:
+        found_qid = await reconciler.search_musician_by_name(identity.library_name)
+        if found_qid:
             await store.upsert_identity(
                 library_name=identity.library_name,
-                wikidata_qid=qid,
+                wikidata_qid=found_qid,
             )
             await store.update_status(identity.id, "reconciled")
             await store.log_reconciliation(
                 identity_id=identity.id,
                 source="wikidata",
-                external_id=qid,
+                external_id=found_qid,
                 method="name_search",
             )
             name_searched += 1
@@ -165,7 +165,7 @@ async def run_wikidata_stage(
     ]
     streaming_fetched = 0
     if need_streaming:
-        qids = [i.wikidata_qid for i in need_streaming]
+        qids: list[str] = [i.wikidata_qid for i in need_streaming if i.wikidata_qid]
         qid_to_identity = {i.wikidata_qid: i for i in need_streaming}
         streaming_map = await reconciler.fetch_streaming_ids(qids)
 
@@ -202,9 +202,9 @@ async def run_musicbrainz_stage(
     # Stage 1: QID -> MBID bridge
     with_qid = [i for i in need_mb if i.wikidata_qid]
     if with_qid:
-        qids = {i.wikidata_qid for i in with_qid}
+        mb_qids: set[str] = {i.wikidata_qid for i in with_qid if i.wikidata_qid}
         qid_to_identity = {i.wikidata_qid: i for i in with_qid}
-        qid_results = await reconciler.resolve_from_qids(qids)
+        qid_results = await reconciler.resolve_from_qids(mb_qids)
 
         for qid, mbid in qid_results.items():
             identity = qid_to_identity.get(qid)

--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -29,17 +29,18 @@ import sys
 import aiosqlite
 from dotenv import load_dotenv
 
-from wxyc_catalog.sources import PgSource, SparqlSource
-
 from scripts.entity_resolution.dedup import EntityDeduplicator
 from scripts.entity_resolution.discogs import DiscogsReconciler
 from scripts.entity_resolution.musicbrainz import MusicBrainzReconciler
+from scripts.entity_resolution.sources import PgSource, SparqlSource
 from scripts.entity_resolution.store import EntityStore
 from scripts.entity_resolution.wikidata import WikidataReconciler
 
 logger = logging.getLogger(__name__)
 
-_LIBRARY_ARTISTS_SQL = "SELECT DISTINCT artist FROM library WHERE artist IS NOT NULL ORDER BY artist"
+_LIBRARY_ARTISTS_SQL = (
+    "SELECT DISTINCT artist FROM library WHERE artist IS NOT NULL ORDER BY artist"
+)
 
 
 async def get_library_artists(db_path: str) -> list[str]:
@@ -158,7 +159,8 @@ async def run_wikidata_stage(
     # Stage 3: Streaming IDs for all identities with QIDs
     all_identities = await store.get_identities_by_status("reconciled")
     need_streaming = [
-        i for i in all_identities
+        i
+        for i in all_identities
         if i.wikidata_qid and not (i.spotify_artist_id or i.apple_music_artist_id or i.bandcamp_id)
     ]
     streaming_fetched = 0
@@ -180,7 +182,9 @@ async def run_wikidata_stage(
 
     logger.info(
         "Wikidata: %d QID bridged, %d name searched, %d streaming fetched",
-        qid_bridged, name_searched, streaming_fetched,
+        qid_bridged,
+        name_searched,
+        streaming_fetched,
     )
     return qid_bridged, name_searched, streaming_fetched
 
@@ -321,7 +325,10 @@ async def main(args: argparse.Namespace) -> None:
         rate = len(reconciled) / total * 100 if total > 0 else 0
         logger.info(
             "Done. %d/%d reconciled (%.1f%%), %d no_match",
-            len(reconciled), total, rate, len(no_match),
+            len(reconciled),
+            total,
+            rate,
+            len(no_match),
         )
 
     finally:
@@ -357,7 +364,8 @@ def parse_args() -> argparse.Namespace:
         help="Skip MusicBrainz reconciliation stage",
     )
     parser.add_argument(
-        "-v", "--verbose",
+        "-v",
+        "--verbose",
         action="store_true",
         help="Enable verbose logging",
     )

--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -1,0 +1,373 @@
+"""CLI entry point for entity resolution.
+
+Usage:
+    python -m scripts.entity_resolution [--library-db PATH] [--batch-size N] [--skip-wikidata] [--skip-musicbrainz]
+
+Environment variables:
+    DATABASE_URL_DISCOGS    -- Required. PostgreSQL URL for discogs-cache (entity store lives here).
+    DATABASE_URL_WIKIDATA   -- Optional. PostgreSQL URL for wikidata-cache.
+    DATABASE_URL_MUSICBRAINZ -- Optional. PostgreSQL URL for musicbrainz-cache.
+    LIBRARY_DB_PATH         -- Path to library.db SQLite file (default: library.db).
+
+The reconciliation pipeline:
+1. Seeds entity.identity with all distinct artist names from library.db
+2. Discogs batch matching (exact -> member/group -> alias -> name variation)
+3. Wikidata QID bridging (cache -> SPARQL fallback) + name search for no_match
+4. Streaming ID fetch (Spotify, Apple Music, Bandcamp) via Wikidata
+5. MusicBrainz matching (QID bridge -> direct name match)
+6. Deduplication by shared Wikidata QID
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+import aiosqlite
+from dotenv import load_dotenv
+
+from wxyc_catalog.sources import PgSource, SparqlSource
+
+from scripts.entity_resolution.dedup import EntityDeduplicator
+from scripts.entity_resolution.discogs import DiscogsReconciler
+from scripts.entity_resolution.musicbrainz import MusicBrainzReconciler
+from scripts.entity_resolution.store import EntityStore
+from scripts.entity_resolution.wikidata import WikidataReconciler
+
+logger = logging.getLogger(__name__)
+
+_LIBRARY_ARTISTS_SQL = "SELECT DISTINCT artist FROM library WHERE artist IS NOT NULL ORDER BY artist"
+
+
+async def get_library_artists(db_path: str) -> list[str]:
+    """Get all distinct artist names from the library SQLite database."""
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(_LIBRARY_ARTISTS_SQL)
+        rows = await cursor.fetchall()
+        return [row[0] for row in rows if row[0]]
+
+
+async def seed_identities(store: EntityStore, artists: list[str]) -> int:
+    """Seed entity.identity with library artist names. Returns count of new rows."""
+    seeded = 0
+    for artist in artists:
+        result = await store.upsert_identity(library_name=artist)
+        if result is not None:
+            seeded += 1
+    return seeded
+
+
+async def run_discogs_stage(
+    store: EntityStore,
+    reconciler: DiscogsReconciler,
+    batch_size: int,
+) -> tuple[int, int]:
+    """Run Discogs reconciliation for unreconciled identities. Returns (matched, no_match)."""
+    identities = await store.get_identities_by_status("unreconciled")
+    if not identities:
+        logger.info("No unreconciled identities for Discogs stage")
+        return 0, 0
+
+    names = [i.library_name for i in identities]
+    name_to_id = {i.library_name: i.id for i in identities}
+
+    matched_count = 0
+    no_match_count = 0
+
+    for i in range(0, len(names), batch_size):
+        batch = names[i : i + batch_size]
+        matches = await reconciler.reconcile_batch(batch)
+
+        for name in batch:
+            identity_id = name_to_id[name]
+            if name in matches:
+                match = matches[name]
+                await store.upsert_identity(
+                    library_name=name,
+                    discogs_artist_id=match.discogs_artist_id,
+                )
+                await store.update_status(identity_id, "reconciled")
+                await store.log_reconciliation(
+                    identity_id=identity_id,
+                    source="discogs",
+                    external_id=str(match.discogs_artist_id),
+                    method=match.method,
+                    confidence=1.0,
+                )
+                matched_count += 1
+            else:
+                await store.update_status(identity_id, "no_match")
+                no_match_count += 1
+
+    logger.info("Discogs: %d matched, %d no_match", matched_count, no_match_count)
+    return matched_count, no_match_count
+
+
+async def run_wikidata_stage(
+    store: EntityStore,
+    reconciler: WikidataReconciler,
+) -> tuple[int, int, int]:
+    """Run Wikidata reconciliation. Returns (qid_bridged, name_searched, streaming_fetched)."""
+    # Stage 1: QID bridging for reconciled identities with discogs_artist_id
+    reconciled = await store.get_identities_by_status("reconciled")
+    need_qid = [i for i in reconciled if i.discogs_artist_id and not i.wikidata_qid]
+
+    qid_bridged = 0
+    if need_qid:
+        discogs_ids = {i.discogs_artist_id for i in need_qid}
+        id_to_identity = {i.discogs_artist_id: i for i in need_qid}
+        qid_map = await reconciler.resolve_qids_from_discogs_ids(discogs_ids)
+
+        for discogs_id, qid in qid_map.items():
+            identity = id_to_identity.get(discogs_id)
+            if identity:
+                await store.upsert_identity(
+                    library_name=identity.library_name,
+                    wikidata_qid=qid,
+                )
+                await store.log_reconciliation(
+                    identity_id=identity.id,
+                    source="wikidata",
+                    external_id=qid,
+                    method="discogs_bridge",
+                )
+                qid_bridged += 1
+
+    # Stage 2: Name search for no_match identities
+    no_match = await store.get_identities_by_status("no_match")
+    name_searched = 0
+    for identity in no_match:
+        qid = await reconciler.search_musician_by_name(identity.library_name)
+        if qid:
+            await store.upsert_identity(
+                library_name=identity.library_name,
+                wikidata_qid=qid,
+            )
+            await store.update_status(identity.id, "reconciled")
+            await store.log_reconciliation(
+                identity_id=identity.id,
+                source="wikidata",
+                external_id=qid,
+                method="name_search",
+            )
+            name_searched += 1
+
+    # Stage 3: Streaming IDs for all identities with QIDs
+    all_identities = await store.get_identities_by_status("reconciled")
+    need_streaming = [
+        i for i in all_identities
+        if i.wikidata_qid and not (i.spotify_artist_id or i.apple_music_artist_id or i.bandcamp_id)
+    ]
+    streaming_fetched = 0
+    if need_streaming:
+        qids = [i.wikidata_qid for i in need_streaming]
+        qid_to_identity = {i.wikidata_qid: i for i in need_streaming}
+        streaming_map = await reconciler.fetch_streaming_ids(qids)
+
+        for qid, ids in streaming_map.items():
+            identity = qid_to_identity.get(qid)
+            if identity:
+                await store.upsert_identity(
+                    library_name=identity.library_name,
+                    spotify_artist_id=ids.spotify_artist_id,
+                    apple_music_artist_id=ids.apple_music_artist_id,
+                    bandcamp_id=ids.bandcamp_id,
+                )
+                streaming_fetched += 1
+
+    logger.info(
+        "Wikidata: %d QID bridged, %d name searched, %d streaming fetched",
+        qid_bridged, name_searched, streaming_fetched,
+    )
+    return qid_bridged, name_searched, streaming_fetched
+
+
+async def run_musicbrainz_stage(
+    store: EntityStore,
+    reconciler: MusicBrainzReconciler,
+) -> int:
+    """Run MusicBrainz reconciliation. Returns count of MB IDs resolved."""
+    reconciled = await store.get_identities_by_status("reconciled")
+    need_mb = [i for i in reconciled if not i.musicbrainz_artist_id]
+
+    mb_resolved = 0
+
+    # Stage 1: QID -> MBID bridge
+    with_qid = [i for i in need_mb if i.wikidata_qid]
+    if with_qid:
+        qids = {i.wikidata_qid for i in with_qid}
+        qid_to_identity = {i.wikidata_qid: i for i in with_qid}
+        qid_results = await reconciler.resolve_from_qids(qids)
+
+        for qid, mbid in qid_results.items():
+            identity = qid_to_identity.get(qid)
+            if identity:
+                await store.upsert_identity(
+                    library_name=identity.library_name,
+                    musicbrainz_artist_id=mbid,
+                )
+                await store.log_reconciliation(
+                    identity_id=identity.id,
+                    source="musicbrainz",
+                    external_id=mbid,
+                    method="qid_bridge",
+                )
+                mb_resolved += 1
+
+    # Stage 2: Direct name match for remaining
+    if with_qid and qid_results:
+        resolved_names = {qid_to_identity[q].library_name for q in qid_results}
+        still_need = [i for i in need_mb if i.library_name not in resolved_names]
+    else:
+        still_need = list(need_mb)
+    if still_need:
+        names = [i.library_name for i in still_need]
+        name_to_identity = {i.library_name: i for i in still_need}
+        name_results = await reconciler.resolve_from_names(names)
+
+        for name, mbid in name_results.items():
+            identity = name_to_identity.get(name)
+            if identity:
+                await store.upsert_identity(
+                    library_name=identity.library_name,
+                    musicbrainz_artist_id=mbid,
+                )
+                await store.log_reconciliation(
+                    identity_id=identity.id,
+                    source="musicbrainz",
+                    external_id=mbid,
+                    method="name_match",
+                )
+                mb_resolved += 1
+
+    logger.info("MusicBrainz: %d resolved", mb_resolved)
+    return mb_resolved
+
+
+async def run_dedup_stage(store_pg: PgSource) -> int:
+    """Run deduplication. Returns count of merged groups."""
+    dedup = EntityDeduplicator(store_pg)
+    groups = await dedup.find_duplicate_groups()
+    for qid, identities in groups:
+        await dedup.merge_group(qid, identities)
+    logger.info("Dedup: %d groups merged", len(groups))
+    return len(groups)
+
+
+async def main(args: argparse.Namespace) -> None:
+    """Run the full entity resolution pipeline."""
+    load_dotenv()
+
+    database_url = os.getenv("DATABASE_URL_DISCOGS")
+    if not database_url:
+        logger.error("DATABASE_URL_DISCOGS is required")
+        sys.exit(1)
+
+    library_db_path = args.library_db or os.getenv("LIBRARY_DB_PATH", "library.db")
+    database_url_wikidata = os.getenv("DATABASE_URL_WIKIDATA")
+    database_url_musicbrainz = os.getenv("DATABASE_URL_MUSICBRAINZ")
+
+    # Create sources
+    discogs_pg = PgSource(database_url)
+    wikidata_pg = PgSource(database_url_wikidata) if database_url_wikidata else None
+    musicbrainz_pg = PgSource(database_url_musicbrainz) if database_url_musicbrainz else None
+    sparql = SparqlSource()
+
+    store = EntityStore(discogs_pg)
+    discogs_reconciler = DiscogsReconciler(discogs_pg, batch_size=args.batch_size)
+    wikidata_reconciler = WikidataReconciler(sparql=sparql, wikidata_pg=wikidata_pg)
+    musicbrainz_reconciler = MusicBrainzReconciler(mb_pg=musicbrainz_pg, wikidata_pg=wikidata_pg)
+
+    try:
+        # Step 1: Seed from library
+        logger.info("Loading artists from %s", library_db_path)
+        artists = await get_library_artists(library_db_path)
+        logger.info("Found %d distinct artists in library", len(artists))
+
+        seeded = await seed_identities(store, artists)
+        logger.info("Seeded %d identities", seeded)
+
+        # Step 2: Discogs reconciliation
+        logger.info("Running Discogs reconciliation...")
+        discogs_matched, discogs_no_match = await run_discogs_stage(
+            store, discogs_reconciler, args.batch_size
+        )
+
+        # Step 3: Wikidata reconciliation
+        if not args.skip_wikidata:
+            logger.info("Running Wikidata reconciliation...")
+            await run_wikidata_stage(store, wikidata_reconciler)
+        else:
+            logger.info("Skipping Wikidata reconciliation")
+
+        # Step 4: MusicBrainz reconciliation
+        if not args.skip_musicbrainz and musicbrainz_pg is not None:
+            logger.info("Running MusicBrainz reconciliation...")
+            await run_musicbrainz_stage(store, musicbrainz_reconciler)
+        else:
+            logger.info("Skipping MusicBrainz reconciliation")
+
+        # Step 5: Deduplication
+        logger.info("Running deduplication...")
+        await run_dedup_stage(discogs_pg)
+
+        # Summary
+        total = len(artists)
+        reconciled = await store.get_identities_by_status("reconciled")
+        no_match = await store.get_identities_by_status("no_match")
+        rate = len(reconciled) / total * 100 if total > 0 else 0
+        logger.info(
+            "Done. %d/%d reconciled (%.1f%%), %d no_match",
+            len(reconciled), total, rate, len(no_match),
+        )
+
+    finally:
+        await discogs_pg.close()
+        if wikidata_pg:
+            await wikidata_pg.close()
+        if musicbrainz_pg:
+            await musicbrainz_pg.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Entity resolution: reconcile WXYC library artists to external IDs"
+    )
+    parser.add_argument(
+        "--library-db",
+        help="Path to library.db SQLite file (default: LIBRARY_DB_PATH env or library.db)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1000,
+        help="Batch size for Discogs reconciliation (default: 1000)",
+    )
+    parser.add_argument(
+        "--skip-wikidata",
+        action="store_true",
+        help="Skip Wikidata reconciliation stage",
+    )
+    parser.add_argument(
+        "--skip-musicbrainz",
+        action="store_true",
+        help="Skip MusicBrainz reconciliation stage",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    asyncio.run(main(args))

--- a/scripts/entity_resolution/dedup.py
+++ b/scripts/entity_resolution/dedup.py
@@ -1,0 +1,135 @@
+"""Entity deduplication by shared Wikidata QID.
+
+When multiple ``entity.identity`` rows resolve to the same Wikidata QID,
+this module merges them into a single identity, preserving all external IDs.
+
+Ported from semantic-index ``entity_store.py`` ``deduplicate_by_qid``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from wxyc_catalog.sources import PgSource
+
+from scripts.entity_resolution.store import Identity, _record_to_identity
+
+logger = logging.getLogger(__name__)
+
+_FIND_DUPLICATES_SQL = """\
+SELECT id, library_name, discogs_artist_id, wikidata_qid,
+       musicbrainz_artist_id, spotify_artist_id,
+       apple_music_artist_id, bandcamp_id, reconciliation_status
+FROM entity.identity
+WHERE wikidata_qid IN (
+    SELECT wikidata_qid FROM entity.identity
+    WHERE wikidata_qid IS NOT NULL
+    GROUP BY wikidata_qid
+    HAVING count(*) > 1
+)
+ORDER BY wikidata_qid, id\
+"""
+
+_UPDATE_MERGED_SQL = """\
+UPDATE entity.identity
+SET discogs_artist_id = COALESCE($2, discogs_artist_id),
+    musicbrainz_artist_id = COALESCE($3, musicbrainz_artist_id),
+    spotify_artist_id = COALESCE($4, spotify_artist_id),
+    apple_music_artist_id = COALESCE($5, apple_music_artist_id),
+    bandcamp_id = COALESCE($6, bandcamp_id),
+    updated_at = now()
+WHERE id = $1\
+"""
+
+_DELETE_DUPLICATE_SQL = """\
+DELETE FROM entity.identity WHERE id = $1\
+"""
+
+_REASSIGN_LOGS_SQL = """\
+UPDATE entity.reconciliation_log SET identity_id = $1 WHERE identity_id = $2\
+"""
+
+
+class EntityDeduplicator:
+    """Deduplicates entity.identity rows that share the same Wikidata QID.
+
+    Args:
+        pg: PgSource connected to the discogs-cache database.
+    """
+
+    def __init__(self, pg: PgSource) -> None:
+        self._pg = pg
+
+    async def find_duplicate_groups(self) -> list[tuple[str, list[Identity]]]:
+        """Find groups of identities that share the same Wikidata QID.
+
+        Returns:
+            List of (qid, [identities]) tuples for QIDs with multiple rows.
+        """
+        rows = await self._pg.fetchall(_FIND_DUPLICATES_SQL)
+        if not rows:
+            return []
+
+        groups: dict[str, list[Identity]] = {}
+        for row in rows:
+            identity = _record_to_identity(row)
+            qid = identity.wikidata_qid
+            if qid:
+                groups.setdefault(qid, []).append(identity)
+
+        return [(qid, ids) for qid, ids in groups.items() if len(ids) > 1]
+
+    async def merge_group(self, qid: str, identities: list[Identity]) -> None:
+        """Merge a group of identities sharing the same QID.
+
+        Keeps the first identity (lowest ID) as the primary record and
+        merges all external IDs from the others into it, then deletes the
+        duplicates. Reconciliation log entries are reassigned to the primary.
+
+        Args:
+            qid: The shared Wikidata QID.
+            identities: List of Identity instances to merge (must have len >= 2).
+        """
+        if len(identities) < 2:
+            return
+
+        primary = identities[0]
+        duplicates = identities[1:]
+
+        # Collect all external IDs across the group
+        merged_discogs = primary.discogs_artist_id
+        merged_mb = primary.musicbrainz_artist_id
+        merged_spotify = primary.spotify_artist_id
+        merged_apple = primary.apple_music_artist_id
+        merged_bandcamp = primary.bandcamp_id
+
+        for dup in duplicates:
+            merged_discogs = merged_discogs or dup.discogs_artist_id
+            merged_mb = merged_mb or dup.musicbrainz_artist_id
+            merged_spotify = merged_spotify or dup.spotify_artist_id
+            merged_apple = merged_apple or dup.apple_music_artist_id
+            merged_bandcamp = merged_bandcamp or dup.bandcamp_id
+
+        # Update the primary identity with all merged IDs
+        await self._pg.execute(
+            _UPDATE_MERGED_SQL,
+            primary.id,
+            merged_discogs,
+            merged_mb,
+            merged_spotify,
+            merged_apple,
+            merged_bandcamp,
+        )
+
+        # Reassign logs and delete duplicates
+        for dup in duplicates:
+            await self._pg.execute(_REASSIGN_LOGS_SQL, primary.id, dup.id)
+            await self._pg.execute(_DELETE_DUPLICATE_SQL, dup.id)
+
+        logger.info(
+            "Merged %d identities for QID %s into identity %d (%s)",
+            len(duplicates),
+            qid,
+            primary.id,
+            primary.library_name,
+        )

--- a/scripts/entity_resolution/dedup.py
+++ b/scripts/entity_resolution/dedup.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 
 import logging
 
-from wxyc_catalog.sources import PgSource
-
+from scripts.entity_resolution.sources import PgSource
 from scripts.entity_resolution.store import Identity, _record_to_identity
 
 logger = logging.getLogger(__name__)

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -1,0 +1,195 @@
+"""Discogs batch matching for artist identity resolution.
+
+Resolves WXYC library artist names to Discogs artist IDs via a cascade:
+1. Exact name match against ``release_artist``
+2. Member/group lookup via ``artist_member``
+3. Alias/name variation fallback via ``artist_alias`` and ``artist_name_variation``
+
+Ported from semantic-index ``reconciliation.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from wxyc_catalog.sources import PgSource
+
+logger = logging.getLogger(__name__)
+
+_EXACT_MATCH_SQL = """\
+SELECT DISTINCT lower(ra.artist_name) AS artist_name, ra.artist_id
+FROM release_artist ra
+WHERE ra.extra = 0
+  AND ra.artist_id IS NOT NULL
+  AND lower(ra.artist_name) = ANY($1)\
+"""
+
+_MEMBER_MATCH_SQL = """\
+SELECT DISTINCT lower(am.member_name) AS member_name, am.member_id
+FROM artist_member am
+WHERE lower(am.member_name) = ANY($1)\
+"""
+
+_ALIAS_MATCH_SQL = """\
+SELECT DISTINCT lower(aa.alias_name) AS alias_name, aa.artist_id
+FROM artist_alias aa
+WHERE lower(aa.alias_name) = ANY($1)\
+"""
+
+_NAME_VARIATION_MATCH_SQL = """\
+SELECT DISTINCT lower(nv.name) AS name, nv.artist_id
+FROM artist_name_variation nv
+WHERE lower(nv.name) = ANY($1)\
+"""
+
+
+@dataclass
+class ReconciliationMatch:
+    """Result of a successful Discogs reconciliation."""
+
+    discogs_artist_id: int
+    method: str  # exact_match, member_group, alias_match, name_variation
+
+
+class DiscogsReconciler:
+    """Batch reconciler for WXYC library artist names against Discogs data.
+
+    Uses a cascade of matching strategies: exact name match, member/group
+    lookup, then alias/name-variation fallback.
+
+    Args:
+        pg: PgSource connected to the discogs-cache database.
+        batch_size: Maximum names per SQL query (default 1000).
+    """
+
+    def __init__(self, pg: PgSource, batch_size: int = 1000) -> None:
+        self._pg = pg
+        self._batch_size = batch_size
+
+    async def reconcile_batch(
+        self,
+        names: list[str],
+        *,
+        skip_names: set[str] | None = None,
+    ) -> dict[str, ReconciliationMatch]:
+        """Reconcile a list of artist names against Discogs data.
+
+        Runs through the cascade: exact match -> member/group -> alias -> name variation.
+        Only unmatched names cascade to the next strategy.
+
+        Args:
+            names: Canonical artist names from the WXYC library.
+            skip_names: Names to exclude from reconciliation (already reconciled).
+
+        Returns:
+            Dict mapping canonical name to ReconciliationMatch for successful matches.
+        """
+        if not names:
+            return {}
+
+        effective_names = [n for n in names if n not in (skip_names or set())]
+        if not effective_names:
+            return {}
+
+        results: dict[str, ReconciliationMatch] = {}
+
+        # Build lowercase -> canonical mapping
+        lower_to_canonical = {n.lower(): n for n in effective_names}
+
+        # Stage 1: Exact match
+        unmatched = set(lower_to_canonical.keys())
+        for batch_lower in self._batches(list(unmatched)):
+            matched = await self._exact_match(batch_lower)
+            for lower_name, artist_id in matched.items():
+                canonical = lower_to_canonical.get(lower_name)
+                if canonical is None:
+                    continue
+                results[canonical] = ReconciliationMatch(artist_id, "exact_match")
+                unmatched.discard(lower_name)
+
+        # Stage 2: Member/group match
+        if unmatched:
+            for batch_lower in self._batches(list(unmatched)):
+                matched = await self._member_match(batch_lower)
+                for lower_name, artist_id in matched.items():
+                    canonical = lower_to_canonical.get(lower_name)
+                    if canonical is None:
+                        continue
+                    results[canonical] = ReconciliationMatch(artist_id, "member_group")
+                    unmatched.discard(lower_name)
+
+        # Stage 3: Alias match
+        if unmatched:
+            for batch_lower in self._batches(list(unmatched)):
+                matched = await self._alias_match(batch_lower)
+                for lower_name, artist_id in matched.items():
+                    canonical = lower_to_canonical.get(lower_name)
+                    if canonical is None:
+                        continue
+                    results[canonical] = ReconciliationMatch(artist_id, "alias_match")
+                    unmatched.discard(lower_name)
+
+        # Stage 4: Name variation fallback
+        if unmatched:
+            for batch_lower in self._batches(list(unmatched)):
+                matched = await self._name_variation_match(batch_lower)
+                for lower_name, artist_id in matched.items():
+                    canonical = lower_to_canonical.get(lower_name)
+                    if canonical is None:
+                        continue
+                    results[canonical] = ReconciliationMatch(artist_id, "name_variation")
+                    unmatched.discard(lower_name)
+
+        return results
+
+    async def _exact_match(self, lower_names: list[str]) -> dict[str, int]:
+        """Stage 1: Exact name match against release_artist."""
+        rows = await self._pg.fetchall(_EXACT_MATCH_SQL, lower_names)
+        if not rows:
+            return {}
+        return {
+            row["artist_name"]: row["artist_id"]
+            for row in rows
+            if row["artist_id"] is not None
+        }
+
+    async def _member_match(self, lower_names: list[str]) -> dict[str, int]:
+        """Stage 2: Member/group lookup via artist_member."""
+        rows = await self._pg.fetchall(_MEMBER_MATCH_SQL, lower_names)
+        if not rows:
+            return {}
+        return {
+            row["member_name"]: row["member_id"]
+            for row in rows
+            if row["member_id"] is not None
+        }
+
+    async def _alias_match(self, lower_names: list[str]) -> dict[str, int]:
+        """Stage 3: Alias lookup via artist_alias."""
+        rows = await self._pg.fetchall(_ALIAS_MATCH_SQL, lower_names)
+        if not rows:
+            return {}
+        return {
+            row["alias_name"]: row["artist_id"]
+            for row in rows
+            if row["artist_id"] is not None
+        }
+
+    async def _name_variation_match(self, lower_names: list[str]) -> dict[str, int]:
+        """Stage 4: Name variation lookup via artist_name_variation."""
+        rows = await self._pg.fetchall(_NAME_VARIATION_MATCH_SQL, lower_names)
+        if not rows:
+            return {}
+        return {
+            row["name"]: row["artist_id"]
+            for row in rows
+            if row["artist_id"] is not None
+        }
+
+    def _batches(self, items: list[str]) -> list[list[str]]:
+        """Split items into batches of self._batch_size."""
+        return [
+            items[i : i + self._batch_size]
+            for i in range(0, len(items), self._batch_size)
+        ]

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from wxyc_catalog.sources import PgSource
+from scripts.entity_resolution.sources import PgSource
 
 logger = logging.getLogger(__name__)
 
@@ -149,9 +149,7 @@ class DiscogsReconciler:
         if not rows:
             return {}
         return {
-            row["artist_name"]: row["artist_id"]
-            for row in rows
-            if row["artist_id"] is not None
+            row["artist_name"]: row["artist_id"] for row in rows if row["artist_id"] is not None
         }
 
     async def _member_match(self, lower_names: list[str]) -> dict[str, int]:
@@ -160,9 +158,7 @@ class DiscogsReconciler:
         if not rows:
             return {}
         return {
-            row["member_name"]: row["member_id"]
-            for row in rows
-            if row["member_id"] is not None
+            row["member_name"]: row["member_id"] for row in rows if row["member_id"] is not None
         }
 
     async def _alias_match(self, lower_names: list[str]) -> dict[str, int]:
@@ -170,26 +166,15 @@ class DiscogsReconciler:
         rows = await self._pg.fetchall(_ALIAS_MATCH_SQL, lower_names)
         if not rows:
             return {}
-        return {
-            row["alias_name"]: row["artist_id"]
-            for row in rows
-            if row["artist_id"] is not None
-        }
+        return {row["alias_name"]: row["artist_id"] for row in rows if row["artist_id"] is not None}
 
     async def _name_variation_match(self, lower_names: list[str]) -> dict[str, int]:
         """Stage 4: Name variation lookup via artist_name_variation."""
         rows = await self._pg.fetchall(_NAME_VARIATION_MATCH_SQL, lower_names)
         if not rows:
             return {}
-        return {
-            row["name"]: row["artist_id"]
-            for row in rows
-            if row["artist_id"] is not None
-        }
+        return {row["name"]: row["artist_id"] for row in rows if row["artist_id"] is not None}
 
     def _batches(self, items: list[str]) -> list[list[str]]:
         """Split items into batches of self._batch_size."""
-        return [
-            items[i : i + self._batch_size]
-            for i in range(0, len(items), self._batch_size)
-        ]
+        return [items[i : i + self._batch_size] for i in range(0, len(items), self._batch_size)]

--- a/scripts/entity_resolution/musicbrainz.py
+++ b/scripts/entity_resolution/musicbrainz.py
@@ -1,0 +1,123 @@
+"""MusicBrainz identity resolution for artist reconciliation.
+
+Resolves:
+- Wikidata QID -> MusicBrainz artist ID (via P434 bridge in wikidata-cache)
+- Artist name -> MusicBrainz artist ID (direct name match in musicbrainz-cache)
+
+Ported from semantic-index ``musicbrainz_client.py`` and ``run_pipeline.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from wxyc_catalog.sources import PgSource
+
+logger = logging.getLogger(__name__)
+
+_P434_BRIDGE_SQL = """\
+SELECT qid, musicbrainz_artist_id
+FROM p434_mapping
+WHERE qid = ANY($1)\
+"""
+
+_MB_CONFIRM_SQL = """\
+SELECT gid, name
+FROM mb_artist
+WHERE gid = ANY($1)\
+"""
+
+_NAME_MATCH_SQL = """\
+SELECT DISTINCT lower(a.name) AS name, a.gid
+FROM mb_artist a
+WHERE lower(a.name) = ANY($1)
+UNION
+SELECT DISTINCT lower(aa.name) AS name, a.gid
+FROM mb_artist_alias aa
+JOIN mb_artist a ON aa.artist_id = a.id
+WHERE lower(aa.name) = ANY($1)\
+"""
+
+
+class MusicBrainzReconciler:
+    """MusicBrainz identity resolver.
+
+    Supports QID -> MB ID bridging via wikidata-cache P434 mapping,
+    and direct name matching against the musicbrainz-cache.
+
+    Args:
+        mb_pg: PgSource for musicbrainz-cache. If None, all resolution is skipped.
+        wikidata_pg: PgSource for wikidata-cache (P434 bridge). If None, QID bridging
+            is skipped.
+    """
+
+    def __init__(
+        self,
+        mb_pg: PgSource | None,
+        wikidata_pg: PgSource | None = None,
+    ) -> None:
+        self._mb_pg = mb_pg
+        self._wikidata_pg = wikidata_pg
+
+    async def resolve_from_qids(self, qids: set[str]) -> dict[str, str]:
+        """Resolve Wikidata QIDs to MusicBrainz artist IDs via P434.
+
+        Uses wikidata-cache for the QID -> MBID mapping, then confirms the
+        MBID exists in musicbrainz-cache.
+
+        Args:
+            qids: Set of Wikidata QIDs to resolve.
+
+        Returns:
+            Dict mapping QID to MusicBrainz artist GUID.
+        """
+        if not qids or self._mb_pg is None or self._wikidata_pg is None:
+            return {}
+
+        # Step 1: QID -> MBID via P434
+        rows = await self._wikidata_pg.fetchall(_P434_BRIDGE_SQL, list(qids))
+        if not rows:
+            return {}
+
+        qid_to_mbid = {row["qid"]: row["musicbrainz_artist_id"] for row in rows}
+
+        # Step 2: Confirm MBIDs exist in MB cache
+        mbids = list(qid_to_mbid.values())
+        confirm_rows = await self._mb_pg.fetchall(_MB_CONFIRM_SQL, mbids)
+        if not confirm_rows:
+            return {}
+
+        confirmed = {row["gid"] for row in confirm_rows}
+        return {
+            qid: mbid for qid, mbid in qid_to_mbid.items() if mbid in confirmed
+        }
+
+    async def resolve_from_names(self, names: list[str]) -> dict[str, str]:
+        """Resolve artist names to MusicBrainz artist IDs via direct matching.
+
+        Matches against ``mb_artist.name`` and ``mb_artist_alias.name``
+        (case-insensitive).
+
+        Args:
+            names: Canonical artist names to look up.
+
+        Returns:
+            Dict mapping canonical name to MusicBrainz artist GUID.
+        """
+        if not names or self._mb_pg is None:
+            return {}
+
+        lower_to_canonical = {n.lower(): n for n in names}
+        lower_names = list(lower_to_canonical.keys())
+
+        rows = await self._mb_pg.fetchall(_NAME_MATCH_SQL, lower_names)
+        if not rows:
+            return {}
+
+        result: dict[str, str] = {}
+        for row in rows:
+            canonical = lower_to_canonical.get(row["name"])
+            if canonical and canonical not in result:
+                result[canonical] = row["gid"]
+
+        return result

--- a/scripts/entity_resolution/musicbrainz.py
+++ b/scripts/entity_resolution/musicbrainz.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 
-from wxyc_catalog.sources import PgSource
+from scripts.entity_resolution.sources import PgSource
 
 logger = logging.getLogger(__name__)
 
@@ -88,9 +88,7 @@ class MusicBrainzReconciler:
             return {}
 
         confirmed = {row["gid"] for row in confirm_rows}
-        return {
-            qid: mbid for qid, mbid in qid_to_mbid.items() if mbid in confirmed
-        }
+        return {qid: mbid for qid, mbid in qid_to_mbid.items() if mbid in confirmed}
 
     async def resolve_from_names(self, names: list[str]) -> dict[str, str]:
         """Resolve artist names to MusicBrainz artist IDs via direct matching.

--- a/scripts/entity_resolution/sources.py
+++ b/scripts/entity_resolution/sources.py
@@ -1,0 +1,183 @@
+"""Source transport protocols for entity resolution.
+
+These are thin protocol definitions mirroring the interface from
+``wxyc_catalog.sources.PgSource`` and ``wxyc_catalog.sources.SparqlSource``.
+When wxyc_catalog is published, these can be replaced with direct imports.
+
+The implementations here are concrete classes wrapping asyncpg and httpx
+for PostgreSQL and Wikidata SPARQL access respectively.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from typing import Any, Protocol, runtime_checkable
+
+import asyncpg
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_QID_PATTERN = re.compile(r"^Q\d+$")
+_RATE_INTERVAL = 1.0  # seconds between Wikidata requests
+
+
+@runtime_checkable
+class PgSourceProtocol(Protocol):
+    """Protocol for PostgreSQL source transport."""
+
+    async def fetchall(self, query: str, *args: Any) -> list[dict[str, Any]]: ...
+    async def fetchone(self, query: str, *args: Any) -> dict[str, Any] | None: ...
+    async def execute(self, query: str, *args: Any) -> str: ...
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
+class SparqlSourceProtocol(Protocol):
+    """Protocol for Wikidata SPARQL source transport."""
+
+    async def query(self, sparql: str) -> list[dict[str, Any]]: ...
+    async def query_batched(
+        self, sparql_template: str, items: list[str]
+    ) -> list[dict[str, Any]]: ...
+    def binding_value(self, binding: dict, key: str) -> str | None: ...
+    def extract_qid(self, uri: str) -> str: ...
+
+
+class PgSource:
+    """PostgreSQL source transport wrapping asyncpg.
+
+    Args:
+        dsn: PostgreSQL connection string.
+    """
+
+    def __init__(self, dsn: str) -> None:
+        self._dsn = dsn
+        self._pool: asyncpg.Pool | None = None
+
+    async def _get_pool(self) -> asyncpg.Pool:
+        if self._pool is None:
+            self._pool = await asyncpg.create_pool(self._dsn, min_size=1, max_size=5)
+        return self._pool
+
+    async def fetchall(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        """Execute a query and return all rows as dicts."""
+        pool = await self._get_pool()
+        records = await pool.fetch(query, *args)
+        return [dict(r) for r in records]
+
+    async def fetchone(self, query: str, *args: Any) -> dict[str, Any] | None:
+        """Execute a query and return the first row as a dict, or None."""
+        pool = await self._get_pool()
+        record = await pool.fetchrow(query, *args)
+        if record is None:
+            return None
+        return dict(record)
+
+    async def execute(self, query: str, *args: Any) -> str:
+        """Execute a query and return the status string."""
+        pool = await self._get_pool()
+        return await pool.execute(query, *args)
+
+    async def close(self) -> None:
+        """Close the connection pool."""
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+
+
+class SparqlSource:
+    """Wikidata SPARQL source transport.
+
+    Wraps httpx for the Wikidata Query Service SPARQL endpoint.
+    Respects rate limits (~1 req/s) and retries on 429/403.
+
+    Args:
+        endpoint: SPARQL endpoint URL.
+        user_agent: User-Agent header (required by Wikidata).
+        batch_size: Max items per VALUES clause in batched queries.
+    """
+
+    _DEFAULT_ENDPOINT = "https://query.wikidata.org/sparql"
+    _DEFAULT_USER_AGENT = "WXYCEntityResolution/0.1 (https://wxyc.org; engineering@wxyc.org)"
+
+    def __init__(
+        self,
+        endpoint: str | None = None,
+        user_agent: str | None = None,
+        batch_size: int = 50,
+    ) -> None:
+        self._endpoint = endpoint or self._DEFAULT_ENDPOINT
+        self._user_agent = user_agent or self._DEFAULT_USER_AGENT
+        self._batch_size = batch_size
+        self._last_request: float = 0
+
+    def _rate_limit(self) -> None:
+        elapsed = time.time() - self._last_request
+        if elapsed < _RATE_INTERVAL:
+            time.sleep(_RATE_INTERVAL - elapsed)
+        self._last_request = time.time()
+
+    async def query(self, sparql: str) -> list[dict[str, Any]]:
+        """Execute a SPARQL query and return result bindings."""
+        max_retries = 3
+        for attempt in range(max_retries):
+            self._rate_limit()
+            async with httpx.AsyncClient(
+                timeout=60,
+                headers={
+                    "User-Agent": self._user_agent,
+                    "Accept": "application/sparql-results+json",
+                },
+            ) as client:
+                resp = await client.get(self._endpoint, params={"query": sparql})
+                if resp.status_code in (403, 429):
+                    backoff = 2 ** (attempt + 1)
+                    logger.warning(
+                        "Wikidata rate limited (HTTP %d), backing off %ds",
+                        resp.status_code,
+                        backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                    continue
+                resp.raise_for_status()
+                return resp.json()["results"]["bindings"]
+        logger.warning("SPARQL query failed after %d retries", max_retries)
+        return []
+
+    async def query_batched(self, sparql_template: str, items: list[str]) -> list[dict[str, Any]]:
+        """Execute a SPARQL query in batches over a VALUES list.
+
+        The template should contain a ``{values}`` placeholder that will be
+        replaced with space-separated items for each batch.
+
+        Args:
+            sparql_template: SPARQL template with ``{values}`` placeholder.
+            items: Items to batch into the VALUES clause.
+
+        Returns:
+            Combined bindings from all batches.
+        """
+        all_bindings: list[dict[str, Any]] = []
+        for i in range(0, len(items), self._batch_size):
+            batch = items[i : i + self._batch_size]
+            values_str = " ".join(batch)
+            sparql = sparql_template.format(values=values_str)
+            bindings = await self.query(sparql)
+            all_bindings.extend(bindings)
+        return all_bindings
+
+    @staticmethod
+    def binding_value(binding: dict, key: str) -> str | None:
+        """Extract a string value from a SPARQL result binding."""
+        if key in binding and isinstance(binding[key], dict):
+            return binding[key].get("value")
+        return None
+
+    @staticmethod
+    def extract_qid(uri: str) -> str:
+        """Extract QID from a Wikidata entity URI."""
+        return uri.rsplit("/", 1)[-1]

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-from wxyc_catalog.sources import PgSource
+from scripts.entity_resolution.sources import PgSource
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -1,0 +1,199 @@
+"""Entity store CRUD operations for identity resolution.
+
+Wraps asyncpg queries against ``entity.identity`` and
+``entity.reconciliation_log`` tables in the discogs-cache PostgreSQL database.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from wxyc_catalog.sources import PgSource
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Identity:
+    """A row from ``entity.identity``."""
+
+    id: int
+    library_name: str
+    discogs_artist_id: int | None = None
+    wikidata_qid: str | None = None
+    musicbrainz_artist_id: str | None = None
+    spotify_artist_id: str | None = None
+    apple_music_artist_id: str | None = None
+    bandcamp_id: str | None = None
+    reconciliation_status: str = "unreconciled"
+
+
+def _record_to_identity(record: dict[str, Any] | Any) -> Identity:
+    """Convert an asyncpg Record (or dict-like) to an Identity dataclass."""
+    return Identity(
+        id=record["id"],
+        library_name=record["library_name"],
+        discogs_artist_id=record["discogs_artist_id"],
+        wikidata_qid=record["wikidata_qid"],
+        musicbrainz_artist_id=record["musicbrainz_artist_id"],
+        spotify_artist_id=record["spotify_artist_id"],
+        apple_music_artist_id=record["apple_music_artist_id"],
+        bandcamp_id=record["bandcamp_id"],
+        reconciliation_status=record["reconciliation_status"],
+    )
+
+
+_UPSERT_IDENTITY_SQL = """\
+INSERT INTO entity.identity (
+    library_name, discogs_artist_id, wikidata_qid,
+    musicbrainz_artist_id, spotify_artist_id,
+    apple_music_artist_id, bandcamp_id
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (library_name) DO UPDATE SET
+    discogs_artist_id = COALESCE(EXCLUDED.discogs_artist_id, entity.identity.discogs_artist_id),
+    wikidata_qid = COALESCE(EXCLUDED.wikidata_qid, entity.identity.wikidata_qid),
+    musicbrainz_artist_id = COALESCE(EXCLUDED.musicbrainz_artist_id, entity.identity.musicbrainz_artist_id),
+    spotify_artist_id = COALESCE(EXCLUDED.spotify_artist_id, entity.identity.spotify_artist_id),
+    apple_music_artist_id = COALESCE(EXCLUDED.apple_music_artist_id, entity.identity.apple_music_artist_id),
+    bandcamp_id = COALESCE(EXCLUDED.bandcamp_id, entity.identity.bandcamp_id),
+    updated_at = now()
+RETURNING id, library_name, discogs_artist_id, wikidata_qid,
+          musicbrainz_artist_id, spotify_artist_id,
+          apple_music_artist_id, bandcamp_id, reconciliation_status\
+"""
+
+_GET_IDENTITY_SQL = """\
+SELECT id, library_name, discogs_artist_id, wikidata_qid,
+       musicbrainz_artist_id, spotify_artist_id,
+       apple_music_artist_id, bandcamp_id, reconciliation_status
+FROM entity.identity
+WHERE library_name = $1\
+"""
+
+_GET_BY_STATUS_SQL = """\
+SELECT id, library_name, discogs_artist_id, wikidata_qid,
+       musicbrainz_artist_id, spotify_artist_id,
+       apple_music_artist_id, bandcamp_id, reconciliation_status
+FROM entity.identity
+WHERE reconciliation_status = $1
+ORDER BY id\
+"""
+
+_UPDATE_STATUS_SQL = """\
+UPDATE entity.identity
+SET reconciliation_status = $2, updated_at = now()
+WHERE id = $1\
+"""
+
+_LOG_RECONCILIATION_SQL = """\
+INSERT INTO entity.reconciliation_log (identity_id, source, external_id, confidence, method)
+VALUES ($1, $2, $3, $4, $5)\
+"""
+
+
+class EntityStore:
+    """CRUD interface for the entity identity store.
+
+    Args:
+        pg: PgSource connected to the discogs-cache database (must have
+            the ``entity`` schema applied).
+    """
+
+    def __init__(self, pg: PgSource) -> None:
+        self._pg = pg
+
+    async def upsert_identity(
+        self,
+        library_name: str,
+        *,
+        discogs_artist_id: int | None = None,
+        wikidata_qid: str | None = None,
+        musicbrainz_artist_id: str | None = None,
+        spotify_artist_id: str | None = None,
+        apple_music_artist_id: str | None = None,
+        bandcamp_id: str | None = None,
+    ) -> Identity | None:
+        """Insert or update an identity row.
+
+        Uses ``ON CONFLICT ... DO UPDATE`` with ``COALESCE`` so that populated
+        fields are never overwritten with NULL.
+
+        Returns:
+            The upserted Identity, or None if the query failed.
+        """
+        record = await self._pg.fetchone(
+            _UPSERT_IDENTITY_SQL,
+            library_name,
+            discogs_artist_id,
+            wikidata_qid,
+            musicbrainz_artist_id,
+            spotify_artist_id,
+            apple_music_artist_id,
+            bandcamp_id,
+        )
+        if record is None:
+            return None
+        return _record_to_identity(record)
+
+    async def get_identity(self, library_name: str) -> Identity | None:
+        """Look up an identity by library name.
+
+        Returns:
+            The matching Identity, or None if not found.
+        """
+        record = await self._pg.fetchone(_GET_IDENTITY_SQL, library_name)
+        if record is None:
+            return None
+        return _record_to_identity(record)
+
+    async def get_identities_by_status(self, status: str) -> list[Identity]:
+        """Return all identities with the given reconciliation status.
+
+        Args:
+            status: One of ``'unreconciled'``, ``'reconciled'``, ``'no_match'``.
+
+        Returns:
+            List of matching identities (empty list if none or on failure).
+        """
+        records = await self._pg.fetchall(_GET_BY_STATUS_SQL, status)
+        if records is None:
+            return []
+        return [_record_to_identity(r) for r in records]
+
+    async def update_status(self, identity_id: int, status: str) -> None:
+        """Change the reconciliation status of an identity.
+
+        Args:
+            identity_id: The ``entity.identity.id`` to update.
+            status: New reconciliation status value.
+        """
+        await self._pg.execute(_UPDATE_STATUS_SQL, identity_id, status)
+
+    async def log_reconciliation(
+        self,
+        identity_id: int,
+        source: str,
+        external_id: str,
+        method: str,
+        confidence: float | None = None,
+    ) -> None:
+        """Record a reconciliation attempt in the log table.
+
+        Args:
+            identity_id: The ``entity.identity.id`` this log entry refers to.
+            source: Source system (e.g., ``'discogs'``, ``'wikidata'``, ``'musicbrainz'``).
+            external_id: The external identifier that was matched.
+            method: Resolution method used (e.g., ``'exact_match'``, ``'member_group'``).
+            confidence: Optional confidence score (0.0 to 1.0).
+        """
+        await self._pg.execute(
+            _LOG_RECONCILIATION_SQL,
+            identity_id,
+            source,
+            external_id,
+            confidence,
+            method,
+        )

--- a/scripts/entity_resolution/wikidata.py
+++ b/scripts/entity_resolution/wikidata.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from wxyc_catalog.sources import PgSource, SparqlSource
+from scripts.entity_resolution.sources import PgSource, SparqlSource
 
 logger = logging.getLogger(__name__)
 
@@ -81,9 +81,7 @@ class WikidataReconciler:
         self._sparql = sparql
         self._wikidata_pg = wikidata_pg
 
-    async def resolve_qids_from_discogs_ids(
-        self, discogs_ids: set[int]
-    ) -> dict[int, str]:
+    async def resolve_qids_from_discogs_ids(self, discogs_ids: set[int]) -> dict[int, str]:
         """Resolve Discogs artist IDs to Wikidata QIDs.
 
         Tries wikidata-cache first (if available), then falls back to SPARQL P1953.
@@ -102,9 +100,7 @@ class WikidataReconciler:
 
         # Stage 1: Try wikidata-cache PG
         if self._wikidata_pg is not None:
-            rows = await self._wikidata_pg.fetchall(
-                _CACHE_DISCOGS_TO_QID_SQL, list(remaining)
-            )
+            rows = await self._wikidata_pg.fetchall(_CACHE_DISCOGS_TO_QID_SQL, list(remaining))
             if rows:
                 for row in rows:
                     result[row["discogs_artist_id"]] = row["qid"]
@@ -121,9 +117,7 @@ class WikidataReconciler:
         """Resolve Discogs IDs to QIDs via SPARQL P1953 property."""
         values_str = " ".join(f'"{did}"' for did in discogs_ids)
         sparql = _SPARQL_DISCOGS_TO_QID.format(values=values_str)
-        bindings = await self._sparql.query_batched(
-            sparql, [f"Q{did}" for did in discogs_ids]
-        )
+        bindings = await self._sparql.query_batched(sparql, [f"Q{did}" for did in discogs_ids])
 
         result: dict[int, str] = {}
         for binding in bindings:
@@ -179,9 +173,7 @@ class WikidataReconciler:
         if not qids:
             return {}
 
-        bindings = await self._sparql.query_batched(
-            _SPARQL_STREAMING_IDS, qids
-        )
+        bindings = await self._sparql.query_batched(_SPARQL_STREAMING_IDS, qids)
 
         result: dict[str, StreamingIds] = {}
         for binding in bindings:

--- a/scripts/entity_resolution/wikidata.py
+++ b/scripts/entity_resolution/wikidata.py
@@ -1,0 +1,204 @@
+"""Wikidata identity resolution for artist reconciliation.
+
+Resolves:
+- Discogs artist ID -> Wikidata QID (via wikidata-cache P1953 mapping or SPARQL)
+- Artist name -> QID (via SPARQL name search for musicians/musical groups)
+- QID -> streaming platform IDs (Spotify P1902, Apple Music P2850, Bandcamp P3283)
+
+Ported from semantic-index ``wikidata_client.py`` and ``reconciliation.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from wxyc_catalog.sources import PgSource, SparqlSource
+
+logger = logging.getLogger(__name__)
+
+_CACHE_DISCOGS_TO_QID_SQL = """\
+SELECT discogs_artist_id, qid
+FROM discogs_mapping
+WHERE discogs_artist_id = ANY($1)\
+"""
+
+_SPARQL_DISCOGS_TO_QID = """\
+SELECT ?item ?discogsId WHERE {{
+  VALUES ?discogsId {{ {values} }}
+  ?item wdt:P1953 ?discogsId .
+}}\
+"""
+
+_SPARQL_NAME_SEARCH = """\
+SELECT ?item ?itemLabel WHERE {{
+  ?item rdfs:label "{name}"@en .
+  {{ ?item wdt:P106/wdt:P279* wd:Q639669 . }}
+  UNION
+  {{ ?item wdt:P31 wd:Q215380 . }}
+  UNION
+  {{ ?item wdt:P31 wd:Q5 . ?item wdt:P106 ?occ . ?occ wdt:P279* wd:Q639669 . }}
+  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en" . }}
+}} LIMIT 5\
+"""
+
+_SPARQL_STREAMING_IDS = """\
+SELECT ?item ?spotifyId ?appleMusicId ?bandcampId WHERE {{
+  VALUES ?item {{ {values} }}
+  OPTIONAL {{ ?item wdt:P1902 ?spotifyId . }}
+  OPTIONAL {{ ?item wdt:P2850 ?appleMusicId . }}
+  OPTIONAL {{ ?item wdt:P3283 ?bandcampId . }}
+}}\
+"""
+
+
+@dataclass
+class StreamingIds:
+    """Streaming platform identifiers from Wikidata."""
+
+    spotify_artist_id: str | None = None
+    apple_music_artist_id: str | None = None
+    bandcamp_id: str | None = None
+
+
+class WikidataReconciler:
+    """Wikidata identity resolver for artist reconciliation.
+
+    Supports Discogs ID -> QID bridging (via PG cache or SPARQL fallback),
+    name search for unmatched artists, and streaming ID extraction.
+
+    Args:
+        sparql: SparqlSource for Wikidata SPARQL endpoint queries.
+        wikidata_pg: Optional PgSource for wikidata-cache (faster lookups).
+            If None, all lookups go through SPARQL.
+    """
+
+    def __init__(
+        self,
+        sparql: SparqlSource,
+        wikidata_pg: PgSource | None = None,
+    ) -> None:
+        self._sparql = sparql
+        self._wikidata_pg = wikidata_pg
+
+    async def resolve_qids_from_discogs_ids(
+        self, discogs_ids: set[int]
+    ) -> dict[int, str]:
+        """Resolve Discogs artist IDs to Wikidata QIDs.
+
+        Tries wikidata-cache first (if available), then falls back to SPARQL P1953.
+
+        Args:
+            discogs_ids: Set of Discogs artist IDs to resolve.
+
+        Returns:
+            Dict mapping Discogs artist ID to Wikidata QID for successful matches.
+        """
+        if not discogs_ids:
+            return {}
+
+        result: dict[int, str] = {}
+        remaining = set(discogs_ids)
+
+        # Stage 1: Try wikidata-cache PG
+        if self._wikidata_pg is not None:
+            rows = await self._wikidata_pg.fetchall(
+                _CACHE_DISCOGS_TO_QID_SQL, list(remaining)
+            )
+            if rows:
+                for row in rows:
+                    result[row["discogs_artist_id"]] = row["qid"]
+                    remaining.discard(row["discogs_artist_id"])
+
+        # Stage 2: SPARQL fallback for remaining
+        if remaining:
+            sparql_result = await self._resolve_qids_via_sparql(remaining)
+            result.update(sparql_result)
+
+        return result
+
+    async def _resolve_qids_via_sparql(self, discogs_ids: set[int]) -> dict[int, str]:
+        """Resolve Discogs IDs to QIDs via SPARQL P1953 property."""
+        values_str = " ".join(f'"{did}"' for did in discogs_ids)
+        sparql = _SPARQL_DISCOGS_TO_QID.format(values=values_str)
+        bindings = await self._sparql.query_batched(
+            sparql, [f"Q{did}" for did in discogs_ids]
+        )
+
+        result: dict[int, str] = {}
+        for binding in bindings:
+            item_uri = self._sparql.binding_value(binding, "item")
+            discogs_id_str = self._sparql.binding_value(binding, "discogsId")
+            if item_uri and discogs_id_str:
+                qid = self._sparql.extract_qid(item_uri)
+                try:
+                    result[int(discogs_id_str)] = qid
+                except (ValueError, TypeError):
+                    continue
+
+        return result
+
+    async def search_musician_by_name(self, name: str) -> str | None:
+        """Search Wikidata for a musician or musical group by name.
+
+        Uses SPARQL to find entities with matching labels that are
+        musicians (P106 -> Q639669) or musical groups (P31 -> Q215380).
+
+        Args:
+            name: Artist name to search for.
+
+        Returns:
+            Wikidata QID of the best match, or None if not found.
+        """
+        escaped_name = name.replace('"', '\\"')
+        sparql = _SPARQL_NAME_SEARCH.format(name=escaped_name)
+        bindings = await self._sparql.query(sparql)
+
+        if not bindings:
+            return None
+
+        item_uri = self._sparql.binding_value(bindings[0], "item")
+        if not item_uri:
+            return None
+
+        return self._sparql.extract_qid(item_uri)
+
+    async def fetch_streaming_ids(self, qids: list[str]) -> dict[str, StreamingIds]:
+        """Fetch streaming platform IDs for Wikidata entities.
+
+        Queries P1902 (Spotify), P2850 (Apple Music), P3283 (Bandcamp)
+        using OPTIONAL clauses for partial results.
+
+        Args:
+            qids: List of Wikidata QIDs to fetch streaming IDs for.
+
+        Returns:
+            Dict mapping QID to StreamingIds for entities that have at least
+            one streaming platform ID.
+        """
+        if not qids:
+            return {}
+
+        bindings = await self._sparql.query_batched(
+            _SPARQL_STREAMING_IDS, qids
+        )
+
+        result: dict[str, StreamingIds] = {}
+        for binding in bindings:
+            item_uri = self._sparql.binding_value(binding, "item")
+            if not item_uri:
+                continue
+
+            qid = self._sparql.extract_qid(item_uri)
+            spotify = self._sparql.binding_value(binding, "spotifyId")
+            apple = self._sparql.binding_value(binding, "appleMusicId")
+            bandcamp = self._sparql.binding_value(binding, "bandcampId")
+
+            if spotify or apple or bandcamp:
+                result[qid] = StreamingIds(
+                    spotify_artist_id=spotify,
+                    apple_music_artist_id=apple,
+                    bandcamp_id=bandcamp,
+                )
+
+        return result

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -1,0 +1,217 @@
+"""Integration tests for the entity resolution pipeline.
+
+These tests run against a test PostgreSQL (Docker on port 5433) with the
+entity schema applied and Discogs fixture data loaded.
+
+Run with: pytest -m postgres -v
+Requires: DATABASE_URL_TEST env var or Docker postgres on port 5433.
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from scripts.entity_resolution.dedup import EntityDeduplicator
+from scripts.entity_resolution.discogs import DiscogsReconciler
+from scripts.entity_resolution.sources import PgSource
+from scripts.entity_resolution.store import EntityStore
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def pg_pool():
+    """Create a connection pool to the test database."""
+    try:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+    yield pool
+    await pool.close()
+
+
+@pytest_asyncio.fixture
+async def pg_source(pg_pool):
+    """PgSource wrapping the test pool."""
+    source = PgSource.__new__(PgSource)
+    source._dsn = DATABASE_URL
+    source._pool = pg_pool
+    return source
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_entity_schema(pg_pool):
+    """Create (or re-create) the entity schema for each test."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        await conn.execute("CREATE SCHEMA entity")
+        await conn.execute("""
+            CREATE TABLE entity.identity (
+                id SERIAL PRIMARY KEY,
+                library_name TEXT NOT NULL UNIQUE,
+                discogs_artist_id INTEGER,
+                wikidata_qid TEXT,
+                musicbrainz_artist_id TEXT,
+                spotify_artist_id TEXT,
+                apple_music_artist_id TEXT,
+                bandcamp_id TEXT,
+                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """)
+        await conn.execute(
+            "CREATE INDEX idx_entity_identity_status ON entity.identity(reconciliation_status)"
+        )
+        await conn.execute("""
+            CREATE TABLE entity.reconciliation_log (
+                id SERIAL PRIMARY KEY,
+                identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
+                source TEXT NOT NULL,
+                external_id TEXT NOT NULL,
+                confidence REAL,
+                method TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """)
+    yield
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+
+
+@pytest.mark.postgres
+class TestEntityStoreCRUD:
+    """Test entity store CRUD operations against real PostgreSQL."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_and_get(self, pg_source):
+        store = EntityStore(pg_source)
+        identity = await store.upsert_identity(library_name="Autechre")
+        assert identity is not None
+        assert identity.library_name == "Autechre"
+        assert identity.reconciliation_status == "unreconciled"
+
+        fetched = await store.get_identity("Autechre")
+        assert fetched is not None
+        assert fetched.id == identity.id
+
+    @pytest.mark.asyncio
+    async def test_upsert_coalesce_semantics(self, pg_source):
+        store = EntityStore(pg_source)
+        await store.upsert_identity(library_name="Stereolab", discogs_artist_id=99)
+        await store.upsert_identity(library_name="Stereolab", wikidata_qid="Q483507")
+        identity = await store.get_identity("Stereolab")
+        assert identity is not None
+        assert identity.discogs_artist_id == 99
+        assert identity.wikidata_qid == "Q483507"
+
+    @pytest.mark.asyncio
+    async def test_status_update_and_filter(self, pg_source):
+        store = EntityStore(pg_source)
+        id1 = await store.upsert_identity(library_name="Autechre")
+        id2 = await store.upsert_identity(library_name="Stereolab")
+
+        await store.update_status(id1.id, "reconciled")
+        await store.update_status(id2.id, "no_match")
+
+        reconciled = await store.get_identities_by_status("reconciled")
+        no_match = await store.get_identities_by_status("no_match")
+        assert len(reconciled) == 1
+        assert reconciled[0].library_name == "Autechre"
+        assert len(no_match) == 1
+        assert no_match[0].library_name == "Stereolab"
+
+    @pytest.mark.asyncio
+    async def test_reconciliation_log(self, pg_source):
+        store = EntityStore(pg_source)
+        identity = await store.upsert_identity(library_name="Autechre")
+        await store.log_reconciliation(
+            identity_id=identity.id,
+            source="discogs",
+            external_id="12",
+            method="exact_match",
+            confidence=1.0,
+        )
+        # Verify via direct query
+        rows = await pg_source.fetchall(
+            "SELECT * FROM entity.reconciliation_log WHERE identity_id = $1",
+            identity.id,
+        )
+        assert len(rows) == 1
+        assert rows[0]["source"] == "discogs"
+        assert rows[0]["method"] == "exact_match"
+
+
+@pytest.mark.postgres
+class TestDiscogsReconciliationIntegration:
+    """Test Discogs reconciliation against real discogs-cache data.
+
+    These tests require the discogs-cache PostgreSQL to have the standard
+    Discogs tables (release_artist, artist_member, artist_alias, etc.)
+    populated with data. If the tables don't exist, the tests are skipped.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reconcile_known_artists(self, pg_source, pg_pool):
+        """Known WXYC artists should resolve against Discogs cache data."""
+        # Check if release_artist table exists and has data
+        async with pg_pool.acquire() as conn:
+            exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = 'release_artist')"
+            )
+            if not exists:
+                pytest.skip("release_artist table not found in test database")
+            count = await conn.fetchval("SELECT count(*) FROM release_artist")
+            if count == 0:
+                pytest.skip("release_artist table is empty -- no Discogs data loaded")
+
+        reconciler = DiscogsReconciler(pg_source)
+        names = ["Autechre", "Stereolab", "Jessica Pratt", "Cat Power", "Juana Molina"]
+        results = await reconciler.reconcile_batch(names)
+
+        # We expect at least some matches (>= 70% is the target)
+        assert len(results) >= 1, f"Expected at least 1 match, got {len(results)}"
+        for _name, match in results.items():
+            assert match.discogs_artist_id > 0
+            assert match.method in ("exact_match", "member_group", "alias_match", "name_variation")
+
+
+@pytest.mark.postgres
+class TestDeduplicationIntegration:
+    """Test deduplication against real PostgreSQL."""
+
+    @pytest.mark.asyncio
+    async def test_dedup_merges_shared_qid(self, pg_source):
+        store = EntityStore(pg_source)
+        await store.upsert_identity(
+            library_name="Autechre", wikidata_qid="Q378288", discogs_artist_id=12
+        )
+        await store.upsert_identity(
+            library_name="autechre",
+            wikidata_qid="Q378288",
+            musicbrainz_artist_id="mbid-1",
+        )
+
+        dedup = EntityDeduplicator(pg_source)
+        groups = await dedup.find_duplicate_groups()
+        assert len(groups) == 1
+
+        await dedup.merge_group(groups[0][0], groups[0][1])
+
+        # After merge, only one identity should remain
+        remaining = await pg_source.fetchall(
+            "SELECT * FROM entity.identity WHERE wikidata_qid = $1", "Q378288"
+        )
+        assert len(remaining) == 1
+        # The merged record should have both discogs and musicbrainz IDs
+        assert remaining[0]["discogs_artist_id"] == 12
+        assert remaining[0]["musicbrainz_artist_id"] == "mbid-1"

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -1,0 +1,140 @@
+"""Unit tests for Discogs batch reconciliation."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.entity_resolution.discogs import DiscogsReconciler, ReconciliationMatch
+
+
+@pytest.fixture
+def mock_pg():
+    """Mock PgSource for discogs-cache queries."""
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetch_with_unnest = AsyncMock(return_value=[])
+    return pg
+
+
+@pytest.fixture
+def reconciler(mock_pg):
+    return DiscogsReconciler(mock_pg)
+
+
+class TestExactMatch:
+    @pytest.mark.asyncio
+    async def test_found(self, reconciler, mock_pg):
+        """Exact match returns discogs_artist_id when release_artist has a match."""
+        mock_pg.fetchall = AsyncMock(
+            return_value=[{"artist_name": "autechre", "artist_id": 12}]
+        )
+        results = await reconciler.reconcile_batch(["Autechre"])
+        assert "Autechre" in results
+        match = results["Autechre"]
+        assert match.discogs_artist_id == 12
+        assert match.method == "exact_match"
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, reconciler, mock_pg):
+        """Exact match returns empty dict when no release_artist match."""
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        results = await reconciler.reconcile_batch(["Nonexistent Artist"])
+        assert results == {}
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive(self, reconciler, mock_pg):
+        """Matching is case-insensitive; result uses original canonical name."""
+        mock_pg.fetchall = AsyncMock(
+            return_value=[{"artist_name": "stereolab", "artist_id": 99}]
+        )
+        results = await reconciler.reconcile_batch(["Stereolab"])
+        assert "Stereolab" in results
+        assert results["Stereolab"].discogs_artist_id == 99
+
+
+class TestMemberGroupMatch:
+    @pytest.mark.asyncio
+    async def test_member_match(self, reconciler, mock_pg):
+        """Member match finds an artist via artist_member table."""
+        # First call (exact match) returns empty, second (member) returns match
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # exact match query
+                [{"member_name": "john lennon", "member_id": 654}],  # member query
+            ]
+        )
+        results = await reconciler.reconcile_batch(["John Lennon"])
+        assert "John Lennon" in results
+        assert results["John Lennon"].discogs_artist_id == 654
+        assert results["John Lennon"].method == "member_group"
+
+
+class TestAliasMatch:
+    @pytest.mark.asyncio
+    async def test_alias_match(self, reconciler, mock_pg):
+        """Alias match finds an artist via artist_alias table."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # exact match
+                [],  # member match
+                [{"alias_name": "aphex twin", "artist_id": 45}],  # alias match
+            ]
+        )
+        results = await reconciler.reconcile_batch(["Aphex Twin"])
+        assert "Aphex Twin" in results
+        assert results["Aphex Twin"].discogs_artist_id == 45
+        assert results["Aphex Twin"].method == "alias_match"
+
+    @pytest.mark.asyncio
+    async def test_name_variation_fallback(self, reconciler, mock_pg):
+        """Name variation fallback matches when alias table misses."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # exact match
+                [],  # member match
+                [],  # alias match
+                [{"name": "bjork", "artist_id": 55}],  # name variation
+            ]
+        )
+        results = await reconciler.reconcile_batch(["Bjork"])
+        assert "Bjork" in results
+        assert results["Bjork"].discogs_artist_id == 55
+        assert results["Bjork"].method == "name_variation"
+
+
+class TestBatchProcessing:
+    @pytest.mark.asyncio
+    async def test_processes_multiple_batches(self, reconciler, mock_pg):
+        """Names exceeding batch_size are split across multiple queries."""
+        reconciler = DiscogsReconciler(mock_pg, batch_size=3)
+        names = [f"Artist {i}" for i in range(7)]
+
+        call_count = 0
+
+        async def count_calls(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return []
+
+        mock_pg.fetchall = AsyncMock(side_effect=count_calls)
+        await reconciler.reconcile_batch(names)
+        # 3 batches for exact match (ceil(7/3)), each unmatched batch cascades
+        assert call_count >= 3
+
+
+class TestSkipsAlreadyReconciled:
+    @pytest.mark.asyncio
+    async def test_filters_already_reconciled(self, reconciler, mock_pg):
+        """reconcile_batch with skip_names filters out already-reconciled names."""
+        mock_pg.fetchall = AsyncMock(
+            return_value=[
+                {"artist_name": "stereolab", "artist_id": 99},
+                {"artist_name": "autechre", "artist_id": 12},
+            ]
+        )
+        results = await reconciler.reconcile_batch(
+            ["Stereolab", "Autechre"],
+            skip_names={"Autechre"},
+        )
+        assert "Stereolab" in results
+        assert "Autechre" not in results

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from scripts.entity_resolution.discogs import DiscogsReconciler, ReconciliationMatch
+from scripts.entity_resolution.discogs import DiscogsReconciler
 
 
 @pytest.fixture
@@ -25,9 +25,7 @@ class TestExactMatch:
     @pytest.mark.asyncio
     async def test_found(self, reconciler, mock_pg):
         """Exact match returns discogs_artist_id when release_artist has a match."""
-        mock_pg.fetchall = AsyncMock(
-            return_value=[{"artist_name": "autechre", "artist_id": 12}]
-        )
+        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "autechre", "artist_id": 12}])
         results = await reconciler.reconcile_batch(["Autechre"])
         assert "Autechre" in results
         match = results["Autechre"]
@@ -44,9 +42,7 @@ class TestExactMatch:
     @pytest.mark.asyncio
     async def test_case_insensitive(self, reconciler, mock_pg):
         """Matching is case-insensitive; result uses original canonical name."""
-        mock_pg.fetchall = AsyncMock(
-            return_value=[{"artist_name": "stereolab", "artist_id": 99}]
-        )
+        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "stereolab", "artist_id": 99}])
         results = await reconciler.reconcile_batch(["Stereolab"])
         assert "Stereolab" in results
         assert results["Stereolab"].discogs_artist_id == 99

--- a/tests/unit/test_entity_dedup.py
+++ b/tests/unit/test_entity_dedup.py
@@ -1,0 +1,98 @@
+"""Unit tests for entity deduplication by shared Wikidata QID."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.entity_resolution.dedup import EntityDeduplicator
+from scripts.entity_resolution.store import Identity
+
+
+@pytest.fixture
+def mock_pg():
+    """Mock PgSource for entity store queries."""
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.execute = AsyncMock(return_value="UPDATE 0")
+    return pg
+
+
+@pytest.fixture
+def dedup(mock_pg):
+    return EntityDeduplicator(mock_pg)
+
+
+class TestFindDuplicateQids:
+    @pytest.mark.asyncio
+    async def test_finds_duplicates(self, dedup, mock_pg):
+        """find_duplicate_groups returns groups of identities sharing a QID."""
+        mock_pg.fetchall = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "library_name": "Autechre",
+                    "discogs_artist_id": 12,
+                    "wikidata_qid": "Q378288",
+                    "musicbrainz_artist_id": None,
+                    "spotify_artist_id": "abc",
+                    "apple_music_artist_id": None,
+                    "bandcamp_id": None,
+                    "reconciliation_status": "reconciled",
+                },
+                {
+                    "id": 2,
+                    "library_name": "autechre",
+                    "discogs_artist_id": None,
+                    "wikidata_qid": "Q378288",
+                    "musicbrainz_artist_id": "mbid-1",
+                    "spotify_artist_id": None,
+                    "apple_music_artist_id": "apple-1",
+                    "bandcamp_id": None,
+                    "reconciliation_status": "reconciled",
+                },
+            ]
+        )
+        groups = await dedup.find_duplicate_groups()
+        assert len(groups) == 1
+        qid, identities = groups[0]
+        assert qid == "Q378288"
+        assert len(identities) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_duplicates(self, dedup, mock_pg):
+        """find_duplicate_groups returns empty list when no shared QIDs."""
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        groups = await dedup.find_duplicate_groups()
+        assert groups == []
+
+
+class TestMergeIdentities:
+    @pytest.mark.asyncio
+    async def test_merge_preserves_all_ids(self, dedup, mock_pg):
+        """merge_group keeps the first identity and merges external IDs from all."""
+        identities = [
+            Identity(
+                id=1,
+                library_name="Autechre",
+                discogs_artist_id=12,
+                wikidata_qid="Q378288",
+                spotify_artist_id="abc",
+                reconciliation_status="reconciled",
+            ),
+            Identity(
+                id=2,
+                library_name="autechre",
+                musicbrainz_artist_id="mbid-1",
+                wikidata_qid="Q378288",
+                apple_music_artist_id="apple-1",
+                reconciliation_status="reconciled",
+            ),
+        ]
+        await dedup.merge_group("Q378288", identities)
+
+        # Should have executed UPDATE for the primary identity and DELETE for dupes
+        calls = [str(c) for c in mock_pg.execute.call_args_list]
+        update_call = [c for c in calls if "UPDATE" in c]
+        delete_call = [c for c in calls if "DELETE" in c]
+        assert len(update_call) >= 1, "Expected UPDATE for merged identity"
+        assert len(delete_call) >= 1, "Expected DELETE for duplicate identity"

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -1,0 +1,181 @@
+"""Unit tests for entity store CRUD operations."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from scripts.entity_resolution.store import (
+    EntityStore,
+    Identity,
+)
+
+
+@pytest.fixture
+def mock_pg():
+    """Mock PgSource with fetchall/fetchone/execute methods."""
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetchone = AsyncMock(return_value=None)
+    pg.execute = AsyncMock(return_value="INSERT 0 1")
+    return pg
+
+
+@pytest.fixture
+def store(mock_pg):
+    return EntityStore(mock_pg)
+
+
+class TestUpsertIdentity:
+    @pytest.mark.asyncio
+    async def test_creates_new_identity(self, store, mock_pg):
+        """upsert_identity inserts a new row and returns it with status='unreconciled'."""
+        mock_pg.fetchone = AsyncMock(
+            return_value={
+                "id": 1,
+                "library_name": "Autechre",
+                "discogs_artist_id": None,
+                "wikidata_qid": None,
+                "musicbrainz_artist_id": None,
+                "spotify_artist_id": None,
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "unreconciled",
+            }
+        )
+        identity = await store.upsert_identity(library_name="Autechre")
+        assert identity is not None
+        assert identity.library_name == "Autechre"
+        assert identity.reconciliation_status == "unreconciled"
+        assert identity.id == 1
+        # Verify the query was an INSERT ... ON CONFLICT
+        call_args = mock_pg.fetchone.call_args
+        assert "INSERT" in call_args[0][0]
+        assert "ON CONFLICT" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_with_coalesce(self, store, mock_pg):
+        """upsert_identity uses COALESCE so populated fields are not overwritten with NULL."""
+        mock_pg.fetchone = AsyncMock(
+            return_value={
+                "id": 1,
+                "library_name": "Autechre",
+                "discogs_artist_id": 42,
+                "wikidata_qid": None,
+                "musicbrainz_artist_id": None,
+                "spotify_artist_id": None,
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "unreconciled",
+            }
+        )
+        identity = await store.upsert_identity(
+            library_name="Autechre", discogs_artist_id=42
+        )
+        assert identity is not None
+        assert identity.discogs_artist_id == 42
+        # Verify COALESCE is used in the UPDATE clause
+        call_args = mock_pg.fetchone.call_args
+        assert "COALESCE" in call_args[0][0]
+
+
+class TestGetIdentity:
+    @pytest.mark.asyncio
+    async def test_returns_identity_by_name(self, store, mock_pg):
+        """get_identity returns the identity for an existing library_name."""
+        mock_pg.fetchone = AsyncMock(
+            return_value={
+                "id": 1,
+                "library_name": "Autechre",
+                "discogs_artist_id": 12,
+                "wikidata_qid": "Q378288",
+                "musicbrainz_artist_id": None,
+                "spotify_artist_id": None,
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "reconciled",
+            }
+        )
+        identity = await store.get_identity("Autechre")
+        assert identity is not None
+        assert identity.library_name == "Autechre"
+        assert identity.discogs_artist_id == 12
+        assert identity.wikidata_qid == "Q378288"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_missing(self, store, mock_pg):
+        """get_identity returns None when no matching library_name exists."""
+        mock_pg.fetchone = AsyncMock(return_value=None)
+        identity = await store.get_identity("Nonexistent")
+        assert identity is None
+
+
+class TestUpdateStatus:
+    @pytest.mark.asyncio
+    async def test_updates_reconciliation_status(self, store, mock_pg):
+        """update_status changes the reconciliation_status for an identity."""
+        await store.update_status(1, "reconciled")
+        mock_pg.execute.assert_called_once()
+        call_args = mock_pg.execute.call_args
+        assert "UPDATE" in call_args[0][0]
+        assert "reconciliation_status" in call_args[0][0]
+
+
+class TestLogReconciliation:
+    @pytest.mark.asyncio
+    async def test_inserts_reconciliation_log(self, store, mock_pg):
+        """log_reconciliation inserts a row into entity.reconciliation_log."""
+        await store.log_reconciliation(
+            identity_id=1,
+            source="discogs",
+            external_id="12",
+            method="exact_match",
+            confidence=1.0,
+        )
+        mock_pg.execute.assert_called_once()
+        call_args = mock_pg.execute.call_args
+        assert "entity.reconciliation_log" in call_args[0][0]
+        assert "INSERT" in call_args[0][0]
+
+
+class TestGetIdentitiesByStatus:
+    @pytest.mark.asyncio
+    async def test_returns_only_matching_status(self, store, mock_pg):
+        """get_identities_by_status returns only identities with the given status."""
+        mock_pg.fetchall = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "library_name": "Autechre",
+                    "discogs_artist_id": None,
+                    "wikidata_qid": None,
+                    "musicbrainz_artist_id": None,
+                    "spotify_artist_id": None,
+                    "apple_music_artist_id": None,
+                    "bandcamp_id": None,
+                    "reconciliation_status": "unreconciled",
+                },
+                {
+                    "id": 3,
+                    "library_name": "Stereolab",
+                    "discogs_artist_id": None,
+                    "wikidata_qid": None,
+                    "musicbrainz_artist_id": None,
+                    "spotify_artist_id": None,
+                    "apple_music_artist_id": None,
+                    "bandcamp_id": None,
+                    "reconciliation_status": "unreconciled",
+                },
+            ]
+        )
+        identities = await store.get_identities_by_status("unreconciled")
+        assert len(identities) == 2
+        assert all(i.reconciliation_status == "unreconciled" for i in identities)
+        call_args = mock_pg.fetchall.call_args
+        assert "reconciliation_status" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_matches(self, store, mock_pg):
+        """get_identities_by_status returns empty list when no identities match."""
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        identities = await store.get_identities_by_status("reconciled")
+        assert identities == []

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -1,12 +1,11 @@
 """Unit tests for entity store CRUD operations."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from scripts.entity_resolution.store import (
     EntityStore,
-    Identity,
 )
 
 
@@ -68,9 +67,7 @@ class TestUpsertIdentity:
                 "reconciliation_status": "unreconciled",
             }
         )
-        identity = await store.upsert_identity(
-            library_name="Autechre", discogs_artist_id=42
-        )
+        identity = await store.upsert_identity(library_name="Autechre", discogs_artist_id=42)
         assert identity is not None
         assert identity.discogs_artist_id == 42
         # Verify COALESCE is used in the UPDATE clause

--- a/tests/unit/test_musicbrainz_reconciliation.py
+++ b/tests/unit/test_musicbrainz_reconciliation.py
@@ -1,0 +1,83 @@
+"""Unit tests for MusicBrainz identity resolution."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.entity_resolution.musicbrainz import MusicBrainzReconciler
+
+
+@pytest.fixture
+def mock_mb_pg():
+    """Mock PgSource for musicbrainz-cache."""
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetchone = AsyncMock(return_value=None)
+    return pg
+
+
+@pytest.fixture
+def mock_wikidata_pg():
+    """Mock PgSource for wikidata-cache (P434 bridge)."""
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    return pg
+
+
+@pytest.fixture
+def reconciler(mock_mb_pg, mock_wikidata_pg):
+    return MusicBrainzReconciler(mb_pg=mock_mb_pg, wikidata_pg=mock_wikidata_pg)
+
+
+class TestQidToMbidViaP434:
+    @pytest.mark.asyncio
+    async def test_bridge_lookup(self, reconciler, mock_wikidata_pg, mock_mb_pg):
+        """QID -> MBID via P434 wikidata-cache bridge, confirmed in MB cache."""
+        mock_wikidata_pg.fetchall = AsyncMock(
+            return_value=[
+                {"qid": "Q378288", "musicbrainz_artist_id": "410c9baf-5469-44f6-9852-826524b80c61"}
+            ]
+        )
+        mock_mb_pg.fetchall = AsyncMock(
+            return_value=[
+                {"gid": "410c9baf-5469-44f6-9852-826524b80c61", "name": "Autechre"}
+            ]
+        )
+        result = await reconciler.resolve_from_qids({"Q378288"})
+        assert "Q378288" in result
+        assert result["Q378288"] == "410c9baf-5469-44f6-9852-826524b80c61"
+
+
+class TestDirectNameMatch:
+    @pytest.mark.asyncio
+    async def test_name_match(self, reconciler, mock_mb_pg):
+        """Direct name match against mb_artist + mb_artist_alias."""
+        mock_mb_pg.fetchall = AsyncMock(
+            return_value=[
+                {
+                    "name": "autechre",
+                    "gid": "410c9baf-5469-44f6-9852-826524b80c61",
+                }
+            ]
+        )
+        result = await reconciler.resolve_from_names(["Autechre"])
+        assert "Autechre" in result
+        assert result["Autechre"] == "410c9baf-5469-44f6-9852-826524b80c61"
+
+    @pytest.mark.asyncio
+    async def test_no_match(self, reconciler, mock_mb_pg):
+        """Returns empty dict when no name match found."""
+        mock_mb_pg.fetchall = AsyncMock(return_value=[])
+        result = await reconciler.resolve_from_names(["ZZZNONEXISTENT"])
+        assert result == {}
+
+
+class TestGracefulDegradation:
+    @pytest.mark.asyncio
+    async def test_no_mb_cache_skips(self):
+        """When mb_pg is None, all resolution methods return empty results."""
+        reconciler = MusicBrainzReconciler(mb_pg=None, wikidata_pg=None)
+        result_qid = await reconciler.resolve_from_qids({"Q378288"})
+        result_name = await reconciler.resolve_from_names(["Autechre"])
+        assert result_qid == {}
+        assert result_name == {}

--- a/tests/unit/test_musicbrainz_reconciliation.py
+++ b/tests/unit/test_musicbrainz_reconciliation.py
@@ -39,9 +39,7 @@ class TestQidToMbidViaP434:
             ]
         )
         mock_mb_pg.fetchall = AsyncMock(
-            return_value=[
-                {"gid": "410c9baf-5469-44f6-9852-826524b80c61", "name": "Autechre"}
-            ]
+            return_value=[{"gid": "410c9baf-5469-44f6-9852-826524b80c61", "name": "Autechre"}]
         )
         result = await reconciler.resolve_from_qids({"Q378288"})
         assert "Q378288" in result

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -1,0 +1,150 @@
+"""Unit tests for Wikidata identity resolution."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.entity_resolution.wikidata import WikidataReconciler, StreamingIds
+
+
+@pytest.fixture
+def mock_sparql():
+    """Mock SparqlSource."""
+    sparql = AsyncMock()
+    sparql.query = AsyncMock(return_value=[])
+    sparql.query_batched = AsyncMock(return_value=[])
+    sparql.extract_qid = lambda uri: uri.rsplit("/", 1)[-1]
+    sparql.binding_value = lambda binding, key: (
+        binding.get(key, {}).get("value") if isinstance(binding.get(key), dict) else None
+    )
+    return sparql
+
+
+@pytest.fixture
+def mock_wikidata_pg():
+    """Mock PgSource for wikidata-cache."""
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetchone = AsyncMock(return_value=None)
+    return pg
+
+
+@pytest.fixture
+def reconciler(mock_sparql, mock_wikidata_pg):
+    return WikidataReconciler(sparql=mock_sparql, wikidata_pg=mock_wikidata_pg)
+
+
+@pytest.fixture
+def reconciler_no_cache(mock_sparql):
+    return WikidataReconciler(sparql=mock_sparql, wikidata_pg=None)
+
+
+class TestDiscogsIdToQidViaCache:
+    @pytest.mark.asyncio
+    async def test_cache_hit(self, reconciler, mock_wikidata_pg):
+        """Discogs ID -> QID lookup succeeds via wikidata-cache discogs_mapping."""
+        mock_wikidata_pg.fetchall = AsyncMock(
+            return_value=[
+                {"discogs_artist_id": 12, "qid": "Q378288"},
+            ]
+        )
+        result = await reconciler.resolve_qids_from_discogs_ids({12, 99})
+        assert result[12] == "Q378288"
+        assert 99 not in result
+
+    @pytest.mark.asyncio
+    async def test_sparql_fallback(self, reconciler, mock_wikidata_pg, mock_sparql):
+        """Falls back to SPARQL P1953 when cache misses."""
+        mock_wikidata_pg.fetchall = AsyncMock(return_value=[])
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q378288"},
+                    "discogsId": {"type": "literal", "value": "12"},
+                }
+            ]
+        )
+        result = await reconciler.resolve_qids_from_discogs_ids({12})
+        assert result[12] == "Q378288"
+        mock_sparql.query_batched.assert_called_once()
+
+
+class TestNameSearch:
+    @pytest.mark.asyncio
+    async def test_finds_musician_by_name(self, reconciler, mock_sparql):
+        """Name search returns QID for a musician match."""
+        mock_sparql.query = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q378288"},
+                    "itemLabel": {"type": "literal", "value": "Autechre"},
+                }
+            ]
+        )
+        qid = await reconciler.search_musician_by_name("Autechre")
+        assert qid == "Q378288"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_no_results(self, reconciler, mock_sparql):
+        """Name search returns None when no musician candidates found."""
+        mock_sparql.query = AsyncMock(return_value=[])
+        qid = await reconciler.search_musician_by_name("ZZZNONEXISTENT")
+        assert qid is None
+
+
+class TestStreamingIdFetch:
+    @pytest.mark.asyncio
+    async def test_fetches_all_streaming_ids(self, reconciler, mock_sparql):
+        """Streaming ID fetch populates Spotify, Apple Music, and Bandcamp."""
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q378288"},
+                    "spotifyId": {"type": "literal", "value": "2cGiltMnETMr482N3F3ILQK"},
+                    "appleMusicId": {"type": "literal", "value": "1234567"},
+                    "bandcampId": {"type": "literal", "value": "autechre"},
+                }
+            ]
+        )
+        result = await reconciler.fetch_streaming_ids(["Q378288"])
+        assert "Q378288" in result
+        ids = result["Q378288"]
+        assert ids.spotify_artist_id == "2cGiltMnETMr482N3F3ILQK"
+        assert ids.apple_music_artist_id == "1234567"
+        assert ids.bandcamp_id == "autechre"
+
+    @pytest.mark.asyncio
+    async def test_partial_streaming_ids(self, reconciler, mock_sparql):
+        """Partial results: some streaming IDs may be absent."""
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q378288"},
+                    "spotifyId": {"type": "literal", "value": "abc123"},
+                }
+            ]
+        )
+        result = await reconciler.fetch_streaming_ids(["Q378288"])
+        ids = result["Q378288"]
+        assert ids.spotify_artist_id == "abc123"
+        assert ids.apple_music_artist_id is None
+        assert ids.bandcamp_id is None
+
+
+class TestGracefulDegradation:
+    @pytest.mark.asyncio
+    async def test_no_wikidata_cache_uses_sparql_only(
+        self, reconciler_no_cache, mock_sparql
+    ):
+        """When wikidata_pg is None, resolve_qids_from_discogs_ids uses SPARQL only."""
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q378288"},
+                    "discogsId": {"type": "literal", "value": "12"},
+                }
+            ]
+        )
+        result = await reconciler_no_cache.resolve_qids_from_discogs_ids({12})
+        assert result[12] == "Q378288"
+        mock_sparql.query_batched.assert_called_once()

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from scripts.entity_resolution.wikidata import WikidataReconciler, StreamingIds
+from scripts.entity_resolution.wikidata import WikidataReconciler
 
 
 @pytest.fixture
@@ -133,9 +133,7 @@ class TestStreamingIdFetch:
 
 class TestGracefulDegradation:
     @pytest.mark.asyncio
-    async def test_no_wikidata_cache_uses_sparql_only(
-        self, reconciler_no_cache, mock_sparql
-    ):
+    async def test_no_wikidata_cache_uses_sparql_only(self, reconciler_no_cache, mock_sparql):
         """When wikidata_pg is None, resolve_qids_from_discogs_ids uses SPARQL only."""
         mock_sparql.query_batched = AsyncMock(
             return_value=[


### PR DESCRIPTION
## Summary

- Implements the entity resolution pipeline as a CLI script (`python -m scripts.entity_resolution`) that reconciles WXYC library artist names to external identifiers (Discogs artist ID, Wikidata QID, MusicBrainz ID, streaming platform IDs)
- Adds `entity.identity` and `entity.reconciliation_log` tables to the discogs-cache PostgreSQL database via the schema already committed at `discogs-cache/schema/entity_schema.sql`
- Provides concrete `PgSource` (asyncpg) and `SparqlSource` (httpx/Wikidata SPARQL) implementations within the package as a stopgap until the `wxyc_catalog.sources` package from task 3d is available
- Reconciliation pipeline runs a 4-stage Discogs cascade (exact name match, member/group, alias, name variation), Wikidata QID bridging + name search + streaming ID fetch, MusicBrainz matching, and entity deduplication by shared QID

## New files

| File | Description |
|------|-------------|
| `scripts/entity_resolution/sources.py` | PgSource and SparqlSource transport implementations |
| `scripts/entity_resolution/store.py` | Entity store CRUD (upsert, get, status update, reconciliation log) |
| `scripts/entity_resolution/discogs.py` | Discogs 4-stage batch reconciler |
| `scripts/entity_resolution/wikidata.py` | Wikidata QID bridging, name search, streaming ID fetch |
| `scripts/entity_resolution/musicbrainz.py` | MusicBrainz QID bridge + direct name matching |
| `scripts/entity_resolution/dedup.py` | Entity deduplication by shared Wikidata QID |
| `scripts/entity_resolution/__main__.py` | CLI entry point orchestrating the full pipeline |

## Test plan

- [x] 30 unit tests covering entity store CRUD, Discogs reconciliation cascade, Wikidata resolution, MusicBrainz matching, and deduplication (all with mocked PgSource/SparqlSource)
- [x] 6 integration tests against real PostgreSQL (requires Docker on port 5433) marked `@pytest.mark.postgres`
- [x] Full test suite passes (952 tests, 0 failures)
- [x] Ruff lint and format clean

Closes WXYC/library-metadata-lookup#96