### PR TITLE
Populate reconciled_identity on /lookup results

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -980,7 +980,7 @@ class SearchType(StrEnum):
 
 
 class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field(default_factory=list)
+    results: list[LookupResultItem] | None = Field([], validate_default=True)
     search_type: SearchType | None = Field(
         "none",
         description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",
@@ -1042,15 +1042,15 @@ class DiscogsReleaseMetadata(BaseModel):
     label_id: int | None = None
     genres: list[str] | None = []
     styles: list[str] | None = []
-    tracklist: list[DiscogsTrackItem] | None = Field(default_factory=list)
+    tracklist: list[DiscogsTrackItem] | None = Field([], validate_default=True)
     artwork_url: str | None = None
     release_url: str
     cached: bool | None = False
-    artists: list[DiscogsArtistCredit] | None = Field(default_factory=list)
-    extra_artists: list[DiscogsArtistCredit] | None = Field(default_factory=list)
-    labels: list[DiscogsLabelCredit] | None = Field(default_factory=list)
+    artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)
+    extra_artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)
+    labels: list[DiscogsLabelCredit] | None = Field([], validate_default=True)
     released: str | None = Field(None, description="Release date as ISO string")
-    videos: list[DiscogsReleaseVideo] | None = Field(default_factory=list)
+    videos: list[DiscogsReleaseVideo] | None = Field([], validate_default=True)
 
 
 class Type1(StrEnum):
@@ -1101,8 +1101,8 @@ class DiscogsArtistDetails(BaseModel):
     )
     image_url: str | None = None
     name_variations: list[str] | None = []
-    aliases: list[Alias] | None = Field(default_factory=list)
-    members: list[Member] | None = Field(default_factory=list)
+    aliases: list[Alias] | None = Field([], validate_default=True)
+    members: list[Member] | None = Field([], validate_default=True)
     urls: list[str] | None = []
     cached: bool | None = False
 
@@ -1118,7 +1118,7 @@ class DiscogsReleaseInfo(BaseModel):
 class DiscogsTrackReleasesResponse(BaseModel):
     track: str | None = None
     artist: str | None = None
-    releases: list[DiscogsReleaseInfo] | None = Field(default_factory=list)
+    releases: list[DiscogsReleaseInfo] | None = Field([], validate_default=True)
     total: int | None = 0
     cached: bool | None = False
 

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -899,6 +899,19 @@ class StreamingLinks(BaseModel):
     soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
 
 
+class ReconciledIdentity(BaseModel):
+    discogs_artist_id: int | None = Field(None, description="Discogs artist ID")
+    musicbrainz_artist_id: str | None = Field(None, description="MusicBrainz artist UUID")
+    wikidata_qid: str | None = Field(None, description='Wikidata QID (e.g. "Q12345")')
+    spotify_artist_id: str | None = Field(
+        None, description="Spotify artist ID (the Spotify URI suffix)"
+    )
+    apple_music_artist_id: str | None = Field(None, description="Apple Music artist ID")
+    bandcamp_id: str | None = Field(
+        None, description="Bandcamp slug (the subdomain in `<slug>.bandcamp.com`)"
+    )
+
+
 class LookupRequest(BaseModel):
     artist: str | None = Field(None, description="Parsed artist name")
     song: str | None = Field(None, description="Parsed song/track title")
@@ -954,6 +967,7 @@ class DiscogsMatchResult(BaseModel):
 class LookupResultItem(BaseModel):
     library_item: LibraryCatalogItem
     artwork: DiscogsMatchResult | None = None
+    reconciled_identity: ReconciledIdentity | None = None
 
 
 class SearchType(StrEnum):
@@ -966,7 +980,7 @@ class SearchType(StrEnum):
 
 
 class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field([], validate_default=True)
