### PR TITLE
Add video support to Discogs cache service

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -21,6 +21,7 @@ from discogs.models import (
     MemberRef,
     ReleaseInfo,
     ReleaseMetadataResponse,
+    ReleaseVideo,
     TrackItem,
 )
 
@@ -243,7 +244,7 @@ class DiscogsCacheService:
                 ),
             )
 
-            # Genre/style tables may not exist if the pipeline hasn't been re-run
+            # Genre/style/video tables may not exist if the pipeline hasn't been re-run
             genre_style_results = await asyncio.gather(
                 self.pool.fetch(
                     "SELECT genre FROM release_genre WHERE release_id = $1",
@@ -251,6 +252,15 @@ class DiscogsCacheService:
                 ),
                 self.pool.fetch(
                     "SELECT style FROM release_style WHERE release_id = $1",
+                    release_id,
+                ),
+                self.pool.fetch(
+                    """
+                    SELECT sequence, src, title, duration, embed
+                    FROM release_video
+                    WHERE release_id = $1
+                    ORDER BY sequence
+                    """,
                     release_id,
                 ),
                 return_exceptions=True,
@@ -263,6 +273,11 @@ class DiscogsCacheService:
             style_rows = (
                 genre_style_results[1]
                 if not isinstance(genre_style_results[1], BaseException)
+                else []
+            )
+            video_rows = (
+                genre_style_results[2]
+                if not isinstance(genre_style_results[2], BaseException)
                 else []
             )
 
@@ -314,6 +329,16 @@ class DiscogsCacheService:
                     )
                 )
 
+            videos = [
+                ReleaseVideo(
+                    src=row["src"],
+                    title=row["title"],
+                    duration=row["duration"],
+                    embed=row["embed"] if row["embed"] is not None else True,
+                )
+                for row in video_rows
+            ]
+
             return ReleaseMetadataResponse(
                 release_id=release_id,
                 title=release_row["title"],
@@ -332,6 +357,7 @@ class DiscogsCacheService:
                 extra_artists=extra_artist_credits,
                 labels=label_credits,
                 released=release_row["released"],
+                videos=videos,
             )
 
         except Exception as e:
@@ -440,6 +466,27 @@ class DiscogsCacheService:
                         await conn.executemany(
                             "INSERT INTO release_style (release_id, style) VALUES ($1, $2)",
                             [(release.release_id, s) for s in release.styles],
+                        )
+                except Exception:
+                    pass
+
+                # Delete + re-insert videos (table may not exist yet)
+                try:
+                    await conn.execute(
+                        "DELETE FROM release_video WHERE release_id = $1",
+                        release.release_id,
+                    )
+                    if release.videos:
+                        await conn.executemany(
+                            """
+                            INSERT INTO release_video
+                                (release_id, sequence, src, title, duration, embed)
+                            VALUES ($1, $2, $3, $4, $5, $6)
+                            """,
+                            [
+                                (release.release_id, i + 1, v.src, v.title, v.duration, v.embed)
+                                for i, v in enumerate(release.videos)
+                            ],
                         )
                 except Exception:
                     pass

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -44,6 +44,15 @@ class TrackItem(BaseModel):
     artists: list[str] = []  # Per-track artists (for compilations)
 
 
+class ReleaseVideo(BaseModel):
+    """A video associated with a release."""
+
+    src: str
+    title: str | None = None
+    duration: int | None = None  # Seconds
+    embed: bool = True
+
+
 class ReleaseInfo(BaseModel):
     """Information about a single release containing a track."""
 
@@ -85,6 +94,7 @@ class ReleaseMetadataResponse(BaseModel):
     extra_artists: list[ArtistCredit] = []
     labels: list[LabelCredit] = []
     released: str | None = None  # full date string, e.g. "2024-03-15"
+    videos: list[ReleaseVideo] = []
 
 
 class ArtistRef(BaseModel):

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -41,6 +41,7 @@ from discogs.models import (
     MemberRef,
     ReleaseInfo,
     ReleaseMetadataResponse,
+    ReleaseVideo,
     TrackItem,
     TrackReleasesResponse,
 )
@@ -539,6 +540,18 @@ class DiscogsService:
             images = data.get("images", [])
             artwork_url = images[0].get("uri") if images else None
 
