### PR TITLE
Expand test coverage for streaming links export and db methods

### DIFF
--- a/tests/integration/test_streaming_links.py
+++ b/tests/integration/test_streaming_links.py
@@ -1,0 +1,116 @@
+"""Integration tests for streaming links in library/db.py with real SQLite."""
+
+import aiosqlite
+import pytest
+
+from library.db import LibraryDB
+
+pytestmark = pytest.mark.integration
+
+
+async def _create_library_db_with_streaming(db_path, *, include_streaming_table=True):
+    """Create a library.db with library + optional streaming_links tables."""
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            "CREATE TABLE library ("
+            "id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+            "call_letters TEXT, artist_call_number INTEGER, "
+            "release_call_number INTEGER, genre TEXT, format TEXT)"
+        )
+        await conn.execute(
+            "INSERT INTO library VALUES "
+            "(100, 'Aluminum Tunes', 'Stereolab', 'RO', 87, 1, 'Rock', 'CD')"
+        )
+        await conn.execute(
+            "INSERT INTO library VALUES "
+            "(200, 'Confield', 'Autechre', 'EL', 16, 1, 'Electronic', 'CD')"
+        )
+        await conn.execute(
+            "INSERT INTO library VALUES (300, 'Moon Pix', 'Cat Power', 'RO', 23, 1, 'Rock', 'CD')"
+        )
+
+        if include_streaming_table:
+            await conn.execute(
+                "CREATE TABLE streaming_links ("
+                "library_id INTEGER PRIMARY KEY, spotify_url TEXT, apple_music_url TEXT, "
+                "deezer_url TEXT, bandcamp_url TEXT, tidal_url TEXT, "
+                "youtube_music_url TEXT, soundcloud_url TEXT)"
+            )
+            await conn.execute(
+                "INSERT INTO streaming_links VALUES "
+                "(100, 'https://open.spotify.com/album/stereolab-aluminum-tunes', "
+                "'https://music.apple.com/album/stereolab-aluminum-tunes', "
+                "NULL, 'https://stereolab.bandcamp.com/album/aluminum-tunes', "
+                "NULL, NULL, NULL)"
+            )
+            await conn.execute(
+                "INSERT INTO streaming_links VALUES "
+                "(200, NULL, NULL, "
+                "'https://www.deezer.com/album/autechre-confield', "
+                "'https://autechre.bandcamp.com/album/confield', "
+                "NULL, NULL, NULL)"
+            )
+
+        await conn.commit()
+
+
+class TestGetStreamingLinksWithRealData:
+    @pytest.mark.asyncio
+    async def test_get_streaming_links_with_real_data(self, tmp_path):
+        """Create full library.db with library + streaming_links. Verify correct URLs."""
+        db_path = tmp_path / "library.db"
+        await _create_library_db_with_streaming(db_path)
+
+        db = LibraryDB(db_path)
+        await db.connect()
+
+        links = await db.get_streaming_links(100)
+        assert links is not None
+        assert links["spotify_url"] == "https://open.spotify.com/album/stereolab-aluminum-tunes"
+        assert links["apple_music_url"] == "https://music.apple.com/album/stereolab-aluminum-tunes"
+        assert links["bandcamp_url"] == "https://stereolab.bandcamp.com/album/aluminum-tunes"
+        assert links["deezer_url"] is None
+        assert links["tidal_url"] is None
+        assert links["youtube_music_url"] is None
+        assert links["soundcloud_url"] is None
+
+        await db.close()
+
+
+class TestGetStreamingStatusBatch:
+    @pytest.mark.asyncio
+    async def test_get_streaming_status_batch(self, tmp_path):
+        """Call with [100, 200, 999]. 100 and 200 have links, 999 is absent."""
+        db_path = tmp_path / "library.db"
+        await _create_library_db_with_streaming(db_path)
+
+        db = LibraryDB(db_path)
+        await db.connect()
+
+        status = await db.get_streaming_status([100, 200, 999])
+
+        assert status[100] is True
+        assert status[200] is True
+        assert 999 not in status
+
+        await db.close()
+
+
+class TestStreamingLinksNotPresent:
+    @pytest.mark.asyncio
+    async def test_streaming_links_not_present(self, tmp_path):
+        """Library DB without streaming_links table. get_streaming_links returns None."""
+        db_path = tmp_path / "library.db"
+        await _create_library_db_with_streaming(db_path, include_streaming_table=False)
+
+        db = LibraryDB(db_path)
+        await db.connect()
+
+        assert db._has_streaming_links is False
+        links = await db.get_streaming_links(100)
+        assert links is None
+
+        status = await db.get_streaming_status([100, 200])
+        assert status == {}
+
+        await db.close()