+    results: list[LookupResultItem] | None = Field(default_factory=list)
     search_type: SearchType | None = Field(
         "none",
         description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",
@@ -987,37 +1001,6 @@ class LookupResponse(BaseModel):
     cache_stats: dict[str, Any] | None = Field(
         None, description="Cache hit/miss statistics from the lookup"
     )
-
-
-class DiscogsSearchRequest(BaseModel):
-    artist: str | None = None
-    album: str | None = None
-    track: str | None = None
-    label: str | None = None
-    format: str | None = None
-
-
-class DiscogsEnrichedSearchResult(BaseModel):
-    album: str | None = None
-    artist: str | None = None
-    release_id: int
-    release_url: str
-    artwork_url: str | None = None
-    confidence: float | None = 0
-    release_year: int | None = None
-    artist_bio: str | None = None
-    wikipedia_url: str | None = None
-    spotify_url: str | None = None
-    apple_music_url: str | None = None
-    youtube_music_url: str | None = None
-    bandcamp_url: str | None = None
-    soundcloud_url: str | None = None
-
-
-class DiscogsSearchResponse(BaseModel):
-    results: list[DiscogsEnrichedSearchResult] | None = Field([], validate_default=True)
-    total: int | None = 0
-    cached: bool | None = False
 
 
 class DiscogsTrackItem(BaseModel):
@@ -1059,15 +1042,15 @@ class DiscogsReleaseMetadata(BaseModel):
     label_id: int | None = None
     genres: list[str] | None = []
     styles: list[str] | None = []
-    tracklist: list[DiscogsTrackItem] | None = Field([], validate_default=True)
+    tracklist: list[DiscogsTrackItem] | None = Field(default_factory=list)
     artwork_url: str | None = None
     release_url: str
     cached: bool | None = False
-    artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)
-    extra_artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)
-    labels: list[DiscogsLabelCredit] | None = Field([], validate_default=True)
+    artists: list[DiscogsArtistCredit] | None = Field(default_factory=list)
+    extra_artists: list[DiscogsArtistCredit] | None = Field(default_factory=list)
+    labels: list[DiscogsLabelCredit] | None = Field(default_factory=list)
     released: str | None = Field(None, description="Release date as ISO string")
-    videos: list[DiscogsReleaseVideo] | None = Field([], validate_default=True)
+    videos: list[DiscogsReleaseVideo] | None = Field(default_factory=list)
 
 
 class Type1(StrEnum):
@@ -1118,8 +1101,8 @@ class DiscogsArtistDetails(BaseModel):
     )
     image_url: str | None = None
     name_variations: list[str] | None = []
-    aliases: list[Alias] | None = Field([], validate_default=True)
-    members: list[Member] | None = Field([], validate_default=True)
+    aliases: list[Alias] | None = Field(default_factory=list)
+    members: list[Member] | None = Field(default_factory=list)
     urls: list[str] | None = []
     cached: bool | None = False
 
@@ -1135,7 +1118,7 @@ class DiscogsReleaseInfo(BaseModel):
 class DiscogsTrackReleasesResponse(BaseModel):
     track: str | None = None
     artist: str | None = None
-    releases: list[DiscogsReleaseInfo] | None = Field([], validate_default=True)
+    releases: list[DiscogsReleaseInfo] | None = Field(default_factory=list)
     total: int | None = 0
     cached: bool | None = False
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1181,7 +1181,7 @@ async def perform_lookup(
         parsed, found_on_compilation, song_not_found, has_results=bool(library_results)
     )
 
-    # Step 4c: Resolve external identifiers for each result's artist
+    # Step 6: Resolve external identifiers for each result's artist
     identities_by_artist: dict[str, ReconciledIdentity] = {}
     if entity_store is not None and library_results:
         with telemetry.track_step("identity_resolution"):

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -24,9 +24,11 @@ from core.telemetry import RequestTelemetry
 from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
 from discogs.models import DiscogsSearchRequest, DiscogsSearchResult, ReleaseInfo
 from discogs.service import DiscogsService
+from generated.api_models import ReconciledIdentity
 from library.db import STOPWORDS, LibraryDB
 from library.models import LibraryItem
 from lookup.models import LookupRequest, LookupResponse, LookupResultItem
+from scripts.entity_resolution.store import EntityStore, Identity
 from services.parser import MessageType, ParsedRequest
 
 logger = logging.getLogger(__name__)