+            # Extract videos (skip entries without a URI)
+            videos = [
+                ReleaseVideo(
+                    src=v["uri"],
+                    title=v.get("title"),
+                    duration=v.get("duration"),
+                    embed=v.get("embed", True),
+                )
+                for v in data.get("videos", [])
+                if v.get("uri")
+            ]
+
             release = ReleaseMetadataResponse(
                 release_id=release_id,
                 title=data.get("title", ""),
@@ -557,6 +570,7 @@ class DiscogsService:
                 extra_artists=extra_artist_credits,
                 labels=label_credits,
                 released=released,
+                videos=videos,
             )
 
             # Write back to cache for future queries

--- a/main.py
+++ b/main.py
@@ -15,10 +15,10 @@ from core.dependencies import (
     flush_posthog,
     shutdown_posthog,
 )
-from identity.dependencies import close_entity_store
 from core.logging import setup_logging
 from core.sentry import init_sentry
 from discogs.router import router as discogs_router
+from identity.dependencies import close_entity_store
 from identity.router import router as identity_router
 from library.router import router as library_router
 from lookup.router import router as lookup_router

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -287,8 +287,20 @@ class TestGetRelease:
                 release_genre=[],
                 release_style=[],
                 release_video=[
-                    {"sequence": 1, "src": "https://www.youtube.com/watch?v=abc", "title": "Metronomic Underground", "duration": 456, "embed": True},
-                    {"sequence": 2, "src": "https://www.youtube.com/watch?v=def", "title": "French Disko", "duration": 204, "embed": False},
+                    {
+                        "sequence": 1,
+                        "src": "https://www.youtube.com/watch?v=abc",
+                        "title": "Metronomic Underground",
+                        "duration": 456,
+                        "embed": True,
+                    },
+                    {
+                        "sequence": 2,
+                        "src": "https://www.youtube.com/watch?v=def",
+                        "title": "French Disko",
+                        "duration": 204,
+                        "embed": False,
+                    },
                 ],
             )
         )
@@ -483,8 +495,17 @@ class TestWriteRelease:
             artist="Stereolab",
             release_url="https://discogs.com/release/1",
             videos=[
-                ReleaseVideo(src="https://www.youtube.com/watch?v=abc", title="Metronomic Underground", duration=456),
-                ReleaseVideo(src="https://www.youtube.com/watch?v=def", title="French Disko", duration=204, embed=False),
+                ReleaseVideo(
+                    src="https://www.youtube.com/watch?v=abc",
+                    title="Metronomic Underground",
+                    duration=456,
+                ),
+                ReleaseVideo(
+                    src="https://www.youtube.com/watch?v=def",
+                    title="French Disko",
+                    duration=204,
+                    embed=False,
+                ),
             ],
         )
 
@@ -497,7 +518,9 @@ class TestWriteRelease:
         all_executemany_sql = [call[0][0] for call in conn.executemany.call_args_list]
         assert any("release_video" in sql for sql in all_executemany_sql)
 
-        video_insert = next(c for c in conn.executemany.call_args_list if "release_video" in c[0][0])
+        video_insert = next(
+            c for c in conn.executemany.call_args_list if "release_video" in c[0][0]
+        )
         rows = video_insert[0][1]
         assert len(rows) == 2
         assert rows[0][1] == 1  # sequence 1
@@ -509,7 +532,9 @@ class TestWriteRelease:
         assert rows[1][5] is False
 
     @pytest.mark.asyncio
