### PR TITLE
[mojibake/p2] Post-mojibake streaming-availability recheck script

### DIFF
--- a/scripts/recheck_streaming_after_mojibake.py
+++ b/scripts/recheck_streaming_after_mojibake.py
@@ -1,0 +1,260 @@
+"""Re-check streaming availability for releases whose ALBUM_ARTIST was previously mojibake'd.
+
+V012 (`/tmp/V012__fix-mojibake-extended.sql`) corrects double-encoded UTF-8 artist
+names in tubafrenzy that V003 missed (e.g. `Î¼-ziq` → `μ-ziq`). When the
+streaming-availability pipeline ran with the corrupted strings, Spotify and
+Deezer didn't recognize them and the rows were recorded as `not_found`. After
+V012 lands and library.db is re-synced, those releases need a fresh check with
+the correct artist name.
+
+This script is read-only by default: it queries library.db, calls LML's
+streaming-check orchestrator for each affected release, and writes a CSV report.
+The actual `on_streaming` propagation runs through the existing
+streaming-status webhook (admin upload diff), not this script.
+
+Usage:
+    uv run python -m scripts.recheck_streaming_after_mojibake \\
+        --library-db library.db [--output recheck_report.csv] [--limit N]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import logging
+import os
+import sqlite3
+import sys
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from scripts.bandcamp_client import BandcampClient
+from scripts.streaming_availability.apple_music_client import AppleMusicClient
+from scripts.streaming_availability.deezer_client import DeezerClient
+from scripts.streaming_availability.spotify_client import SpotifyClient
+from streaming.orchestrator import check_streaming_availability
+
+logger = logging.getLogger(__name__)
+
+
+# Round-trippable corrections from V012's FLOWSHEET_ENTRY_PROD.ARTIST_NAME block.
+# Source: /tmp/V012__fix-mojibake-extended.sql.
+MOJIBAKE_CORRECTED_ARTISTS: tuple[str, ...] = (
+    "μ-ziq",
+    "GrOun士 + Kabamix",
+    "Luboš Fišer",
+    "Mustafah 'Abd Al'-Azīz",
+    "Σtella, Las Palabras",
+)
+
+
+@dataclass(frozen=True)
+class AffectedRelease:
+    library_id: int
+    artist: str
+    title: str
+
+
+@dataclass(frozen=True)
+class RecheckResult:
+    library_id: int
+    artist: str
+    title: str
+    on_streaming: bool | None
+    sources: dict[str, str | None]
+
+
+def find_affected_releases(
+    library_db_path: Path,
+    corrected_artists: list[str] | tuple[str, ...] = MOJIBAKE_CORRECTED_ARTISTS,
+) -> list[AffectedRelease]:
+    """Return library rows whose `artist` or `album_artist` matches a corrected name."""
+    if not corrected_artists:
+        return []
+
+    conn = sqlite3.connect(str(library_db_path))
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(library)").fetchall()}
+        has_album_artist = "album_artist" in cols
+
+        placeholders = ",".join("?" for _ in corrected_artists)
+        if has_album_artist:
+            sql = (
+                f"SELECT id, artist, title, album_artist FROM library "
+                f"WHERE artist IN ({placeholders}) OR album_artist IN ({placeholders})"
+            )
+            params: list[str] = list(corrected_artists) + list(corrected_artists)
+        else:
+            sql = (
+                f"SELECT id, artist, title, NULL AS album_artist FROM library "
+                f"WHERE artist IN ({placeholders})"
+            )
+            params = list(corrected_artists)
+        rows = conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()
+
+    corrected_set = set(corrected_artists)
+    seen: set[int] = set()
+    affected: list[AffectedRelease] = []
+    for lid, artist, title, album_artist in rows:
+        if lid in seen:
+            continue
+        seen.add(lid)
+        # Prefer the album_artist value when it's the column that matched —
+        # that's the canonical credit for VA / compilation releases.
+        chosen = album_artist if album_artist in corrected_set else artist
+        affected.append(AffectedRelease(library_id=lid, artist=chosen or "", title=title or ""))
+    return affected
+
+
+async def recheck_releases(
+    releases: list[AffectedRelease],
+    *,
+    spotify: SpotifyClient | None = None,
+    deezer: DeezerClient | None = None,
+    apple_music: AppleMusicClient | None = None,
+    bandcamp: BandcampClient | None = None,
+) -> list[RecheckResult]:
+    """Re-run the streaming-check orchestrator for each release, sequentially."""
+    out: list[RecheckResult] = []
+    for release in releases:
+        resp = await check_streaming_availability(
+            release.artist,
+            release.title,
+            spotify=spotify,
+            deezer=deezer,
+            apple_music=apple_music,
+            bandcamp=bandcamp,
+        )
+        sources: dict[str, str | None] = {
+            "spotify": resp.sources.spotify.url if resp.sources.spotify else None,
+            "deezer": resp.sources.deezer.url if resp.sources.deezer else None,
+            "apple_music": resp.sources.apple_music.url if resp.sources.apple_music else None,
+            "bandcamp": resp.sources.bandcamp.url if resp.sources.bandcamp else None,
+        }
+        out.append(
+            RecheckResult(
+                library_id=release.library_id,
+                artist=release.artist,
+                title=release.title,
+                on_streaming=resp.on_streaming,
+                sources=sources,
+            )
+        )
+    return out
+
+
+def write_report(results: list[RecheckResult], output_path: Path) -> None:
+    with output_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "library_id",
+                "artist",
+                "title",
+                "on_streaming",
+                "spotify_url",
+                "deezer_url",
+                "apple_music_url",
+                "bandcamp_url",
+            ]
+        )
+        for r in results:
+            writer.writerow(
+                [
+                    r.library_id,
+                    r.artist,
+                    r.title,
+                    "" if r.on_streaming is None else int(r.on_streaming),
+                    r.sources.get("spotify") or "",
+                    r.sources.get("deezer") or "",
+                    r.sources.get("apple_music") or "",
+                    r.sources.get("bandcamp") or "",
+                ]
+            )
+
+
+def _build_clients() -> tuple[SpotifyClient | None, DeezerClient, AppleMusicClient, BandcampClient]:
+    spotify: SpotifyClient | None = None
+    cid = os.environ.get("SPOTIFY_CLIENT_ID")
+    csec = os.environ.get("SPOTIFY_CLIENT_SECRET")
+    if cid and csec:
+        spotify = SpotifyClient(cid, csec)
+    else:
+        logger.warning("SPOTIFY_CLIENT_ID/SECRET not set — skipping Spotify check")
+    return spotify, DeezerClient(), AppleMusicClient(), BandcampClient()
+
+
+async def _close_clients(*clients) -> None:
+    for c in clients:
+        if c is not None:
+            try:
+                await c.close()
+            except Exception:
+                logger.exception("Failed to close client %r", c)
+
+
+async def run(args) -> None:
+    affected = find_affected_releases(args.library_db, MOJIBAKE_CORRECTED_ARTISTS)
+    if args.limit:
+        affected = affected[: args.limit]
+
+    logger.info(
+        "Found %d affected release(s) for %d corrected artist(s)",
+        len(affected),
+        len(MOJIBAKE_CORRECTED_ARTISTS),
+    )
+
+    if not affected:
+        write_report([], args.output)
+        return
+
+    spotify, deezer, apple, bandcamp = _build_clients()
+    try:
+        results = await recheck_releases(
+            affected, spotify=spotify, deezer=deezer, apple_music=apple, bandcamp=bandcamp
+        )
+    finally:
+        await _close_clients(spotify, deezer, apple, bandcamp)
+
+    write_report(results, args.output)
+    flips_true = sum(1 for r in results if r.on_streaming is True)
+    flips_false = sum(1 for r in results if r.on_streaming is False)
+    inconclusive = sum(1 for r in results if r.on_streaming is None)
+    logger.info(
+        "Recheck complete: on_streaming=true:%d false:%d inconclusive:%d. Report: %s",
+        flips_true,
+        flips_false,
+        inconclusive,
+        args.output,
+    )
+
+
+def main() -> int:
+    load_dotenv()
+    parser = ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument("--library-db", type=Path, default=Path("library.db"))
+    parser.add_argument("--output", type=Path, default=Path("recheck_streaming_report.csv"))
+    parser.add_argument("--limit", type=int, default=0, help="Cap the number of releases (0 = all)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if not args.library_db.exists():
+        logger.error("Library DB not found: %s", args.library_db)
+        return 1
+
+    asyncio.run(run(args))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_recheck_streaming_after_mojibake.py
+++ b/tests/unit/test_recheck_streaming_after_mojibake.py
@@ -1,0 +1,201 @@
+"""Tests for the post-mojibake streaming recheck script.
+
+V012 corrects mojibake'd artist names in tubafrenzy MySQL (e.g. 'Î¼-ziq' → 'μ-ziq').
+After library.db is re-synced, releases by these artists need a fresh streaming
+availability check because earlier runs queried Spotify/Deezer with the corrupted
+form and recorded `not_found`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.recheck_streaming_after_mojibake import (
+    MOJIBAKE_CORRECTED_ARTISTS,
+    AffectedRelease,
+    find_affected_releases,
+    recheck_releases,
+    write_report,
+)
+
+
+def _build_library_db(path: Path, rows: list[tuple]) -> None:
+    """Build a minimal library.db with the columns the script reads."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """CREATE TABLE library (
+            id INTEGER PRIMARY KEY,
+            artist TEXT,
+            title TEXT,
+            album_artist TEXT
+        )"""
+    )
+    conn.executemany(
+        "INSERT INTO library (id, artist, title, album_artist) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestMojibakeCorrectedArtists:
+    """The hardcoded list mirrors V012's ARTIST_NAME corrections."""
+
+    def test_includes_v012_artist_name_corrections(self):
+        # Source: /tmp/V012__fix-mojibake-extended.sql, ARTIST_NAME block
+        assert "μ-ziq" in MOJIBAKE_CORRECTED_ARTISTS
+        assert "Σtella, Las Palabras" in MOJIBAKE_CORRECTED_ARTISTS
+        assert "Luboš Fišer" in MOJIBAKE_CORRECTED_ARTISTS
+        assert "GrOun士 + Kabamix" in MOJIBAKE_CORRECTED_ARTISTS
+        assert "Mustafah 'Abd Al'-Azīz" in MOJIBAKE_CORRECTED_ARTISTS
+
+
+class TestFindAffectedReleases:
+    def test_matches_artist_column(self, tmp_path):
+        db = tmp_path / "library.db"
+        _build_library_db(
+            db,
+            [
+                (1, "μ-ziq", "Lunatic Harness", None),
+                (2, "Stereolab", "Aluminum Tunes", None),
+            ],
+        )
+        affected = find_affected_releases(db, ["μ-ziq"])
+        assert [r.library_id for r in affected] == [1]
+        assert affected[0].artist == "μ-ziq"
+        assert affected[0].title == "Lunatic Harness"
+
+    def test_matches_album_artist_column(self, tmp_path):
+        db = tmp_path / "library.db"
+        _build_library_db(
+            db,
+            [
+                (1, "Various Artists", "Some Comp", "Σtella, Las Palabras"),
+                (2, "Other", "Other", "Different"),
+            ],
+        )
+        affected = find_affected_releases(db, ["Σtella, Las Palabras"])
+        assert [r.library_id for r in affected] == [1]
+        # Prefer the matching album_artist value over the generic 'Various Artists'.
+        assert affected[0].artist == "Σtella, Las Palabras"
+
+    def test_skips_unrelated_releases(self, tmp_path):
+        db = tmp_path / "library.db"
+        _build_library_db(
+            db,
+            [
+                (1, "Stereolab", "Aluminum Tunes", None),
+                (2, "Cat Power", "Moon Pix", None),
+            ],
+        )
+        affected = find_affected_releases(db, ["μ-ziq", "Σtella, Las Palabras"])
+        assert affected == []
+
+    def test_dedupes_when_artist_and_album_artist_both_match(self, tmp_path):
+        db = tmp_path / "library.db"
+        _build_library_db(db, [(1, "μ-ziq", "Lunatic Harness", "μ-ziq")])
+        affected = find_affected_releases(db, ["μ-ziq"])
+        assert len(affected) == 1
+
+    def test_empty_corrected_list_returns_empty(self, tmp_path):
+        db = tmp_path / "library.db"
+        _build_library_db(db, [(1, "μ-ziq", "Lunatic Harness", None)])
+        assert find_affected_releases(db, []) == []
+
+    def test_works_when_album_artist_column_missing(self, tmp_path):
+        db = tmp_path / "library.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE library (id INTEGER PRIMARY KEY, artist TEXT, title TEXT)")
+        conn.execute(
+            "INSERT INTO library (id, artist, title) VALUES (1, 'μ-ziq', 'Lunatic Harness')"
+        )
+        conn.commit()
+        conn.close()
+        affected = find_affected_releases(db, ["μ-ziq"])
+        assert [r.library_id for r in affected] == [1]
+
+
+class TestRecheckReleases:
+    @pytest.mark.asyncio
+    async def test_calls_streaming_check_with_corrected_artist(self):
+        release = AffectedRelease(library_id=1, artist="μ-ziq", title="Lunatic Harness")
+        spotify = AsyncMock()
+        spotify.search_album = AsyncMock(
+            return_value=[
+                {
+                    "artists": [{"name": "μ-ziq"}],
+                    "name": "Lunatic Harness",
+                    "external_urls": {"spotify": "https://open.spotify.com/album/x"},
+                    "id": "x",
+                }
+            ]
+        )
+
+        results = await recheck_releases([release], spotify=spotify)
+
+        assert len(results) == 1
+        assert results[0].library_id == 1
+        assert results[0].on_streaming is True
+        assert results[0].sources["spotify"] == "https://open.spotify.com/album/x"
+        spotify.search_album.assert_awaited_with("μ-ziq", "Lunatic Harness")
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_match(self):
+        release = AffectedRelease(library_id=2, artist="μ-ziq", title="Bluff Limbo")
+        spotify = AsyncMock()
+        spotify.search_album = AsyncMock(return_value=[])
+
+        results = await recheck_releases([release], spotify=spotify)
+
+        assert results[0].on_streaming is False
+        assert results[0].sources["spotify"] is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_clients(self):
+        release = AffectedRelease(library_id=1, artist="μ-ziq", title="Lunatic Harness")
+        results = await recheck_releases([release])
+        assert results[0].on_streaming is None
+
+
+class TestWriteReport:
+    def test_writes_csv_with_header_and_results(self, tmp_path):
+        from scripts.recheck_streaming_after_mojibake import RecheckResult
+
+        results = [
+            RecheckResult(
+                library_id=1,
+                artist="μ-ziq",
+                title="Lunatic Harness",
+                on_streaming=True,
+                sources={
+                    "spotify": "https://open.spotify.com/album/x",
+                    "deezer": None,
+                    "apple_music": None,
+                    "bandcamp": None,
+                },
+            ),
+            RecheckResult(
+                library_id=2,
+                artist="μ-ziq",
+                title="Bluff Limbo",
+                on_streaming=False,
+                sources={"spotify": None, "deezer": None, "apple_music": None, "bandcamp": None},
+            ),
+        ]
+        out = tmp_path / "report.csv"
+        write_report(results, out)
+
+        text = out.read_text(encoding="utf-8")
+        # Diacritics survive the round-trip.
+        assert "μ-ziq" in text
+        assert "Lunatic Harness" in text
+        assert "https://open.spotify.com/album/x" in text
+        # First non-header row is the True result; CSV writes 1/0 for the boolean.
+        lines = text.splitlines()
+        assert lines[0].startswith("library_id,")
+        assert ",1," in lines[1]
+        assert ",0," in lines[2]


