### PR TITLE
Add track-level streaming availability for singles and compilations

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -934,7 +934,7 @@ class SearchType(StrEnum):
 
 
 class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field(default_factory=list)
+    results: list[LookupResultItem] | None = Field([], validate_default=True)
     search_type: SearchType | None = Field(
         "none",
         description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -429,6 +429,10 @@ class Album(BaseModel):
     add_date: AwareDatetime | None = None
     disc_quantity: int | None = None
     alternate_artist_name: str | None = None
+    album_artist: str | None = Field(
+        None,
+        description='Credited album artist for compilations (e.g., "Kruder & Dorfmeister" on a DJ-Kicks release filed under Various Artists).',
+    )
 
 
 class AlbumSearchResult(BaseModel):
@@ -452,6 +456,7 @@ class AlbumSearchResult(BaseModel):
         None,
         description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
     )
+    album_artist: str | None = Field(None, description="Credited album artist for compilations.")
 
 
 class AddAlbumRequest(BaseModel):
@@ -464,6 +469,7 @@ class AddAlbumRequest(BaseModel):
     format_id: int
     disc_quantity: int | None = None
     alternate_artist_name: str | None = None
+    album_artist: str | None = None
 
 
 class Label(BaseModel):
@@ -928,7 +934,7 @@ class SearchType(StrEnum):
 
 
 class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field([], validate_default=True)
+    results: list[LookupResultItem] | None = Field(default_factory=list)
     search_type: SearchType | None = Field(
         "none",
         description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",

--- a/scripts/export_streaming_links.py
+++ b/scripts/export_streaming_links.py
@@ -70,7 +70,37 @@ def main(args: argparse.Namespace) -> None:
             if soundcloud and "soundcloud_url" not in entry:
                 entry["soundcloud_url"] = soundcloud
 
-    log.info(f"Library release IDs with streaming links: {len(links)}")
+    log.info(f"Library release IDs with streaming links (album-level): {len(links)}")
+
+    # Supplement with track-level results for singles and compilations
+    # Check if track_results table exists
+    has_tracks = sa.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='track_results'"
+    ).fetchone()
+    track_links_added = 0
+    if has_tracks:
+        track_rows = sa.execute("""
+            SELECT a.library_ids, tr.spotify_url, tr.deezer_url
+            FROM track_results tr
+            JOIN albums a ON a.id = tr.album_id
+            WHERE tr.resolution_status IN ('local_match', 'api_match')
+              AND (tr.spotify_url IS NOT NULL OR tr.deezer_url IS NOT NULL)
+        """).fetchall()
+        for lib_ids_json, spotify, deezer in track_rows:
+            lib_ids = json.loads(lib_ids_json)
+            for lib_id in lib_ids:
+                if lib_id not in links:
+                    links[lib_id] = {}
+                entry = links[lib_id]
+                if spotify and "spotify_url" not in entry:
+                    entry["spotify_url"] = spotify
+                    track_links_added += 1
+                if deezer and "deezer_url" not in entry:
+                    entry["deezer_url"] = deezer
+                    track_links_added += 1
+        log.info(f"Track-level URLs added: {track_links_added}")
+
+    log.info(f"Library release IDs with streaming links (total): {len(links)}")
     sa.close()
 
     if args.dry_run:

--- a/scripts/streaming_availability/results_db.py
+++ b/scripts/streaming_availability/results_db.py
@@ -401,6 +401,15 @@ class ResultsDB:
         )
         return list(await cursor.fetchall())
 
+    async def get_local_miss_tracks(self, limit: int = 100) -> list[aiosqlite.Row]:
+        """Get tracks that missed local resolution, ready for API search."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT * FROM track_results WHERE resolution_status = 'local_miss' LIMIT ?",
+            (limit,),
+        )
+        return list(await cursor.fetchall())
+
     async def update_track_resolution(
         self,
         track_id: int,
@@ -461,7 +470,11 @@ class ResultsDB:
         counts = {row[0]: row[1] for row in await cursor.fetchall()}
         total = sum(counts.values())
         resolved = (
-            total - counts.get("pending", 0) - counts.get("not_found", 0) - counts.get("error", 0)
+            total
+            - counts.get("pending", 0)
+            - counts.get("local_miss", 0)
+            - counts.get("not_found", 0)
+            - counts.get("error", 0)
         )
         return {
             "total": total,

--- a/scripts/streaming_availability/results_db.py
+++ b/scripts/streaming_availability/results_db.py
@@ -52,6 +52,30 @@ CREATE TABLE IF NOT EXISTS albums (
 
 CREATE INDEX IF NOT EXISTS idx_albums_spotify_status ON albums(spotify_status);
 CREATE INDEX IF NOT EXISTS idx_albums_apple_status ON albums(apple_status);
+
+CREATE TABLE IF NOT EXISTS track_results (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    album_id INTEGER NOT NULL,
+    artist TEXT NOT NULL,
+    title TEXT NOT NULL,
+    position TEXT,
+    source TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    resolution_status TEXT NOT NULL DEFAULT 'pending',
+    resolved_via TEXT,
+    resolved_album_id INTEGER,
+    resolved_release_id INTEGER,
+    spotify_url TEXT,
+    spotify_confidence REAL,
+    deezer_url TEXT,
+    deezer_confidence REAL,
+    checked_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(album_id, artist, title)
+);
+
+CREATE INDEX IF NOT EXISTS idx_track_results_status ON track_results(resolution_status);
+CREATE INDEX IF NOT EXISTS idx_track_results_album ON track_results(album_id);
 """
 
 
@@ -339,3 +363,110 @@ class ResultsDB:
             "SELECT * FROM albums ORDER BY display_artist, display_title"
         )
         return list(await cursor.fetchall())
+
+    # -----------------------------------------------------------------------
+    # Track-level results
+    # -----------------------------------------------------------------------
+
+    async def insert_tracks(self, tracks: list[dict]) -> int:
+        """Bulk insert track results. Uses INSERT OR IGNORE for idempotent resume."""
+        assert self._db is not None
+        inserted = 0
+        async with self._write_lock:
+            for t in tracks:
+                cursor = await self._db.execute(
+                    """INSERT OR IGNORE INTO track_results
+                       (album_id, artist, title, position, source, source_type)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        t["album_id"],
+                        t["artist"],
+                        t["title"],
+                        t.get("position"),
+                        t["source"],
+                        t["source_type"],
+                    ),
+                )
+                if cursor.rowcount > 0:
+                    inserted += 1
+            await self._db.commit()
+        return inserted
+
+    async def get_pending_tracks(self, limit: int = 100) -> list[aiosqlite.Row]:
+        """Get tracks with resolution_status = 'pending'."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT * FROM track_results WHERE resolution_status = 'pending' LIMIT ?",
+            (limit,),
+        )
+        return list(await cursor.fetchall())
+
+    async def update_track_resolution(
+        self,
+        track_id: int,
+        status: str,
+        *,
+        resolved_via: str | None = None,
+        resolved_album_id: int | None = None,
+        resolved_release_id: int | None = None,
+        spotify_url: str | None = None,
+        spotify_confidence: float | None = None,
+        deezer_url: str | None = None,
+        deezer_confidence: float | None = None,
+    ) -> None:
+        """Update resolution status for a track."""
+        assert self._db is not None
+        now = datetime.now(UTC).isoformat()
+        async with self._write_lock:
+            await self._db.execute(
+                """UPDATE track_results SET
+                   resolution_status = ?, resolved_via = ?,
+                   resolved_album_id = ?, resolved_release_id = ?,
+                   spotify_url = ?, spotify_confidence = ?,
+                   deezer_url = ?, deezer_confidence = ?,
+                   checked_at = ?
+                   WHERE id = ?""",
+                (
+                    status,
+                    resolved_via,
+                    resolved_album_id,
+                    resolved_release_id,
+                    spotify_url,
+                    spotify_confidence,
+                    deezer_url,
+                    deezer_confidence,
+                    now,
+                    track_id,
+                ),
+            )
+            await self._db.commit()
+
+    async def get_track_stats(self) -> dict:
+        """Get counts of track results by resolution status."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT resolution_status, COUNT(*) FROM track_results GROUP BY resolution_status"
+        )
+        stats = {row[0]: row[1] for row in await cursor.fetchall()}
+        stats["total"] = sum(stats.values())
+        return stats
+
+    async def get_album_track_summary(self, album_id: int) -> dict:
+        """Summarize track resolution for a single album."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT resolution_status, COUNT(*) FROM track_results WHERE album_id = ? GROUP BY resolution_status",
+            (album_id,),
+        )
+        counts = {row[0]: row[1] for row in await cursor.fetchall()}
+        total = sum(counts.values())
+        resolved = (
+            total - counts.get("pending", 0) - counts.get("not_found", 0) - counts.get("error", 0)
+        )
+        return {
+            "total": total,
+            "resolved": resolved,
+            "not_found": counts.get("not_found", 0),
+            "pending": counts.get("pending", 0),
+            "on_streaming": resolved > 0,
+        }

--- a/scripts/streaming_availability/results_db.py
+++ b/scripts/streaming_availability/results_db.py
@@ -474,6 +474,7 @@ class ResultsDB:
             - counts.get("pending", 0)
             - counts.get("local_miss", 0)
             - counts.get("not_found", 0)
