### PR TITLE
Add Discogs markup parser with async entity resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ All strategy implementations live in `lookup/orchestrator.py`.
 - `discogs/cache_service.py` -- PostgreSQL cache (asyncpg + pg_trgm)
 - `discogs/memory_cache.py` -- In-memory TTL cache (cachetools)
 - `core/search.py` -- Declarative search strategy pattern + ambiguous format detection
+- `discogs/markup_parser.py` -- Discogs markup parser: tokenize/resolve `[a=Name]`, `[a12345]`, `[b]...[/b]`, etc. into structured `ResolvedToken` models. Includes `EntityResolver` protocol and `DiscogsServiceResolver` adapter for async ID resolution. Translated from iOS `DiscogsMarkupParser.swift`.
 - `discogs/matching.py` -- Discogs-specific normalization (strip_discogs_suffix, normalize_for_track_comparison, normalize_artist_for_validation)
 - `core/dependencies.py` -- FastAPI DI for LibraryDB + DiscogsService
 - `identity/router.py` -- `GET /identity/resolve` and `POST /identity/bulk` endpoints for identity resolution

--- a/discogs/markup_parser.py
+++ b/discogs/markup_parser.py
@@ -285,12 +285,12 @@ def _resolve_token(token: _DiscogsToken, resolved_ids: dict[str, str]) -> Resolv
             return ArtistLinkToken(name=name, display_name=display_name, url=url)
 
         case _ArtistId(id=id):
-            name = resolved_ids.get(f"artist-{id}")
-            if name is None:
+            resolved_name = resolved_ids.get(f"artist-{id}")
+            if resolved_name is None:
                 return None
-            display_name = strip_disambiguation_suffix(name)
+            display_name = strip_disambiguation_suffix(resolved_name)
             url = f"https://www.discogs.com/artist/{id}"
-            return ArtistLinkToken(name=name, display_name=display_name, url=url)
+            return ArtistLinkToken(name=resolved_name, display_name=display_name, url=url)
 
         case _ReleaseId(id=id):
             title = resolved_ids.get(f"release-{id}")

