### PR TITLE
Add /identity/resolve and /identity/bulk REST endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,19 @@ All strategy implementations live in `lookup/orchestrator.py`.
 - `core/search.py` -- Declarative search strategy pattern + ambiguous format detection
 - `discogs/matching.py` -- Discogs-specific normalization (strip_discogs_suffix, normalize_for_track_comparison, normalize_artist_for_validation)
 - `core/dependencies.py` -- FastAPI DI for LibraryDB + DiscogsService
+- `identity/router.py` -- `GET /identity/resolve` and `POST /identity/bulk` endpoints for identity resolution
+- `identity/models.py` -- Pydantic models for identity resolution responses
+- `identity/dependencies.py` -- FastAPI DI for EntityStore (reuses `DATABASE_URL_DISCOGS` pool)
+- `scripts/entity_resolution/store.py` -- Entity store CRUD against `entity.identity` PG table
+
+### Identity Resolution Endpoints
+
+The service exposes REST endpoints for querying the `entity.identity` table in the discogs-cache PostgreSQL database. These endpoints are consumed by semantic-index (via `--entity-source=lml`) and other pipeline tools.
+
+- `GET /identity/resolve?name=Stereolab` -- Look up a single artist name. Returns 200 with external IDs or 404.
+- `POST /identity/bulk` with `{"names": ["Stereolab", "Autechre", ...]}` -- Resolve a batch of names. Returns `identities` (found) and `unresolved` (not found).
+
+Both endpoints return 503 when `DATABASE_URL_DISCOGS` is not set or the entity schema is not applied.
 
 ### Discogs Cache (Optional)
 

--- a/identity/__init__.py
+++ b/identity/__init__.py
@@ -1,0 +1,1 @@
+"""Identity resolution REST API package."""

--- a/identity/dependencies.py
+++ b/identity/dependencies.py
@@ -1,0 +1,54 @@
+"""FastAPI dependency providers for identity resolution."""
+
+import logging
+
+from fastapi import Depends
+
+from config.settings import Settings, get_settings
+from scripts.entity_resolution.sources import PgSource
+from scripts.entity_resolution.store import EntityStore
+
+logger = logging.getLogger(__name__)
+
+_entity_store: EntityStore | None = None
+_entity_pg: PgSource | None = None
+
+
+async def get_entity_store(
+    settings: Settings = Depends(get_settings),
+) -> EntityStore | None:
+    """Get EntityStore instance backed by the discogs-cache database.
+
+    The entity store reuses the ``DATABASE_URL_DISCOGS`` connection since
+    the ``entity`` schema lives in the discogs-cache PostgreSQL database.
+
+    Returns:
+        EntityStore if the database is configured, None otherwise.
+    """
+    global _entity_store, _entity_pg
+
+    if _entity_store is not None:
+        return _entity_store
+
+    dsn = settings.database_url_discogs
+    if not dsn:
+        logger.debug("DATABASE_URL_DISCOGS not set -- entity store disabled")
+        return None
+
+    try:
+        _entity_pg = PgSource(dsn)
+        _entity_store = EntityStore(_entity_pg)
+        logger.info("Entity store initialized")
+        return _entity_store
+    except Exception as e:
+        logger.warning("Failed to initialize entity store: %s: %s", type(e).__name__, e)
+        return None
+
+
+async def close_entity_store() -> None:
+    """Close the entity store PgSource connection."""
+    global _entity_store, _entity_pg
+    if _entity_pg is not None:
+        await _entity_pg.close()
+        _entity_pg = None
+    _entity_store = None

--- a/identity/models.py
+++ b/identity/models.py
@@ -1,0 +1,32 @@
+"""Pydantic response models for identity resolution endpoints."""
+
+from pydantic import BaseModel
+
+
+class IdentityResponse(BaseModel):
+    """A single resolved artist identity with external identifiers."""
+
+    library_name: str
+    discogs_artist_id: int | None = None
+    wikidata_qid: str | None = None
+    musicbrainz_artist_id: str | None = None
+    spotify_artist_id: str | None = None
+    apple_music_artist_id: str | None = None
+    bandcamp_id: str | None = None
+    reconciliation_status: str = "unreconciled"
+
+
+class BulkIdentityRequest(BaseModel):
+    """Request body for bulk identity resolution."""
+
+    names: list[str]
+
+
+class BulkIdentityResponse(BaseModel):
+    """Response for bulk identity resolution.
+
+    Separates successfully resolved identities from unresolved names.
+    """
+
+    identities: list[IdentityResponse]
+    unresolved: list[str]

