### PR TITLE
Regenerate api_models.py from latest wxyc-shared schema

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -891,13 +891,21 @@ class DiscogsRelease(BaseModel):
     images: list[DiscogsImage] | None = None
 
 
+class StreamingLinks(BaseModel):
+    spotify_url: str | None = Field(None, description="Spotify album URL")
+    apple_music_url: str | None = Field(None, description="Apple Music album URL")
+    youtube_music_url: str | None = Field(None, description="YouTube Music search URL")
+    bandcamp_url: str | None = Field(None, description="Bandcamp album URL")
+    soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
+
+
 class LookupRequest(BaseModel):
     artist: str | None = Field(None, description="Parsed artist name")
     song: str | None = Field(None, description="Parsed song/track title")
     album: str | None = Field(None, description="Parsed album name")
-    raw_message: str = Field(
-        ...,
-        description="Original request message (needed for ambiguous format detection)",
+    raw_message: str | None = Field(
+        None,
+        description="Original request message (used for ambiguous format detection). Optional when structured fields (artist, album, song) are provided.\n",
     )
 
 
@@ -933,6 +941,14 @@ class DiscogsMatchResult(BaseModel):
     release_url: str = Field(..., description="URL to the release on Discogs")
     artwork_url: str | None = Field(None, description="Artwork image URL")
     confidence: confloat(ge=0.0, le=1.0) | None = Field(0, description="Match confidence score")
+    release_year: int | None = Field(None, description="Release year from Discogs")
+    artist_bio: str | None = Field(None, description="Artist biography from Discogs profile")
+    wikipedia_url: str | None = Field(None, description="Wikipedia URL for the artist")
+    spotify_url: str | None = Field(None, description="Spotify album URL")
+    apple_music_url: str | None = Field(None, description="Apple Music album URL")
+    youtube_music_url: str | None = Field(None, description="YouTube Music search URL")
+    bandcamp_url: str | None = Field(None, description="Bandcamp album URL")
+    soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
 
 
 class LookupResultItem(BaseModel):

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1013,13 +1013,14 @@ async def perform_lookup(
     """
     # Build a ParsedRequest from the LookupRequest for compatibility with
     # search functions that expect ParsedRequest
+    raw_message = request.raw_message or ""
     parsed = ParsedRequest(
         song=request.song,
         album=request.album,
         artist=request.artist,
         is_request=True,
         message_type=MessageType.REQUEST,
-        raw_message=request.raw_message,
+        raw_message=raw_message,
     )
 
     library_results: list[LibraryItem] = []
@@ -1064,7 +1065,7 @@ async def perform_lookup(
         search_state = await execute_search_pipeline(
             parsed=parsed,
             db=db,
-            raw_message=request.raw_message,
+            raw_message=raw_message,
             strategies=strategies,
             albums_for_search=albums_for_search,
             song_not_found=song_not_found,

--- a/tests/unit/test_generated_models.py
+++ b/tests/unit/test_generated_models.py
@@ -34,9 +34,12 @@ class TestLookupRequest:
         assert req.song is None
         assert req.album is None
 
-    def test_raw_message_required(self):
-        with pytest.raises(ValueError):
-            LookupRequest()
+    def test_all_fields_optional(self):
+        req = LookupRequest()
+        assert req.artist is None
+        assert req.song is None
+        assert req.album is None
+        assert req.raw_message is None
 
 
 class TestLibraryCatalogItem:


### PR DESCRIPTION
## Summary

- Regenerate `generated/api_models.py` from `wxyc-shared@main` to clear the `Codegen Freshness` failure (currently breaking PR #147 and any other branch off `main`).
- Update `tests/unit/test_generated_models.py` to reflect that `LookupRequest.raw_message` is now optional in the schema.
- Coalesce `request.raw_message` to `""` at the entry point of `perform_lookup` so downstream search functions (which type their `raw_message` parameter as `str`) keep working unchanged. Without this, `mypy` fails and `parsed.raw_message.lower()` would crash if callers omit the field.

Closes #149

## Test plan

- [x] `bash scripts/generate_api_models.sh` produces this exact diff (matches the diff CI expects on #147)
- [x] `ruff check` / `ruff format --check` succeed
- [x] `mypy . --ignore-missing-imports` succeeds (188 source files)
- [x] `pytest tests/unit/` passes (1364 tests)
- [ ] Wait for CI to confirm `Codegen Freshness` passes
- [ ] Rebase #147 against `main` once this lands and confirm its CI clears