### PR TITLE
Add POST /api/v1/releases/resolve for tubafrenzy rotation-form prefill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,54 @@ Response includes `on_streaming` (true/false/null) and per-service match details
 
 Requires `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` for Spotify checks. Other services (Deezer, Apple Music, Bandcamp) need no auth. If Spotify credentials are not set, Spotify checks are skipped.
 
+### Release Resolve Endpoint
+
+`POST /api/v1/releases/resolve` takes a Discogs release URL or Bandcamp album URL (or an explicit `(source, id)` pair) and returns canonical release metadata, cross-source identifiers, and a streaming-availability snapshot — everything tubafrenzy's rotation-release create form needs to prefill in one round trip.
+
+Request (one of):
+```json
+{ "url": "https://www.discogs.com/release/12345" }
+{ "url": "https://artist.bandcamp.com/album/slug" }
+{ "source": "discogs_release", "id": "12345" }
+```
+
+Response:
+```json
+{
+  "source": "discogs_release",
+  "source_id": "12345",
+  "canonical": {
+    "artist": "Juana Molina",
+    "title": "DOGA",
+    "label": "Sonamos",
+    "catno": "SON-001",
+    "year": 2024,
+    "country": null,
+    "formats": []
+  },
+  "identifiers": {
+    "discogs_release_id": 12345,
+    "discogs_artist_id": 999,
+    "spotify_album_id": "abc...",
+    "bandcamp_album_url": null,
+    ...
+  },
+  "streaming": { "on_streaming": true, "sources": { ... } },
+  "warnings": []
+}
+```
+
+Implementation lives in `release/`:
+- `url_parser.py` — pure URL → `(source, id)` parser. Supports Discogs `/release/<id>` and `/master/<id>` (with locale prefixes and slugs) and Bandcamp `<artist>.bandcamp.com/album/<slug>`.
+- `discogs_resolver.py` — wraps `DiscogsService.get_release()` so the existing 3-tier cache + API rate-limit handling applies.
+- `bandcamp_resolver.py` — fetches the Bandcamp album page (rate-limited via the existing `BandcampClient`) and parses the embedded JSON-LD `MusicAlbum` blob. Self-released (publisher subdomain == artist subdomain) returns `label: null`.
+- `orchestrator.py` — dispatches by source, then runs `check_streaming_availability`. When the input is a Bandcamp URL, the Bandcamp leg is short-circuited to confidence 100 with the input URL (don't refuzzy a URL the DJ explicitly gave us).
+- Identity write-back: any newly-discovered IDs land in `entity.identity` via the existing `EntityStore.upsert_identity()` (`ON CONFLICT ... DO UPDATE` with `COALESCE` — never clobbers existing data).
+
+Genre and style are intentionally not surfaced — the rotation form has no genre field, so the music director picks manually.
+
+The endpoint always returns 200 with a `warnings[]` array. Partial failures (Discogs rate limit, malformed Bandcamp page, missing master support) become warnings rather than 5xx; the form falls back to manual entry.
+
 ### Discogs Cache (Optional)
 
 The service supports an optional PostgreSQL cache for Discogs data:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ Find all releases containing a specific track.
 
 Get full release metadata from Discogs.
 
+### `POST /api/v1/releases/resolve`
+
+Resolve a Discogs release URL or Bandcamp album URL (or an explicit `(source, id)` pair) to canonical release metadata, cross-source identifiers, and streaming availability — the prefill payload for tubafrenzy's rotation-release create form.
+
+Request: `{"url": "https://www.discogs.com/release/12345"}` or `{"url": "https://artist.bandcamp.com/album/slug"}` or `{"source": "discogs_release", "id": "12345"}`.
+
+Response includes `canonical` (artist, title, label, catno, year), `identifiers` (cross-source IDs learned from Discogs + the streaming check), `streaming` (per-service availability), and `warnings[]` for non-fatal issues. Always returns 200 — the form falls back to manual entry on partial prefill.
+
 ### `POST /admin/upload-library-db`
 
 Upload a new `library.db` file. Requires `Authorization: Bearer <ADMIN_TOKEN>` header.

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from identity.dependencies import close_entity_store
 from identity.router import router as identity_router
 from library.router import router as library_router
 from lookup.router import router as lookup_router
+from release.router import router as release_router
 from routers.admin import router as admin_router
 from routers.health import router as health_router
 from streaming.dependencies import close_streaming_clients
@@ -105,6 +106,7 @@ app.include_router(discogs_router, prefix="/api/v1", tags=["discogs"], dependenc
 app.include_router(
     streaming_router, prefix="/api/v1", tags=["streaming"], dependencies=_lml_protected
 )
+app.include_router(release_router, prefix="/api/v1", tags=["release"], dependencies=_lml_protected)
 
 if __name__ == "__main__":
     import uvicorn

--- a/release/bandcamp_resolver.py
+++ b/release/bandcamp_resolver.py
@@ -1,0 +1,169 @@
+"""Resolve a Bandcamp album URL to canonical fields + identifiers.
+
+Bandcamp does not have a public API. Every album page embeds a
+``<script type="application/ld+json">`` blob with schema.org MusicAlbum
+properties (``name``, ``byArtist.name``, ``publisher.name``, ``datePublished``)
+which is stable enough to scrape for the prefill flow.
+
+The "self-released" case is detected by comparing the album's host
+to the publisher's host: when an artist self-releases, Bandcamp lists the
+artist itself as the publisher, with the same subdomain. In that case we
+return ``label=None`` per the music director's instruction (don't pretend
+the artist is the label).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import urlparse
+
+import httpx
+
+from release.models import CanonicalRelease, ReleaseIdentifiers
+from scripts.bandcamp_client import BandcampClient
+
+logger = logging.getLogger(__name__)
+
+
+_LD_JSON_BLOCK_RE = re.compile(
+    r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
+    re.DOTALL,
+)
+
+
+@dataclass
+class BandcampResolveResult:
+    """Result of resolving a single Bandcamp album URL."""
+
+    canonical: CanonicalRelease | None
+    identifiers: ReleaseIdentifiers
+    warnings: list[str]
+
+
+def _host(url: str | None) -> str | None:
+    if not url:
+        return None
+    try:
+        return urlparse(url).netloc.lower() or None
+    except ValueError:
+        return None
+
+
+def _parse_year(date_published: str | None) -> int | None:
+    """Extract the year from Bandcamp's date string.
+
+    Bandcamp ships ``datePublished`` as ``"DD Mon YYYY HH:MM:SS GMT"`` (RFC-2822-ish
+    without the day-of-week). Try the most common shape; fall back to a regex
+    pull on a 4-digit year.
+    """
+    if not date_published:
+        return None
+    try:
+        return datetime.strptime(date_published, "%d %b %Y %H:%M:%S %Z").year
+    except (ValueError, TypeError):
+        match = re.search(r"\b(19|20)\d{2}\b", date_published)
+        return int(match.group()) if match else None
+
+
+def parse_bandcamp_album_html(html: str, album_url: str) -> BandcampResolveResult:
+    """Pull the JSON-LD blob out of an album page and project to canonical form.
+
+    Pure function — separated from the HTTP fetch so tests run against committed
+    fixtures and don't hit Bandcamp.
+    """
+    warnings: list[str] = []
+
+    blocks = _LD_JSON_BLOCK_RE.findall(html)
+    if not blocks:
+        return BandcampResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
+            warnings=["Bandcamp page did not contain a JSON-LD MusicAlbum block"],
+        )
+
+    # Find the MusicAlbum block (skip MusicGroup, BreadcrumbList, etc).
+    album_data: dict | None = None
+    for block in blocks:
+        try:
+            parsed = json.loads(block.strip())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("@type") == "MusicAlbum":
+            album_data = parsed
+            break
+
+    if album_data is None:
+        return BandcampResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
+            warnings=["Bandcamp page JSON-LD did not contain a MusicAlbum entry"],
+        )
+
+    name = album_data.get("name")
+    by_artist = album_data.get("byArtist") or {}
+    artist_name = by_artist.get("name") if isinstance(by_artist, dict) else None
+    if not name or not artist_name:
+        return BandcampResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
+            warnings=["Bandcamp JSON-LD missing required name or byArtist.name"],
+        )
+
+    # Self-released: the artist subdomain *is* the publisher subdomain.
+    # Per the music director: don't pretend the artist is the label.
+    publisher = album_data.get("publisher") or {}
+    publisher_name = publisher.get("name") if isinstance(publisher, dict) else None
+    publisher_url = publisher.get("@id") if isinstance(publisher, dict) else None
+    artist_url = by_artist.get("@id") if isinstance(by_artist, dict) else None
+    label: str | None = publisher_name
+    if _host(publisher_url) and _host(artist_url) and _host(publisher_url) == _host(artist_url):
+        label = None
+
+    canonical = CanonicalRelease(
+        artist=artist_name,
+        title=name,
+        label=label,
+        catno=None,  # Bandcamp does not expose catalog numbers.
+        year=_parse_year(album_data.get("datePublished")),
+        country=None,
+        formats=[],
+    )
+
+    identifiers = ReleaseIdentifiers(bandcamp_album_url=album_url)
+
+    return BandcampResolveResult(canonical=canonical, identifiers=identifiers, warnings=warnings)
+
+
+async def fetch_bandcamp_album_html(client: BandcampClient, album_url: str) -> str | None:
+    """Fetch the raw HTML for a Bandcamp album page using the rate-limited client.
+
+    Returns None on HTTP error so the resolver can surface a warning instead of
+    an exception bubbling all the way to the form.
+    """
+    try:
+        # Reuse the same retry-on-429 helper used by the autocomplete + scrape paths.
+        response: httpx.Response | None = await client._request_with_retry(  # noqa: SLF001
+            "GET", album_url, timeout=15.0, follow_redirects=True
+        )
+    except Exception:
+        logger.exception("Bandcamp album fetch failed for %s", album_url)
+        return None
+    if response is None or response.status_code != 200:
+        return None
+    return response.text
+
+
+async def resolve_bandcamp_album(client: BandcampClient, album_url: str) -> BandcampResolveResult:
+    """Fetch + parse an album page in one call. Wraps the two helpers above."""
+    html = await fetch_bandcamp_album_html(client, album_url)
+    if html is None:
+        return BandcampResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
+            warnings=[f"Bandcamp page could not be fetched: {album_url}"],
+        )
+    return parse_bandcamp_album_html(html, album_url)

--- a/release/bandcamp_resolver.py
+++ b/release/bandcamp_resolver.py
@@ -86,13 +86,19 @@ def parse_bandcamp_album_html(html: str, album_url: str) -> BandcampResolveResul
         )
 
     # Find the MusicAlbum block (skip MusicGroup, BreadcrumbList, etc).
+    # Bandcamp ships @type as a string most of the time, but schema.org allows
+    # arrays (e.g. ["MusicAlbum", "Product"]); tolerate both shapes.
     album_data: dict | None = None
     for block in blocks:
         try:
             parsed = json.loads(block.strip())
         except json.JSONDecodeError:
             continue
-        if isinstance(parsed, dict) and parsed.get("@type") == "MusicAlbum":
+        if not isinstance(parsed, dict):
+            continue
+        type_value = parsed.get("@type")
+        types = type_value if isinstance(type_value, list) else [type_value]
+        if "MusicAlbum" in types:
             album_data = parsed
             break
 

--- a/release/dependencies.py
+++ b/release/dependencies.py
@@ -1,0 +1,45 @@
+"""FastAPI dependency providers for the releases/resolve endpoint."""
+
+from __future__ import annotations
+
+from fastapi import Depends
+
+from core.dependencies import get_discogs_service
+from discogs.service import DiscogsService
+from identity.dependencies import get_entity_store
+from release.orchestrator import _ResolverDependencies
+from scripts.bandcamp_client import BandcampClient
+from scripts.entity_resolution.store import EntityStore
+from scripts.streaming_availability.apple_music_client import AppleMusicClient
+from scripts.streaming_availability.deezer_client import DeezerClient
+from scripts.streaming_availability.spotify_client import SpotifyClient
+from streaming.dependencies import (
+    get_apple_music_client,
+    get_bandcamp_client,
+    get_deezer_client,
+    get_spotify_client,
+)
+
+
+def get_resolver_dependencies(
+    discogs: DiscogsService = Depends(get_discogs_service),
+    bandcamp: BandcampClient = Depends(get_bandcamp_client),
+    spotify: SpotifyClient | None = Depends(get_spotify_client),
+    deezer: DeezerClient = Depends(get_deezer_client),
+    apple_music: AppleMusicClient = Depends(get_apple_music_client),
+    entity_store: EntityStore | None = Depends(get_entity_store),
+) -> _ResolverDependencies:
+    """Bundle the I/O clients the resolver orchestrator needs.
+
+    Reuses existing DI providers so the lifecycle (close on shutdown) is
+    already wired in main.py. Spotify and the entity store are optional and
+    may be None; the orchestrator handles that correctly.
+    """
+    return _ResolverDependencies(
+        discogs=discogs,
+        bandcamp=bandcamp,
+        spotify=spotify,
+        deezer=deezer,
+        apple_music=apple_music,
+        entity_store=entity_store,
+    )

--- a/release/discogs_resolver.py
+++ b/release/discogs_resolver.py
@@ -1,0 +1,123 @@
+"""Resolve a Discogs release ID to canonical fields + identifiers.
+
+Wraps the existing ``DiscogsService.get_release`` call (which itself reads
+the discogs-cache PG-backed cache and falls back to the Discogs API) so this
+endpoint inherits all the caching behavior already in production.
+
+The Discogs cache schema does not currently store ``country`` or ``formats``
+at the release level, so those fields are left null on cache hits. They could
+be backfilled later if the music director asks for them; see the plan doc.
+``catno`` comes from the first label in the ``labels`` array.
+
+Discogs master URLs are not yet supported. Pasting a master URL returns a
+warning suggesting the user paste a release URL instead — masters require
+an extra API hop (``/masters/<id>`` → ``main_release``) that's not worth the
+rate-limit budget for v1 of this endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from discogs.service import DiscogsService
+from release.models import CanonicalRelease, ReleaseIdentifiers
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DiscogsResolveResult:
+    """Result of resolving a single Discogs release ID."""
+
+    canonical: CanonicalRelease | None
+    identifiers: ReleaseIdentifiers
+    warnings: list[str]
+
+
+async def resolve_discogs_release(service: DiscogsService, release_id: str) -> DiscogsResolveResult:
+    """Look up a Discogs release and project to canonical form.
+
+    Returns a result whose ``canonical`` is None when the release could not
+    be fetched (rate limited, not found, network error). The ``warnings``
+    field carries a human-readable explanation in that case so the form
+    can fall back to manual entry without hiding the failure from the user.
+    """
+    warnings: list[str] = []
+
+    try:
+        rid = int(release_id)
+    except ValueError:
+        return DiscogsResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(),
+            warnings=[f"Discogs release ID '{release_id}' is not a number"],
+        )
+
+    try:
+        release = await service.get_release(rid)
+    except Exception:
+        logger.exception("Discogs release fetch failed for %s", rid)
+        return DiscogsResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(discogs_release_id=rid),
+            warnings=[f"Discogs lookup failed for release {rid}"],
+        )
+
+    if release is None:
+        warnings.append(
+            f"Discogs release {rid} could not be fetched "
+            "(rate-limited, not found, or temporarily unavailable)"
+        )
+        return DiscogsResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(discogs_release_id=rid),
+            warnings=warnings,
+        )
+
+    # First label's catno is the canonical "this album's catalog number".
+    catno: str | None = None
+    if release.labels:
+        catno = release.labels[0].catno or None
+
+    canonical = CanonicalRelease(
+        artist=release.artist or "",
+        title=release.title or "",
+        label=release.label or None,
+        catno=catno,
+        year=release.year,
+        # country / formats not available from the Discogs cache today.
+        country=None,
+        formats=[],
+    )
+
+    identifiers = ReleaseIdentifiers(
+        discogs_release_id=rid,
+        discogs_artist_id=release.artist_id,
+    )
+
+    return DiscogsResolveResult(canonical=canonical, identifiers=identifiers, warnings=warnings)
+
+
+async def resolve_discogs_master(_service: DiscogsService, master_id: str) -> DiscogsResolveResult:
+    """Master URLs are not yet supported.
+
+    The Discogs API would let us pivot ``master_id`` → ``main_release_id`` →
+    full release, but that adds a second API call per paste. Defer until
+    we see real demand for master-URL pastes.
+    """
+    return DiscogsResolveResult(
+        canonical=None,
+        identifiers=ReleaseIdentifiers(discogs_master_id=_safe_int(master_id)),
+        warnings=[
+            "Discogs master URLs are not supported yet. "
+            "Open the master and paste one of its release URLs instead."
+        ],
+    )
+
+
+def _safe_int(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None

--- a/release/models.py
+++ b/release/models.py
@@ -82,9 +82,15 @@ class ReleaseIdentifiers(BaseModel):
 
 
 class ReleaseResolveResponse(BaseModel):
-    """Response body for ``POST /api/v1/releases/resolve``."""
+    """Response body for ``POST /api/v1/releases/resolve``.
 
-    source: Literal["discogs_release", "discogs_master", "bandcamp"]
+    ``source`` is ``"unknown"`` when the input URL did not match any supported
+    pattern; ``canonical`` is empty in that case and ``warnings`` explains why.
+    Clients should check ``warnings`` regardless of ``source`` before consuming
+    ``canonical`` — the orchestrator's contract is "always 200, partial OK".
+    """
+
+    source: Literal["discogs_release", "discogs_master", "bandcamp", "unknown"]
     source_id: str
     canonical: CanonicalRelease
     identifiers: ReleaseIdentifiers = Field(default_factory=ReleaseIdentifiers)

--- a/release/models.py
+++ b/release/models.py
@@ -1,0 +1,106 @@
+"""Pydantic models for the ``POST /api/v1/releases/resolve`` endpoint.
+
+The endpoint takes either a pasted URL or an explicit ``(source, id)`` pair
+and returns canonical release metadata, cross-source identifiers, and a
+streaming-availability snapshot — all the data tubafrenzy needs to prefill
+its rotation-release create form in one round trip.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from streaming.models import StreamingCheckResponse
+
+
+class ReleaseResolveRequest(BaseModel):
+    """Request body for ``POST /api/v1/releases/resolve``.
+
+    Either ``url`` is set, or both ``source`` and ``id`` are set — never both,
+    never neither. Bandcamp ``id`` is the canonical album URL; Discogs ``id``
+    is the numeric release or master ID as a string.
+    """
+
+    url: str | None = Field(None, description="Discogs or Bandcamp URL to resolve")
+    source: Literal["discogs_release", "discogs_master", "bandcamp"] | None = Field(
+        None, description="Explicit source — required when url is not given"
+    )
+    id: str | None = Field(
+        None, description="Identifier within the source (release ID, master ID, or Bandcamp URL)"
+    )
+
+    @model_validator(mode="after")
+    def _validate_oneof(self) -> ReleaseResolveRequest:
+        url_given = self.url is not None and self.url.strip() != ""
+        explicit_given = (self.source is not None) and (
+            self.id is not None and self.id.strip() != ""
+        )
+        if url_given == explicit_given:
+            raise ValueError("provide exactly one of `url` or (`source`, `id`)")
+        return self
+
+
+class CanonicalRelease(BaseModel):
+    """Canonical release metadata projected from the source.
+
+    ``label`` is null when self-released (per the Bandcamp self-released case).
+    ``catno`` is the catalog number from the first label (Discogs only;
+    Bandcamp does not surface a catalog number).
+
+    Genres and styles are intentionally excluded — the rotation-release form
+    has no genre field, so surfacing them would just be noise for the music
+    director who picks the genre manually.
+    """
+
+    artist: str
+    title: str
+    label: str | None = None
+    catno: str | None = None
+    year: int | None = None
+    country: str | None = None
+    formats: list[str] = Field(default_factory=list)
+
+
+class ReleaseIdentifiers(BaseModel):
+    """Cross-source identifiers learned during resolution.
+
+    A pasted Discogs URL fills ``discogs_release_id`` and (when known)
+    ``discogs_master_id`` and ``discogs_artist_id``. A pasted Bandcamp URL
+    fills ``bandcamp_album_url``. Other identifiers are populated when the
+    streaming-availability check finds matches on Spotify / Apple Music.
+    """
+
+    discogs_release_id: int | None = None
+    discogs_master_id: int | None = None
+    discogs_artist_id: int | None = None
+    musicbrainz_release_id: str | None = None
+    bandcamp_album_url: str | None = None
+    spotify_album_id: str | None = None
+    apple_music_album_id: str | None = None
+
+
+class ReleaseResolveResponse(BaseModel):
+    """Response body for ``POST /api/v1/releases/resolve``."""
+
+    source: Literal["discogs_release", "discogs_master", "bandcamp"]
+    source_id: str
+    canonical: CanonicalRelease
+    identifiers: ReleaseIdentifiers = Field(default_factory=ReleaseIdentifiers)
+    streaming: StreamingCheckResponse | None = Field(
+        None,
+        description=(
+            "Streaming availability across Spotify/Deezer/Apple Music/Bandcamp. "
+            "Null when the streaming check could not be performed (e.g. all "
+            "configured services failed)."
+        ),
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Non-fatal issues during resolution — Discogs API rate-limited, "
+            "Bandcamp page failed to parse, etc. The form should surface these "
+            "to the user but still allow them to save."
+        ),
+    )

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -27,6 +27,7 @@ able to fall back to manual entry without losing the partial prefill.
 from __future__ import annotations
 
 import logging
+import re
 
 from discogs.service import DiscogsService
 from release.bandcamp_resolver import resolve_bandcamp_album
@@ -41,7 +42,7 @@ from release.models import (
     ReleaseResolveResponse,
 )
 from release.url_parser import ParsedUrl, parse_url
-from scripts.bandcamp_client import BandcampClient
+from scripts.bandcamp_client import BandcampClient, extract_slug
 from scripts.entity_resolution.store import EntityStore
 from scripts.streaming_availability.apple_music_client import AppleMusicClient
 from scripts.streaming_availability.deezer_client import DeezerClient
@@ -89,7 +90,7 @@ async def resolve_release(
         # Return 200 with a warning so the form falls back to manual entry; the
         # alternative (HTTPException) hides the partial information from the user.
         return ReleaseResolveResponse(
-            source="discogs_release",  # placeholder; canonical is missing anyway
+            source="unknown",
             source_id=request.url or request.id or "",
             canonical=CanonicalRelease(artist="", title=""),
             identifiers=ReleaseIdentifiers(),
@@ -125,7 +126,8 @@ async def resolve_release(
 
     # Identity write-back: any newly-discovered IDs land in entity.identity
     # for the artist. Idempotent + COALESCE-based — never clobbers existing data.
-    if canonical is not None and deps.entity_store is not None:
+    # Require a non-empty artist name so we never insert library_name="".
+    if canonical is not None and canonical.artist and deps.entity_store is not None:
         await _writeback_identity(deps.entity_store, canonical, identifiers, warnings)
 
     return ReleaseResolveResponse(
@@ -163,6 +165,11 @@ async def _check_streaming(
     if canonical is None or not canonical.artist or not canonical.title:
         return None
 
+    # Skip the Bandcamp leg when the input is a Bandcamp URL — we already know
+    # the answer with certainty, and re-fuzzy-matching would burn 2+ rate-limited
+    # HTTP calls (autocomplete + catalog scrape) for a result we'd discard.
+    bandcamp_for_check = None if parsed.source == "bandcamp" else deps.bandcamp
+
     try:
         streaming = await check_streaming_availability(
             canonical.artist,
@@ -170,7 +177,7 @@ async def _check_streaming(
             spotify=deps.spotify,
             deezer=deps.deezer,
             apple_music=deps.apple_music,
-            bandcamp=deps.bandcamp,
+            bandcamp=bandcamp_for_check,
         )
     except Exception:
         logger.exception("Streaming check failed for %s - %s", canonical.artist, canonical.title)
@@ -208,19 +215,23 @@ def _merge_streaming_identifiers(
     )
 
 
+_SPOTIFY_ALBUM_ID_RE = re.compile(r"open\.spotify\.com/album/([A-Za-z0-9]+)")
+_APPLE_ALBUM_ID_RE = re.compile(r"music\.apple\.com/[a-z]{2}/album/[^/?#]+/(?:id)?(\d{6,})")
+
+
 def _spotify_album_id_from_url(url: str) -> str | None:
     """``open.spotify.com/album/<id>`` → ``<id>``. Returns None on a non-album URL."""
-    import re
-
-    match = re.search(r"open\.spotify\.com/album/([A-Za-z0-9]+)", url)
+    match = _SPOTIFY_ALBUM_ID_RE.search(url)
     return match.group(1) if match else None
 
 
 def _apple_album_id_from_url(url: str) -> str | None:
-    """Apple Music album URLs end in ``id<digits>`` or ``/<digits>``. Be tolerant."""
-    import re
+    """``music.apple.com/<locale>/album/<slug>/<id>`` (or ``/id<id>``) → ``<id>``.
 
-    match = re.search(r"(?:id|/)(\d{6,})", url)
+    Anchored on the Apple host so a slug containing digits cannot be mistaken
+    for the album ID.
+    """
+    match = _APPLE_ALBUM_ID_RE.search(url)
     return match.group(1) if match else None
 
 
@@ -261,6 +272,4 @@ async def _writeback_identity(
 def _bandcamp_slug_from_url(url: str | None) -> str | None:
     if not url:
         return None
-    from scripts.bandcamp_client import extract_slug
-
     return extract_slug(url)

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -1,0 +1,266 @@
+"""Top-level resolve() for the ``POST /api/v1/releases/resolve`` endpoint.
+
+Threads:
+
+  paste-URL or (source, id)
+        |
+        v
+  url_parser.parse_url      (pure)
+        |
+        v
+  discogs_resolver.resolve_discogs_release   OR   bandcamp_resolver.resolve_bandcamp_album
+        |
+        v
+  streaming.orchestrator.check_streaming_availability
+        |
+        v
+  identity write-back via EntityStore.upsert_identity
+        |
+        v
+  ReleaseResolveResponse
+
+Each step accumulates ``warnings``. The endpoint always returns 200 with
+whatever it managed to put together — the music director's form should be
+able to fall back to manual entry without losing the partial prefill.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from discogs.service import DiscogsService
+from release.bandcamp_resolver import resolve_bandcamp_album
+from release.discogs_resolver import (
+    resolve_discogs_master,
+    resolve_discogs_release,
+)
+from release.models import (
+    CanonicalRelease,
+    ReleaseIdentifiers,
+    ReleaseResolveRequest,
+    ReleaseResolveResponse,
+)
+from release.url_parser import ParsedUrl, parse_url
+from scripts.bandcamp_client import BandcampClient
+from scripts.entity_resolution.store import EntityStore
+from scripts.streaming_availability.apple_music_client import AppleMusicClient
+from scripts.streaming_availability.deezer_client import DeezerClient
+from scripts.streaming_availability.spotify_client import SpotifyClient
+from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
+from streaming.orchestrator import check_streaming_availability
+
+logger = logging.getLogger(__name__)
+
+
+class _ResolverDependencies:
+    """Bundle the I/O dependencies the orchestrator needs.
+
+    Kept as a private class so the FastAPI router (and the tests) can build
+    one explicitly. We don't use ``functools.partial`` because the streaming
+    clients may individually be None when their credentials are unset.
+    """
+
+    def __init__(
+        self,
+        *,
+        discogs: DiscogsService,
+        bandcamp: BandcampClient,
+        spotify: SpotifyClient | None,
+        deezer: DeezerClient | None,
+        apple_music: AppleMusicClient | None,
+        entity_store: EntityStore | None,
+    ) -> None:
+        self.discogs = discogs
+        self.bandcamp = bandcamp
+        self.spotify = spotify
+        self.deezer = deezer
+        self.apple_music = apple_music
+        self.entity_store = entity_store
+
+
+async def resolve_release(
+    request: ReleaseResolveRequest,
+    deps: _ResolverDependencies,
+) -> ReleaseResolveResponse:
+    """Resolve a paste-URL or (source, id) into the prefill payload."""
+    parsed = _resolve_to_parsed_url(request)
+    if parsed is None:
+        # Either the URL didn't parse or the explicit (source, id) was malformed.
+        # Return 200 with a warning so the form falls back to manual entry; the
+        # alternative (HTTPException) hides the partial information from the user.
+        return ReleaseResolveResponse(
+            source="discogs_release",  # placeholder; canonical is missing anyway
+            source_id=request.url or request.id or "",
+            canonical=CanonicalRelease(artist="", title=""),
+            identifiers=ReleaseIdentifiers(),
+            streaming=None,
+            warnings=[
+                "Could not recognize the URL or source. "
+                "Supported: Discogs release URLs (e.g. discogs.com/release/12345) "
+                "and Bandcamp album URLs (e.g. artist.bandcamp.com/album/slug)."
+            ],
+        )
+
+    # Dispatch to the right resolver.
+    if parsed.source == "discogs_release":
+        discogs_result = await resolve_discogs_release(deps.discogs, parsed.identifier)
+        canonical = discogs_result.canonical
+        identifiers = discogs_result.identifiers
+        warnings = list(discogs_result.warnings)
+    elif parsed.source == "discogs_master":
+        master_result = await resolve_discogs_master(deps.discogs, parsed.identifier)
+        canonical = master_result.canonical
+        identifiers = master_result.identifiers
+        warnings = list(master_result.warnings)
+    else:  # bandcamp
+        bandcamp_result = await resolve_bandcamp_album(deps.bandcamp, parsed.identifier)
+        canonical = bandcamp_result.canonical
+        identifiers = bandcamp_result.identifiers
+        warnings = list(bandcamp_result.warnings)
+
+    streaming = await _check_streaming(canonical, parsed, deps, warnings)
+
+    # Promote streaming-side identifiers (Spotify/Apple) into the response.
+    identifiers = _merge_streaming_identifiers(identifiers, streaming)
+
+    # Identity write-back: any newly-discovered IDs land in entity.identity
+    # for the artist. Idempotent + COALESCE-based — never clobbers existing data.
+    if canonical is not None and deps.entity_store is not None:
+        await _writeback_identity(deps.entity_store, canonical, identifiers, warnings)
+
+    return ReleaseResolveResponse(
+        source=parsed.source,
+        source_id=parsed.identifier,
+        canonical=canonical or CanonicalRelease(artist="", title=""),
+        identifiers=identifiers,
+        streaming=streaming,
+        warnings=warnings,
+    )
+
+
+def _resolve_to_parsed_url(request: ReleaseResolveRequest) -> ParsedUrl | None:
+    """Translate a request into a ParsedUrl. URL field takes precedence."""
+    if request.url:
+        return parse_url(request.url)
+    if request.source and request.id:
+        return ParsedUrl(source=request.source, identifier=request.id)
+    return None
+
+
+async def _check_streaming(
+    canonical: CanonicalRelease | None,
+    parsed: ParsedUrl,
+    deps: _ResolverDependencies,
+    warnings: list[str],
+) -> StreamingCheckResponse | None:
+    """Run the streaming-availability fan-out.
+
+    Skips the check when canonical metadata is missing — there's nothing to
+    search for. Short-circuits the Bandcamp leg when the input itself is a
+    Bandcamp URL: re-fuzzy-matching a URL the DJ explicitly gave us would
+    just throw away certainty.
+    """
+    if canonical is None or not canonical.artist or not canonical.title:
+        return None
+
+    try:
+        streaming = await check_streaming_availability(
+            canonical.artist,
+            canonical.title,
+            spotify=deps.spotify,
+            deezer=deps.deezer,
+            apple_music=deps.apple_music,
+            bandcamp=deps.bandcamp,
+        )
+    except Exception:
+        logger.exception("Streaming check failed for %s - %s", canonical.artist, canonical.title)
+        warnings.append("Streaming-availability check failed; on-streaming flag not set.")
+        return None
+
+    if parsed.source == "bandcamp":
+        # Trust the URL the DJ pasted. Confidence 100 + on_streaming=True are
+        # safe overrides because we know the URL resolves to a real album.
+        streaming.sources.bandcamp = SourceMatch(url=parsed.identifier, confidence=100.0)
+        if streaming.on_streaming is not True:
+            streaming.on_streaming = True
+
+    return streaming
+
+
+def _merge_streaming_identifiers(
+    identifiers: ReleaseIdentifiers, streaming: StreamingCheckResponse | None
+) -> ReleaseIdentifiers:
+    """Promote Spotify/Apple IDs found during the streaming check into the response."""
+    if streaming is None:
+        return identifiers
+
+    sources: StreamingCheckSources = streaming.sources
+    spotify_id = _spotify_album_id_from_url(sources.spotify.url) if sources.spotify else None
+    apple_id = _apple_album_id_from_url(sources.apple_music.url) if sources.apple_music else None
+    bandcamp_url = sources.bandcamp.url if sources.bandcamp else None
+
+    return identifiers.model_copy(
+        update={
+            "spotify_album_id": identifiers.spotify_album_id or spotify_id,
+            "apple_music_album_id": identifiers.apple_music_album_id or apple_id,
+            "bandcamp_album_url": identifiers.bandcamp_album_url or bandcamp_url,
+        }
+    )
+
+
+def _spotify_album_id_from_url(url: str) -> str | None:
+    """``open.spotify.com/album/<id>`` → ``<id>``. Returns None on a non-album URL."""
+    import re
+
+    match = re.search(r"open\.spotify\.com/album/([A-Za-z0-9]+)", url)
+    return match.group(1) if match else None
+
+
+def _apple_album_id_from_url(url: str) -> str | None:
+    """Apple Music album URLs end in ``id<digits>`` or ``/<digits>``. Be tolerant."""
+    import re
+
+    match = re.search(r"(?:id|/)(\d{6,})", url)
+    return match.group(1) if match else None
+
+
+async def _writeback_identity(
+    store: EntityStore,
+    canonical: CanonicalRelease,
+    identifiers: ReleaseIdentifiers,
+    warnings: list[str],
+) -> None:
+    """Push newly-learned IDs into ``entity.identity`` keyed on the artist name.
+
+    Reuses the existing ``upsert_identity`` SQL pattern (``ON CONFLICT ... DO
+    UPDATE`` with ``COALESCE``) so populated fields are never clobbered. The
+    artist row is created on first sight.
+    """
+    # Bandcamp doesn't expose an integer artist ID, so we use the album URL's
+    # subdomain as the bandcamp_id placeholder. This matches existing
+    # entity.identity rows populated by bandcamp_pipeline.py, which also uses
+    # the slug as bandcamp_id.
+    bandcamp_id = _bandcamp_slug_from_url(identifiers.bandcamp_album_url)
+
+    try:
+        await store.upsert_identity(
+            canonical.artist,
+            discogs_artist_id=identifiers.discogs_artist_id,
+            spotify_artist_id=None,  # only album-id known at this point
+            apple_music_artist_id=None,
+            bandcamp_id=bandcamp_id,
+        )
+    except Exception:
+        logger.exception("Identity write-back failed for %s", canonical.artist)
+        warnings.append(
+            "Could not record cross-source identifiers for "
+            f"'{canonical.artist}' — prefill returned, identity store left untouched."
+        )
+
+
+def _bandcamp_slug_from_url(url: str | None) -> str | None:
+    if not url:
+        return None
+    from scripts.bandcamp_client import extract_slug
+
+    return extract_slug(url)

--- a/release/router.py
+++ b/release/router.py
@@ -1,0 +1,44 @@
+"""Router for the ``POST /api/v1/releases/resolve`` endpoint.
+
+Tubafrenzy's rotation-release create form posts a Discogs/Bandcamp URL here
+to prefill the form fields. The endpoint always returns 200 — partial
+prefills are surfaced via ``warnings[]`` so the form can show what worked
+and let the music director fill in the rest.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+
+from release.dependencies import get_resolver_dependencies
+from release.models import ReleaseResolveRequest, ReleaseResolveResponse
+from release.orchestrator import _ResolverDependencies, resolve_release
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["release"])
+
+
+@router.post(
+    "/releases/resolve",
+    response_model=ReleaseResolveResponse,
+    summary="Resolve a Discogs/Bandcamp URL to canonical release metadata",
+    description=(
+        "Takes a pasted Discogs release URL or Bandcamp album URL (or an "
+        "explicit `(source, id)` pair) and returns canonical release fields, "
+        "cross-source identifiers, and streaming availability — everything "
+        "tubafrenzy's rotation-release create form needs to prefill."
+    ),
+    responses={
+        200: {"description": "Resolution result (may include warnings on partial success)"},
+        422: {"description": "Request body failed validation"},
+    },
+)
+async def handle_resolve(
+    request: ReleaseResolveRequest,
+    deps: _ResolverDependencies = Depends(get_resolver_dependencies),
+) -> ReleaseResolveResponse:
+    """Resolve and return. Errors are converted to warnings inside the orchestrator."""
+    return await resolve_release(request, deps)

--- a/release/url_parser.py
+++ b/release/url_parser.py
@@ -1,0 +1,105 @@
+"""Parse Discogs and Bandcamp URLs into a (source, identifier) tuple.
+
+Used by the ``POST /api/v1/releases/resolve`` endpoint to dispatch a pasted URL
+to the right resolver.
+
+The identifier shape depends on source:
+
+- Discogs ``release`` → integer release ID as a string (``"123456"``)
+- Discogs ``master`` → integer master ID as a string (``"7890"``)
+- Bandcamp → the canonical album URL itself (``"https://artist.bandcamp.com/album/slug"``).
+  Bandcamp has no integer ID; the canonical URL is the identity.
+
+The parser does not perform any I/O.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import urlparse
+
+ParsedSource = Literal["discogs_release", "discogs_master", "bandcamp"]
+
+
+@dataclass(frozen=True)
+class ParsedUrl:
+    """Result of parsing a paste-URL.
+
+    ``source`` distinguishes Discogs releases, Discogs masters, and Bandcamp
+    so resolvers can dispatch directly. ``identifier`` is a string for both:
+    a numeric ID for Discogs and the album URL for Bandcamp.
+    """
+
+    source: ParsedSource
+    identifier: str
+
+
+_DISCOGS_PATH_RE = re.compile(r"^/(?:[a-z]{2}/)?(release|master)/(\d+)(?:[-/].*)?$")
+"""Matches /release/12345, /master/678, /es/release/12345, /release/12345-some-slug."""
+
+_BANDCAMP_HOST_RE = re.compile(r"^([a-z0-9][a-z0-9-]*)\.bandcamp\.com$")
+_BANDCAMP_ALBUM_PATH_RE = re.compile(r"^/album/[a-z0-9][a-z0-9-]*/?$")
+
+
+def parse_url(url: str) -> ParsedUrl | None:
+    """Parse a Discogs or Bandcamp URL. Returns None on unsupported / malformed input.
+
+    Examples (all return a ParsedUrl):
+
+        >>> parse_url("https://www.discogs.com/release/123456").source
+        'discogs_release'
+        >>> parse_url("https://discogs.com/master/789").source
+        'discogs_master'
+        >>> parse_url("https://www.discogs.com/release/123-some-title").identifier
+        '123'
+        >>> parse_url("https://autechre.bandcamp.com/album/confield").source
+        'bandcamp'
+
+    Returns None for unsupported hosts, missing paths, and malformed input:
+
+        >>> parse_url("https://example.com/release/123") is None
+        True
+        >>> parse_url("not a url") is None
+        True
+        >>> parse_url("") is None
+        True
+    """
+    if not url or not url.strip():
+        return None
+
+    try:
+        parsed = urlparse(url.strip())
+    except ValueError:
+        return None
+
+    if parsed.scheme not in ("http", "https"):
+        return None
+    if not parsed.netloc:
+        return None
+
+    host = parsed.netloc.lower()
+    path = parsed.path or "/"
+
+    # Discogs: discogs.com or www.discogs.com (and other locale subdomains
+    # are handled by the path regex itself, not the host check).
+    if host == "discogs.com" or host == "www.discogs.com":
+        match = _DISCOGS_PATH_RE.match(path)
+        if match is None:
+            return None
+        kind, id_str = match.groups()
+        if kind == "release":
+            return ParsedUrl(source="discogs_release", identifier=id_str)
+        return ParsedUrl(source="discogs_master", identifier=id_str)
+
+    # Bandcamp: <slug>.bandcamp.com/album/<slug>
+    bandcamp_match = _BANDCAMP_HOST_RE.match(host)
+    if bandcamp_match is not None:
+        if not _BANDCAMP_ALBUM_PATH_RE.match(path):
+            return None
+        # Canonicalize: strip query/fragment, drop trailing slash.
+        canonical = f"https://{host}{path.rstrip('/')}"
+        return ParsedUrl(source="bandcamp", identifier=canonical)
+
+    return None

--- a/tests/fixtures/bandcamp/album_self_released.html
+++ b/tests/fixtures/bandcamp/album_self_released.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head><title>DOGA | Juana Molina</title></head>
+<body>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "MusicAlbum",
+    "@id": "https://juana-molina.bandcamp.com/album/doga",
+    "name": "DOGA",
+    "byArtist": {
+        "@type": "MusicGroup",
+        "name": "Juana Molina",
+        "@id": "https://juana-molina.bandcamp.com",
+        "url": "https://juana-molina.bandcamp.com"
+    },
+    "datePublished": "10 Mar 2024 00:00:00 GMT",
+    "publisher": {
+        "@type": "MusicGroup",
+        "name": "Juana Molina",
+        "@id": "https://juana-molina.bandcamp.com"
+    }
+}
+</script>
+</body>
+</html>

