### PR TITLE
Add on_streaming flag to lookup API response

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -442,6 +442,10 @@ class AlbumSearchResult(BaseModel):
     rotation_bin: RotationBin | None = None
     rotation_id: int | None = None
     plays: int | None = None
+    on_streaming: bool | None = Field(
+        None,
+        description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
+    )
 
 
 class AddAlbumRequest(BaseModel):
@@ -887,6 +891,10 @@ class LibraryCatalogItem(BaseModel):
         description='Full call number for shelf lookup, e.g. "Rock CD ABC 123/45". Computed from genre, format, call_letters, artist_call_number, and release_call_number.\n',
     )
     library_url: str = Field(..., description="URL to view this release in the WXYC library")
+    on_streaming: bool | None = Field(
+        None,
+        description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
+    )
 
 
 class DiscogsMatchResult(BaseModel):
@@ -913,7 +921,7 @@ class SearchType(StrEnum):
 
 
 class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field([], validate_default=True)
+    results: list[LookupResultItem] | None = Field(default_factory=list)
     search_type: SearchType | None = Field(
         "none",
         description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -86,6 +86,7 @@ class FlowsheetEntryResponse(FlowsheetEntryBase):
     rotation_id: int | None = None
     rotation_bin: RotationBin | None = None
     request_flag: bool
+    segue: bool | None = None
     message: str | None = None
     artwork_url: str | None = None
     discogs_url: str | None = None
@@ -106,6 +107,7 @@ class FlowsheetSongEntry(FlowsheetEntryBase):
     record_label: str
     label_id: int | None = None
     request_flag: bool
+    segue: bool | None = None
     album_id: int | None = None
     rotation_id: int | None = None
     rotation_bin: RotationBin | None = None
@@ -129,6 +131,7 @@ class FlowsheetCreateSongFromCatalog(BaseModel):
     track_title: str
     rotation_id: int | None = None
     request_flag: bool
+    segue: bool | None = None
     record_label: str | None = None
 
 
@@ -137,6 +140,7 @@ class FlowsheetCreateSongFreeform(BaseModel):
     album_title: str
     track_title: str
     request_flag: bool
+    segue: bool | None = None
     record_label: str | None = None
     label_id: int | None = None
 
@@ -162,6 +166,7 @@ class FlowsheetUpdateRequest(BaseModel):
     record_label: str | None = None
     label_id: int | None = None
     request_flag: bool | None = None
+    segue: bool | None = None
 
 
 class FlowsheetQueryParams(BaseModel):
@@ -241,6 +246,7 @@ class FlowsheetV2TrackEntry(FlowsheetV2Base):
     track_title: str | None = None
     record_label: str | None = None
     request_flag: bool
+    segue: bool | None = None
     rotation_bin: RotationBin | None = None
     artwork_url: str | None = None
     discogs_url: str | None = None
@@ -868,7 +874,8 @@ class LookupRequest(BaseModel):
     song: str | None = Field(None, description="Parsed song/track title")
     album: str | None = Field(None, description="Parsed album name")
     raw_message: str = Field(
-        ..., description="Original request message (needed for ambiguous format detection)"
+        ...,
+        description="Original request message (needed for ambiguous format detection)",
     )
 
 

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -874,8 +874,7 @@ class LookupRequest(BaseModel):
     song: str | None = Field(None, description="Parsed song/track title")
     album: str | None = Field(None, description="Parsed album name")
     raw_message: str = Field(
-        ...,
-        description="Original request message (needed for ambiguous format detection)",
+        ..., description="Original request message (needed for ambiguous format detection)"
     )
 
 
@@ -928,7 +927,7 @@ class SearchType(StrEnum):
 
 
 class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field(default_factory=list)
+    results: list[LookupResultItem] | None = Field([], validate_default=True)
     search_type: SearchType | None = Field(
         "none",
         description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",

--- a/library/db.py
+++ b/library/db.py
@@ -528,3 +528,20 @@ class LibraryDB:
             "youtube_music_url": row[5],
             "soundcloud_url": row[6],
         }
+
+    async def get_streaming_status(self, library_ids: list[int]) -> dict[int, bool]:
+        """Check which library releases have streaming links.
+
+        Returns a dict mapping library_id → True for IDs that have at least one
+        streaming link. IDs not in the result are not on streaming.
+        """
+        if not self._has_streaming_links or self._conn is None or not library_ids:
+            return {}
+
+        placeholders = ",".join("?" * len(library_ids))
+        cursor = await self._conn.execute(
+            f"SELECT library_id FROM streaming_links WHERE library_id IN ({placeholders})",
+            library_ids,
+        )
+        rows = await cursor.fetchall()
+        return {row[0]: True for row in rows}

--- a/library/models.py
+++ b/library/models.py
@@ -30,6 +30,7 @@ class LibraryItem(BaseModel):
     format: str | None = None
     alternate_artist_name: str | None = None
     label: str | None = None
+    on_streaming: bool | None = None
 
     @property
     def call_number(self) -> str:
@@ -69,6 +70,7 @@ class LibraryItem(BaseModel):
             label=self.label,
             call_number=self.call_number,
             library_url=self.library_url,
+            on_streaming=self.on_streaming,
         )
 
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1099,6 +1099,12 @@ async def perform_lookup(
                     merged.extend(library_results)
                     library_results = merged
 
+    # Step 3c: Populate streaming status
+    if library_results and getattr(db, "_has_streaming_links", None) is True:
+        streaming_status = await db.get_streaming_status([r.id for r in library_results])
+        for result in library_results:
+            result.on_streaming = streaming_status.get(result.id, False)
+
     # Step 4: Fetch artwork
     with telemetry.track_step("artwork_fetch"):
         if library_results:

--- a/tests/unit/test_library_db.py
+++ b/tests/unit/test_library_db.py
@@ -1294,3 +1294,85 @@ class TestStreamingLinks:
         await db.close()
 
         assert links is None
+
+
+class TestStreamingStatus:
+    """Tests for get_streaming_status() batch method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_ids_with_links(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.execute(
+                "CREATE TABLE streaming_links ("
+                "library_id INTEGER PRIMARY KEY, spotify_url TEXT, apple_music_url TEXT, "
+                "deezer_url TEXT, bandcamp_url TEXT, tidal_url TEXT, "
+                "youtube_music_url TEXT, soundcloud_url TEXT)"
+            )
+            await conn.execute(
+                "INSERT INTO streaming_links (library_id, spotify_url) VALUES (100, 'https://x')"
+            )
+            await conn.execute(
+                "INSERT INTO streaming_links (library_id, bandcamp_url) VALUES (200, 'https://y')"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        status = await db.get_streaming_status([100, 200, 300])
+        await db.close()
+
+        assert status == {100: True, 200: True}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_missing_ids(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.execute(
+                "CREATE TABLE streaming_links ("
+                "library_id INTEGER PRIMARY KEY, spotify_url TEXT, apple_music_url TEXT, "
+                "deezer_url TEXT, bandcamp_url TEXT, tidal_url TEXT, "
+                "youtube_music_url TEXT, soundcloud_url TEXT)"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        status = await db.get_streaming_status([999])
+        await db.close()
+
+        assert status == {}
+
+    @pytest.mark.asyncio
+    async def test_graceful_without_table(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        status = await db.get_streaming_status([100])
+        await db.close()
+
+        assert status == {}


### PR DESCRIPTION
## Summary

- New `get_streaming_status()` batch method on `LibraryDB` — efficiently queries streaming_links table for multiple IDs
- `LibraryItem` gains `on_streaming: bool | None` field, passed through to `LibraryCatalogItem` via `to_catalog_item()`
- Orchestrator populates `on_streaming` after search results are finalized, before artwork enrichment
- Regenerated API models from updated `wxyc-shared/api.yaml`

Depends on WXYC/wxyc-shared#43. Closes #115.

## Test plan

- [x] 3 new tests for `get_streaming_status()` (with links, missing IDs, no table)
- [x] All 1,016 unit tests pass
- [x] Lint and format clean