### PR TITLE
ci: add e2e + postgres jobs and marker-sync guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,84 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install wxyc-etl from source
+        run: |
+          pip install maturin
+          git clone --depth 1 https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
+          cd /tmp/wxyc-etl/wxyc-etl-python
+          maturin build --release
+          pip install /tmp/wxyc-etl/target/wheels/*.whl
+      - run: pip install -e ".[dev]"
+      - name: Run E2E tests
+        # tests/e2e/test_lookup_e2e.py runs against in-memory SQLite + mock Discogs.
+        # tests/e2e/discogs/* requires DISCOGS_TOKEN and self-skips at collection
+        # when no credentials are present (see tests/e2e/discogs/conftest.py); it
+        # is exercised by the deploy-time integration job, not on every PR.
+        env:
+          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
+        run: pytest tests/e2e/ -v -m "e2e"
+
+  test-postgres:
+    name: Postgres Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: discogs
+          POSTGRES_PASSWORD: discogs
+          POSTGRES_DB: discogs
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U discogs"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install wxyc-etl from source
+        run: |
+          pip install maturin
+          git clone --depth 1 https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
+          cd /tmp/wxyc-etl/wxyc-etl-python
+          maturin build --release
+          pip install /tmp/wxyc-etl/target/wheels/*.whl
+      - run: pip install -e ".[dev]"
+      - name: Run Postgres tests
+        # Reconciliation tests skip themselves when release_artist is missing,
+        # which is fine: the discogs-cache fixture is too large to load in CI.
+        # The EntityStore CRUD tests run fully against a fresh schema.
+        env:
+          DATABASE_URL_TEST: postgresql://discogs:discogs@localhost:5433/discogs
+        run: pytest tests/integration/ -v -m "postgres"
+
+  marker-sync:
+    name: CI Marker Sync
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    with:
+      repo-path: "."
+      workflows-dir: ".github/workflows"
+      tests-dir: "tests"
+
   deploy-staging:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [lint, typecheck, test]
+    needs: [lint, typecheck, test, e2e, test-postgres]
     steps:
       - uses: actions/checkout@v4
       - name: Install Railway CLI
@@ -155,13 +228,13 @@ jobs:
         env:
           DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
           TEST_ENV: staging
-        run: pytest tests/integration/ -v -m integration
+        run: pytest tests/integration/ -v -m "integration"
 
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'
-    needs: [lint, typecheck, test]
+    needs: [lint, typecheck, test, e2e, test-postgres]
     steps:
       - uses: actions/checkout@v4
       - name: Install Railway CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,11 +200,20 @@ Untouched: `/health`, `/identity/resolve`, `/identity/bulk`. Identity routes are
 | Lint & Format | All pushes + PRs | -- |
 | Type Check | All pushes + PRs | -- |
 | Unit Tests | All pushes + PRs | -- |
-| Deploy to Staging | Push to `main` | lint, typecheck, test |
+| E2E Tests | All pushes + PRs | -- |
+| Postgres Tests | All pushes + PRs | -- |
+| CI Marker Sync | All pushes + PRs | -- |
+| Deploy to Staging | Push to `main` | lint, typecheck, test, e2e, test-postgres |
 | Smoke Test (Staging) | Push to `main` | deploy-staging |
 | Integration Tests | Push to `main` | smoke-test-staging |
-| Deploy to Production | Push to `prod` | lint, typecheck, test |
+| Deploy to Production | Push to `prod` | lint, typecheck, test, e2e, test-postgres |
 | Smoke Test (Production) | Push to `prod` | deploy-production |
+
+**E2E Tests** run `pytest tests/e2e/ -v -m e2e`. The `tests/e2e/test_lookup_e2e.py` suite uses an in-memory SQLite library and a mock Discogs service — no credentials required. The `tests/e2e/discogs/test_endpoints.py` suite hits the real Discogs API and self-skips at collection if `DISCOGS_TOKEN` is unset (PR runs from forks may have no secret access).
+
+**Postgres Tests** run `pytest tests/integration/ -v -m postgres` against a `postgres:16-alpine` service container on port 5433. The `EntityStore` CRUD tests run end-to-end against a fresh `entity` schema. The Discogs reconciliation tests skip themselves when the `release_artist` table is missing — that table is part of the discogs-cache fixture and is too large to load in CI.
+
+**CI Marker Sync** invokes the reusable workflow at `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml` to guarantee that every `@pytest.mark.<X>` actually used by a test is either re-selected by some CI `pytest -m` invocation or explicitly opted out via a `# ci-sync-skip: <marker> reason: <text>` comment in `pyproject.toml`. This guards against the silent-deselection bug pattern (WXYC/discogs-etl#103, WXYC/library-metadata-lookup#159).
 
 ### Library Database Upload
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,9 @@ markers = [
     "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
     "integration: needs external service or fixture data",
     "e2e: full pipeline end-to-end test",
-    "parity: old vs new implementation comparison",
     "slow: marks tests as slow",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
+addopts = "-m 'not integration and not postgres and not e2e and not slow'"
 console_output_style = "progress"
 testpaths = ["tests"]
 pythonpath = ["."]


### PR DESCRIPTION
## Problem

`pyproject.toml` declares `addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"`. The CI workflow had jobs for `unit` and `integration` only:

- `Unit Tests` runs `pytest tests/unit/ -v ...` — fine, no marker collision.
- `Integration Tests` runs `pytest tests/integration/ -v -m integration` — covers `integration`.

Nothing re-selected `e2e` or `postgres`. So:

- 12 `@pytest.mark.e2e` tests in `tests/e2e/test_lookup_e2e.py` (in-memory SQLite + mock Discogs)
- 7 `@pytest.mark.e2e` tests in `tests/e2e/discogs/test_endpoints.py` (real Discogs API, self-skips at collection without `DISCOGS_TOKEN`)
- 6 `@pytest.mark.postgres` tests across 3 classes in `tests/integration/test_entity_resolution.py`

were silently deselected. Pytest reports them as deselected, which looks fine in logs. Same structural failure mode as WXYC/discogs-etl#103.

## Per-marker fix

| Marker | Fix |
|--------|-----|
| `e2e` | New `e2e` job runs `pytest tests/e2e/ -v -m "e2e"`. The lookup suite hits in-memory SQLite + mock Discogs and runs unconditionally on every push/PR. The discogs subdir self-skips at collection when `DISCOGS_TOKEN` is unset (so fork PRs don't fail), and runs when the secret is present. |
| `postgres` | New `test-postgres` job runs `pytest tests/integration/ -v -m "postgres"` against a `postgres:16-alpine` service container on port 5433 (mirrors discogs-etl's pattern). EntityStore CRUD tests run end-to-end against a fresh `entity` schema; the Discogs reconciliation tests skip themselves when `release_artist` is missing (the discogs-cache fixture is too large to load in CI). Verified locally: 5 passed, 1 skipped. |
| `integration` | Already covered by the deploy-time `Integration Tests` job. Quoted the `-m` arg so the marker-sync script recognizes it. |
| `parity` | Removed from declared markers in `pyproject.toml`. No test in the repo uses it. |
| `slow` | Still declared, no test uses it, no gap. |

## Marker-sync guardrail

Wires in the reusable workflow at `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main` as the `marker-sync` job. From now on, any future marker that's deselected by addopts and not re-selected by some CI `pytest -m "<marker>"` invocation will trip a hard CI failure rather than going unnoticed. Opt-out is supported via `# ci-sync-skip: <marker> reason: <text>` in `pyproject.toml` for markers that are intentionally manual-only.

## Local verification

- `python3 /tmp/sync.py --repo-path .` → `PASS: every used marker is reachable from CI`
- `pytest tests/e2e/test_lookup_e2e.py -v -m "e2e"` → 12 passed
- `DATABASE_URL_TEST=postgresql://discogs:discogs@localhost:5433/discogs pytest tests/integration/test_entity_resolution.py -v -m "postgres"` → 5 passed, 1 skipped
- `pytest tests/unit/` → 1414 passed (no regression)
- `ruff check .` and `ruff format --check .` → clean

## Deploy gating

`deploy-staging` and `deploy-production` now gate on `e2e` and `test-postgres` in addition to `lint`, `typecheck`, `test`. A regression in either marker now blocks deploy.

Closes #159