-    async def test_write_release_without_videos_skips_insert(self, cache_service, mock_asyncpg_pool):
+    async def test_write_release_without_videos_skips_insert(
+        self, cache_service, mock_asyncpg_pool
+    ):
         """write_release with no videos deletes old rows but skips executemany INSERT."""
         release = ReleaseMetadataResponse(
             release_id=1,

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -12,6 +12,7 @@ from discogs.models import (
     LabelCredit,
     MemberRef,
     ReleaseMetadataResponse,
+    ReleaseVideo,
     TrackItem,
 )
 
@@ -264,6 +265,98 @@ class TestGetRelease:
         assert result.tracklist[0].artists == ["Some Artist"]
 
     @pytest.mark.asyncio
+    async def test_reads_videos(self, cache_service, mock_asyncpg_pool):
+        """get_release returns videos fetched from release_video table."""
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 1,
+                "title": "Emperor Tomato Ketchup",
+                "release_year": 1996,
+                "artwork_url": None,
+                "released": None,
+            }
+        )
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[],
+                release_track=[],
+                release_artist=[
+                    {"artist_id": None, "artist_name": "Stereolab", "extra": 0, "role": None}
+                ],
+                release_label=[],
+                release_genre=[],
+                release_style=[],
+                release_video=[
+                    {"sequence": 1, "src": "https://www.youtube.com/watch?v=abc", "title": "Metronomic Underground", "duration": 456, "embed": True},
+                    {"sequence": 2, "src": "https://www.youtube.com/watch?v=def", "title": "French Disko", "duration": 204, "embed": False},
+                ],
+            )
+        )
+
+        result = await cache_service.get_release(1)
+        assert result is not None
+        assert len(result.videos) == 2
+        assert result.videos[0].src == "https://www.youtube.com/watch?v=abc"
+        assert result.videos[0].title == "Metronomic Underground"
+        assert result.videos[0].duration == 456
+        assert result.videos[0].embed is True
+        assert result.videos[1].embed is False
+
+    @pytest.mark.asyncio
+    async def test_reads_videos_empty_when_none_exist(self, cache_service, mock_asyncpg_pool):
+        """get_release returns empty videos list when release has no videos."""
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 1,
+                "title": "Aluminum Tunes",
+                "release_year": 1998,
+                "artwork_url": None,
+                "released": None,
+            }
+        )
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[],
+                release_track=[],
+                release_artist=[
+                    {"artist_id": None, "artist_name": "Stereolab", "extra": 0, "role": None}
+                ],
+                release_label=[],
+                release_genre=[],
+                release_style=[],
+                release_video=[],
+            )
+        )
+
+        result = await cache_service.get_release(1)
+        assert result is not None
+        assert result.videos == []
+
+    @pytest.mark.asyncio
+    async def test_videos_gracefully_absent(self, cache_service, mock_asyncpg_pool):
+        """get_release returns empty videos list when release_video table does not exist."""
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 1,
+                "title": "Emperor Tomato Ketchup",
+                "release_year": 1996,
+                "artwork_url": None,
+                "released": None,
+            }
+        )
+
+        def raise_on_video(query, *args):
+            if "release_video" in query:
+                raise Exception("relation does not exist")
+            return []
+
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=raise_on_video)
+
+        result = await cache_service.get_release(1)
+        assert result is not None
+        assert result.videos == []
+
+    @pytest.mark.asyncio
     async def test_error_raises(self, cache_service, mock_asyncpg_pool):
         mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=Exception("db error"))
         with pytest.raises(CacheUnavailableError):
@@ -380,6 +473,84 @@ class TestWriteRelease:
         # The data should contain all 3 artists
         artist_data = artist_inserts[0][0][1]
         assert len(artist_data) == 3
