### PR TITLE
chore: migrate pytest markers to architecture A

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - run: mypy . --ignore-missing-imports
 
   test:
-    name: Unit Tests
+    name: Default Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,10 @@ jobs:
           maturin build --release
           pip install /tmp/wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[dev]"
-      - run: pytest tests/unit/ -v --cov=. --cov-report=xml
+      # Default `pytest` honours pyproject addopts (`-m 'not pg and not external_api'`),
+      # so this job runs every unmarked test across tests/unit/, tests/integration/, and
+      # tests/e2e/. Infra-tagged tests run in their own jobs (`pg`, `external_api`).
+      - run: pytest -v --cov=. --cov-report=xml
       - name: Upload coverage reports
         uses: codecov/codecov-action@v4
         with:
@@ -90,8 +93,8 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  e2e:
-    name: E2E Tests
+  external_api:
+    name: External API Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -107,17 +110,16 @@ jobs:
           maturin build --release
           pip install /tmp/wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[dev]"
-      - name: Run E2E tests
-        # tests/e2e/test_lookup_e2e.py runs against in-memory SQLite + mock Discogs.
-        # tests/e2e/discogs/* requires DISCOGS_TOKEN and self-skips at collection
-        # when no credentials are present (see tests/e2e/discogs/conftest.py); it
-        # is exercised by the deploy-time integration job, not on every PR.
+      - name: Run external_api tests
+        # tests/e2e/discogs/* and the real-API classes in tests/integration/test_api_discogs.py
+        # require DISCOGS_TOKEN. They self-skip at collection if no credentials are present
+        # (PR runs from forks may have no secret access).
         env:
           DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
-        run: pytest tests/e2e/ -v -m "e2e"
+        run: pytest -v -m "external_api"
 