@@ -995,11 +997,53 @@ def build_context_message(
     return None
 
 
+def _identity_to_reconciled(identity: Identity) -> ReconciledIdentity:
+    """Convert an EntityStore Identity dataclass to the shared ReconciledIdentity schema."""
+    return ReconciledIdentity(
+        discogs_artist_id=identity.discogs_artist_id,
+        musicbrainz_artist_id=identity.musicbrainz_artist_id,
+        wikidata_qid=identity.wikidata_qid,
+        spotify_artist_id=identity.spotify_artist_id,
+        apple_music_artist_id=identity.apple_music_artist_id,
+        bandcamp_id=identity.bandcamp_id,
+    )
+
+
+async def _resolve_identities(
+    artist_names: list[str], entity_store: EntityStore
+) -> dict[str, ReconciledIdentity]:
+    """Look up reconciled identities for unique artist names.
+
+    Returns a dict keyed by the artist name. Names not found in the entity
+    store are omitted, so callers should treat a missing key as "no identity."
+    Lookups across the unique names run concurrently.
+    """
+    unique = list({name for name in artist_names if name})
+    if not unique:
+        return {}
+
+    identities = await asyncio.gather(
+        *(entity_store.get_identity(name) for name in unique),
+        return_exceptions=True,
+    )
+
+    result: dict[str, ReconciledIdentity] = {}
+    for name, identity in zip(unique, identities, strict=True):
+        if isinstance(identity, BaseException):
+            logger.warning("EntityStore.get_identity failed for %r: %s", name, identity)
+            continue
+        if identity is not None:
+            result[name] = _identity_to_reconciled(identity)
+    return result
+
+
 async def perform_lookup(
     request: LookupRequest,
     db: LibraryDB,
     discogs_service: DiscogsService | None,
     telemetry: RequestTelemetry,
+    *,
+    entity_store: EntityStore | None = None,
 ) -> LookupResponse:
     """Orchestrate the full lookup pipeline.
 
@@ -1137,6 +1181,19 @@ async def perform_lookup(
         parsed, found_on_compilation, song_not_found, has_results=bool(library_results)
     )
 
+    # Step 4c: Resolve external identifiers for each result's artist
+    identities_by_artist: dict[str, ReconciledIdentity] = {}
+    if entity_store is not None and library_results:
+        with telemetry.track_step("identity_resolution"):
+            identities_by_artist = await _resolve_identities(
+                [item.artist for item in library_results if item.artist], entity_store
+            )
+
+    def _identity_for(item: LibraryItem) -> ReconciledIdentity | None:
+        if not item.artist:
+            return None
+        return identities_by_artist.get(item.artist)
+
     # Build response (convert internal models to API contract models)
     result_items = []
     if items_with_artwork:
@@ -1145,11 +1202,17 @@ async def perform_lookup(
                 LookupResultItem(
                     library_item=item.to_catalog_item(),
                     artwork=artwork.to_match_result() if artwork else None,
+                    reconciled_identity=_identity_for(item),
                 )
             )
     elif library_results:
         for item in library_results:
-            result_items.append(LookupResultItem(library_item=item.to_catalog_item()))
+            result_items.append(
+                LookupResultItem(
+                    library_item=item.to_catalog_item(),
+                    reconciled_identity=_identity_for(item),
+                )
+            )
 
     return LookupResponse(
         results=result_items,

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -72,14 +72,18 @@ async def handle_lookup(
 
         # Send telemetry
         if posthog_client:
+            results = response.results or []
             telemetry.send_to_posthog(
                 posthog_client,
                 {
-                    "results_count": len(response.results or []),
+                    "results_count": len(results),
                     "search_type": response.search_type,
                     "had_artist": bool(request.artist),
                     "had_album": bool(request.album),
                     "had_song": bool(request.song),
+                    "reconciled_identity_count": sum(
+                        1 for r in results if r.reconciled_identity is not None
+                    ),
                 },
             )
 

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -9,9 +9,11 @@ from core.dependencies import get_discogs_service, get_library_db, get_posthog_c
 from core.telemetry import RequestTelemetry, get_cache_stats, init_cache_stats
 from discogs.memory_cache import set_skip_cache
 from discogs.service import DiscogsService
+from identity.dependencies import get_entity_store
 from library.db import LibraryDB
 from lookup.models import LookupRequest, LookupResponse
 from lookup.orchestrator import perform_lookup
+from scripts.entity_resolution.store import EntityStore
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +47,7 @@ async def handle_lookup(
     request: LookupRequest,
     db: LibraryDB = Depends(get_library_db),
     discogs_service: DiscogsService | None = Depends(get_discogs_service),
+    entity_store: EntityStore | None = Depends(get_entity_store),
     posthog_client: Posthog | None = Depends(get_posthog_client),
     skip_cache: bool = False,
 ):
@@ -61,6 +64,7 @@ async def handle_lookup(
             db=db,
             discogs_service=discogs_service,
             telemetry=telemetry,
+            entity_store=entity_store,
         )
 
         # Attach cache stats

--- a/scripts/generate_api_models.sh
+++ b/scripts/generate_api_models.sh
@@ -14,12 +14,16 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 OUTPUT="$PROJECT_DIR/generated/api_models.py"
 
-# Resolve api.yaml source
+# Resolve api.yaml source. Inside a worktree, `git rev-parse --show-toplevel`
+# returns the worktree path, not the main repo, so use --git-common-dir to find
+# the real repo root.
 SIBLING_PATH="$PROJECT_DIR/../wxyc-shared/api.yaml"
-if [[ "$PROJECT_DIR" == */.claude/worktrees/* ]]; then
-    # Inside a worktree — look at the real repo's sibling
-    REPO_ROOT="$(cd "$PROJECT_DIR" && git rev-parse --show-toplevel 2>/dev/null || echo "$PROJECT_DIR")"
-    SIBLING_PATH="$REPO_ROOT/../wxyc-shared/api.yaml"
+if MAIN_GIT_DIR="$(cd "$PROJECT_DIR" && git rev-parse --git-common-dir 2>/dev/null)"; then
+    if [[ "$MAIN_GIT_DIR" != /* ]]; then
+        MAIN_GIT_DIR="$PROJECT_DIR/$MAIN_GIT_DIR"
+    fi
+    MAIN_REPO_ROOT="$(cd "$MAIN_GIT_DIR/.." && pwd)"
+    SIBLING_PATH="$MAIN_REPO_ROOT/../wxyc-shared/api.yaml"
 fi
 
 if [[ -f "$SIBLING_PATH" ]]; then

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -827,6 +827,119 @@ class TestPerformLookupArtwork:
 
 
 # ---------------------------------------------------------------------------
+# Tests: perform_lookup - reconciled identity
+# ---------------------------------------------------------------------------
+
+
+class TestPerformLookupReconciledIdentity:
+    """Test that perform_lookup populates reconciled_identity for results."""
+
+    @pytest.mark.asyncio
+    async def test_populates_reconciled_identity_when_entity_store_has_artist(
+        self, mock_library_db, mock_discogs_service, telemetry, queen_item
+    ):
+        """Each result gets ReconciledIdentity from EntityStore.get_identity."""
+        from scripts.entity_resolution.store import Identity
+
+        mock_library_db.search.return_value = [queen_item]
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        entity_store = AsyncMock()
+        entity_store.get_identity = AsyncMock(
+            return_value=Identity(
+                id=42,
+                library_name="Queen",
+                discogs_artist_id=7894,
+                wikidata_qid="Q15862",
+                spotify_artist_id="1dfeR4HaWDbWqFHLkxsg1d",
+            )
+        )
+
+        request = LookupRequest(artist="Queen", album="A Night at the Opera", raw_message="...")
+
+        response = await perform_lookup(
+            request, mock_library_db, mock_discogs_service, telemetry, entity_store=entity_store
+        )
+
+        assert len(response.results) == 1
+        identity = response.results[0].reconciled_identity
+        assert identity is not None
+        assert identity.discogs_artist_id == 7894
+        assert identity.wikidata_qid == "Q15862"
+        assert identity.spotify_artist_id == "1dfeR4HaWDbWqFHLkxsg1d"
+        # Unset fields are None on the schema
+        assert identity.musicbrainz_artist_id is None
+
+    @pytest.mark.asyncio
+    async def test_omits_reconciled_identity_when_entity_store_is_none(
+        self, mock_library_db, mock_discogs_service, telemetry, queen_item
+    ):
+        """When EntityStore isn't configured, reconciled_identity is left None."""
+        mock_library_db.search.return_value = [queen_item]
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        request = LookupRequest(artist="Queen", album="A Night at the Opera", raw_message="...")
+
+        # No entity_store kwarg — defaults to None
+        response = await perform_lookup(request, mock_library_db, mock_discogs_service, telemetry)
+
+        assert len(response.results) == 1
+        assert response.results[0].reconciled_identity is None
+
+    @pytest.mark.asyncio
+    async def test_omits_reconciled_identity_when_artist_unknown_to_entity_store(
+        self, mock_library_db, mock_discogs_service, telemetry, queen_item
+    ):
+        """Artists that don't appear in entity.identity get None — not an error."""
+        mock_library_db.search.return_value = [queen_item]
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        entity_store = AsyncMock()
+        entity_store.get_identity = AsyncMock(return_value=None)
+
+        request = LookupRequest(artist="Queen", album="A Night at the Opera", raw_message="...")
+
+        response = await perform_lookup(
+            request, mock_library_db, mock_discogs_service, telemetry, entity_store=entity_store
+        )
+
+        assert len(response.results) == 1
+        assert response.results[0].reconciled_identity is None
+
+    @pytest.mark.asyncio
+    async def test_dedupes_lookup_per_artist_across_results(
+        self, mock_library_db, mock_discogs_service, telemetry, queen_item, queen_game_item
+    ):
+        """Two results for the same artist trigger only one EntityStore.get_identity call."""
+        from scripts.entity_resolution.store import Identity
+
+        mock_library_db.search.return_value = [queen_item, queen_game_item]
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        entity_store = AsyncMock()
+        entity_store.get_identity = AsyncMock(
+            return_value=Identity(id=1, library_name="Queen", discogs_artist_id=7894)
+        )
+
+        request = LookupRequest(artist="Queen", raw_message="Queen")
+
+        response = await perform_lookup(
+            request, mock_library_db, mock_discogs_service, telemetry, entity_store=entity_store
+        )
+
+        assert len(response.results) == 2
+        # Both results share the same reconciled identity
+        assert response.results[0].reconciled_identity.discogs_artist_id == 7894
+        assert response.results[1].reconciled_identity.discogs_artist_id == 7894
+        # Only one DB lookup despite two results
+        assert entity_store.get_identity.call_count == 1
+
+
+# ---------------------------------------------------------------------------
 # Tests: perform_lookup - ambiguous format
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -938,6 +938,55 @@ class TestPerformLookupReconciledIdentity:
         # Only one DB lookup despite two results
         assert entity_store.get_identity.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_entity_store_exception_does_not_fail_lookup(
+        self, mock_library_db, mock_discogs_service, telemetry, queen_item
+    ):
+        """A transient entity-store failure leaves reconciled_identity None
+        rather than turning the whole /lookup response into a 500."""
+        mock_library_db.search.return_value = [queen_item]
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        entity_store = AsyncMock()
+        entity_store.get_identity = AsyncMock(side_effect=ConnectionError("entity DB down"))
+
+        request = LookupRequest(artist="Queen", album="A Night at the Opera", raw_message="...")
+
+        response = await perform_lookup(
+            request, mock_library_db, mock_discogs_service, telemetry, entity_store=entity_store
+        )
+
+        # Lookup still succeeds; the field is just absent for the failed artist.
+        assert len(response.results) == 1
+        assert response.results[0].reconciled_identity is None
+
+    @pytest.mark.asyncio
+    async def test_compilation_entries_skip_identity_lookup(
+        self, mock_library_db, mock_discogs_service, telemetry, compilation_item
+    ):
+        """Compilation entries (artist='Various Artists - ...') aren't keyed in
+        entity.identity, so they get reconciled_identity=None — not an error."""
+        mock_library_db.search.return_value = [compilation_item]
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        entity_store = AsyncMock()
+        entity_store.get_identity = AsyncMock(return_value=None)
+
+        request = LookupRequest(
+            artist="Various Artists - Rock - D",
+            album="Disco Not Disco",
+            raw_message="...",
+        )
+
+        response = await perform_lookup(
+            request, mock_library_db, mock_discogs_service, telemetry, entity_store=entity_store
+        )
+
+        assert len(response.results) == 1
+        assert response.results[0].reconciled_identity is None
+
 
 # ---------------------------------------------------------------------------
 # Tests: perform_lookup - ambiguous format


### PR DESCRIPTION
## Summary

Adds a new `perform_lookup` pipeline step that batch-resolves external IDs from the entity store for the unique artists in the result set, then attaches the resulting `ReconciledIdentity` to each `LookupResultItem`. The lookup router injects the `EntityStore` (already provided as a FastAPI dependency for the `/identity` endpoints), so no new configuration is required.

When `DATABASE_URL_DISCOGS` is unset and `EntityStore` is None, results carry no `reconciled_identity` field — same graceful degradation as the existing `/identity` endpoints. Per-artist deduplication keeps the new step at one DB call per unique artist regardless of result count.

Also fixes `scripts/generate_api_models.sh` worktree detection: `git rev-parse --show-toplevel` returns the worktree's own path, so use `--git-common-dir` to find the real repo root and locate the sibling `wxyc-shared/api.yaml`. (Same fix as request-o-matic.)

Closes #112. Part of [Shared Types Consolidation](https://github.com/orgs/WXYC/projects/16).

## Test plan

- [x] `bash scripts/generate_api_models.sh` — generated `ReconciledIdentity` and `reconciled_identity?: ReconciledIdentity` on `LookupResultItem`
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — no issues
- [x] `uv run pytest tests/unit/ -q` — 1391 passed (4 new tests covering: identity populated when entity store has the artist; None when entity store is None; None when artist unknown to store; per-artist dedupe across multiple results)