### PR TITLE
Add E2E tests for Discogs HTTP endpoints

### DIFF
--- a/tests/e2e/discogs/conftest.py
+++ b/tests/e2e/discogs/conftest.py
@@ -1,0 +1,67 @@
+"""E2E fixtures for tests that hit the real Discogs API.
+
+Provides an httpx AsyncClient wired to the FastAPI app with a real
+DiscogsService backed by actual credentials. Supports two auth methods:
+
+  1. ``DISCOGS_TOKEN`` -- personal access token (preferred when both are set)
+  2. ``DISCOGS_API_KEY`` + ``DISCOGS_API_SECRET`` -- OAuth consumer pair
+
+Tests in this package are skipped at collection time when no credentials
+are available, so CI without secrets won't fail spuriously.
+"""
+
+import os
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import Settings, get_settings
+from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+from discogs.service import DiscogsService
+from main import app
+
+_token = os.environ.get("DISCOGS_TOKEN")
+_key = os.environ.get("DISCOGS_API_KEY")
+_secret = os.environ.get("DISCOGS_API_SECRET")
+
+if not _token and not (_key and _secret):
+    pytest.skip(
+        "Set DISCOGS_TOKEN or DISCOGS_API_KEY + DISCOGS_API_SECRET -- skipping",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def e2e_settings() -> Settings:
+    """Settings with real Discogs credentials, telemetry/cache disabled."""
+    return Settings(
+        discogs_token=_token,
+        discogs_api_key=_key,
+        discogs_api_secret=_secret,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+        library_db_path="test_library.db",
+    )
+
+
+@pytest_asyncio.fixture
+async def real_discogs_client(e2e_settings: Settings):
+    """httpx AsyncClient with a real DiscogsService hitting the Discogs API."""
+    if _token:
+        service = DiscogsService(token=_token, cache_service=None)
+    else:
+        service = DiscogsService(api_key=_key, api_secret=_secret, cache_service=None)
+
+    app.dependency_overrides[get_discogs_service] = lambda: service
+    app.dependency_overrides[get_library_db] = lambda: None
+    app.dependency_overrides[get_posthog_client] = lambda: None
+    app.dependency_overrides[get_settings] = lambda: e2e_settings
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        yield client
+
+    await service.close()
+    app.dependency_overrides.clear()

--- a/tests/e2e/discogs/test_endpoints.py
+++ b/tests/e2e/discogs/test_endpoints.py
@@ -1,0 +1,69 @@
+"""E2E tests for Discogs HTTP endpoints using the real Discogs API.
+
+Tests are skipped at collection time when neither DISCOGS_TOKEN nor
+DISCOGS_API_KEY + DISCOGS_API_SECRET is set (see conftest).
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.e2e, pytest.mark.asyncio]
+
+
+class TestDiscogsSearch:
+    async def test_search_returns_results_for_known_artist(self, real_discogs_client):
+        response = await real_discogs_client.post(
+            "/api/v1/discogs/search",
+            json={"artist": "Stereolab", "album": "Dots and Loops"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["results"]) > 0
+        assert data["results"][0]["release_id"] is not None
+        assert "release_url" in data["results"][0]
+
+    async def test_search_returns_empty_for_nonexistent(self, real_discogs_client):
+        response = await real_discogs_client.post(
+            "/api/v1/discogs/search",
+            json={"artist": "xyznonexistent12345", "album": "nothing"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["results"] == []
+
+
+class TestDiscogsRelease:
+    async def test_release_returns_metadata(self, real_discogs_client):
+        response = await real_discogs_client.get("/api/v1/discogs/release/90416")
+        assert response.status_code == 200
+        data = response.json()
+        assert "Dots" in data["title"]  # "Dots And Loops"
+        assert data["tracklist"] is not None
+        assert len(data["tracklist"]) > 0
+
+    async def test_release_404_for_nonexistent(self, real_discogs_client):
+        response = await real_discogs_client.get("/api/v1/discogs/release/999999999")
+        assert response.status_code == 404
+
+
+class TestDiscogsArtist:
+    async def test_artist_returns_details(self, real_discogs_client):
+        response = await real_discogs_client.get("/api/v1/discogs/artist/388")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Stereolab"
+        assert data["artist_id"] == 388
+        assert data["profile"] is not None and len(data["profile"]) > 0
+
+    async def test_artist_404_for_nonexistent(self, real_discogs_client):
+        response = await real_discogs_client.get("/api/v1/discogs/artist/999999999")
+        assert response.status_code == 404
+
+
+class TestDiscogsEntity:
+    async def test_entity_resolves_artist(self, real_discogs_client):
+        response = await real_discogs_client.get("/api/v1/discogs/entity/artist/388")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Stereolab"
+        assert data["type"] == "artist"
+        assert data["id"] == 388


### PR DESCRIPTION
## Summary

Seven E2E tests covering `/api/v1/discogs/{search,release,artist,entity}` against the real Discogs API. Picks up where #152 left off — the auth code is in `main`, this PR adds the test coverage that verifies the secured endpoints work end-to-end.

## Layout decision

Placed under `tests/e2e/discogs/` with its own `conftest.py` (rather than appending to `tests/e2e/conftest.py`). The existing e2e conftest wires a *mocked* `DiscogsService` for lookup-pipeline tests; the new tests need a *real* service. Both fixtures install dependency overrides on the same FastAPI app and would race on `app.dependency_overrides.clear()`. Subdirectory isolation keeps each conftest's overrides scoped to its own tests.

## Skip behavior

Tests are skipped at collection time when neither `DISCOGS_TOKEN` nor `DISCOGS_API_KEY` + `DISCOGS_API_SECRET` is set. Default pytest runs already exclude the `e2e` marker via `addopts`, so:

- **CI unit-test job**: not affected (e2e marker excluded).
- **Local without creds**: tests collected but skipped at module level.
- **Local with creds**: tests run against the real Discogs API.

## Test plan

- [x] `uv run pytest tests/unit/` — 1,380 passed
- [x] `uv run pytest tests/e2e/discogs/ -m e2e` (with valid creds) — runs against real API
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] CI green