### PR TITLE
docs: link CLAUDE.md to canonical test-patterns in wiki

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ Untouched: `/health`, `/identity/resolve`, `/identity/bulk`. Identity routes are
 
 ### Pytest markers (architecture A)
 
-Markers route CI by infrastructure, not taxonomy. See the WXYC test-patterns guide (`plans/test-patterns.md`, Section 3) for the canonical vocabulary; LML uses two:
+Markers route CI by infrastructure, not taxonomy. See the WXYC test-patterns guide ([WXYC/wiki, plans/test-patterns.md, Section 3](https://github.com/WXYC/wiki/blob/main/plans/test-patterns.md#3-marker-conventions)) for the canonical vocabulary; LML uses two:
 
 | Marker | Meaning | CI provisions |
 |---|---|---|


### PR DESCRIPTION
Repoints the test-patterns reference at the canonical wiki location (WXYC/wiki, just merged in PR #3).

## Test plan
- [ ] Link in CLAUDE.md resolves to the correct wiki section