--- a/tests/fixtures/bandcamp/album_with_label.html
+++ b/tests/fixtures/bandcamp/album_with_label.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head><title>Confield | Autechre</title></head>
+<body>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "MusicAlbum",
+    "@id": "https://autechre.bandcamp.com/album/confield",
+    "name": "Confield",
+    "byArtist": {
+        "@type": "MusicGroup",
+        "name": "Autechre",
+        "@id": "https://autechre.bandcamp.com",
+        "url": "https://autechre.bandcamp.com"
+    },
+    "datePublished": "16 Apr 2001 00:00:00 GMT",
+    "publisher": {
+        "@type": "MusicGroup",
+        "name": "Warp Records",
+        "@id": "https://warprecords.bandcamp.com",
+        "url": "https://warprecords.bandcamp.com"
+    }
+}
+</script>
+</body>
+</html>

--- a/tests/unit/release/test_bandcamp_resolver.py
+++ b/tests/unit/release/test_bandcamp_resolver.py
@@ -1,0 +1,167 @@
+"""Tests for release/bandcamp_resolver.py.
+
+The pure parser is tested against committed fixtures. The HTTP fetch path
+is tested with a mock BandcampClient — no real Bandcamp traffic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from release.bandcamp_resolver import (
+    fetch_bandcamp_album_html,
+    parse_bandcamp_album_html,
+    resolve_bandcamp_album,
+)
+
+FIXTURES = Path(__file__).resolve().parent.parent.parent / "fixtures" / "bandcamp"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+class TestParseBandcampAlbumHtml:
+    def test_self_released_label_is_null(self):
+        # When publisher subdomain == artist subdomain, treat as self-released.
+        # Per the music director: don't pretend the artist is the label.
+        html = _load("album_self_released.html")
+        url = "https://juana-molina.bandcamp.com/album/doga"
+
+        result = parse_bandcamp_album_html(html, url)
+
+        assert result.canonical is not None
+        assert result.canonical.artist == "Juana Molina"
+        assert result.canonical.title == "DOGA"
+        assert result.canonical.label is None
+        assert result.canonical.catno is None
+        assert result.canonical.year == 2024
+        assert result.identifiers.bandcamp_album_url == url
+        assert result.warnings == []
+
+    def test_label_account_populates_label(self):
+        # When publisher is on a different subdomain (a real label account),
+        # use the publisher name as the label.
+        html = _load("album_with_label.html")
+        url = "https://autechre.bandcamp.com/album/confield"
+
+        result = parse_bandcamp_album_html(html, url)
+
+        assert result.canonical is not None
+        assert result.canonical.artist == "Autechre"
+        assert result.canonical.title == "Confield"
+        assert result.canonical.label == "Warp Records"
+        assert result.canonical.catno is None  # Bandcamp never has catnos.
+        assert result.canonical.year == 2001
+        assert result.identifiers.bandcamp_album_url == url
+
+    def test_warns_when_no_jsonld_block(self):
+        result = parse_bandcamp_album_html(
+            "<html><body>no script here</body></html>",
+            "https://x.bandcamp.com/album/y",
+        )
+
+        assert result.canonical is None
+        assert result.identifiers.bandcamp_album_url == "https://x.bandcamp.com/album/y"
+        assert len(result.warnings) == 1
+        assert "JSON-LD" in result.warnings[0]
+
+    def test_warns_when_jsonld_has_no_musicalbum(self):
+        # Bandcamp pages sometimes contain MusicGroup or BreadcrumbList LD blocks
+        # but no MusicAlbum. Don't crash — warn and return null canonical.
+        html = """<html><body>
+            <script type="application/ld+json">{"@type":"MusicGroup","name":"X"}</script>
+        </body></html>"""
+
+        result = parse_bandcamp_album_html(html, "https://x.bandcamp.com/album/y")
+
+        assert result.canonical is None
+        assert "MusicAlbum" in result.warnings[0]
+
+    def test_warns_when_jsonld_is_malformed(self):
+        # Truncated/invalid JSON-LD shouldn't bubble a JSONDecodeError.
+        html = """<html><body>
+            <script type="application/ld+json">{not json</script>
+        </body></html>"""
+
+        result = parse_bandcamp_album_html(html, "https://x.bandcamp.com/album/y")
+
+        assert result.canonical is None
+        assert len(result.warnings) == 1
+
+
+class TestFetchBandcampAlbumHtml:
+    @pytest.mark.asyncio
+    async def test_returns_text_on_200(self):
+        client = MagicMock()
+        client._request_with_retry = AsyncMock()
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "<html>ok</html>"
+        client._request_with_retry.return_value = response
+
+        html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
+
+        assert html == "<html>ok</html>"
+        client._request_with_retry.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_non_200(self):
+        client = MagicMock()
+        response = MagicMock()
+        response.status_code = 404
+        client._request_with_retry = AsyncMock(return_value=response)
+
+        html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
+
+        assert html is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_request_failure(self):
+        client = MagicMock()
+        client._request_with_retry = AsyncMock(return_value=None)
+
+        html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
+
+        assert html is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_exception(self):
+        client = MagicMock()
+        client._request_with_retry = AsyncMock(side_effect=RuntimeError("boom"))
+
+        html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
+
+        assert html is None
+
+
+class TestResolveBandcampAlbum:
+    @pytest.mark.asyncio
+    async def test_end_to_end_with_fixture(self):
+        client = MagicMock()
+        response = MagicMock()
+        response.status_code = 200
+        response.text = _load("album_with_label.html")
+        client._request_with_retry = AsyncMock(return_value=response)
+
+        result = await resolve_bandcamp_album(
+            client, "https://autechre.bandcamp.com/album/confield"
+        )
+
+        assert result.canonical is not None
+        assert result.canonical.artist == "Autechre"
+        assert result.canonical.label == "Warp Records"
+
+    @pytest.mark.asyncio
+    async def test_warns_when_fetch_fails(self):
+        client = MagicMock()
+        client._request_with_retry = AsyncMock(return_value=None)
+
+        result = await resolve_bandcamp_album(client, "https://x.bandcamp.com/album/y")
+
+        assert result.canonical is None
+        assert len(result.warnings) == 1
+        assert "could not be fetched" in result.warnings[0]

--- a/tests/unit/release/test_discogs_resolver.py
+++ b/tests/unit/release/test_discogs_resolver.py
@@ -1,0 +1,126 @@
+"""Tests for release/discogs_resolver.py — projects DiscogsService.get_release()
+output to CanonicalRelease + ReleaseIdentifiers, with warnings on failure."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from generated.api_models import (
+    DiscogsLabelCredit,
+    DiscogsReleaseMetadata,
+)
+from release.discogs_resolver import (
+    DiscogsResolveResult,
+    resolve_discogs_master,
+    resolve_discogs_release,
+)
+
+
+def _make_release(**overrides) -> DiscogsReleaseMetadata:
+    """Produce a minimal valid release for projection tests."""
+    base = {
+        "release_id": 12345,
+        "title": "DOGA",
+        "artist": "Juana Molina",
+        "year": 2024,
+        "label": "Sonamos",
+        "artist_id": 999,
+        "labels": [DiscogsLabelCredit(label_id=42, name="Sonamos", catno="SON-001")],
+        "release_url": "https://www.discogs.com/release/12345",
+    }
+    base.update(overrides)
+    return DiscogsReleaseMetadata.model_validate(base)
+
+
+@pytest.fixture
+def mock_service():
+    return AsyncMock()
+
+
+class TestResolveDiscogsRelease:
+    @pytest.mark.asyncio
+    async def test_projects_basic_release(self, mock_service):
+        mock_service.get_release.return_value = _make_release()
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        mock_service.get_release.assert_awaited_once_with(12345)
+        assert isinstance(result, DiscogsResolveResult)
+        assert result.canonical is not None
+        assert result.canonical.artist == "Juana Molina"
+        assert result.canonical.title == "DOGA"
+        assert result.canonical.label == "Sonamos"
+        assert result.canonical.catno == "SON-001"
+        assert result.canonical.year == 2024
+        assert result.identifiers.discogs_release_id == 12345
+        assert result.identifiers.discogs_artist_id == 999
+        assert result.warnings == []
+
+    @pytest.mark.asyncio
+    async def test_label_null_when_no_labels(self, mock_service):
+        # A self-released album on Discogs sometimes has no labels at all.
+        mock_service.get_release.return_value = _make_release(label=None, labels=[])
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        assert result.canonical is not None
+        assert result.canonical.label is None
+        assert result.canonical.catno is None
+
+    @pytest.mark.asyncio
+    async def test_catno_null_when_label_has_no_catno(self, mock_service):
+        mock_service.get_release.return_value = _make_release(
+            labels=[DiscogsLabelCredit(label_id=42, name="Sonamos", catno=None)]
+        )
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        assert result.canonical is not None
+        assert result.canonical.label == "Sonamos"
+        assert result.canonical.catno is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_canonical_with_warning_on_miss(self, mock_service):
+        # get_release returns None on rate-limit / not-found / API error.
+        mock_service.get_release.return_value = None
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        assert result.canonical is None
+        assert result.identifiers.discogs_release_id == 12345
+        assert len(result.warnings) == 1
+        assert "12345" in result.warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_canonical_with_warning_on_exception(self, mock_service):
+        mock_service.get_release.side_effect = RuntimeError("network exploded")
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        assert result.canonical is None
+        assert result.identifiers.discogs_release_id == 12345
+        assert any("failed" in w.lower() for w in result.warnings)
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_numeric_id(self, mock_service):
+        result = await resolve_discogs_release(mock_service, "not-a-number")
+
+        assert result.canonical is None
+        assert result.identifiers.discogs_release_id is None
+        assert len(result.warnings) == 1
+        mock_service.get_release.assert_not_called()
+
+
+class TestResolveDiscogsMaster:
+    @pytest.mark.asyncio
+    async def test_master_returns_warning_with_master_id(self, mock_service):
+        # Master URLs aren't supported in v1; return a clear warning.
+        result = await resolve_discogs_master(mock_service, "789")
+
+        assert result.canonical is None
+        assert result.identifiers.discogs_master_id == 789
+        assert len(result.warnings) == 1
+        assert "master" in result.warnings[0].lower()
+        mock_service.get_release.assert_not_called()