+            - counts.get("false_positive", 0)
             - counts.get("error", 0)
         )
         return {

--- a/scripts/track_streaming/__main__.py
+++ b/scripts/track_streaming/__main__.py
@@ -1,0 +1,495 @@
+"""Track-level streaming availability for singles and compilations.
+
+Extracts individual tracks, resolves them against an in-memory index of
+on-streaming Discogs tracklists, then falls back to Spotify/Deezer track
+search for unresolved tracks.
+
+Usage:
+    uv run python -m scripts.track_streaming [OPTIONS]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import sys
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from scripts.streaming_availability.results_db import ResultsDB
+from scripts.track_streaming.api_search import search_track_on_services
+from scripts.track_streaming.local_index import LocalStreamingIndex, TrackEntry
+from scripts.track_streaming.track_extractor import (
+    extract_compilation_tracks,
+    extract_single_tracks,
+)
+
+logger = logging.getLogger("track_streaming")
+
+_shutdown_requested = False
+
+
+def _handle_signal(signum, frame):
+    global _shutdown_requested
+    if _shutdown_requested:
+        logger.warning("Force quit requested, exiting immediately")
+        sys.exit(1)
+    logger.info("Shutdown requested, finishing current batch...")
+    _shutdown_requested = True
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Extract tracks
+# ---------------------------------------------------------------------------
+
+
+async def phase_extract(results_db: ResultsDB, args) -> int:
+    """Extract tracks from singles and compilations into track_results table."""
+    assert results_db._db is not None
+    inserted = 0
+
+    # Singles
+    cursor = await results_db._db.execute(
+        """SELECT id, display_artist, display_title, discogs_release_id
+           FROM albums WHERE is_single = 1
+           AND id NOT IN (SELECT DISTINCT album_id FROM track_results WHERE source_type = 'single')
+           ORDER BY id LIMIT ?""",
+        (args.limit,),
+    )
+    singles = [dict(row) for row in await cursor.fetchall()]
+    logger.info("Singles to extract: %d", len(singles))
+
+    # Connect to Discogs cache if available
+    discogs_cache = None
+    discogs_pool = None
+    discogs_url = os.environ.get("DATABASE_URL_DISCOGS")
+    if discogs_url:
+        try:
+            import asyncpg
+
+            from discogs.cache_service import DiscogsCacheService
+
+            discogs_pool = await asyncpg.create_pool(discogs_url, min_size=1, max_size=5)
+            discogs_cache = DiscogsCacheService(discogs_pool)
+            logger.info("Connected to Discogs cache")
+        except Exception:
+            logger.warning("Could not connect to Discogs cache, using title parsing only")
+
+    try:
+        for i, row in enumerate(singles, 1):
+            if _shutdown_requested:
+                break
+            tracks = await extract_single_tracks(row, discogs_cache=discogs_cache)
+            if tracks:
+                count = await results_db.insert_tracks(tracks)
+                inserted += count
+            if i % 500 == 0:
+                logger.info("  Singles: %d / %d extracted (%d tracks)", i, len(singles), inserted)
+    finally:
+        if discogs_pool:
+            await discogs_pool.close()
+
+    logger.info("Singles extraction complete: %d tracks from %d singles", inserted, len(singles))
+
+    if _shutdown_requested:
+        return inserted
+
+    # Compilations
+    comp_json_path = args.comp_json
+    if not Path(comp_json_path).is_file():
+        logger.warning(
+            "compilation_track_artists.json not found at %s, skipping compilations", comp_json_path
+        )
+        return inserted
+
+    with open(comp_json_path) as f:
+        comp_data_list = json.load(f)
+    comp_data_by_id = {entry["comp_id"]: entry for entry in comp_data_list}
+    logger.info("Loaded %d compilations from JSON", len(comp_data_by_id))
+
+    cursor = await results_db._db.execute(
+        """SELECT id, display_artist, display_title
+           FROM albums WHERE is_compilation = 1
+           AND id NOT IN (SELECT DISTINCT album_id FROM track_results WHERE source_type = 'compilation')
+           ORDER BY id LIMIT ?""",
+        (args.limit,),
+    )
+    comps = [dict(row) for row in await cursor.fetchall()]
+    logger.info("Compilations to extract: %d", len(comps))
+
+    comp_inserted = 0
+    for i, row in enumerate(comps, 1):
+        if _shutdown_requested:
+            break
+        comp_data = comp_data_by_id.get(row["id"])
+        tracks = extract_compilation_tracks(row, comp_data)
+        if tracks:
+            count = await results_db.insert_tracks(tracks)
+            comp_inserted += count
+        if i % 500 == 0:
+            logger.info(
+                "  Compilations: %d / %d extracted (%d tracks)", i, len(comps), comp_inserted
+            )
+
+    logger.info(
+        "Compilation extraction complete: %d tracks from %d compilations", comp_inserted, len(comps)
+    )
+    inserted += comp_inserted
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Build local index
+# ---------------------------------------------------------------------------
+
+
+async def phase_build_index(results_db: ResultsDB) -> LocalStreamingIndex:
+    """Build in-memory index from on-streaming albums with Discogs tracklists."""
+    discogs_url = os.environ.get("DATABASE_URL_DISCOGS")
+    if not discogs_url:
+        logger.warning("DATABASE_URL_DISCOGS not set, local index will be empty")
+        return LocalStreamingIndex()
+
+    import asyncpg
+
+    pool = await asyncpg.create_pool(discogs_url, min_size=2, max_size=10)
+
+    try:
+        # Get on-streaming album IDs with Discogs release IDs
+        assert results_db._db is not None
+        cursor = await results_db._db.execute(
+            """SELECT id, discogs_release_id, spotify_url, deezer_url
+               FROM albums
+               WHERE (spotify_status = 'found' OR deezer_status = 'found'
+                      OR apple_status = 'found' OR bandcamp_url IS NOT NULL)
+                 AND discogs_release_id IS NOT NULL"""
+        )
+        albums = [dict(row) for row in await cursor.fetchall()]
+        logger.info(
+            "Building local index from %d on-streaming albums with Discogs data", len(albums)
+        )
+
+        # Map discogs_release_id → album info
+        release_to_album = {}
+        for a in albums:
+            release_to_album[a["discogs_release_id"]] = a
+
+        # Batch fetch tracklists from Discogs PG
+        index = LocalStreamingIndex()
+        release_ids = list(release_to_album.keys())
+        batch_size = 1000
+
+        for batch_start in range(0, len(release_ids), batch_size):
+            if _shutdown_requested:
+                break
+            batch = release_ids[batch_start : batch_start + batch_size]
+            rows = await pool.fetch(
+                """SELECT rt.release_id, rt.title, rt.sequence,
+                          COALESCE(rta.artist_name, ra.artist_name) as artist_name
+                   FROM release_track rt
+                   JOIN release_artist ra ON ra.release_id = rt.release_id AND ra.extra = 0
+                   LEFT JOIN release_track_artist rta ON rta.release_id = rt.release_id
+                             AND rta.track_sequence = rt.sequence
+                   WHERE rt.release_id = ANY($1)""",
+                batch,
+            )
+            for row in rows:
+                album = release_to_album.get(row["release_id"])
+                if not album:
+                    continue
+                index.add(
+                    TrackEntry(
+                        artist=row["artist_name"],
+                        title=row["title"],
+                        album_id=album["id"],
+                        discogs_release_id=row["release_id"],
+                        spotify_url=album.get("spotify_url"),
+                        deezer_url=album.get("deezer_url"),
+                    )
+                )
+
+            if (batch_start + batch_size) % 5000 == 0:
+                logger.info(
+                    "  Index: %d / %d releases loaded (%d tracks)",
+                    min(batch_start + batch_size, len(release_ids)),
+                    len(release_ids),
+                    index.track_count,
+                )
+
+        logger.info(
+            "Local index built: %d tracks, %d unique titles from %d releases",
+            index.track_count,
+            index.title_count,
+            len(release_ids),
+        )
+        return index
+    finally:
+        await pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Local resolution
+# ---------------------------------------------------------------------------
+
+
+async def phase_local_resolve(results_db: ResultsDB, index: LocalStreamingIndex) -> tuple[int, int]:
+    """Resolve pending tracks against the local index. Returns (resolved, checked)."""
+    resolved = 0
+    checked = 0
+
+    while not _shutdown_requested:
+        pending = await results_db.get_pending_tracks(limit=500)
+        if not pending:
+            break
+
+        for row in pending:
+            if _shutdown_requested:
+                break
+            checked += 1
+            match = index.lookup(row["artist"], row["title"])
+            if match:
+                await results_db.update_track_resolution(
+                    track_id=row["id"],
+                    status="local_match",
+                    resolved_via="local_index",
+                    resolved_album_id=match.album_id,
+                    resolved_release_id=match.discogs_release_id,
+                    spotify_url=match.spotify_url,
+                    deezer_url=match.deezer_url,
+                )
+                resolved += 1
+            else:
+                # Mark as checked_local so we don't re-check, but leave pending for API
+                # Actually, leave as pending — the API phase picks up pending tracks
+                pass
+
+        if checked % 5000 == 0:
+            logger.info("  Local resolve: %d checked, %d resolved", checked, resolved)
+
+    # Mark remaining pending tracks that weren't matched locally as 'pending_api'
+    # so the API phase can distinguish them. Actually, the API phase just reads
+    # all pending tracks, so no status change needed.
+    logger.info("Local resolution complete: %d resolved out of %d checked", resolved, checked)
+    return resolved, checked
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: API fallback
+# ---------------------------------------------------------------------------
+
+
+async def phase_api_search(results_db: ResultsDB, args) -> tuple[int, int]:
+    """Search Spotify/Deezer for tracks not resolved locally. Returns (found, checked)."""
+    spotify = None
+    deezer = None
+
+    client_id = os.environ.get("SPOTIFY_CLIENT_ID")
+    client_secret = os.environ.get("SPOTIFY_CLIENT_SECRET")
+    if client_id and client_secret:
+        from scripts.streaming_availability.spotify_client import SpotifyClient
+
+        spotify = SpotifyClient(client_id, client_secret)
+
+    from scripts.streaming_availability.deezer_client import DeezerClient
+
+    deezer = DeezerClient()
+
+    found = 0
+    checked = 0
+
+    try:
+        while not _shutdown_requested:
+            pending = await results_db.get_pending_tracks(limit=args.batch_size)
+            if not pending:
+                break
+
+            for row in pending:
+                if _shutdown_requested:
+                    break
+                checked += 1
+                try:
+                    result = await search_track_on_services(
+                        row["artist"], row["title"], spotify, deezer
+                    )
+                    if result:
+                        await results_db.update_track_resolution(
+                            track_id=row["id"],
+                            status="api_match",
+                            resolved_via="spotify_track"
+                            if result.get("spotify_url")
+                            else "deezer_track",
+                            spotify_url=result.get("spotify_url"),
+                            spotify_confidence=result.get("spotify_confidence"),
+                            deezer_url=result.get("deezer_url"),
+                            deezer_confidence=result.get("deezer_confidence"),
+                        )
+                        found += 1
+                    else:
+                        await results_db.update_track_resolution(
+                            track_id=row["id"], status="not_found"
+                        )
+                except Exception:
+                    logger.exception("Error searching for %s - %s", row["artist"], row["title"])
+                    await results_db.update_track_resolution(track_id=row["id"], status="error")
+
+                if checked % 100 == 0:
+                    hit_rate = found / checked * 100 if checked else 0
+                    logger.info(
+                        "  API search: %d checked | found: %d (%.0f%%)",
+                        checked,
+                        found,
+                        hit_rate,
+                    )
+    finally:
+        if spotify:
+            await spotify.close()
+        await deezer.close()
+
+    logger.info("API search complete: %d found out of %d checked", found, checked)
+    return found, checked
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Album-level rollup
+# ---------------------------------------------------------------------------
+
+
+async def phase_album_rollup(results_db: ResultsDB) -> tuple[int, int]:
+    """Update album status based on track results. Returns (on_streaming, off_streaming)."""
+    assert results_db._db is not None
+
+    # Get all albums that have track results
+    cursor = await results_db._db.execute("SELECT DISTINCT album_id FROM track_results")
+    album_ids = [row[0] for row in await cursor.fetchall()]
+    logger.info("Rolling up track results for %d albums", len(album_ids))
+
+    on_streaming = 0
+    off_streaming = 0
+
+    for album_id in album_ids:
+        if _shutdown_requested:
+            break
+        summary = await results_db.get_album_track_summary(album_id)
+        if summary["pending"] > 0:
+            continue  # Not fully resolved yet
+
+        if summary["on_streaming"]:
+            on_streaming += 1
+        else:
+            off_streaming += 1
+
+    logger.info(
+        "Album rollup: %d on streaming, %d off streaming, %d total",
+        on_streaming,
+        off_streaming,
+        len(album_ids),
+    )
+    return on_streaming, off_streaming
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+async def run(args) -> None:
+    results_db = ResultsDB(args.results_db)
+    await results_db.connect()
+
+    try:
+        if args.stats:
+            stats = await results_db.get_track_stats()
+            print(f"\nTrack results: {stats.get('total', 0)} total")
+            for status, count in sorted(stats.items()):
+                if status != "total":
+                    print(f"  {status}: {count}")
+            return
+
+        # Phase 1: Extract
+        if args.phase in ("extract", "all"):
+            extracted = await phase_extract(results_db, args)
+            logger.info("Phase 1 complete: %d tracks extracted", extracted)
+            if args.dry_run:
+                logger.info("Dry run — stopping after extraction")
+                return
+
+        # Phase 2: Build index
+        if args.phase in ("resolve", "all") and not _shutdown_requested:
+            index = await phase_build_index(results_db)
+
+            # Phase 3: Local resolution
+            resolved, checked = await phase_local_resolve(results_db, index)
+            logger.info("Phase 3 complete: %d / %d resolved locally", resolved, checked)
+
+        # Phase 4: API search
+        if args.phase in ("search", "all") and not _shutdown_requested:
+            if not args.skip_api:
+                found, checked = await phase_api_search(results_db, args)
+                logger.info("Phase 4 complete: %d / %d found via API", found, checked)
+
+        # Phase 5: Album rollup
+        if args.phase in ("rollup", "all") and not _shutdown_requested:
+            on, off = await phase_album_rollup(results_db)
+            logger.info("Phase 5 complete: %d on streaming, %d off streaming", on, off)
+
+        # Final stats
+        stats = await results_db.get_track_stats()
+        logger.info(
+            "Final: %d total tracks | %s",
+            stats.get("total", 0),
+            " | ".join(f"{k}: {v}" for k, v in sorted(stats.items()) if k != "total"),
+        )
+
+    finally:
+        await results_db.close()
+
+
+def parse_args(argv: list[str] | None = None) -> Namespace:
+    parser = ArgumentParser(
+        description="Track-level streaming availability for singles and compilations.",
+    )
+    parser.add_argument("--results-db", default="streaming_availability.db")
+    parser.add_argument(
+        "--comp-json",
+        default="compilation_track_artists.json",
+        help="Path to compilation_track_artists.json",
+    )
+    parser.add_argument(
+        "--phase",
+        choices=["extract", "resolve", "search", "rollup", "all"],
+        default="all",
+    )
+    parser.add_argument("--batch-size", type=int, default=100)
+    parser.add_argument("--limit", type=int, default=100000)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--stats", action="store_true")
+    parser.add_argument("--skip-api", action="store_true", help="Skip API search phase")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main():
+    load_dotenv()
+    args = parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/track_streaming/__main__.py
+++ b/scripts/track_streaming/__main__.py
@@ -353,6 +353,73 @@ async def phase_api_search(results_db: ResultsDB, args) -> tuple[int, int]:
 
 
 # ---------------------------------------------------------------------------
+# Phase 4.5: URL validation
+# ---------------------------------------------------------------------------
+
+
+async def phase_validate(results_db: ResultsDB, args) -> tuple[int, int]:
+    """Validate matched track URLs against service metadata. Returns (valid, invalid)."""
+    import httpx
+
+    from scripts.track_streaming.validate import validate_deezer_url, validate_spotify_url
+
+    assert results_db._db is not None
+    cursor = await results_db._db.execute(
+        """SELECT id, artist, title, spotify_url, deezer_url
+           FROM track_results
+           WHERE resolution_status = 'api_match'
+             AND (spotify_url IS NOT NULL OR deezer_url IS NOT NULL)"""
+    )
+    rows = [dict(r) for r in await cursor.fetchall()]
+    logger.info("Validating %d API-matched track URLs", len(rows))
+
+    valid = 0
+    invalid = 0
+
+    async with httpx.AsyncClient() as http:
+        for i, row in enumerate(rows, 1):
+            if _shutdown_requested:
+                break
+
+            is_valid = True
+            if row["spotify_url"]:
+                is_valid = await validate_spotify_url(
+                    http, row["spotify_url"], row["artist"], row["title"]
+                )
+            if is_valid and row["deezer_url"]:
+                is_valid = await validate_deezer_url(
+                    http, row["deezer_url"], row["artist"], row["title"]
+                )
+
+            if is_valid:
+                valid += 1
+            else:
+                invalid += 1
+                logger.debug(
+                    "False positive: %s - %s (%s / %s)",
+                    row["artist"],
+                    row["title"],
+                    row["spotify_url"],
+                    row["deezer_url"],
+                )
+                await results_db.update_track_resolution(
+                    track_id=row["id"], status="false_positive"
+                )
+
+            if i % 100 == 0:
+                logger.info(
+                    "  Validate: %d / %d | valid: %d | false positive: %d",
+                    i,
+                    len(rows),
+                    valid,
+                    invalid,
+                )
+
+    logger.info("Validation complete: %d valid, %d false positives", valid, invalid)
+    return valid, invalid
+
+
+# ---------------------------------------------------------------------------
 # Phase 5: Album-level rollup
 # ---------------------------------------------------------------------------
 
@@ -442,6 +509,11 @@ async def run(args) -> None:
                 found, checked = await phase_api_search(results_db, args)
                 logger.info("Phase 4 complete: %d / %d found via API", found, checked)
 
+        # Phase 4.5: Validate API matches
+        if args.phase in ("validate", "all") and not _shutdown_requested:
+            valid, invalid = await phase_validate(results_db, args)
+            logger.info("Phase 4.5 complete: %d valid, %d false positives", valid, invalid)
+
         # Phase 5: Album rollup
         if args.phase in ("rollup", "all") and not _shutdown_requested:
             on, off = await phase_album_rollup(results_db)
@@ -471,7 +543,7 @@ def parse_args(argv: list[str] | None = None) -> Namespace:
     )
     parser.add_argument(
         "--phase",
-        choices=["extract", "resolve", "search", "rollup", "all"],
+        choices=["extract", "resolve", "search", "validate", "rollup", "all"],
         default="all",
     )
     parser.add_argument("--batch-size", type=int, default=100)

--- a/scripts/track_streaming/__main__.py
+++ b/scripts/track_streaming/__main__.py
@@ -378,8 +378,20 @@ async def phase_album_rollup(results_db: ResultsDB) -> tuple[int, int]:
 
         if summary["on_streaming"]:
             on_streaming += 1
+            # Update albums table so populate-on-streaming.py sees the result
+            await results_db._db.execute(
+                "UPDATE albums SET spotify_status = 'found' WHERE id = ? AND spotify_status != 'found'",
+                (album_id,),
+            )
         else:
             off_streaming += 1
+            await results_db._db.execute(
+                "UPDATE albums SET spotify_status = 'not_found' WHERE id = ? AND spotify_status = 'skipped'",
+                (album_id,),
+            )
+
+    async with results_db._write_lock:
+        await results_db._db.commit()
 
     logger.info(
         "Album rollup: %d on streaming, %d off streaming, %d total",

--- a/scripts/track_streaming/__main__.py
+++ b/scripts/track_streaming/__main__.py
@@ -264,11 +264,9 @@ async def phase_local_resolve(results_db: ResultsDB, index: LocalStreamingIndex)
                 )
                 resolved += 1
             else:
-                # Mark as checked_local so we don't re-check, but leave pending for API
-                # Actually, leave as pending — the API phase picks up pending tracks
-                pass
+                await results_db.update_track_resolution(track_id=row["id"], status="local_miss")
 
-        if checked % 5000 == 0:
+        if checked % 5000 == 0 and checked > 0:
             logger.info("  Local resolve: %d checked, %d resolved", checked, resolved)
 
     # Mark remaining pending tracks that weren't matched locally as 'pending_api'
@@ -304,11 +302,11 @@ async def phase_api_search(results_db: ResultsDB, args) -> tuple[int, int]:
 
     try:
         while not _shutdown_requested:
-            pending = await results_db.get_pending_tracks(limit=args.batch_size)
-            if not pending:
+            tracks = await results_db.get_local_miss_tracks(limit=args.batch_size)
+            if not tracks:
                 break
 
-            for row in pending:
+            for row in tracks:
                 if _shutdown_requested:
                     break
                 checked += 1

--- a/scripts/track_streaming/api_search.py
+++ b/scripts/track_streaming/api_search.py
@@ -1,7 +1,8 @@
 """Track-level search on Spotify and Deezer APIs.
 
 Wraps the existing SpotifyClient.search_track and DeezerClient.search_track
-with find_best_match scoring.
+with find_best_match scoring. Applies a higher confidence floor for short
+titles to reduce false positives on generic track names.
 """
 
 from __future__ import annotations
@@ -12,6 +13,9 @@ from scripts.streaming_availability.matching import find_best_match
 
 logger = logging.getLogger(__name__)
 
+SHORT_TITLE_LENGTH = 4
+SHORT_TITLE_CONFIDENCE = 95.0
+
 # Spotify track result accessors
 _SPOTIFY_ARTIST = lambda r: r.get("artists", [{}])[0].get("name", "")  # noqa: E731
 _SPOTIFY_TITLE = lambda r: r.get("name", "")  # noqa: E731
@@ -21,6 +25,13 @@ _SPOTIFY_URL = lambda r: r.get("external_urls", {}).get("spotify", "")  # noqa: 
 _DEEZER_ARTIST = lambda r: r.get("artist", {}).get("name", "")  # noqa: E731
 _DEEZER_TITLE = lambda r: r.get("title", "")  # noqa: E731
 _DEEZER_URL = lambda r: r.get("link", "")  # noqa: E731
+
+
+def _passes_confidence_floor(title: str, match: dict) -> bool:
+    """Check if a match meets the confidence floor for its title length."""
+    if len(title.strip()) <= SHORT_TITLE_LENGTH:
+        return match["confidence"] >= SHORT_TITLE_CONFIDENCE
+    return True
 
 
 async def search_track_on_services(
@@ -48,7 +59,7 @@ async def search_track_on_services(
                 title_fn=_DEEZER_TITLE,
                 url_fn=_DEEZER_URL,
             )
-            if match:
+            if match and _passes_confidence_floor(title, match):
                 result["deezer_url"] = match["url"]
                 result["deezer_confidence"] = match["confidence"]
         except Exception:
@@ -66,7 +77,7 @@ async def search_track_on_services(
                 title_fn=_SPOTIFY_TITLE,
                 url_fn=_SPOTIFY_URL,
             )
-            if match:
+            if match and _passes_confidence_floor(title, match):
                 result["spotify_url"] = match["url"]
                 result["spotify_confidence"] = match["confidence"]
         except Exception:

--- a/scripts/track_streaming/api_search.py
+++ b/scripts/track_streaming/api_search.py
@@ -1,0 +1,75 @@
+"""Track-level search on Spotify and Deezer APIs.
+
+Wraps the existing SpotifyClient.search_track and DeezerClient.search_track
+with find_best_match scoring.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from scripts.streaming_availability.matching import find_best_match
+
+logger = logging.getLogger(__name__)
+
+# Spotify track result accessors
+_SPOTIFY_ARTIST = lambda r: r.get("artists", [{}])[0].get("name", "")  # noqa: E731
+_SPOTIFY_TITLE = lambda r: r.get("name", "")  # noqa: E731
+_SPOTIFY_URL = lambda r: r.get("external_urls", {}).get("spotify", "")  # noqa: E731
+
+# Deezer track result accessors
+_DEEZER_ARTIST = lambda r: r.get("artist", {}).get("name", "")  # noqa: E731
+_DEEZER_TITLE = lambda r: r.get("title", "")  # noqa: E731
+_DEEZER_URL = lambda r: r.get("link", "")  # noqa: E731
+
+
+async def search_track_on_services(
+    artist: str,
+    title: str,
+    spotify=None,
+    deezer=None,
+) -> dict | None:
+    """Search for a track on Spotify and Deezer.
+
+    Returns a dict with spotify_url, spotify_confidence, deezer_url,
+    deezer_confidence keys, or None if not found on either.
+    """
+    result: dict = {}
+
+    # Deezer first (cheaper rate limit)
+    if deezer is not None:
+        try:
+            deezer_results = await deezer.search_track(artist, title)
+            match = find_best_match(
+                deezer_results,
+                artist,
+                title,
+                artist_fn=_DEEZER_ARTIST,
+                title_fn=_DEEZER_TITLE,
+                url_fn=_DEEZER_URL,
+            )
+            if match:
+                result["deezer_url"] = match["url"]
+                result["deezer_confidence"] = match["confidence"]
+        except Exception:
+            logger.warning("Deezer track search error for %s - %s", artist, title)
+
+    # Spotify
+    if spotify is not None:
+        try:
+            spotify_results = await spotify.search_track(artist, title)
+            match = find_best_match(
+                spotify_results,
+                artist,
+                title,
+                artist_fn=_SPOTIFY_ARTIST,
+                title_fn=_SPOTIFY_TITLE,
+                url_fn=_SPOTIFY_URL,
+            )
+            if match:
+                result["spotify_url"] = match["url"]
+                result["spotify_confidence"] = match["confidence"]
+        except Exception:
+            logger.warning("Spotify track search error for %s - %s", artist, title)
+
+    return result if result else None

--- a/scripts/track_streaming/local_index.py
+++ b/scripts/track_streaming/local_index.py
@@ -1,0 +1,77 @@
+"""In-memory index of tracks on on-streaming albums for local resolution.
+
+Builds a dict keyed by normalized track title, mapping to a list of
+TrackEntry records. Lookup scores the query artist against each candidate
+using the existing score_match() function.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import NamedTuple
+
+from wxyc_etl.text import normalize_artist_name as normalize_for_comparison
+
+from scripts.streaming_availability.matching import score_match
+
+
+class TrackEntry(NamedTuple):
+    """A track on an on-streaming album in the local index."""
+
+    artist: str
+    title: str
+    album_id: int
+    discogs_release_id: int
+    spotify_url: str | None
+    deezer_url: str | None
+
+
+class LocalStreamingIndex:
+    """In-memory index for resolving tracks against on-streaming albums.
+
+    Keyed by normalized track title for O(1) lookup, then scored by artist
+    similarity using score_match().
+    """
+
+    ARTIST_THRESHOLD = 80.0
+
+    def __init__(self):
+        self._index: dict[str, list[TrackEntry]] = defaultdict(list)
+        self._track_count = 0
+
+    def add(self, entry: TrackEntry) -> None:
+        """Add a track entry to the index."""
+        key = normalize_for_comparison(entry.title)
+        self._index[key].append(entry)
+        self._track_count += 1
+
+    def lookup(self, artist: str, title: str) -> TrackEntry | None:
+        """Look up a track by artist and title.
+
+        Returns the best-matching TrackEntry if the artist score meets the
+        threshold, or None if no match.
+        """
+        key = normalize_for_comparison(title)
+        candidates = self._index.get(key)
+        if not candidates:
+            return None
+
+        best_entry = None
+        best_score = 0.0
+        for entry in candidates:
+            artist_score = score_match(artist, entry.artist)
+            if artist_score >= self.ARTIST_THRESHOLD and artist_score > best_score:
+                best_score = artist_score
+                best_entry = entry
+
+        return best_entry
+
+    @property
+    def track_count(self) -> int:
+        """Total number of track entries in the index."""
+        return self._track_count
+
+    @property
+    def title_count(self) -> int:
+        """Number of unique normalized titles in the index."""
+        return len(self._index)

--- a/scripts/track_streaming/local_index.py
+++ b/scripts/track_streaming/local_index.py
@@ -34,6 +34,8 @@ class LocalStreamingIndex:
     """
 
     ARTIST_THRESHOLD = 80.0
+    SHORT_TITLE_THRESHOLD = 95.0  # Stricter for titles <= 4 chars
+    SHORT_TITLE_LENGTH = 4
 
     def __init__(self):
         self._index: dict[str, list[TrackEntry]] = defaultdict(list)
@@ -56,11 +58,17 @@ class LocalStreamingIndex:
         if not candidates:
             return None
 
+        threshold = (
+            self.SHORT_TITLE_THRESHOLD
+            if len(title.strip()) <= self.SHORT_TITLE_LENGTH
+            else self.ARTIST_THRESHOLD
+        )
+
         best_entry = None
         best_score = 0.0
         for entry in candidates:
             artist_score = score_match(artist, entry.artist)
-            if artist_score >= self.ARTIST_THRESHOLD and artist_score > best_score:
+            if artist_score >= threshold and artist_score > best_score:
                 best_score = artist_score
                 best_entry = entry
 

--- a/scripts/track_streaming/title_parser.py
+++ b/scripts/track_streaming/title_parser.py
@@ -1,0 +1,77 @@
+"""Parse single release titles into individual track names.
+
+Handles WXYC library catalog patterns:
+  - b/w (A-side / B-side): "Pickup Song b/w 3 Angels"
+  - // (split release): "Up with People // Dive for Your Memory"
+  - / (multi-track): "Versatile / Secret Secret"
+  - +N (bonus tracks): "Drawbridge + 3"
+  - Bracket tags: "Ego Trippin' (Part Two) [single]"
+  - Format suffixes: 'Do My Thing 12"'
+"""
+
+from __future__ import annotations
+
+import re
+
+from scripts.streaming_availability.matching import strip_format_suffix
+
+# Bracket tags: [single], [ep], [split 7-inch], [missing], [45 rpm EP], etc.
+_BRACKET_RE = re.compile(r"\s*\[[^\]]*\]\s*$")
+
+# b/w (backed with): A-side b/w B-side
+_BW_RE = re.compile(r"\s+b/w\s+", re.IGNORECASE)
+
+# Double slash: split releases
+_DOUBLE_SLASH_RE = re.compile(r"\s*//\s*")
+
+# Single slash with spaces on both sides
+_SLASH_RE = re.compile(r"\s+/\s+")
+
+# +N bonus tracks: "Title + 3"
+_PLUS_N_RE = re.compile(r"^(.+?)\s*\+\s*(\d+)\s*$")
+
+
+def _strip_plus_n(title: str) -> str:
+    """Strip trailing '+N' from a track segment, returning just the lead track."""
+    m = _PLUS_N_RE.match(title)
+    return m.group(1).strip() if m else title
+
+
+def parse_single_title(title: str) -> list[str]:
+    """Parse a single release title into individual track names.
+
+    Returns a list of cleaned track titles. Empty/whitespace input returns [].
+    """
+    if not title or not title.strip():
+        return []
+
+    # Step 1: Strip bracket tags
+    cleaned = _BRACKET_RE.sub("", title).strip()
+
+    # Step 2: Strip format suffixes (12", LP, EP, CD, reissue tags)
+    cleaned = strip_format_suffix(cleaned)
+
+    if not cleaned:
+        return []
+
+    # Step 3: Try b/w split (highest priority delimiter)
+    if _BW_RE.search(cleaned):
+        parts = _BW_RE.split(cleaned, maxsplit=1)
+        return [_strip_plus_n(p.strip()) for p in parts if p.strip()]
+
+    # Step 4: Try // split
+    if "//" in cleaned:
+        parts = _DOUBLE_SLASH_RE.split(cleaned)
+        return [_strip_plus_n(p.strip()) for p in parts if p.strip()]
+
+    # Step 5: Try / split (require spaces on both sides)
+    if _SLASH_RE.search(cleaned):
+        parts = _SLASH_RE.split(cleaned)
+        # Guard: each segment must be >= 3 chars to avoid splitting "S/t", "w/", etc.
+        if all(len(p.strip()) >= 3 for p in parts):
+            return [_strip_plus_n(p.strip()) for p in parts if p.strip()]
+
+    # Step 6: Strip +N from the whole title
+    cleaned = _strip_plus_n(cleaned)
+
+    return [cleaned] if cleaned else []

--- a/scripts/track_streaming/track_extractor.py
+++ b/scripts/track_streaming/track_extractor.py
@@ -1,0 +1,111 @@
+"""Extract individual tracks from singles and compilations.
+
+Singles: use Discogs tracklist when available, fall back to title parsing.
+Compilations: use pre-computed per-track artist data from JSON.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from scripts.track_streaming.title_parser import parse_single_title
+
+logger = logging.getLogger(__name__)
+
+
+def _make_track(
+    album_id: int,
+    artist: str,
+    title: str,
+    position: str | None,
+    source: str,
+    source_type: str,
+) -> dict:
+    return {
+        "album_id": album_id,
+        "artist": artist,
+        "title": title,
+        "position": position,
+        "source": source,
+        "source_type": source_type,
+    }
+
+
+def _extract_from_title(row: dict) -> list[dict]:
+    """Parse tracks from the display_title using delimiter patterns."""
+    album_id = row["id"]
+    artist = row["display_artist"]
+    titles = parse_single_title(row["display_title"])
+    return [_make_track(album_id, artist, t, None, "title_parse", "single") for t in titles]
+
+
+async def extract_single_tracks(row: dict, discogs_cache=None) -> list[dict]:
+    """Extract tracks from a single.
+
+    If discogs_cache is provided and the row has a discogs_release_id,
+    fetches the authoritative tracklist from the Discogs cache.
+    Falls back to title parsing on cache miss or error.
+    """
+    release_id = row.get("discogs_release_id")
+    if release_id and discogs_cache is not None:
+        try:
+            release = await discogs_cache.get_release(release_id)
+        except Exception:
+            logger.warning("Discogs cache error for release %d", release_id)
+            return _extract_from_title(row)
+
+        if release is not None and release.tracklist:
+            album_id = row["id"]
+            artist = row["display_artist"]
+            tracks = []
+            for t in release.tracklist:
+                track_artist = t.artists[0] if t.artists else artist
+                tracks.append(
+                    _make_track(
+                        album_id,
+                        track_artist,
+                        t.title,
+                        t.position,
+                        "discogs_tracklist",
+                        "single",
+                    )
+                )
+            return tracks
+
+    return _extract_from_title(row)
+
+
+def extract_compilation_tracks(row: dict, comp_data: dict | None) -> list[dict]:
+    """Extract per-track artist credits from compilation JSON data.
+
+    Args:
+        row: Album row from streaming_availability.db.
+        comp_data: Entry from compilation_track_artists.json, or None.
+
+    Returns:
+        List of track dicts, or [] if no data available.
+    """
+    if not comp_data:
+        return []
+
+    tracks_data = comp_data.get("tracks", [])
+    if not tracks_data:
+        return []
+
+    album_id = row["id"]
+    tracks = []
+    for t in tracks_data:
+        artists = t.get("artists", [])
+        if not artists:
+            continue
+        tracks.append(
+            _make_track(
+                album_id,
+                artists[0],
+                t["title"],
+                t.get("position"),
+                "discogs_tracklist",
+                "compilation",
+            )
+        )
+    return tracks

--- a/scripts/track_streaming/validate.py
+++ b/scripts/track_streaming/validate.py
@@ -1,0 +1,105 @@
+"""Validate track-level streaming URLs against service metadata.
+
+Uses Spotify oEmbed and Deezer public API to verify that matched URLs
+actually correspond to the expected artist and track.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import httpx
+from rapidfuzz import fuzz
+
+logger = logging.getLogger(__name__)
+
+SPOTIFY_OEMBED = "https://open.spotify.com/oembed"
+DEEZER_API = "https://api.deezer.com"
+
+# Minimum fuzzy score for the service metadata to match our expected artist/title
+VALIDATION_THRESHOLD = 40
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip parentheticals and common noise."""
+    t = text.lower().strip()
+    t = re.sub(r"\s*\([^)]*\)", "", t)
+    t = re.sub(r"\s*\[[^\]]*\]", "", t)
+    return t.strip()
+
+
+def _is_valid_match(expected_artist: str, expected_title: str, actual_text: str) -> bool:
+    """Check if the service metadata text matches our expected artist/title."""
+    actual = _normalize(actual_text)
+    exp_artist = _normalize(expected_artist)
+    exp_title = _normalize(expected_title)
+
+    # Check if artist name appears in the metadata
+    if exp_artist in actual:
+        return True
+
+    # Check if title appears in the metadata
+    if len(exp_title) >= 4 and exp_title in actual:
+        return True
+
+    # Fuzzy check on the title portion
+    # oEmbed often returns "Track - Artist" or just "Track"
+    parts = actual.split(" - ", 1)
+    for part in parts:
+        if fuzz.token_sort_ratio(exp_title, part) >= VALIDATION_THRESHOLD:
+            return True
+
+    return False
+
+
+async def validate_spotify_url(
+    http: httpx.AsyncClient,
+    url: str,
+    expected_artist: str,
+    expected_title: str,
+) -> bool:
+    """Validate a Spotify track URL via oEmbed."""
+    try:
+        resp = await http.get(SPOTIFY_OEMBED, params={"url": url}, timeout=10)
+        if resp.status_code != 200:
+            return False
+        data = resp.json()
+        title = data.get("title", "")
+        return _is_valid_match(expected_artist, expected_title, title)
+    except Exception:
+        logger.debug("Spotify oEmbed error for %s", url)
+        return True  # Assume valid on error (don't discard good data)
+
+
+async def validate_deezer_url(
+    http: httpx.AsyncClient,
+    url: str,
+    expected_artist: str,
+    expected_title: str,
+) -> bool:
+    """Validate a Deezer track URL via public API."""
+    # Extract track ID from URL: https://www.deezer.com/track/123456
+    match = re.search(r"/track/(\d+)", url)
+    if not match:
+        return False
+    track_id = match.group(1)
+    try:
+        resp = await http.get(f"{DEEZER_API}/track/{track_id}", timeout=10)
+        if resp.status_code != 200:
+            return False
+        data = resp.json()
+        actual_title = data.get("title", "")
+        actual_artist = data.get("artist", {}).get("name", "")
+        artist_ok = (
+            fuzz.token_sort_ratio(_normalize(expected_artist), _normalize(actual_artist))
+            >= VALIDATION_THRESHOLD
+        )
+        title_ok = (
+            fuzz.token_sort_ratio(_normalize(expected_title), _normalize(actual_title))
+            >= VALIDATION_THRESHOLD
+        )
+        return artist_ok and title_ok
+    except Exception:
+        logger.debug("Deezer API error for %s", url)
+        return True  # Assume valid on error

--- a/tests/unit/test_api_search.py
+++ b/tests/unit/test_api_search.py
@@ -100,3 +100,33 @@ class TestSearchTrackOnServices:
     async def test_no_clients_returns_none(self):
         result = await search_track_on_services("Codeine", "Pickup Song", None, None)
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_short_title_exact_artist_accepted(self):
+        """Short title 'Dub' with exact artist match should pass the confidence floor."""
+        deezer = AsyncMock()
+        deezer.search_track.return_value = [
+            {
+                "title": "Dub",
+                "artist": {"name": "Autechre"},
+                "link": "https://www.deezer.com/track/999",
+            }
+        ]
+        result = await search_track_on_services("Autechre", "Dub", None, deezer)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_short_title_fuzzy_artist_rejected(self):
+        """Short title with a marginal artist match should be rejected for short titles."""
+        deezer = AsyncMock()
+        # "Sango" vs "Sangoma" scores ~83 artist, 100 title → combined ~92
+        # Passes the normal 80 threshold but fails the 95 short-title floor
+        deezer.search_track.return_value = [
+            {
+                "title": "Dub",
+                "artist": {"name": "Sangoma"},
+                "link": "https://www.deezer.com/track/999",
+            }
+        ]
+        result = await search_track_on_services("Sango", "Dub", None, deezer)
+        assert result is None

--- a/tests/unit/test_api_search.py
+++ b/tests/unit/test_api_search.py
@@ -1,0 +1,102 @@
+"""Tests for the track-level API search wrapper."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.track_streaming.api_search import search_track_on_services
+
+
+class TestSearchTrackOnServices:
+    @pytest.mark.asyncio
+    async def test_found_on_spotify(self):
+        spotify = AsyncMock()
+        spotify.search_track.return_value = [
+            {
+                "name": "Pickup Song",
+                "artists": [{"name": "Codeine"}],
+                "external_urls": {"spotify": "https://open.spotify.com/track/abc"},
+                "id": "abc",
+            }
+        ]
+        deezer = AsyncMock()
+        deezer.search_track.return_value = []
+
+        result = await search_track_on_services("Codeine", "Pickup Song", spotify, deezer)
+        assert result is not None
+        assert result["spotify_url"] == "https://open.spotify.com/track/abc"
+
+    @pytest.mark.asyncio
+    async def test_found_on_deezer(self):
+        spotify = AsyncMock()
+        spotify.search_track.return_value = []
+        deezer = AsyncMock()
+        deezer.search_track.return_value = [
+            {
+                "title": "Pickup Song",
+                "artist": {"name": "Codeine"},
+                "link": "https://www.deezer.com/track/123",
+            }
+        ]
+
+        result = await search_track_on_services("Codeine", "Pickup Song", spotify, deezer)
+        assert result is not None
+        assert result["deezer_url"] == "https://www.deezer.com/track/123"
+
+    @pytest.mark.asyncio
+    async def test_not_found_on_either(self):
+        spotify = AsyncMock()
+        spotify.search_track.return_value = []
+        deezer = AsyncMock()
+        deezer.search_track.return_value = []
+
+        result = await search_track_on_services("Codeine", "Pickup Song", spotify, deezer)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_found_on_both(self):
+        spotify = AsyncMock()
+        spotify.search_track.return_value = [
+            {
+                "name": "Pickup Song",
+                "artists": [{"name": "Codeine"}],
+                "external_urls": {"spotify": "https://open.spotify.com/track/abc"},
+                "id": "abc",
+            }
+        ]
+        deezer = AsyncMock()
+        deezer.search_track.return_value = [
+            {
+                "title": "Pickup Song",
+                "artist": {"name": "Codeine"},
+                "link": "https://www.deezer.com/track/123",
+            }
+        ]
+
+        result = await search_track_on_services("Codeine", "Pickup Song", spotify, deezer)
+        assert result is not None
+        assert result["spotify_url"] is not None
+        assert result["deezer_url"] is not None
+
+    @pytest.mark.asyncio
+    async def test_spotify_error_still_returns_deezer(self):
+        spotify = AsyncMock()
+        spotify.search_track.side_effect = Exception("rate limited")
+        deezer = AsyncMock()
+        deezer.search_track.return_value = [
+            {
+                "title": "Pickup Song",
+                "artist": {"name": "Codeine"},
+                "link": "https://www.deezer.com/track/123",
+            }
+        ]
+
+        result = await search_track_on_services("Codeine", "Pickup Song", spotify, deezer)
+        assert result is not None
+        assert result["deezer_url"] is not None
+        assert result.get("spotify_url") is None
+
+    @pytest.mark.asyncio
+    async def test_no_clients_returns_none(self):
+        result = await search_track_on_services("Codeine", "Pickup Song", None, None)
+        assert result is None

--- a/tests/unit/test_local_index.py
+++ b/tests/unit/test_local_index.py
@@ -94,6 +94,29 @@ class TestLocalStreamingIndex:
         match = index.lookup("Duke Ellington", "Love")
         assert match is None
 
+    def test_short_title_requires_higher_artist_score(self):
+        """Short titles like 'Dub' need a stricter artist match to avoid false positives."""
+        index = self._build_index(
+            [
+                ("Autechre", "Dub", 1, None),
+            ]
+        )
+        # Exact artist match should still work even for short titles
+        match = index.lookup("Autechre", "Dub")
+        assert match is not None
+
+    def test_short_title_rejects_fuzzy_artist(self):
+        """Short title + fuzzy artist = too risky."""
+        index = self._build_index(
+            [
+                ("The Chemical Brothers", "Love", 1, None),
+            ]
+        )
+        # "Chemical Brothers" vs "The Chemical Brothers" would pass normal threshold
+        # but with a 3-char title, we need near-exact artist
+        match = index.lookup("Chemical Sisters", "Love")
+        assert match is None
+
     def test_stats(self):
         index = self._build_index(
             [

--- a/tests/unit/test_local_index.py
+++ b/tests/unit/test_local_index.py
@@ -1,0 +1,106 @@
+"""Tests for the in-memory local streaming index."""
+
+from scripts.track_streaming.local_index import LocalStreamingIndex, TrackEntry
+
+
+class TestLocalStreamingIndex:
+    def _build_index(self, entries: list[tuple[str, str, int, str | None]]):
+        """Build an index from (artist, title, album_id, spotify_url) tuples."""
+        index = LocalStreamingIndex()
+        for artist, title, album_id, spotify_url in entries:
+            index.add(
+                TrackEntry(
+                    artist=artist,
+                    title=title,
+                    album_id=album_id,
+                    discogs_release_id=0,
+                    spotify_url=spotify_url,
+                    deezer_url=None,
+                )
+            )
+        return index
+
+    def test_exact_match(self):
+        index = self._build_index(
+            [
+                ("Codeine", "Pickup Song", 42, "https://open.spotify.com/track/abc"),
+            ]
+        )
+        match = index.lookup("Codeine", "Pickup Song")
+        assert match is not None
+        assert match.album_id == 42
+        assert match.spotify_url == "https://open.spotify.com/track/abc"
+
+    def test_case_insensitive(self):
+        index = self._build_index(
+            [
+                ("Codeine", "Pickup Song", 42, None),
+            ]
+        )
+        match = index.lookup("codeine", "pickup song")
+        assert match is not None
+
+    def test_no_match_wrong_artist(self):
+        index = self._build_index(
+            [
+                ("Codeine", "Pickup Song", 42, None),
+            ]
+        )
+        match = index.lookup("Stereolab", "Pickup Song")
+        assert match is None
+
+    def test_no_match_wrong_title(self):
+        index = self._build_index(
+            [
+                ("Codeine", "Pickup Song", 42, None),
+            ]
+        )
+        match = index.lookup("Codeine", "Nonexistent Track")
+        assert match is None
+
+    def test_fuzzy_artist_match(self):
+        """'The Chemical Brothers' should match 'Chemical Brothers'."""
+        index = self._build_index(
+            [
+                ("The Chemical Brothers", "Block Rockin' Beats", 10, None),
+            ]
+        )
+        match = index.lookup("Chemical Brothers", "Block Rockin' Beats")
+        assert match is not None
+
+    def test_multiple_candidates_best_artist_wins(self):
+        index = self._build_index(
+            [
+                ("Codeine", "Love", 1, "https://spotify/1"),
+                ("Cat Power", "Love", 2, "https://spotify/2"),
+            ]
+        )
+        match = index.lookup("Cat Power", "Love")
+        assert match is not None
+        assert match.album_id == 2
+
+    def test_empty_index(self):
+        index = LocalStreamingIndex()
+        match = index.lookup("Codeine", "Pickup Song")
+        assert match is None
+
+    def test_artist_below_threshold_rejected(self):
+        """Completely different artist should not match even with same title."""
+        index = self._build_index(
+            [
+                ("Autechre", "Love", 1, None),
+            ]
+        )
+        match = index.lookup("Duke Ellington", "Love")
+        assert match is None
+
+    def test_stats(self):
+        index = self._build_index(
+            [
+                ("A", "T1", 1, None),
+                ("A", "T2", 1, None),
+                ("B", "T3", 2, None),
+            ]
+        )
+        assert index.track_count == 3
+        assert index.title_count >= 2  # At least 2 unique normalized titles

--- a/tests/unit/test_title_parser.py
+++ b/tests/unit/test_title_parser.py
@@ -1,0 +1,169 @@
+"""Tests for single title parsing into individual tracks."""
+
+from scripts.track_streaming.title_parser import parse_single_title
+
+
+class TestBwSplitting:
+    """b/w pattern: A-side b/w B-side."""
+
+    def test_basic_bw(self):
+        assert parse_single_title("Pickup Song b/w 3 Angels") == [
+            "Pickup Song",
+            "3 Angels",
+        ]
+
+    def test_bw_case_insensitive(self):
+        assert parse_single_title("Forces B/W Hey! Hey! Hey!") == [
+            "Forces",
+            "Hey! Hey! Hey!",
+        ]
+
+    def test_bw_with_format_suffix(self):
+        result = parse_single_title('Absenter b/w Chinese Fork Tie 12"')
+        assert result == ["Absenter", "Chinese Fork Tie"]
+
+    def test_bw_with_bracket_tag(self):
+        result = parse_single_title(
+            "My Forgotten Favorite b/w Why Should I Be Nice to You? [single]"
+        )
+        assert result == ["My Forgotten Favorite", "Why Should I Be Nice to You?"]
+
+    def test_bw_with_parenthetical_track(self):
+        result = parse_single_title("Paralyzed b/w Caught, Punished and Punished")
+        assert result == ["Paralyzed", "Caught, Punished and Punished"]
+
+
+class TestDoubleSlashSplitting:
+    """// pattern: split releases."""
+
+    def test_basic_double_slash(self):
+        assert parse_single_title("Up with People // Dive for Your Memory") == [
+            "Up with People",
+            "Dive for Your Memory",
+        ]
+
+    def test_double_slash_with_plus_n(self):
+        result = parse_single_title("Full Throttle // Self Service + 1")
+        assert result == ["Full Throttle", "Self Service"]
+
+    def test_double_slash_with_both_plus_n(self):
+        result = parse_single_title("American Cooter + 2 // Lech")
+        assert result == ["American Cooter", "Lech"]
+
+    def test_double_slash_with_bracket(self):
+        result = parse_single_title("The Mad Stretch // To Cause a Fracas [split 7-inch]")
+        assert result == ["The Mad Stretch", "To Cause a Fracas"]
+
+
+class TestSlashSplitting:
+    """/ pattern: multiple tracks on one release."""
+
+    def test_basic_slash(self):
+        assert parse_single_title("Versatile / Secret Secret") == [
+            "Versatile",
+            "Secret Secret",
+        ]
+
+    def test_triple_slash(self):
+        result = parse_single_title("Info Kill / Population Control / Get it Poppin'")
+        assert result == ["Info Kill", "Population Control", "Get it Poppin'"]
+
+    def test_slash_with_plus_n(self):
+        result = parse_single_title("Merckx / Recommend for Digestion + 1")
+        assert result == ["Merckx", "Recommend for Digestion"]
+
+    def test_no_split_without_spaces(self):
+        """'My Neighbor/ My Creator' has no space before / — should NOT split."""
+        result = parse_single_title("My Neighbor/ My Creator")
+        assert result == ["My Neighbor/ My Creator"]
+
+    def test_no_split_short_segment(self):
+        """S/t (self-titled) should NOT split."""
+        result = parse_single_title("S/t")
+        assert result == ["S/t"]
+
+    def test_tw33tz_slash(self):
+        """'TW33tz / Oscillate' has spaces — should split."""
+        result = parse_single_title("TW33tz / Oscillate")
+        assert result == ["TW33tz", "Oscillate"]
+
+
+class TestPlusN:
+    """+N pattern: lead track plus unnamed bonus tracks."""
+
+    def test_basic_plus_n(self):
+        assert parse_single_title("Drawbridge + 3") == ["Drawbridge"]
+
+    def test_plus_n_with_bracket(self):
+        result = parse_single_title("She Pays the Rent + 2 [single]")
+        assert result == ["She Pays the Rent"]
+
+    def test_some_jingle_jangle(self):
+        result = parse_single_title("Some Jingle Jangle Morning + 2")
+        assert result == ["Some Jingle Jangle Morning"]
+
+    def test_plus_in_title_not_plus_n(self):
+        """'Sinning Is Easy + 2' is +N, but 'C+ in F' is not."""
+        # This is intentionally not a +N pattern (no trailing digit after +)
+        result = parse_single_title("C+ in F")
+        assert result == ["C+ in F"]
+
+
+class TestBracketAndFormatStripping:
+    """Bracket tags and format suffixes are stripped before splitting."""
+
+    def test_single_bracket(self):
+        result = parse_single_title("Ego Trippin' (Part Two) [single]")
+        assert result == ["Ego Trippin' (Part Two)"]
+
+    def test_ep_bracket(self):
+        result = parse_single_title("Salt On Everything [ep]")
+        assert result == ["Salt On Everything"]
+
+    def test_format_suffix_12_inch(self):
+        result = parse_single_title('Do My Thing 12"')
+        assert result == ["Do My Thing"]
+
+    def test_45_rpm_ep(self):
+        result = parse_single_title("4AD [45 rpm EP]")
+        assert result == ["4AD"]
+
+    def test_missing_bracket(self):
+        result = parse_single_title("Kidding on the Square // If You Hurt Me [missing]")
+        assert result == ["Kidding on the Square", "If You Hurt Me"]
+
+
+class TestNoDelimiter:
+    """Titles with no delimiter produce a single track."""
+
+    def test_simple_title(self):
+        assert parse_single_title("Dirge") == ["Dirge"]
+
+    def test_title_with_parenthetical(self):
+        assert parse_single_title("Remix") == ["Remix"]
+
+    def test_single_word(self):
+        assert parse_single_title("Cymbals") == ["Cymbals"]
+
+    def test_multi_word(self):
+        assert parse_single_title("Walk along the Bottom") == ["Walk along the Bottom"]
+
+
+class TestEdgeCases:
+    """Edge cases and empty input."""
+
+    def test_empty_string(self):
+        assert parse_single_title("") == []
+
+    def test_whitespace_only(self):
+        assert parse_single_title("   ") == []
+
+    def test_bw_takes_priority_over_slash(self):
+        """If a title has both b/w and /, b/w wins."""
+        result = parse_single_title("Track A b/w Track B / Track C")
+        assert result == ["Track A", "Track B / Track C"]
+
+    def test_double_slash_takes_priority_over_slash(self):
+        """// wins over /."""
+        result = parse_single_title("Track A // Track B / Track C")
+        assert result == ["Track A", "Track B / Track C"]

--- a/tests/unit/test_track_extractor.py
+++ b/tests/unit/test_track_extractor.py
@@ -1,0 +1,177 @@
+"""Tests for track extraction from singles and compilations."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.models import ReleaseMetadataResponse, TrackItem
+from scripts.track_streaming.track_extractor import (
+    extract_compilation_tracks,
+    extract_single_tracks,
+)
+
+
+def _make_album_row(
+    album_id=1,
+    display_artist="Codeine",
+    display_title='Pickup Song b/w 3 Angels 7"',
+    discogs_release_id=None,
+    is_single=1,
+    is_compilation=0,
+):
+    """Create a dict resembling a streaming_availability.db album row."""
+    return {
+        "id": album_id,
+        "display_artist": display_artist,
+        "display_title": display_title,
+        "discogs_release_id": discogs_release_id,
+        "is_single": is_single,
+        "is_compilation": is_compilation,
+    }
+
+
+def _make_release_metadata(tracks):
+    """Create a ReleaseMetadataResponse with the given tracks."""
+    return ReleaseMetadataResponse(
+        release_id=12345,
+        title="Test Release",
+        artist="Test Artist",
+        release_url="https://www.discogs.com/release/12345",
+        tracklist=tracks,
+    )
+
+
+class TestExtractSingleTracksFromTitle:
+    """When no discogs_release_id, parse the display_title."""
+
+    @pytest.mark.asyncio
+    async def test_bw_title(self):
+        row = _make_album_row()
+        tracks = await extract_single_tracks(row, discogs_cache=None)
+        assert len(tracks) == 2
+        assert tracks[0]["artist"] == "Codeine"
+        assert tracks[0]["title"] == "Pickup Song"
+        assert tracks[0]["source"] == "title_parse"
+        assert tracks[0]["source_type"] == "single"
+        assert tracks[1]["title"] == "3 Angels"
+
+    @pytest.mark.asyncio
+    async def test_single_track_title(self):
+        row = _make_album_row(display_title="Dirge")
+        tracks = await extract_single_tracks(row, discogs_cache=None)
+        assert len(tracks) == 1
+        assert tracks[0]["title"] == "Dirge"
+
+    @pytest.mark.asyncio
+    async def test_plus_n_title(self):
+        row = _make_album_row(display_title="Drawbridge + 3")
+        tracks = await extract_single_tracks(row, discogs_cache=None)
+        assert len(tracks) == 1
+        assert tracks[0]["title"] == "Drawbridge"
+
+    @pytest.mark.asyncio
+    async def test_album_id_propagated(self):
+        row = _make_album_row(album_id=42)
+        tracks = await extract_single_tracks(row, discogs_cache=None)
+        assert all(t["album_id"] == 42 for t in tracks)
+
+
+class TestExtractSingleTracksFromDiscogs:
+    """When discogs_release_id is set, fetch tracklist from cache."""
+
+    @pytest.mark.asyncio
+    async def test_uses_discogs_tracklist(self):
+        cache = AsyncMock()
+        cache.get_release.return_value = _make_release_metadata(
+            [
+                TrackItem(position="A", title="Pickup Song"),
+                TrackItem(position="B", title="3 Angels"),
+            ]
+        )
+        row = _make_album_row(discogs_release_id=12345)
+        tracks = await extract_single_tracks(row, discogs_cache=cache)
+        assert len(tracks) == 2
+        assert tracks[0]["title"] == "Pickup Song"
+        assert tracks[0]["position"] == "A"
+        assert tracks[0]["source"] == "discogs_tracklist"
+        cache.get_release.assert_called_once_with(12345)
+
+    @pytest.mark.asyncio
+    async def test_discogs_with_per_track_artists(self):
+        """Remixes may have different per-track artists."""
+        cache = AsyncMock()
+        cache.get_release.return_value = _make_release_metadata(
+            [
+                TrackItem(position="A", title="Egypt Egypt", artists=[]),
+                TrackItem(position="B", title="Egypt Egypt (Dub Mix)", artists=["DJ Shadow"]),
+            ]
+        )
+        row = _make_album_row(display_artist="Egyptian Lover", discogs_release_id=99)
+        tracks = await extract_single_tracks(row, discogs_cache=cache)
+        assert tracks[0]["artist"] == "Egyptian Lover"
+        assert tracks[1]["artist"] == "DJ Shadow"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_title_parse_on_cache_miss(self):
+        cache = AsyncMock()
+        cache.get_release.return_value = None
+        row = _make_album_row(display_title="Forces b/w Hey! Hey! Hey!", discogs_release_id=999)
+        tracks = await extract_single_tracks(row, discogs_cache=cache)
+        assert len(tracks) == 2
+        assert tracks[0]["source"] == "title_parse"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_cache_error(self):
+        cache = AsyncMock()
+        cache.get_release.side_effect = Exception("connection refused")
+        row = _make_album_row(display_title="Dirge", discogs_release_id=888)
+        tracks = await extract_single_tracks(row, discogs_cache=cache)
+        assert len(tracks) == 1
+        assert tracks[0]["source"] == "title_parse"
+
+
+class TestExtractCompilationTracks:
+    """Extract per-track artist credits from compilation JSON data."""
+
+    def test_basic_compilation(self):
+        comp_data = {
+            "comp_id": 935,
+            "tracks": [
+                {"position": "1-01", "title": "The Lost Planet", "artists": ["Planisphere"]},
+                {"position": "1-02", "title": "Subraumstimulation", "artists": ["Oliver Lieb"]},
+            ],
+        }
+        row = _make_album_row(album_id=935, is_compilation=1)
+        tracks = extract_compilation_tracks(row, comp_data)
+        assert len(tracks) == 2
+        assert tracks[0]["artist"] == "Planisphere"
+        assert tracks[0]["title"] == "The Lost Planet"
+        assert tracks[0]["position"] == "1-01"
+        assert tracks[0]["source"] == "discogs_tracklist"
+        assert tracks[0]["source_type"] == "compilation"
+
+    def test_multi_artist_track_uses_first(self):
+        comp_data = {
+            "comp_id": 1,
+            "tracks": [
+                {
+                    "position": "A1",
+                    "title": "Collaboration",
+                    "artists": ["Artist A", "Artist B"],
+                },
+            ],
+        }
+        row = _make_album_row(album_id=1, is_compilation=1)
+        tracks = extract_compilation_tracks(row, comp_data)
+        assert tracks[0]["artist"] == "Artist A"
+
+    def test_no_comp_data_returns_empty(self):
+        row = _make_album_row(album_id=999, is_compilation=1)
+        tracks = extract_compilation_tracks(row, comp_data=None)
+        assert tracks == []
+
+    def test_empty_tracks_returns_empty(self):
+        comp_data = {"comp_id": 1, "tracks": []}
+        row = _make_album_row(album_id=1, is_compilation=1)
+        tracks = extract_compilation_tracks(row, comp_data)
+        assert tracks == []

--- a/tests/unit/test_track_results_db.py
+++ b/tests/unit/test_track_results_db.py
@@ -1,0 +1,268 @@
+"""Tests for track_results table CRUD in ResultsDB."""
+
+import pytest
+import pytest_asyncio
+
+from scripts.streaming_availability.results_db import ResultsDB
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    results_db = ResultsDB(str(tmp_path / "test.db"))
+    await results_db.connect()
+    yield results_db
+    await results_db.close()
+
+
+class TestTrackResultsSchema:
+    """Test that the track_results table is created on connect."""
+
+    @pytest.mark.asyncio
+    async def test_table_exists(self, db):
+        cursor = await db._db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='track_results'"
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+
+    @pytest.mark.asyncio
+    async def test_table_columns(self, db):
+        cursor = await db._db.execute("PRAGMA table_info(track_results)")
+        columns = {row[1] for row in await cursor.fetchall()}
+        expected = {
+            "id",
+            "album_id",
+            "artist",
+            "title",
+            "position",
+            "source",
+            "source_type",
+            "resolution_status",
+            "resolved_via",
+            "resolved_album_id",
+            "resolved_release_id",
+            "spotify_url",
+            "spotify_confidence",
+            "deezer_url",
+            "deezer_confidence",
+            "checked_at",
+            "created_at",
+        }
+        assert expected.issubset(columns)
+
+
+class TestInsertTracks:
+    @pytest.mark.asyncio
+    async def test_insert_and_count(self, db):
+        tracks = [
+            {
+                "album_id": 1,
+                "artist": "Codeine",
+                "title": "Pickup Song",
+                "position": "A",
+                "source": "title_parse",
+                "source_type": "single",
+            },
+            {
+                "album_id": 1,
+                "artist": "Codeine",
+                "title": "3 Angels",
+                "position": "B",
+                "source": "title_parse",
+                "source_type": "single",
+            },
+        ]
+        inserted = await db.insert_tracks(tracks)
+        assert inserted == 2
+
+    @pytest.mark.asyncio
+    async def test_insert_deduplicates(self, db):
+        track = {
+            "album_id": 1,
+            "artist": "Codeine",
+            "title": "Pickup Song",
+            "position": "A",
+            "source": "title_parse",
+            "source_type": "single",
+        }
+        await db.insert_tracks([track])
+        inserted = await db.insert_tracks([track])
+        assert inserted == 0
+
+
+class TestGetPendingTracks:
+    @pytest.mark.asyncio
+    async def test_returns_pending_only(self, db):
+        tracks = [
+            {
+                "album_id": 1,
+                "artist": "Codeine",
+                "title": "Pickup Song",
+                "position": "A",
+                "source": "title_parse",
+                "source_type": "single",
+            },
+            {
+                "album_id": 1,
+                "artist": "Codeine",
+                "title": "3 Angels",
+                "position": "B",
+                "source": "title_parse",
+                "source_type": "single",
+            },
+        ]
+        await db.insert_tracks(tracks)
+        # Resolve one track
+        await db.update_track_resolution(
+            track_id=1,
+            status="local_match",
+            resolved_via="local_index",
+            resolved_album_id=99,
+            spotify_url="https://open.spotify.com/track/abc",
+            spotify_confidence=95.0,
+        )
+        pending = await db.get_pending_tracks(limit=100)
+        assert len(pending) == 1
+        assert pending[0]["title"] == "3 Angels"
+
+
+class TestUpdateTrackResolution:
+    @pytest.mark.asyncio
+    async def test_local_match(self, db):
+        await db.insert_tracks(
+            [
+                {
+                    "album_id": 1,
+                    "artist": "Codeine",
+                    "title": "Pickup Song",
+                    "position": "A",
+                    "source": "title_parse",
+                    "source_type": "single",
+                }
+            ]
+        )
+        await db.update_track_resolution(
+            track_id=1,
+            status="local_match",
+            resolved_via="local_index",
+            resolved_album_id=42,
+            spotify_url="https://open.spotify.com/track/xyz",
+            spotify_confidence=90.0,
+        )
+        cursor = await db._db.execute("SELECT * FROM track_results WHERE id = 1")
+        row = await cursor.fetchone()
+        assert row["resolution_status"] == "local_match"
+        assert row["resolved_via"] == "local_index"
+        assert row["resolved_album_id"] == 42
+        assert row["spotify_url"] == "https://open.spotify.com/track/xyz"
+        assert row["checked_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, db):
+        await db.insert_tracks(
+            [
+                {
+                    "album_id": 1,
+                    "artist": "Codeine",
+                    "title": "Pickup Song",
+                    "position": "A",
+                    "source": "title_parse",
+                    "source_type": "single",
+                }
+            ]
+        )
+        await db.update_track_resolution(track_id=1, status="not_found")
+        cursor = await db._db.execute("SELECT * FROM track_results WHERE id = 1")
+        row = await cursor.fetchone()
+        assert row["resolution_status"] == "not_found"
+        assert row["resolved_via"] is None
+
+
+class TestTrackStats:
+    @pytest.mark.asyncio
+    async def test_stats_by_status(self, db):
+        tracks = [
+            {
+                "album_id": 1,
+                "artist": "A",
+                "title": "T1",
+                "position": None,
+                "source": "title_parse",
+                "source_type": "single",
+            },
+            {
+                "album_id": 1,
+                "artist": "A",
+                "title": "T2",
+                "position": None,
+                "source": "title_parse",
+                "source_type": "single",
+            },
+            {
+                "album_id": 2,
+                "artist": "B",
+                "title": "T3",
+                "position": None,
+                "source": "discogs_tracklist",
+                "source_type": "compilation",
+            },
+        ]
+        await db.insert_tracks(tracks)
+        await db.update_track_resolution(
+            track_id=1, status="local_match", resolved_via="local_index"
+        )
+        stats = await db.get_track_stats()
+        assert stats["pending"] == 2
+        assert stats["local_match"] == 1
+        assert stats["total"] == 3
+
+
+class TestAlbumTrackSummary:
+    @pytest.mark.asyncio
+    async def test_any_resolved_means_on_streaming(self, db):
+        tracks = [
+            {
+                "album_id": 10,
+                "artist": "X",
+                "title": "A",
+                "position": None,
+                "source": "title_parse",
+                "source_type": "single",
+            },
+            {
+                "album_id": 10,
+                "artist": "X",
+                "title": "B",
+                "position": None,
+                "source": "title_parse",
+                "source_type": "single",
+            },
+        ]
+        await db.insert_tracks(tracks)
+        await db.update_track_resolution(
+            track_id=1, status="local_match", resolved_via="local_index"
+        )
+        await db.update_track_resolution(track_id=2, status="not_found")
+        summary = await db.get_album_track_summary(album_id=10)
+        assert summary["total"] == 2
+        assert summary["resolved"] == 1
+        assert summary["not_found"] == 1
+        assert summary["on_streaming"] is True
+
+    @pytest.mark.asyncio
+    async def test_all_not_found_means_off_streaming(self, db):
+        await db.insert_tracks(
+            [
+                {
+                    "album_id": 20,
+                    "artist": "Y",
+                    "title": "C",
+                    "position": None,
+                    "source": "title_parse",
+                    "source_type": "single",
+                }
+            ]
+        )
+        await db.update_track_resolution(track_id=1, status="not_found")
+        summary = await db.get_album_track_summary(album_id=20)
+        assert summary["on_streaming"] is False


### PR DESCRIPTION
## Summary

- Adds `scripts/track_streaming/` pipeline that extracts individual tracks from singles (title parsing + Discogs tracklists) and compilations (per-track artist JSON), resolves them against an in-memory index of on-streaming album tracklists, and falls back to Spotify/Deezer track search for unresolved tracks
- Adds `track_results` table to `streaming_availability.db` for track-level resolution status
- Updates `export_streaming_links.py` to include track-level URLs for singles/compilations

Closes #128

## Test plan

- [ ] `uv run pytest tests/unit/ -v` — 1,165 tests passing (69 new)
- [ ] `uv run python -m scripts.track_streaming --phase extract --dry-run` — verify extraction on real data
- [ ] `uv run python -m scripts.track_streaming --phase resolve --skip-api` — verify local resolution with Discogs PG
- [ ] `uv run python -m scripts.track_streaming` — full pipeline run
- [ ] Rerun `populate-on-streaming.py` and verify exclusive count changes