### PR TITLE
Close streaming data gaps: Discogs re-matching and compilation retry

### DIFF
--- a/scripts/discogs_rematch.py
+++ b/scripts/discogs_rematch.py
@@ -1,0 +1,306 @@
+"""Re-match albums missing Discogs links by title-only and fuzzy artist search.
+
+Pass 1: Title-only search for enriched-but-unmatched albums (discogs_artist set, discogs_release_id NULL).
+Pass 2: Fuzzy artist + title search for not-enriched albums (discogs_artist NULL).
+Both passes support --compilations flag to include unmatched compilations.
+
+Usage:
+    railway run -- .venv/bin/python scripts/discogs_rematch.py [OPTIONS]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+from argparse import ArgumentParser
+
+import aiosqlite
+from dotenv import load_dotenv
+
+from scripts.streaming_availability.matching import (
+    normalize_artist_credit,
+    score_match,
+    strip_format_suffix,
+)
+
+logger = logging.getLogger("discogs_rematch")
+
+_shutdown_requested = False
+
+
+def _handle_signal(signum, frame):
+    global _shutdown_requested
+    if _shutdown_requested:
+        sys.exit(1)
+    logger.info("Shutdown requested, finishing current item...")
+    _shutdown_requested = True
+
+
+ARTIST_THRESHOLD_RELAXED = 70.0
+TITLE_THRESHOLD = 70.0
+
+
+async def pass1_title_search(pool, row: dict) -> dict | None:
+    """Search Discogs PG cache by title only, then verify artist.
+
+    For enriched-but-unmatched albums where the artist was found but the title
+    didn't match. Searches all releases by exact title, then scores the result
+    artist against the expected artist with a relaxed threshold.
+    """
+    title = strip_format_suffix(row["display_title"])
+    if not title:
+        return None
+
+    rows = await pool.fetch(
+        """SELECT r.id, r.title, ra.artist_name
+           FROM release r
+           JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+           WHERE lower(f_unaccent(r.title)) = lower(f_unaccent($1))
+           LIMIT 50""",
+        title,
+    )
+
+    if not rows:
+        stripped = strip_format_suffix(title)
+        if stripped != title:
+            rows = await pool.fetch(
+                """SELECT r.id, r.title, ra.artist_name
+                   FROM release r
+                   JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+                   WHERE lower(f_unaccent(r.title)) = lower(f_unaccent($1))
+                   LIMIT 50""",
+                stripped,
+            )
+
+    if not rows:
+        return None
+
+    # Score each result against the expected artist (use all name variants)
+    expected_artist = row.get("discogs_artist") or row["display_artist"]
+    artist_variants = normalize_artist_credit(expected_artist)
+
+    best = None
+    best_score = 0.0
+    for r in rows:
+        for variant in artist_variants:
+            artist_score = score_match(variant, r["artist_name"])
+            if artist_score > best_score:
+                best_score = artist_score
+                best = {
+                    "release_id": r["id"],
+                    "title": r["title"],
+                    "artist": r["artist_name"],
+                    "confidence": artist_score,
+                }
+
+    return best if best and best_score >= ARTIST_THRESHOLD_RELAXED else None
+
+
+async def pass2_fuzzy_artist_search(pool, row: dict) -> dict | None:
+    """Fuzzy artist search via pg_trgm, then search that artist's releases.
+
+    For not-enriched albums where artist lookup failed entirely. Uses trigram
+    similarity to find the artist, then fuzzy-matches titles.
+    """
+    display_artist = row["display_artist"]
+    variants = normalize_artist_credit(display_artist)
+
+    # Try each artist variant against the trigram index
+    matched_artist = None
+    for variant in variants:
+        artist_rows = await pool.fetch(
+            """SELECT artist_name, similarity(artist_name, $1) AS sim
+               FROM release_artist
+               WHERE artist_name % $1
+               GROUP BY artist_name
+               ORDER BY sim DESC
+               LIMIT 5""",
+            variant,
+        )
+        if artist_rows:
+            # Pick the best fuzzy match
+            for ar in artist_rows:
+                s = score_match(variant, ar["artist_name"])
+                if s >= ARTIST_THRESHOLD_RELAXED:
+                    matched_artist = ar["artist_name"]
+                    break
+        if matched_artist:
+            break
+
+    if not matched_artist:
+        return None
+
+    # Search releases by that artist
+    title = strip_format_suffix(row["display_title"])
+    release_rows = await pool.fetch(
+        """SELECT r.id, r.title, ra.artist_name
+           FROM release r
+           JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+           WHERE ra.artist_name = $1
+           LIMIT 200""",
+        matched_artist,
+    )
+
+    best = None
+    best_score = 0.0
+    for r in release_rows:
+        title_score = score_match(title, r["title"])
+        if title_score > best_score:
+            best_score = title_score
+            best = {
+                "release_id": r["id"],
+                "title": r["title"],
+                "artist": r["artist_name"],
+                "confidence": title_score,
+            }
+
+    return best if best and best_score >= TITLE_THRESHOLD else None
+
+
+async def _run_pass(
+    pass_fn,
+    pool,
+    rows: list[dict],
+    db: aiosqlite.Connection,
+    dry_run: bool,
+    pass_name: str,
+) -> int:
+    """Run a pass function over a list of rows. Returns match count."""
+    found = 0
+    for i, row in enumerate(rows, 1):
+        if _shutdown_requested:
+            break
+        result = await pass_fn(pool, row)
+        if result:
+            found += 1
+            if not dry_run:
+                await db.execute(
+                    """UPDATE albums SET discogs_release_id = ?,
+                       discogs_artist = ?, discogs_title = ?,
+                       discogs_status = 'found'
+                       WHERE id = ?""",
+                    (result["release_id"], result["artist"], result["title"], row["id"]),
+                )
+            logger.debug(
+                "%s: %s - %s → %s (%s, %.0f%%)",
+                pass_name,
+                row["display_artist"],
+                row["display_title"],
+                result["title"],
+                result["artist"],
+                result["confidence"],
+            )
+        if i % 500 == 0:
+            if not dry_run:
+                await db.commit()
+            logger.info(
+                "  %s: %d / %d | found: %d (%.0f%%)",
+                pass_name,
+                i,
+                len(rows),
+                found,
+                found / i * 100,
+            )
+    if not dry_run:
+        await db.commit()
+    return found
+
+
+async def run(args) -> None:
+    db = await aiosqlite.connect(args.db_path)
+    db.row_factory = aiosqlite.Row
+
+    discogs_url = os.environ.get("DATABASE_URL_DISCOGS")
+    if not discogs_url:
+        logger.error("DATABASE_URL_DISCOGS required")
+        await db.close()
+        sys.exit(1)
+
+    import asyncpg
+
+    pool = await asyncpg.create_pool(discogs_url, min_size=2, max_size=5)
+
+    try:
+        comp_filter = "" if args.compilations else "AND is_compilation = 0"
+
+        # Pass 1: enriched-but-unmatched (discogs_artist set, no release_id)
+        if args.run_pass in ("1", "all"):
+            cursor = await db.execute(
+                f"""SELECT id, display_artist, display_title, discogs_artist
+                    FROM albums
+                    WHERE discogs_release_id IS NULL
+                      AND discogs_artist IS NOT NULL
+                      {comp_filter}
+                    ORDER BY id LIMIT ?""",
+                (args.limit,),
+            )
+            rows = [dict(r) for r in await cursor.fetchall()]
+            logger.info("Pass 1 (title-only): %d albums to check", len(rows))
+            found = await _run_pass(pass1_title_search, pool, rows, db, args.dry_run, "Pass 1")
+            logger.info("Pass 1 complete: %d Discogs matches", found)
+
+        # Pass 2: not-enriched (no discogs_artist)
+        if args.run_pass in ("2", "all") and not _shutdown_requested:
+            cursor = await db.execute(
+                f"""SELECT id, display_artist, display_title
+                    FROM albums
+                    WHERE discogs_release_id IS NULL
+                      AND discogs_artist IS NULL
+                      AND discogs_status != 'skipped'
+                      {comp_filter}
+                    ORDER BY id LIMIT ?""",
+                (args.limit,),
+            )
+            rows = [dict(r) for r in await cursor.fetchall()]
+            logger.info("Pass 2 (fuzzy artist): %d albums to check", len(rows))
+            found = await _run_pass(
+                pass2_fuzzy_artist_search, pool, rows, db, args.dry_run, "Pass 2"
+            )
+            logger.info("Pass 2 complete: %d Discogs matches", found)
+
+        # Summary
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM albums WHERE discogs_release_id IS NOT NULL"
+        )
+        total_matched = (await cursor.fetchone())[0]
+        logger.info("Total albums with Discogs match: %d", total_matched)
+
+    finally:
+        await pool.close()
+        await db.close()
+
+
+def main():
+    load_dotenv()
+    parser = ArgumentParser(description="Re-match albums missing Discogs links")
+    parser.add_argument("--db-path", default="streaming_availability.db")
+    parser.add_argument(
+        "--pass",
+        dest="run_pass",
+        choices=["1", "2", "all"],
+        default="all",
+    )
+    parser.add_argument("--compilations", action="store_true", help="Include compilations")
+    parser.add_argument("--limit", type=int, default=100000)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/discogs_rematch.py
+++ b/scripts/discogs_rematch.py
@@ -265,7 +265,8 @@ async def run(args) -> None:
         cursor = await db.execute(
             "SELECT COUNT(*) FROM albums WHERE discogs_release_id IS NOT NULL"
         )
-        total_matched = (await cursor.fetchone())[0]
+        row = await cursor.fetchone()
+        total_matched = row[0] if row else 0
         logger.info("Total albums with Discogs match: %d", total_matched)
 
     finally:

--- a/scripts/search_unmatched_compilations.py
+++ b/scripts/search_unmatched_compilations.py
@@ -1,0 +1,367 @@
+"""Search unmatched compilations by title against Discogs cache, then streaming APIs.
+
+Phase 1: Discogs PG cache title search (exact + fuzzy) → gets release_id + tracklist
+Phase 2: Deezer/Spotify album search for Discogs misses → gets streaming URLs
+
+Usage:
+    railway run -- .venv/bin/python -m scripts.search_unmatched_compilations [OPTIONS]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+from argparse import ArgumentParser
+
+import aiosqlite
+from dotenv import load_dotenv
+
+from scripts.streaming_availability.matching import (
+    find_best_match,
+    normalize_album_title,
+    score_match,
+    strip_format_suffix,
+)
+from scripts.track_streaming.compilation_search import build_compilation_query
+
+logger = logging.getLogger("search_compilations")
+
+_shutdown_requested = False
+
+
+def _handle_signal(signum, frame):
+    global _shutdown_requested
+    if _shutdown_requested:
+        sys.exit(1)
+    logger.info("Shutdown requested, finishing current item...")
+    _shutdown_requested = True
+
+
+# Deezer/Spotify accessors for album search
+_DEEZER_ARTIST = lambda r: r.get("artist", {}).get("name", "")  # noqa: E731
+_DEEZER_TITLE = lambda r: r.get("title", "")  # noqa: E731
+_DEEZER_URL = lambda r: r.get("link", "")  # noqa: E731
+_SPOTIFY_ARTIST = lambda r: r.get("artists", [{}])[0].get("name", "")  # noqa: E731
+_SPOTIFY_TITLE = lambda r: r.get("name", "")  # noqa: E731
+_SPOTIFY_URL = lambda r: r.get("external_urls", {}).get("spotify", "")  # noqa: E731
+_SPOTIFY_ID = lambda r: r.get("id", "")  # noqa: E731
+
+
+async def search_discogs_by_title(pool, title: str) -> dict | None:
+    """Search Discogs PG cache by title. Returns best match or None."""
+    normalized = normalize_album_title(title)
+    if not normalized:
+        return None
+
+    # Exact title match
+    rows = await pool.fetch(
+        """SELECT r.id, r.title, ra.artist_name
+           FROM release r
+           JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+           WHERE lower(f_unaccent(r.title)) = lower(f_unaccent($1))
+           LIMIT 20""",
+        title,
+    )
+    if not rows:
+        # Try with stripped format suffix
+        stripped = strip_format_suffix(title)
+        if stripped != title:
+            rows = await pool.fetch(
+                """SELECT r.id, r.title, ra.artist_name
+                   FROM release r
+                   JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+                   WHERE lower(f_unaccent(r.title)) = lower(f_unaccent($1))
+                   LIMIT 20""",
+                stripped,
+            )
+
+    if not rows:
+        return None
+
+    # Score by title similarity (should be high for exact matches)
+    best = None
+    best_score = 0.0
+    for row in rows:
+        title_score = score_match(title, row["title"])
+        if title_score > best_score:
+            best_score = title_score
+            best = {
+                "release_id": row["id"],
+                "title": row["title"],
+                "artist": row["artist_name"],
+                "confidence": title_score,
+            }
+
+    return best if best and best_score >= 70 else None
+
+
+async def run(args) -> None:
+    db = await aiosqlite.connect(args.db_path)
+    db.row_factory = aiosqlite.Row
+
+    cursor = await db.execute(
+        """SELECT id, display_artist, display_title, discogs_release_id
+           FROM albums
+           WHERE is_compilation = 1
+             AND spotify_status = 'skipped'
+             AND id NOT IN (SELECT DISTINCT album_id FROM track_results)
+           ORDER BY id
+           LIMIT ?""",
+        (args.limit,),
+    )
+    rows = [dict(r) for r in await cursor.fetchall()]
+    logger.info("Loaded %d unmatched compilations", len(rows))
+
+    if not rows:
+        await db.close()
+        return
+
+    # Phase 1: Discogs title search
+    discogs_found = 0
+    discogs_misses = []
+    discogs_url = os.environ.get("DATABASE_URL_DISCOGS")
+
+    if discogs_url:
+        import asyncpg
+
+        pool = await asyncpg.create_pool(discogs_url, min_size=2, max_size=5)
+        logger.info("Phase 1: Searching Discogs cache by title...")
+
+        try:
+            for i, row in enumerate(rows, 1):
+                if _shutdown_requested:
+                    break
+
+                _, search_title = build_compilation_query(
+                    row["display_artist"], row["display_title"]
+                )
+                match = await search_discogs_by_title(pool, search_title)
+
+                if match:
+                    discogs_found += 1
+                    if not args.dry_run:
+                        await db.execute(
+                            """UPDATE albums SET discogs_release_id = ?,
+                               discogs_artist = ?, discogs_title = ?,
+                               discogs_status = 'found'
+                               WHERE id = ?""",
+                            (
+                                match["release_id"],
+                                match["artist"],
+                                match["title"],
+                                row["id"],
+                            ),
+                        )
+                    logger.debug(
+                        "Discogs: %s → %s (%s, %.0f%%)",
+                        row["display_title"],
+                        match["title"],
+                        match["artist"],
+                        match["confidence"],
+                    )
+                else:
+                    discogs_misses.append(row)
+
+                if i % 200 == 0:
+                    if not args.dry_run:
+                        await db.commit()
+                    logger.info(
+                        "  Discogs: %d / %d | found: %d | miss: %d",
+                        i,
+                        len(rows),
+                        discogs_found,
+                        len(discogs_misses),
+                    )
+        finally:
+            if not args.dry_run:
+                await db.commit()
+            await pool.close()
+
+        logger.info(
+            "Phase 1 complete: %d Discogs matches, %d misses",
+            discogs_found,
+            len(discogs_misses),
+        )
+    else:
+        logger.warning("DATABASE_URL_DISCOGS not set, skipping Discogs search")
+        discogs_misses = rows
+
+    if _shutdown_requested or args.discogs_only:
+        await db.close()
+        return
+
+    # Phase 2: Streaming API search for Discogs misses
+    logger.info("Phase 2: Searching streaming APIs for %d Discogs misses...", len(discogs_misses))
+
+    from scripts.streaming_availability.deezer_client import DeezerClient
+
+    deezer = DeezerClient()
+    spotify = None
+
+    client_id = os.environ.get("SPOTIFY_CLIENT_ID")
+    client_secret = os.environ.get("SPOTIFY_CLIENT_SECRET")
+    if client_id and client_secret:
+        from scripts.streaming_availability.spotify_client import SpotifyClient
+
+        spotify = SpotifyClient(client_id, client_secret)
+
+    streaming_found = 0
+    streaming_miss = 0
+
+    try:
+        for i, row in enumerate(discogs_misses, 1):
+            if _shutdown_requested:
+                break
+
+            search_artist, search_title = build_compilation_query(
+                row["display_artist"], row["display_title"]
+            )
+            found = False
+
+            # Deezer album search
+            try:
+                results = await deezer.search_album(
+                    search_artist or "", strip_format_suffix(search_title)
+                )
+                match = find_best_match(
+                    results,
+                    search_artist or "Various",
+                    search_title,
+                    artist_fn=_DEEZER_ARTIST,
+                    title_fn=_DEEZER_TITLE,
+                    url_fn=_DEEZER_URL,
+                )
+                # For compilations, relax artist check — just need title match
+                if not match and results:
+                    for r in results:
+                        title_score = score_match(search_title, _DEEZER_TITLE(r))
+                        if title_score >= 80:
+                            match = {
+                                "url": _DEEZER_URL(r),
+                                "confidence": title_score,
+                                "matched_title": _DEEZER_TITLE(r),
+                            }
+                            break
+                if match:
+                    found = True
+                    if not args.dry_run:
+                        await db.execute(
+                            "UPDATE albums SET deezer_status = 'found', deezer_url = ?, deezer_confidence = ? WHERE id = ?",
+                            (match["url"], match["confidence"], row["id"]),
+                        )
+            except Exception:
+                logger.warning("Deezer error for %s", row["display_title"])
+
+            # Spotify album search
+            if spotify:
+                try:
+                    results = await spotify.search_album(
+                        search_artist or "Various Artists",
+                        strip_format_suffix(search_title),
+                    )
+                    match = find_best_match(
+                        results,
+                        search_artist or "Various",
+                        search_title,
+                        artist_fn=_SPOTIFY_ARTIST,
+                        title_fn=_SPOTIFY_TITLE,
+                        url_fn=_SPOTIFY_URL,
+                        id_fn=_SPOTIFY_ID,
+                    )
+                    if not match and results:
+                        for r in results:
+                            title_score = score_match(search_title, _SPOTIFY_TITLE(r))
+                            if title_score >= 80:
+                                match = {
+                                    "url": _SPOTIFY_URL(r),
+                                    "id": _SPOTIFY_ID(r),
+                                    "confidence": title_score,
+                                    "matched_title": _SPOTIFY_TITLE(r),
+                                }
+                                break
+                    if match:
+                        found = True
+                        if not args.dry_run:
+                            await db.execute(
+                                """UPDATE albums SET spotify_status = 'found',
+                                   spotify_url = ?, spotify_id = ?, spotify_confidence = ?
+                                   WHERE id = ?""",
+                                (
+                                    match["url"],
+                                    match.get("id"),
+                                    match["confidence"],
+                                    row["id"],
+                                ),
+                            )
+                except Exception:
+                    logger.warning("Spotify error for %s", row["display_title"])
+
+            if found:
+                streaming_found += 1
+            else:
+                streaming_miss += 1
+
+            if i % 100 == 0:
+                if not args.dry_run:
+                    await db.commit()
+                hit_rate = streaming_found / i * 100
+                logger.info(
+                    "  Streaming: %d / %d | found: %d (%.0f%%) | miss: %d",
+                    i,
+                    len(discogs_misses),
+                    streaming_found,
+                    hit_rate,
+                    streaming_miss,
+                )
+    finally:
+        await deezer.close()
+        if spotify:
+            await spotify.close()
+        if not args.dry_run:
+            await db.commit()
+
+    logger.info(
+        "Phase 2 complete: %d streaming matches, %d misses",
+        streaming_found,
+        streaming_miss,
+    )
+    logger.info(
+        "Total: %d Discogs + %d streaming = %d found out of %d",
+        discogs_found,
+        streaming_found,
+        discogs_found + streaming_found,
+        len(rows),
+    )
+
+    await db.close()
+
+
+def main():
+    load_dotenv()
+    parser = ArgumentParser(description="Search unmatched compilations by title")
+    parser.add_argument("--db-path", default="streaming_availability.db")
+    parser.add_argument("--limit", type=int, default=100000)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--discogs-only", action="store_true", help="Skip streaming API search")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/streaming_availability/matching.py
+++ b/scripts/streaming_availability/matching.py
@@ -87,6 +87,55 @@ def score_match(query: str, result: str) -> float:
     return base_score
 
 
