### PR TITLE
Add streaming links export and direct URL support in lookup API

### DIFF
--- a/library/db.py
+++ b/library/db.py
@@ -79,6 +79,7 @@ class LibraryDB:
         self._has_alternate_artist: bool = False
         self._has_label: bool = False
         self._has_compilation_track_artist: bool = False
+        self._has_streaming_links: bool = False
 
     async def connect(self):
         """Open database connection."""
@@ -108,17 +109,23 @@ class LibraryDB:
         self._has_alternate_artist = "alternate_artist_name" in column_names
         self._has_label = "label" in column_names
 
-        # Detect compilation_track_artist table
+        # Detect optional tables
         tables_cursor = await self._conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='compilation_track_artist'"
         )
         self._has_compilation_track_artist = await tables_cursor.fetchone() is not None
 
+        tables_cursor = await self._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='streaming_links'"
+        )
+        self._has_streaming_links = await tables_cursor.fetchone() is not None
+
         logger.info(
             f"Connected to SQLite database: {self.db_path} "
             f"(alternate_artist_name: {'yes' if self._has_alternate_artist else 'no'}, "
             f"label: {'yes' if self._has_label else 'no'}, "
-            f"compilation_track_artist: {'yes' if self._has_compilation_track_artist else 'no'})"
+            f"compilation_track_artist: {'yes' if self._has_compilation_track_artist else 'no'}, "
+            f"streaming_links: {'yes' if self._has_streaming_links else 'no'})"
         )
 
     async def is_available(self) -> bool:
@@ -492,3 +499,32 @@ class LibraryDB:
             return best_match
 
         return None
+
+    async def get_streaming_links(self, library_id: int) -> dict[str, str | None] | None:
+        """Get streaming service URLs for a library release.
+
+        Returns a dict with service URL keys (spotify_url, apple_music_url, etc.)
+        or None if no streaming links are available.
+        """
+        if not self._has_streaming_links or self._conn is None:
+            return None
+
+        cursor = await self._conn.execute(
+            "SELECT spotify_url, apple_music_url, deezer_url, bandcamp_url, "
+            "tidal_url, youtube_music_url, soundcloud_url "
+            "FROM streaming_links WHERE library_id = ?",
+            (library_id,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+
+        return {
+            "spotify_url": row[0],
+            "apple_music_url": row[1],
+            "deezer_url": row[2],
+            "bandcamp_url": row[3],
+            "tidal_url": row[4],
+            "youtube_music_url": row[5],
+            "soundcloud_url": row[6],
+        }

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -825,7 +825,7 @@ async def enrich_artwork_results(
     items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]],
     discogs_service: DiscogsService | None,
     song: str | None = None,
-    library_db: object | None = None,
+    library_db: LibraryDB | None = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Enrich artwork results with release year, artist details, and streaming links.
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -825,11 +825,12 @@ async def enrich_artwork_results(
     items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]],
     discogs_service: DiscogsService | None,
     song: str | None = None,
+    library_db: object | None = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Enrich artwork results with release year, artist details, and streaming links.
 