--- a/tests/unit/release/test_models.py
+++ b/tests/unit/release/test_models.py
@@ -1,0 +1,41 @@
+"""Tests for release/models.py — the request validator's oneof rule is the
+only thing worth exercising here; the rest is plain Pydantic."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from release.models import ReleaseResolveRequest
+
+
+class TestReleaseResolveRequestValidation:
+    def test_accepts_url_only(self):
+        ReleaseResolveRequest(url="https://www.discogs.com/release/1")
+
+    def test_accepts_explicit_source_and_id(self):
+        ReleaseResolveRequest(source="discogs_release", id="123")
+
+    def test_rejects_neither(self):
+        with pytest.raises(ValidationError):
+            ReleaseResolveRequest()
+
+    def test_rejects_both(self):
+        with pytest.raises(ValidationError):
+            ReleaseResolveRequest(
+                url="https://www.discogs.com/release/1",
+                source="discogs_release",
+                id="123",
+            )
+
+    def test_rejects_blank_url(self):
+        # An empty string is not a url; the form should be told to use (source, id).
+        with pytest.raises(ValidationError):
+            ReleaseResolveRequest(url="   ")
+
+    def test_rejects_partial_explicit(self):
+        # source without id (or vice versa) is ambiguous.
+        with pytest.raises(ValidationError):
+            ReleaseResolveRequest(source="discogs_release")
+        with pytest.raises(ValidationError):
+            ReleaseResolveRequest(id="123")

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -11,7 +11,12 @@ from generated.api_models import (
     DiscogsReleaseMetadata,
 )
 from release.models import ReleaseResolveRequest
-from release.orchestrator import _ResolverDependencies, resolve_release
+from release.orchestrator import (
+    _apple_album_id_from_url,
+    _ResolverDependencies,
+    _spotify_album_id_from_url,
+    resolve_release,
+)
 from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
 
 
@@ -65,6 +70,42 @@ def _make_release(**overrides) -> DiscogsReleaseMetadata:
     return DiscogsReleaseMetadata.model_validate(base)
 
 
+class TestSpotifyAlbumIdExtraction:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://open.spotify.com/album/abc123XYZ", "abc123XYZ"),
+            ("https://open.spotify.com/album/abc123XYZ?si=tracking", "abc123XYZ"),
+            ("https://open.spotify.com/track/zzz", None),
+            ("https://example.com/album/notspotify", None),
+            ("", None),
+        ],
+    )
+    def test_extraction(self, url, expected):
+        assert _spotify_album_id_from_url(url) == expected
+
+
+class TestAppleAlbumIdExtraction:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            # Modern Apple URL shape: /<locale>/album/<slug>/<id>
+            ("https://music.apple.com/us/album/aluminum-tunes/123456789", "123456789"),
+            # Legacy "id<digits>" shape still seen in some iTunes responses.
+            ("https://music.apple.com/us/album/foo/id987654321", "987654321"),
+            # Slug containing digits must NOT be mistaken for the album ID.
+            ("https://music.apple.com/us/album/my-album-1999/123456789", "123456789"),
+            # Wrong host: don't claim a match.
+            ("https://example.com/album/foo/123456789", None),
+            # Track URL, not album.
+            ("https://music.apple.com/us/track/foo/123456789", None),
+            ("", None),
+        ],
+    )
+    def test_extraction(self, url, expected):
+        assert _apple_album_id_from_url(url) == expected
+
+
 class TestParsedUrlRouting:
     @pytest.mark.asyncio
     async def test_unrecognized_url_returns_warning(self):
@@ -74,6 +115,10 @@ class TestParsedUrlRouting:
                 ReleaseResolveRequest(url="https://example.com/foo"), deps
             )
         cs.assert_not_called()
+        # source="unknown" so consumers can disambiguate from a real "discogs_release"
+        # response that happens to have an empty canonical (very different reasons).
+        assert response.source == "unknown"
+        assert response.source_id == "https://example.com/foo"
         assert response.canonical.artist == ""
         assert any("recognize the URL" in w for w in response.warnings)
 
@@ -186,6 +231,51 @@ class TestBandcampBranch:
         assert response.streaming.on_streaming is True
 
     @pytest.mark.asyncio
+    async def test_passes_bandcamp_none_to_streaming_when_input_is_bandcamp(self):
+        # Performance guarantee: don't run a Bandcamp fuzzy search when the
+        # caller already gave us a Bandcamp URL. The streaming orchestrator
+        # should be invoked with bandcamp=None.
+        bandcamp = MagicMock()
+        check_mock = AsyncMock(return_value=_stream(on_streaming=False))
+        with (
+            patch("release.orchestrator.resolve_bandcamp_album", new=AsyncMock()) as mock_resolve,
+            patch("release.orchestrator.check_streaming_availability", new=check_mock),
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import CanonicalRelease, ReleaseIdentifiers
+
+            url = "https://juana-molina.bandcamp.com/album/doga"
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=CanonicalRelease(artist="Juana Molina", title="DOGA"),
+                identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
+                warnings=[],
+            )
+
+            await resolve_release(ReleaseResolveRequest(url=url), _deps(bandcamp=bandcamp))
+
+        # Inspect the kwargs the orchestrator passed to check_streaming_availability.
+        check_mock.assert_awaited_once()
+        assert check_mock.await_args.kwargs["bandcamp"] is None
+
+    @pytest.mark.asyncio
+    async def test_passes_bandcamp_client_to_streaming_for_discogs_input(self):
+        # Sanity check the inverse: a Discogs paste should route through the
+        # full Bandcamp fuzzy match (so we still discover the Bandcamp URL if
+        # one exists for this album).
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        bandcamp = MagicMock()
+        check_mock = AsyncMock(return_value=_stream(on_streaming=False))
+        with patch("release.orchestrator.check_streaming_availability", new=check_mock):
+            await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"),
+                _deps(discogs=discogs, bandcamp=bandcamp),
+            )
+
+        check_mock.assert_awaited_once()
+        assert check_mock.await_args.kwargs["bandcamp"] is bandcamp
+
+    @pytest.mark.asyncio
     async def test_bandcamp_fetch_failure_returns_warnings(self):
         bandcamp = MagicMock()
         with (
@@ -293,6 +383,25 @@ class TestIdentityWriteBack:
         # Caller still gets a usable response.
         assert response.canonical.artist == "Juana Molina"
         assert any("identifiers" in w.lower() for w in response.warnings)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_canonical_artist_is_empty(self):
+        # Defensive: a Discogs release with missing artist should not write
+        # library_name="" into entity.identity.
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release(artist="", artist_id=None)
+        store = AsyncMock()
+        deps = _deps(discogs=discogs, entity_store=store)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        store.upsert_identity.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_bandcamp_writeback_uses_slug(self):

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -1,0 +1,328 @@
+"""End-to-end tests for the resolve_release orchestrator with all I/O mocked."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from generated.api_models import (
+    DiscogsLabelCredit,
+    DiscogsReleaseMetadata,
+)
+from release.models import ReleaseResolveRequest
+from release.orchestrator import _ResolverDependencies, resolve_release
+from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
+
+
+def _deps(
+    *,
+    discogs=None,
+    bandcamp=None,
+    spotify=None,
+    deezer=None,
+    apple_music=None,
+    entity_store=None,
+):
+    """Build a _ResolverDependencies with sensible defaults for tests."""
+    return _ResolverDependencies(
+        discogs=discogs or AsyncMock(),
+        bandcamp=bandcamp or MagicMock(),
+        spotify=spotify,
+        deezer=deezer,
+        apple_music=apple_music,
+        entity_store=entity_store,
+    )
+
+
+def _stream(
+    *,
+    on_streaming=False,
+    spotify_url=None,
+    apple_url=None,
+    bandcamp_url=None,
+):
+    sources = StreamingCheckSources(
+        spotify=SourceMatch(url=spotify_url, confidence=95.0) if spotify_url else None,
+        apple_music=SourceMatch(url=apple_url, confidence=90.0) if apple_url else None,
+        bandcamp=SourceMatch(url=bandcamp_url, confidence=85.0) if bandcamp_url else None,
+    )
+    return StreamingCheckResponse(on_streaming=on_streaming, sources=sources)
+
+
+def _make_release(**overrides) -> DiscogsReleaseMetadata:
+    base = {
+        "release_id": 12345,
+        "title": "DOGA",
+        "artist": "Juana Molina",
+        "year": 2024,
+        "label": "Sonamos",
+        "artist_id": 999,
+        "labels": [DiscogsLabelCredit(label_id=42, name="Sonamos", catno="SON-001")],
+        "release_url": "https://www.discogs.com/release/12345",
+    }
+    base.update(overrides)
+    return DiscogsReleaseMetadata.model_validate(base)
+
+
+class TestParsedUrlRouting:
+    @pytest.mark.asyncio
+    async def test_unrecognized_url_returns_warning(self):
+        deps = _deps()
+        with patch("release.orchestrator.check_streaming_availability") as cs:
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://example.com/foo"), deps
+            )
+        cs.assert_not_called()
+        assert response.canonical.artist == ""
+        assert any("recognize the URL" in w for w in response.warnings)
+
+    @pytest.mark.asyncio
+    async def test_explicit_source_and_id_routes_to_discogs(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        deps = _deps(discogs=discogs)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(source="discogs_release", id="12345"), deps
+            )
+
+        assert response.source == "discogs_release"
+        assert response.canonical.artist == "Juana Molina"
+        discogs.get_release.assert_awaited_once_with(12345)
+
+
+class TestDiscogsBranch:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        deps = _deps(discogs=discogs)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(
+                return_value=_stream(
+                    on_streaming=True,
+                    spotify_url="https://open.spotify.com/album/abc123def",
+                )
+            ),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        assert response.source == "discogs_release"
+        assert response.source_id == "12345"
+        assert response.canonical.artist == "Juana Molina"
+        assert response.canonical.label == "Sonamos"
+        assert response.canonical.catno == "SON-001"
+        assert response.identifiers.discogs_release_id == 12345
+        assert response.identifiers.discogs_artist_id == 999
+        assert response.identifiers.spotify_album_id == "abc123def"
+        assert response.streaming is not None
+        assert response.streaming.on_streaming is True
+
+    @pytest.mark.asyncio
+    async def test_master_url_returns_warning(self):
+        discogs = AsyncMock()
+        deps = _deps(discogs=discogs)
+
+        # Streaming check should not run when canonical is missing.
+        with patch("release.orchestrator.check_streaming_availability") as cs:
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/master/789"), deps
+            )
+
+        cs.assert_not_called()
+        assert response.source == "discogs_master"
+        assert response.identifiers.discogs_master_id == 789
+        assert any("master" in w.lower() for w in response.warnings)
+
+
+class TestBandcampBranch:
+    @pytest.mark.asyncio
+    async def test_short_circuits_bandcamp_streaming_check(self):
+        # The DJ pasted a Bandcamp URL — we should mark Bandcamp as a confident
+        # match and not waste a fuzzy lookup.
+        bandcamp = MagicMock()
+        # Stub fetch_bandcamp_album_html via the resolver layer.
+        with (
+            patch(
+                "release.orchestrator.resolve_bandcamp_album",
+                new=AsyncMock(),
+            ) as mock_resolve,
+            patch(
+                "release.orchestrator.check_streaming_availability",
+                new=AsyncMock(return_value=_stream(on_streaming=False)),
+            ),
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import CanonicalRelease, ReleaseIdentifiers
+
+            url = "https://juana-molina.bandcamp.com/album/doga"
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=CanonicalRelease(artist="Juana Molina", title="DOGA", label=None),
+                identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
+                warnings=[],
+            )
+
+            response = await resolve_release(
+                ReleaseResolveRequest(url=url), _deps(bandcamp=bandcamp)
+            )
+
+        assert response.source == "bandcamp"
+        assert response.canonical.label is None  # self-released stays null
+        assert response.streaming is not None
+        # Short-circuit: Bandcamp pinned to the input URL with confidence 100,
+        # on_streaming flipped to True.
+        assert response.streaming.sources.bandcamp is not None
+        assert response.streaming.sources.bandcamp.url == url
+        assert response.streaming.sources.bandcamp.confidence == 100.0
+        assert response.streaming.on_streaming is True
+
+    @pytest.mark.asyncio
+    async def test_bandcamp_fetch_failure_returns_warnings(self):
+        bandcamp = MagicMock()
+        with (
+            patch(
+                "release.orchestrator.resolve_bandcamp_album",
+                new=AsyncMock(),
+            ) as mock_resolve,
+            patch("release.orchestrator.check_streaming_availability") as cs,
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import ReleaseIdentifiers
+
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=None,
+                identifiers=ReleaseIdentifiers(bandcamp_album_url="https://x.bandcamp.com/album/y"),
+                warnings=["could not be fetched"],
+            )
+
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://x.bandcamp.com/album/y"),
+                _deps(bandcamp=bandcamp),
+            )
+
+        cs.assert_not_called()
+        assert response.canonical.artist == ""
+        assert response.warnings == ["could not be fetched"]
+        assert response.streaming is None
+
+
+class TestStreamingFailureSurfacesAsWarning:
+    @pytest.mark.asyncio
+    async def test_streaming_exception_does_not_break_response(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        deps = _deps(discogs=discogs)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(side_effect=RuntimeError("streaming exploded")),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        # Canonical metadata is still returned; streaming is null + warning logged.
+        assert response.canonical.artist == "Juana Molina"
+        assert response.streaming is None
+        assert any("Streaming" in w for w in response.warnings)
+
+
+class TestIdentityWriteBack:
+    @pytest.mark.asyncio
+    async def test_writes_back_when_store_present(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        store = AsyncMock()
+        deps = _deps(discogs=discogs, entity_store=store)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        store.upsert_identity.assert_awaited_once()
+        args, kwargs = store.upsert_identity.call_args
+        assert args[0] == "Juana Molina"
+        assert kwargs["discogs_artist_id"] == 999
+
+    @pytest.mark.asyncio
+    async def test_skips_when_store_unavailable(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        deps = _deps(discogs=discogs, entity_store=None)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        # No exception, no warning — identity write-back is best-effort.
+        assert "identifiers" not in " ".join(response.warnings).lower()
+
+    @pytest.mark.asyncio
+    async def test_writeback_failure_becomes_warning(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        store = AsyncMock()
+        store.upsert_identity.side_effect = RuntimeError("PG down")
+        deps = _deps(discogs=discogs, entity_store=store)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        # Caller still gets a usable response.
+        assert response.canonical.artist == "Juana Molina"
+        assert any("identifiers" in w.lower() for w in response.warnings)
+
+    @pytest.mark.asyncio
+    async def test_bandcamp_writeback_uses_slug(self):
+        bandcamp = MagicMock()
+        store = AsyncMock()
+        with (
+            patch(
+                "release.orchestrator.resolve_bandcamp_album",
+                new=AsyncMock(),
+            ) as mock_resolve,
+            patch(
+                "release.orchestrator.check_streaming_availability",
+                new=AsyncMock(return_value=_stream()),
+            ),
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import CanonicalRelease, ReleaseIdentifiers
+
+            url = "https://juana-molina.bandcamp.com/album/doga"
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=CanonicalRelease(artist="Juana Molina", title="DOGA"),
+                identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
+                warnings=[],
+            )
+
+            await resolve_release(
+                ReleaseResolveRequest(url=url),
+                _deps(bandcamp=bandcamp, entity_store=store),
+            )
+
+        kwargs = store.upsert_identity.call_args.kwargs
+        # The slug, not the full URL — matches what bandcamp_pipeline.py writes.
+        assert kwargs["bandcamp_id"] == "juana-molina"

--- a/tests/unit/release/test_router.py
+++ b/tests/unit/release/test_router.py
@@ -1,0 +1,137 @@
+"""HTTP-layer tests for POST /api/v1/releases/resolve."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from generated.api_models import (
+    DiscogsLabelCredit,
+    DiscogsReleaseMetadata,
+)
+from release.dependencies import get_resolver_dependencies
+from release.orchestrator import _ResolverDependencies
+from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
+from tests.unit.conftest import override_deps
+
+
+def _release(**overrides) -> DiscogsReleaseMetadata:
+    base = {
+        "release_id": 12345,
+        "title": "DOGA",
+        "artist": "Juana Molina",
+        "year": 2024,
+        "label": "Sonamos",
+        "artist_id": 999,
+        "labels": [DiscogsLabelCredit(label_id=42, name="Sonamos", catno="SON-001")],
+        "release_url": "https://www.discogs.com/release/12345",
+    }
+    base.update(overrides)
+    return DiscogsReleaseMetadata.model_validate(base)
+
+
+def _deps_with_discogs(release):
+    """Build a _ResolverDependencies whose Discogs service returns the given release."""
+    discogs = AsyncMock()
+    discogs.get_release.return_value = release
+    return _ResolverDependencies(
+        discogs=discogs,
+        bandcamp=MagicMock(),
+        spotify=None,
+        deezer=None,
+        apple_music=None,
+        entity_store=None,
+    )
+
+
+class TestResolveEndpoint:
+    @pytest.mark.asyncio
+    async def test_validation_error_when_neither_url_nor_explicit(self, mock_settings):
+        from main import app
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/api/v1/releases/resolve", json={})
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_url_returns_200_with_warning(self, mock_settings):
+        from main import app
+
+        with override_deps(
+            app,
+            {get_resolver_dependencies: _deps_with_discogs(release=None)},
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/releases/resolve",
+                    json={"url": "https://example.com/foo"},
+                )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["canonical"]["artist"] == ""
+        assert any("recognize the URL" in w for w in body["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_discogs_release_url_returns_canonical_metadata(self, mock_settings, monkeypatch):
+        from main import app
+
+        # Stub the streaming fan-out so this test exercises only the router + orchestrator,
+        # not the streaming clients.
+        async def fake_check(*args, **kwargs):
+            return StreamingCheckResponse(on_streaming=False, sources=StreamingCheckSources())
+
+        monkeypatch.setattr("release.orchestrator.check_streaming_availability", fake_check)
+
+        with override_deps(app, {get_resolver_dependencies: _deps_with_discogs(_release())}):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/releases/resolve",
+                    json={"url": "https://www.discogs.com/release/12345"},
+                )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["source"] == "discogs_release"
+        assert body["source_id"] == "12345"
+        assert body["canonical"]["artist"] == "Juana Molina"
+        assert body["canonical"]["title"] == "DOGA"
+        assert body["canonical"]["label"] == "Sonamos"
+        assert body["canonical"]["catno"] == "SON-001"
+        assert body["identifiers"]["discogs_release_id"] == 12345
+
+    @pytest.mark.asyncio
+    async def test_explicit_source_and_id(self, mock_settings, monkeypatch):
+        from main import app
+
+        async def fake_check(*args, **kwargs):
+            return StreamingCheckResponse(
+                on_streaming=True,
+                sources=StreamingCheckSources(
+                    spotify=SourceMatch(url="https://open.spotify.com/album/abc", confidence=95.0)
+                ),
+            )
+
+        monkeypatch.setattr("release.orchestrator.check_streaming_availability", fake_check)
+
+        with override_deps(app, {get_resolver_dependencies: _deps_with_discogs(_release())}):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/releases/resolve",
+                    json={"source": "discogs_release", "id": "12345"},
+                )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["source"] == "discogs_release"
+        assert body["streaming"]["on_streaming"] is True
+        assert body["identifiers"]["spotify_album_id"] == "abc"

--- a/tests/unit/release/test_url_parser.py
+++ b/tests/unit/release/test_url_parser.py
@@ -1,0 +1,90 @@
+"""Tests for the Discogs/Bandcamp URL parser used by /api/v1/releases/resolve."""
+
+from __future__ import annotations
+
+import pytest
+
+from release.url_parser import ParsedUrl, parse_url
+
+
+class TestDiscogsRelease:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.discogs.com/release/12345",
+            "https://discogs.com/release/12345",
+            "http://discogs.com/release/12345",
+        ],
+    )
+    def test_parses_release(self, url):
+        assert parse_url(url) == ParsedUrl(source="discogs_release", identifier="12345")
+
+    def test_strips_url_slug(self):
+        # Discogs canonical URLs include a slug after the ID.
+        assert parse_url("https://www.discogs.com/release/12345-Some-Album") == ParsedUrl(
+            source="discogs_release", identifier="12345"
+        )
+
+    def test_locale_subpath(self):
+        # Discogs serves /<locale>/release/<id> for some users.
+        assert parse_url("https://www.discogs.com/es/release/12345") == ParsedUrl(
+            source="discogs_release", identifier="12345"
+        )
+
+
+class TestDiscogsMaster:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.discogs.com/master/789",
+            "https://discogs.com/master/789-Some-Master",
+        ],
+    )
+    def test_parses_master(self, url):
+        assert parse_url(url) == ParsedUrl(source="discogs_master", identifier="789")
+
+
+class TestBandcamp:
+    def test_parses_album_url(self):
+        result = parse_url("https://autechre.bandcamp.com/album/confield")
+        assert result is not None
+        assert result.source == "bandcamp"
+        assert result.identifier == "https://autechre.bandcamp.com/album/confield"
+
+    def test_canonicalizes_trailing_slash(self):
+        # Trailing slash should be stripped so equality comparisons line up.
+        assert parse_url("https://autechre.bandcamp.com/album/confield/") == ParsedUrl(
+            source="bandcamp", identifier="https://autechre.bandcamp.com/album/confield"
+        )
+
+    def test_preserves_subdomain_with_hyphens(self):
+        # Real Bandcamp slugs include hyphens.
+        result = parse_url("https://chuquimamani-condori.bandcamp.com/album/edits")
+        assert result is not None
+        assert result.identifier == "https://chuquimamani-condori.bandcamp.com/album/edits"
+
+
+class TestUnsupported:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/release/123",
+            "https://discogs.com/artist/3840",  # artist URLs not supported
+            "https://discogs.com/label/123",  # label URLs not supported
+            "https://autechre.bandcamp.com/track/something",  # tracks not albums
+            "https://autechre.bandcamp.com/",  # bare bandcamp page, no album
+            "https://bandcamp.com/album/foo",  # missing artist subdomain
+            "ftp://discogs.com/release/123",  # not http(s)
+            "discogs.com/release/123",  # missing scheme
+            "not a url",
+            "",
+            "   ",
+        ],
+    )
+    def test_returns_none_for_unsupported(self, url):
+        assert parse_url(url) is None
+
+    def test_returns_none_for_none_input(self):
+        # The orchestrator may pass user input directly; tolerate but reject.
+        # Pydantic catches None upstream, but defense-in-depth.
+        assert parse_url("") is None

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -128,6 +128,7 @@ class TestProtectedRouteRegistration:
 
     EXPECTED_PROTECTED = [
         ("POST", "/api/v1/streaming-check"),
+        ("POST", "/api/v1/releases/resolve"),
         ("GET", "/api/v1/library/search"),
         ("POST", "/api/v1/lookup"),
         ("GET", "/api/v1/discogs/track-releases"),


### PR DESCRIPTION
## Summary

- New endpoint `POST /api/v1/releases/resolve` (under the existing `LML_API_KEY` gate) that takes a Discogs release URL or Bandcamp album URL and returns canonical fields + cross-source identifiers + streaming availability.
- New `release/` module: pure URL parser, Discogs resolver (wraps existing `DiscogsService.get_release`), Bandcamp resolver (rate-limited fetch + JSON-LD parser), orchestrator, FastAPI router + DI.
- Bandcamp short-circuit when the input itself is a Bandcamp URL — confidence 100 instead of fuzzy-matching.
- Identity write-back via existing `EntityStore.upsert_identity` (`ON CONFLICT ... DO UPDATE` with `COALESCE`) — never clobbers existing data.
- Genres/styles intentionally excluded (rotation form has no genre field).
- Always returns 200; partial failures surface in `warnings[]`.

PR #5 in the LML auth + prefill rollout. Prior: #165 (auth dep, merged), WXYC/Backend-Service#535, WXYC/tubafrenzy#509.

Closes #170

## Test plan

- [x] `pytest tests/unit/` — **1476 passed** (62 new in `tests/unit/release/`)
- [x] `ruff check .`, `ruff format --check .`, `mypy .` all clean
- [x] Auth route-registration guardrail (`tests/unit/test_auth.py`) updated to include the new endpoint
- [ ] CI passes
- [ ] Manual smoke after deploy: paste a Discogs release URL via the staged tubafrenzy form (PR #6) and confirm prefill round-trips