### PR TITLE
Add artist name variation audit script

### DIFF
--- a/scripts/variation_audit/__main__.py
+++ b/scripts/variation_audit/__main__.py
@@ -1,0 +1,365 @@
+"""WXYC artist name variation audit.
+
+Analyzes cross-references and alternate_artist_name entries to determine
+which artists sharing a library code should have independent codes.
+Cross-references against local Discogs and MusicBrainz datasets.
+
+Usage:
+    python -m scripts.variation_audit [OPTIONS]
+"""
+
+import argparse
+import csv
+import logging
+from collections import Counter
+from pathlib import Path
+
+from scripts.variation_audit.classifier import (
+    ALIAS,
+    COLLABORATION,
+    MEMBER_OF_GROUP,
+    SEPARATE_ARTIST,
+    SPELLING_VARIANT,
+    SPLIT_RELEASE,
+    UNRESOLVED,
+    RelationshipClassifier,
+)
+from scripts.variation_audit.loaders import (
+    load_cross_references_from_dump,
+    load_discogs_aliases,
+    load_discogs_members,
+    load_graph_db,
+    load_library_artists,
+    load_library_codes_from_dump,
+    load_mb_aliases,
+    normalize_name,
+)
+from scripts.variation_audit.phases import (
+    phase_1_cross_references,
+    phase_2_alt_names,
+    phase_3_duplicates,
+    phase_4_missing_links,
+)
+
+logger = logging.getLogger("variation_audit")
+
+
+def write_csv_rows(rows: list[dict], path: Path, fieldnames: list[str]) -> None:
+    """Write a list of dicts to a CSV file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+    logger.info("Wrote %d rows to %s", len(rows), path)
+
+
+def write_summary(
+    phase_1_results: list[dict],
+    phase_2_results: list[dict],
+    phase_3_results: list[dict],
+    phase_4_results: list[dict],
+    path: Path,
+) -> None:
+    """Write a human-readable summary."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = []
+    lines.append("WXYC Artist Name Variation Audit")
+    lines.append("=" * 40)
+    lines.append("")
+
+    # Phase 1 summary
+    p1_counts = Counter(r["classification"] for r in phase_1_results)
+    lines.append(f"Phase 1: Cross-References ({len(phase_1_results)} total)")
+    lines.append("-" * 40)
+    for cls in [
+        ALIAS,
+        MEMBER_OF_GROUP,
+        COLLABORATION,
+        SEPARATE_ARTIST,
+        SPELLING_VARIANT,
+        SPLIT_RELEASE,
+        UNRESOLVED,
+    ]:
+        if p1_counts[cls]:
+            lines.append(f"  {cls}: {p1_counts[cls]}")
+    lines.append("")
+
+    # Phase 2 summary
+    p2_counts = Counter(r["classification"] for r in phase_2_results)
+    lines.append(f"Phase 2: Alternate Artist Names ({len(phase_2_results)} total)")
+    lines.append("-" * 40)
+    for cls in [
+        ALIAS,
+        MEMBER_OF_GROUP,
+        COLLABORATION,
+        SEPARATE_ARTIST,
+        SPELLING_VARIANT,
+        SPLIT_RELEASE,
+        UNRESOLVED,
+    ]:
+        if p2_counts[cls]:
+            lines.append(f"  {cls}: {p2_counts[cls]}")
+    needs_own_code = p2_counts[MEMBER_OF_GROUP] + p2_counts[SEPARATE_ARTIST]
+    lines.append(f"  -> Should have own library code: {needs_own_code}")
+    lines.append("")
+
+    # Phase 3 summary
+    lines.append(f"Phase 3: Duplicate Library Codes ({len(phase_3_results)} groups)")
+    lines.append("-" * 40)
+    total_artists = sum(len(r["artist_names"]) for r in phase_3_results)
+    lines.append(f"  {total_artists} artists across {len(phase_3_results)} entity groups")
+    if phase_3_results:
+        lines.append("  Top groups:")
+        for r in sorted(phase_3_results, key=lambda x: len(x["artist_names"]), reverse=True)[:10]:
+            lines.append(f"    {' / '.join(r['artist_names'])}")
+    lines.append("")
+
+    # Phase 4 summary
+    lines.append(f"Phase 4: Missing Group-Member Links ({len(phase_4_results)} pairs)")
+    lines.append("-" * 40)
+    if phase_4_results:
+        lines.append("  Examples:")
+        for r in phase_4_results[:10]:
+            lines.append(f"    {r['member_name']} -> {r['group_name']}")
+    lines.append("")
+
+    # Overall recommendations
+    lines.append("Recommendations")
+    lines.append("=" * 40)
+    lines.append(f"1. {needs_own_code} alternate name entries should have their own library code")
+    lines.append(
+        f"   (MEMBER_OF_GROUP: {p2_counts[MEMBER_OF_GROUP]}, SEPARATE_ARTIST: {p2_counts[SEPARATE_ARTIST]})"
+    )
+    lines.append(
+        f"2. {len(phase_3_results)} entity groups have duplicate library codes (consider merging)"
+    )
+    lines.append(f"3. {len(phase_4_results)} group-member relationships lack cross-references")
+    xref_separate = p1_counts[SEPARATE_ARTIST] + p1_counts[MEMBER_OF_GROUP]
+    lines.append(f"4. {xref_separate} existing cross-references link separate artists")
+    lines.append("   (these artists may need their own library code)")
+
+    text = "\n".join(lines) + "\n"
+    path.write_text(text)
+    # Also print to stdout
+    print(text)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="WXYC artist name variation audit",
+    )
+    parser.add_argument(
+        "--library-db",
+        required=True,
+        help="Path to library.db (SQLite export of WXYC catalog)",
+    )
+    parser.add_argument(
+        "--graph-db",
+        required=True,
+        help="Path to wxyc_artist_graph.db (semantic index)",
+    )
+    parser.add_argument(
+        "--sql-dump",
+        required=True,
+        help="Path to tubafrenzy MySQL dump (.sql)",
+    )
+    parser.add_argument(
+        "--discogs-csv-dir",
+        default=None,
+        help="Directory with artist_alias.csv and artist_member.csv from discogs-xml-converter",
+    )
+    parser.add_argument(
+        "--mb-alias-tsv",
+        default=None,
+        help="Path to MusicBrainz artist_alias TSV",
+    )
+    parser.add_argument(
+        "--mb-artist-tsv",
+        default=None,
+        help="Path to MusicBrainz artist TSV (for int_id -> UUID mapping)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="../docs/variation-audit",
+        help="Output directory for CSV reports",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load data
+    logger.info("Loading library data...")
+    artist_to_codes, alt_pairs = load_library_artists(args.library_db)
+    logger.info(
+        "  %d unique artists, %d alternate name pairs", len(artist_to_codes), len(alt_pairs)
+    )
+
+    logger.info("Loading SQL dump...")
+    library_codes = load_library_codes_from_dump(args.sql_dump)
+    xrefs = load_cross_references_from_dump(args.sql_dump)
+
+    logger.info("Loading graph database...")
+    graph = load_graph_db(args.graph_db)
+
+    # Discogs data (optional)
+    discogs_aliases: dict[int, set[str]] = {}
+    discogs_members: dict[int, set[tuple[int, str]]] = {}
+    if args.discogs_csv_dir:
+        relevant_discogs_ids = set(graph.name_to_discogs.values())
+        logger.info("Loading Discogs CSVs (filtering to %d IDs)...", len(relevant_discogs_ids))
+        discogs_aliases = load_discogs_aliases(args.discogs_csv_dir, relevant_discogs_ids)
+        discogs_members = load_discogs_members(args.discogs_csv_dir, relevant_discogs_ids)
+    else:
+        logger.warning(
+            "No --discogs-csv-dir provided; skipping Discogs alias/member classification"
+        )
+
+    # MusicBrainz data (optional)
+    mb_aliases: dict[str, set[str]] = {}
+    if args.mb_alias_tsv and args.mb_artist_tsv:
+        relevant_mb_uuids = set(graph.name_to_mb.values())
+        logger.info("Loading MusicBrainz TSVs (filtering to %d UUIDs)...", len(relevant_mb_uuids))
+        mb_aliases = load_mb_aliases(args.mb_alias_tsv, args.mb_artist_tsv, relevant_mb_uuids)
+    else:
+        logger.warning(
+            "No --mb-alias-tsv/--mb-artist-tsv provided; skipping MB alias classification"
+        )
+
+    # Build classifier
+    classifier = RelationshipClassifier(
+        graph=graph,
+        discogs_aliases=discogs_aliases,
+        discogs_members=discogs_members,
+        mb_aliases=mb_aliases,
+    )
+
+    # Build play count and release count lookups for enrichment
+    logger.info("Building play count and release count lookups...")
+    play_counts = {}
+    conn = __import__("sqlite3").connect(args.graph_db)
+    for name, plays in conn.execute(
+        "SELECT canonical_name, total_plays FROM artist WHERE total_plays > 0"
+    ):
+        play_counts[normalize_name(name)] = plays
+    conn.close()
+
+    own_release_counts = {}
+    conn = __import__("sqlite3").connect(args.library_db)
+    for name, count in conn.execute("SELECT artist, count(*) FROM library GROUP BY artist"):
+        own_release_counts[name] = count
+    conn.close()
+    logger.info(
+        "  %d artists with plays, %d with own releases", len(play_counts), len(own_release_counts)
+    )
+
+    # Run phases
+    logger.info("Running Phase 1: Cross-references...")
+    p1 = phase_1_cross_references(library_codes, xrefs, classifier, play_counts, own_release_counts)
+
+    logger.info("Running Phase 3: Duplicate library codes...")
+    p3 = phase_3_duplicates(graph, artist_to_codes)
+
+    logger.info("Running Phase 2: Alternate artist names...")
+    p2 = phase_2_alt_names(alt_pairs, classifier, play_counts, own_release_counts)
+
+    # Build existing xref pairs for Phase 4
+    existing_xref_pairs: set[tuple[str, str]] = set()
+    for r in p1:
+        norm_a = normalize_name(r["artist_a"])
+        norm_b = normalize_name(r["artist_b"])
+        existing_xref_pairs.add((norm_a, norm_b))
+        existing_xref_pairs.add((norm_b, norm_a))
+
+    logger.info("Running Phase 4: Missing group-member links...")
+    p4 = phase_4_missing_links(graph, artist_to_codes, existing_xref_pairs)
+
+    # Write output
+    logger.info("Writing output...")
+    write_csv_rows(
+        p1,
+        output_dir / "cross-refs.csv",
+        [
+            "xref_id",
+            "artist_a",
+            "artist_b",
+            "comment",
+            "discogs_id_a",
+            "discogs_id_b",
+            "entity_id_a",
+            "entity_id_b",
+            "plays_a",
+            "plays_b",
+            "own_releases_a",
+            "own_releases_b",
+            "classification",
+            "evidence",
+        ],
+    )
+    write_csv_rows(
+        p2,
+        output_dir / "alt-names.csv",
+        [
+            "library_artist",
+            "alternate_name",
+            "genre",
+            "call_letters",
+            "call_number",
+            "release_count",
+            "alt_flowsheet_plays",
+            "alt_own_releases",
+            "classification",
+            "evidence",
+        ],
+    )
+
+    # Phase 3 needs special handling for list fields
+    p3_flat = []
+    for r in p3:
+        p3_flat.append(
+            {
+                "entity_id": r["entity_id"],
+                "artist_names": " / ".join(r["artist_names"]),
+                "library_codes": " / ".join(r["library_codes"]),
+                "discogs_ids": " / ".join(r["discogs_ids"]),
+                "recommendation": r["recommendation"],
+            }
+        )
+    write_csv_rows(
+        p3_flat,
+        output_dir / "duplicates.csv",
+        ["entity_id", "artist_names", "library_codes", "discogs_ids", "recommendation"],
+    )
+
+    write_csv_rows(
+        p4,
+        output_dir / "missing-links.csv",
+        [
+            "group_name",
+            "member_name",
+            "group_discogs_id",
+            "member_discogs_id",
+            "group_library_code",
+            "member_library_code",
+        ],
+    )
+
+    write_summary(p1, p2, p3, p4, output_dir / "summary.txt")
+    logger.info("Done. Output written to %s", output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/variation_audit/classifier.py
+++ b/scripts/variation_audit/classifier.py
@@ -1,0 +1,146 @@
+"""Relationship classification for artist name variation audit."""
+
+import re
+
+from scripts.variation_audit.loaders import GraphData, normalize_name
+
+# Classification categories
+ALIAS = "ALIAS"
+MEMBER_OF_GROUP = "MEMBER_OF_GROUP"
+COLLABORATION = "COLLABORATION"
+SEPARATE_ARTIST = "SEPARATE_ARTIST"
+SPELLING_VARIANT = "SPELLING_VARIANT"
+SPLIT_RELEASE = "SPLIT_RELEASE"
+UNRESOLVED = "UNRESOLVED"
+
+# Patterns that indicate collaboration credits
+_COLLAB_PATTERNS = re.compile(
+    r"\s+(?:&|feat\.?|featuring|with|meets|vs\.?)\s+|"
+    r"\s*/\s*",  # slash separator
+    re.IGNORECASE,
+)
+
+
+class RelationshipClassifier:
+    """Classifies the relationship between two artist names using external data."""
+
+    def __init__(
+        self,
+        graph: GraphData,
+        discogs_aliases: dict[int, set[str]],
+        discogs_members: dict[int, set[tuple[int, str]]],
+        mb_aliases: dict[str, set[str]],
+    ):
+        self._graph = graph
+        self._discogs_aliases = discogs_aliases
+        self._discogs_members = discogs_members
+        self._mb_aliases = mb_aliases
+
+        # Build reverse Discogs member index: {member_discogs_id: set(group_discogs_id)}
+        self._member_to_groups: dict[int, set[int]] = {}
+        for group_id, members in discogs_members.items():
+            for member_id, _ in members:
+                self._member_to_groups.setdefault(member_id, set()).add(group_id)
+
+    def classify(self, name_a: str, name_b: str) -> tuple[str, str]:
+        """Classify the relationship between two artist names.
+
+        Returns (classification, evidence_string).
+        """
+        norm_a = normalize_name(name_a)
+        norm_b = normalize_name(name_b)
+
+        # 1. Spelling variant (normalized names match)
+        if norm_a == norm_b:
+            return SPELLING_VARIANT, f"Normalized forms match: '{norm_a}'"
+
+        # 2. Split release
+        if "<split>" in name_b.lower() or "<split>" in name_a.lower():
+            return SPLIT_RELEASE, "Contains <split> marker"
+
+        # 3. Collaboration (one name contains the other plus a collab separator)
+        collab = self._check_collaboration(name_a, name_b, norm_a, norm_b)
+        if collab:
+            return COLLABORATION, collab
+
+        # 4. Alias: same entity_id
+        entity_a = self._graph.name_to_entity.get(norm_a)
+        entity_b = self._graph.name_to_entity.get(norm_b)
+        if entity_a is not None and entity_b is not None and entity_a == entity_b:
+            return ALIAS, f"Same entity ID {entity_a} in semantic index"
+
+        # 5. Alias: same Discogs ID
+        discogs_a = self._graph.name_to_discogs.get(norm_a)
+        discogs_b = self._graph.name_to_discogs.get(norm_b)
+        if discogs_a is not None and discogs_b is not None and discogs_a == discogs_b:
+            return ALIAS, f"Same Discogs artist ID {discogs_a}"
+
+        # 6. Alias: Discogs alias table
+        if discogs_a is not None and norm_b in self._discogs_aliases.get(discogs_a, set()):
+            return ALIAS, f"'{name_b}' is Discogs alias of '{name_a}' (ID {discogs_a})"
+        if discogs_b is not None and norm_a in self._discogs_aliases.get(discogs_b, set()):
+            return ALIAS, f"'{name_a}' is Discogs alias of '{name_b}' (ID {discogs_b})"
+
+        # 7. Alias: MusicBrainz alias table
+        mb_a = self._graph.name_to_mb.get(norm_a)
+        mb_b = self._graph.name_to_mb.get(norm_b)
+        if mb_a is not None and norm_b in self._mb_aliases.get(mb_a, set()):
+            return ALIAS, f"'{name_b}' is MusicBrainz alias of '{name_a}'"
+        if mb_b is not None and norm_a in self._mb_aliases.get(mb_b, set()):
+            return ALIAS, f"'{name_a}' is MusicBrainz alias of '{name_b}'"
+
+        # 8. Member of group: semantic-index member_of
+        if (norm_b, norm_a) in self._graph.member_of:
+            return MEMBER_OF_GROUP, f"'{name_a}' is member of '{name_b}' per semantic index"
+        if (norm_a, norm_b) in self._graph.member_of:
+            return MEMBER_OF_GROUP, f"'{name_b}' is member of '{name_a}' per semantic index"
+
+        # 9. Member of group: Discogs artist_member
+        if discogs_a is not None and discogs_b is not None:
+            # Check if A is member of B
+            if discogs_b in self._discogs_members:
+                for member_id, _ in self._discogs_members[discogs_b]:
+                    if member_id == discogs_a:
+                        return (
+                            MEMBER_OF_GROUP,
+                            f"'{name_a}' is Discogs member of '{name_b}' (group ID {discogs_b})",
+                        )
+            # Check if B is member of A
+            if discogs_a in self._discogs_members:
+                for member_id, _ in self._discogs_members[discogs_a]:
+                    if member_id == discogs_b:
+                        return (
+                            MEMBER_OF_GROUP,
+                            f"'{name_b}' is Discogs member of '{name_a}' (group ID {discogs_a})",
+                        )
+
+        # 10. Separate artist: both have external IDs but no relationship
+        has_id_a = discogs_a is not None or mb_a is not None
+        has_id_b = discogs_b is not None or mb_b is not None
+        if has_id_a and has_id_b:
+            ids_a = f"Discogs={discogs_a}" if discogs_a else f"MB={mb_a}"
+            ids_b = f"Discogs={discogs_b}" if discogs_b else f"MB={mb_b}"
+            return SEPARATE_ARTIST, f"No relationship found: {name_a}({ids_a}), {name_b}({ids_b})"
+
+        # 11. Unresolved
+        return UNRESOLVED, "Insufficient external data to classify"
+
+    def _check_collaboration(
+        self, name_a: str, name_b: str, norm_a: str, norm_b: str
+    ) -> str | None:
+        """Check if one name is a collaboration credit involving the other."""
+        # Check if name_b contains name_a plus a collab separator
+        parts = _COLLAB_PATTERNS.split(name_b)
+        if len(parts) > 1:
+            normalized_parts = {normalize_name(p) for p in parts}
+            if norm_a in normalized_parts:
+                return f"'{name_b}' is collaboration involving '{name_a}'"
+
+        # Check reverse
+        parts = _COLLAB_PATTERNS.split(name_a)
+        if len(parts) > 1:
+            normalized_parts = {normalize_name(p) for p in parts}
+            if norm_b in normalized_parts:
+                return f"'{name_a}' is collaboration involving '{name_b}'"
+
+        return None

--- a/scripts/variation_audit/loaders.py
+++ b/scripts/variation_audit/loaders.py
@@ -1,0 +1,354 @@
+"""Data loading functions for the variation audit."""
+
+import csv
+import logging
+import re
+import sqlite3
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_name(name: str) -> str:
+    """Normalize an artist name for comparison: NFKD, strip diacritics, lowercase, trim."""
+    decomposed = unicodedata.normalize("NFKD", name)
+    stripped = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return stripped.lower().strip()
+
+
+# -- Library DB --
+
+
+def load_library_artists(
+    library_db_path: str,
+) -> tuple[dict[str, list[tuple[str, str, int]]], list[tuple[str, str, str, str, int, int]]]:
+    """Load artist-to-library-code mappings and alternate name pairs from library.db.
+
+    Returns:
+        artist_to_codes: {artist_name: [(genre, call_letters, call_number), ...]}
+        alt_name_pairs: [(artist, alternate_name, genre, call_letters, call_number, release_count)]
+    """
+    conn = sqlite3.connect(library_db_path)
+
+    # Unique library codes per artist (excluding Various Artists)
+    artist_to_codes: dict[str, list[tuple[str, str, int]]] = defaultdict(list)
+    rows = conn.execute("""
+        SELECT DISTINCT artist, genre, call_letters, artist_call_number
+        FROM library
+        WHERE artist NOT LIKE 'Various Artists%'
+    """).fetchall()
+    for artist, genre, cl, cn in rows:
+        code = (genre, cl, cn)
+        if code not in artist_to_codes[artist]:
+            artist_to_codes[artist].append(code)
+
+    # Alternate name pairs where alternate differs from main artist
+    alt_name_pairs = []
+    alt_rows = conn.execute("""
+        SELECT artist, alternate_artist_name, genre, call_letters, artist_call_number, count(*) as cnt
+        FROM library
+        WHERE artist NOT LIKE 'Various Artists%'
+          AND alternate_artist_name IS NOT NULL
+          AND alternate_artist_name != ''
+          AND alternate_artist_name != artist
+        GROUP BY artist, alternate_artist_name, genre, call_letters, artist_call_number
+    """).fetchall()
+    for artist, alt, genre, cl, cn, count in alt_rows:
+        alt_name_pairs.append((artist, alt, genre, cl, cn, count))
+
+    conn.close()
+    return dict(artist_to_codes), alt_name_pairs
+
+
+# -- SQL Dump Parsing --
+
+
+def _parse_sql_values(sql_line: str) -> list[tuple]:
+    """Parse a MySQL INSERT INTO ... VALUES (...),(...); statement into tuples.
+
+    Handles escaped single quotes (\\') and commas within quoted strings.
+    """
+    # Find the VALUES portion
+    match = re.search(r"VALUES\s+", sql_line, re.IGNORECASE)
+    if not match:
+        return []
+
+    values_str = sql_line[match.end() :]
+    results = []
+    i = 0
+    n = len(values_str)
+
+    while i < n:
+        if values_str[i] != "(":
+            i += 1
+            continue
+
+        # Parse one tuple
+        i += 1  # skip (
+        fields = []
+        current = []
+        in_quote = False
+
+        while i < n:
+            c = values_str[i]
+            if in_quote:
+                if c == "\\" and i + 1 < n and values_str[i + 1] == "'":
+                    current.append("'")
+                    i += 2
+                    continue
+                elif c == "'":
+                    in_quote = False
+                else:
+                    current.append(c)
+            else:
+                if c == "'":
+                    in_quote = True
+                elif c == ",":
+                    fields.append("".join(current))
+                    current = []
+                elif c == ")":
+                    fields.append("".join(current))
+                    results.append(tuple(fields))
+                    i += 1
+                    break
+                else:
+                    current.append(c)
+            i += 1
+
+    return results
+
+
+def load_library_codes_from_dump(sql_dump_path: str) -> dict[int, str]:
+    """Parse LIBRARY_CODE table from SQL dump. Returns {id: presentation_name}."""
+    codes = {}
+    with open(sql_dump_path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            if "INSERT INTO `LIBRARY_CODE`" in line:
+                for row in _parse_sql_values(line):
+                    # Columns: ID, GENRE_ID, CALL_LETTERS, CALL_NUMBERS, ARTIST_ID,
+                    #          TIME_LAST_MODIFIED, TIME_CREATED, PRESENTATION_NAME, ALPHABETICAL_NAME
+                    if len(row) >= 8:
+                        try:
+                            code_id = int(row[0])
+                            name = row[7]
+                            codes[code_id] = name
+                        except (ValueError, IndexError):
+                            continue
+    logger.info("Loaded %d library codes from SQL dump", len(codes))
+    return codes
+
+
+def load_cross_references_from_dump(
+    sql_dump_path: str,
+) -> list[tuple[int, int, int, str]]:
+    """Parse LIBRARY_CODE_CROSS_REFERENCE from SQL dump.
+
+    Returns list of (id, source_code_id, target_code_id, comment).
+    """
+    xrefs = []
+    with open(sql_dump_path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            if "INSERT INTO `LIBRARY_CODE_CROSS_REFERENCE`" in line:
+                for row in _parse_sql_values(line):
+                    # Columns: ID, CROSS_REFERENCING_ARTIST_ID, CROSS_REFERENCED_LIBRARY_CODE_ID,
+                    #          COMMENT, TIME_LAST_MODIFIED, TIME_CREATED
+                    if len(row) >= 4:
+                        try:
+                            xrefs.append((int(row[0]), int(row[1]), int(row[2]), row[3]))
+                        except (ValueError, IndexError):
+                            continue
+    logger.info("Loaded %d cross-references from SQL dump", len(xrefs))
+    return xrefs
+
+
+# -- Semantic Index (Graph DB) --
+
+
+@dataclass
+class GraphData:
+    """Data loaded from the semantic-index graph database."""
+
+    name_to_discogs: dict[str, int] = field(default_factory=dict)
+    name_to_mb: dict[str, str] = field(default_factory=dict)
+    name_to_entity: dict[str, int] = field(default_factory=dict)
+    entity_groups: dict[int, list[str]] = field(default_factory=dict)
+    member_of: set[tuple[str, str]] = field(default_factory=set)  # (group_name, member_name)
+
+
+def load_graph_db(graph_db_path: str) -> GraphData:
+    """Load identity resolution data from wxyc_artist_graph.db."""
+    conn = sqlite3.connect(graph_db_path)
+    data = GraphData()
+
+    # Name to Discogs/MB ID mappings (normalize keys for consistent lookup)
+    rows = conn.execute("""
+        SELECT canonical_name, discogs_artist_id, musicbrainz_artist_id, entity_id
+        FROM artist
+    """).fetchall()
+    for name, discogs_id, mb_id, entity_id in rows:
+        norm = normalize_name(name)
+        if discogs_id is not None:
+            data.name_to_discogs[norm] = discogs_id
+        if mb_id is not None:
+            data.name_to_mb[norm] = mb_id
+        if entity_id is not None:
+            data.name_to_entity[norm] = entity_id
+
+    # Entity groups (entities with multiple artists)
+    entity_artists: dict[int, list[str]] = defaultdict(list)
+    for name, entity_id in data.name_to_entity.items():
+        entity_artists[entity_id].append(name)
+    data.entity_groups = {eid: names for eid, names in entity_artists.items() if len(names) > 1}
+
+    # Member-of relationships (normalize names)
+    member_rows = conn.execute("""
+        SELECT g.canonical_name, m.canonical_name
+        FROM member_of mo
+        JOIN artist g ON mo.group_id = g.id
+        JOIN artist m ON mo.member_id = m.id
+    """).fetchall()
+    data.member_of = {
+        (normalize_name(group), normalize_name(member)) for group, member in member_rows
+    }
+
+    conn.close()
+    logger.info(
+        "Loaded graph DB: %d discogs IDs, %d MB IDs, %d entity groups, %d member_of pairs",
+        len(data.name_to_discogs),
+        len(data.name_to_mb),
+        len(data.entity_groups),
+        len(data.member_of),
+    )
+    return data
+
+
+# -- Discogs CSV --
+
+
+def load_discogs_aliases(csv_dir: str, relevant_ids: set[int]) -> dict[int, set[str]]:
+    """Load artist_alias.csv from Discogs converter output, filtered to relevant IDs.
+
+    Returns {discogs_artist_id: set(normalized_alias_names)}.
+    """
+    alias_path = Path(csv_dir) / "artist_alias.csv"
+    if not alias_path.exists():
+        logger.warning("Discogs artist_alias.csv not found at %s", alias_path)
+        return {}
+
+    result: dict[int, set[str]] = defaultdict(set)
+    with open(alias_path, newline="", encoding="utf-8", errors="replace") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                artist_id = int(row["artist_id"])
+            except (ValueError, KeyError):
+                continue
+            if artist_id in relevant_ids:
+                alias_name = normalize_name(row.get("alias_name", ""))
+                if alias_name:
+                    result[artist_id].add(alias_name)
+
+    logger.info(
+        "Loaded %d Discogs aliases for %d artists",
+        sum(len(v) for v in result.values()),
+        len(result),
+    )
+    return dict(result)
+
+
+def load_discogs_members(csv_dir: str, relevant_ids: set[int]) -> dict[int, set[tuple[int, str]]]:
+    """Load artist_member.csv from Discogs converter output, filtered to relevant IDs.
+
+    Returns {group_discogs_id: set((member_discogs_id, normalized_member_name))}.
+    """
+    member_path = Path(csv_dir) / "artist_member.csv"
+    if not member_path.exists():
+        logger.warning("Discogs artist_member.csv not found at %s", member_path)
+        return {}
+
+    result: dict[int, set[tuple[int, str]]] = defaultdict(set)
+    with open(member_path, newline="", encoding="utf-8", errors="replace") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                group_id = int(row["group_artist_id"])
+            except (ValueError, KeyError):
+                continue
+            if group_id in relevant_ids:
+                try:
+                    member_id = int(row["member_artist_id"])
+                except (ValueError, KeyError):
+                    member_id = 0
+                member_name = normalize_name(row.get("member_name", ""))
+                if member_name:
+                    result[group_id].add((member_id, member_name))
+
+    logger.info(
+        "Loaded %d Discogs member entries for %d groups",
+        sum(len(v) for v in result.values()),
+        len(result),
+    )
+    return dict(result)
+
+
+# -- MusicBrainz TSV --
+
+
+def load_mb_aliases(
+    alias_tsv_path: str,
+    artist_tsv_path: str,
+    relevant_uuids: set[str],
+) -> dict[str, set[str]]:
+    """Load MusicBrainz artist aliases, filtered to relevant UUIDs.
+
+    The MB artist_alias TSV uses integer artist IDs, but the graph DB stores UUIDs.
+    We first build a {int_id: uuid} map from the artist TSV, then filter aliases.
+
+    Returns {mb_uuid: set(normalized_alias_names)}.
+    """
+    if not Path(artist_tsv_path).exists() or not Path(alias_tsv_path).exists():
+        logger.warning("MusicBrainz TSV files not found")
+        return {}
+
+    # Step 1: Build int_id -> uuid map, filtered to relevant UUIDs
+    int_to_uuid: dict[int, str] = {}
+    with open(artist_tsv_path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            parts = line.split("\t", 3)
+            if len(parts) < 3:
+                continue
+            try:
+                int_id = int(parts[0])
+                uuid = parts[1]
+                if uuid in relevant_uuids:
+                    int_to_uuid[int_id] = uuid
+            except ValueError:
+                continue
+
+    logger.info("Mapped %d MB integer IDs to UUIDs", len(int_to_uuid))
+    relevant_int_ids = set(int_to_uuid.keys())
+
+    # Step 2: Load aliases filtered by relevant integer IDs
+    result: dict[str, set[str]] = defaultdict(set)
+    with open(alias_tsv_path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            parts = line.split("\t", 4)
+            if len(parts) < 3:
+                continue
+            try:
+                artist_int_id = int(parts[1])
+            except ValueError:
+                continue
+            if artist_int_id in relevant_int_ids:
+                alias_name = normalize_name(parts[2])
+                if alias_name:
+                    uuid = int_to_uuid[artist_int_id]
+                    result[uuid].add(alias_name)
+
+    logger.info(
+        "Loaded %d MB aliases for %d artists", sum(len(v) for v in result.values()), len(result)
+    )
+    return dict(result)

--- a/scripts/variation_audit/phases.py
+++ b/scripts/variation_audit/phases.py
@@ -1,0 +1,236 @@
+"""Analysis phases for the variation audit."""
+
+import logging
+import sqlite3
+
+from scripts.variation_audit.classifier import UNRESOLVED, RelationshipClassifier
+from scripts.variation_audit.loaders import GraphData, normalize_name
+
+logger = logging.getLogger(__name__)
+
+
+def _build_play_counts(graph_db_path: str | None) -> dict[str, int]:
+    """Build {normalized_name: total_plays} from the graph DB."""
+    if not graph_db_path:
+        return {}
+    conn = sqlite3.connect(graph_db_path)
+    rows = conn.execute(
+        "SELECT canonical_name, total_plays FROM artist WHERE total_plays > 0"
+    ).fetchall()
+    conn.close()
+    return {normalize_name(name): plays for name, plays in rows}
+
+
+def _build_own_release_counts(library_db_path: str | None) -> dict[str, int]:
+    """Build {artist_name: release_count} from library.db."""
+    if not library_db_path:
+        return {}
+    conn = sqlite3.connect(library_db_path)
+    rows = conn.execute("SELECT artist, count(*) FROM library GROUP BY artist").fetchall()
+    conn.close()
+    return dict(rows)
+
+
+def phase_1_cross_references(
+    library_codes: dict[int, str],
+    xrefs: list[tuple[int, int, int, str]],
+    classifier: RelationshipClassifier,
+    play_counts: dict[str, int] | None = None,
+    own_release_counts: dict[str, int] | None = None,
+) -> list[dict]:
+    """Classify all LIBRARY_CODE_CROSS_REFERENCE entries.
+
+    Args:
+        library_codes: {code_id: presentation_name}
+        xrefs: [(id, source_code_id, target_code_id, comment)]
+        classifier: RelationshipClassifier instance
+        play_counts: {normalized_name: total_plays} from graph DB
+        own_release_counts: {artist_name: release_count} from library.db
+    """
+    play_counts = play_counts or {}
+    own_release_counts = own_release_counts or {}
+    results = []
+    for xref_id, source_id, target_id, comment in xrefs:
+        name_a = library_codes.get(source_id, f"[unknown code {source_id}]")
+        name_b = library_codes.get(target_id, f"[unknown code {target_id}]")
+
+        if name_a.startswith("[unknown") or name_b.startswith("[unknown"):
+            classification, evidence = UNRESOLVED, f"Missing library code: {name_a} or {name_b}"
+        else:
+            classification, evidence = classifier.classify(name_a, name_b)
+
+        norm_a = normalize_name(name_a)
+        norm_b = normalize_name(name_b)
+        graph = classifier._graph
+
+        results.append(
+            {
+                "xref_id": xref_id,
+                "artist_a": name_a,
+                "artist_b": name_b,
+                "comment": comment,
+                "discogs_id_a": graph.name_to_discogs.get(norm_a),
+                "discogs_id_b": graph.name_to_discogs.get(norm_b),
+                "entity_id_a": graph.name_to_entity.get(norm_a),
+                "entity_id_b": graph.name_to_entity.get(norm_b),
+                "plays_a": play_counts.get(norm_a, 0),
+                "plays_b": play_counts.get(norm_b, 0),
+                "own_releases_a": own_release_counts.get(name_a, 0),
+                "own_releases_b": own_release_counts.get(name_b, 0),
+                "classification": classification,
+                "evidence": evidence,
+            }
+        )
+
+    logger.info("Phase 1: Classified %d cross-references", len(results))
+    return results
+
+
+def phase_2_alt_names(
+    alt_pairs: list[tuple[str, str, str, str, int, int]],
+    classifier: RelationshipClassifier,
+    play_counts: dict[str, int] | None = None,
+    own_release_counts: dict[str, int] | None = None,
+) -> list[dict]:
+    """Classify alternate_artist_name variations.
+
+    Args:
+        alt_pairs: [(artist, alternate_name, genre, call_letters, call_number, release_count)]
+        classifier: RelationshipClassifier instance
+        play_counts: {normalized_name: total_plays} from graph DB
+        own_release_counts: {artist_name: release_count} from library.db
+    """
+    play_counts = play_counts or {}
+    own_release_counts = own_release_counts or {}
+    results = []
+    for artist, alt_name, genre, cl, cn, count in alt_pairs:
+        classification, evidence = classifier.classify(artist, alt_name)
+
+        norm_alt = normalize_name(alt_name)
+        results.append(
+            {
+                "library_artist": artist,
+                "alternate_name": alt_name,
+                "genre": genre,
+                "call_letters": cl,
+                "call_number": cn,
+                "release_count": count,
+                "alt_flowsheet_plays": play_counts.get(norm_alt, 0),
+                "alt_own_releases": own_release_counts.get(alt_name, 0),
+                "classification": classification,
+                "evidence": evidence,
+            }
+        )
+
+    logger.info("Phase 2: Classified %d alternate name pairs", len(results))
+    return results
+
+
+def phase_3_duplicates(
+    graph: GraphData,
+    artist_to_codes: dict[str, list[tuple[str, str, int]]],
+) -> list[dict]:
+    """Find library codes that map to the same real-world person.
+
+    Uses entity groups from the semantic index to find cases where
+    multiple WXYC library artists resolve to the same entity.
+    """
+    # Build normalized name -> original name lookup for library artists
+    norm_to_orig: dict[str, str] = {}
+    for name in artist_to_codes:
+        norm_to_orig[normalize_name(name)] = name
+
+    results = []
+    for entity_id, entity_names in graph.entity_groups.items():
+        # Find which entity members are in the library catalog
+        library_matches = []
+        for norm_name in entity_names:
+            if norm_name in norm_to_orig:
+                orig_name = norm_to_orig[norm_name]
+                codes = artist_to_codes[orig_name]
+                library_matches.append((orig_name, codes))
+
+        if len(library_matches) < 2:
+            continue
+
+        # Collect Discogs IDs for these artists
+        discogs_ids = []
+        for orig_name, _ in library_matches:
+            norm = normalize_name(orig_name)
+            did = graph.name_to_discogs.get(norm)
+            discogs_ids.append(str(did) if did else "None")
+
+        artist_names = [m[0] for m in library_matches]
+        code_strs = [
+            f"{codes[0][0]} {codes[0][1]} {codes[0][2]}" if codes else "?"
+            for _, codes in library_matches
+        ]
+
+        results.append(
+            {
+                "entity_id": entity_id,
+                "artist_names": artist_names,
+                "library_codes": code_strs,
+                "discogs_ids": discogs_ids,
+                "recommendation": "Consider merging or cross-referencing",
+            }
+        )
+
+    logger.info("Phase 3: Found %d duplicate library code groups", len(results))
+    return results
+
+
+def phase_4_missing_links(
+    graph: GraphData,
+    artist_to_codes: dict[str, list[tuple[str, str, int]]],
+    existing_xref_pairs: set[tuple[str, str]],
+) -> list[dict]:
+    """Find group-member relationships not in cross-references.
+
+    Args:
+        graph: GraphData with member_of relationships
+        artist_to_codes: library artist code mappings
+        existing_xref_pairs: set of (norm_a, norm_b) for already-linked pairs
+    """
+    # Build normalized name -> original name lookup for library artists
+    norm_to_orig: dict[str, str] = {}
+    for name in artist_to_codes:
+        norm_to_orig[normalize_name(name)] = name
+
+    results = []
+    for group_norm, member_norm in graph.member_of:
+        # Both must be in the library catalog
+        if group_norm not in norm_to_orig or member_norm not in norm_to_orig:
+            continue
+
+        # Skip if already linked (check both directions)
+        if (group_norm, member_norm) in existing_xref_pairs:
+            continue
+        if (member_norm, group_norm) in existing_xref_pairs:
+            continue
+
+        group_orig = norm_to_orig[group_norm]
+        member_orig = norm_to_orig[member_norm]
+        group_codes = artist_to_codes[group_orig]
+        member_codes = artist_to_codes[member_orig]
+
+        group_discogs = graph.name_to_discogs.get(group_norm)
+        member_discogs = graph.name_to_discogs.get(member_norm)
+
+        results.append(
+            {
+                "group_name": group_orig,
+                "member_name": member_orig,
+                "group_discogs_id": group_discogs,
+                "member_discogs_id": member_discogs,
+                "group_library_code": f"{group_codes[0][0]} {group_codes[0][1]} {group_codes[0][2]}"
+                if group_codes
+                else "?",
+                "member_library_code": f"{member_codes[0][0]} {member_codes[0][1]} {member_codes[0][2]}"
+                if member_codes
+                else "?",
+            }
+        )
+
+    logger.info("Phase 4: Found %d missing group-member links", len(results))
+    return results

--- a/tests/unit/test_variation_audit_classifier.py
+++ b/tests/unit/test_variation_audit_classifier.py
@@ -1,0 +1,221 @@
+"""Unit tests for scripts/variation_audit/classifier.py."""
+
+from scripts.variation_audit.classifier import (
+    ALIAS,
+    COLLABORATION,
+    MEMBER_OF_GROUP,
+    SEPARATE_ARTIST,
+    SPELLING_VARIANT,
+    SPLIT_RELEASE,
+    UNRESOLVED,
+    RelationshipClassifier,
+)
+from scripts.variation_audit.loaders import GraphData
+
+
+def _make_classifier(
+    name_to_discogs=None,
+    name_to_mb=None,
+    name_to_entity=None,
+    entity_groups=None,
+    member_of=None,
+    discogs_aliases=None,
+    discogs_members=None,
+    mb_aliases=None,
+):
+    graph = GraphData(
+        name_to_discogs=name_to_discogs or {},
+        name_to_mb=name_to_mb or {},
+        name_to_entity=name_to_entity or {},
+        entity_groups=entity_groups or {},
+        member_of=member_of or set(),
+    )
+    return RelationshipClassifier(
+        graph=graph,
+        discogs_aliases=discogs_aliases or {},
+        discogs_members=discogs_members or {},
+        mb_aliases=mb_aliases or {},
+    )
+
+
+class TestSpellingVariant:
+    def test_case_difference(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Autechre", "AUTECHRE")
+        assert cls == SPELLING_VARIANT
+
+    def test_diacritic_difference(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Björk", "Bjork")
+        assert cls == SPELLING_VARIANT
+
+    def test_whitespace_difference(self):
+        c = _make_classifier()
+        cls, _ = c.classify("808 State", "808 State ")
+        assert cls == SPELLING_VARIANT
+
+    def test_different_names_not_variant(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Autechre", "Aphex Twin")
+        assert cls != SPELLING_VARIANT
+
+
+class TestSplitRelease:
+    def test_split_marker(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Band A", "Band A <split> Band B")
+        assert cls == SPLIT_RELEASE
+
+    def test_no_split_marker(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Band A", "Band B")
+        assert cls != SPLIT_RELEASE
+
+
+class TestCollaboration:
+    def test_ampersand(self):
+        c = _make_classifier()
+        cls, _ = c.classify("DJ Krush", "DJ Krush & Coldcut")
+        assert cls == COLLABORATION
+
+    def test_feat(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Artist A", "Artist A feat Artist B")
+        assert cls == COLLABORATION
+
+    def test_featuring(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Artist A", "Artist A featuring Artist B")
+        assert cls == COLLABORATION
+
+    def test_with(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Duke Ellington", "Duke Ellington with John Coltrane")
+        assert cls == COLLABORATION
+
+    def test_slash_separator(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Band A", "Band A / Band B")
+        assert cls == COLLABORATION
+
+
+class TestAlias:
+    def test_same_entity_id(self):
+        c = _make_classifier(
+            name_to_entity={"aphex twin": 10, "polygon window": 10},
+            entity_groups={10: ["aphex twin", "polygon window"]},
+        )
+        cls, evidence = c.classify("Aphex Twin", "Polygon Window")
+        assert cls == ALIAS
+        assert "entity" in evidence.lower()
+
+    def test_same_discogs_id(self):
+        c = _make_classifier(
+            name_to_discogs={"j dilla": 45, "jay dee": 45},
+        )
+        cls, evidence = c.classify("J Dilla", "Jay Dee")
+        assert cls == ALIAS
+        assert "discogs" in evidence.lower()
+
+    def test_discogs_alias_table(self):
+        c = _make_classifier(
+            name_to_discogs={"autechre": 12},
+            discogs_aliases={12: {"gescom", "lego feet"}},
+        )
+        cls, evidence = c.classify("Autechre", "Gescom")
+        assert cls == ALIAS
+        assert "alias" in evidence.lower()
+
+    def test_mb_alias_table(self):
+        c = _make_classifier(
+            name_to_mb={"autechre": "mb-uuid-1"},
+            mb_aliases={"mb-uuid-1": {"gescom", "ae"}},
+        )
+        cls, evidence = c.classify("Autechre", "Gescom")
+        assert cls == ALIAS
+        assert "musicbrainz" in evidence.lower()
+
+
+class TestMemberOfGroup:
+    def test_graph_member_of(self):
+        c = _make_classifier(
+            member_of={("the mothers", "frank zappa")},
+        )
+        cls, evidence = c.classify("Frank Zappa", "The Mothers")
+        assert cls == MEMBER_OF_GROUP
+        assert "member" in evidence.lower()
+
+    def test_discogs_member(self):
+        c = _make_classifier(
+            name_to_discogs={"frank zappa": 56, "the mothers": 78},
+            discogs_members={78: {(56, "frank zappa")}},
+        )
+        cls, evidence = c.classify("Frank Zappa", "The Mothers")
+        assert cls == MEMBER_OF_GROUP
+        assert "discogs" in evidence.lower()
+
+    def test_reverse_direction(self):
+        """Member-of should be detected regardless of argument order."""
+        c = _make_classifier(
+            member_of={("the mothers", "frank zappa")},
+        )
+        cls, _ = c.classify("The Mothers", "Frank Zappa")
+        assert cls == MEMBER_OF_GROUP
+
+
+class TestSeparateArtist:
+    def test_both_have_discogs_no_relationship(self):
+        c = _make_classifier(
+            name_to_discogs={"sneaker pimps": 100, "iamx": 200},
+        )
+        cls, evidence = c.classify("Sneaker Pimps", "IamX")
+        assert cls == SEPARATE_ARTIST
+        assert "100" in evidence and "200" in evidence
+
+    def test_both_have_mb_no_relationship(self):
+        c = _make_classifier(
+            name_to_mb={"sneaker pimps": "mb-1", "iamx": "mb-2"},
+        )
+        cls, evidence = c.classify("Sneaker Pimps", "IamX")
+        assert cls == SEPARATE_ARTIST
+
+
+class TestUnresolved:
+    def test_no_external_ids(self):
+        c = _make_classifier()
+        cls, _ = c.classify("Unknown Artist A", "Unknown Artist B")
+        assert cls == UNRESOLVED
+
+    def test_one_has_id_other_does_not(self):
+        c = _make_classifier(
+            name_to_discogs={"known artist": 123},
+        )
+        cls, _ = c.classify("Known Artist", "Unknown Artist")
+        assert cls == UNRESOLVED
+
+
+class TestPrecedence:
+    def test_spelling_variant_beats_alias(self):
+        """If normalized names match, it's a spelling variant even if same entity."""
+        c = _make_classifier(
+            name_to_entity={"bjork": 10},
+        )
+        cls, _ = c.classify("Björk", "Bjork")
+        assert cls == SPELLING_VARIANT
+
+    def test_alias_beats_member_of(self):
+        """If same entity, classify as alias even if also in member_of."""
+        c = _make_classifier(
+            name_to_entity={"aphex twin": 10, "afx": 10},
+            entity_groups={10: ["aphex twin", "afx"]},
+            member_of={("aphex twin", "afx")},
+        )
+        cls, _ = c.classify("Aphex Twin", "AFX")
+        assert cls == ALIAS
+
+    def test_split_beats_alias(self):
+        c = _make_classifier(
+            name_to_entity={"band a": 10, "band a <split> band b": 10},
+        )
+        cls, _ = c.classify("Band A", "Band A <split> Band B")
+        assert cls == SPLIT_RELEASE

--- a/tests/unit/test_variation_audit_loaders.py
+++ b/tests/unit/test_variation_audit_loaders.py
@@ -1,0 +1,355 @@
+"""Unit tests for scripts/variation_audit/loaders.py."""
+
+import sqlite3
+from pathlib import Path
+
+from scripts.variation_audit.loaders import (
+    load_cross_references_from_dump,
+    load_discogs_aliases,
+    load_discogs_members,
+    load_graph_db,
+    load_library_artists,
+    load_library_codes_from_dump,
+    load_mb_aliases,
+    normalize_name,
+)
+
+# -- normalize_name --
+
+
+class TestNormalizeName:
+    def test_lowercases(self):
+        assert normalize_name("Autechre") == "autechre"
+
+    def test_strips_whitespace(self):
+        assert normalize_name("  Stereolab  ") == "stereolab"
+
+    def test_strips_diacritics(self):
+        assert normalize_name("Björk") == "bjork"
+
+    def test_nfkd_decomposition(self):
+        assert normalize_name("café") == "cafe"
+
+    def test_preserves_numbers(self):
+        assert normalize_name("808 State") == "808 state"
+
+
+# -- load_library_artists --
+
+
+def _create_test_library(tmp_path: Path) -> str:
+    db_path = str(tmp_path / "library.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE library (
+            id INTEGER PRIMARY KEY,
+            title TEXT,
+            artist TEXT,
+            call_letters TEXT,
+            artist_call_number INTEGER,
+            release_call_number INTEGER,
+            genre TEXT,
+            format TEXT,
+            alternate_artist_name TEXT,
+            label TEXT
+        )
+    """)
+    conn.executemany(
+        "INSERT INTO library VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (
+                1,
+                "Aluminum Tunes",
+                "Stereolab",
+                "ST",
+                105,
+                1,
+                "Rock",
+                "cd",
+                "Stereolab",
+                "Duophonic",
+            ),
+            (
+                2,
+                "Dots and Loops",
+                "Stereolab",
+                "ST",
+                105,
+                2,
+                "Rock",
+                "cd",
+                "Stereolab",
+                "Duophonic",
+            ),
+            (3, "Confield", "Autechre", "AU", 40, 1, "Electronic", "cd", "Autechre", "Warp"),
+            (4, "Moon Pix", "Cat Power", "CA", 37, 1, "Rock", "cd", "Chan Marshall", "Matador"),
+            (5, "Fillmore East", "Frank Zappa", "ZA", 2, 1, "Rock", "cd", "The Mothers", "Ryko"),
+            (6, "Kiss & Swallow", "Sneaker Pimps", "SN", 5, 1, "Hiphop", "cd", "IamX", "Virgin"),
+            (7, "V/A Comp", "Various Artists", "Z-A", 0, 1, "Rock", "cd", "Various Artists", None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestLoadLibraryArtists:
+    def test_returns_artist_to_codes_mapping(self, tmp_path):
+        db_path = _create_test_library(tmp_path)
+        artists, _ = load_library_artists(db_path)
+        assert "Stereolab" in artists
+        assert artists["Stereolab"] == [("Rock", "ST", 105)]
+
+    def test_deduplicates_library_codes(self, tmp_path):
+        db_path = _create_test_library(tmp_path)
+        artists, _ = load_library_artists(db_path)
+        # Stereolab has 2 releases but 1 library code
+        assert len(artists["Stereolab"]) == 1
+
+    def test_returns_alt_name_pairs(self, tmp_path):
+        db_path = _create_test_library(tmp_path)
+        _, alt_pairs = load_library_artists(db_path)
+        # Only pairs where alternate differs from artist
+        alt_dict = {(a, alt): count for a, alt, g, cl, cn, count in alt_pairs}
+        assert ("Cat Power", "Chan Marshall") in alt_dict
+        assert ("Frank Zappa", "The Mothers") in alt_dict
+        assert ("Sneaker Pimps", "IamX") in alt_dict
+        # Stereolab's alt matches artist, should be excluded
+        assert ("Stereolab", "Stereolab") not in alt_dict
+
+    def test_excludes_various_artists(self, tmp_path):
+        db_path = _create_test_library(tmp_path)
+        artists, _ = load_library_artists(db_path)
+        assert "Various Artists" not in artists
+
+    def test_alt_pairs_include_release_count(self, tmp_path):
+        db_path = _create_test_library(tmp_path)
+        _, alt_pairs = load_library_artists(db_path)
+        for artist, alt, genre, cl, cn, count in alt_pairs:
+            if artist == "Cat Power" and alt == "Chan Marshall":
+                assert count == 1
+                assert genre == "Rock"
+                assert cl == "CA"
+                assert cn == 37
+
+
+# -- load_library_codes_from_dump --
+
+
+SAMPLE_LIBRARY_CODE_SQL = """
+INSERT INTO `LIBRARY_CODE` VALUES (100,1,'AU',40,100,1000,1000,'Autechre','Autechre'),(200,1,'ST',105,200,1000,1000,'Stereolab','Stereolab'),(300,2,'ZA',2,300,1000,1000,'Frank Zappa','Zappa, Frank');
+"""
+
+
+class TestLoadLibraryCodesFromDump:
+    def test_parses_library_codes(self, tmp_path):
+        dump_path = tmp_path / "dump.sql"
+        dump_path.write_text(SAMPLE_LIBRARY_CODE_SQL)
+        codes = load_library_codes_from_dump(str(dump_path))
+        assert codes[100] == "Autechre"
+        assert codes[200] == "Stereolab"
+        assert codes[300] == "Frank Zappa"
+
+    def test_handles_escaped_quotes(self, tmp_path):
+        sql = "INSERT INTO `LIBRARY_CODE` VALUES (400,1,'ER',7,400,1000,1000,'Eric\\'s Trip','Eric\\'s Trip');\n"
+        dump_path = tmp_path / "dump.sql"
+        dump_path.write_text(sql)
+        codes = load_library_codes_from_dump(str(dump_path))
+        assert codes[400] == "Eric's Trip"
+
+
+# -- load_cross_references_from_dump --
+
+
+SAMPLE_XREF_SQL = """
+INSERT INTO `LIBRARY_CODE_CROSS_REFERENCE` VALUES (2,100,200,'shared member Adrian Finch',1000,1000),(4,300,200,'Grace\\'s solo work is filed w/ DQE',1000,1000);
+"""
+
+
+class TestLoadCrossReferencesFromDump:
+    def test_parses_cross_references(self, tmp_path):
+        dump_path = tmp_path / "dump.sql"
+        dump_path.write_text(SAMPLE_XREF_SQL)
+        xrefs = load_cross_references_from_dump(str(dump_path))
+        assert len(xrefs) == 2
+        assert xrefs[0] == (2, 100, 200, "shared member Adrian Finch")
+        assert xrefs[1] == (4, 300, 200, "Grace's solo work is filed w/ DQE")
+
+    def test_handles_empty_comments(self, tmp_path):
+        sql = "INSERT INTO `LIBRARY_CODE_CROSS_REFERENCE` VALUES (56,100,200,'',1000,1000);\n"
+        dump_path = tmp_path / "dump.sql"
+        dump_path.write_text(sql)
+        xrefs = load_cross_references_from_dump(str(dump_path))
+        assert xrefs[0] == (56, 100, 200, "")
+
+
+# -- load_graph_db --
+
+
+def _create_test_graph_db(tmp_path: Path) -> str:
+    db_path = str(tmp_path / "graph.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE artist (
+            id INTEGER PRIMARY KEY,
+            canonical_name TEXT NOT NULL,
+            discogs_artist_id INTEGER,
+            musicbrainz_artist_id TEXT,
+            entity_id INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE entity (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE member_of (
+            group_id INTEGER NOT NULL,
+            member_id INTEGER NOT NULL,
+            PRIMARY KEY (group_id, member_id)
+        )
+    """)
+    conn.executemany(
+        "INSERT INTO artist VALUES (?, ?, ?, ?, ?)",
+        [
+            (1, "autechre", 12, "mb-uuid-1", None),
+            (2, "stereolab", 34, "mb-uuid-2", None),
+            (3, "aphex twin", 45, None, 10),
+            (4, "polygon window", 45, None, 10),
+            (5, "frank zappa", 56, None, None),
+            (6, "the mothers", 78, None, None),
+        ],
+    )
+    conn.execute("INSERT INTO entity VALUES (10, 'Richard D. James')")
+    conn.executemany(
+        "INSERT INTO member_of VALUES (?, ?)",
+        [
+            (6, 5),  # Frank Zappa is member of The Mothers
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestLoadGraphDb:
+    def test_returns_name_to_discogs(self, tmp_path):
+        db_path = _create_test_graph_db(tmp_path)
+        result = load_graph_db(db_path)
+        assert result.name_to_discogs["autechre"] == 12
+        assert result.name_to_discogs["stereolab"] == 34
+
+    def test_returns_name_to_mb(self, tmp_path):
+        db_path = _create_test_graph_db(tmp_path)
+        result = load_graph_db(db_path)
+        assert result.name_to_mb["autechre"] == "mb-uuid-1"
+
+    def test_returns_entity_groups(self, tmp_path):
+        db_path = _create_test_graph_db(tmp_path)
+        result = load_graph_db(db_path)
+        # Entity 10 has aphex twin and polygon window
+        assert any(
+            {"aphex twin", "polygon window"} == set(group)
+            for group in result.entity_groups.values()
+        )
+
+    def test_returns_member_of_pairs(self, tmp_path):
+        db_path = _create_test_graph_db(tmp_path)
+        result = load_graph_db(db_path)
+        assert ("the mothers", "frank zappa") in result.member_of
+
+    def test_returns_name_to_entity(self, tmp_path):
+        db_path = _create_test_graph_db(tmp_path)
+        result = load_graph_db(db_path)
+        assert result.name_to_entity["aphex twin"] == 10
+        assert result.name_to_entity["polygon window"] == 10
+
+    def test_shared_discogs_id_detected(self, tmp_path):
+        db_path = _create_test_graph_db(tmp_path)
+        result = load_graph_db(db_path)
+        # aphex twin and polygon window both have discogs_artist_id=45
+        assert result.name_to_discogs["aphex twin"] == 45
+        assert result.name_to_discogs["polygon window"] == 45
+
+
+# -- load_discogs_aliases --
+
+
+class TestLoadDiscogsAliases:
+    def test_loads_and_filters_by_id(self, tmp_path):
+        csv_path = tmp_path / "artist_alias.csv"
+        csv_path.write_text(
+            "artist_id,artist_name,alias_name\n"
+            "12,Autechre,Gescom\n"
+            "12,Autechre,Lego Feet\n"
+            "999,Nobody,Irrelevant\n"
+        )
+        result = load_discogs_aliases(str(tmp_path), relevant_ids={12})
+        assert "gescom" in result[12]
+        assert "lego feet" in result[12]
+        assert 999 not in result
+
+    def test_empty_when_no_csv(self, tmp_path):
+        result = load_discogs_aliases(str(tmp_path / "nonexistent"), relevant_ids={12})
+        assert result == {}
+
+
+# -- load_discogs_members --
+
+
+class TestLoadDiscogsMembers:
+    def test_loads_and_filters_by_id(self, tmp_path):
+        csv_path = tmp_path / "artist_member.csv"
+        csv_path.write_text(
+            "group_artist_id,group_name,member_artist_id,member_name\n"
+            "78,The Mothers,56,Frank Zappa\n"
+            "78,The Mothers,90,Ray Collins\n"
+            "999,Nobody,888,Irrelevant\n"
+        )
+        result = load_discogs_members(str(tmp_path), relevant_ids={78, 56})
+        assert (56, "frank zappa") in result[78]
+        assert (90, "ray collins") in result[78]
+        assert 999 not in result
+
+    def test_empty_when_no_csv(self, tmp_path):
+        result = load_discogs_members(str(tmp_path / "nonexistent"), relevant_ids={78})
+        assert result == {}
+
+
+# -- load_mb_aliases --
+
+
+class TestLoadMbAliases:
+    def test_loads_and_filters_by_uuid(self, tmp_path):
+        # MB artist TSV: columns 0=id, 1=gid, 2=name (tab-separated, no header)
+        artist_tsv = tmp_path / "artist"
+        artist_tsv.write_text(
+            "100\tmb-uuid-1\tAutechre\tAutechre\t2\t\t\t\t\t\t\t\t\t\n"
+            "200\tmb-uuid-2\tStereolab\tStereolab\t2\t\t\t\t\t\t\t\t\t\n"
+            "300\tmb-uuid-999\tNobody\tNobody\t2\t\t\t\t\t\t\t\t\t\n"
+        )
+        # MB artist_alias TSV: columns 0=id, 1=artist_id(int), 2=name
+        alias_tsv = tmp_path / "artist_alias"
+        alias_tsv.write_text(
+            "1\t100\tGescom\t\t\t\t\t\t\t\t\t\t\t\t\t\n"
+            "2\t100\tLego Feet\t\t\t\t\t\t\t\t\t\t\t\t\t\n"
+            "3\t300\tIrrelevant\t\t\t\t\t\t\t\t\t\t\t\t\t\n"
+        )
+        result = load_mb_aliases(
+            str(alias_tsv),
+            str(artist_tsv),
+            relevant_uuids={"mb-uuid-1", "mb-uuid-2"},
+        )
+        assert "gescom" in result["mb-uuid-1"]
+        assert "lego feet" in result["mb-uuid-1"]
+        assert "mb-uuid-999" not in result
+
+    def test_empty_when_no_file(self, tmp_path):
+        result = load_mb_aliases(
+            str(tmp_path / "nonexistent"),
+            str(tmp_path / "nonexistent2"),
+            relevant_uuids={"mb-uuid-1"},
+        )
+        assert result == {}

--- a/tests/unit/test_variation_audit_phases.py
+++ b/tests/unit/test_variation_audit_phases.py
@@ -1,0 +1,193 @@
+"""Unit tests for scripts/variation_audit/phases.py."""
+
+from scripts.variation_audit.classifier import (
+    ALIAS,
+    MEMBER_OF_GROUP,
+    SEPARATE_ARTIST,
+    UNRESOLVED,
+    RelationshipClassifier,
+)
+from scripts.variation_audit.loaders import GraphData
+from scripts.variation_audit.phases import (
+    phase_1_cross_references,
+    phase_2_alt_names,
+    phase_3_duplicates,
+    phase_4_missing_links,
+)
+
+
+def _make_classifier(**kwargs):
+    graph = GraphData(
+        name_to_discogs=kwargs.get("name_to_discogs", {}),
+        name_to_mb=kwargs.get("name_to_mb", {}),
+        name_to_entity=kwargs.get("name_to_entity", {}),
+        entity_groups=kwargs.get("entity_groups", {}),
+        member_of=kwargs.get("member_of", set()),
+    )
+    return RelationshipClassifier(
+        graph=graph,
+        discogs_aliases=kwargs.get("discogs_aliases", {}),
+        discogs_members=kwargs.get("discogs_members", {}),
+        mb_aliases=kwargs.get("mb_aliases", {}),
+    )
+
+
+# -- Phase 1: Cross-references --
+
+
+class TestPhase1CrossReferences:
+    def test_classifies_cross_references(self):
+        library_codes = {100: "Autechre", 200: "Gescom"}
+        xrefs = [(1, 100, 200, "same artist")]
+        classifier = _make_classifier(
+            name_to_entity={"autechre": 10, "gescom": 10},
+            entity_groups={10: ["autechre", "gescom"]},
+        )
+        results = phase_1_cross_references(library_codes, xrefs, classifier)
+        assert len(results) == 1
+        assert results[0]["artist_a"] == "Autechre"
+        assert results[0]["artist_b"] == "Gescom"
+        assert results[0]["classification"] == ALIAS
+
+    def test_handles_missing_library_code(self):
+        library_codes = {100: "Autechre"}
+        xrefs = [(1, 100, 999, "unknown target")]
+        classifier = _make_classifier()
+        results = phase_1_cross_references(library_codes, xrefs, classifier)
+        assert len(results) == 1
+        assert results[0]["artist_b"] == "[unknown code 999]"
+        assert results[0]["classification"] == UNRESOLVED
+
+    def test_preserves_comment(self):
+        library_codes = {100: "Why?", 200: "Clouddead"}
+        xrefs = [(8, 100, 200, "Why? a member of Clouddead")]
+        classifier = _make_classifier(
+            member_of={("clouddead", "why?")},
+        )
+        results = phase_1_cross_references(library_codes, xrefs, classifier)
+        assert results[0]["comment"] == "Why? a member of Clouddead"
+        assert results[0]["classification"] == MEMBER_OF_GROUP
+
+
+# -- Phase 2: Alternate names --
+
+
+class TestPhase2AltNames:
+    def test_classifies_alt_name_pairs(self):
+        alt_pairs = [
+            ("Sneaker Pimps", "IamX", "Hiphop", "SN", 5, 1),
+        ]
+        classifier = _make_classifier(
+            name_to_discogs={"sneaker pimps": 100, "iamx": 200},
+        )
+        results = phase_2_alt_names(alt_pairs, classifier)
+        assert len(results) == 1
+        assert results[0]["library_artist"] == "Sneaker Pimps"
+        assert results[0]["alternate_name"] == "IamX"
+        assert results[0]["classification"] == SEPARATE_ARTIST
+
+    def test_includes_library_code_info(self):
+        alt_pairs = [
+            ("Cat Power", "Chan Marshall", "Rock", "CA", 37, 2),
+        ]
+        classifier = _make_classifier(
+            name_to_entity={"cat power": 5, "chan marshall": 5},
+            entity_groups={5: ["cat power", "chan marshall"]},
+        )
+        results = phase_2_alt_names(alt_pairs, classifier)
+        assert results[0]["genre"] == "Rock"
+        assert results[0]["call_letters"] == "CA"
+        assert results[0]["call_number"] == 37
+        assert results[0]["release_count"] == 2
+        assert results[0]["classification"] == ALIAS
+
+    def test_filters_split_releases(self):
+        alt_pairs = [
+            ("Band A", "Band A <split> Band B", "Rock", "BA", 1, 1),
+        ]
+        classifier = _make_classifier()
+        results = phase_2_alt_names(alt_pairs, classifier)
+        # Split releases should still appear but classified as SPLIT_RELEASE
+        assert results[0]["classification"] == "SPLIT_RELEASE"
+
+
+# -- Phase 3: Duplicates --
+
+
+class TestPhase3Duplicates:
+    def test_finds_entity_duplicates(self):
+        graph = GraphData(
+            name_to_entity={"aphex twin": 10, "polygon window": 10, "caustic window": 10},
+            entity_groups={10: ["aphex twin", "polygon window", "caustic window"]},
+            name_to_discogs={"aphex twin": 45, "polygon window": 45, "caustic window": 45},
+        )
+        artist_to_codes = {
+            "Aphex Twin": [("Electronic", "AP", 1)],
+            "Polygon Window": [("Electronic", "PO", 50)],
+            # Caustic Window not in library
+        }
+        results = phase_3_duplicates(graph, artist_to_codes)
+        assert len(results) >= 1
+        # At least one result should include both Aphex Twin and Polygon Window
+        found = False
+        for r in results:
+            names = r["artist_names"]
+            if "Aphex Twin" in names and "Polygon Window" in names:
+                found = True
+                assert "Caustic Window" not in names  # not in library
+        assert found
+
+    def test_skips_single_library_artist(self):
+        graph = GraphData(
+            name_to_entity={"aphex twin": 10, "polygon window": 10},
+            entity_groups={10: ["aphex twin", "polygon window"]},
+        )
+        artist_to_codes = {
+            "Aphex Twin": [("Electronic", "AP", 1)],
+            # Polygon Window not in library
+        }
+        results = phase_3_duplicates(graph, artist_to_codes)
+        assert len(results) == 0  # Need 2+ library artists to be a duplicate
+
+
+# -- Phase 4: Missing links --
+
+
+class TestPhase4MissingLinks:
+    def test_finds_missing_group_member_links(self):
+        graph = GraphData(
+            member_of={("the jackson 5", "michael jackson")},
+        )
+        artist_to_codes = {
+            "The Jackson 5": [("Rock", "JA", 1)],
+            "Michael Jackson": [("Rock", "JA", 50)],
+        }
+        existing_xref_pairs = set()
+        results = phase_4_missing_links(graph, artist_to_codes, existing_xref_pairs)
+        assert len(results) == 1
+        assert results[0]["group_name"] == "The Jackson 5"
+        assert results[0]["member_name"] == "Michael Jackson"
+
+    def test_skips_already_linked(self):
+        graph = GraphData(
+            member_of={("the mothers", "frank zappa")},
+        )
+        artist_to_codes = {
+            "The Mothers": [("Rock", "MO", 1)],
+            "Frank Zappa": [("Rock", "ZA", 2)],
+        }
+        existing_xref_pairs = {("frank zappa", "the mothers")}
+        results = phase_4_missing_links(graph, artist_to_codes, existing_xref_pairs)
+        assert len(results) == 0
+
+    def test_skips_when_member_not_in_library(self):
+        graph = GraphData(
+            member_of={("the mothers", "ray collins")},
+        )
+        artist_to_codes = {
+            "The Mothers": [("Rock", "MO", 1)],
+            # Ray Collins not in library
+        }
+        existing_xref_pairs = set()
+        results = phase_4_missing_links(graph, artist_to_codes, existing_xref_pairs)
+        assert len(results) == 0


### PR DESCRIPTION
## Summary

- Add `scripts/variation_audit/` package that classifies artist name variations against Discogs and MusicBrainz data
- 62 unit tests covering loaders, classifier, and phase logic
- Output enriched with flowsheet play counts and own-release counts for prioritization

Closes #132

## Test plan

- [x] 62 unit tests pass (`pytest tests/unit/test_variation_audit_*.py`)
- [x] ruff lint and format clean
- [x] Full audit run verified against production data (24K library artists, 54K Discogs IDs, 32K MB IDs)
- [x] Spot-checked classifications: Sneaker Pimps/IamX → SEPARATE_ARTIST, Aphex Twin/Polygon Window → ALIAS (entity), Crooked Fingers/Eric Bachmann → MEMBER_OF_GROUP