### PR TITLE
Replace build_artist_mapping() with entity store reads

### DIFF
--- a/scripts/streaming_availability/__main__.py
+++ b/scripts/streaming_availability/__main__.py
@@ -23,9 +23,9 @@ from scripts.streaming_availability.apple_music_client import AppleMusicClient
 from scripts.streaming_availability.dedup import deduplicate_library
 from scripts.streaming_availability.deezer_client import DeezerClient
 from scripts.streaming_availability.discogs_enricher import (
-    build_artist_mapping,
     check_wxyc_schema,
     enrich_album,
+    load_entity_store_mapping,
 )
 from scripts.streaming_availability.matching import (
     find_best_match,
@@ -335,7 +335,7 @@ async def _process_discogs_enrichment(
     results_db: ResultsDB,
     pool: object,
     batch_size: int,
-    artist_mapping: dict[str, str] | None = None,
+    entity_mapping: dict[str, int] | None = None,
 ) -> None:
     """Enrich all pending albums with Discogs canonical names."""
     rows = await results_db.get_pending_discogs(limit=1)
@@ -345,9 +345,11 @@ async def _process_discogs_enrichment(
 
     all_pending = await results_db.get_pending_discogs(limit=100_000)
     total_pending = len(all_pending)
-    mapped = len(artist_mapping) if artist_mapping else 0
+    mapped = len(entity_mapping) if entity_mapping else 0
     logger.info(
-        "Discogs enrichment: %d albums to process (%d artist mappings)", total_pending, mapped
+        "Discogs enrichment: %d albums to process (%d entity store mappings)",
+        total_pending,
+        mapped,
     )
 
     processed = 0
@@ -369,7 +371,8 @@ async def _process_discogs_enrichment(
             title = strip_format_suffix(row["display_title"])
 
             try:
-                match = await enrich_album(pool, artist, title, artist_mapping=artist_mapping)
+                artist_id = entity_mapping.get(artist) if entity_mapping else None
+                match = await enrich_album(pool, artist, title, discogs_artist_id=artist_id)
                 if match:
                     await results_db.update_discogs_result(
                         album_id,
@@ -579,25 +582,20 @@ async def run(args: argparse.Namespace) -> None:
         from scripts.streaming_availability.pipeline import Pipeline, Stage
 
         discogs_pool = None
-        artist_mapping: dict[str, str] = {}
+        entity_mapping: dict[str, int] = {}
         discogs_url = os.environ.get("DATABASE_URL_DISCOGS")
         if discogs_url:
             import asyncpg
 
-            async def _init_conn(conn: asyncpg.Connection) -> None:
-                await conn.execute("SET pg_trgm.similarity_threshold = 0.4")
-
-            discogs_pool = await asyncpg.create_pool(
-                discogs_url, min_size=2, max_size=10, init=_init_conn
-            )
+            discogs_pool = await asyncpg.create_pool(discogs_url, min_size=2, max_size=10)
             use_wxyc = await check_wxyc_schema(discogs_pool)
             if use_wxyc:
+                entity_mapping = await load_entity_store_mapping(discogs_pool)
                 unique_artists = sorted({a.display_artist for a in albums if not a.is_compilation})
-                logger.info("Building artist mapping for %d artists...", len(unique_artists))
-                artist_mapping = await build_artist_mapping(discogs_pool, unique_artists)
+                mapped = sum(1 for a in unique_artists if a in entity_mapping)
                 logger.info(
-                    "Artist mapping: %d of %d artists have Discogs name variants",
-                    len(artist_mapping),
+                    "Entity store: %d of %d artists have Discogs artist IDs",
+                    mapped,
                     len(unique_artists),
                 )
             else:
@@ -633,9 +631,8 @@ async def run(args: argparse.Namespace) -> None:
             artist = item["display_artist"]
             title = strip_format_suffix(item["display_title"])
             if discogs_pool:
-                match = await enrich_album(
-                    discogs_pool, artist, title, artist_mapping=artist_mapping
-                )
+                artist_id = entity_mapping.get(artist)
+                match = await enrich_album(discogs_pool, artist, title, discogs_artist_id=artist_id)
                 if match:
                     await results_db.update_discogs_result(
                         album_id,

--- a/scripts/streaming_availability/discogs_enricher.py
+++ b/scripts/streaming_availability/discogs_enricher.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING
 
-from rapidfuzz import fuzz
-
-from core.matching import strip_diacritics
 from scripts.streaming_availability.matching import (
     is_acceptable_match,
     score_match,
@@ -19,11 +17,35 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Artist name fuzzy lookup on the small wxyc.artist_names table (~130K rows, ~1ms)
-_ARTIST_FUZZY_QUERY = """
-    SELECT artist_name FROM wxyc.artist_names
-    WHERE lower(f_unaccent(artist_name)) % lower(f_unaccent($1))
-    LIMIT 10
+# SQL to load the artist mapping from the entity store.
+# Returns all reconciled artists with a known Discogs artist ID.
+_ENTITY_STORE_QUERY = """
+    SELECT library_name, discogs_artist_id
+    FROM entity.identity
+    WHERE reconciliation_status = 'reconciled'
+      AND discogs_artist_id IS NOT NULL
+"""
+
+# Release lookup by artist ID on wxyc schema (direct, no fuzzy matching needed)
+_WXYC_RELEASE_BY_ARTIST_ID_QUERY = """
+    SELECT DISTINCT ON (r.id)
+        r.id as release_id, r.title, ra.artist_name, r.artwork_url
+    FROM wxyc.release r
+    JOIN wxyc.release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+    WHERE ra.artist_id = $1
+    ORDER BY r.id
+    LIMIT 200
+"""
+
+# Fallback: release lookup by artist ID on full public schema
+_PUBLIC_RELEASE_BY_ARTIST_ID_QUERY = """
+    SELECT DISTINCT ON (r.id)
+        r.id as release_id, r.title, ra.artist_name, r.artwork_url
+    FROM release r
+    JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+    WHERE ra.artist_id = $1
+    ORDER BY r.id
+    LIMIT 200
 """
 
 # Release lookup by artist name on wxyc schema (~10ms)
@@ -80,82 +102,75 @@ def pick_best_match(query_artist: str, query_title: str, results: list[dict]) ->
     return best
 
 
-def _best_artist_match(query: str, candidates: list[str]) -> str | None:
-    """Pick the best fuzzy match from candidate artist names.
+async def load_entity_store_mapping(pool: asyncpg.Pool) -> dict[str, int]:
+    """Load artist mapping from the entity store.
 
-    Strips Discogs disambiguation suffixes before comparison.
+    Queries ``entity.identity`` for all reconciled artists with a known
+    Discogs artist ID. Returns a dict mapping library_name to discogs_artist_id.
+
+    If the entity schema does not exist or the query fails, returns an empty dict
+    so the pipeline can fall back to name-based lookups.
     """
-    query_normalized = strip_diacritics(query).lower()
-    best_name = None
-    best_score = 0.0
-
-    for name in candidates:
-        clean = strip_discogs_suffix(name)
-        score = fuzz.token_sort_ratio(query_normalized, strip_diacritics(clean).lower())
-        if score > best_score and score >= 80:
-            best_score = score
-            best_name = name
-
-    return best_name
-
-
-async def build_artist_mapping(pool: asyncpg.Pool, artists: list[str]) -> dict[str, str]:
-    """Build a mapping from library artist names to Discogs canonical names.
-
-    Uses trigram fuzzy search on the small wxyc.artist_names table (~130K rows).
-    Only includes entries where the names actually differ.
-
-    Returns dict mapping library_name -> discogs_canonical_name.
-    """
-    mapping: dict[str, str] = {}
-
-    for artist in artists:
-        try:
-            rows = await pool.fetch(_ARTIST_FUZZY_QUERY, artist)
-            candidates = [row["artist_name"] for row in rows]
-            if not candidates:
-                continue
-
-            best = _best_artist_match(artist, candidates)
-            if best and best.lower() != artist.lower():
-                mapping[artist] = best
-        except Exception:
-            logger.debug("Artist mapping failed for %s", artist)
-
-    return mapping
+    t0 = time.monotonic()
+    try:
+        rows = await pool.fetch(_ENTITY_STORE_QUERY)
+        mapping = {
+            row["library_name"]: row["discogs_artist_id"]
+            for row in rows
+            if row["discogs_artist_id"] is not None
+        }
+        elapsed = time.monotonic() - t0
+        logger.info(
+            "Entity store: loaded %d artist mappings in %.2fs",
+            len(mapping),
+            elapsed,
+        )
+        return mapping
+    except Exception:
+        logger.warning("Entity store query failed, falling back to name-based lookups")
+        return {}
 
 
 async def enrich_album(
     pool: asyncpg.Pool,
     artist: str,
     title: str,
-    artist_mapping: dict[str, str] | None = None,
+    *,
+    discogs_artist_id: int | None = None,
 ) -> dict | None:
     """Search the Discogs PG cache for canonical artist/title.
 
-    Uses the artist_mapping to resolve the canonical Discogs artist name,
-    then does exact match release lookups. Tries wxyc schema first, falls
-    back to public schema if no match found.
+    When ``discogs_artist_id`` is provided (from the entity store), uses direct
+    ID-based release lookups which are faster and more accurate than name matching.
+    When absent, falls back to name-based release lookups.
+
+    Tries wxyc schema first, falls back to public schema if no match found.
 
     Returns a dict with 'artist_name', 'title', 'release_id' if found, else None.
     """
     try:
-        # Use mapped name if available, otherwise use original
-        search_artist = artist
-        if artist_mapping and artist in artist_mapping:
-            search_artist = artist_mapping[artist]
+        if discogs_artist_id is not None:
+            # Direct lookup by artist ID (fast, precise)
+            rows = await pool.fetch(_WXYC_RELEASE_BY_ARTIST_ID_QUERY, discogs_artist_id)
+            results = [dict(row) for row in rows]
+            match = pick_best_match(artist, title, results)
+            if match:
+                return match
 
-        # Try wxyc schema first
-        rows = await pool.fetch(_WXYC_RELEASE_QUERY, search_artist)
-        results = [dict(row) for row in rows]
-        match = pick_best_match(artist, title, results)
-        if match:
-            return match
+            rows = await pool.fetch(_PUBLIC_RELEASE_BY_ARTIST_ID_QUERY, discogs_artist_id)
+            results = [dict(row) for row in rows]
+            return pick_best_match(artist, title, results)
+        else:
+            # Name-based lookup (fallback for unreconciled artists)
+            rows = await pool.fetch(_WXYC_RELEASE_QUERY, artist)
+            results = [dict(row) for row in rows]
+            match = pick_best_match(artist, title, results)
+            if match:
+                return match
 
-        # Fall back to public schema
-        rows = await pool.fetch(_PUBLIC_RELEASE_QUERY, search_artist)
-        results = [dict(row) for row in rows]
-        return pick_best_match(artist, title, results)
+            rows = await pool.fetch(_PUBLIC_RELEASE_QUERY, artist)
+            results = [dict(row) for row in rows]
+            return pick_best_match(artist, title, results)
     except Exception:
         logger.exception("Discogs enrichment failed for %s - %s", artist, title)
         return None

--- a/tests/unit/test_discogs_enricher.py
+++ b/tests/unit/test_discogs_enricher.py
@@ -7,8 +7,8 @@ import pytest
 from scripts.streaming_availability.discogs_enricher import (
     _PUBLIC_RELEASE_QUERY,
     _WXYC_RELEASE_QUERY,
-    build_artist_mapping,
     enrich_album,
+    load_entity_store_mapping,
     pick_best_match,
 )
 
@@ -83,37 +83,48 @@ class TestPickBestMatch:
         assert match["artist_name"] == "Björk"
 
 
-class TestBuildArtistMapping:
+class TestLoadEntityStoreMapping:
     @pytest.mark.asyncio
-    async def test_builds_mapping_from_fuzzy_results(self):
+    async def test_loads_reconciled_artists(self):
+        """load_entity_store_mapping returns a dict mapping library_name -> discogs_artist_id."""
         pool = AsyncMock()
-        # Mock the artist_names fuzzy lookup
         pool.fetch = AsyncMock(
-            side_effect=[
-                [{"artist_name": "Björk"}],  # fuzzy match for "Bjork"
-                [{"artist_name": "Stetsasonic"}],  # fuzzy match for "Stetasonic"
-                [],  # no match for "Unknown Artist"
+            return_value=[
+                {"library_name": "Bjork", "discogs_artist_id": 1001},
+                {"library_name": "Stereolab", "discogs_artist_id": 1002},
             ]
         )
-        mapping = await build_artist_mapping(pool, ["Bjork", "Stetasonic", "Unknown Artist"])
-        assert mapping["Bjork"] == "Björk"
-        assert mapping["Stetasonic"] == "Stetsasonic"
-        assert "Unknown Artist" not in mapping
+        mapping = await load_entity_store_mapping(pool)
+        assert mapping == {"Bjork": 1001, "Stereolab": 1002}
 
     @pytest.mark.asyncio
-    async def test_skips_exact_matches(self):
-        """If library name already matches Discogs exactly, no mapping needed."""
+    async def test_skips_null_artist_ids(self):
+        """Rows with NULL discogs_artist_id are excluded from the mapping."""
         pool = AsyncMock()
-        pool.fetch = AsyncMock(return_value=[{"artist_name": "Stereolab"}])
-        mapping = await build_artist_mapping(pool, ["Stereolab"])
-        # Exact match (case-insensitive) should not be in the mapping
-        assert "Stereolab" not in mapping
+        pool.fetch = AsyncMock(
+            return_value=[
+                {"library_name": "Bjork", "discogs_artist_id": 1001},
+                {"library_name": "Unknown", "discogs_artist_id": None},
+            ]
+        )
+        mapping = await load_entity_store_mapping(pool)
+        assert "Unknown" not in mapping
+        assert mapping == {"Bjork": 1001}
 
     @pytest.mark.asyncio
-    async def test_handles_errors_gracefully(self):
+    async def test_returns_empty_on_no_entity_schema(self):
+        """When entity schema doesn't exist, returns empty dict gracefully."""
         pool = AsyncMock()
-        pool.fetch = AsyncMock(side_effect=Exception("Connection failed"))
-        mapping = await build_artist_mapping(pool, ["Stereolab"])
+        pool.fetch = AsyncMock(side_effect=Exception("relation entity.identity does not exist"))
+        mapping = await load_entity_store_mapping(pool)
+        assert mapping == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_reconciled_rows(self):
+        """When no artists are reconciled, returns empty dict."""
+        pool = AsyncMock()
+        pool.fetch = AsyncMock(return_value=[])
+        mapping = await load_entity_store_mapping(pool)
         assert mapping == {}
 
 
@@ -137,7 +148,8 @@ class TestEnrichAlbum:
         assert result["title"] == "Aluminum Tunes"
 
     @pytest.mark.asyncio
-    async def test_uses_mapped_artist_name(self):
+    async def test_uses_discogs_artist_id_for_direct_lookup(self):
+        """When discogs_artist_id is provided, enrich_album uses ID-based release queries."""
         pool = AsyncMock()
         pool.fetch = AsyncMock(
             return_value=[
@@ -149,13 +161,48 @@ class TestEnrichAlbum:
                 },
             ]
         )
-        artist_mapping = {"Bjork": "Björk"}
-        result = await enrich_album(pool, "Bjork", "Homogenic", artist_mapping=artist_mapping)
+        result = await enrich_album(pool, "Bjork", "Homogenic", discogs_artist_id=1001)
         assert result is not None
         assert result["artist_name"] == "Björk"
-        # Should have queried with the mapped name
-        query_artist = pool.fetch.call_args[0][1]
-        assert query_artist == "Björk"
+        # Should have queried with the artist ID, not the name
+        query_arg = pool.fetch.call_args[0][1]
+        assert query_arg == 1001
+
+    @pytest.mark.asyncio
+    async def test_discogs_artist_id_falls_back_to_public_schema(self):
+        """When wxyc schema returns nothing with artist ID, falls back to public schema."""
+        pool = AsyncMock()
+        album_data = {
+            "release_id": 789,
+            "title": "Homogenic",
+            "artist_name": "Björk",
+            "artwork_url": None,
+        }
+        # First call (wxyc schema by ID) returns empty, second (public by ID) returns result
+        pool.fetch = AsyncMock(side_effect=[[], [album_data]])
+        result = await enrich_album(pool, "Bjork", "Homogenic", discogs_artist_id=1001)
+        assert result is not None
+        assert pool.fetch.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_name_based_fallback_when_no_artist_id(self):
+        """When no discogs_artist_id is given, uses name-based release lookup."""
+        pool = AsyncMock()
+        pool.fetch = AsyncMock(
+            return_value=[
+                {
+                    "release_id": 123,
+                    "title": "Aluminum Tunes",
+                    "artist_name": "Stereolab",
+                    "artwork_url": None,
+                },
+            ]
+        )
+        result = await enrich_album(pool, "Stereolab", "Aluminum Tunes")
+        assert result is not None
+        # Should have queried with the artist name string
+        query_arg = pool.fetch.call_args[0][1]
+        assert query_arg == "Stereolab"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_full_schema(self):


### PR DESCRIPTION
## Summary

- Replace the ephemeral trigram-based artist mapping (~130K fuzzy queries per run) with a single `SELECT` from `entity.identity`, loaded by `load_entity_store_mapping()`
- Add direct artist-ID-based release lookup queries for reconciled artists, falling back to name-based queries for unreconciled artists
- Delete `build_artist_mapping()`, `_best_artist_match()`, `_ARTIST_FUZZY_QUERY`, and their `rapidfuzz`/`strip_diacritics` imports
- Remove the `pg_trgm.similarity_threshold` connection init (no longer needed since trigram queries are eliminated)

Closes WXYC/library-metadata-lookup#97

## Test plan

- [x] Unit tests for `load_entity_store_mapping()`: loads reconciled artists, skips null IDs, gracefully handles missing entity schema, handles empty results
- [x] Unit tests for `enrich_album()` with `discogs_artist_id`: direct ID lookup, fallback to public schema, name-based fallback when no ID provided
- [x] All 955 existing unit tests pass (no regressions)
- [x] Lint (`ruff check`) and format (`ruff format --check`) pass
- [ ] Integration test: validate entity store coverage >= 95% vs old `build_artist_mapping()` approach (requires populated entity store + discogs-cache database)