-  test-postgres:
-    name: Postgres Tests
+  pg:
+    name: PG Tests
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -147,13 +149,14 @@ jobs:
           maturin build --release
           pip install /tmp/wxyc-etl/target/wheels/*.whl
       - run: pip install -e ".[dev]"
-      - name: Run Postgres tests
-        # Reconciliation tests skip themselves when release_artist is missing,
-        # which is fine: the discogs-cache fixture is too large to load in CI.
-        # The EntityStore CRUD tests run fully against a fresh schema.
+      - name: Run PG tests
+        # EntityStore CRUD runs end-to-end against a fresh schema. Reconciliation tests
+        # skip themselves when release_artist is missing -- the discogs-cache fixture is
+        # too large to load in CI. test_va_discogs_lookup.py self-skips without
+        # DATABASE_URL_DISCOGS, which is intentional in CI.
         env:
           DATABASE_URL_TEST: postgresql://discogs:discogs@localhost:5433/discogs
-        run: pytest tests/integration/ -v -m "postgres"
+        run: pytest -v -m "pg"
 
   marker-sync:
     name: CI Marker Sync
@@ -167,7 +170,7 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [lint, typecheck, test, e2e, test-postgres]
+    needs: [lint, typecheck, test, external_api, pg]
     steps:
       - uses: actions/checkout@v4
       - name: Install Railway CLI
@@ -205,36 +208,11 @@ jobs:
           print('Smoke test passed:', json.dumps(services))
           "
 
-  integration:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [smoke-test-staging]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from source
-        run: |
-          pip install maturin
-          git clone --depth 1 https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python
-          maturin build --release
-          pip install /tmp/wxyc-etl/target/wheels/*.whl
-      - run: pip install -e ".[dev]"
-      - name: Run integration tests
-        env:
-          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
-          TEST_ENV: staging
-        run: pytest tests/integration/ -v -m "integration"
-
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'
-    needs: [lint, typecheck, test, e2e, test-postgres]
+    needs: [lint, typecheck, test, external_api, pg]
     steps:
       - uses: actions/checkout@v4
       - name: Install Railway CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,19 +199,31 @@ Untouched: `/health`, `/identity/resolve`, `/identity/bulk`. Identity routes are
 |---|---|---|
 | Lint & Format | All pushes + PRs | -- |
 | Type Check | All pushes + PRs | -- |
-| Unit Tests | All pushes + PRs | -- |
-| E2E Tests | All pushes + PRs | -- |
-| Postgres Tests | All pushes + PRs | -- |
+| Default Tests | All pushes + PRs | -- |
+| External API Tests | All pushes + PRs | -- |
+| PG Tests | All pushes + PRs | -- |
 | CI Marker Sync | All pushes + PRs | -- |
-| Deploy to Staging | Push to `main` | lint, typecheck, test, e2e, test-postgres |
+| Deploy to Staging | Push to `main` | lint, typecheck, test, external_api, pg |
 | Smoke Test (Staging) | Push to `main` | deploy-staging |
-| Integration Tests | Push to `main` | smoke-test-staging |
-| Deploy to Production | Push to `prod` | lint, typecheck, test, e2e, test-postgres |
+| Deploy to Production | Push to `prod` | lint, typecheck, test, external_api, pg |
 | Smoke Test (Production) | Push to `prod` | deploy-production |
 
-**E2E Tests** run `pytest tests/e2e/ -v -m e2e`. The `tests/e2e/test_lookup_e2e.py` suite uses an in-memory SQLite library and a mock Discogs service — no credentials required. The `tests/e2e/discogs/test_endpoints.py` suite hits the real Discogs API and self-skips at collection if `DISCOGS_TOKEN` is unset (PR runs from forks may have no secret access).
+### Pytest markers (architecture A)
 
-**Postgres Tests** run `pytest tests/integration/ -v -m postgres` against a `postgres:16-alpine` service container on port 5433. The `EntityStore` CRUD tests run end-to-end against a fresh `entity` schema. The Discogs reconciliation tests skip themselves when the `release_artist` table is missing — that table is part of the discogs-cache fixture and is too large to load in CI.
+Markers route CI by infrastructure, not taxonomy. See the WXYC test-patterns guide (`plans/test-patterns.md`, Section 3) for the canonical vocabulary; LML uses two:
+
+| Marker | Meaning | CI provisions |
+|---|---|---|
+| `pg` | needs a PostgreSQL service | `postgres:16-alpine` service container, `DATABASE_URL_TEST` |
+| `external_api` | needs a real third-party API key (Discogs) | `DISCOGS_TOKEN` secret |
+
+Default `pytest` (no `-m`) runs every unmarked test across `tests/unit/`, `tests/integration/`, and `tests/e2e/`. Tier directories are documentation; CI routes by markers.
+
+**Default Tests** runs `pytest -v --cov=...` -- pyproject's `addopts = "-m 'not pg and not external_api'"` excludes the infra-tagged tests.
+
+**External API Tests** runs `pytest -v -m external_api`. The `tests/e2e/discogs/*` suite and the `TestDiscogsApiSearch` / `TestEntityResolution` classes in `tests/integration/test_api_discogs.py` hit the real Discogs API; they self-skip at collection if `DISCOGS_TOKEN` is unset (PR runs from forks may have no secret access).
+
+**PG Tests** runs `pytest -v -m pg` against a `postgres:16-alpine` service container on port 5433. The `EntityStore` CRUD tests in `tests/integration/test_entity_resolution.py` run end-to-end against a fresh `entity` schema. The Discogs reconciliation tests skip themselves when the `release_artist` table is missing -- that table is part of the discogs-cache fixture and is too large to load in CI. `tests/integration/test_va_discogs_lookup.py` self-skips without `DATABASE_URL_DISCOGS`, which is intentional in CI.
 
 **CI Marker Sync** invokes the reusable workflow at `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml` to guarantee that every `@pytest.mark.<X>` actually used by a test is either re-selected by some CI `pytest -m` invocation or explicitly opted out via a `# ci-sync-skip: <marker> reason: <text>` comment in `pyproject.toml`. This guards against the silent-deselection bug pattern (WXYC/discogs-etl#103, WXYC/library-metadata-lookup#159).
 

--- a/README.md
+++ b/README.md
@@ -178,19 +178,19 @@ uvicorn main:app --reload
 
 ### Running tests
 
+The repo follows the architecture-A marker scheme (see the WXYC test-patterns guide, Section 3): markers route CI by infrastructure, not by tier. Tier directories (`tests/unit/`, `tests/integration/`, `tests/e2e/`) survive for documentation only.
+
 ```bash
-# Unit tests only (default, fast -- 472 tests)
-uv run pytest tests/unit/ -v
+# Default: every unmarked test (unit-equivalent + the in-memory-SQLite/mocked
+# integration + e2e tests). Excludes pg + external_api per pyproject addopts.
+uv run pytest -v
 
-# Integration tests only (real SQLite/FTS5 -- 48 tests)
-uv run pytest -m integration -v
+# PG-backed tests (entity store CRUD, etc.). Needs DATABASE_URL_TEST.
+uv run pytest -v -m pg
 
-# All tests with coverage (520 tests, 97% source coverage)
-uv run pytest -m "" --cov=. --cov-report=term-missing -v
+# Real-Discogs-API tests. Needs DISCOGS_TOKEN.
+uv run pytest -v -m external_api
 ```
-
-Integration tests use a real in-memory SQLite database with FTS5 and seed data.
-They are excluded by default (`addopts = "-m 'not integration'"` in `pyproject.toml`).
 
 ## Environment Variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,13 +95,10 @@ follow_untyped_imports = true
 
 [tool.pytest.ini_options]
 markers = [
-    "unit: pure logic tests, no external dependencies",
-    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
-    "integration: needs external service or fixture data",
-    "e2e: full pipeline end-to-end test",
-    "slow: marks tests as slow",
+    "pg: needs a PostgreSQL service (DATABASE_URL_TEST)",
+    "external_api: needs network + a real API key (e.g. DISCOGS_TOKEN)",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not slow'"
+addopts = "-m 'not pg and not external_api'"
 console_output_style = "progress"
 testpaths = ["tests"]
 pythonpath = ["."]

--- a/tests/e2e/discogs/test_endpoints.py
+++ b/tests/e2e/discogs/test_endpoints.py
@@ -6,29 +6,11 @@ DISCOGS_API_KEY + DISCOGS_API_SECRET is set (see conftest).
 
 import pytest
 
-pytestmark = [pytest.mark.e2e, pytest.mark.asyncio]
+pytestmark = [pytest.mark.external_api, pytest.mark.asyncio]
 
 
-class TestDiscogsSearch:
-    async def test_search_returns_results_for_known_artist(self, real_discogs_client):
-        response = await real_discogs_client.post(
-            "/api/v1/discogs/search",
-            json={"artist": "Stereolab", "album": "Dots and Loops"},
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data["results"]) > 0
-        assert data["results"][0]["release_id"] is not None
-        assert "release_url" in data["results"][0]
-
-    async def test_search_returns_empty_for_nonexistent(self, real_discogs_client):
-        response = await real_discogs_client.post(
-            "/api/v1/discogs/search",
-            json={"artist": "xyznonexistent12345", "album": "nothing"},
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["results"] == []
+# /api/v1/discogs/search was removed in commit c5f1e65 (PR #157), so the
+# TestDiscogsSearch class that previously lived here is gone.
 
 
 class TestDiscogsRelease:

--- a/tests/e2e/test_lookup_e2e.py
+++ b/tests/e2e/test_lookup_e2e.py
@@ -12,8 +12,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-pytestmark = pytest.mark.e2e
-
 
 class TestDirectLookup:
     """Artist + album lookups that hit the library directly."""

--- a/tests/integration/test_api_discogs.py
+++ b/tests/integration/test_api_discogs.py
@@ -7,8 +7,6 @@ import pytest
 from discogs.models import DiscogsSearchRequest
 from discogs.service import DiscogsService
 
-pytestmark = pytest.mark.integration
-
 
 class TestDiscogsEndpoints:
     @pytest.mark.asyncio
@@ -21,10 +19,7 @@ class TestDiscogsEndpoints:
         resp = await app_client.get("/api/v1/discogs/release/123")
         assert resp.status_code == 503
 
-    @pytest.mark.asyncio
-    async def test_search_503_without_service(self, app_client):
-        resp = await app_client.post("/api/v1/discogs/search", json={"artist": "Queen"})
-        assert resp.status_code == 503
+    # /api/v1/discogs/search was removed in commit c5f1e65 (PR #157).
 
     @pytest.mark.asyncio
     async def test_artist_503_without_service(self, app_client):
@@ -37,6 +32,7 @@ class TestDiscogsEndpoints:
         assert resp.status_code == 503
 
 
+@pytest.mark.external_api
 class TestDiscogsApiSearch:
     """Tests that hit the real Discogs API (no cache) to verify search results."""
 
@@ -66,6 +62,7 @@ class TestDiscogsApiSearch:
         )
 
 
+@pytest.mark.external_api
 class TestEntityResolution:
     """Integration tests for entity resolution using real Discogs API."""
 

--- a/tests/integration/test_api_health.py
+++ b/tests/integration/test_api_health.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.integration
-
 
 class TestHealthEndpoint:
     @pytest.mark.asyncio

--- a/tests/integration/test_api_library.py
+++ b/tests/integration/test_api_library.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.integration
-
 
 class TestLibrarySearchEndpoint:
     @pytest.mark.asyncio

--- a/tests/integration/test_cache_fallback.py
+++ b/tests/integration/test_cache_fallback.py
@@ -13,8 +13,6 @@ import pytest
 
 from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 
-pytestmark = pytest.mark.integration
-
 
 class TestCacheFallbackOnCorruptedData:
     """Cache DB with corrupted release rows triggers fallback to API."""

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -3,7 +3,7 @@
 These tests run against a test PostgreSQL (Docker on port 5433) with the
 entity schema applied and Discogs fixture data loaded.
 
-Run with: pytest -m postgres -v
+Run with: pytest -m pg -v
 Requires: DATABASE_URL_TEST env var or Docker postgres on port 5433.
 """
 
@@ -87,7 +87,7 @@ async def set_up_entity_schema(pg_pool):
         await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
 
 
-@pytest.mark.postgres
+@pytest.mark.pg
 class TestEntityStoreCRUD:
     """Test entity store CRUD operations against real PostgreSQL."""
 
@@ -150,7 +150,7 @@ class TestEntityStoreCRUD:
         assert rows[0]["method"] == "exact_match"
 
 
-@pytest.mark.postgres
+@pytest.mark.pg
 class TestDiscogsReconciliationIntegration:
     """Test Discogs reconciliation against real discogs-cache data.
 
@@ -185,7 +185,7 @@ class TestDiscogsReconciliationIntegration:
             assert match.method in ("exact_match", "member_group", "alias_match", "name_variation")
 
 
-@pytest.mark.postgres
+@pytest.mark.pg
 class TestDeduplicationIntegration:
     """Test deduplication against real PostgreSQL."""
 

--- a/tests/integration/test_error_resilience.py
+++ b/tests/integration/test_error_resilience.py
@@ -16,9 +16,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import pytest_asyncio
 
-pytestmark = pytest.mark.integration
-
-
 # ---------------------------------------------------------------------------
 # WXYC example artist names for bulk tests
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_library_db.py
+++ b/tests/integration/test_library_db.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.integration
-
 
 class TestFTS5Search:
     @pytest.mark.asyncio

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -13,8 +13,6 @@ from discogs.models import (
     TrackReleasesResponse,
 )
 
-pytestmark = pytest.mark.integration
-
 
 class TestLookupPipeline:
     @pytest.mark.asyncio

--- a/tests/integration/test_memory_cache.py
+++ b/tests/integration/test_memory_cache.py
@@ -10,8 +10,6 @@ from discogs.memory_cache import (
     set_skip_cache,
 )
 
-pytestmark = pytest.mark.integration
-
 
 class TestCacheIntegration:
     @pytest.fixture(autouse=True)

--- a/tests/integration/test_streaming_links.py
+++ b/tests/integration/test_streaming_links.py
@@ -5,8 +5,6 @@ import pytest
 
 from library.db import LibraryDB
 
-pytestmark = pytest.mark.integration
-
 
 async def _create_library_db_with_streaming(db_path, *, include_streaming_table=True):
     """Create a library.db with library + optional streaming_links tables."""

--- a/tests/integration/test_va_discogs_lookup.py
+++ b/tests/integration/test_va_discogs_lookup.py
@@ -17,7 +17,10 @@ from scripts.va_disambiguate.discogs_lookup import (
 )
 
 DATABASE_URL = os.environ.get("DATABASE_URL_DISCOGS")
-pytestmark = pytest.mark.skipif(not DATABASE_URL, reason="DATABASE_URL_DISCOGS not set")
+pytestmark = [
+    pytest.mark.pg,
+    pytest.mark.skipif(not DATABASE_URL, reason="DATABASE_URL_DISCOGS not set"),
+]
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Summary

Drops the legacy `unit / integration / e2e / postgres / slow` marker scheme in favour of architecture A from the WXYC test-patterns guide (`plans/test-patterns.md`, Section 3): markers route CI by infrastructure, tier directories carry no semantic weight. Resulting LML marker vocabulary is just `pg` and `external_api`.

## Rename mapping (from the test-patterns migration table)

- `unit` -> default (no marker). Unused in LML anyway.
- `postgres` -> `pg`.
- `integration` -> unmarked OR `pg` OR `external_api`, per file-by-file judgment (LML is a consumer, so the mix is heterogeneous).
- `e2e` -> unmarked OR `external_api`. Tier directory `tests/e2e/` survives.

## Per-marker counts (file/decoration level)

Before: `integration` 9 file-level, `e2e` 2 file-level, `postgres` 3 class-level. `unit`, `parity`, `slow` 0.

After: `pg` 1 file-level + 4 class-level (test_va_discogs_lookup file + 3 classes in test_entity_resolution + 1 added comment use). `external_api` 1 file-level + 2 class-level (test_endpoints file + TestDiscogsApiSearch + TestEntityResolution).

Test collection (1553 total): default `pytest` collects 1530 (23 deselected), `pytest -m pg` 9, `pytest -m external_api` 14.

## Per-file integration reclassification (judgment calls)

Unmarked (in-memory SQLite or pure-mock; no infra needed): `test_api_health.py`, `test_api_library.py`, `test_library_db.py`, `test_memory_cache.py`, `test_cache_fallback.py`, `test_lookup_pipeline.py`, `test_streaming_links.py`, `test_alternate_artist.py`, `test_error_resilience.py`. The lone real-PG test in `test_error_resilience.py::TestSourceTransportFailures::test_pg_source_bad_credentials` self-skips when port 5433 is closed -- not worth a dedicated `pg` marker for one case.

`test_api_discogs.py`: split into 3 classes via class-level decoration. `TestDiscogsEndpoints` stays unmarked (uses `app_client`); `TestDiscogsApiSearch` and `TestEntityResolution` become `external_api` (real Discogs API).

`test_va_discogs_lookup.py`: `pg`. Kept the existing `pytest.mark.skipif(not DATABASE_URL_DISCOGS, ...)` so it self-skips in CI where the discogs-cache-shaped data isn't present.

`test_entity_resolution.py`: `pg` (renamed from `postgres` on each of 3 classes; entity schema is created fresh per test against the CI PG service container).

## E2E reclassification

`tests/e2e/test_lookup_e2e.py` -> unmarked. Uses in-memory SQLite + mocked Discogs; no credentials needed.

`tests/e2e/discogs/test_endpoints.py` -> `external_api`. The conftest already self-skips at collection without `DISCOGS_TOKEN` (which is what PR #167 wired).

## CI changes

- Rename `e2e` job -> `external_api` (`pytest -v -m "external_api"`).
- Rename `test-postgres` job -> `pg` (`pytest -v -m "pg"`).
- Broaden the default `test` job to `pytest -v --cov=...` -- no more `tests/unit/` restriction, so unmarked tests across `tests/integration/` and `tests/e2e/` run there. pyproject's `addopts = "-m 'not pg and not external_api'"` keeps infra tests out.
- Drop the post-deploy `Integration Tests` job (`-m integration` is gone; the staging smoke test covers post-deploy validation).
- Keep the `marker-sync` job from PR #167 wired exactly as-is.

## Drive-by fixes

PR #167 added `TestDiscogsSearch` in `tests/e2e/discogs/test_endpoints.py` and `TestDiscogsEndpoints.test_search_503_without_service` in `tests/integration/test_api_discogs.py` that hit `POST /api/v1/discogs/search`. That endpoint was removed in commit c5f1e65 (PR #157). Both tests were masked by addopts deselecting the legacy markers on PRs. Broadening the default `test` job in this PR would surface them immediately, so I dropped both rather than leave the migration with red CI.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy . --ignore-missing-imports` -- success in 210 files
- [x] `python3 check_marker_ci_sync.py --repo-path .` -- PASS
- [x] `pytest -q --no-cov` (default) -- 1527 passed, 21 deselected, 2 xfailed
- [x] `pytest --collect-only -m pg` -- 9 collected
- [x] `pytest --collect-only -m external_api` -- 14 collected
- [ ] CI green on the new `pg` and `external_api` jobs (pending)