### PR TITLE
Re-deliver Discogs key/secret auth (recovery of PR #72)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -10,8 +10,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
-    # API Keys - Optional
-    discogs_token: str | None = Field(None, description="Discogs API token for artwork lookup")
+    # API Keys - Optional (Discogs: token OR key+secret, token takes precedence)
+    discogs_token: str | None = Field(None, description="Discogs personal access token")
+    discogs_api_key: str | None = Field(None, description="Discogs OAuth consumer key")
+    discogs_api_secret: str | None = Field(None, description="Discogs OAuth consumer secret")
     spotify_client_id: str | None = Field(
         None, description="Spotify client ID for streaming availability checks"
     )

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -80,8 +80,10 @@ async def get_discogs_service(
     global _discogs_service
     global _discogs_pool
 
-    if not settings.discogs_token:
-        logger.debug("DISCOGS_TOKEN not set - Discogs service disabled")
+    has_token = bool(settings.discogs_token)
+    has_key_secret = bool(settings.discogs_api_key and settings.discogs_api_secret)
+    if not has_token and not has_key_secret:
+        logger.debug("No Discogs credentials set - Discogs service disabled")
         return None
 
     if _discogs_service is None:
@@ -103,7 +105,16 @@ async def get_discogs_service(
             cache_service = DiscogsCacheService(_discogs_pool)
             logger.info("Discogs cache service enabled")
 
-        _discogs_service = DiscogsService(settings.discogs_token, cache_service=cache_service)
+        if has_token:
+            _discogs_service = DiscogsService(
+                token=settings.discogs_token, cache_service=cache_service
+            )
+        else:
+            _discogs_service = DiscogsService(
+                api_key=settings.discogs_api_key,
+                api_secret=settings.discogs_api_secret,
+                cache_service=cache_service,
+            )
         logger.info(
             f"Discogs service initialized (cache: {'enabled' if cache_service else 'disabled'})"
         )

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -160,14 +160,27 @@ class DiscogsService:
     then fall back to Discogs API, and cache API results for future queries.
     """
 
-    def __init__(self, token: str, cache_service: DiscogsCacheService | None = None):
-        """Initialize the service with a Discogs API token.
+    def __init__(
+        self,
+        token: str | None = None,
+        cache_service: DiscogsCacheService | None = None,
+        *,
+        api_key: str | None = None,
+        api_secret: str | None = None,
+    ):
+        """Initialize the service with Discogs API credentials.
 
-        Args:
-            token: Discogs API token
-            cache_service: Optional PostgreSQL cache service for local caching
+        Supports two auth methods (token takes precedence when both are supplied):
+          1. Personal access token: ``DiscogsService(token="abc123")``
+          2. OAuth consumer key/secret: ``DiscogsService(api_key="k", api_secret="s")``
         """
-        self.token = token
+        if token:
+            self._auth_header = f"Discogs token={token}"
+        elif api_key and api_secret:
+            self._auth_header = f"Discogs key={api_key}, secret={api_secret}"
+        else:
+            raise ValueError("Provide either token or api_key+api_secret")
+        self.token = token or api_key  # backward-compat for callers reading .token
         self.cache_service = cache_service
         self._client: httpx.AsyncClient | None = None
 
@@ -177,7 +190,7 @@ class DiscogsService:
             self._client = httpx.AsyncClient(
                 base_url=DISCOGS_API_BASE,
                 headers={
-                    "Authorization": f"Discogs token={self.token}",
+                    "Authorization": self._auth_header,
                     "User-Agent": "LibraryMetadataLookupService/1.0",
                 },
                 timeout=10.0,

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -143,8 +143,19 @@ class TestCloseLibraryDB:
 
 class TestGetDiscogsService:
     @pytest.mark.asyncio
-    async def test_no_token_returns_none(self, mock_settings):
+    async def test_no_credentials_returns_none(self, mock_settings):
         mock_settings.discogs_token = None
+        mock_settings.discogs_api_key = None
+        mock_settings.discogs_api_secret = None
+        result = await get_discogs_service(mock_settings)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_partial_key_secret_treated_as_no_credentials(self, mock_settings):
+        # Only one of key/secret is set — not enough to authenticate.
+        mock_settings.discogs_token = None
+        mock_settings.discogs_api_key = "only-key"
+        mock_settings.discogs_api_secret = None
         result = await get_discogs_service(mock_settings)
         assert result is None
 
@@ -159,8 +170,39 @@ class TestGetDiscogsService:
 
             result = await get_discogs_service(mock_settings)
 
-            mock_svc_cls.assert_called_once_with("test-token", cache_service=None)
+            mock_svc_cls.assert_called_once_with(token="test-token", cache_service=None)
             assert result is mock_svc
+
+    @pytest.mark.asyncio
+    async def test_creates_service_with_key_secret(self, mock_settings):
+        mock_settings.discogs_token = None
+        mock_settings.discogs_api_key = "my-key"
+        mock_settings.discogs_api_secret = "my-secret"
+        mock_settings.database_url_discogs = None
+
+        with patch("core.dependencies.DiscogsService") as mock_svc_cls:
+            mock_svc = AsyncMock()
+            mock_svc_cls.return_value = mock_svc
+
+            result = await get_discogs_service(mock_settings)
+
+            mock_svc_cls.assert_called_once_with(
+                api_key="my-key", api_secret="my-secret", cache_service=None
+            )
+            assert result is mock_svc
+
+    @pytest.mark.asyncio
+    async def test_token_takes_precedence_over_key_secret(self, mock_settings):
+        mock_settings.discogs_token = "test-token"
+        mock_settings.discogs_api_key = "my-key"
+        mock_settings.discogs_api_secret = "my-secret"
+        mock_settings.database_url_discogs = None
+
+        with patch("core.dependencies.DiscogsService") as mock_svc_cls:
+            mock_svc_cls.return_value = AsyncMock()
+            await get_discogs_service(mock_settings)
+            # Token wins; key/secret are not passed.
+            mock_svc_cls.assert_called_once_with(token="test-token", cache_service=None)
 
     @pytest.mark.asyncio
     async def test_creates_pool_with_database_url(self, mock_settings):
@@ -184,7 +226,7 @@ class TestGetDiscogsService:
 
             mock_create.assert_called_once()
             mock_cache_cls.assert_called_once_with(mock_pool)
-            mock_svc_cls.assert_called_once_with("test-token", cache_service=mock_cache)
+            mock_svc_cls.assert_called_once_with(token="test-token", cache_service=mock_cache)
 
     @pytest.mark.asyncio
     async def test_pool_error_degrades_gracefully(self, mock_settings):
@@ -205,7 +247,7 @@ class TestGetDiscogsService:
             await get_discogs_service(mock_settings)
 
             # Service created without cache
-            mock_svc_cls.assert_called_once_with("test-token", cache_service=None)
+            mock_svc_cls.assert_called_once_with(token="test-token", cache_service=None)
 
     @pytest.mark.asyncio
     async def test_cached_instance(self, mock_settings):

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -39,6 +39,33 @@ class TestDiscogsServiceInit:
         assert service.cache_service is None
         assert service._client is None
 
+    def test_init_with_token_builds_token_auth_header(self):
+        svc = DiscogsService(token="abc123")
+        assert svc._auth_header == "Discogs token=abc123"
+
+    def test_init_with_key_secret_builds_key_secret_auth_header(self):
+        svc = DiscogsService(api_key="my-key", api_secret="my-secret")
+        assert svc._auth_header == "Discogs key=my-key, secret=my-secret"
+
+    def test_init_token_takes_precedence_over_key_secret(self):
+        svc = DiscogsService(token="abc123", api_key="my-key", api_secret="my-secret")
+        assert svc._auth_header == "Discogs token=abc123"
+
+    def test_init_with_no_credentials_raises(self):
+        with pytest.raises(ValueError, match="token or api_key"):
+            DiscogsService()
+
+    def test_init_with_partial_key_secret_raises(self):
+        with pytest.raises(ValueError, match="token or api_key"):
+            DiscogsService(api_key="only-key")
+
+    @pytest.mark.asyncio
+    async def test_get_client_uses_auth_header(self):
+        svc = DiscogsService(api_key="my-key", api_secret="my-secret")
+        client = await svc._get_client()
+        assert client.headers["Authorization"] == "Discogs key=my-key, secret=my-secret"
+        await svc.close()
+
     @pytest.mark.asyncio
     async def test_get_client_creates_once(self, service):
         client = await service._get_client()


### PR DESCRIPTION
## Summary

- Adds `DISCOGS_API_KEY` + `DISCOGS_API_SECRET` as an alternative to `DISCOGS_TOKEN` for authenticating against the Discogs API. Token auth wins when both are configured.
- `DiscogsService.__init__` accepts either credential pair; `get_discogs_service` wires Settings → service accordingly.
- 6 new unit tests cover the auth-header construction (token, key/secret, precedence, missing creds) and the dependency wiring (no creds, partial creds, key/secret-only, token-only, token-precedence).

## Why this PR exists

This re-delivers the work originally merged as PR #72 on 2026-03-31. That work was silently lost from `main` sometime between then and 2026-04-14, when a force-push dropped the 6 commits without a revert PR. Symptom noticed after-the-fact in #103 (empty `tests/e2e/`); root cause not identified until today.

The original tip survives at `origin/recover/key-secret-auth-and-e2e-tests` for reference. This PR is a clean re-implementation against current `main` rather than a cherry-pick — the original commits had mid-development noise (an autocomplete leak from another workstream, an interim `KeySecretDiscogsService` class) that isn't worth re-introducing.

Closes #68

## Test plan

- [x] `uv run pytest tests/unit/` — 1,389 passed (includes 18 covering this feature)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy . --ignore-missing-imports` — clean
- [ ] CI green
- [ ] Manual: set only `DISCOGS_API_KEY` + `DISCOGS_API_SECRET` (no `DISCOGS_TOKEN`) and confirm a Discogs call succeeds