### PR TITLE
Fix Unicode garbling in VA disambiguation MySQL commands

### DIFF
--- a/scripts/va_disambiguate/extract.py
+++ b/scripts/va_disambiguate/extract.py
@@ -58,6 +58,7 @@ def _run_query(query: str, columns: list[str]) -> list[dict]:
     ssh_target = f"{SSH_USER}@{SSH_HOST}"
     mysql_cmd = (
         f"mysql -h {MYSQL_HOST} -u {MYSQL_USER} -p'{MYSQL_PASSWORD}' "
+        f"--default-character-set=utf8 "
         f'-B -N {MYSQL_DATABASE} -e "{query}"'
     )
 
@@ -157,7 +158,7 @@ def apply_sql_file(sql_path: str) -> None:
         raise RuntimeError("TUBAFRENZY_DB_PASSWORD not set.")
 
     ssh_target = f"{SSH_USER}@{SSH_HOST}"
-    mysql_cmd = f"mysql -h {MYSQL_HOST} -u {MYSQL_USER} -p'{MYSQL_PASSWORD}' {MYSQL_DATABASE}"
+    mysql_cmd = f"mysql -h {MYSQL_HOST} -u {MYSQL_USER} -p'{MYSQL_PASSWORD}' --default-character-set=utf8 {MYSQL_DATABASE}"
 
     logger.info(f"Applying {sql_path} via {ssh_target}...")
     start = time.time()


### PR DESCRIPTION
## Summary

- Add `--default-character-set=utf8` to both `mysql` CLI invocations in `scripts/va_disambiguate/extract.py` (`_run_query()` and `apply_sql_file()`)
- Without this flag, MySQL 4.1's CLI defaults to `latin1`, garbling all non-latin1 characters in COMPILATION_TRACK_ARTIST (artist names like `BÃ©la Fleck` instead of `Béla Fleck`, double-encoded CJK/Cyrillic/Arabic text)

Closes #145

## Test plan

- [ ] Re-run the VA disambiguation script to regenerate COMPILATION_TRACK_ARTIST from the Discogs cache
- [ ] Verify non-ASCII artist names are stored correctly (e.g., `Béla Fleck`, Greek/Japanese/Cyrillic text)
- [ ] Spot-check Lucene search results for compilation track artists with diacritics