+
+    @pytest.mark.asyncio
+    async def test_writes_videos(self, cache_service, mock_asyncpg_pool):
+        """write_release persists videos to release_video table."""
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Emperor Tomato Ketchup",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/1",
+            videos=[
+                ReleaseVideo(src="https://www.youtube.com/watch?v=abc", title="Metronomic Underground", duration=456),
+                ReleaseVideo(src="https://www.youtube.com/watch?v=def", title="French Disko", duration=204, embed=False),
+            ],
+        )
+
+        await cache_service.write_release(release)
+        conn = mock_asyncpg_pool._mock_conn
+
+        all_sql = [call[0][0] for call in conn.execute.call_args_list]
+        assert any("DELETE FROM release_video" in sql for sql in all_sql)
+
+        all_executemany_sql = [call[0][0] for call in conn.executemany.call_args_list]
+        assert any("release_video" in sql for sql in all_executemany_sql)
+
+        video_insert = next(c for c in conn.executemany.call_args_list if "release_video" in c[0][0])
+        rows = video_insert[0][1]
+        assert len(rows) == 2
+        assert rows[0][1] == 1  # sequence 1
+        assert rows[0][2] == "https://www.youtube.com/watch?v=abc"
+        assert rows[0][3] == "Metronomic Underground"
+        assert rows[0][4] == 456
+        assert rows[0][5] is True
+        assert rows[1][1] == 2  # sequence 2
+        assert rows[1][5] is False
+
+    @pytest.mark.asyncio
+    async def test_write_release_without_videos_skips_insert(self, cache_service, mock_asyncpg_pool):
+        """write_release with no videos deletes old rows but skips executemany INSERT."""
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Aluminum Tunes",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/1",
+        )
+
+        await cache_service.write_release(release)
+        conn = mock_asyncpg_pool._mock_conn
+
+        # DELETE FROM release_video should still be called (to clear stale data)
+        all_sql = [call[0][0] for call in conn.execute.call_args_list]
+        assert any("DELETE FROM release_video" in sql for sql in all_sql)
+
+        # No executemany INSERT for release_video (no videos to write)
+        all_executemany_sql = [call[0][0] for call in conn.executemany.call_args_list]
+        assert not any("release_video" in sql for sql in all_executemany_sql)
+
+    @pytest.mark.asyncio
+    async def test_videos_table_absent_is_nonfatal(self, cache_service, mock_asyncpg_pool):
+        """write_release does not raise if release_video table does not exist."""
+        conn = mock_asyncpg_pool._mock_conn
+
+        def raise_on_video(sql, *args):
+            if "release_video" in sql:
+                raise Exception("relation does not exist")
+
+        conn.execute = AsyncMock(side_effect=raise_on_video)
+
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Emperor Tomato Ketchup",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/1",
+            videos=[
+                ReleaseVideo(src="https://www.youtube.com/watch?v=abc"),
+            ],
+        )
+        # Must not raise
+        await cache_service.write_release(release)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_discogs_models.py
+++ b/tests/unit/test_discogs_models.py
@@ -241,8 +241,14 @@ class TestReleaseMetadataResponseVideos:
             artist="Stereolab",
             release_url="https://www.discogs.com/release/1",
             videos=[
-                ReleaseVideo(src="https://www.youtube.com/watch?v=abc", title="Metronomic Underground", duration=456),
-                ReleaseVideo(src="https://www.youtube.com/watch?v=def", title="French Disko", duration=204),
+                ReleaseVideo(
+                    src="https://www.youtube.com/watch?v=abc",
+                    title="Metronomic Underground",
+                    duration=456,
+                ),
+                ReleaseVideo(
+                    src="https://www.youtube.com/watch?v=def", title="French Disko", duration=204
+                ),
             ],
         )
         assert len(release.videos) == 2

--- a/tests/unit/test_discogs_models.py
+++ b/tests/unit/test_discogs_models.py
@@ -8,6 +8,7 @@ from discogs.models import (
     LabelCredit,
     MemberRef,
     ReleaseMetadataResponse,
+    ReleaseVideo,
 )
 from generated.api_models import DiscogsMatchResult
 
@@ -192,3 +193,58 @@ class TestArtistDetails:
     def test_member_ref_defaults(self):
         ref = MemberRef(id=200, name="Rob Brown")
         assert ref.active is True
+
+
+# ---------------------------------------------------------------------------
+# ReleaseVideo model
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseVideo:
+    def test_required_field(self):
+        video = ReleaseVideo(src="https://www.youtube.com/watch?v=abc")
+        assert video.src == "https://www.youtube.com/watch?v=abc"
+        assert video.title is None
+        assert video.duration is None
+        assert video.embed is True
+
+    def test_all_fields(self):
+        video = ReleaseVideo(
+            src="https://www.youtube.com/watch?v=abc",
+            title="Stereolab - French Disko",
+            duration=204,
+            embed=False,
+        )
+        assert video.title == "Stereolab - French Disko"
+        assert video.duration == 204
+        assert video.embed is False
+
+    def test_embed_defaults_true(self):
+        video = ReleaseVideo(src="https://www.youtube.com/watch?v=abc")
+        assert video.embed is True
+
+
+class TestReleaseMetadataResponseVideos:
+    def test_videos_default_to_empty(self):
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Emperor Tomato Ketchup",
+            artist="Stereolab",
+            release_url="https://www.discogs.com/release/1",
+        )
+        assert release.videos == []
+
+    def test_videos_populated(self):
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Emperor Tomato Ketchup",
+            artist="Stereolab",
+            release_url="https://www.discogs.com/release/1",
+            videos=[
+                ReleaseVideo(src="https://www.youtube.com/watch?v=abc", title="Metronomic Underground", duration=456),
+                ReleaseVideo(src="https://www.youtube.com/watch?v=def", title="French Disko", duration=204),
+            ],
+        )
+        assert len(release.videos) == 2
+        assert release.videos[0].title == "Metronomic Underground"
+        assert release.videos[1].duration == 204

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -469,6 +469,95 @@ class TestGetRelease:
 
         assert result is not None
 
