### PR TITLE
Add Bandcamp branch to /api/v1/releases/resolve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,12 @@ Requires `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` for Spotify checks. Oth
 
 ### Release Resolve Endpoint
 
-`POST /api/v1/releases/resolve` takes a Discogs release URL (or an explicit `(source, id)` pair) and returns canonical release metadata, cross-source identifiers, and a streaming-availability snapshot — everything tubafrenzy's rotation-release create form needs to prefill in one round trip. Bandcamp URL support lands in a follow-up PR; pasting a Bandcamp URL today returns a clear "not yet supported" warning.
+`POST /api/v1/releases/resolve` takes a Discogs release URL or Bandcamp album URL (or an explicit `(source, id)` pair) and returns canonical release metadata, cross-source identifiers, and a streaming-availability snapshot — everything tubafrenzy's rotation-release create form needs to prefill in one round trip.
 
-Request:
+Request (one of):
 ```json
 { "url": "https://www.discogs.com/release/12345" }
+{ "url": "https://artist.bandcamp.com/album/slug" }
 { "source": "discogs_release", "id": "12345" }
 ```
 
@@ -86,20 +87,21 @@ Response:
   "source": "discogs_release",
   "source_id": "12345",
   "canonical": { "artist": "Juana Molina", "title": "DOGA", "label": "Sonamos", "catno": "SON-001", "year": 2024, "country": null, "formats": [] },