### PR DESCRIPTION
## Summary

Adds `scripts/recheck_streaming_after_mojibake.py` for re-running the streaming-availability check on releases whose `ALBUM_ARTIST` was previously mojibake'd.

V012 corrects double-encoded UTF-8 artist names in tubafrenzy that V003 missed (e.g. `Î¼-ziq` → `μ-ziq`). Earlier streaming-availability pipeline runs queried Spotify/Deezer with the corrupted strings and recorded `not_found`. Once V012 lands and library.db is re-synced from MySQL, those releases need a fresh check.

The script is read-only by default: it queries library.db for releases whose `artist` or `album_artist` matches a V012-corrected name, calls the existing `check_streaming_availability` orchestrator (Spotify + Deezer + Apple Music + Bandcamp) for each, and writes a CSV report. `on_streaming` propagation continues to flow through the existing admin-upload diff webhook (`LibraryReleaseService.updateOnStreaming()`), so this script does not mutate any database.

The hardcoded `MOJIBAKE_CORRECTED_ARTISTS` list mirrors V012's `FLOWSHEET_ENTRY_PROD.ARTIST_NAME` block (5 corrected names): `μ-ziq`, `GrOun士 + Kabamix`, `Luboš Fišer`, `Mustafah 'Abd Al'-Azīz`, `Σtella, Las Palabras`.

## Test plan

- [x] Unit tests cover library.db lookup (artist column, album_artist column, dedup, missing-column tolerance), the orchestrator wrapper (true/false/null cases), and CSV report writing with diacritics — `tests/unit/test_recheck_streaming_after_mojibake.py`
- [x] `ruff check .` + `ruff format --check .` clean
- [x] `mypy scripts/recheck_streaming_after_mojibake.py` clean
- [x] Full default `pytest` suite passes (1614 passed)
- [ ] In-session run after V012 lands: invoke against the post-V012 staging library.db, attach the resulting CSV + flip count to issue #161

Closes #161
Refs WXYC/docs#6