+    @pytest.mark.asyncio
+    async def test_api_maps_videos(self, service):
+        """Videos in API response are mapped to ReleaseVideo objects."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "Emperor Tomato Ketchup",
+            "artists": [{"name": "Stereolab"}],
+            "year": 1996,
+            "labels": [],
+            "genres": ["Electronic"],
+            "styles": ["Krautrock"],
+            "tracklist": [],
+            "images": [],
+            "videos": [
+                {"uri": "https://www.youtube.com/watch?v=abc", "title": "Metronomic Underground", "duration": 456, "embed": True},
+                {"uri": "https://www.youtube.com/watch?v=def", "title": "French Disko", "duration": 204, "embed": False},
+            ],
+        }
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_release(12345)
+
+        assert result is not None
+        assert len(result.videos) == 2
+        assert result.videos[0].src == "https://www.youtube.com/watch?v=abc"
+        assert result.videos[0].title == "Metronomic Underground"
+        assert result.videos[0].duration == 456
+        assert result.videos[0].embed is True
+        assert result.videos[1].embed is False
+
+    @pytest.mark.asyncio
+    async def test_empty_uri_videos_are_skipped(self, service):
+        """Videos without a URI are not included in the result."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "On Your Own Love Again",
+            "artists": [{"name": "Jessica Pratt"}],
+            "year": 2015,
+            "labels": [],
+            "genres": [],
+            "styles": [],
+            "tracklist": [],
+            "images": [],
+            "videos": [
+                {"uri": "https://www.youtube.com/watch?v=abc", "title": "Moon Dust", "duration": 180, "embed": True},
+                {"uri": "", "title": "No URI video", "duration": 100, "embed": True},
+                {"title": "Missing URI key entirely", "duration": 100, "embed": True},
+            ],
+        }
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_release(99)
+
+        assert result is not None
+        assert len(result.videos) == 1
+        assert result.videos[0].src == "https://www.youtube.com/watch?v=abc"
+
+    @pytest.mark.asyncio
+    async def test_no_videos_in_api_response(self, service):
+        """Releases without videos return an empty videos list."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "DOGA",
+            "artists": [{"name": "Juana Molina"}],
+            "labels": [],
+            "genres": [],
+            "styles": [],
+            "tracklist": [],
+            "images": [],
+        }
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_release(55)
+
+        assert result is not None
+        assert result.videos == []
+
 
 # ---------------------------------------------------------------------------
 # search

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -485,8 +485,18 @@ class TestGetRelease:
             "tracklist": [],
             "images": [],
             "videos": [
-                {"uri": "https://www.youtube.com/watch?v=abc", "title": "Metronomic Underground", "duration": 456, "embed": True},
-                {"uri": "https://www.youtube.com/watch?v=def", "title": "French Disko", "duration": 204, "embed": False},
+                {
+                    "uri": "https://www.youtube.com/watch?v=abc",
+                    "title": "Metronomic Underground",
+                    "duration": 456,
+                    "embed": True,
+                },
+                {
+                    "uri": "https://www.youtube.com/watch?v=def",
+                    "title": "French Disko",
+                    "duration": 204,
+                    "embed": False,
+                },
             ],
         }
 
@@ -519,7 +529,12 @@ class TestGetRelease:
             "tracklist": [],
             "images": [],
             "videos": [
-                {"uri": "https://www.youtube.com/watch?v=abc", "title": "Moon Dust", "duration": 180, "embed": True},
+                {
+                    "uri": "https://www.youtube.com/watch?v=abc",
+                    "title": "Moon Dust",
+                    "duration": 180,
+                    "embed": True,
+                },
                 {"uri": "", "title": "No URI video", "duration": 100, "embed": True},
                 {"title": "Missing URI key entirely", "duration": 100, "embed": True},
             ],

--- a/tests/unit/test_fallback_paths.py
+++ b/tests/unit/test_fallback_paths.py
@@ -17,9 +17,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from scripts.streaming_availability.discogs_enricher import (
-    build_artist_mapping,
     check_wxyc_schema,
     enrich_album,
+    load_entity_store_mapping,
     pick_best_match,
 )
 from scripts.streaming_availability.matching import score_match
@@ -210,41 +210,43 @@ class TestEnrichAlbumFallbackPath:
         assert result is None
 
 
-class TestArtistMappingFallbackPath:
-    """Test that when the artist_names fuzzy table is unavailable (connection error),
-    build_artist_mapping gracefully returns an empty mapping instead of crashing."""
+class TestEntityStoreMappingFallbackPath:
+    """Test that when the entity store is unavailable (connection error),
+    load_entity_store_mapping gracefully returns an empty mapping instead of crashing."""
 
     @pytest.mark.asyncio
     async def test_connection_failure_returns_empty_mapping(self) -> None:
-        """When the PG pool raises on every fetch, mapping is empty (not crash)."""
+        """When the PG pool raises on fetch, mapping is empty (not crash)."""
         pool = AsyncMock()
         pool.fetch = AsyncMock(side_effect=Exception("Connection refused"))
-        mapping = await build_artist_mapping(pool, LIBRARY_ARTISTS)
+        mapping = await load_entity_store_mapping(pool)
         assert mapping == {}
 
     @pytest.mark.asyncio
-    async def test_partial_failure_returns_partial_mapping(self) -> None:
-        """When some artist lookups fail, the mapping includes successful ones only."""
+    async def test_successful_mapping(self) -> None:
+        """When entity.identity has reconciled artists, they appear in the mapping."""
         pool = AsyncMock()
-        # First call succeeds (Bjork -> Bjork with diacritics), second fails
         pool.fetch = AsyncMock(
-            side_effect=[
-                [{"artist_name": "Bjork"}],
-                Exception("timeout"),
+            return_value=[
+                {"library_name": "Stereolab", "discogs_artist_id": 1000},
+                {"library_name": "Autechre", "discogs_artist_id": 77},
             ]
         )
-        mapping = await build_artist_mapping(pool, ["Bjork", "Stereolab"])
-        # Bjork matches exactly (case-insensitive), so it's excluded from mapping
-        # Stereolab errored out, so no mapping entry
-        assert mapping == {}
+        mapping = await load_entity_store_mapping(pool)
+        assert mapping == {"Stereolab": 1000, "Autechre": 77}
 
     @pytest.mark.asyncio
-    async def test_successful_mapping_with_name_variant(self) -> None:
-        """When artist_names returns a variant, it appears in the mapping."""
+    async def test_null_discogs_id_excluded(self) -> None:
+        """Rows with null discogs_artist_id are excluded from the mapping."""
         pool = AsyncMock()
-        pool.fetch = AsyncMock(return_value=[{"artist_name": "Stetsasonic"}])
-        mapping = await build_artist_mapping(pool, ["Stetasonic"])
-        assert mapping == {"Stetasonic": "Stetsasonic"}
+        pool.fetch = AsyncMock(
+            return_value=[
+                {"library_name": "Stereolab", "discogs_artist_id": 1000},
+                {"library_name": "Unknown Artist", "discogs_artist_id": None},
+            ]
+        )
+        mapping = await load_entity_store_mapping(pool)
+        assert mapping == {"Stereolab": 1000}
 
 
 class TestPickBestMatchFallbackParity:

--- a/tests/unit/test_identity_router.py
+++ b/tests/unit/test_identity_router.py
@@ -1,6 +1,6 @@
 """Unit tests for identity/router.py REST endpoints."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient


### PR DESCRIPTION
## Summary

- Add `ReleaseVideo` model to discogs/models.py
- Update `write_release()` to persist video data
- Update `get_release()` to read video data from cache
- Map Discogs API video response (`uri` field) to model
- Graceful degradation when `release_video` table doesn't exist

## Test plan

- [x] Unit tests: ReleaseVideo model, ReleaseMetadataResponseVideos
- [x] Unit tests: cache_service write/read with video data
- [x] Unit tests: service.py video extraction from API response