-  "identifiers": { "discogs_release_id": 12345, "discogs_artist_id": 999, "spotify_album_id": "abc...", ... },
+  "identifiers": { "discogs_release_id": 12345, "discogs_artist_id": 999, "spotify_album_id": "abc...", "bandcamp_album_url": null, ... },
   "streaming": { "on_streaming": true, "sources": { ... } },
   "warnings": []
 }
 ```
 
 Implementation lives in `release/`:
-- `url_parser.py` — pure URL → `(source, id)` parser. Supports Discogs `/release/<id>` and `/master/<id>` (with locale prefixes and slugs); also recognizes Bandcamp `<artist>.bandcamp.com/album/<slug>` so the orchestrator can return a clean "not yet supported" warning instead of "unknown URL".
+- `url_parser.py` — pure URL → `(source, id)` parser. Supports Discogs `/release/<id>` and `/master/<id>` (with locale prefixes and slugs) and Bandcamp `<artist>.bandcamp.com/album/<slug>`.
 - `discogs_resolver.py` — wraps `DiscogsService.get_release()` so the existing 3-tier cache + API rate-limit handling applies.
-- `orchestrator.py` — dispatches by source, runs `check_streaming_availability` (Spotify / Deezer / Apple Music; the Bandcamp leg is wired in the follow-up PR), and writes any newly-discovered IDs back into `entity.identity` via the existing `EntityStore.upsert_identity()` (`ON CONFLICT ... DO UPDATE` with `COALESCE` — never clobbers).
+- `bandcamp_resolver.py` — fetches the Bandcamp album page (rate-limited via the existing `BandcampClient`) and parses the embedded JSON-LD `MusicAlbum` blob. Self-released (publisher subdomain == artist subdomain) returns `label: null`.
+- `orchestrator.py` — dispatches by source, runs `check_streaming_availability`. When the input is a Bandcamp URL, the Bandcamp leg of the streaming check is short-circuited (skipped) — we already know the answer and re-fuzzy-matching would burn 2+ rate-limited HTTP calls. Identity write-back via the existing `EntityStore.upsert_identity()` (`ON CONFLICT ... DO UPDATE` with `COALESCE` — never clobbers); Bandcamp `bandcamp_id` is the URL's slug, matching what `bandcamp_pipeline.py` writes.
 
 Genre and style are intentionally not surfaced — the rotation form has no genre field, so the music director picks manually.
 
-The endpoint always returns 200 with a `warnings[]` array. Partial failures (Discogs rate limit, missing master support, Bandcamp not yet wired) become warnings rather than 5xx; the form falls back to manual entry.
+The endpoint always returns 200 with a `warnings[]` array. Partial failures (Discogs rate limit, malformed Bandcamp page, missing master support) become warnings rather than 5xx; the form falls back to manual entry.
 
 `source` may be `"discogs_release"`, `"discogs_master"`, `"bandcamp"`, or `"unknown"`. Consumers should always check `warnings` before consuming `canonical`.
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ Get full release metadata from Discogs.
 
 ### `POST /api/v1/releases/resolve`
 
-Resolve a Discogs release URL (or an explicit `(source, id)` pair) to canonical release metadata, cross-source identifiers, and streaming availability — the prefill payload for tubafrenzy's rotation-release create form.
+Resolve a Discogs release URL or Bandcamp album URL (or an explicit `(source, id)` pair) to canonical release metadata, cross-source identifiers, and streaming availability — the prefill payload for tubafrenzy's rotation-release create form.
 
-Request: `{"url": "https://www.discogs.com/release/12345"}` or `{"source": "discogs_release", "id": "12345"}`.
+Request: `{"url": "https://www.discogs.com/release/12345"}` or `{"url": "https://artist.bandcamp.com/album/slug"}` or `{"source": "discogs_release", "id": "12345"}`.
 
-Response includes `canonical` (artist, title, label, catno, year), `identifiers` (cross-source IDs learned from Discogs + the streaming check), `streaming` (per-service availability), and `warnings[]` for non-fatal issues. Always returns 200 — the form falls back to manual entry on partial prefill. Bandcamp URL support comes in a follow-up PR.
+Response includes `canonical` (artist, title, label, catno, year), `identifiers` (cross-source IDs learned from Discogs + the streaming check), `streaming` (per-service availability), and `warnings[]` for non-fatal issues. Always returns 200 — the form falls back to manual entry on partial prefill.
 
 ### `POST /admin/upload-library-db`
 

--- a/release/bandcamp_resolver.py
+++ b/release/bandcamp_resolver.py
@@ -1,0 +1,175 @@
+"""Resolve a Bandcamp album URL to canonical fields + identifiers.
+
+Bandcamp does not have a public API. Every album page embeds a
+``<script type="application/ld+json">`` blob with schema.org MusicAlbum
+properties (``name``, ``byArtist.name``, ``publisher.name``, ``datePublished``)
+which is stable enough to scrape for the prefill flow.
+
+The "self-released" case is detected by comparing the album's host
+to the publisher's host: when an artist self-releases, Bandcamp lists the
+artist itself as the publisher, with the same subdomain. In that case we
+return ``label=None`` per the music director's instruction (don't pretend
+the artist is the label).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import urlparse
+
+import httpx
+
+from release.models import CanonicalRelease, ReleaseIdentifiers
+from scripts.bandcamp_client import BandcampClient
+
+logger = logging.getLogger(__name__)
+
+
+_LD_JSON_BLOCK_RE = re.compile(
+    r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
+    re.DOTALL,
+)
+
+
+@dataclass
+class BandcampResolveResult:
+    """Result of resolving a single Bandcamp album URL."""
+
+    canonical: CanonicalRelease | None
+    identifiers: ReleaseIdentifiers
+    warnings: list[str]
+
+
+def _host(url: str | None) -> str | None:
+    if not url:
+        return None
+    try:
+        return urlparse(url).netloc.lower() or None
+    except ValueError:
+        return None
+
+
+def _parse_year(date_published: str | None) -> int | None:
+    """Extract the year from Bandcamp's date string.
+
+    Bandcamp ships ``datePublished`` as ``"DD Mon YYYY HH:MM:SS GMT"`` (RFC-2822-ish
+    without the day-of-week). Try the most common shape; fall back to a regex
+    pull on a 4-digit year.
+    """
+    if not date_published:
+        return None
+    try:
+        return datetime.strptime(date_published, "%d %b %Y %H:%M:%S %Z").year
+    except (ValueError, TypeError):
+        match = re.search(r"\b(19|20)\d{2}\b", date_published)
+        return int(match.group()) if match else None
+
+
+def parse_bandcamp_album_html(html: str, album_url: str) -> BandcampResolveResult:
+    """Pull the JSON-LD blob out of an album page and project to canonical form.
+
+    Pure function — separated from the HTTP fetch so tests run against committed
+    fixtures and don't hit Bandcamp.
+    """
+    warnings: list[str] = []
+
+    blocks = _LD_JSON_BLOCK_RE.findall(html)
+    if not blocks:
+        return BandcampResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
+            warnings=["Bandcamp page did not contain a JSON-LD MusicAlbum block"],
+        )
+
+    # Find the MusicAlbum block (skip MusicGroup, BreadcrumbList, etc).
+    # Bandcamp ships @type as a string most of the time, but schema.org allows
+    # arrays (e.g. ["MusicAlbum", "Product"]); tolerate both shapes.
+    album_data: dict | None = None
+    for block in blocks:
+        try:
+            parsed = json.loads(block.strip())
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        type_value = parsed.get("@type")
+        types = type_value if isinstance(type_value, list) else [type_value]
+        if "MusicAlbum" in types:
+            album_data = parsed
+            break
+
+    if album_data is None:
+        return BandcampResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
+            warnings=["Bandcamp page JSON-LD did not contain a MusicAlbum entry"],
+        )
+
+    name = album_data.get("name")
+    by_artist = album_data.get("byArtist") or {}
+    artist_name = by_artist.get("name") if isinstance(by_artist, dict) else None
+    if not name or not artist_name:
+        return BandcampResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
+            warnings=["Bandcamp JSON-LD missing required name or byArtist.name"],
+        )
+
+    # Self-released: the artist subdomain *is* the publisher subdomain.
+    # Per the music director: don't pretend the artist is the label.
+    publisher = album_data.get("publisher") or {}
+    publisher_name = publisher.get("name") if isinstance(publisher, dict) else None
+    publisher_url = publisher.get("@id") if isinstance(publisher, dict) else None
+    artist_url = by_artist.get("@id") if isinstance(by_artist, dict) else None
+    label: str | None = publisher_name
+    if _host(publisher_url) and _host(artist_url) and _host(publisher_url) == _host(artist_url):
+        label = None
+
+    canonical = CanonicalRelease(
+        artist=artist_name,
+        title=name,
+        label=label,
+        catno=None,  # Bandcamp does not expose catalog numbers.
+        year=_parse_year(album_data.get("datePublished")),
+        country=None,
+        formats=[],
+    )
+
+    identifiers = ReleaseIdentifiers(bandcamp_album_url=album_url)
+
+    return BandcampResolveResult(canonical=canonical, identifiers=identifiers, warnings=warnings)
+
+
+async def fetch_bandcamp_album_html(client: BandcampClient, album_url: str) -> str | None:
+    """Fetch the raw HTML for a Bandcamp album page using the rate-limited client.
+
+    Returns None on HTTP error so the resolver can surface a warning instead of
+    an exception bubbling all the way to the form.
+    """
+    try:
+        # Reuse the same retry-on-429 helper used by the autocomplete + scrape paths.
+        response: httpx.Response | None = await client._request_with_retry(  # noqa: SLF001
+            "GET", album_url, timeout=15.0, follow_redirects=True
+        )
+    except Exception:
+        logger.exception("Bandcamp album fetch failed for %s", album_url)
+        return None
+    if response is None or response.status_code != 200:
+        return None
+    return response.text
+
+
+async def resolve_bandcamp_album(client: BandcampClient, album_url: str) -> BandcampResolveResult:
+    """Fetch + parse an album page in one call. Wraps the two helpers above."""
+    html = await fetch_bandcamp_album_html(client, album_url)
+    if html is None:
+        return BandcampResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
+            warnings=[f"Bandcamp page could not be fetched: {album_url}"],
+        )
+    return parse_bandcamp_album_html(html, album_url)

--- a/release/dependencies.py
+++ b/release/dependencies.py
@@ -8,12 +8,14 @@ from core.dependencies import get_discogs_service
 from discogs.service import DiscogsService
 from identity.dependencies import get_entity_store
 from release.orchestrator import _ResolverDependencies
+from scripts.bandcamp_client import BandcampClient
 from scripts.entity_resolution.store import EntityStore
 from scripts.streaming_availability.apple_music_client import AppleMusicClient
 from scripts.streaming_availability.deezer_client import DeezerClient
 from scripts.streaming_availability.spotify_client import SpotifyClient
 from streaming.dependencies import (
     get_apple_music_client,
+    get_bandcamp_client,
     get_deezer_client,
     get_spotify_client,
 )
@@ -21,6 +23,7 @@ from streaming.dependencies import (
 
 def get_resolver_dependencies(
     discogs: DiscogsService = Depends(get_discogs_service),
+    bandcamp: BandcampClient = Depends(get_bandcamp_client),
     spotify: SpotifyClient | None = Depends(get_spotify_client),
     deezer: DeezerClient = Depends(get_deezer_client),
     apple_music: AppleMusicClient = Depends(get_apple_music_client),
@@ -31,12 +34,10 @@ def get_resolver_dependencies(
     Reuses existing DI providers so the lifecycle (close on shutdown) is
     already wired in main.py. Spotify and the entity store are optional and
     may be None; the orchestrator handles that correctly.
-
-    The Bandcamp client is intentionally not wired here yet — it's added in
-    the follow-up PR that brings the Bandcamp album resolver online.
     """
     return _ResolverDependencies(
         discogs=discogs,
+        bandcamp=bandcamp,
         spotify=spotify,
         deezer=deezer,
         apple_music=apple_music,

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -251,7 +251,9 @@ async def _writeback_identity(
     # subdomain as the bandcamp_id placeholder. This matches existing
     # entity.identity rows populated by bandcamp_pipeline.py, which also uses
     # the slug as bandcamp_id.
-    bandcamp_id = extract_slug(identifiers.bandcamp_album_url) if identifiers.bandcamp_album_url else None
+    bandcamp_id = (
+        extract_slug(identifiers.bandcamp_album_url) if identifiers.bandcamp_album_url else None
+    )
 
     try:
         await store.upsert_identity(

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -8,7 +8,7 @@ Threads:
   url_parser.parse_url      (pure)
         |
         v
-  discogs_resolver.resolve_discogs_release    (Bandcamp branch added in a follow-up PR)
+  discogs_resolver.resolve_discogs_release   OR   bandcamp_resolver.resolve_bandcamp_album
         |
         v
   streaming.orchestrator.check_streaming_availability
@@ -22,12 +22,6 @@ Threads:
 Each step accumulates ``warnings``. The endpoint always returns 200 with
 whatever it managed to put together — the music director's form should be
 able to fall back to manual entry without losing the partial prefill.
-
-Bandcamp URLs are recognized by the URL parser but, in this PR, return a
-warning that says they're not yet supported. The follow-up PR adds the
-Bandcamp branch (album page fetch + JSON-LD parse + streaming-check
-short-circuit). Splitting the work this way keeps each PR reviewable in one
-sitting without blocking the Discogs prefill flow on the HTML-scraping path.
 """
 
 from __future__ import annotations
@@ -36,6 +30,7 @@ import logging
 import re
 
 from discogs.service import DiscogsService
+from release.bandcamp_resolver import resolve_bandcamp_album
 from release.discogs_resolver import (
     resolve_discogs_master,
     resolve_discogs_release,
@@ -47,11 +42,12 @@ from release.models import (
     ReleaseResolveResponse,
 )
 from release.url_parser import ParsedUrl, parse_url
+from scripts.bandcamp_client import BandcampClient, extract_slug
 from scripts.entity_resolution.store import EntityStore
 from scripts.streaming_availability.apple_music_client import AppleMusicClient
 from scripts.streaming_availability.deezer_client import DeezerClient
 from scripts.streaming_availability.spotify_client import SpotifyClient
-from streaming.models import StreamingCheckResponse, StreamingCheckSources
+from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
 from streaming.orchestrator import check_streaming_availability
 
 logger = logging.getLogger(__name__)
@@ -69,12 +65,14 @@ class _ResolverDependencies:
         self,
         *,
         discogs: DiscogsService,
+        bandcamp: BandcampClient,
         spotify: SpotifyClient | None,
         deezer: DeezerClient | None,
         apple_music: AppleMusicClient | None,
         entity_store: EntityStore | None,
     ) -> None:
         self.discogs = discogs
+        self.bandcamp = bandcamp
         self.spotify = spotify
         self.deezer = deezer
         self.apple_music = apple_music
@@ -99,8 +97,8 @@ async def resolve_release(
             streaming=None,
             warnings=[
                 "Could not recognize the URL or source. "
-                "Supported: Discogs release URLs (e.g. discogs.com/release/12345). "
-                "Bandcamp album URLs are recognized by the parser but not yet wired up."
+                "Supported: Discogs release URLs (e.g. discogs.com/release/12345) "
+                "and Bandcamp album URLs (e.g. artist.bandcamp.com/album/slug)."
             ],
         )
 
@@ -115,22 +113,15 @@ async def resolve_release(
         canonical = master_result.canonical
         identifiers = master_result.identifiers
         warnings = list(master_result.warnings)
-    else:  # bandcamp — recognized by the parser, not yet wired up in the orchestrator
-        return ReleaseResolveResponse(
-            source="bandcamp",
-            source_id=parsed.identifier,
-            canonical=CanonicalRelease(artist="", title=""),
-            identifiers=ReleaseIdentifiers(bandcamp_album_url=parsed.identifier),
-            streaming=None,
-            warnings=[
-                "Bandcamp album URLs are not yet supported. "
-                "Coming in a follow-up PR — paste a Discogs release URL for now."
-            ],
-        )
+    else:  # bandcamp
+        bandcamp_result = await resolve_bandcamp_album(deps.bandcamp, parsed.identifier)
+        canonical = bandcamp_result.canonical
+        identifiers = bandcamp_result.identifiers
+        warnings = list(bandcamp_result.warnings)
 
-    streaming = await _check_streaming(canonical, deps, warnings)
+    streaming = await _check_streaming(canonical, parsed, deps, warnings)
 
-    # Promote streaming-side identifiers (Spotify/Apple) into the response.
+    # Promote streaming-side identifiers (Spotify/Apple/Bandcamp) into the response.
     identifiers = _merge_streaming_identifiers(identifiers, streaming)
 
     # Identity write-back: any newly-discovered IDs land in entity.identity
@@ -160,32 +151,47 @@ def _resolve_to_parsed_url(request: ReleaseResolveRequest) -> ParsedUrl | None:
 
 async def _check_streaming(
     canonical: CanonicalRelease | None,
+    parsed: ParsedUrl,
     deps: _ResolverDependencies,
     warnings: list[str],
 ) -> StreamingCheckResponse | None:
-    """Run the streaming-availability fan-out across configured services.
+    """Run the streaming-availability fan-out.
 
     Skips the check when canonical metadata is missing — there's nothing to
-    search for. The Bandcamp leg of the streaming check is intentionally
-    not configured here yet (no BandcampClient dep); it's added in the
-    follow-up PR alongside the Bandcamp resolver.
+    search for. Short-circuits the Bandcamp leg when the input itself is a
+    Bandcamp URL: re-fuzzy-matching a URL the DJ explicitly gave us would
+    just throw away certainty.
     """
     if canonical is None or not canonical.artist or not canonical.title:
         return None
 
+    # Skip the Bandcamp leg when the input is a Bandcamp URL — we already know
+    # the answer with certainty, and re-fuzzy-matching would burn 2+ rate-limited
+    # HTTP calls (autocomplete + catalog scrape) for a result we'd discard.
+    bandcamp_for_check = None if parsed.source == "bandcamp" else deps.bandcamp
+
     try:
-        return await check_streaming_availability(
+        streaming = await check_streaming_availability(
             canonical.artist,
             canonical.title,
             spotify=deps.spotify,
             deezer=deps.deezer,
             apple_music=deps.apple_music,
-            bandcamp=None,
+            bandcamp=bandcamp_for_check,
         )
     except Exception:
         logger.exception("Streaming check failed for %s - %s", canonical.artist, canonical.title)
         warnings.append("Streaming-availability check failed; on-streaming flag not set.")
         return None
+
+    if parsed.source == "bandcamp":
+        # Trust the URL the DJ pasted. Confidence 100 + on_streaming=True are
+        # safe overrides because we know the URL resolves to a real album.
+        streaming.sources.bandcamp = SourceMatch(url=parsed.identifier, confidence=100.0)
+        if streaming.on_streaming is not True:
+            streaming.on_streaming = True
+
+    return streaming
 
 
 _SPOTIFY_ALBUM_ID_RE = re.compile(r"open\.spotify\.com/album/([A-Za-z0-9]+)")
@@ -211,18 +217,20 @@ def _apple_album_id_from_url(url: str) -> str | None:
 def _merge_streaming_identifiers(
     identifiers: ReleaseIdentifiers, streaming: StreamingCheckResponse | None
 ) -> ReleaseIdentifiers:
-    """Promote Spotify/Apple IDs found during the streaming check into the response."""
+    """Promote Spotify/Apple/Bandcamp IDs found during the streaming check into the response."""
     if streaming is None:
         return identifiers
 
     sources: StreamingCheckSources = streaming.sources
     spotify_id = _spotify_album_id_from_url(sources.spotify.url) if sources.spotify else None
     apple_id = _apple_album_id_from_url(sources.apple_music.url) if sources.apple_music else None
+    bandcamp_url = sources.bandcamp.url if sources.bandcamp else None
 
     return identifiers.model_copy(
         update={
             "spotify_album_id": identifiers.spotify_album_id or spotify_id,
             "apple_music_album_id": identifiers.apple_music_album_id or apple_id,
+            "bandcamp_album_url": identifiers.bandcamp_album_url or bandcamp_url,
         }
     )
 
@@ -239,10 +247,17 @@ async def _writeback_identity(
     UPDATE`` with ``COALESCE``) so populated fields are never clobbered. The
     artist row is created on first sight.
     """
+    # Bandcamp doesn't expose an integer artist ID, so we use the album URL's
+    # subdomain as the bandcamp_id placeholder. This matches existing
+    # entity.identity rows populated by bandcamp_pipeline.py, which also uses
+    # the slug as bandcamp_id.
+    bandcamp_id = extract_slug(identifiers.bandcamp_album_url) if identifiers.bandcamp_album_url else None
+
     try:
         await store.upsert_identity(
             canonical.artist,
             discogs_artist_id=identifiers.discogs_artist_id,
+            bandcamp_id=bandcamp_id,
         )
     except Exception:
         logger.exception("Identity write-back failed for %s", canonical.artist)

--- a/tests/fixtures/bandcamp/album_self_released.html
+++ b/tests/fixtures/bandcamp/album_self_released.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head><title>DOGA | Juana Molina</title></head>
+<body>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "MusicAlbum",
+    "@id": "https://juana-molina.bandcamp.com/album/doga",
+    "name": "DOGA",
+    "byArtist": {
+        "@type": "MusicGroup",
+        "name": "Juana Molina",
+        "@id": "https://juana-molina.bandcamp.com",
+        "url": "https://juana-molina.bandcamp.com"
+    },
+    "datePublished": "10 Mar 2024 00:00:00 GMT",
+    "publisher": {
+        "@type": "MusicGroup",
+        "name": "Juana Molina",
+        "@id": "https://juana-molina.bandcamp.com"
+    }
+}
+</script>
+</body>
+</html>

--- a/tests/fixtures/bandcamp/album_with_label.html
+++ b/tests/fixtures/bandcamp/album_with_label.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head><title>Confield | Autechre</title></head>
+<body>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "MusicAlbum",
+    "@id": "https://autechre.bandcamp.com/album/confield",
+    "name": "Confield",
+    "byArtist": {
+        "@type": "MusicGroup",
+        "name": "Autechre",
+        "@id": "https://autechre.bandcamp.com",
+        "url": "https://autechre.bandcamp.com"
+    },
+    "datePublished": "16 Apr 2001 00:00:00 GMT",
+    "publisher": {
+        "@type": "MusicGroup",
+        "name": "Warp Records",
+        "@id": "https://warprecords.bandcamp.com",
+        "url": "https://warprecords.bandcamp.com"
+    }
+}
+</script>
+</body>
+</html>

--- a/tests/unit/release/test_bandcamp_resolver.py
+++ b/tests/unit/release/test_bandcamp_resolver.py
@@ -1,0 +1,167 @@
+"""Tests for release/bandcamp_resolver.py.
+
+The pure parser is tested against committed fixtures. The HTTP fetch path
+is tested with a mock BandcampClient — no real Bandcamp traffic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from release.bandcamp_resolver import (
+    fetch_bandcamp_album_html,
+    parse_bandcamp_album_html,
+    resolve_bandcamp_album,
+)
+
+FIXTURES = Path(__file__).resolve().parent.parent.parent / "fixtures" / "bandcamp"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+class TestParseBandcampAlbumHtml:
+    def test_self_released_label_is_null(self):
+        # When publisher subdomain == artist subdomain, treat as self-released.
+        # Per the music director: don't pretend the artist is the label.
+        html = _load("album_self_released.html")
+        url = "https://juana-molina.bandcamp.com/album/doga"
+
+        result = parse_bandcamp_album_html(html, url)
+
+        assert result.canonical is not None
+        assert result.canonical.artist == "Juana Molina"
+        assert result.canonical.title == "DOGA"
+        assert result.canonical.label is None
+        assert result.canonical.catno is None
+        assert result.canonical.year == 2024
+        assert result.identifiers.bandcamp_album_url == url
+        assert result.warnings == []
+
+    def test_label_account_populates_label(self):
+        # When publisher is on a different subdomain (a real label account),
+        # use the publisher name as the label.
+        html = _load("album_with_label.html")
+        url = "https://autechre.bandcamp.com/album/confield"
+
+        result = parse_bandcamp_album_html(html, url)
+
+        assert result.canonical is not None
+        assert result.canonical.artist == "Autechre"
+        assert result.canonical.title == "Confield"
+        assert result.canonical.label == "Warp Records"
+        assert result.canonical.catno is None  # Bandcamp never has catnos.
+        assert result.canonical.year == 2001
+        assert result.identifiers.bandcamp_album_url == url
+
+    def test_warns_when_no_jsonld_block(self):
+        result = parse_bandcamp_album_html(
+            "<html><body>no script here</body></html>",
+            "https://x.bandcamp.com/album/y",
+        )
+
+        assert result.canonical is None
+        assert result.identifiers.bandcamp_album_url == "https://x.bandcamp.com/album/y"
+        assert len(result.warnings) == 1
+        assert "JSON-LD" in result.warnings[0]
+
+    def test_warns_when_jsonld_has_no_musicalbum(self):
+        # Bandcamp pages sometimes contain MusicGroup or BreadcrumbList LD blocks
+        # but no MusicAlbum. Don't crash — warn and return null canonical.
+        html = """<html><body>
+            <script type="application/ld+json">{"@type":"MusicGroup","name":"X"}</script>
+        </body></html>"""
+
+        result = parse_bandcamp_album_html(html, "https://x.bandcamp.com/album/y")
+
+        assert result.canonical is None
+        assert "MusicAlbum" in result.warnings[0]
+
+    def test_warns_when_jsonld_is_malformed(self):
+        # Truncated/invalid JSON-LD shouldn't bubble a JSONDecodeError.
+        html = """<html><body>
+            <script type="application/ld+json">{not json</script>
+        </body></html>"""
+
+        result = parse_bandcamp_album_html(html, "https://x.bandcamp.com/album/y")
+
+        assert result.canonical is None
+        assert len(result.warnings) == 1
+
+
+class TestFetchBandcampAlbumHtml:
+    @pytest.mark.asyncio
+    async def test_returns_text_on_200(self):
+        client = MagicMock()
+        client._request_with_retry = AsyncMock()
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "<html>ok</html>"
+        client._request_with_retry.return_value = response
+
+        html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
+
+        assert html == "<html>ok</html>"
+        client._request_with_retry.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_non_200(self):
+        client = MagicMock()
+        response = MagicMock()
+        response.status_code = 404
+        client._request_with_retry = AsyncMock(return_value=response)
+
+        html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
+
+        assert html is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_request_failure(self):
+        client = MagicMock()
+        client._request_with_retry = AsyncMock(return_value=None)
+
+        html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
+
+        assert html is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_exception(self):
+        client = MagicMock()
+        client._request_with_retry = AsyncMock(side_effect=RuntimeError("boom"))
+
+        html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
+
+        assert html is None
+
+
+class TestResolveBandcampAlbum:
+    @pytest.mark.asyncio
+    async def test_end_to_end_with_fixture(self):
+        client = MagicMock()
+        response = MagicMock()
+        response.status_code = 200
+        response.text = _load("album_with_label.html")
+        client._request_with_retry = AsyncMock(return_value=response)
+
+        result = await resolve_bandcamp_album(
+            client, "https://autechre.bandcamp.com/album/confield"
+        )
+
+        assert result.canonical is not None
+        assert result.canonical.artist == "Autechre"
+        assert result.canonical.label == "Warp Records"
+
+    @pytest.mark.asyncio
+    async def test_warns_when_fetch_fails(self):
+        client = MagicMock()
+        client._request_with_retry = AsyncMock(return_value=None)
+
+        result = await resolve_bandcamp_album(client, "https://x.bandcamp.com/album/y")
+
+        assert result.canonical is None
+        assert len(result.warnings) == 1
+        assert "could not be fetched" in result.warnings[0]

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -1,13 +1,8 @@
-"""End-to-end tests for the resolve_release orchestrator with all I/O mocked.
-
-Bandcamp branch is intentionally tested only at the "returns warning, not yet
-supported" level here. Full Bandcamp orchestration tests come with the
-follow-up PR that wires the resolver in.
-"""
+"""End-to-end tests for the resolve_release orchestrator with all I/O mocked."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -28,6 +23,7 @@ from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheck
 def _deps(
     *,
     discogs=None,
+    bandcamp=None,
     spotify=None,
     deezer=None,
     apple_music=None,
@@ -36,6 +32,7 @@ def _deps(
     """Build a _ResolverDependencies with sensible defaults for tests."""
     return _ResolverDependencies(
         discogs=discogs or AsyncMock(),
+        bandcamp=bandcamp or MagicMock(),
         spotify=spotify,
         deezer=deezer,
         apple_music=apple_music,
@@ -190,24 +187,149 @@ class TestDiscogsBranch:
         assert any("master" in w.lower() for w in response.warnings)
 
 
-class TestBandcampNotYetSupported:
+class TestBandcampBranch:
     @pytest.mark.asyncio
-    async def test_bandcamp_url_returns_warning_without_io(self):
-        # The URL parser recognizes Bandcamp, but the resolver isn't wired up yet.
-        # Until the follow-up PR lands, a bandcamp paste returns a clear warning
-        # and never touches the streaming or identity paths.
-        deps = _deps()
-        with patch("release.orchestrator.check_streaming_availability") as cs:
+    async def test_short_circuits_bandcamp_streaming_check(self):
+        # The DJ pasted a Bandcamp URL — we should mark Bandcamp as a confident
+        # match and not waste a fuzzy lookup.
+        bandcamp = MagicMock()
+        with (
+            patch(
+                "release.orchestrator.resolve_bandcamp_album",
+                new=AsyncMock(),
+            ) as mock_resolve,
+            patch(
+                "release.orchestrator.check_streaming_availability",
+                new=AsyncMock(return_value=_stream(on_streaming=False)),
+            ),
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import CanonicalRelease, ReleaseIdentifiers
+
+            url = "https://juana-molina.bandcamp.com/album/doga"
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=CanonicalRelease(artist="Juana Molina", title="DOGA", label=None),
+                identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
+                warnings=[],
+            )
+
             response = await resolve_release(
-                ReleaseResolveRequest(url="https://juana-molina.bandcamp.com/album/doga"), deps
+                ReleaseResolveRequest(url=url), _deps(bandcamp=bandcamp)
+            )
+
+        assert response.source == "bandcamp"
+        assert response.canonical.label is None  # self-released stays null
+        assert response.streaming is not None
+        # Short-circuit: Bandcamp pinned to the input URL with confidence 100,
+        # on_streaming flipped to True.
+        assert response.streaming.sources.bandcamp is not None
+        assert response.streaming.sources.bandcamp.url == url
+        assert response.streaming.sources.bandcamp.confidence == 100.0
+        assert response.streaming.on_streaming is True
+
+    @pytest.mark.asyncio
+    async def test_passes_bandcamp_none_to_streaming_when_input_is_bandcamp(self):
+        # Performance guarantee: don't run a Bandcamp fuzzy search when the
+        # caller already gave us a Bandcamp URL.
+        bandcamp = MagicMock()
+        check_mock = AsyncMock(return_value=_stream(on_streaming=False))
+        with (
+            patch("release.orchestrator.resolve_bandcamp_album", new=AsyncMock()) as mock_resolve,
+            patch("release.orchestrator.check_streaming_availability", new=check_mock),
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import CanonicalRelease, ReleaseIdentifiers
+
+            url = "https://juana-molina.bandcamp.com/album/doga"
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=CanonicalRelease(artist="Juana Molina", title="DOGA"),
+                identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
+                warnings=[],
+            )
+
+            await resolve_release(ReleaseResolveRequest(url=url), _deps(bandcamp=bandcamp))
+
+        check_mock.assert_awaited_once()
+        assert check_mock.await_args.kwargs["bandcamp"] is None
+
+    @pytest.mark.asyncio
+    async def test_passes_bandcamp_client_to_streaming_for_discogs_input(self):
+        # Sanity check the inverse: a Discogs paste should route through the
+        # full Bandcamp fuzzy match (so we still discover the Bandcamp URL).
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        bandcamp = MagicMock()
+        check_mock = AsyncMock(return_value=_stream(on_streaming=False))
+        with patch("release.orchestrator.check_streaming_availability", new=check_mock):
+            await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"),
+                _deps(discogs=discogs, bandcamp=bandcamp),
+            )
+
+        check_mock.assert_awaited_once()
+        assert check_mock.await_args.kwargs["bandcamp"] is bandcamp
+
+    @pytest.mark.asyncio
+    async def test_bandcamp_fetch_failure_returns_warnings(self):
+        bandcamp = MagicMock()
+        with (
+            patch(
+                "release.orchestrator.resolve_bandcamp_album",
+                new=AsyncMock(),
+            ) as mock_resolve,
+            patch("release.orchestrator.check_streaming_availability") as cs,
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import ReleaseIdentifiers
+
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=None,
+                identifiers=ReleaseIdentifiers(bandcamp_album_url="https://x.bandcamp.com/album/y"),
+                warnings=["could not be fetched"],
+            )
+
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://x.bandcamp.com/album/y"),
+                _deps(bandcamp=bandcamp),
             )
 
         cs.assert_not_called()
-        assert response.source == "bandcamp"
-        assert response.source_id == "https://juana-molina.bandcamp.com/album/doga"
-        assert response.identifiers.bandcamp_album_url == response.source_id
         assert response.canonical.artist == ""
-        assert any("not yet supported" in w.lower() for w in response.warnings)
+        assert response.warnings == ["could not be fetched"]
+        assert response.streaming is None
+
+    @pytest.mark.asyncio
+    async def test_bandcamp_writeback_uses_slug(self):
+        bandcamp = MagicMock()
+        store = AsyncMock()
+        with (
+            patch(
+                "release.orchestrator.resolve_bandcamp_album",
+                new=AsyncMock(),
+            ) as mock_resolve,
+            patch(
+                "release.orchestrator.check_streaming_availability",
+                new=AsyncMock(return_value=_stream()),
+            ),
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import CanonicalRelease, ReleaseIdentifiers
+
+            url = "https://juana-molina.bandcamp.com/album/doga"
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=CanonicalRelease(artist="Juana Molina", title="DOGA"),
+                identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
+                warnings=[],
+            )
+
+            await resolve_release(
+                ReleaseResolveRequest(url=url),
+                _deps(bandcamp=bandcamp, entity_store=store),
+            )
+
+        kwargs = store.upsert_identity.call_args.kwargs
+        # The slug, not the full URL — matches what bandcamp_pipeline.py writes.
+        assert kwargs["bandcamp_id"] == "juana-molina"
 
 
 class TestStreamingFailureSurfacesAsWarning:

--- a/tests/unit/release/test_router.py
+++ b/tests/unit/release/test_router.py
@@ -1,8 +1,8 @@
-"""HTTP-layer tests for POST /api/v1/releases/resolve (Discogs path)."""
+"""HTTP-layer tests for POST /api/v1/releases/resolve."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -38,6 +38,7 @@ def _deps_with_discogs(release):
     discogs.get_release.return_value = release
     return _ResolverDependencies(
         discogs=discogs,
+        bandcamp=MagicMock(),
         spotify=None,
         deezer=None,
         apple_music=None,


### PR DESCRIPTION
## Summary

PR 5b of 5a/5b split — stacked on #174 (Discogs branch). Merge #174 first; this PR's diff against `main` will then reduce to just the Bandcamp additions.

- New `release/bandcamp_resolver.py` — fetches album page via rate-limited `BandcampClient`, parses JSON-LD `MusicAlbum` (tolerates `@type` as string or list).
- Bandcamp branch in orchestrator + streaming-check short-circuit (skip Bandcamp leg when input is Bandcamp; saves 2+ rate-limited HTTP calls per paste).
- Self-released detection: publisher subdomain == artist subdomain → `label=null`.
- `BandcampClient` dep wired into `get_resolver_dependencies`.
- Slug-based `bandcamp_id` write-back into `entity.identity` (matches `bandcamp_pipeline.py`).
- Committed JSON-LD fixtures so parser tests don't hit live Bandcamp.

Closes #175

## Test plan

- [x] `pytest tests/unit/` — **1490 passed** (15 new in this PR on top of 5a's 61)
- [x] `ruff check .`, `ruff format --check .`, `mypy .` all clean
- [ ] Merge #174 first, then rebase this onto main
- [ ] CI passes
- [ ] After merge: tubafrenzy PR #6 (rotation form's paste-URL UI) consumes both Discogs + Bandcamp paths