### PR TITLE
Add LML_API_KEY bearer auth on tubafrenzy/Backend-Service routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,25 @@ Optional:
 - `LIBRARY_DB_PATH` -- Path to SQLite database (default: `library.db`)
 - `ADMIN_TOKEN` -- Bearer token for admin endpoints (upload endpoint)
 - `STREAMING_WEBHOOK_URLS` -- Comma-separated URLs to POST streaming status changes after library.db upload
-- `ETL_NOTIFY_KEY` -- Bearer token for streaming webhook authentication
+- `ETL_NOTIFY_KEY` -- Bearer token used by LML when *pushing* the streaming-status webhook to tubafrenzy
+- `LML_API_KEY` -- Bearer token required from tubafrenzy / Backend-Service callers (see "Inbound Auth" below)
+- `LML_REQUIRE_AUTH` -- When `true`, enforce `LML_API_KEY` on protected endpoints. Default `false` (see rollout phasing in `core/auth.py`)
+
+### Inbound Auth (`LML_API_KEY`)
+
+`core/auth.py:require_lml_key` is a FastAPI dependency that validates `Authorization: Bearer <LML_API_KEY>` on every tubafrenzy / Backend-Service-facing endpoint. Wired in `main.py` via `app.include_router(..., dependencies=[Depends(require_lml_key)])` for the `lookup`, `library`, `discogs`, and `streaming` routers.
+
+Three auth surfaces in this service, intentionally separate:
+
+| Surface | Direction | Env var | Implementation |
+|---|---|---|---|
+| Inbound from tubafrenzy / Backend-Service | tubafrenzy → LML | `LML_API_KEY` | `core/auth.py:require_lml_key` (router-level dep) |
+| `/admin/*` (library.db upload) | ETL → LML | `ADMIN_TOKEN` | `routers/admin.py:_validate_auth` (per-route call) |
+| Outbound streaming-status webhook | LML → tubafrenzy | `ETL_NOTIFY_KEY` | `routers/admin.py:_send_streaming_webhook` (sends `Authorization: Bearer ...`) |
+
+Untouched: `/health`, `/identity/resolve`, `/identity/bulk`. Identity routes are consumed by semantic-index too, so locking them down is a separate decision.
+
+**Rollout:** `LML_REQUIRE_AUTH` defaults to `false` so the dep can ship before consumers send the header. Once tubafrenzy and Backend-Service are updated, flip the flag in Railway to enforce.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,23 @@ They are excluded by default (`addopts = "-m 'not integration'"` in `pyproject.t
 - `LIBRARY_DB_PATH` -- Path to SQLite library database (default: `library.db`)
 - `ADMIN_TOKEN` -- Bearer token for admin endpoints (library.db upload)
 - `STREAMING_WEBHOOK_URLS` -- Comma-separated URLs to POST streaming status changes after library.db upload
-- `ETL_NOTIFY_KEY` -- Bearer token for streaming webhook authentication
+- `ETL_NOTIFY_KEY` -- Bearer token used by LML when *pushing* the streaming-status webhook to tubafrenzy
+- `LML_API_KEY` -- Bearer token required from tubafrenzy / Backend-Service callers on protected endpoints (see "Inbound auth" below)
+- `LML_REQUIRE_AUTH` -- When `true`, enforce `LML_API_KEY` on protected endpoints. Defaults to `false` so the dep can be deployed before consumers are updated; flip after all callers send the bearer header.
 - `LOG_LEVEL` -- Logging level (default: `INFO`)
+
+### Inbound auth (`LML_API_KEY`)
+
+Tubafrenzy and Backend-Service call LML for streaming checks, library search, autocomplete, and Discogs lookups. When `LML_REQUIRE_AUTH=true`, those callers must send `Authorization: Bearer <LML_API_KEY>` on every request to:
+
+- `POST /api/v1/streaming-check`
+- `POST /api/v1/lookup`
+- `GET /api/v1/library/search`
+- `GET /api/v1/discogs/...` (all five endpoints)
+
+`/health`, `/admin/*` (uses its own `ADMIN_TOKEN`), and `/identity/*` are not gated by `LML_API_KEY`.
+
+If `LML_REQUIRE_AUTH=true` and `LML_API_KEY` is unset, protected endpoints return 500 (fail loudly rather than silently accepting all requests).
 
 ### Discogs cache TTL settings
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -100,6 +100,23 @@ class Settings(BaseSettings):
         None, description="Bearer token for admin endpoints (e.g. library.db upload)"
     )
 
+    # LML API Auth (tubafrenzy / Backend-Service -> LML)
+    lml_api_key: str | None = Field(
+        None,
+        description=(
+            "Bearer token required from tubafrenzy / Backend-Service callers. "
+            "Compared against the Authorization header on protected endpoints."
+        ),
+    )
+    lml_require_auth: bool = Field(
+        default=False,
+        description=(
+            "When True, enforce LML_API_KEY on tubafrenzy/Backend-Service-facing endpoints. "
+            "Default False so the dep can be deployed before consumers are updated; "
+            "flip to True after all callers send the bearer header."
+        ),
+    )
+
     # Streaming Webhook Configuration
     streaming_webhook_urls: str | None = Field(
         None,

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,0 +1,54 @@
+"""Bearer-token auth for tubafrenzy / Backend-Service -> LML calls.
+
+This is a separate auth mechanism from ``routers/admin.py``'s ``ADMIN_TOKEN``
+(used for library.db uploads) and from the ``ETL_NOTIFY_KEY`` LML uses when
+*pushing* the streaming-status webhook to tubafrenzy. ``LML_API_KEY`` covers
+the *inbound* direction: callers like tubafrenzy (servlets) and Backend-Service
+include ``Authorization: Bearer <LML_API_KEY>`` on every request to a
+protected endpoint.
+
+Enforcement is gated by ``LML_REQUIRE_AUTH`` so the dep can be deployed and
+attached to routes before consumers are updated. Roll out: deploy with the
+flag off, update each consumer to send the bearer header, then flip the flag
+on. See ``docs/lml-release-resolve-plan.md`` (in tubafrenzy) for the full
+phasing.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends, Header, HTTPException
+
+from config.settings import Settings, get_settings
+
+
+async def require_lml_key(
+    settings: Settings = Depends(get_settings),
+    authorization: str | None = Header(None),
+) -> None:
+    """Validate the ``Authorization: Bearer <token>`` header against ``LML_API_KEY``.
+
+    Behavior matrix:
+
+    - ``LML_REQUIRE_AUTH=false`` -> no-op (the deploy-then-flip rollout window).
+    - ``LML_REQUIRE_AUTH=true`` and ``LML_API_KEY`` unset -> 500 (misconfig; fail loudly
+      so we don't accept all requests by accident).
+    - ``LML_REQUIRE_AUTH=true`` and header missing -> 401.
+    - ``LML_REQUIRE_AUTH=true`` and header present but malformed or wrong token -> 403.
+    - ``LML_REQUIRE_AUTH=true`` and header is ``Bearer <correct>`` (case-insensitive
+      scheme per RFC 7235) -> pass.
+    """
+    if not settings.lml_require_auth:
+        return
+
+    if not settings.lml_api_key:
+        raise HTTPException(
+            status_code=500,
+            detail="LML auth required but LML_API_KEY is not configured",
+        )
+
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing authorization")
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer" or parts[1] != settings.lml_api_key:
+        raise HTTPException(status_code=403, detail="Invalid token")

--- a/main.py
+++ b/main.py
@@ -5,10 +5,11 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from config.settings import get_settings
+from core.auth import require_lml_key
 from core.dependencies import (
     close_discogs_service,
     close_library_db,
@@ -87,13 +88,23 @@ async def posthog_flush_middleware(request: Request, call_next):
     return response
 
 
+# Health and admin keep their own auth posture:
+#   - /health is open for Railway healthchecks
+#   - /admin/* uses ADMIN_TOKEN (see routers/admin.py:_validate_auth)
+# Identity is open for now (semantic-index consumes it; separate decision).
 app.include_router(health_router, prefix="", tags=["health"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])
-app.include_router(lookup_router, prefix="/api/v1", tags=["lookup"])
-app.include_router(library_router, prefix="/api/v1", tags=["library"])
-app.include_router(discogs_router, prefix="/api/v1", tags=["discogs"])
 app.include_router(identity_router, prefix="/identity", tags=["identity"])
-app.include_router(streaming_router, prefix="/api/v1", tags=["streaming"])
+
+# Tubafrenzy / Backend-Service-facing routers: protected by LML_API_KEY when
+# LML_REQUIRE_AUTH is true. See core/auth.py for the rollout phasing.
+_lml_protected = [Depends(require_lml_key)]
+app.include_router(lookup_router, prefix="/api/v1", tags=["lookup"], dependencies=_lml_protected)
+app.include_router(library_router, prefix="/api/v1", tags=["library"], dependencies=_lml_protected)
+app.include_router(discogs_router, prefix="/api/v1", tags=["discogs"], dependencies=_lml_protected)
+app.include_router(
+    streaming_router, prefix="/api/v1", tags=["streaming"], dependencies=_lml_protected
+)
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,198 @@
+"""Unit tests for core/auth.py — bearer token enforcement on tubafrenzy/Backend-Service routes."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from config.settings import Settings
+
+
+def _settings(*, require_auth: bool = False, key: str | None = None) -> Settings:
+    """Settings with auth-related fields set and unrelated config quieted."""
+    return Settings(
+        lml_require_auth=require_auth,
+        lml_api_key=key,
+        discogs_token=None,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+        library_db_path="test.db",
+    )
+
+
+class TestRequireLmlKey:
+    """Direct unit tests for the FastAPI dep."""
+
+    @pytest.mark.asyncio
+    async def test_flag_off_no_header_passes(self):
+        from core.auth import require_lml_key
+
+        await require_lml_key(settings=_settings(require_auth=False), authorization=None)
+
+    @pytest.mark.asyncio
+    async def test_flag_off_with_garbage_header_passes(self):
+        # When auth is disabled, the dep does not even inspect the header.
+        from core.auth import require_lml_key
+
+        await require_lml_key(
+            settings=_settings(require_auth=False),
+            authorization="not even bearer-shaped",
+        )
+
+    @pytest.mark.asyncio
+    async def test_flag_on_no_header_returns_401(self):
+        from core.auth import require_lml_key
+
+        with pytest.raises(HTTPException) as exc:
+            await require_lml_key(
+                settings=_settings(require_auth=True, key="secret"),
+                authorization=None,
+            )
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_flag_on_wrong_token_returns_403(self):
+        from core.auth import require_lml_key
+
+        with pytest.raises(HTTPException) as exc:
+            await require_lml_key(
+                settings=_settings(require_auth=True, key="secret"),
+                authorization="Bearer wrong",
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_flag_on_malformed_header_returns_403(self):
+        # Header present but not in "<scheme> <token>" form.
+        from core.auth import require_lml_key
+
+        with pytest.raises(HTTPException) as exc:
+            await require_lml_key(
+                settings=_settings(require_auth=True, key="secret"),
+                authorization="secret",
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_flag_on_wrong_scheme_returns_403(self):
+        from core.auth import require_lml_key
+
+        with pytest.raises(HTTPException) as exc:
+            await require_lml_key(
+                settings=_settings(require_auth=True, key="secret"),
+                authorization="Basic c2VjcmV0",
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_flag_on_correct_bearer_passes(self):
+        from core.auth import require_lml_key
+
+        await require_lml_key(
+            settings=_settings(require_auth=True, key="secret"),
+            authorization="Bearer secret",
+        )
+
+    @pytest.mark.asyncio
+    async def test_flag_on_lowercase_scheme_passes(self):
+        # RFC 7235 says the scheme is case-insensitive.
+        from core.auth import require_lml_key
+
+        await require_lml_key(
+            settings=_settings(require_auth=True, key="secret"),
+            authorization="bearer secret",
+        )
+
+    @pytest.mark.asyncio
+    async def test_flag_on_key_unset_returns_500(self):
+        # Misconfiguration: enforcement on but no key configured. Fail loudly.
+        from core.auth import require_lml_key
+
+        with pytest.raises(HTTPException) as exc:
+            await require_lml_key(
+                settings=_settings(require_auth=True, key=None),
+                authorization="Bearer anything",
+            )
+        assert exc.value.status_code == 500
+
+
+class TestProtectedRouteRegistration:
+    """Smoke test: verify each route's dep tree includes (or excludes) require_lml_key.
+
+    This guards against the easy mistake of adding a new tubafrenzy/Backend-Service-facing
+    endpoint and forgetting to attach the dep, or — conversely — accidentally locking
+    down /health or an /identity/* route.
+    """
+
+    EXPECTED_PROTECTED = [
+        ("POST", "/api/v1/streaming-check"),
+        ("GET", "/api/v1/library/search"),
+        ("POST", "/api/v1/lookup"),
+        ("GET", "/api/v1/discogs/track-releases"),
+        ("GET", "/api/v1/discogs/release/{release_id}"),
+        ("GET", "/api/v1/discogs/artist/{artist_id}"),
+        ("GET", "/api/v1/discogs/entity/{entity_type}/{entity_id}"),
+        ("GET", "/api/v1/discogs/tracks/autocomplete"),
+    ]
+
+    EXPECTED_UNPROTECTED = [
+        ("GET", "/health"),
+        ("GET", "/identity/resolve"),
+        ("POST", "/identity/bulk"),
+        # /admin/* has its own ADMIN_TOKEN validation, not require_lml_key.
+        ("POST", "/admin/upload-library-db"),
+    ]
+
+    @pytest.mark.parametrize("method,path", EXPECTED_PROTECTED)
+    def test_route_has_require_lml_key(self, method, path):
+        from core.auth import require_lml_key
+        from main import app
+
+        route = _find_route(app, method, path)
+        assert route is not None, f"Route {method} {path} not found in app.routes"
+        deps = _collect_dep_callables(route)
+        assert require_lml_key in deps, (
+            f"Route {method} {path} is missing require_lml_key dep. "
+            f"Resolved deps: {sorted(d.__name__ for d in deps)}"
+        )
+
+    @pytest.mark.parametrize("method,path", EXPECTED_UNPROTECTED)
+    def test_route_does_not_have_require_lml_key(self, method, path):
+        from core.auth import require_lml_key
+        from main import app
+
+        route = _find_route(app, method, path)
+        assert route is not None, f"Route {method} {path} not found in app.routes"
+        deps = _collect_dep_callables(route)
+        assert require_lml_key not in deps, (
+            f"Route {method} {path} should NOT have require_lml_key. "
+            f"Resolved deps: {sorted(d.__name__ for d in deps)}"
+        )
+
+
+def _find_route(app, method, path):
+    for r in app.routes:
+        if getattr(r, "path", None) == path and method in getattr(r, "methods", set()):
+            return r
+    return None
+
+
+def _collect_dep_callables(route):
+    """Walk the FastAPI dependant tree and return all callables reached via Depends()."""
+    deps: set = set()
+    dependant = getattr(route, "dependant", None)
+    if dependant is None:
+        return deps
+    stack = [dependant]
+    seen = set()
+    while stack:
+        d = stack.pop()
+        if id(d) in seen:
+            continue
+        seen.add(id(d))
+        if d.call is not None:
+            deps.add(d.call)
+        stack.extend(d.dependencies)
+    return deps


### PR DESCRIPTION
## Summary

- Adds `core/auth.py:require_lml_key`, a FastAPI dep that enforces `Authorization: Bearer <LML_API_KEY>` on the `lookup`, `library`, `discogs`, and `streaming` routers (9 endpoints).
- Gated by `LML_REQUIRE_AUTH` (default `false`) so the dep can ship before consumers send the header. Flip the flag in Railway once Backend-Service and tubafrenzy are updated.
- Leaves `/health`, `/admin/*` (uses `ADMIN_TOKEN`), and `/identity/*` (semantic-index consumes it; separate decision) untouched.

This is PR #1 in a 6-PR rollout across LML, Backend-Service, and tubafrenzy. See `tubafrenzy/docs/lml-release-resolve-plan.md` for the full plan.

Closes #164

## Test plan

- [x] `pytest tests/unit/` — 1414 passed, including 21 new tests in `test_auth.py`
- [x] `ruff check .` and `ruff format --check .`
- [x] `mypy core/auth.py main.py` — no issues
- [x] CI passes
- [ ] Deploy to staging with `LML_REQUIRE_AUTH=false` and `LML_API_KEY=<set>`. Verify `/api/v1/streaming-check` still answers existing unauth'd traffic.
- [ ] Deploy to production with same flag posture. Wait for Backend-Service and tubafrenzy PRs to land before flipping.