--- a/tests/unit/test_export_streaming_links.py
+++ b/tests/unit/test_export_streaming_links.py
@@ -2,7 +2,11 @@
 
 import argparse
 import json
+import logging
 import sqlite3
+from unittest.mock import patch
+
+import pytest
 
 from scripts.export_streaming_links import main
 
@@ -159,3 +163,490 @@ class TestFullExport:
             "https://www.deezer.com/album/autechre-confield",
             "https://autechre.bandcamp.com/album/confield",
         )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate handling
+# ---------------------------------------------------------------------------
+
+
+def _create_streaming_db(path, album_rows):
+    """Helper to create a streaming_availability.db with the given album rows."""
+    sa = sqlite3.connect(path)
+    sa.execute("""
+        CREATE TABLE albums (
+            library_ids TEXT,
+            spotify_url TEXT,
+            apple_url TEXT,
+            deezer_url TEXT,
+            bandcamp_url TEXT,
+            tidal_url TEXT,
+            youtube_music_url TEXT,
+            soundcloud_url TEXT
+        )
+    """)
+    for row in album_rows:
+        sa.execute("INSERT INTO albums VALUES (?, ?, ?, ?, ?, ?, ?, ?)", row)
+    sa.commit()
+    sa.close()
+
+
+class TestDuplicateHandling:
+    def test_first_url_wins_for_same_library_id(self, tmp_path):
+        """Two album rows map to the same library_id with different spotify_urls. First URL wins."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        _create_streaming_db(
+            streaming_db,
+            [
+                # First row: Autechre Confield with spotify
+                (
+                    json.dumps([101]),
+                    "https://open.spotify.com/album/autechre-confield-FIRST",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+                # Second row: same library_id, different spotify
+                (
+                    json.dumps([101]),
+                    "https://open.spotify.com/album/autechre-confield-SECOND",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+        main(args)
+
+        lib = sqlite3.connect(library_db)
+        row = lib.execute(
+            "SELECT spotify_url FROM streaming_links WHERE library_id = 101"
+        ).fetchone()
+        lib.close()
+
+        assert row[0] == "https://open.spotify.com/album/autechre-confield-FIRST"
+
+    def test_different_services_merge_for_same_id(self, tmp_path):
+        """Row 1 has spotify for lib_id=101, Row 2 has apple_music for lib_id=101. Both appear."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        _create_streaming_db(
+            streaming_db,
+            [
+                # First row: spotify only
+                (
+                    json.dumps([101]),
+                    "https://open.spotify.com/album/stereolab-aluminum-tunes",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+                # Second row: apple_music only
+                (
+                    json.dumps([101]),
+                    None,
+                    "https://music.apple.com/album/stereolab-aluminum-tunes",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+        main(args)
+
+        lib = sqlite3.connect(library_db)
+        row = lib.execute(
+            "SELECT spotify_url, apple_music_url FROM streaming_links WHERE library_id = 101"
+        ).fetchone()
+        lib.close()
+
+        assert row[0] == "https://open.spotify.com/album/stereolab-aluminum-tunes"
+        assert row[1] == "https://music.apple.com/album/stereolab-aluminum-tunes"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_invalid_json_in_library_ids(self, tmp_path):
+        """Row with library_ids='not json' should raise json.JSONDecodeError."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        _create_streaming_db(
+            streaming_db,
+            [
+                (
+                    "not json",
+                    "https://open.spotify.com/album/cat-power-moon-pix",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+        with pytest.raises(json.JSONDecodeError):
+            main(args)
+
+    def test_empty_array_library_ids(self, tmp_path):
+        """library_ids='[]' produces no streaming_links rows for this album."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        _create_streaming_db(
+            streaming_db,
+            [
+                (
+                    json.dumps([]),
+                    "https://open.spotify.com/album/jessica-pratt",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+        main(args)
+
+        lib = sqlite3.connect(library_db)
+        count = lib.execute("SELECT COUNT(*) FROM streaming_links").fetchone()[0]
+        lib.close()
+
+        assert count == 0
+
+    def test_all_services_populated(self, tmp_path):
+        """Row with all 7 URL columns filled. All 7 appear in output."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        urls = (
+            "https://open.spotify.com/album/cat-power-moon-pix",
+            "https://music.apple.com/album/cat-power-moon-pix",
+            "https://www.deezer.com/album/cat-power-moon-pix",
+            "https://catpower.bandcamp.com/album/moon-pix",
+            "https://tidal.com/album/cat-power-moon-pix",
+            "https://music.youtube.com/cat-power-moon-pix",
+            "https://soundcloud.com/cat-power/moon-pix",
+        )
+        _create_streaming_db(
+            streaming_db,
+            [(json.dumps([101]), *urls)],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+        main(args)
+
+        lib = sqlite3.connect(library_db)
+        row = lib.execute(
+            "SELECT spotify_url, apple_music_url, deezer_url, bandcamp_url, "
+            "tidal_url, youtube_music_url, soundcloud_url "
+            "FROM streaming_links WHERE library_id = 101"
+        ).fetchone()
+        lib.close()
+
+        assert row == urls
+
+    def test_only_bandcamp_populated(self, tmp_path):
+        """Row with only bandcamp_url set. Included in output."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        _create_streaming_db(
+            streaming_db,
+            [
+                (
+                    json.dumps([201]),
+                    None,
+                    None,
+                    None,
+                    "https://autechre.bandcamp.com/album/confield",
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+        main(args)
+
+        lib = sqlite3.connect(library_db)
+        row = lib.execute(
+            "SELECT bandcamp_url FROM streaming_links WHERE library_id = 201"
+        ).fetchone()
+        lib.close()
+
+        assert row[0] == "https://autechre.bandcamp.com/album/confield"
+
+    def test_all_null_urls_excluded(self, tmp_path):
+        """Row where all 7 URL columns are NULL is NOT in output (WHERE clause filters it)."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        _create_streaming_db(
+            streaming_db,
+            [
+                (json.dumps([301]), None, None, None, None, None, None, None),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+        main(args)
+
+        lib = sqlite3.connect(library_db)
+        count = lib.execute("SELECT COUNT(*) FROM streaming_links").fetchone()[0]
+        lib.close()
+
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    def test_dry_run_does_not_modify_library_db(self, tmp_path):
+        """Run with dry_run=True. Library DB should NOT have a streaming_links table."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        _create_streaming_db(
+            streaming_db,
+            [
+                (
+                    json.dumps([101]),
+                    "https://open.spotify.com/album/stereolab-aluminum-tunes",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=True)
+        main(args)
+
+        lib = sqlite3.connect(library_db)
+        tables = lib.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='streaming_links'"
+        ).fetchall()
+        lib.close()
+
+        assert len(tables) == 0
+
+    def test_dry_run_logs_coverage_stats(self, tmp_path, caplog):
+        """dry_run=True logs service counts."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        _create_streaming_db(
+            streaming_db,
+            [
+                (
+                    json.dumps([101]),
+                    "https://open.spotify.com/album/stereolab-aluminum-tunes",
+                    None,
+                    None,
+                    "https://stereolab.bandcamp.com/album/aluminum-tunes",
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=True)
+        with caplog.at_level(logging.INFO):
+            main(args)
+
+        assert "spotify_url" in caplog.text
+        assert "bandcamp_url" in caplog.text
+        assert "Service coverage" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_reexport_replaces_streaming_links(self, tmp_path):
+        """Run main() twice with different data. Second run's data wins."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        # First export: Stereolab with spotify
+        _create_streaming_db(
+            streaming_db,
+            [
+                (
+                    json.dumps([101]),
+                    "https://open.spotify.com/album/stereolab-aluminum-tunes",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+        main(args)
+
+        # Verify first export
+        lib = sqlite3.connect(library_db)
+        count1 = lib.execute("SELECT COUNT(*) FROM streaming_links").fetchone()[0]
+        lib.close()
+        assert count1 == 1
+
+        # Second export: different data (Cat Power with deezer)
+        import os
+
+        os.remove(streaming_db)
+        _create_streaming_db(
+            streaming_db,
+            [
+                (
+                    json.dumps([201]),
+                    None,
+                    None,
+                    "https://www.deezer.com/album/cat-power-moon-pix",
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            ],
+        )
+
+        main(args)
+
+        # Second run's data should replace first
+        lib = sqlite3.connect(library_db)
+        rows = lib.execute("SELECT library_id, deezer_url FROM streaming_links").fetchall()
+        lib.close()
+
+        assert len(rows) == 1
+        assert rows[0][0] == 201
+        assert rows[0][1] == "https://www.deezer.com/album/cat-power-moon-pix"
+
+
+# ---------------------------------------------------------------------------
+# Commits
+# ---------------------------------------------------------------------------
+
+
+class _CommitTrackingConnection:
+    """Wrapper around sqlite3.Connection that counts commit() calls."""
+
+    def __init__(self, real_conn):
+        self._real = real_conn
+        self.commit_count = 0
+
+    def commit(self):
+        self.commit_count += 1
+        self._real.commit()
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+class TestCommitBehavior:
+    def test_commit_called_periodically(self, tmp_path):
+        """Create >10k album rows. Verify lib.commit is called more than once."""
+        streaming_db = str(tmp_path / "streaming.db")
+        library_db = str(tmp_path / "library.db")
+
+        # Create streaming DB with 10,001 albums, each mapping to a unique library_id
+        sa = sqlite3.connect(streaming_db)
+        sa.execute("""
+            CREATE TABLE albums (
+                library_ids TEXT,
+                spotify_url TEXT,
+                apple_url TEXT,
+                deezer_url TEXT,
+                bandcamp_url TEXT,
+                tidal_url TEXT,
+                youtube_music_url TEXT,
+                soundcloud_url TEXT
+            )
+        """)
+        rows = [
+            (
+                json.dumps([i]),
+                f"https://open.spotify.com/album/{i}",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            for i in range(10_001)
+        ]
+        sa.executemany("INSERT INTO albums VALUES (?, ?, ?, ?, ?, ?, ?, ?)", rows)
+        sa.commit()
+        sa.close()
+
+        sqlite3.connect(library_db).close()
+
+        args = argparse.Namespace(library_db=library_db, streaming_db=streaming_db, dry_run=False)
+
+        real_sa = sqlite3.connect(streaming_db)
+        tracking_lib = _CommitTrackingConnection(sqlite3.connect(library_db))
+
+        with patch("scripts.export_streaming_links.sqlite3") as mock_sqlite3:
+            mock_sqlite3.connect = lambda path: real_sa if "streaming" in path else tracking_lib
+
+            main(args)
+
+        real_sa.close()
+        tracking_lib._real.close()
+
+        # With 10,001 rows and commits every 10,000, we expect at least 2 commits
+        assert tracking_lib.commit_count > 1

--- a/tests/unit/test_library_db.py
+++ b/tests/unit/test_library_db.py
@@ -1295,6 +1295,93 @@ class TestStreamingLinks:
 
         assert links is None
 
+    @pytest.mark.asyncio
+    async def test_all_null_urls_returns_dict_with_nones(self, tmp_path):
+        """Insert streaming_links row where every URL is NULL. Returns dict with all None values."""
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.execute(
+                "INSERT INTO library VALUES (100, 'Confield', 'Autechre', "
+                "'EL', 16, 1, 'Electronic', 'CD')"
+            )
+            await conn.execute(
+                "CREATE TABLE streaming_links ("
+                "library_id INTEGER PRIMARY KEY, spotify_url TEXT, apple_music_url TEXT, "
+                "deezer_url TEXT, bandcamp_url TEXT, tidal_url TEXT, "
+                "youtube_music_url TEXT, soundcloud_url TEXT)"
+            )
+            await conn.execute("INSERT INTO streaming_links (library_id) VALUES (100)")
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        links = await db.get_streaming_links(100)
+        await db.close()
+
+        assert links is not None
+        assert all(v is None for v in links.values())
+
+    @pytest.mark.asyncio
+    async def test_has_streaming_links_flag_true_on_connect(self, tmp_path):
+        """Create DB with streaming_links table. After connect(), flag is True."""
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.execute(
+                "CREATE TABLE streaming_links ("
+                "library_id INTEGER PRIMARY KEY, spotify_url TEXT, apple_music_url TEXT, "
+                "deezer_url TEXT, bandcamp_url TEXT, tidal_url TEXT, "
+                "youtube_music_url TEXT, soundcloud_url TEXT)"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        assert db._has_streaming_links is True
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_has_streaming_links_flag_false_without_table(self, tmp_path):
+        """Create DB without streaming_links table. Flag is False."""
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        assert db._has_streaming_links is False
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_conn_is_none(self):
+        """Set db._conn = None. get_streaming_links() returns None."""
+        db = LibraryDB()
+        db._conn = None
+        db._has_streaming_links = True
+
+        result = await db.get_streaming_links(100)
+        assert result is None
+
 
 class TestStreamingStatus:
     """Tests for get_streaming_status() batch method."""
@@ -1375,4 +1462,51 @@ class TestStreamingStatus:
         status = await db.get_streaming_status([100])
         await db.close()
 
+        assert status == {}
+
+    @pytest.mark.asyncio
+    async def test_streaming_status_empty_list(self, tmp_path):
+        """get_streaming_status([]) returns {}."""
+        db_path = tmp_path / "test.db"
+        import aiosqlite
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT, "
+                "call_letters TEXT, artist_call_number INTEGER, release_call_number INTEGER, "
+                "genre TEXT, format TEXT)"
+            )
+            await conn.execute(
+                "CREATE TABLE streaming_links ("
+                "library_id INTEGER PRIMARY KEY, spotify_url TEXT, apple_music_url TEXT, "
+                "deezer_url TEXT, bandcamp_url TEXT, tidal_url TEXT, "
+                "youtube_music_url TEXT, soundcloud_url TEXT)"
+            )
+            await conn.commit()
+
+        db = LibraryDB(db_path)
+        await db.connect()
+        status = await db.get_streaming_status([])
+        await db.close()
+
+        assert status == {}
+
+    @pytest.mark.asyncio
+    async def test_streaming_status_when_flag_false(self):
+        """_has_streaming_links=False returns {}."""
+        db = LibraryDB()
+        db._conn = AsyncMock()
+        db._has_streaming_links = False
+
+        status = await db.get_streaming_status([100, 200])
+        assert status == {}
+
+    @pytest.mark.asyncio
+    async def test_streaming_status_when_conn_none(self):
+        """_conn=None returns {}."""
+        db = LibraryDB()
+        db._conn = None
+        db._has_streaming_links = True
+
+        status = await db.get_streaming_status([100, 200])
         assert status == {}


### PR DESCRIPTION
## Summary
- Add 18 new unit tests and 3 integration tests (21 total)
- `export_streaming_links.py`: duplicate handling, edge cases, dry-run, idempotency, periodic commits
- `library/db.py`: all-NULL URLs, flag detection, None connection, empty list input
- Integration tests for streaming links round-trip with real SQLite

Closes #121

## Test plan
- [x] All 21 new tests pass
- [x] All 91 tests pass (including 4 pre-existing streaming tests)
- [x] Ruff lint and format clean