### PR TITLE
Add CLI path arguments to export_streaming_links.py

### DIFF
--- a/scripts/export_streaming_links.py
+++ b/scripts/export_streaming_links.py
@@ -5,7 +5,7 @@ to verified streaming service URLs. This makes streaming data available to
 the LML API and all downstream clients.
 
 Usage:
-    .venv/bin/python scripts/export_streaming_links.py [--dry-run]
+    .venv/bin/python scripts/export_streaming_links.py [--library-db PATH] [--streaming-db PATH] [--dry-run]
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sqlite3
 
 logging.basicConfig(
@@ -22,13 +23,14 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-LIBRARY_DB = "library.db"
-STREAMING_DB = "streaming_availability.db"
-
 
 def main(args: argparse.Namespace) -> None:
-    sa = sqlite3.connect(STREAMING_DB)
-    lib = sqlite3.connect(LIBRARY_DB)
+    if not os.path.exists(args.streaming_db):
+        log.error(f"Streaming database {args.streaming_db} does not exist; skipping export")
+        return
+
+    sa = sqlite3.connect(args.streaming_db)
+    lib = sqlite3.connect(args.library_db)
 
     # Get all albums with at least one streaming URL
     rows = sa.execute("""
@@ -122,7 +124,7 @@ def main(args: argparse.Namespace) -> None:
             lib.commit()
 
     lib.commit()
-    log.info(f"Inserted {inserted:,} streaming_links rows into {LIBRARY_DB}")
+    log.info(f"Inserted {inserted:,} streaming_links rows into {args.library_db}")
 
     # Verify
     count = lib.execute("SELECT COUNT(*) FROM streaming_links").fetchone()[0]
@@ -132,6 +134,14 @@ def main(args: argparse.Namespace) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Export streaming URLs to library.db")
+    parser.add_argument(
+        "--library-db", default="library.db", help="Path to library.db (default: library.db)"
+    )
+    parser.add_argument(
+        "--streaming-db",
+        default="streaming_availability.db",
+        help="Path to streaming_availability.db (default: streaming_availability.db)",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Show stats without writing")
     args = parser.parse_args()
     main(args)

--- a/tests/unit/test_export_streaming_links.py
+++ b/tests/unit/test_export_streaming_links.py
@@ -1,0 +1,161 @@
+"""Unit tests for scripts/export_streaming_links.py."""
+
+import argparse
+import json
+import sqlite3
+
+from scripts.export_streaming_links import main
+
+
+class TestCliArgs:
+    def test_defaults(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--library-db", default="library.db")
+        parser.add_argument("--streaming-db", default="streaming_availability.db")
+        parser.add_argument("--dry-run", action="store_true")
+        args = parser.parse_args([])
+        assert args.library_db == "library.db"
+        assert args.streaming_db == "streaming_availability.db"
+
+    def test_custom_paths_override_defaults(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--library-db", default="library.db")
+        parser.add_argument("--streaming-db", default="streaming_availability.db")
+        parser.add_argument("--dry-run", action="store_true")
+        args = parser.parse_args(["--library-db", "/tmp/foo.db", "--streaming-db", "/tmp/bar.db"])
+        assert args.library_db == "/tmp/foo.db"
+        assert args.streaming_db == "/tmp/bar.db"
+
+
+class TestMissingStreamingDb:
+    def test_exits_gracefully_when_streaming_db_missing(self, tmp_path, caplog):
+        """When the streaming DB path doesn't exist, main() should log an error and return."""
+        library_db = str(tmp_path / "library.db")
+        missing_streaming_db = str(tmp_path / "nonexistent.db")
+
+        args = argparse.Namespace(
+            library_db=library_db,
+            streaming_db=missing_streaming_db,
+            dry_run=False,
+        )
+
+        import logging
+
+        with caplog.at_level(logging.ERROR):
+            main(args)
+
+        assert "does not exist" in caplog.text
+        # Should NOT have created the library.db since we bailed out
+        import os
+
+        assert not os.path.exists(library_db)
+
+
+class TestFullExport:
+    def test_creates_streaming_links_table(self, tmp_path):
+        """Create minimal SQLite databases, run main(), verify streaming_links table."""
+        streaming_db_path = str(tmp_path / "streaming_availability.db")
+        library_db_path = str(tmp_path / "library.db")
+
+        # Set up streaming_availability.db with test data
+        sa = sqlite3.connect(streaming_db_path)
+        sa.execute("""
+            CREATE TABLE albums (
+                library_ids TEXT,
+                spotify_url TEXT,
+                apple_url TEXT,
+                deezer_url TEXT,
+                bandcamp_url TEXT,
+                tidal_url TEXT,
+                youtube_music_url TEXT,
+                soundcloud_url TEXT
+            )
+        """)
+        sa.execute(
+            "INSERT INTO albums VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                json.dumps([101, 102]),
+                "https://open.spotify.com/album/stereolab-aluminum-tunes",
+                "https://music.apple.com/album/stereolab-aluminum-tunes",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        sa.execute(
+            "INSERT INTO albums VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                json.dumps([201]),
+                None,
+                None,
+                "https://www.deezer.com/album/autechre-confield",
+                "https://autechre.bandcamp.com/album/confield",
+                None,
+                None,
+                None,
+            ),
+        )
+        # Album with no streaming URLs at all -- should be excluded
+        sa.execute(
+            "INSERT INTO albums VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                json.dumps([301]),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        sa.commit()
+        sa.close()
+
+        # Set up an empty library.db
+        lib = sqlite3.connect(library_db_path)
+        lib.close()
+
+        args = argparse.Namespace(
+            library_db=library_db_path,
+            streaming_db=streaming_db_path,
+            dry_run=False,
+        )
+        main(args)
+
+        # Verify streaming_links table
+        lib = sqlite3.connect(library_db_path)
+        rows = lib.execute(
+            "SELECT library_id, spotify_url, apple_music_url, deezer_url, bandcamp_url "
+            "FROM streaming_links ORDER BY library_id"
+        ).fetchall()
+        lib.close()
+
+        assert len(rows) == 3  # IDs 101, 102, 201
+
+        # Stereolab -- library_id 101
+        assert rows[0] == (
+            101,
+            "https://open.spotify.com/album/stereolab-aluminum-tunes",
+            "https://music.apple.com/album/stereolab-aluminum-tunes",
+            None,
+            None,
+        )
+        # Stereolab -- library_id 102 (same album, second library ID)
+        assert rows[1] == (
+            102,
+            "https://open.spotify.com/album/stereolab-aluminum-tunes",
+            "https://music.apple.com/album/stereolab-aluminum-tunes",
+            None,
+            None,
+        )
+        # Autechre -- library_id 201
+        assert rows[2] == (
+            201,
+            None,
+            None,
+            "https://www.deezer.com/album/autechre-confield",
+            "https://autechre.bandcamp.com/album/confield",
+        )


### PR DESCRIPTION
## Summary
- Add `--library-db` and `--streaming-db` CLI arguments to `export_streaming_links.py` (defaults unchanged)
- Exit gracefully when the streaming database doesn't exist
- Add unit tests for CLI arg parsing, missing-file handling, and full export integration

Closes #117

## Test plan
- [x] Unit tests pass (`pytest tests/unit/test_export_streaming_links.py -v`)
- [ ] Manual verification: `scripts/export_streaming_links.py --library-db /tmp/test.db --streaming-db ./streaming_availability.db`