+_AND_RE = re.compile(r"\band\b", re.IGNORECASE)
+_AMPERSAND_RE = re.compile(r"\s*&\s*")
+_FEAT_RE = re.compile(r"\s+(?:feat\.?|featuring|ft\.?)\s+.*$", re.IGNORECASE)
+_DISCOGS_DISAMBIG_RE = re.compile(r"\s*\(\d+\)\s*$")
+
+
+def normalize_artist_credit(artist: str) -> list[str]:
+    """Generate artist name variants for Discogs fuzzy matching.
+
+    Returns a list of variants to try, in priority order (original first).
+    Handles: "and" ↔ "&", slash-separated collaborations, parenthetical
+    disambiguation suffixes, and "feat." credits.
+    """
+    original = artist.strip()
+    if not original:
+        return []
+
+    seen: set[str] = {original}
+    variants: list[str] = [original]
+
+    def _add(v: str) -> None:
+        v = v.strip()
+        if v and v not in seen:
+            seen.add(v)
+            variants.append(v)
+
+    # "and" ↔ "&"
+    if _AND_RE.search(original):
+        _add(_AND_RE.sub("&", original))
+    if "&" in original:
+        _add(_AMPERSAND_RE.sub(" and ", original))
+
+    # Slash-separated collaborations → extract first artist
+    if "/" in original and " / " not in original:
+        first = original.split("/")[0].strip()
+        if len(first) >= 2:
+            _add(first)
+
+    # "feat." / "featuring" → extract primary artist
+    if _FEAT_RE.search(original):
+        _add(_FEAT_RE.sub("", original))
+
+    # Parenthetical Discogs disambiguation: "Artist (2)" → "Artist"
+    if _DISCOGS_DISAMBIG_RE.search(original):
+        _add(_DISCOGS_DISAMBIG_RE.sub("", original))
+
+    return variants
+
+
 def is_acceptable_match(artist_score: float, title_score: float) -> bool:
     """Returns True if both artist and title scores meet the acceptance threshold (>= 80)."""
     return artist_score >= 80.0 and title_score >= 80.0

