### PR TITLE
Remove dj-site from CORS allow_origins

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -469,6 +469,10 @@ class AlbumSearchResult(BaseModel):
         None,
         description="When a previously missing release was found. Null if never lost.",
     )
+    artwork_url: str | None = Field(
+        None,
+        description="Album cover artwork URL from Discogs. Null if artwork has not been fetched yet or is unavailable.",
+    )
 
 
 class AddAlbumRequest(BaseModel):

--- a/main.py
+++ b/main.py
@@ -73,10 +73,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",
-        "https://dj.wxyc.org",
-    ],
+    allow_origins=[],
     allow_methods=["GET", "POST"],
     allow_headers=["Content-Type"],
 )


### PR DESCRIPTION
dj-site no longer calls LML directly — all library search requests now route through Backend-Service's GET /proxy/library/search (WXYC/dj-site#397). Empty the CORS origins list since all remaining callers are server-to-server (Backend-Service, request-o-matic) and don't need CORS.