--- a/discogs/markup_parser.py
+++ b/discogs/markup_parser.py
@@ -1,0 +1,444 @@
+"""Discogs markup parser.
+
+Parses Discogs-style markup (links, formatting) to structured tokens.
+Faithful Python translation of iOS DiscogsMarkupParser.swift.
+
+Three-phase architecture:
+1. Tokenize — parse markup into a flat token list
+2. Resolve — resolve ID-based tokens (sync mode skips them)
+3. Output — return structured ResolvedToken models for API serialization
+
+Supported formats:
+- ``[a=Artist Name]`` — artist link (displays the artist name)
+- ``[a12345]`` — artist link by ID (resolved via EntityResolver)
+- ``[l=Label Name]`` — label name (plain text)
+- ``[b]text[/b]`` — bold text
+- ``[i]text[/i]`` — italic text
+- ``[u]text[/u]`` — underlined text
+- ``[url=http://example.com]Link Text[/url]`` — URL link
+- ``[r12345]`` or ``[r=12345]`` — release link by ID
+- ``[m123]`` or ``[m=123]`` — master link by ID
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import quote, urlparse
+
+from discogs.models import (
+    ArtistLinkToken,
+    BoldToken,
+    ItalicToken,
+    LabelNameToken,
+    MasterLinkToken,
+    PlainTextToken,
+    ReleaseLinkToken,
+    ResolvedToken,
+    UnderlineToken,
+    UrlLinkToken,
+)
+
+logger = logging.getLogger(__name__)
+
+# MARK: - Regex Patterns
+
+ARTIST_NAME_PATTERN = re.compile(r"^a=(.+)$")
+ARTIST_ID_PATTERN = re.compile(r"^a(\d+)$")
+RELEASE_ID_PATTERN = re.compile(r"^r=?(\d+)$")
+MASTER_ID_PATTERN = re.compile(r"^m=?(\d+)$")
+LABEL_NAME_PATTERN = re.compile(r"^l=(.+)$")
+URL_OPEN_PATTERN = re.compile(r"^url=(.+)$")
+CLOSING_TAG_PATTERN = re.compile(r"^/(.+)$")
+DISAMBIGUATION_SUFFIX = re.compile(r" \(\d+\)$")
+
+# MARK: - Raw Token Types (internal)
+
+
+@dataclass(frozen=True)
+class _PlainText:
+    text: str
+
+
+@dataclass(frozen=True)
+class _ArtistName:
+    name: str
+
+
+@dataclass(frozen=True)
+class _ArtistId:
+    id: int
+
+
+@dataclass(frozen=True)
+class _ReleaseId:
+    id: int
+
+
+@dataclass(frozen=True)
+class _MasterId:
+    id: int
+
+
+@dataclass(frozen=True)
+class _LabelName:
+    name: str
+
+
+@dataclass(frozen=True)
+class _Bold:
+    content: str
+
+
+@dataclass(frozen=True)
+class _Italic:
+    content: str
+
+
+@dataclass(frozen=True)
+class _Underline:
+    content: str
+
+
+@dataclass(frozen=True)
+class _Url:
+    href: str
+    content: str
+
+
+_DiscogsToken = (
+    _PlainText
+    | _ArtistName
+    | _ArtistId
+    | _ReleaseId
+    | _MasterId
+    | _LabelName
+    | _Bold
+    | _Italic
+    | _Underline
+    | _Url
+)
+
+# MARK: - Utility
+
+
+def strip_disambiguation_suffix(name: str) -> str:
+    """Remove Discogs disambiguation suffix like " (8)" from artist names.
+
+    e.g., "Salamanda (8)" becomes "Salamanda"
+    """
+    return DISAMBIGUATION_SUFFIX.sub("", name)
+
+
+# MARK: - Phase 1: Tokenize
+
+
+def _find_closing_tag(text: str, start_index: int, tag: str) -> tuple[str, int] | None:
+    """Find a closing tag like [/tag] in the text, handling same-type nesting.
+
+    Returns (content_between_tags, index_after_closing_bracket) or None.
+    """
+    search_start = start_index
+    depth = 1
+
+    while search_start < len(text):
+        open_bracket = text.find("[", search_start)
+        if open_bracket == -1:
+            break
+
+        close_bracket = text.find("]", open_bracket)
+        if close_bracket == -1:
+            break
+
+        tag_content = text[open_bracket + 1 : close_bracket]
+
+        if tag_content == tag:
+            depth += 1
+        elif tag_content == f"/{tag}":
+            depth -= 1
+            if depth == 0:
+                content = text[start_index:open_bracket]
+                return (content, close_bracket + 1)
+
+        search_start = close_bracket + 1
+
+    return None
+
+
+def _classify_tag(tag: str, text: str, pos_after_tag: int) -> tuple[_DiscogsToken, int] | None:
+    """Classify a tag and return the appropriate token with updated position."""
+    # Artist name: [a=Name]
+    match = ARTIST_NAME_PATTERN.match(tag)
+    if match:
+        return (_ArtistName(name=match.group(1)), pos_after_tag)
+
+    # Artist ID: [a12345]
+    match = ARTIST_ID_PATTERN.match(tag)
+    if match:
+        return (_ArtistId(id=int(match.group(1))), pos_after_tag)
+
+    # Release ID: [r12345] or [r=12345]
+    match = RELEASE_ID_PATTERN.match(tag)
+    if match:
+        return (_ReleaseId(id=int(match.group(1))), pos_after_tag)
+
+    # Master ID: [m123] or [m=123]
+    match = MASTER_ID_PATTERN.match(tag)
+    if match:
+        return (_MasterId(id=int(match.group(1))), pos_after_tag)
+
+    # Label name: [l=Name]
+    match = LABEL_NAME_PATTERN.match(tag)
+    if match:
+        return (_LabelName(name=match.group(1)), pos_after_tag)
+
+    # URL: [url=...]...[/url]
+    match = URL_OPEN_PATTERN.match(tag)
+    if match:
+        url_string = match.group(1)
+        closing = _find_closing_tag(text, pos_after_tag, "url")
+        if closing:
+            content, end_index = closing
+            return (_Url(href=url_string, content=content), end_index)
+        else:
+            # No closing tag — show URL and remaining text combined
+            remaining = text[pos_after_tag:]
+            return (_PlainText(text=url_string + remaining), len(text))
+
+    # Formatting tags: [b]...[/b], [i]...[/i], [u]...[/u]
+    if tag in ("b", "i", "u"):
+        closing = _find_closing_tag(text, pos_after_tag, tag)
+        if closing:
+            content, end_index = closing
+            if tag == "b":
+                return (_Bold(content=content), end_index)
+            elif tag == "i":
+                return (_Italic(content=content), end_index)
+            else:
+                return (_Underline(content=content), end_index)
+        else:
+            # No closing tag — skip
+            return None
+
+    # Orphaned closing tags — skip
+    if CLOSING_TAG_PATTERN.match(tag):
+        return None
+
+    # Unknown tag — skip
+    return None
+
+
+def tokenize(text: str) -> list[_DiscogsToken]:
+    """Tokenize Discogs markup into a flat list of raw tokens."""
+    tokens: list[_DiscogsToken] = []
+    pos = 0
+
+    while pos < len(text):
+        bracket_index = text.find("[", pos)
+        if bracket_index == -1:
+            tokens.append(_PlainText(text=text[pos:]))
+            break
+
+        # Add plain text before the bracket
+        if bracket_index > pos:
+            tokens.append(_PlainText(text=text[pos:bracket_index]))
+
+        # Find closing bracket
+        closing_bracket = text.find("]", bracket_index)
+        if closing_bracket == -1:
+            # No closing bracket — append from opening bracket onward as plain text
+            tokens.append(_PlainText(text=text[bracket_index:]))
+            break
+
+        tag_content = text[bracket_index + 1 : closing_bracket]
+        pos = closing_bracket + 1
+
+        if len(tag_content) == 0:
+            continue
+
+        # Classify and handle the tag
+        result = _classify_tag(tag_content, text, pos)
+        if result:
+            token, pos = result
+            tokens.append(token)
+        # Unknown/orphaned/empty tags are silently skipped
+
+    return tokens
+
+
+# MARK: - Phase 2: Resolve
+
+
+def _resolve_token(token: _DiscogsToken, resolved_ids: dict[str, str]) -> ResolvedToken | None:
+    """Resolve a single raw token to a ResolvedToken using the resolved ID map."""
+    match token:
+        case _PlainText(text=text):
+            return PlainTextToken(text=text)
+
+        case _ArtistName(name=name):
+            display_name = strip_disambiguation_suffix(name)
+            encoded = quote(name, safe="")
+            url = f"https://www.discogs.com/search/?q={encoded}&type=artist"
+            return ArtistLinkToken(name=name, display_name=display_name, url=url)
+
+        case _ArtistId(id=id):
+            name = resolved_ids.get(f"artist-{id}")
+            if name is None:
+                return None
+            display_name = strip_disambiguation_suffix(name)
+            url = f"https://www.discogs.com/artist/{id}"
+            return ArtistLinkToken(name=name, display_name=display_name, url=url)
+
+        case _ReleaseId(id=id):
+            title = resolved_ids.get(f"release-{id}")
+            if title is None:
+                return None
+            url = f"https://www.discogs.com/release/{id}"
+            return ReleaseLinkToken(title=title, url=url)
+
+        case _MasterId(id=id):
+            title = resolved_ids.get(f"master-{id}")
+            if title is None:
+                return None
+            url = f"https://www.discogs.com/master/{id}"
+            return MasterLinkToken(title=title, url=url)
+
+        case _LabelName(name=name):
+            return LabelNameToken(name=name)
+
+        case _Bold(content=content):
+            return BoldToken(content=content)
+
+        case _Italic(content=content):
+            return ItalicToken(content=content)
+
+        case _Underline(content=content):
+            return UnderlineToken(content=content)
+
+        case _Url(href=href, content=content):
+            parsed = urlparse(href)
+            valid_href = href if parsed.scheme else None
+            return UrlLinkToken(href=valid_href, content=content)
+
+
+def resolve(
+    tokens: list[_DiscogsToken],
+    resolved_ids: dict[str, str] | None = None,
+) -> list[ResolvedToken]:
+    """Resolve raw tokens to ResolvedTokens (sync, skips unresolved ID tokens)."""
+    ids = resolved_ids or {}
+    return [r for t in tokens if (r := _resolve_token(t, ids)) is not None]
+
+
+def parse(text: str) -> list[ResolvedToken]:
+    """Parse Discogs markup and return resolved tokens (sync, no entity resolution).
+
+    ID-based tokens ([a12345], [r12345], [m123]) are silently dropped.
+    """
+    return resolve(tokenize(text))
+
+
+# MARK: - Async Entity Resolution
+
+
+class EntityResolver(Protocol):
+    """Protocol for resolving Discogs entity IDs to names."""
+
+    async def resolve_artist(self, id: int) -> str | None: ...
+    async def resolve_release(self, id: int) -> str | None: ...
+    async def resolve_master(self, id: int) -> str | None: ...
+
+
+async def _safe_resolve(coro, key: str) -> tuple[str, str | None]:
+    """Wrap a resolver coroutine, catching all exceptions."""
+    try:
+        result = await coro
+        return (key, result)
+    except Exception:
+        logger.warning("Failed to resolve entity %s", key)
+        return (key, None)
+
+
+async def resolve_async(
+    tokens: list[_DiscogsToken],
+    resolver: EntityResolver,
+) -> list[ResolvedToken]:
+    """Resolve raw tokens with async entity resolution.
+
+    Collects unique entity IDs, resolves them concurrently, then rebuilds tokens.
+    """
+    # Collect unique IDs
+    artist_ids: set[int] = set()
+    release_ids: set[int] = set()
+    master_ids: set[int] = set()
+
+    for token in tokens:
+        match token:
+            case _ArtistId(id=id):
+                artist_ids.add(id)
+            case _ReleaseId(id=id):
+                release_ids.add(id)
+            case _MasterId(id=id):
+                master_ids.add(id)
+
+    # Resolve all IDs concurrently
+    tasks = []
+    for id in artist_ids:
+        tasks.append(_safe_resolve(resolver.resolve_artist(id), f"artist-{id}"))
+    for id in release_ids:
+        tasks.append(_safe_resolve(resolver.resolve_release(id), f"release-{id}"))
+    for id in master_ids:
+        tasks.append(_safe_resolve(resolver.resolve_master(id), f"master-{id}"))
+
+    results = await asyncio.gather(*tasks)
+
+    # Build resolved IDs map (skip None values)
+    resolved_ids: dict[str, str] = {key: value for key, value in results if value is not None}
+
+    # Rebuild with resolved values
+    return resolve(tokens, resolved_ids)
+
+
+async def parse_async(
+    text: str,
+    resolver: EntityResolver,
+) -> list[ResolvedToken]:
+    """Parse Discogs markup with async entity resolution.
+
+    Resolves [a12345], [r12345], [m123] tags via the provided resolver.
+    """
+    return await resolve_async(tokenize(text), resolver)
+
+
+# MARK: - DiscogsService Adapter
+
+
+class DiscogsServiceResolver:
+    """Adapts DiscogsService methods to the EntityResolver protocol."""
+
+    def __init__(self, service) -> None:
+        self._service = service
+
+    async def resolve_artist(self, id: int) -> str | None:
+        try:
+            details = await self._service.get_artist_details(id)
+            return details.name if details else None
+        except Exception:
+            return None
+
+    async def resolve_release(self, id: int) -> str | None:
+        try:
+            release = await self._service.get_release(id)
+            return release.title if release else None
+        except Exception:
+            return None
+
+    async def resolve_master(self, id: int) -> str | None:
+        try:
+            master = await self._service.get_master(id)
+            return master.title if master else None
+        except Exception:
+            return None

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Annotated, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Discriminator
 
 from generated.api_models import DiscogsMatchResult as _GeneratedDiscogsMatchResult
 
@@ -112,12 +113,98 @@ class MemberRef(BaseModel):
     active: bool = True
 
 
+# MARK: - Resolved Markup Tokens
+
+
+class PlainTextToken(BaseModel):
+    """Plain text content."""
+
+    type: Literal["plainText"] = "plainText"
+    text: str
+
+
+class ArtistLinkToken(BaseModel):
+    """Artist link with display name and URL."""
+
+    type: Literal["artistLink"] = "artistLink"
+    name: str  # original name (may include disambiguation suffix)
+    display_name: str  # suffix stripped for display
+    url: str
+
+
+class LabelNameToken(BaseModel):
+    """Label name (displayed as plain text, not linked)."""
+
+    type: Literal["labelName"] = "labelName"
+    name: str
+
+
+class ReleaseLinkToken(BaseModel):
+    """Release link with title and URL."""
+
+    type: Literal["releaseLink"] = "releaseLink"
+    title: str
+    url: str
+
+
+class MasterLinkToken(BaseModel):
+    """Master release link with title and URL."""
+
+    type: Literal["masterLink"] = "masterLink"
+    title: str
+    url: str
+
+
+class BoldToken(BaseModel):
+    """Bold text content."""
+
+    type: Literal["bold"] = "bold"
+    content: str
+
+
+class ItalicToken(BaseModel):
+    """Italic text content."""
+
+    type: Literal["italic"] = "italic"
+    content: str
+
+
+class UnderlineToken(BaseModel):
+    """Underlined text content."""
+
+    type: Literal["underline"] = "underline"
+    content: str
+
+
+class UrlLinkToken(BaseModel):
+    """URL link with optional href and display content."""
+
+    type: Literal["urlLink"] = "urlLink"
+    href: str | None  # None when URL string is invalid
+    content: str
+
+
+ResolvedToken = Annotated[
+    PlainTextToken
+    | ArtistLinkToken
+    | LabelNameToken
+    | ReleaseLinkToken
+    | MasterLinkToken
+    | BoldToken
+    | ItalicToken
+    | UnderlineToken
+    | UrlLinkToken,
+    Discriminator("type"),
+]
+
+
 class ArtistDetails(BaseModel):
     """Full artist details from Discogs."""
 
     artist_id: int
     name: str
     profile: str | None = None
+    profile_tokens: list[ResolvedToken] | None = None
     image_url: str | None = None
     name_variations: list[str] = []
     aliases: list[ArtistRef] = []

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from core.dependencies import get_discogs_cache_service, get_discogs_service
 from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
+from discogs.markup_parser import DiscogsServiceResolver, parse_async
 from discogs.models import (
     ArtistDetails,
     DiscogsSearchRequest,
@@ -131,6 +132,13 @@ async def get_artist(
             status_code=404,
             detail=f"Artist {artist_id} not found",
         )
+
+    if result.profile:
+        try:
+            resolver = DiscogsServiceResolver(svc)
+            result.profile_tokens = await parse_async(result.profile, resolver)
+        except Exception:
+            logger.warning("Failed to parse profile markup for artist %d", artist_id)
 
     return result
 

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -946,7 +946,7 @@ class SearchType(StrEnum):
 
 
 class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field(default_factory=list)
+    results: list[LookupResultItem] | None = Field([], validate_default=True)
     search_type: SearchType | None = Field(
         "none",
         description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -258,6 +258,10 @@ class FlowsheetV2TrackEntry(FlowsheetV2Base):
     soundcloud_url: str | None = None
     artist_bio: str | None = None
     artist_wikipedia_url: str | None = None
+    on_streaming: bool | None = Field(
+        None,
+        description="Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.",
+    )
 
 
 class EntryType2(StrEnum):
@@ -457,6 +461,14 @@ class AlbumSearchResult(BaseModel):
         description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
     )
     album_artist: str | None = Field(None, description="Credited album artist for compilations.")
+    date_lost: AwareDatetime | None = Field(
+        None,
+        description="When the release was marked missing from the physical library. Null if in library.",
+    )
+    date_found: AwareDatetime | None = Field(
+        None,
+        description="When a previously missing release was found. Null if never lost.",
+    )
 
 
 class AddAlbumRequest(BaseModel):
@@ -934,7 +946,7 @@ class SearchType(StrEnum):
 
 
 class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field([], validate_default=True)
+    results: list[LookupResultItem] | None = Field(default_factory=list)
     search_type: SearchType | None = Field(
         "none",
         description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",

--- a/tests/unit/test_markup_parser.py
+++ b/tests/unit/test_markup_parser.py
@@ -1,0 +1,522 @@
+"""Tests for Discogs markup parser.
+
+Faithful translation of iOS DiscogsMarkupParserTests.swift.
+Covers: artist links, bold/italic/underline formatting, label links,
+URL links, release/master links, edge cases, async entity resolution.
+"""
+
+import pytest
+
+from discogs.markup_parser import (
+    _ArtistId,
+    _ArtistName,
+    _PlainText,
+    parse,
+    parse_async,
+    resolve,
+    strip_disambiguation_suffix,
+    tokenize,
+)
+from discogs.models import (
+    ArtistLinkToken,
+    BoldToken,
+    ItalicToken,
+    LabelNameToken,
+    MasterLinkToken,
+    PlainTextToken,
+    ReleaseLinkToken,
+    ResolvedToken,
+    UnderlineToken,
+    UrlLinkToken,
+)
+
+# MARK: - Test Helpers
+
+
+class MockEntityResolver:
+    """Mock resolver for testing async entity resolution."""
+
+    def __init__(
+        self,
+        artists: dict[int, str] | None = None,
+        releases: dict[int, str] | None = None,
+        masters: dict[int, str] | None = None,
+        should_throw: bool = False,
+    ):
+        self.artists = artists or {}
+        self.releases = releases or {}
+        self.masters = masters or {}
+        self.should_throw = should_throw
+
+    async def resolve_artist(self, id: int) -> str | None:
+        if self.should_throw:
+            raise RuntimeError("resolution failed")
+        return self.artists.get(id)
+
+    async def resolve_release(self, id: int) -> str | None:
+        if self.should_throw:
+            raise RuntimeError("resolution failed")
+        return self.releases.get(id)
+
+    async def resolve_master(self, id: int) -> str | None:
+        if self.should_throw:
+            raise RuntimeError("resolution failed")
+        return self.masters.get(id)
+
+
+def text_content(tokens: list[ResolvedToken]) -> str:
+    """Extract display text from resolved tokens."""
+    parts: list[str] = []
+    for t in tokens:
+        match t:
+            case PlainTextToken():
+                parts.append(t.text)
+            case ArtistLinkToken():
+                parts.append(t.display_name)
+            case LabelNameToken():
+                parts.append(t.name)
+            case ReleaseLinkToken():
+                parts.append(t.title)
+            case MasterLinkToken():
+                parts.append(t.title)
+            case BoldToken():
+                parts.append(t.content)
+            case ItalicToken():
+                parts.append(t.content)
+            case UnderlineToken():
+                parts.append(t.content)
+            case UrlLinkToken():
+                parts.append(t.content)
+    return "".join(parts)
+
+
+# MARK: - Artist Tag Tests
+
+
+class TestArtistTags:
+    def test_parses_artist_link_with_name(self):
+        result = parse("[a=The Beatles]")
+        assert text_content(result) == "The Beatles"
+
+    def test_parses_artist_link_with_special_characters(self):
+        result = parse("[a=Guns N' Roses]")
+        assert text_content(result) == "Guns N' Roses"
+
+    def test_skips_artist_link_by_id_in_sync_mode(self):
+        result = parse("[a12345]")
+        assert text_content(result) == ""
+
+    def test_skips_artist_link_with_large_id(self):
+        result = parse("[a9999999]")
+        assert text_content(result) == ""
+
+    def test_preserves_text_around_artist_id_link(self):
+        result = parse("See [a12345] for more")
+        assert text_content(result) == "See  for more"
+
+    def test_artist_link_has_correct_url(self):
+        result = parse("[a=Test Artist]")
+        artist_token = next(t for t in result if isinstance(t, ArtistLinkToken))
+        assert "discogs.com/search" in artist_token.url
+        assert "type=artist" in artist_token.url
+
+
+# MARK: - Bold Tag Tests
+
+
+class TestBoldTags:
+    def test_parses_bold_text(self):
+        result = parse("[b]bold text[/b]")
+        assert text_content(result) == "bold text"
+        assert any(isinstance(t, BoldToken) and t.content == "bold text" for t in result)
+
+    def test_parses_bold_with_surrounding_content(self):
+        result = parse("This is [b]bold[/b] text")
+        assert text_content(result) == "This is bold text"
+
+    def test_skips_orphaned_bold_closing_tag(self):
+        result = parse("text [/b] more")
+        assert text_content(result) == "text  more"
+
+    def test_handles_unclosed_bold_tag(self):
+        result = parse("[b]no closing tag")
+        assert text_content(result) == "no closing tag"
+
+    def test_handles_empty_bold_content(self):
+        result = parse("[b][/b]")
+        assert text_content(result) == ""
+
+
+# MARK: - Italic Tag Tests
+
+
+class TestItalicTags:
+    def test_parses_italic_text(self):
+        result = parse("[i]italic text[/i]")
+        assert text_content(result) == "italic text"
+        assert any(isinstance(t, ItalicToken) and t.content == "italic text" for t in result)
+
+    def test_parses_italic_with_surrounding_content(self):
+        result = parse("This is [i]italic[/i] text")
+        assert text_content(result) == "This is italic text"
+
+    def test_skips_orphaned_italic_closing_tag(self):
+        result = parse("text [/i] more")
+        assert text_content(result) == "text  more"
+
+    def test_handles_unclosed_italic_tag(self):
+        result = parse("[i]no closing tag")
+        assert text_content(result) == "no closing tag"
+
+
+# MARK: - Underline Tag Tests
+
+
+class TestUnderlineTags:
+    def test_parses_underlined_text(self):
+        result = parse("[u]underlined text[/u]")
+        assert text_content(result) == "underlined text"
+        assert any(isinstance(t, UnderlineToken) and t.content == "underlined text" for t in result)
+
+    def test_parses_underline_with_surrounding_content(self):
+        result = parse("This is [u]underlined[/u] text")
+        assert text_content(result) == "This is underlined text"
+
+    def test_skips_orphaned_underline_closing_tag(self):
+        result = parse("text [/u] more")
+        assert text_content(result) == "text  more"
+
+    def test_handles_unclosed_underline_tag(self):
+        result = parse("[u]no closing tag")
+        assert text_content(result) == "no closing tag"
+
+
+# MARK: - Label Tag Tests
+
+
+class TestLabelTags:
+    def test_parses_label_link(self):
+        result = parse("[l=Blue Note Records]")
+        assert text_content(result) == "Blue Note Records"
+
+    def test_parses_label_link_with_special_characters(self):
+        result = parse("[l=4AD]")
+        assert text_content(result) == "4AD"
+
+    def test_parses_label_link_with_surrounding_text(self):
+        result = parse("Released on [l=Motown] in 1965")
+        assert text_content(result) == "Released on Motown in 1965"
+
+
+# MARK: - URL Tag Tests
+
+
+class TestUrlTags:
+    def test_parses_url_link(self):
+        result = parse("[url=https://example.com]Click here[/url]")
+        assert text_content(result) == "Click here"
+        url_token = next(t for t in result if isinstance(t, UrlLinkToken))
+        assert url_token.href == "https://example.com"
+
+    def test_parses_url_link_has_href(self):
+        result = parse("[url=https://example.com]Link[/url]")
+        url_token = next(t for t in result if isinstance(t, UrlLinkToken))
+        assert url_token.href is not None
+
+    def test_handles_url_without_closing_tag(self):
+        result = parse("[url=https://example.com]orphaned")
+        assert text_content(result) == "https://example.comorphaned"
+
+    def test_handles_invalid_url_gracefully(self):
+        result = parse("[url=not a valid url]text[/url]")
+        assert text_content(result) == "text"
+        url_token = next(t for t in result if isinstance(t, UrlLinkToken))
+        assert url_token.href is None
+
+    def test_parses_url_with_complex_query_string(self):
+        result = parse("[url=https://example.com/path?query=value&other=123]Link[/url]")
+        assert text_content(result) == "Link"
+        url_token = next(t for t in result if isinstance(t, UrlLinkToken))
+        assert url_token.href == "https://example.com/path?query=value&other=123"
+
+
+# MARK: - ID-based Tag Tests
+
+
+class TestIdTags:
+    def test_skips_release_link_by_id(self):
+        assert text_content(parse("[r12345]")) == ""
+
+    def test_skips_master_link_by_id(self):
+        assert text_content(parse("[m123]")) == ""
+
+    def test_skips_release_link_with_equals(self):
+        assert text_content(parse("[r=621811]")) == ""
+
+    def test_skips_master_link_with_equals(self):
+        assert text_content(parse("[m=199386]")) == ""
+
+    def test_preserves_text_around_release_id(self):
+        result = parse("See release [r99999] for details")
+        assert text_content(result) == "See release  for details"
+
+    def test_preserves_text_around_master_id(self):
+        result = parse("Master [m456] version")
+        assert text_content(result) == "Master  version"
+
+
+# MARK: - Edge Cases
+
+
+class TestEdgeCases:
+    def test_handles_plain_text(self):
+        result = parse("Just plain text with no formatting")
+        assert text_content(result) == "Just plain text with no formatting"
+
+    def test_handles_empty_string(self):
+        result = parse("")
+        assert text_content(result) == ""
+
+    def test_handles_multiple_consecutive_tags(self):
+        result = parse("[a=Artist A][a=Artist B][a=Artist C]")
+        assert text_content(result) == "Artist AArtist BArtist C"
+
+    def test_handles_mixed_tags_and_text(self):
+        result = parse("Check out [a=The Beatles] on [l=Apple Records]!")
+        assert text_content(result) == "Check out The Beatles on Apple Records!"
+
+    def test_handles_nested_formatting_tags(self):
+        result = parse("[b]bold [i]and italic[/i][/b]")
+        assert text_content(result) == "bold [i]and italic[/i]"
+
+    def test_handles_unclosed_bracket(self):
+        result = parse("Text with [unclosed bracket")
+        assert text_content(result) == "Text with [unclosed bracket"
+
+    def test_handles_unknown_tags(self):
+        result = parse("[unknown]text[/unknown]")
+        assert text_content(result) == "text"
+
+    def test_handles_real_world_discogs_text(self):
+        result = parse(
+            "Written by [a=John Lennon] and [a=Paul McCartney]. "
+            "Released on [l=Apple Records] in 1969. See [r123456] for more info."
+        )
+        assert text_content(result) == (
+            "Written by John Lennon and Paul McCartney. "
+            "Released on Apple Records in 1969. See  for more info."
+        )
+
+    def test_handles_text_with_only_brackets(self):
+        result = parse("[]")
+        assert text_content(result) == ""
+
+    def test_handles_deeply_nested_same_type_tags(self):
+        result = parse("[b]outer [b]inner[/b] outer[/b]")
+        assert text_content(result) == "outer [b]inner[/b] outer"
+
+    def test_handles_multiple_formatting_in_sequence(self):
+        result = parse("[b]bold[/b] then [i]italic[/i] then [u]underline[/u]")
+        assert text_content(result) == "bold then italic then underline"
+
+    def test_does_not_confuse_url_with_u_tag(self):
+        result = parse("[url=https://example.com]link[/url]")
+        assert text_content(result) == "link"
+        url_token = next(t for t in result if isinstance(t, UrlLinkToken))
+        assert url_token.href is not None
+
+
+# MARK: - Entity Resolution Tests
+
+
+class TestEntityResolution:
+    @pytest.mark.asyncio
+    async def test_resolves_artist_id_to_name(self):
+        resolver = MockEntityResolver(artists={8390436: "Salamanda (8)"})
+        result = await parse_async("[a8390436]", resolver)
+        assert text_content(result) == "Salamanda"
+        artist = next(t for t in result if isinstance(t, ArtistLinkToken))
+        assert artist.url == "https://www.discogs.com/artist/8390436"
+
+    @pytest.mark.asyncio
+    async def test_resolves_multiple_artist_ids(self):
+        resolver = MockEntityResolver(artists={123: "Artist One", 456: "Artist Two"})
+        result = await parse_async("Featuring [a123] and [a456]", resolver)
+        assert text_content(result) == "Featuring Artist One and Artist Two"
+
+    @pytest.mark.asyncio
+    async def test_resolves_release_id_to_title(self):
+        resolver = MockEntityResolver(releases={99999: "Abbey Road"})
+        result = await parse_async("[r99999]", resolver)
+        assert text_content(result) == "Abbey Road"
+        release = next(t for t in result if isinstance(t, ReleaseLinkToken))
+        assert release.url == "https://www.discogs.com/release/99999"
+
+    @pytest.mark.asyncio
+    async def test_resolves_master_id_to_title(self):
+        resolver = MockEntityResolver(masters={12345: "Kind of Blue"})
+        result = await parse_async("[m12345]", resolver)
+        assert text_content(result) == "Kind of Blue"
+        master = next(t for t in result if isinstance(t, MasterLinkToken))
+        assert master.url == "https://www.discogs.com/master/12345"
+
+    @pytest.mark.asyncio
+    async def test_resolves_release_id_with_equals(self):
+        resolver = MockEntityResolver(releases={621811: "The Cover Up"})
+        result = await parse_async("[r=621811]", resolver)
+        assert text_content(result) == "The Cover Up"
+        release = next(t for t in result if isinstance(t, ReleaseLinkToken))
+        assert release.url == "https://www.discogs.com/release/621811"
+
+    @pytest.mark.asyncio
+    async def test_resolves_master_id_with_equals(self):
+        resolver = MockEntityResolver(masters={199386: "Out Of The Loop"})
+        result = await parse_async("[m=199386]", resolver)
+        assert text_content(result) == "Out Of The Loop"
+        master = next(t for t in result if isinstance(t, MasterLinkToken))
+        assert master.url == "https://www.discogs.com/master/199386"
+
+    @pytest.mark.asyncio
+    async def test_handles_mixed_resolved_and_named(self):
+        resolver = MockEntityResolver(artists={999: "Yoko Ono"})
+        result = await parse_async("[a=John Lennon] collaborated with [a999]", resolver)
+        assert text_content(result) == "John Lennon collaborated with Yoko Ono"
+
+    @pytest.mark.asyncio
+    async def test_skips_unresolvable_ids(self):
+        resolver = MockEntityResolver()
+        result = await parse_async("See [a99999999] for more", resolver)
+        assert text_content(result) == "See  for more"
+
+    @pytest.mark.asyncio
+    async def test_handles_resolver_errors(self):
+        resolver = MockEntityResolver(should_throw=True)
+        result = await parse_async("[a123] was great", resolver)
+        assert text_content(result) == " was great"
+
+    @pytest.mark.asyncio
+    async def test_resolves_complex_real_world_text(self):
+        resolver = MockEntityResolver(
+            artists={5678: "George Martin"},
+            releases={12345: "Sgt. Pepper's"},
+        )
+        result = await parse_async(
+            "Written by [a=John Lennon] and [a=Paul McCartney]. "
+            "Produced by [a5678]. See release [r12345] for credits.",
+            resolver,
+        )
+        assert text_content(result) == (
+            "Written by John Lennon and Paul McCartney. "
+            "Produced by George Martin. See release Sgt. Pepper's for credits."
+        )
+
+    @pytest.mark.asyncio
+    async def test_preserves_formatting_with_resolved_ids(self):
+        resolver = MockEntityResolver(artists={100: "Test Artist"})
+        result = await parse_async("[b]Bold[/b] by [a100]", resolver)
+        assert text_content(result) == "Bold by Test Artist"
+        assert any(isinstance(t, BoldToken) for t in result)
+
+    @pytest.mark.asyncio
+    async def test_resolves_all_entity_types(self):
+        resolver = MockEntityResolver(
+            artists={1: "The Artist"},
+            releases={2: "The Album"},
+            masters={3: "The Master"},
+        )
+        result = await parse_async("Artist [a1], Release [r2], Master [m3]", resolver)
+        assert text_content(result) == "Artist The Artist, Release The Album, Master The Master"
+
+    @pytest.mark.asyncio
+    async def test_strips_disambiguation_suffix_from_artists(self):
+        resolver = MockEntityResolver(
+            artists={
+                1: "Prince (2)",
+                2: "Nirvana (123)",
+                3: "The Beatles",
+                4: "Blink-182",
+                5: "Level 42",
+                6: "Test (Band)",
+            }
+        )
+        assert text_content(await parse_async("[a1]", resolver)) == "Prince"
+        assert text_content(await parse_async("[a2]", resolver)) == "Nirvana"
+        assert text_content(await parse_async("[a3]", resolver)) == "The Beatles"
+        assert text_content(await parse_async("[a4]", resolver)) == "Blink-182"
+        assert text_content(await parse_async("[a5]", resolver)) == "Level 42"
+        assert text_content(await parse_async("[a6]", resolver)) == "Test (Band)"
+
+    @pytest.mark.asyncio
+    async def test_does_not_strip_suffix_from_releases_or_masters(self):
+        resolver = MockEntityResolver(
+            releases={1: "Album Title (2)"},
+            masters={1: "Master Title (Remastered) (3)"},
+        )
+        result1 = await parse_async("[r1]", resolver)
+        result2 = await parse_async("[m1]", resolver)
+        assert text_content(result1) == "Album Title (2)"
+        assert text_content(result2) == "Master Title (Remastered) (3)"
+
+
+# MARK: - Utility Tests
+
+
+class TestStripDisambiguationSuffix:
+    def test_removes_numeric_suffix(self):
+        assert strip_disambiguation_suffix("Artist (2)") == "Artist"
+        assert strip_disambiguation_suffix("Artist (123)") == "Artist"
+
+    def test_preserves_non_numeric_parentheses(self):
+        assert strip_disambiguation_suffix("Artist (Band)") == "Artist (Band)"
+        assert strip_disambiguation_suffix("Level 42") == "Level 42"
+
+    def test_handles_no_suffix(self):
+        assert strip_disambiguation_suffix("Artist") == "Artist"
+
+
+# MARK: - Tokenizer Unit Tests
+
+
+class TestTokenize:
+    def test_tokenizes_plain_text(self):
+        tokens = tokenize("hello world")
+        assert tokens == [_PlainText(text="hello world")]
+
+    def test_tokenizes_artist_name(self):
+        tokens = tokenize("[a=Autechre]")
+        assert tokens == [_ArtistName(name="Autechre")]
+
+    def test_tokenizes_artist_id(self):
+        tokens = tokenize("[a41]")
+        assert tokens == [_ArtistId(id=41)]
+
+    def test_tokenizes_mixed_content(self):
+        tokens = tokenize("By [a=Rob Brown] and [a=Sean Booth]")
+        assert len(tokens) == 4
+        assert tokens[0] == _PlainText(text="By ")
+        assert tokens[1] == _ArtistName(name="Rob Brown")
+        assert tokens[2] == _PlainText(text=" and ")
+        assert tokens[3] == _ArtistName(name="Sean Booth")
+
+
+# MARK: - Resolve Unit Tests
+
+
+class TestResolve:
+    def test_resolves_artist_name_to_link(self):
+        tokens = tokenize("[a=Autechre]")
+        resolved = resolve(tokens)
+        assert len(resolved) == 1
+        assert isinstance(resolved[0], ArtistLinkToken)
+        assert resolved[0].display_name == "Autechre"
+
+    def test_strips_disambiguation_suffix(self):
+        tokens = tokenize("[a=Salamanda (8)]")
+        resolved = resolve(tokens)
+        assert isinstance(resolved[0], ArtistLinkToken)
+        assert resolved[0].display_name == "Salamanda"
+
+    def test_drops_id_tokens_in_sync_mode(self):
+        tokens = tokenize("[a41]")
+        resolved = resolve(tokens)
+        assert len(resolved) == 0


### PR DESCRIPTION
## Summary

- Translate iOS `DiscogsMarkupParser.swift` to Python for server-side markup parsing and entity resolution
- `GET /api/v1/discogs/artist/{id}` now returns `profile_tokens` (structured token array) alongside raw `profile` text
- 69 unit tests translated 1:1 from the iOS test suite

Closes #136

## Test plan

- [x] All 69 markup parser tests pass (`pytest tests/unit/test_markup_parser.py -v`)
- [x] Full unit suite passes (1237 tests)
- [x] Ruff lint and format pass
- [ ] Verify `profile_tokens` populated in staging via `GET /api/v1/discogs/artist/{artist_id}` with a real Discogs artist ID