### PR TITLE
Add streaming-check endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ All strategy implementations live in `lookup/orchestrator.py`.
 - `core/search.py` -- Declarative search strategy pattern + ambiguous format detection
 - `discogs/matching.py` -- Discogs-specific normalization (strip_discogs_suffix, normalize_for_track_comparison, normalize_artist_for_validation)
 - `core/dependencies.py` -- FastAPI DI for LibraryDB + DiscogsService
+- `streaming/router.py` -- `POST /streaming-check` endpoint for single-release streaming availability
+- `streaming/orchestrator.py` -- Concurrent streaming checks across Spotify, Deezer, Apple Music, Bandcamp
+- `streaming/models.py` -- Request/response Pydantic models (`StreamingCheckRequest`, `StreamingCheckResponse`)
+- `streaming/dependencies.py` -- FastAPI DI for streaming service clients (SpotifyClient, DeezerClient, etc.)
 - `identity/router.py` -- `GET /identity/resolve` and `POST /identity/bulk` endpoints for identity resolution
 - `identity/models.py` -- Pydantic models for identity resolution responses
 - `identity/dependencies.py` -- FastAPI DI for EntityStore (reuses `DATABASE_URL_DISCOGS` pool)
@@ -54,6 +58,16 @@ The service exposes REST endpoints for querying the `entity.identity` table in t
 - `POST /identity/bulk` with `{"names": ["Stereolab", "Autechre", ...]}` -- Resolve a batch of names. Returns `identities` (found) and `unresolved` (not found).
 
 Both endpoints return 503 when `DATABASE_URL_DISCOGS` is not set or the entity schema is not applied.
+
+### Streaming Check Endpoint
+
+`POST /api/v1/streaming-check` checks whether an album is available on streaming platforms. Used by tubafrenzy and Backend-Service to set the `on_streaming` flag when a new release is added to the library.
+
+Request: `{"artist": "Stereolab", "title": "Aluminum Tunes"}`
+
+Response includes `on_streaming` (true/false/null) and per-service match details with URLs and confidence scores. Checks run concurrently across Spotify, Deezer, Apple Music, and Bandcamp. The endpoint is stateless -- it does not cache results.
+
+Requires `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` for Spotify checks. Other services (Deezer, Apple Music, Bandcamp) need no auth. If Spotify credentials are not set, Spotify checks are skipped.
 
 ### Discogs Cache (Optional)
 
@@ -128,6 +142,8 @@ Required:
 
 Optional:
 - `DATABASE_URL_DISCOGS` -- PostgreSQL URL for Discogs cache
+- `SPOTIFY_CLIENT_ID` -- Spotify client ID for streaming availability checks
+- `SPOTIFY_CLIENT_SECRET` -- Spotify client secret for streaming availability checks
 - `SENTRY_DSN` -- Sentry error tracking
 - `POSTHOG_API_KEY` -- PostHog telemetry
 - `LIBRARY_DB_PATH` -- Path to SQLite database (default: `library.db`)

--- a/config/settings.py
+++ b/config/settings.py
@@ -12,6 +12,12 @@ class Settings(BaseSettings):
 
     # API Keys - Optional
     discogs_token: str | None = Field(None, description="Discogs API token for artwork lookup")
+    spotify_client_id: str | None = Field(
+        None, description="Spotify client ID for streaming availability checks"
+    )
+    spotify_client_secret: str | None = Field(
+        None, description="Spotify client secret for streaming availability checks"
+    )
 
     # Database Configuration
     library_db_path: Path = Field(

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -258,6 +258,10 @@ class FlowsheetV2TrackEntry(FlowsheetV2Base):
     soundcloud_url: str | None = None
     artist_bio: str | None = None
     artist_wikipedia_url: str | None = None
+    on_streaming: bool | None = Field(
+        None,
+        description="Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.",
+    )
 
 
 class EntryType2(StrEnum):
@@ -457,6 +461,14 @@ class AlbumSearchResult(BaseModel):
         description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
     )
     album_artist: str | None = Field(None, description="Credited album artist for compilations.")