--- a/identity/router.py
+++ b/identity/router.py
@@ -1,0 +1,101 @@
+"""Identity resolution REST API router.
+
+Provides ``GET /identity/resolve`` and ``POST /identity/bulk`` endpoints
+that query the ``entity.identity`` table in the discogs-cache database.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from identity.dependencies import get_entity_store
+from identity.models import (
+    BulkIdentityRequest,
+    BulkIdentityResponse,
+    IdentityResponse,
+)
+from scripts.entity_resolution.store import EntityStore, Identity
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["identity"])
+
+
+def _identity_to_response(identity: Identity) -> IdentityResponse:
+    """Convert an EntityStore Identity dataclass to a Pydantic response model."""
+    return IdentityResponse(
+        library_name=identity.library_name,
+        discogs_artist_id=identity.discogs_artist_id,
+        wikidata_qid=identity.wikidata_qid,
+        musicbrainz_artist_id=identity.musicbrainz_artist_id,
+        spotify_artist_id=identity.spotify_artist_id,
+        apple_music_artist_id=identity.apple_music_artist_id,
+        bandcamp_id=identity.bandcamp_id,
+        reconciliation_status=identity.reconciliation_status,
+    )
+
+
+def _require_entity_store(store: EntityStore | None) -> EntityStore:
+    """Raise 503 if the entity store is not available."""
+    if store is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
+            "and the entity schema has been applied.",
+        )
+    return store
+
+
+@router.get(
+    "/resolve",
+    response_model=IdentityResponse,
+    summary="Resolve a single artist name to external identifiers",
+    responses={
+        200: {"description": "Identity found"},
+        404: {"description": "No identity found for the given name"},
+        503: {"description": "Entity store not available"},
+    },
+)
+async def resolve_identity(
+    name: str = Query(..., description="Artist name to resolve"),
+    entity_store: EntityStore | None = Depends(get_entity_store),
+) -> IdentityResponse:
+    """Look up a single artist name in the entity identity store."""
+    store = _require_entity_store(entity_store)
+    identity = await store.get_identity(name)
+    if identity is None:
+        raise HTTPException(status_code=404, detail=f"No identity found for '{name}'")
+    return _identity_to_response(identity)
+
+
+@router.post(
+    "/bulk",
+    response_model=BulkIdentityResponse,
+    summary="Resolve multiple artist names to external identifiers",
+    responses={
+        200: {"description": "Bulk resolution completed"},
+        503: {"description": "Entity store not available"},
+    },
+)
+async def bulk_resolve_identities(
+    request: BulkIdentityRequest,
+    entity_store: EntityStore | None = Depends(get_entity_store),
+) -> BulkIdentityResponse:
+    """Resolve multiple artist names in a single request.
+
+    Returns resolved identities and a list of names that could not be found.
+    Designed for batch consumers like semantic-index (20-30K artists).
+    """
+    store = _require_entity_store(entity_store)
+
+    identities: list[IdentityResponse] = []
+    unresolved: list[str] = []
+
+    for name in request.names:
+        identity = await store.get_identity(name)
+        if identity is not None:
+            identities.append(_identity_to_response(identity))
+        else:
+            unresolved.append(name)
+
+    return BulkIdentityResponse(identities=identities, unresolved=unresolved)

--- a/main.py
+++ b/main.py
@@ -15,9 +15,11 @@ from core.dependencies import (
     flush_posthog,
     shutdown_posthog,
 )
+from identity.dependencies import close_entity_store
 from core.logging import setup_logging
 from core.sentry import init_sentry
 from discogs.router import router as discogs_router
+from identity.router import router as identity_router
 from library.router import router as library_router
 from lookup.router import router as lookup_router
 from routers.admin import router as admin_router
@@ -55,6 +57,7 @@ async def lifespan(app: FastAPI):
     shutdown_posthog()
     await close_library_db()
     await close_discogs_service()
+    await close_entity_store()
     logger.info("All services shut down")
 
 
@@ -89,6 +92,7 @@ app.include_router(admin_router, prefix="/admin", tags=["admin"])
 app.include_router(lookup_router, prefix="/api/v1", tags=["lookup"])
 app.include_router(library_router, prefix="/api/v1", tags=["library"])
 app.include_router(discogs_router, prefix="/api/v1", tags=["discogs"])
+app.include_router(identity_router, prefix="/identity", tags=["identity"])
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/unit/test_identity_router.py
+++ b/tests/unit/test_identity_router.py
@@ -1,0 +1,211 @@
+"""Unit tests for identity/router.py REST endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tests.unit.conftest import override_deps
+
+
+@pytest.fixture
+def mock_entity_store():
+    """Mock EntityStore with async methods."""
+    store = AsyncMock()
+    return store
+
+
+@pytest.fixture
+def app_client(mock_settings, mock_entity_store):
+    from config.settings import get_settings
+    from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+    from identity.dependencies import get_entity_store
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: None,
+            get_posthog_client: None,
+            get_settings: mock_settings,
+            get_entity_store: mock_entity_store,
+        },
+    ):
+        yield app
+
+
+def _make_identity_record(
+    library_name: str,
+    *,
+    id: int = 1,
+    discogs_artist_id: int | None = 2154,
+    wikidata_qid: str | None = "Q484464",
+    musicbrainz_artist_id: str | None = "d4133898-91ea-48ea-8820-1b85825901fe",
+    spotify_artist_id: str | None = "1p6GVMFhLhSrRE7qgy8aAS",
+    apple_music_artist_id: str | None = "5765873",
+    bandcamp_id: str | None = None,
+    reconciliation_status: str = "reconciled",
+):
+    """Build a mock Identity dataclass-like object."""
+    from scripts.entity_resolution.store import Identity
+
+    return Identity(
+        id=id,
+        library_name=library_name,
+        discogs_artist_id=discogs_artist_id,
+        wikidata_qid=wikidata_qid,
+        musicbrainz_artist_id=musicbrainz_artist_id,
+        spotify_artist_id=spotify_artist_id,
+        apple_music_artist_id=apple_music_artist_id,
+        bandcamp_id=bandcamp_id,
+        reconciliation_status=reconciliation_status,
+    )
+
+
+class TestResolveEndpoint:
+    @pytest.mark.asyncio
+    async def test_resolve_found(self, app_client, mock_entity_store):
+        """GET /identity/resolve?name=Stereolab returns 200 with full identity."""
+        mock_entity_store.get_identity.return_value = _make_identity_record(
+            "Stereolab",
+            discogs_artist_id=2154,
+            wikidata_qid="Q484464",
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["library_name"] == "Stereolab"
+        assert data["discogs_artist_id"] == 2154
+        assert data["wikidata_qid"] == "Q484464"
+        assert data["reconciliation_status"] == "reconciled"
+        mock_entity_store.get_identity.assert_awaited_once_with("Stereolab")
+
+    @pytest.mark.asyncio
+    async def test_resolve_not_found(self, app_client, mock_entity_store):
+        """GET /identity/resolve?name=Nonexistent returns 404."""
+        mock_entity_store.get_identity.return_value = None
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/identity/resolve", params={"name": "Nonexistent"})
+
+        assert resp.status_code == 404
+        assert "Nonexistent" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_missing_param(self, app_client):
+        """GET /identity/resolve without name param returns 422."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/identity/resolve")
+
+        assert resp.status_code == 422
+
+
+class TestBulkEndpoint:
+    @pytest.mark.asyncio
+    async def test_bulk_resolve(self, app_client, mock_entity_store):
+        """POST /identity/bulk resolves multiple names, separating found and unresolved."""
+        autechre = _make_identity_record("Autechre", id=1, discogs_artist_id=12)
+        stereolab = _make_identity_record("Stereolab", id=2, discogs_artist_id=2154)
+
+        async def mock_get_identity(name: str):
+            mapping = {"Autechre": autechre, "Stereolab": stereolab}
+            return mapping.get(name)
+
+        mock_entity_store.get_identity.side_effect = mock_get_identity
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/identity/bulk",
+                json={"names": ["Autechre", "Stereolab", "Unknown Artist"]},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["identities"]) == 2
+        assert data["unresolved"] == ["Unknown Artist"]
+        names = {i["library_name"] for i in data["identities"]}
+        assert names == {"Autechre", "Stereolab"}
+
+    @pytest.mark.asyncio
+    async def test_bulk_empty_list(self, app_client, mock_entity_store):
+        """POST /identity/bulk with empty names list returns empty results."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/identity/bulk", json={"names": []})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["identities"] == []
+        assert data["unresolved"] == []
+
+    @pytest.mark.asyncio
+    async def test_bulk_large_batch(self, app_client, mock_entity_store):
+        """POST /identity/bulk handles 1000 names without error."""
+        mock_entity_store.get_identity.return_value = None
+        names = [f"Artist_{i}" for i in range(1000)]
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/identity/bulk", json={"names": names})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["unresolved"]) == 1000
+
+    @pytest.mark.asyncio
+    async def test_bulk_all_found(self, app_client, mock_entity_store):
+        """POST /identity/bulk where all names resolve returns no unresolved."""
+        mock_entity_store.get_identity.side_effect = lambda name: _make_identity_record(name)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/identity/bulk",
+                json={"names": ["Autechre", "Stereolab"]},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["identities"]) == 2
+        assert data["unresolved"] == []
+
+
+class TestEntityStoreUnavailable:
+    @pytest.mark.asyncio
+    async def test_resolve_returns_503_when_store_unavailable(self, mock_settings):
+        """GET /identity/resolve returns 503 when entity store is not configured."""
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from identity.dependencies import get_entity_store
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+                get_entity_store: None,
+            },
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
+
+        assert resp.status_code == 503
+        assert "entity store" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

- Add `GET /identity/resolve?name=<artist>` endpoint that queries `entity.identity` for a single artist name, returning external IDs (Discogs, Wikidata, MusicBrainz, Spotify, Apple Music, Bandcamp) or 404
- Add `POST /identity/bulk` endpoint that resolves a batch of artist names, returning found identities and unresolved names separately -- designed for semantic-index's batch needs (20-30K artists)
- Add `identity/` package with Pydantic response models, FastAPI dependency provider (reuses `DATABASE_URL_DISCOGS` pool), and router
- Both endpoints return 503 when the entity store is not configured
- 8 unit tests covering found/not-found/missing-param/bulk/empty/large-batch/all-found/store-unavailable scenarios

Replaces #102. Closes WXYC/library-metadata-lookup#98

## Test plan

- [x] All 8 identity router tests pass
- [x] Existing tests (main.py, health router) unaffected
- [x] ruff check and format pass