### PR TITLE
Adopt shared Discogs schemas from api.yaml

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -410,7 +410,7 @@ class DiscogsCacheService:
                         (release.release_id, release.artist_id, release.artist, 0, None)
                     )
                 # Extra artists (extra=1)
-                for a in release.extra_artists:
+                for a in release.extra_artists or []:
                     artist_data.append((release.release_id, a.artist_id, a.name, 1, a.role))
 
                 if artist_data:
@@ -511,8 +511,8 @@ class DiscogsCacheService:
                     )
 
                     track_artist_data = []
-                    for i, t in enumerate(release.tracklist):
-                        for artist in t.artists:
+                    for i, t in enumerate(release.tracklist or []):
+                        for artist in t.artists or []:
                             track_artist_data.append((release.release_id, i + 1, artist))
 
                     if track_artist_data:

--- a/discogs/lookup.py
+++ b/discogs/lookup.py
@@ -60,7 +60,7 @@ async def lookup_releases_by_track(
 
     # Validate that the track actually exists on each release
     releases = []
-    for release_info in response.releases:
+    for release_info in response.releases or []:
         if artist and release_info.release_id:
             is_valid = await service.validate_track_on_release(
                 release_info.release_id, track, artist

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -7,7 +7,36 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Discriminator
 
+from generated.api_models import (
+    Alias,
+    DiscogsArtistCredit,
+    DiscogsLabelCredit,
+    DiscogsReleaseInfo,
+    DiscogsReleaseMetadata,
+    DiscogsReleaseVideo,
+    DiscogsTrackItem,
+    DiscogsTrackReleasesResponse,
+    Member,
+)
 from generated.api_models import DiscogsMatchResult as _GeneratedDiscogsMatchResult
+
+# Backward-compatible aliases for Discogs schemas now defined in api.yaml.
+# See WXYC/library-metadata-lookup#111.
+#
+# ArtistDetails is intentionally NOT aliased to the generated DiscogsArtistDetails:
+# its profile_tokens field uses the locally-defined ResolvedToken discriminated
+# union (markup tokens), which the api.yaml schema currently flattens into a
+# permissive single class. Keeping ArtistDetails local preserves type-safe
+# variant access for callers that read profile_tokens.
+ArtistCredit = DiscogsArtistCredit
+LabelCredit = DiscogsLabelCredit
+TrackItem = DiscogsTrackItem
+ReleaseVideo = DiscogsReleaseVideo
+ReleaseInfo = DiscogsReleaseInfo
+TrackReleasesResponse = DiscogsTrackReleasesResponse
+ReleaseMetadataResponse = DiscogsReleaseMetadata
+ArtistRef = Alias
+MemberRef = Member
 
 
 class TracksAutocompleteResponse(BaseModel):
@@ -17,100 +46,6 @@ class TracksAutocompleteResponse(BaseModel):
     total: int = 0
     artist: str
     cached: bool = True
-
-
-class ArtistCredit(BaseModel):
-    """An artist credit on a release."""
-
-    artist_id: int | None = None
-    name: str
-    join: str = ""  # join phrase: " & ", ", ", etc.
-    role: str | None = None  # for extra artists: "Producer", "Mixed By"
-
-
-class LabelCredit(BaseModel):
-    """A label credit on a release."""
-
-    label_id: int | None = None
-    name: str
-    catno: str | None = None
-
-
-class TrackItem(BaseModel):
-    """A single track on a release."""
-
-    position: str
-    title: str
-    duration: str | None = None
-    artists: list[str] = []  # Per-track artists (for compilations)
-
-
-class ReleaseVideo(BaseModel):
-    """A video associated with a release."""
-
-    src: str
-    title: str | None = None
-    duration: int | None = None  # Seconds
-    embed: bool = True
-
-
-class ReleaseInfo(BaseModel):
-    """Information about a single release containing a track."""
-
-    album: str
-    artist: str
-    release_id: int
-    release_url: str
-    is_compilation: bool = False
-
-
-class TrackReleasesResponse(BaseModel):
-    """Response for finding all releases containing a track."""
-
-    track: str
-    artist: str | None = None
-    releases: list[ReleaseInfo] = []
-    total: int = 0
-    cached: bool = False
-
-
-class ReleaseMetadataResponse(BaseModel):
-    """Full release metadata from Discogs."""
-
-    release_id: int
-    title: str
-    artist: str
-    year: int | None = None
-    label: str | None = None
-    artist_id: int | None = None
-    label_id: int | None = None
-    genres: list[str] = []
-    styles: list[str] = []
-    tracklist: list[TrackItem] = []
-    artwork_url: str | None = None
-    release_url: str
-    cached: bool = False
-    # Enriched fields (additive, backward-compatible)
-    artists: list[ArtistCredit] = []
-    extra_artists: list[ArtistCredit] = []
-    labels: list[LabelCredit] = []
-    released: str | None = None  # full date string, e.g. "2024-03-15"
-    videos: list[ReleaseVideo] = []
-
-
-class ArtistRef(BaseModel):
-    """Reference to a related artist (alias or similar)."""
-
-    id: int
-    name: str
-
-
-class MemberRef(BaseModel):
-    """Reference to a group member."""
-
-    id: int
-    name: str
-    active: bool = True
 
 
 # MARK: - Resolved Markup Tokens

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -988,7 +988,7 @@ class DiscogsService:
         track_lower = normalize_for_track_comparison(track)
         artist_lower = normalize_artist_for_validation(artist)
 
-        for item in release.tracklist:
+        for item in release.tracklist or []:
             item_title = normalize_for_track_comparison(item.title)
             # Check if track title matches
             if track_lower not in item_title and item_title not in track_lower:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -442,13 +442,13 @@ async def search_compilations_for_track(
                     song_search, parsed.artist, artist_as_keyword=True
                 ),
             )
-            raw_releases = list(response.releases)
+            raw_releases = list(response.releases or [])
 
             # Only merge VA results if the artist-scoped search found no compilations
             has_compilation = any(r.is_compilation for r in raw_releases)
             if not has_compilation:
                 seen_album_keys = {r.album.lower() for r in raw_releases}
-                for r in va_response.releases:
+                for r in va_response.releases or []:
                     if r.is_compilation and r.album.lower() not in seen_album_keys:
                         raw_releases.append(r)
                         seen_album_keys.add(r.album.lower())


### PR DESCRIPTION
## Summary

- Replace seven local Pydantic class definitions in `discogs/models.py` with backward-compatible aliases pointing at the generated `DiscogsXxx` types in `generated/api_models.py`
- Also alias `ArtistRef`/`MemberRef`/`ReleaseInfo` to the generated `Alias`/`Member`/`DiscogsReleaseInfo` so `DiscogsArtistDetails` (which references those nested types) stays buildable
- Existing call sites compile unchanged via the aliases — no churn outside the model file and a handful of `or []` narrowings

`ArtistDetails` is intentionally kept as a local class because its `profile_tokens` field uses the locally-defined `ResolvedToken` discriminated union (markup tokens), while `DiscogsArtistDetails` in `api.yaml` flattens those into a permissive single-class schema. Aliasing would silently weaken type-safe variant access for callers that read `profile_tokens`. Folding the markup-token discriminated union into `api.yaml` is a follow-up to consider after WXYC/wxyc-shared#41.

Five call sites needed `or []` narrowing because the generated schemas declare `list[X] | None` where the deleted local types declared `list[X] = []`.

Closes #111. Part of [Shared Types Consolidation](https://github.com/orgs/WXYC/projects/16).

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — no issues
- [x] `uv run pytest tests/unit/ -q` — 1387 passed