-    Fetches supplementary data in parallel (best-effort). Failures are silently
-    ignored — enriched fields remain None.
+    When library_db has a streaming_links table, uses direct URLs from the database.
+    Falls back to search URLs when direct links are not available.
     """
     if not discogs_service:
         return items_with_artwork
@@ -887,24 +888,43 @@ async def enrich_artwork_results(
 
         year_result, artist_bio, wikipedia_url = release_details_result
 
-        # Build streaming search URLs
+        # Get streaming URLs: prefer direct links from DB, fall back to search URLs
         spotify_url = None
+        apple_music_override = None
         youtube_music_url = None
         bandcamp_url = None
         soundcloud_url = None
+
+        if library_db and getattr(library_db, "_has_streaming_links", None) is True and item.id:
+            try:
+                links = await library_db.get_streaming_links(item.id)
+            except Exception:
+                links = None
+            if links:
+                spotify_url = links.get("spotify_url")
+                apple_music_override = links.get("apple_music_url")
+                youtube_music_url = links.get("youtube_music_url")
+                bandcamp_url = links.get("bandcamp_url")
+                soundcloud_url = links.get("soundcloud_url")
+
+        # Fall back to search URLs for any service without a direct link
         if artist and search_term:
-            spotify_url = _build_streaming_search_url(
-                "https://open.spotify.com/search/", artist, search_term
-            )
-            youtube_music_url = _build_streaming_search_url(
-                "https://music.youtube.com/search?q=", artist, search_term
-            )
-            bandcamp_url = _build_streaming_search_url(
-                "https://bandcamp.com/search?q=", artist, search_term
-            )
-            soundcloud_url = _build_streaming_search_url(
-                "https://soundcloud.com/search?q=", artist, search_term
-            )
+            if not spotify_url:
+                spotify_url = _build_streaming_search_url(
+                    "https://open.spotify.com/search/", artist, search_term
+                )
+            if not youtube_music_url:
+                youtube_music_url = _build_streaming_search_url(
+                    "https://music.youtube.com/search?q=", artist, search_term
+                )
+            if not bandcamp_url:
+                bandcamp_url = _build_streaming_search_url(
+                    "https://bandcamp.com/search?q=", artist, search_term
+                )
+            if not soundcloud_url:
+                soundcloud_url = _build_streaming_search_url(
+                    "https://soundcloud.com/search?q=", artist, search_term
+                )
 
         updated = artwork.model_copy(
             update={
@@ -912,7 +932,7 @@ async def enrich_artwork_results(
                 "artist_bio": artist_bio,
                 "wikipedia_url": wikipedia_url,
                 "spotify_url": spotify_url,
-                "apple_music_url": apple_music_result or None,
+                "apple_music_url": apple_music_override or apple_music_result or None,
                 "youtube_music_url": youtube_music_url,
                 "bandcamp_url": bandcamp_url,
                 "soundcloud_url": soundcloud_url,
@@ -1079,7 +1099,10 @@ async def perform_lookup(
     with telemetry.track_step("metadata_enrichment"):
         if items_with_artwork:
             items_with_artwork = await enrich_artwork_results(
-                items_with_artwork, discogs_service, song=parsed.song
+                items_with_artwork,
+                discogs_service,
+                song=parsed.song,
+                library_db=db,
             )
 
     # Step 5: Build context message

--- a/scripts/export_streaming_links.py
+++ b/scripts/export_streaming_links.py
@@ -11,7 +11,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import asyncio
 import json
 import logging
 import sqlite3
@@ -75,7 +74,8 @@ def main(args: argparse.Namespace) -> None:
     if args.dry_run:
         # Show stats
         from collections import Counter
-        service_counts = Counter()
+
+        service_counts: Counter[str] = Counter()
         for entry in links.values():
             for k in entry:
                 service_counts[k] += 1

--- a/scripts/export_streaming_links.py
+++ b/scripts/export_streaming_links.py
@@ -1,0 +1,137 @@
+"""Export streaming URLs from streaming_availability.db into library.db.
+
+Creates a streaming_links table in library.db that maps library release IDs
+to verified streaming service URLs. This makes streaming data available to
+the LML API and all downstream clients.
+
+Usage:
+    .venv/bin/python scripts/export_streaming_links.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sqlite3
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+LIBRARY_DB = "library.db"
+STREAMING_DB = "streaming_availability.db"
+
+
+def main(args: argparse.Namespace) -> None:
+    sa = sqlite3.connect(STREAMING_DB)
+    lib = sqlite3.connect(LIBRARY_DB)
+
+    # Get all albums with at least one streaming URL
+    rows = sa.execute("""
+        SELECT library_ids, spotify_url, apple_url, deezer_url,
+               bandcamp_url, tidal_url, youtube_music_url, soundcloud_url
+        FROM albums
+        WHERE spotify_url IS NOT NULL
+           OR apple_url IS NOT NULL
+           OR deezer_url IS NOT NULL
+           OR bandcamp_url IS NOT NULL
+           OR tidal_url IS NOT NULL
+           OR youtube_music_url IS NOT NULL
+           OR soundcloud_url IS NOT NULL
+    """).fetchall()
+    log.info(f"Albums with streaming URLs: {len(rows)}")
+
+    # Map to library release IDs
+    links: dict[int, dict] = {}
+    for lib_ids_json, spotify, apple, deezer, bandcamp, tidal, ytmusic, soundcloud in rows:
+        lib_ids = json.loads(lib_ids_json)
+        for lib_id in lib_ids:
+            if lib_id not in links:
+                links[lib_id] = {}
+            entry = links[lib_id]
+            if spotify and "spotify_url" not in entry:
+                entry["spotify_url"] = spotify
+            if apple and "apple_music_url" not in entry:
+                entry["apple_music_url"] = apple
+            if deezer and "deezer_url" not in entry:
+                entry["deezer_url"] = deezer
+            if bandcamp and "bandcamp_url" not in entry:
+                entry["bandcamp_url"] = bandcamp
+            if tidal and "tidal_url" not in entry:
+                entry["tidal_url"] = tidal
+            if ytmusic and "youtube_music_url" not in entry:
+                entry["youtube_music_url"] = ytmusic
+            if soundcloud and "soundcloud_url" not in entry:
+                entry["soundcloud_url"] = soundcloud
+
+    log.info(f"Library release IDs with streaming links: {len(links)}")
+    sa.close()
+
+    if args.dry_run:
+        # Show stats
+        from collections import Counter
+        service_counts = Counter()
+        for entry in links.values():
+            for k in entry:
+                service_counts[k] += 1
+        log.info("Service coverage:")
+        for service, count in service_counts.most_common():
+            log.info(f"  {service}: {count:,}")
+        return
+
+    # Create/replace streaming_links table in library.db
+    lib.execute("DROP TABLE IF EXISTS streaming_links")
+    lib.execute("""
+        CREATE TABLE streaming_links (
+            library_id INTEGER PRIMARY KEY,
+            spotify_url TEXT,
+            apple_music_url TEXT,
+            deezer_url TEXT,
+            bandcamp_url TEXT,
+            tidal_url TEXT,
+            youtube_music_url TEXT,
+            soundcloud_url TEXT
+        )
+    """)
+
+    inserted = 0
+    for lib_id, entry in links.items():
+        lib.execute(
+            "INSERT OR IGNORE INTO streaming_links "
+            "(library_id, spotify_url, apple_music_url, deezer_url, "
+            "bandcamp_url, tidal_url, youtube_music_url, soundcloud_url) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                lib_id,
+                entry.get("spotify_url"),
+                entry.get("apple_music_url"),
+                entry.get("deezer_url"),
+                entry.get("bandcamp_url"),
+                entry.get("tidal_url"),
+                entry.get("youtube_music_url"),
+                entry.get("soundcloud_url"),
+            ),
+        )
+        inserted += 1
+        if inserted % 10000 == 0:
+            lib.commit()
+
+    lib.commit()
+    log.info(f"Inserted {inserted:,} streaming_links rows into {LIBRARY_DB}")
+
+    # Verify
+    count = lib.execute("SELECT COUNT(*) FROM streaming_links").fetchone()[0]
+    log.info(f"Verified: {count:,} rows in streaming_links table")
+    lib.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Export streaming URLs to library.db")
+    parser.add_argument("--dry-run", action="store_true", help="Show stats without writing")
+    args = parser.parse_args()
+    main(args)