+    date_lost: AwareDatetime | None = Field(
+        None,
+        description="When the release was marked missing from the physical library. Null if in library.",
+    )
+    date_found: AwareDatetime | None = Field(
+        None,
+        description="When a previously missing release was found. Null if never lost.",
+    )
 
 
 class AddAlbumRequest(BaseModel):

--- a/main.py
+++ b/main.py
@@ -24,6 +24,8 @@ from library.router import router as library_router
 from lookup.router import router as lookup_router
 from routers.admin import router as admin_router
 from routers.health import router as health_router
+from streaming.dependencies import close_streaming_clients
+from streaming.router import router as streaming_router
 
 load_dotenv()
 
@@ -58,6 +60,7 @@ async def lifespan(app: FastAPI):
     await close_library_db()
     await close_discogs_service()
     await close_entity_store()
+    await close_streaming_clients()
     logger.info("All services shut down")
 
 
@@ -93,6 +96,7 @@ app.include_router(lookup_router, prefix="/api/v1", tags=["lookup"])
 app.include_router(library_router, prefix="/api/v1", tags=["library"])
 app.include_router(discogs_router, prefix="/api/v1", tags=["discogs"])
 app.include_router(identity_router, prefix="/identity", tags=["identity"])
+app.include_router(streaming_router, prefix="/api/v1", tags=["streaming"])
 
 if __name__ == "__main__":
     import uvicorn

--- a/streaming/dependencies.py
+++ b/streaming/dependencies.py
@@ -1,0 +1,90 @@
+"""FastAPI dependency providers for streaming service clients."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Depends
+
+from config.settings import Settings, get_settings
+from scripts.bandcamp_client import BandcampClient
+from scripts.streaming_availability.apple_music_client import AppleMusicClient
+from scripts.streaming_availability.deezer_client import DeezerClient
+from scripts.streaming_availability.spotify_client import SpotifyClient
+
+logger = logging.getLogger(__name__)
+
+# Module-level instances for lifecycle management
+_spotify_client: SpotifyClient | None = None
+_deezer_client: DeezerClient | None = None
+_apple_music_client: AppleMusicClient | None = None
+_bandcamp_client: BandcampClient | None = None
+
+
+def get_spotify_client(settings: Settings = Depends(get_settings)) -> SpotifyClient | None:
+    """Get Spotify client instance. Requires SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET."""
+    global _spotify_client
+
+    if _spotify_client is not None:
+        return _spotify_client
+
+    if not settings.spotify_client_id or not settings.spotify_client_secret:
+        logger.debug("Spotify credentials not set — Spotify streaming check disabled")
+        return None
+
+    _spotify_client = SpotifyClient(settings.spotify_client_id, settings.spotify_client_secret)
+    logger.info("Spotify client initialized")
+    return _spotify_client
+
+
+def get_deezer_client() -> DeezerClient:
+    """Get Deezer client instance. No auth required."""
+    global _deezer_client
+
+    if _deezer_client is None:
+        _deezer_client = DeezerClient()
+        logger.info("Deezer client initialized")
+
+    return _deezer_client
+
+
+def get_apple_music_client() -> AppleMusicClient:
+    """Get Apple Music (iTunes) client instance. No auth required."""
+    global _apple_music_client
+
+    if _apple_music_client is None:
+        _apple_music_client = AppleMusicClient()
+        logger.info("Apple Music client initialized")
+
+    return _apple_music_client
+
+
+def get_bandcamp_client() -> BandcampClient:
+    """Get Bandcamp client instance. No auth required."""
+    global _bandcamp_client
+
+    if _bandcamp_client is None:
+        _bandcamp_client = BandcampClient()
+        logger.info("Bandcamp client initialized")
+
+    return _bandcamp_client
+
+
+async def close_streaming_clients() -> None:
+    """Close all streaming clients. Called during application shutdown."""
+    global _spotify_client, _deezer_client, _apple_music_client, _bandcamp_client
+
+    for name, client in [
+        ("Spotify", _spotify_client),
+        ("Deezer", _deezer_client),
+        ("Apple Music", _apple_music_client),
+        ("Bandcamp", _bandcamp_client),
+    ]:
+        if client is not None:
+            await client.close()
+            logger.info("%s client closed", name)
+
+    _spotify_client = None
+    _deezer_client = None
+    _apple_music_client = None
+    _bandcamp_client = None

--- a/streaming/models.py
+++ b/streaming/models.py
@@ -1,0 +1,41 @@
+"""Request and response models for the streaming-check endpoint."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class StreamingCheckRequest(BaseModel):
+    """Request body for POST /api/v1/streaming-check."""
+
+    artist: str = Field(..., description="Artist name to search for")
+    title: str = Field(..., description="Album title to search for")
+
+
+class SourceMatch(BaseModel):
+    """A match found on a single streaming service."""
+
+    url: str = Field(..., description="URL to the matched album on the service")
+    confidence: float = Field(..., description="Match confidence score (0-100)")
+
+
+class StreamingCheckSources(BaseModel):
+    """Per-service match results."""
+
+    spotify: SourceMatch | None = None
+    deezer: SourceMatch | None = None
+    apple_music: SourceMatch | None = None
+    bandcamp: SourceMatch | None = None
+
+
+class StreamingCheckResponse(BaseModel):
+    """Response body for POST /api/v1/streaming-check."""
+
+    on_streaming: bool | None = Field(
+        ...,
+        description=(
+            "True if found on any service, False if confirmed absent on all, "
+            "None if inconclusive (e.g., all checks errored)"
+        ),
+    )
+    sources: StreamingCheckSources = Field(..., description="Per-service match results")

