### PR TITLE
Fix false positive in track validation for album name mismatches

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -698,6 +698,19 @@ async def filter_results_by_track_validation(
 
             best_result = response.results[0]
             if best_result.release_id:
+                # Verify the Discogs result is actually the same album, not a
+                # different release that shares words with the library title.
+                # e.g., searching for "808 State" might return "The Best Of
+                # 808 State: Blueprint" — a different album entirely.
+                discogs_album = (best_result.album or "").lower()
+                library_title = (item.title or "").lower()
+                if not album_title_acceptable(library_title, discogs_album):
+                    logger.debug(
+                        f"Track validation: Discogs returned '{best_result.album}' "
+                        f"for library item '{item.title}' — album mismatch, skipping"
+                    )
+                    return None
+
                 is_valid = await discogs_service.validate_track_on_release(
                     best_result.release_id, song, artist
                 )

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -591,9 +591,9 @@ class TestSearchLibraryWithFallback:
         )
         # The self-titled album should be included because "S/t" means the
         # album name is the same as the artist name.
-        assert any(r.title == "S/t" for r in results), (
-            "Self-titled album 'S/t' should match when Discogs album is the artist name"
-        )
+        assert any(
+            r.title == "S/t" for r in results
+        ), "Self-titled album 'S/t' should match when Discogs album is the artist name"
         assert fallback is False
 
     @pytest.mark.asyncio
@@ -715,6 +715,31 @@ class TestFilterResultsByTrackValidation:
 
         result = await filter_results_by_track_validation(
             items, "Unknown Song", "Queen", mock_discogs_service
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_discogs_returns_different_album(self, mock_discogs_service):
+        """Discogs search for library album '808 State' returns 'The Best Of 808 State:
+        Blueprint' — a different album that contains the track. The validation should
+        reject this because the Discogs album doesn't match the library item's title.
+
+        Bug: WXYC/library-metadata-lookup#115
+        """
+        items = [make_library_item(id=958, artist="808 State", title="808 State")]
+
+        # Discogs search for album="808 State" returns a best-of compilation
+        wrong_album = make_discogs_result(
+            release_id=7641756,
+            album="The Best Of 808 State: Blueprint",
+            artist="808 State",
+        )
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[wrong_album])
+        # Track IS on that compilation — but it's the wrong album
+        mock_discogs_service.validate_track_on_release.return_value = True
+
+        result = await filter_results_by_track_validation(
+            items, "Flow Coma", "808 State", mock_discogs_service
         )
         assert result is None
 

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -591,9 +591,9 @@ class TestSearchLibraryWithFallback:
         )
         # The self-titled album should be included because "S/t" means the
         # album name is the same as the artist name.
-        assert any(
-            r.title == "S/t" for r in results
-        ), "Self-titled album 'S/t' should match when Discogs album is the artist name"
+        assert any(r.title == "S/t" for r in results), (
+            "Self-titled album 'S/t' should match when Discogs album is the artist name"
+        )
         assert fallback is False
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `filter_results_by_track_validation()` now checks that the Discogs search result album name actually matches the library item's title before validating the track
- Prevents false positives where Discogs returns a different album that shares words with the library title

## Bug

Searching for "Flow Coma by 808 State":
1. Artist fallback returns library album "808 State" (self-titled)
2. Track validation searches Discogs for `album="808 State", artist="808 State"`
3. Discogs returns "The Best Of 808 State: Blueprint" (shares "808 State" in title)
4. Track validation confirms "Flow Coma" is on that release — but it's a different album
5. False positive: the self-titled "808 State" album doesn't have "Flow Coma"

The fix uses the existing `album_title_acceptable()` function to verify the Discogs result corresponds to the same album before running track validation.

Fixes #115

## Test plan

- [x] New unit test `test_rejects_when_discogs_returns_different_album` reproduces the exact bug scenario
- [x] All 1009 unit tests pass
- [x] Existing track validation tests still pass (correct matches are not affected)