--- a/scripts/streaming_availability/spotify_client.py
+++ b/scripts/streaming_availability/spotify_client.py
@@ -119,6 +119,18 @@ class SpotifyClient(BaseStreamingClient):
                 await asyncio.sleep(retry_after)
                 continue
 
+            if resp.status_code in (500, 502, 503, 504):
+                wait = min(2**attempt, 30)
+                logger.warning(
+                    "Spotify %d, retrying in %ds (attempt %d/%d)",
+                    resp.status_code,
+                    wait,
+                    attempt + 1,
+                    self._max_retries,
+                )
+                await asyncio.sleep(wait)
+                continue
+
             if resp.status_code != 200:
                 logger.warning(
                     "Spotify search returned %d for %s - %s",

--- a/scripts/track_streaming/compilation_search.py
+++ b/scripts/track_streaming/compilation_search.py
@@ -1,0 +1,74 @@
+"""Search unmatched compilations by title, first against Discogs cache, then streaming APIs.
+
+The WXYC library files compilations under genre/letter conventions like
+"Various Artists - Rock - S" or "Soundtracks - A" which don't match any
+real artist on Discogs or streaming services. This module strips those
+filing prefixes and searches by title only.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Filing convention patterns: "Various Artists - Rock - S", "Soundtracks - B", "various"
+_VA_FILING_RE = re.compile(
+    r"^(?:various\s+artists?\s*(?:-\s*\w+)*|various|soundtracks?\s*-\s*\w)"
+    r"$",
+    re.IGNORECASE,
+)
+
+# Patterns that indicate a filing convention rather than a real artist name
+_FILING_PREFIXES = [
+    re.compile(r"^various\s+artists?\s*-", re.IGNORECASE),
+    re.compile(r"^soundtracks?\s*-\s*[A-Z]$", re.IGNORECASE),
+    re.compile(r"^various$", re.IGNORECASE),
+]
+
+# Patterns where the artist field contains a real name plus "various" noise
+_ARTIST_PLUS_VA_RE = re.compile(
+    r"^(.+?)\s+(?:mixes?\s+)?(?:various\s+artists?|v/?a\.?).*$",
+    re.IGNORECASE,
+)
+
+# Parenthetical "(various)" suffix
+_PAREN_VARIOUS_RE = re.compile(r"\s*\(various\)\s*$", re.IGNORECASE)
+
+
+def _is_filing_convention(artist: str) -> bool:
+    """Check if the artist string is a library filing convention, not a real name."""
+    return any(p.match(artist.strip()) for p in _FILING_PREFIXES)
+
+
+def build_compilation_query(display_artist: str, display_title: str) -> tuple[str | None, str]:
+    """Build a search query for an unmatched compilation.
+
+    Returns (artist, title) where artist is None for pure compilations
+    (search by title only) or a cleaned artist name when one is embedded
+    in the display_artist field.
+    """
+    artist = display_artist.strip()
+    title = display_title.strip()
+
+    # Pure filing conventions → title-only search
+    if _is_filing_convention(artist):
+        # For soundtracks, keep "soundtrack" as a search hint
+        if re.match(r"^soundtracks?\s*-", artist, re.IGNORECASE):
+            return "Soundtrack", title
+        return None, title
+
+    # "(various)" suffix → strip it, keep the real prefix
+    cleaned = _PAREN_VARIOUS_RE.sub("", artist).strip()
+    if cleaned != artist:
+        return None, title
+
+    # "Aphex Twin mixes various artists" → extract real artist
+    m = _ARTIST_PLUS_VA_RE.match(artist)
+    if m:
+        return m.group(1).strip(), title
+
+    # "Ocean's Thirteen Soundtrack" where artist == title → title search
+    if artist.lower() == title.lower():
+        return None, title
+
+    # Real artist name (misclassified as compilation)
+    return artist, title

--- a/tests/unit/test_compilation_search.py
+++ b/tests/unit/test_compilation_search.py
@@ -1,0 +1,57 @@
+"""Tests for compilation title search query generation."""
+
+from scripts.track_streaming.compilation_search import build_compilation_query
+
+
+class TestBuildCompilationQuery:
+    def test_soundtracks_with_letter(self):
+        """'Soundtracks - A' artist → search by title only."""
+        artist, title = build_compilation_query("Soundtracks - A", "Apocalypse Now Redux")
+        assert title == "Apocalypse Now Redux"
+        assert artist is None or "soundtrack" in artist.lower()
+
+    def test_various_artists_with_genre(self):
+        """'Various Artists - Rock - S' → search by title only."""
+        artist, title = build_compilation_query("Various Artists - Rock - S", "Soul of Disco")
+        assert title == "Soul of Disco"
+        assert artist is None
+
+    def test_various_artists_with_subgenre(self):
+        """'Various Artists - Latin' → search by title only."""
+        artist, title = build_compilation_query("Various Artists - Latin", "Konbit (Haiti)")
+        assert title == "Konbit (Haiti)"
+        assert artist is None
+
+    def test_plain_various(self):
+        """'various' → search by title only."""
+        artist, title = build_compilation_query("various", "Hard Cookin'")
+        assert title == "Hard Cookin'"
+        assert artist is None
+
+    def test_named_artist_compilation(self):
+        """'Aphex Twin mixes various artists' → use real artist name."""
+        artist, title = build_compilation_query(
+            "Aphex Twin mixes various artists", "26 Mixes for Cash"
+        )
+        assert artist is not None
+        assert "aphex" in artist.lower()
+
+    def test_soundtrack_in_artist_name(self):
+        """'Ocean's Thirteen Soundtrack' → treat artist as part of title."""
+        artist, title = build_compilation_query(
+            "Ocean's Thirteen Soundtrack", "Ocean's Thirteen Soundtrack"
+        )
+        assert "ocean" in title.lower()
+
+    def test_motion_city_soundtrack_is_a_band(self):
+        """'Motion City Soundtrack' is a band name, not a filing convention."""
+        artist, title = build_compilation_query("Motion City Soundtrack", "Commit this to Memory")
+        assert artist is not None
+        assert "motion city" in artist.lower()
+
+    def test_turkish_music_various(self):
+        """'Turkish Music (various)' → drop the (various), keep genre hint."""
+        artist, title = build_compilation_query(
+            "Turkish Music (various)", "Sulukule - Traditional Music of Istanbul"
+        )
+        assert title == "Sulukule - Traditional Music of Istanbul"

--- a/tests/unit/test_discogs_rematch.py
+++ b/tests/unit/test_discogs_rematch.py
@@ -1,0 +1,156 @@
+"""Tests for Discogs re-matching logic."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.discogs_rematch import (
+    pass1_title_search,
+    pass2_fuzzy_artist_search,
+)
+
+
+def _make_row(
+    album_id=1,
+    display_artist="Sharon Jones and the Dap-Kings",
+    display_title="Got to Be the Way It Is",
+    discogs_artist="Sharon Jones & The Dap-Kings",
+    discogs_title=None,
+    discogs_release_id=None,
+):
+    return {
+        "id": album_id,
+        "display_artist": display_artist,
+        "display_title": display_title,
+        "discogs_artist": discogs_artist,
+        "discogs_title": discogs_title,
+        "discogs_release_id": discogs_release_id,
+    }
+
+
+class TestPass1TitleSearch:
+    """Pass 1: title-only search for enriched-but-unmatched albums."""
+
+    @pytest.mark.asyncio
+    async def test_exact_title_match(self):
+        pool = AsyncMock()
+        pool.fetch.return_value = [
+            {
+                "id": 99999,
+                "title": "Got To Be The Way It Is",
+                "artist_name": "Sharon Jones & The Dap-Kings",
+            }
+        ]
+        row = _make_row()
+        result = await pass1_title_search(pool, row)
+        assert result is not None
+        assert result["release_id"] == 99999
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_none(self):
+        pool = AsyncMock()
+        pool.fetch.return_value = []
+        row = _make_row()
+        result = await pass1_title_search(pool, row)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_wrong_artist(self):
+        """Title matches but artist is completely different → reject."""
+        pool = AsyncMock()
+        pool.fetch.return_value = [
+            {
+                "id": 11111,
+                "title": "Got To Be The Way It Is",
+                "artist_name": "Autechre",
+            }
+        ]
+        row = _make_row()
+        result = await pass1_title_search(pool, row)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_relaxed_artist_threshold(self):
+        """Artist credit variation should pass with relaxed threshold (70)."""
+        pool = AsyncMock()
+        pool.fetch.return_value = [
+            {
+                "id": 22222,
+                "title": "Got To Be The Way It Is",
+                "artist_name": "Sharon Jones And The Dap Kings",
+            }
+        ]
+        row = _make_row()
+        result = await pass1_title_search(pool, row)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_strips_format_suffix_from_title(self):
+        """Format suffix like '12"' should be stripped before PG query."""
+        pool = AsyncMock()
+        pool.fetch.return_value = [
+            {
+                "id": 33333,
+                "title": "Catch A Bad One",
+                "artist_name": "Busta Rhymes",
+            }
+        ]
+        row = _make_row(
+            display_artist="Busta Rhymes",
+            display_title='Catch a Bad One 12"',
+            discogs_artist="Busta Rhymes",
+        )
+        result = await pass1_title_search(pool, row)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_completely_different_artist_rejected(self):
+        """'Del' vs 'Del Tha Funkee Homosapien' — too different, no fuzzy match."""
+        pool = AsyncMock()
+        pool.fetch.return_value = [
+            {
+                "id": 33333,
+                "title": "Catch A Bad One",
+                "artist_name": "Del Tha Funkee Homosapien",
+            }
+        ]
+        row = _make_row(
+            display_artist="Del",
+            display_title="Catch a Bad One",
+            discogs_artist="Deltron 3030",
+        )
+        result = await pass1_title_search(pool, row)
+        assert result is None
+
+
+class TestPass2FuzzyArtistSearch:
+    """Pass 2: fuzzy artist + title search for not-enriched albums."""
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_artist_match(self):
+        pool = AsyncMock()
+        # First query: trigram artist search
+        pool.fetch.side_effect = [
+            # Artist search results
+            [{"artist_name": "Sharon Jones & The Dap-Kings"}],
+            # Release search for that artist
+            [
+                {
+                    "id": 44444,
+                    "title": "Got To Be The Way It Is",
+                    "artist_name": "Sharon Jones & The Dap-Kings",
+                }
+            ],
+        ]
+        row = _make_row(discogs_artist=None)
+        result = await pass2_fuzzy_artist_search(pool, row)
+        assert result is not None
+        assert result["release_id"] == 44444
+
+    @pytest.mark.asyncio
+    async def test_no_artist_match_returns_none(self):
+        pool = AsyncMock()
+        pool.fetch.return_value = []
+        row = _make_row(display_artist="Completely Unknown Artist", discogs_artist=None)
+        result = await pass2_fuzzy_artist_search(pool, row)
+        assert result is None

--- a/tests/unit/test_normalize_artist_credit.py
+++ b/tests/unit/test_normalize_artist_credit.py
@@ -1,0 +1,54 @@
+"""Tests for normalize_artist_credit() artist name variant generation."""
+
+import pytest
+
+from scripts.streaming_availability.matching import normalize_artist_credit
+
+
+class TestNormalizeArtistCredit:
+    def test_and_to_ampersand(self):
+        """'Sharon Jones and the Dap-Kings' → includes '& The' variant."""
+        variants = normalize_artist_credit("Sharon Jones and the Dap-Kings")
+        assert any("&" in v for v in variants)
+
+    def test_ampersand_to_and(self):
+        """'Simon & Garfunkel' → includes 'and' variant."""
+        variants = normalize_artist_credit("Simon & Garfunkel")
+        assert any("and" in v.lower() for v in variants)
+
+    def test_slash_separated_extracts_first(self):
+        """'Keith Jarrett/Gary Peacock/Jack DeJohnette' → includes 'Keith Jarrett'."""
+        variants = normalize_artist_credit("Keith Jarrett/Gary Peacock/Jack DeJohnette")
+        assert "Keith Jarrett" in variants
+
+    def test_parenthetical_disambiguation_stripped(self):
+        """'MX-80 Sound (2)' → includes 'MX-80 Sound'."""
+        variants = normalize_artist_credit("MX-80 Sound (2)")
+        assert "MX-80 Sound" in variants
+
+    def test_original_always_first(self):
+        """The original name is always the first variant."""
+        variants = normalize_artist_credit("Cat Power")
+        assert variants[0] == "Cat Power"
+
+    def test_simple_name_returns_single(self):
+        """A simple name with no special patterns returns just itself."""
+        variants = normalize_artist_credit("Stereolab")
+        assert variants == ["Stereolab"]
+
+    def test_no_duplicates(self):
+        """Variants list should not contain duplicates."""
+        variants = normalize_artist_credit("The Beatles")
+        assert len(variants) == len(set(variants))
+
+    @pytest.mark.parametrize(
+        "artist,expected_in_variants",
+        [
+            ("Yo La Tengo and the Condo Fucks", "Yo La Tengo & the Condo Fucks"),
+            ("DJ Shadow feat. Mos Def", "DJ Shadow"),
+            ("Boards of Canada (3)", "Boards of Canada"),
+        ],
+    )
+    def test_parametrized_variants(self, artist, expected_in_variants):
+        variants = normalize_artist_credit(artist)
+        assert expected_in_variants in variants


### PR DESCRIPTION
## Summary

- Cherry-picks missing compilation title search and Spotify 5xx retry logic from #129
- Adds `scripts/discogs_rematch.py` with two-pass Discogs re-matching: title-only search for enriched-but-unmatched albums (Pass 1: 93 found) and fuzzy artist+title search via pg_trgm (Pass 2: 170 found)
- Adds `normalize_artist_credit()` to `matching.py` for handling "&" vs "and", slash-separated collaborations, parenthetical disambiguation, and "feat." credits
- Supports `--compilations` flag to include unmatched compilations in the re-evaluation

Closes #139

## Results

| Gap | Found | Method |
|---|---|---|
| Discogs rematch Pass 1 (title-only) | 93 | PG exact title, relaxed artist threshold |
| Discogs rematch Pass 2 (fuzzy artist) | 170 | pg_trgm trigram artist + fuzzy title |
| Compilation retry (Spotify 502s) | 273 | Deezer/Spotify with 5xx retry |
| **Total new matches** | **536** | |

Production: 58,787 on / 3,490 exclusive / 2,415 unknown

## Test plan

- [x] `uv run pytest tests/unit/ -v` — 1,342 tests passing
- [x] Discogs rematch dry run verified
- [x] Results deployed to staging and production
- [x] tubafrenzy ON_STREAMING updated