--- a/streaming/orchestrator.py
+++ b/streaming/orchestrator.py
@@ -1,0 +1,174 @@
+"""Orchestrates streaming availability checks across multiple services."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from scripts.bandcamp_client import BandcampClient
+from scripts.streaming_availability.apple_music_client import AppleMusicClient
+from scripts.streaming_availability.deezer_client import DeezerClient
+from scripts.streaming_availability.matching import find_best_match, score_match
+from scripts.streaming_availability.spotify_client import SpotifyClient
+from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
+
+logger = logging.getLogger(__name__)
+
+
+async def check_streaming_availability(
+    artist: str,
+    title: str,
+    *,
+    spotify: SpotifyClient | None = None,
+    deezer: DeezerClient | None = None,
+    apple_music: AppleMusicClient | None = None,
+    bandcamp: BandcampClient | None = None,
+) -> StreamingCheckResponse:
+    """Check streaming availability for an artist+title across all configured services.
+
+    Runs all service checks concurrently. Returns on_streaming=True if any service
+    has a match, False if all checked services returned no match, None if all errored.
+
+    Args:
+        artist: Artist name to search for.
+        title: Album title to search for.
+        spotify: Optional Spotify client.
+        deezer: Optional Deezer client.
+        apple_music: Optional Apple Music client.
+        bandcamp: Optional Bandcamp client.
+
+    Returns:
+        StreamingCheckResponse with on_streaming boolean and per-source match details.
+    """
+    tasks: dict[str, asyncio.Task] = {}
+
+    if spotify:
+        tasks["spotify"] = asyncio.create_task(_check_spotify(spotify, artist, title))
+    if deezer:
+        tasks["deezer"] = asyncio.create_task(_check_deezer(deezer, artist, title))
+    if apple_music:
+        tasks["apple_music"] = asyncio.create_task(_check_apple_music(apple_music, artist, title))
+    if bandcamp:
+        tasks["bandcamp"] = asyncio.create_task(_check_bandcamp(bandcamp, artist, title))
+
+    sources = StreamingCheckSources()
+    any_checked = False
+    any_found = False
+
+    for service, task in tasks.items():
+        try:
+            match = await task
+            any_checked = True
+            if match is not None:
+                any_found = True
+                setattr(sources, service, match)
+        except Exception:
+            logger.exception("Streaming check failed for %s on %s - %s", service, artist, title)
+
+    if not any_checked:
+        on_streaming = None
+    elif any_found:
+        on_streaming = True
+    else:
+        on_streaming = False
+
+    return StreamingCheckResponse(on_streaming=on_streaming, sources=sources)
+
+
+async def _check_spotify(client: SpotifyClient, artist: str, title: str) -> SourceMatch | None:
+    """Search Spotify for an album match."""
+    results = await client.search_album(artist, title)
+    if not results:
+        return None
+
+    best = find_best_match(
+        results,
+        artist,
+        title,
+        artist_fn=lambda x: x["artists"][0]["name"],
+        title_fn=lambda x: x["name"],
+        url_fn=lambda x: x["external_urls"]["spotify"],
+        id_fn=lambda x: x["id"],
+    )
+    if best is None:
+        return None
+    return SourceMatch(url=best["url"], confidence=best["confidence"])
+
+
+async def _check_deezer(client: DeezerClient, artist: str, title: str) -> SourceMatch | None:
+    """Search Deezer for an album match."""
+    results = await client.search_album(artist, title)
+    if not results:
+        return None
+
+    best = find_best_match(
+        results,
+        artist,
+        title,
+        artist_fn=lambda x: x["artist"]["name"],
+        title_fn=lambda x: x["title"],
+        url_fn=lambda x: x["link"],
+    )
+    if best is None:
+        return None
+    return SourceMatch(url=best["url"], confidence=best["confidence"])
+
+
+async def _check_apple_music(
+    client: AppleMusicClient, artist: str, title: str
+) -> SourceMatch | None:
+    """Search Apple Music (iTunes) for an album match."""
+    results = await client.search_album(artist, title)
+    if not results:
+        return None
+
+    best = find_best_match(
+        results,
+        artist,
+        title,
+        artist_fn=lambda x: x["artistName"],
+        title_fn=lambda x: x["collectionName"],
+        url_fn=lambda x: x["collectionViewUrl"],
+    )
+    if best is None:
+        return None
+    return SourceMatch(url=best["url"], confidence=best["confidence"])
+
+
+async def _check_bandcamp(client: BandcampClient, artist: str, title: str) -> SourceMatch | None:
+    """Search Bandcamp for an album match.
+
+    Two-phase: first find the artist page via autocomplete, then scrape the catalog
+    and fuzzy-match the album title.
+    """
+    artist_results = await client.search_artist(artist)
+    if not artist_results:
+        return None
+
+    # Find best artist match
+    best_artist = None
+    best_artist_score = 0.0
+    for result in artist_results:
+        s = score_match(artist, result["name"])
+        if s >= 80.0 and s > best_artist_score:
+            best_artist = result
+            best_artist_score = s
+
+    if best_artist is None:
+        return None
+
+    catalog = await client.fetch_artist_catalog(best_artist["slug"])
+    if not catalog:
+        return None
+
+    best = find_best_match(
+        catalog,
+        artist,
+        title,
+        artist_fn=lambda _: best_artist["name"],
+        title_fn=lambda x: x["title"],
+        url_fn=lambda x: x["url"],
+    )
+    if best is None:
+        return None
+    return SourceMatch(url=best["url"], confidence=best["confidence"])

--- a/streaming/router.py
+++ b/streaming/router.py
@@ -1,0 +1,61 @@
+"""Router for the streaming availability check endpoint."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from scripts.bandcamp_client import BandcampClient
+from scripts.streaming_availability.apple_music_client import AppleMusicClient
+from scripts.streaming_availability.deezer_client import DeezerClient
+from scripts.streaming_availability.spotify_client import SpotifyClient
+from streaming.dependencies import (
+    get_apple_music_client,
+    get_bandcamp_client,
+    get_deezer_client,
+    get_spotify_client,
+)
+from streaming.models import StreamingCheckRequest, StreamingCheckResponse
+from streaming.orchestrator import check_streaming_availability
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["streaming"])
+
+
+@router.post(
+    "/streaming-check",
+    response_model=StreamingCheckResponse,
+    summary="Check streaming availability for an album",
+    description=(
+        "Checks Spotify, Deezer, Apple Music, and Bandcamp for a given artist+title. "
+        "Returns whether the album is available on streaming platforms and URLs for each match."
+    ),
+    responses={
+        200: {"description": "Streaming availability result"},
+        500: {"description": "Internal server error"},
+    },
+)
+async def handle_streaming_check(
+    request: StreamingCheckRequest,
+    spotify: SpotifyClient | None = Depends(get_spotify_client),
+    deezer: DeezerClient = Depends(get_deezer_client),
+    apple_music: AppleMusicClient = Depends(get_apple_music_client),
+    bandcamp: BandcampClient = Depends(get_bandcamp_client),
+) -> StreamingCheckResponse:
+    """Check streaming availability across all configured services."""
+    try:
+        return await check_streaming_availability(
+            request.artist,
+            request.title,
+            spotify=spotify,
+            deezer=deezer,
+            apple_music=apple_music,
+            bandcamp=bandcamp,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Streaming check failed for %s - %s", request.artist, request.title)
+        raise HTTPException(status_code=500, detail="Streaming check failed") from e

--- a/tests/unit/test_streaming_check_orchestrator.py
+++ b/tests/unit/test_streaming_check_orchestrator.py
@@ -1,0 +1,230 @@
+"""Tests for the streaming check orchestrator."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from streaming.orchestrator import check_streaming_availability
+
+
+def _make_spotify_result(
+    artist="Stereolab", title="Aluminum Tunes", url="https://open.spotify.com/album/abc123"
+):
+    """Build a minimal Spotify API album result."""
+    return {
+        "artists": [{"name": artist}],
+        "name": title,
+        "external_urls": {"spotify": url},
+        "id": "abc123",
+    }
+
+
+def _make_deezer_result(
+    artist="Stereolab", title="Aluminum Tunes", url="https://www.deezer.com/album/123"
+):
+    """Build a minimal Deezer API album result."""
+    return {
+        "artist": {"name": artist},
+        "title": title,
+        "link": url,
+    }
+
+
+def _make_apple_result(
+    artist="Stereolab", title="Aluminum Tunes", url="https://music.apple.com/album/123"
+):
+    """Build a minimal iTunes Search API album result."""
+    return {
+        "artistName": artist,
+        "collectionName": title,
+        "collectionViewUrl": url,
+    }
+
+
+def _make_bandcamp_artist(name="Stereolab", slug="stereolab"):
+    """Build a Bandcamp autocomplete artist result."""
+    return {"name": name, "url": f"https://{slug}.bandcamp.com", "slug": slug}
+
+
+def _make_bandcamp_album(title="Aluminum Tunes", slug="stereolab"):
+    """Build a Bandcamp catalog album entry."""
+    path = title.lower().replace(" ", "-")
+    return {"title": title, "url": f"https://{slug}.bandcamp.com/album/{path}"}
+
+
+@pytest.mark.asyncio
+async def test_found_on_spotify():
+    """Returns on_streaming=True with spotify source when Spotify has a match."""
+    spotify = AsyncMock()
+    spotify.search_album = AsyncMock(return_value=[_make_spotify_result()])
+
+    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", spotify=spotify)
+
+    assert result.on_streaming is True
+    assert result.sources.spotify is not None
+    assert "spotify.com" in result.sources.spotify.url
+    assert result.sources.spotify.confidence >= 80.0
+
+
+@pytest.mark.asyncio
+async def test_found_on_deezer():
+    """Returns on_streaming=True with deezer source when Deezer has a match."""
+    deezer = AsyncMock()
+    deezer.search_album = AsyncMock(return_value=[_make_deezer_result()])
+
+    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", deezer=deezer)
+
+    assert result.on_streaming is True
+    assert result.sources.deezer is not None
+    assert "deezer.com" in result.sources.deezer.url
+
+
+@pytest.mark.asyncio
+async def test_found_on_apple_music():
+    """Returns on_streaming=True with apple_music source when iTunes has a match."""
+    apple = AsyncMock()
+    apple.search_album = AsyncMock(return_value=[_make_apple_result()])
+
+    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", apple_music=apple)
+
+    assert result.on_streaming is True
+    assert result.sources.apple_music is not None
+    assert "apple.com" in result.sources.apple_music.url
+
+
+@pytest.mark.asyncio
+async def test_found_on_bandcamp():
+    """Returns on_streaming=True with bandcamp source when Bandcamp has a match."""
+    bandcamp = AsyncMock()
+    bandcamp.search_artist = AsyncMock(return_value=[_make_bandcamp_artist()])
+    bandcamp.fetch_artist_catalog = AsyncMock(return_value=[_make_bandcamp_album()])
+
+    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", bandcamp=bandcamp)
+
+    assert result.on_streaming is True
+    assert result.sources.bandcamp is not None
+    assert "bandcamp.com" in result.sources.bandcamp.url
+
+
+@pytest.mark.asyncio
+async def test_not_found_on_any_service():
+    """Returns on_streaming=False when all services return no match."""
+    spotify = AsyncMock()
+    spotify.search_album = AsyncMock(return_value=[])
+    deezer = AsyncMock()
+    deezer.search_album = AsyncMock(return_value=[])
+
+    result = await check_streaming_availability(
+        "Stereolab", "Aluminum Tunes", spotify=spotify, deezer=deezer
+    )
+
+    assert result.on_streaming is False
+    assert result.sources.spotify is None
+    assert result.sources.deezer is None
+
+
+@pytest.mark.asyncio
+async def test_no_clients_returns_inconclusive():
+    """Returns on_streaming=None when no clients are provided."""
+    result = await check_streaming_availability("Stereolab", "Aluminum Tunes")
+
+    assert result.on_streaming is None
+
+
+@pytest.mark.asyncio
+async def test_all_clients_error_returns_inconclusive():
+    """Returns on_streaming=None when all client checks raise exceptions."""
+    spotify = AsyncMock()
+    spotify.search_album = AsyncMock(side_effect=Exception("network error"))
+    deezer = AsyncMock()
+    deezer.search_album = AsyncMock(side_effect=Exception("timeout"))
+
+    result = await check_streaming_availability(
+        "Stereolab", "Aluminum Tunes", spotify=spotify, deezer=deezer
+    )
+
+    assert result.on_streaming is None
+
+
+@pytest.mark.asyncio
+async def test_partial_error_still_returns_result():
+    """One service errors, another succeeds — returns on_streaming=True."""
+    spotify = AsyncMock()
+    spotify.search_album = AsyncMock(side_effect=Exception("network error"))
+    deezer = AsyncMock()
+    deezer.search_album = AsyncMock(return_value=[_make_deezer_result()])
+
+    result = await check_streaming_availability(
+        "Stereolab", "Aluminum Tunes", spotify=spotify, deezer=deezer
+    )
+
+    assert result.on_streaming is True
+    assert result.sources.spotify is None
+    assert result.sources.deezer is not None
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_match_rejected():
+    """A result with a poor fuzzy match is not accepted."""
+    spotify = AsyncMock()
+    spotify.search_album = AsyncMock(
+        return_value=[
+            _make_spotify_result(artist="Completely Different Artist", title="Unrelated Album")
+        ]
+    )
+
+    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", spotify=spotify)
+
+    assert result.on_streaming is False
+    assert result.sources.spotify is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_services_all_match():
+    """All sources populated when multiple services find the album."""
+    spotify = AsyncMock()
+    spotify.search_album = AsyncMock(return_value=[_make_spotify_result()])
+    deezer = AsyncMock()
+    deezer.search_album = AsyncMock(return_value=[_make_deezer_result()])
+    apple = AsyncMock()
+    apple.search_album = AsyncMock(return_value=[_make_apple_result()])
+
+    result = await check_streaming_availability(
+        "Stereolab",
+        "Aluminum Tunes",
+        spotify=spotify,
+        deezer=deezer,
+        apple_music=apple,
+    )
+
+    assert result.on_streaming is True
+    assert result.sources.spotify is not None
+    assert result.sources.deezer is not None
+    assert result.sources.apple_music is not None
+
+
+@pytest.mark.asyncio
+async def test_bandcamp_no_artist_match():
+    """Returns None for bandcamp when artist autocomplete finds no match."""
+    bandcamp = AsyncMock()
+    bandcamp.search_artist = AsyncMock(return_value=[])
+
+    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", bandcamp=bandcamp)
+
+    assert result.on_streaming is False
+    assert result.sources.bandcamp is None
+
+
+@pytest.mark.asyncio
+async def test_bandcamp_artist_match_no_album():
+    """Returns None for bandcamp when artist is found but album is not in catalog."""
+    bandcamp = AsyncMock()
+    bandcamp.search_artist = AsyncMock(return_value=[_make_bandcamp_artist()])
+    bandcamp.fetch_artist_catalog = AsyncMock(
+        return_value=[_make_bandcamp_album(title="Completely Different Album")]
+    )
+
+    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", bandcamp=bandcamp)
+
+    assert result.on_streaming is False
+    assert result.sources.bandcamp is None

--- a/tests/unit/test_streaming_check_router.py
+++ b/tests/unit/test_streaming_check_router.py
@@ -1,0 +1,120 @@
+"""Tests for the streaming-check router endpoint."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import get_settings
+from streaming.dependencies import (
+    get_apple_music_client,
+    get_bandcamp_client,
+    get_deezer_client,
+    get_spotify_client,
+)
+from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
+from tests.unit.conftest import override_deps
+
+
+@pytest.fixture
+def app_client(mock_settings):
+    """FastAPI test app with streaming dependencies overridden."""
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_settings: mock_settings,
+            get_spotify_client: None,
+            get_deezer_client: AsyncMock(),
+            get_apple_music_client: None,
+            get_bandcamp_client: None,
+        },
+    ):
+        yield app
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_success(app_client):
+    """POST /api/v1/streaming-check returns 200 with valid response."""
+    mock_response = StreamingCheckResponse(
+        on_streaming=True,
+        sources=StreamingCheckSources(
+            spotify=SourceMatch(url="https://open.spotify.com/album/abc", confidence=95.0),
+        ),
+    )
+
+    with patch(
+        "streaming.router.check_streaming_availability",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v1/streaming-check",
+                json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["on_streaming"] is True
+    assert data["sources"]["spotify"]["url"] == "https://open.spotify.com/album/abc"
+    assert data["sources"]["spotify"]["confidence"] == 95.0
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_not_found(app_client):
+    """POST /api/v1/streaming-check returns on_streaming=False when no match."""
+    mock_response = StreamingCheckResponse(
+        on_streaming=False,
+        sources=StreamingCheckSources(),
+    )
+
+    with patch(
+        "streaming.router.check_streaming_availability",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v1/streaming-check",
+                json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["on_streaming"] is False
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_missing_fields(app_client):
+    """POST /api/v1/streaming-check returns 422 when required fields are missing."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app_client), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/v1/streaming-check", json={})
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_internal_error(app_client):
+    """POST /api/v1/streaming-check returns 500 on unexpected exception."""
+    with patch(
+        "streaming.router.check_streaming_availability",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("unexpected"),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/v1/streaming-check",
+                json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+            )
+
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/streaming-check` endpoint that checks Spotify, Deezer, Apple Music, and Bandcamp for a given artist+title pair
- Wire existing streaming clients from `scripts/streaming_availability/` into FastAPI dependency injection
- Run all service checks concurrently, return per-source match URLs with confidence scores
- Add `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` to settings (other services need no auth)

Closes #134

## Test plan

- [x] 12 orchestrator unit tests (all service combos, errors, fuzzy match rejection)
- [x] 4 router unit tests (success, not-found, 422, 500)
- [x] Full suite (1247 tests) passes
- [x] Lint + format checks pass
- [ ] CI passes