### PR TITLE
Remove /api/v1/discogs/search endpoint

### DIFF
--- a/discogs/router.py
+++ b/discogs/router.py
@@ -9,8 +9,6 @@ from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 from discogs.markup_parser import DiscogsServiceResolver, parse_async
 from discogs.models import (
     ArtistDetails,
-    DiscogsSearchRequest,
-    DiscogsSearchResponse,
     EntityResolveResponse,
     EntityType,
     ReleaseMetadataResponse,
@@ -80,33 +78,6 @@ async def get_release(
         )
 
     return result
-
-
-@router.post(
-    "/search",
-    response_model=DiscogsSearchResponse,
-    summary="Search Discogs releases",
-    responses={
-        200: {"description": "Search results returned"},
-        400: {"description": "No search parameters provided"},
-        503: {"description": "Discogs service not configured"},
-    },
-)
-async def search_releases(
-    request: DiscogsSearchRequest,
-    limit: int = Query(5, ge=1, le=50, description="Maximum number of results"),
-    service: DiscogsService | None = Depends(get_discogs_service),
-) -> DiscogsSearchResponse:
-    """Search Discogs for releases matching the criteria."""
-    svc = _require_service(service)
-
-    if not request.artist and not request.album and not request.track:
-        raise HTTPException(
-            status_code=400,
-            detail="At least one of artist, album, or track must be provided",
-        )
-
-    return await svc.search(request, limit=limit)
 
 
 @router.get(

--- a/tests/unit/test_discogs_router.py
+++ b/tests/unit/test_discogs_router.py
@@ -9,7 +9,6 @@ from httpx import ASGITransport, AsyncClient
 from discogs.models import (
     ArtistDetails,
     ArtistRef,
-    DiscogsSearchResponse,
     MasterRelease,
     MemberRef,
     ReleaseMetadataResponse,
@@ -17,7 +16,6 @@ from discogs.models import (
 )
 from discogs.router import _require_service
 from discogs.service import DiscogsService
-from tests.factories import make_discogs_result
 from tests.unit.conftest import override_deps
 
 # ---------------------------------------------------------------------------
@@ -148,22 +146,11 @@ class TestGetRelease:
         assert resp.status_code == 503
 
 
-class TestSearchReleases:
-    @pytest.mark.asyncio
-    async def test_success(self, app_with_discogs, mock_discogs):
-        mock_discogs.search = AsyncMock(
-            return_value=DiscogsSearchResponse(
-                results=[
-                    make_discogs_result(
-                        release_id=1,
-                        album="Album",
-                        artist="Artist",
-                    )
-                ],
-                total=1,
-            )
-        )
+class TestSearchReleasesRemoved:
+    """The /discogs/search endpoint has been removed. All callers use /lookup instead."""
 
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_404(self, app_with_discogs):
         async with AsyncClient(
             transport=ASGITransport(app=app_with_discogs), base_url="http://test"
         ) as client:
@@ -172,26 +159,7 @@ class TestSearchReleases:
                 json={"artist": "Artist", "album": "Album"},
             )
 
-        assert resp.status_code == 200
-        assert resp.json()["total"] == 1
-
-    @pytest.mark.asyncio
-    async def test_no_params_returns_400(self, app_with_discogs):
-        async with AsyncClient(
-            transport=ASGITransport(app=app_with_discogs), base_url="http://test"
-        ) as client:
-            resp = await client.post("/api/v1/discogs/search", json={})
-
-        assert resp.status_code == 400
-
-    @pytest.mark.asyncio
-    async def test_no_service_returns_503(self, app_without_discogs):
-        async with AsyncClient(
-            transport=ASGITransport(app=app_without_discogs), base_url="http://test"
-        ) as client:
-            resp = await client.post("/api/v1/discogs/search", json={"artist": "Artist"})
-
-        assert resp.status_code == 503
+        assert resp.status_code == 404 or resp.status_code == 405
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Remove the `POST /api/v1/discogs/search` route handler from `discogs/router.py`
- Remove unused `DiscogsSearchRequest` and `DiscogsSearchResponse` imports from the router
- Replace endpoint tests with a test confirming the endpoint returns 404

All production callers have been migrated to `/api/v1/lookup`:
- Backend-Service: WXYC/Backend-Service#463 (merged)
- library-scanner: WXYC/library-scanner#18 (merged)
- request-o-matic: already removed in a prior commit

The internal `DiscogsSearchRequest`, `DiscogsSearchResponse`, and `DiscogsSearchResult` models remain — they're used by `DiscogsService.search()` and the lookup orchestrator's internal pipeline, not tied to the HTTP endpoint.

Closes #144

## Test plan

- [x] New test confirms endpoint returns 404/405
- [x] All 1372 unit tests pass
- [x] `ruff check` and `ruff format --check` pass
- [ ] Deploy to staging, monitor Railway logs for residual traffic before promoting to prod