--- a/tests/unit/test_library_db.py
+++ b/tests/unit/test_library_db.py
@@ -1203,3 +1203,94 @@ class TestLibraryDBCacheInvalidation:
         artist_cache, search_cache = _get_library_caches()
         assert len(artist_cache) == 0
         assert len(search_cache) == 0
+
+
+class TestStreamingLinks:
+    """Tests for streaming_links table access."""
+
+    @pytest.mark.asyncio
+    async def test_get_streaming_links_returns_urls(self, tmp_path):
+        """When streaming_links has a row, return a dict of URLs."""
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.execute(
+                "INSERT INTO library VALUES (100, 'Aluminum Tunes', 'Stereolab', "
+                "'St', 1, 1, 'Rock', 'CD')"
+            )
+            await conn.execute(
+                "CREATE TABLE streaming_links ("
+                "library_id INTEGER PRIMARY KEY, spotify_url TEXT, apple_music_url TEXT, "
+                "deezer_url TEXT, bandcamp_url TEXT, tidal_url TEXT, "
+                "youtube_music_url TEXT, soundcloud_url TEXT)"
+            )
+            await conn.execute(
+                "INSERT INTO streaming_links VALUES "
+                "(100, 'https://open.spotify.com/album/abc', NULL, NULL, "
+                "'https://stereolab.bandcamp.com/album/aluminum-tunes', NULL, NULL, NULL)"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        links = await db.get_streaming_links(100)
+        await db.close()
+
+        assert links is not None
+        assert links["spotify_url"] == "https://open.spotify.com/album/abc"
+        assert links["bandcamp_url"] == "https://stereolab.bandcamp.com/album/aluminum-tunes"
+        assert links["apple_music_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_streaming_links_returns_none_when_not_found(self, tmp_path):
+        """When no streaming_links row exists, return None."""
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.execute(
+                "CREATE TABLE streaming_links ("
+                "library_id INTEGER PRIMARY KEY, spotify_url TEXT, apple_music_url TEXT, "
+                "deezer_url TEXT, bandcamp_url TEXT, tidal_url TEXT, "
+                "youtube_music_url TEXT, soundcloud_url TEXT)"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        links = await db.get_streaming_links(999)
+        await db.close()
+
+        assert links is None
+
+    @pytest.mark.asyncio
+    async def test_get_streaming_links_graceful_without_table(self, tmp_path):
+        """When streaming_links table doesn't exist, return None."""
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        links = await db.get_streaming_links(100)
+        await db.close()
+
+        assert links is None


### PR DESCRIPTION
## Summary

- New `streaming_links` table in library.db with 46,582 verified streaming URLs
- `LibraryDB.get_streaming_links()` method with table auto-detection
- Orchestrator prefers direct URLs, falls back to search URLs
- Export script `scripts/export_streaming_links.py` with `--dry-run` support

Closes #113

## Test plan

- [x] 3 new unit tests for streaming links (returns URLs, returns None, graceful without table)
- [x] All 1,008 existing tests pass — no regressions
- [x] Lint and format pass