### PR TITLE
Add include_external_caches fallback to /api/v1/lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,17 @@ The service supports an optional PostgreSQL cache for Discogs data:
 
 Set `DATABASE_URL_DISCOGS` to enable. The cache schema is defined in [WXYC/discogs-etl](https://github.com/WXYC/discogs-etl).
 
+### External-Cache Fallback for `/api/v1/lookup` (Phase 1.5 mojibake recovery)
+
+`POST /api/v1/lookup` accepts an opt-in `include_external_caches: bool` flag (default `false`). When the WXYC library catalog returns no results AND the request supplies an `artist` field AND the flag is set, the orchestrator runs a fuzzy artist-name search against the discogs-cache PostgreSQL DB; on miss it falls through to musicbrainz-cache. The matched canonical name is wrapped in a synthetic `LookupResultItem` (`library_item.id = 0`, `call_number = "(external)"`, `library_url = ""`) so the caller's existing scoring code applies as-is. The response carries an `external_source` field — `'library' | 'discogs' | 'musicbrainz' | null` — for provenance.
+
+Used by the lossy-mojibake matcher (`tubafrenzy/scripts/db/recovery/lossy_mojibake_recovery.py`) to recover canonical artist names for skeletons not in the WXYC physical catalog. Implementation in `lookup/external_search.py`; the discogs-cache trigram query lives in `discogs/cache_service.py:search_artists_by_name`.
+
+Wiring:
+- `DATABASE_URL_DISCOGS` (already required for the standard cache) covers the discogs leg.
+- `DATABASE_URL_MUSICBRAINZ` is new — when unset the MB leg is skipped silently.
+- Existing callers (no flag) see no behavior change and no extra queries.
+
 ## Development
 
 ### Running locally
@@ -178,6 +189,7 @@ Required:
 
 Optional:
 - `DATABASE_URL_DISCOGS` -- PostgreSQL URL for Discogs cache
+- `DATABASE_URL_MUSICBRAINZ` -- PostgreSQL URL for the musicbrainz-cache. Powers the MB leg of the `/api/v1/lookup` external-cache fallback (Phase 1.5 mojibake recovery). Optional; when unset the MB leg is skipped.
 - `SPOTIFY_CLIENT_ID` -- Spotify client ID for streaming availability checks
 - `SPOTIFY_CLIENT_SECRET` -- Spotify client secret for streaming availability checks
 - `SENTRY_DSN` -- Sentry error tracking

--- a/config/settings.py
+++ b/config/settings.py
@@ -57,6 +57,16 @@ class Settings(BaseSettings):
         description="PostgreSQL connection URL for Discogs cache",
     )
 
+    # MusicBrainz Cache Database Configuration
+    database_url_musicbrainz: str | None = Field(
+        None,
+        description=(
+            "PostgreSQL connection URL for the musicbrainz-cache. Used by the "
+            "Phase 1.5 mojibake-recovery external-cache fallback in /api/v1/lookup. "
+            "Optional; when unset, the MB leg of the fallback is skipped."
+        ),
+    )
+
     # Discogs Cache Configuration
     discogs_track_cache_ttl: int = Field(
         default=3600, description="TTL in seconds for Discogs track cache (default: 1 hour)"

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -11,6 +11,7 @@ from core.exceptions import ServiceInitializationError
 from discogs.cache_service import DiscogsCacheService
 from discogs.service import DiscogsService
 from library.db import LibraryDB
+from scripts.entity_resolution.sources import PgSource
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ _library_db: LibraryDB | None = None
 _discogs_service: DiscogsService | None = None
 _discogs_pool: asyncpg.Pool | None = None
 _posthog_client: Posthog | None = None
+_musicbrainz_pg: PgSource | None = None
 
 
 async def get_library_db(settings: Settings = Depends(get_settings)) -> LibraryDB:
@@ -154,6 +156,43 @@ async def get_discogs_cache_service(
         return None
 
     return DiscogsCacheService(_discogs_pool)
+
+
+async def get_musicbrainz_pg(
+    settings: Settings = Depends(get_settings),
+) -> PgSource | None:
+    """Get a PgSource for the musicbrainz-cache PostgreSQL DB, if configured.
+
+    Used by the Phase 1.5 mojibake-recovery external-cache fallback in
+    ``/api/v1/lookup``. Returns ``None`` when ``DATABASE_URL_MUSICBRAINZ`` is
+    unset so the lookup endpoint gracefully degrades to discogs-only fallback
+    (or library-only when neither cache is configured).
+    """
+    global _musicbrainz_pg
+
+    if _musicbrainz_pg is not None:
+        return _musicbrainz_pg
+
+    dsn = settings.database_url_musicbrainz
+    if not dsn:
+        logger.debug("DATABASE_URL_MUSICBRAINZ not set -- MB cache fallback disabled")
+        return None
+
+    try:
+        _musicbrainz_pg = PgSource(dsn)
+        logger.info("MusicBrainz cache source initialized")
+        return _musicbrainz_pg
+    except Exception as e:
+        logger.warning("Failed to initialize MusicBrainz cache source: %s: %s", type(e).__name__, e)
+        return None
+
+
+async def close_musicbrainz_pg() -> None:
+    """Close the musicbrainz-cache PgSource."""
+    global _musicbrainz_pg
+    if _musicbrainz_pg is not None:
+        await _musicbrainz_pg.close()
+        _musicbrainz_pg = None
 
 
 def get_posthog_client(settings: Settings = Depends(get_settings)) -> Posthog | None:

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -136,6 +136,48 @@ class DiscogsCacheService:
             logger.error(f"Cache search failed: {e}")
             raise CacheUnavailableError(f"Cache search failed: {e}") from e
 
+    async def search_artists_by_name(self, name: str, *, limit: int = 5) -> list[dict]:
+        """Fuzzy-match an artist name against ``artist`` and ``artist_name_variation``.
+
+        Used by the Phase 1.5 mojibake-recovery fallback in the lookup
+        endpoint. Trigram similarity over diacritic-stripped lowercased
+        names; the canonical ``artist.name`` is returned even when the
+        match comes via ``artist_name_variation``.
+
+        Args:
+            name: Artist name (or skeleton) to search for.
+            limit: Maximum number of distinct artists to return.
+
+        Returns:
+            List of dicts with keys ``id``, ``name``, ``score``.
+
+        Raises:
+            CacheUnavailableError: If the database is unreachable.
+        """
+        try:
+            query = """
+                SELECT id, name, max(score) AS score FROM (
+                    SELECT a.id, a.name,
+                        similarity(lower(f_unaccent(a.name)), lower(f_unaccent($1))) AS score
+                    FROM artist a
+                    WHERE lower(f_unaccent(a.name)) % lower(f_unaccent($1))
+                    UNION ALL
+                    SELECT a.id, a.name,
+                        similarity(lower(f_unaccent(anv.name)), lower(f_unaccent($1))) AS score
+                    FROM artist a
+                    JOIN artist_name_variation anv ON anv.artist_id = a.id
+                    WHERE lower(f_unaccent(anv.name)) % lower(f_unaccent($1))
+                ) sub
+                GROUP BY id, name
+                ORDER BY score DESC
+                LIMIT $2
+            """
+            rows = await self.pool.fetch(query, name, limit)
+            return [{"id": r["id"], "name": r["name"], "score": float(r["score"])} for r in rows]
+        except Exception as e:
+            logger.error(f"Cache search_artists_by_name failed: {e}")
+            raise CacheUnavailableError(f"Cache search_artists_by_name failed: {e}") from e
+
     async def autocomplete_tracks(
         self, artist: str, q: str, *, release: str | None = None, limit: int = 20
     ) -> list[str]:

--- a/lookup/external_search.py
+++ b/lookup/external_search.py
@@ -1,0 +1,82 @@
+"""External cache fallback for artist-name lookup.
+
+When the WXYC library catalog returns no results, callers that opt in via
+``LookupRequest.include_external_caches`` get a fuzzy artist-name search
+against the discogs-cache PostgreSQL DB and, on miss, the musicbrainz-cache
+PostgreSQL DB. Used by the lossy-mojibake matcher
+(tubafrenzy/scripts/db/recovery/lossy_mojibake_recovery.py) to recover
+canonical artist names for skeletons that don't appear in the WXYC physical
+catalog.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
+from scripts.entity_resolution.sources import PgSourceProtocol
+
+logger = logging.getLogger(__name__)
+
+ExternalSource = Literal["discogs", "musicbrainz"]
+
+_MB_ARTIST_FUZZY_SQL = """\
+SELECT gid AS id, name,
+       similarity(lower(name), lower($1)) AS score
+FROM mb_artist
+WHERE lower(name) %% lower($1)
+ORDER BY score DESC
+LIMIT $2\
+""".replace("%%", "%")
+
+
+async def search_external_artists(
+    skeleton: str,
+    *,
+    discogs_cache: DiscogsCacheService | None,
+    mb_pg: PgSourceProtocol | None,
+    limit: int = 5,
+) -> tuple[list[dict[str, Any]], ExternalSource | None]:
+    """Fuzzy-match ``skeleton`` against external artist caches.
+
+    Tries discogs-cache first (broadest coverage), then falls through to
+    musicbrainz-cache on miss. Each cache is independently optional —
+    callers wire ``None`` when the corresponding DSN isn't configured.
+
+    Returns a list of ``{"id", "name"}`` dicts and the source that produced
+    them, or ``([], None)`` if neither cache returned a hit. Errors against
+    one cache do not block the next.
+    """
+    if not skeleton or not skeleton.strip():
+        return [], None
+
+    if discogs_cache is not None:
+        try:
+            rows = await discogs_cache.search_artists_by_name(skeleton, limit=limit)
+            if rows:
+                logger.info(
+                    "External fallback: discogs cache returned %d artists for %r",
+                    len(rows),
+                    skeleton,
+                )
+                return [{"id": r["id"], "name": r["name"]} for r in rows], "discogs"
+        except CacheUnavailableError as e:
+            logger.warning("Discogs cache unavailable for external fallback: %s", e)
+        except Exception as e:  # defensive: any unexpected error shouldn't block MB
+            logger.warning("Discogs external-fallback query failed: %s", e)
+
+    if mb_pg is not None:
+        try:
+            rows = await mb_pg.fetchall(_MB_ARTIST_FUZZY_SQL, skeleton, limit)
+            if rows:
+                logger.info(
+                    "External fallback: musicbrainz cache returned %d artists for %r",
+                    len(rows),
+                    skeleton,
+                )
+                return [{"id": r["id"], "name": r["name"]} for r in rows], "musicbrainz"
+        except Exception as e:
+            logger.warning("MusicBrainz external-fallback query failed: %s", e)
+
+    return [], None

--- a/lookup/models.py
+++ b/lookup/models.py
@@ -7,15 +7,25 @@ respective modules for domain logic.
 LookupResultItem and LookupResponse are overridden here to use SerializeAsAny
 so that EnrichedDiscogsMatchResult (a subclass of DiscogsMatchResult) is
 serialized with all its fields, not just the base class fields.
+
+LookupRequest and LookupResponse are extended with mojibake-cleanup
+Phase 1.5 fields (``include_external_caches`` / ``external_source``) ahead
+of the api.yaml regen so the lossy-mojibake matcher can opt in without
+waiting on the wxyc-shared release cycle. Fields default to opt-out so
+existing callers see no behavior change.
 """
 
-from pydantic import SerializeAsAny
+from typing import Literal
+
+from pydantic import Field, SerializeAsAny
 
 from generated.api_models import (
     DiscogsMatchResult,
     LibraryCatalogItem,
-    LookupRequest,
     SearchType,
+)
+from generated.api_models import (
+    LookupRequest as _GeneratedLookupRequest,
 )
 from generated.api_models import (
     LookupResponse as _GeneratedLookupResponse,
@@ -23,6 +33,26 @@ from generated.api_models import (
 from generated.api_models import (
     LookupResultItem as _GeneratedLookupResultItem,
 )
+
+
+class LookupRequest(_GeneratedLookupRequest):
+    """Override to add the Phase 1.5 ``include_external_caches`` opt-in.
+
+    Defaults to ``False`` so existing callers (Backend-Service, tubafrenzy
+    autocomplete, streaming-check) see no behavior change. The
+    lossy-mojibake matcher passes ``True`` to widen the search to the
+    discogs-cache + musicbrainz-cache PostgreSQL DBs when the WXYC library
+    catalog has no hit.
+    """
+
+    include_external_caches: bool = Field(
+        False,
+        description=(
+            "When True and the library returns no results, fall back to "
+            "fuzzy artist-name search against discogs-cache and then "
+            "musicbrainz-cache. Used by the mojibake-recovery matcher."
+        ),
+    )
 
 
 class LookupResultItem(_GeneratedLookupResultItem):
@@ -35,6 +65,15 @@ class LookupResponse(_GeneratedLookupResponse):
     """Override so results use our LookupResultItem with SerializeAsAny."""
 
     results: list[LookupResultItem] | None = None  # type: ignore[assignment]
+    external_source: Literal["library", "discogs", "musicbrainz"] | None = Field(
+        None,
+        description=(
+            "Provenance for the returned results: 'library' when the WXYC "
+            "catalog produced them, 'discogs'/'musicbrainz' when an external "
+            "cache fallback did, None when no results were found. Always "
+            "None for legacy callers that don't set include_external_caches."
+        ),
+    )
 
 
 __all__ = [

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -21,13 +21,16 @@ from core.search import (
     get_search_type_from_state,
 )
 from core.telemetry import RequestTelemetry
+from discogs.cache_service import DiscogsCacheService
 from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
 from discogs.models import DiscogsSearchRequest, DiscogsSearchResult, ReleaseInfo
 from discogs.service import DiscogsService
-from generated.api_models import ReconciledIdentity
+from generated.api_models import LibraryCatalogItem, ReconciledIdentity
 from library.db import STOPWORDS, LibraryDB
 from library.models import LibraryItem
+from lookup.external_search import search_external_artists
 from lookup.models import LookupRequest, LookupResponse, LookupResultItem
+from scripts.entity_resolution.sources import PgSourceProtocol
 from scripts.entity_resolution.store import EntityStore, Identity
 from services.parser import MessageType, ParsedRequest
 
@@ -1044,6 +1047,8 @@ async def perform_lookup(
     telemetry: RequestTelemetry,
     *,
     entity_store: EntityStore | None = None,
+    discogs_cache: DiscogsCacheService | None = None,
+    mb_pg: PgSourceProtocol | None = None,
 ) -> LookupResponse:
     """Orchestrate the full lookup pipeline.
 
@@ -1214,6 +1219,31 @@ async def perform_lookup(
                 )
             )
 
+    # Step 7: External-cache fallback (Phase 1.5 mojibake recovery).
+    # Opt-in via include_external_caches; only artist-keyed requests trigger
+    # the fallback today (the lossy bucket is dominated by artist skeletons).
+    external_source: str | None = "library" if result_items else None
+    if not result_items and request.include_external_caches and parsed.artist:
+        with telemetry.track_step("external_cache_fallback"):
+            candidates, source = await search_external_artists(
+                parsed.artist,
+                discogs_cache=discogs_cache,
+                mb_pg=mb_pg,
+            )
+        if candidates:
+            external_source = source
+            for candidate in candidates:
+                result_items.append(
+                    LookupResultItem(
+                        library_item=LibraryCatalogItem(
+                            id=0,
+                            artist=candidate["name"],
+                            call_number="(external)",
+                            library_url="",
+                        ),
+                    )
+                )
+
     return LookupResponse(
         results=result_items,
         search_type=search_type,
@@ -1221,4 +1251,5 @@ async def perform_lookup(
         found_on_compilation=found_on_compilation,
         context_message=context,
         corrected_artist=corrected_artist,
+        external_source=external_source,
     )

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -5,14 +5,22 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 from posthog import Posthog
 
-from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+from core.dependencies import (
+    get_discogs_cache_service,
+    get_discogs_service,
+    get_library_db,
+    get_musicbrainz_pg,
+    get_posthog_client,
+)
 from core.telemetry import RequestTelemetry, get_cache_stats, init_cache_stats
+from discogs.cache_service import DiscogsCacheService
 from discogs.memory_cache import set_skip_cache
 from discogs.service import DiscogsService
 from identity.dependencies import get_entity_store
 from library.db import LibraryDB
 from lookup.models import LookupRequest, LookupResponse
 from lookup.orchestrator import perform_lookup
+from scripts.entity_resolution.sources import PgSource
 from scripts.entity_resolution.store import EntityStore
 
 logger = logging.getLogger(__name__)
@@ -47,6 +55,8 @@ async def handle_lookup(
     request: LookupRequest,
     db: LibraryDB = Depends(get_library_db),
     discogs_service: DiscogsService | None = Depends(get_discogs_service),
+    discogs_cache: DiscogsCacheService | None = Depends(get_discogs_cache_service),
+    mb_pg: PgSource | None = Depends(get_musicbrainz_pg),
     entity_store: EntityStore | None = Depends(get_entity_store),
     posthog_client: Posthog | None = Depends(get_posthog_client),
     skip_cache: bool = False,
@@ -65,6 +75,8 @@ async def handle_lookup(
             discogs_service=discogs_service,
             telemetry=telemetry,
             entity_store=entity_store,
+            discogs_cache=discogs_cache,
+            mb_pg=mb_pg,
         )
 
         # Attach cache stats

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from core.auth import require_lml_key
 from core.dependencies import (
     close_discogs_service,
     close_library_db,
+    close_musicbrainz_pg,
     flush_posthog,
     shutdown_posthog,
 )
@@ -62,6 +63,7 @@ async def lifespan(app: FastAPI):
     await close_library_db()
     await close_discogs_service()
     await close_entity_store()
+    await close_musicbrainz_pg()
     await close_streaming_clients()
     logger.info("All services shut down")
 

--- a/tests/integration/test_external_cache_fallback.py
+++ b/tests/integration/test_external_cache_fallback.py
@@ -1,0 +1,133 @@
+"""Integration tests for the Phase 1.5 external-cache fallback.
+
+End-to-end coverage of the ``include_external_caches`` opt-in on
+``POST /api/v1/lookup``: ordering across library -> discogs -> MB,
+and that legacy callers see no behavior change.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def app_client_with_external_caches(library_db, test_settings):
+    """app_client with mocked discogs-cache and musicbrainz-cache PgSources."""
+    from httpx import ASGITransport, AsyncClient
+
+    from config.settings import get_settings
+    from core.dependencies import (
+        get_discogs_cache_service,
+        get_discogs_service,
+        get_library_db,
+        get_musicbrainz_pg,
+        get_posthog_client,
+    )
+    from main import app
+
+    discogs_cache = AsyncMock()
+    discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+
+    mb_pg = AsyncMock()
+    mb_pg.fetchall = AsyncMock(return_value=[])
+
+    app.dependency_overrides[get_library_db] = lambda: library_db
+    app.dependency_overrides[get_discogs_service] = lambda: None
+    app.dependency_overrides[get_discogs_cache_service] = lambda: discogs_cache
+    app.dependency_overrides[get_musicbrainz_pg] = lambda: mb_pg
+    app.dependency_overrides[get_posthog_client] = lambda: None
+    app.dependency_overrides[get_settings] = lambda: test_settings
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Expose the mocks on the client for assertions / per-test programming
+        client.discogs_cache = discogs_cache  # type: ignore[attr-defined]
+        client.mb_pg = mb_pg  # type: ignore[attr-defined]
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+class TestExternalCacheFallback:
+    @pytest.mark.asyncio
+    async def test_legacy_caller_does_not_trigger_external_query(
+        self, app_client_with_external_caches
+    ):
+        """Default request (no include_external_caches) preserves prior behavior."""
+        client = app_client_with_external_caches
+        resp = await client.post(
+            "/api/v1/lookup",
+            json={"artist": "ZZZNONEXISTENT", "raw_message": "ZZZNONEXISTENT"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["results"] == []
+        # external_source either omitted or null — both signal "no fallback ran"
+        assert body.get("external_source") is None
+        client.discogs_cache.search_artists_by_name.assert_not_called()
+        client.mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_library_hit_marks_source_library(self, app_client_with_external_caches):
+        """When the library has results, external caches are NOT consulted even with the flag."""
+        client = app_client_with_external_caches
+        resp = await client.post(
+            "/api/v1/lookup",
+            json={
+                "artist": "Stereolab",
+                "raw_message": "Stereolab",
+                "include_external_caches": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["results"]) >= 1
+        assert body["external_source"] == "library"
+        client.discogs_cache.search_artists_by_name.assert_not_called()
+        client.mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discogs_fallback_returns_canonical_name(self, app_client_with_external_caches):
+        """Library miss + discogs hit -> result with canonical artist + external_source='discogs'."""
+        client = app_client_with_external_caches
+        client.discogs_cache.search_artists_by_name.return_value = [
+            {"id": 99, "name": "Astrid Øster Mortensen", "score": 0.71},
+        ]
+
+        resp = await client.post(
+            "/api/v1/lookup",
+            json={
+                "artist": "Astrid ster Mortenson",
+                "raw_message": "Astrid ster Mortenson",
+                "include_external_caches": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["external_source"] == "discogs"
+        assert len(body["results"]) == 1
+        assert body["results"][0]["library_item"]["artist"] == "Astrid Øster Mortensen"
+        client.mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_musicbrainz_fallback_when_discogs_misses(self, app_client_with_external_caches):
+        """Library miss + discogs miss + MB hit -> external_source='musicbrainz'."""
+        client = app_client_with_external_caches
+        client.discogs_cache.search_artists_by_name.return_value = []
+        client.mb_pg.fetchall.return_value = [
+            {"id": "mb-uuid-1", "name": "Csillagrablók", "score": 0.83},
+        ]
+
+        resp = await client.post(
+            "/api/v1/lookup",
+            json={
+                "artist": "Csillagrablok",
+                "raw_message": "Csillagrablok",
+                "include_external_caches": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["external_source"] == "musicbrainz"
+        assert len(body["results"]) == 1
+        assert body["results"][0]["library_item"]["artist"] == "Csillagrablók"

--- a/tests/unit/test_external_artist_search.py
+++ b/tests/unit/test_external_artist_search.py
@@ -1,0 +1,151 @@
+"""Unit tests for lookup.external_search — discogs/MB fallback artist matching.
+
+Phase 1.5 of the mojibake-cleanup project (WXYC/library-metadata-lookup#184).
+The lossy-mojibake matcher passes ``include_external_caches=True`` on
+``POST /api/v1/lookup``. When the library catalog returns no hits, the
+orchestrator falls back to fuzzy artist-name search against the
+discogs-cache PostgreSQL DB and then the musicbrainz-cache PG DB so the
+matcher can resolve skeletons (``Astrid ster Mortenson``) to canonical
+artist names that aren't in the WXYC physical catalog.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.cache_service import CacheUnavailableError
+from lookup.external_search import search_external_artists
+
+
+@pytest.fixture
+def mock_discogs_cache():
+    cache = AsyncMock()
+    cache.search_artists_by_name = AsyncMock(return_value=[])
+    return cache
+
+
+@pytest.fixture
+def mock_mb_pg():
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    return pg
+
+
+class TestSearchExternalArtists:
+    @pytest.mark.asyncio
+    async def test_returns_discogs_hit_when_library_empty(self, mock_discogs_cache, mock_mb_pg):
+        """When discogs has a fuzzy hit, return it tagged 'discogs' and skip MB."""
+        mock_discogs_cache.search_artists_by_name.return_value = [
+            {"id": 99, "name": "Astrid Øster Mortensen", "score": 0.71},
+        ]
+
+        candidates, source = await search_external_artists(
+            "Astrid ster Mortenson",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert source == "discogs"
+        assert [c["name"] for c in candidates] == ["Astrid Øster Mortensen"]
+        mock_mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_musicbrainz(self, mock_discogs_cache, mock_mb_pg):
+        """When discogs returns nothing, query musicbrainz-cache."""
+        mock_discogs_cache.search_artists_by_name.return_value = []
+        mock_mb_pg.fetchall.return_value = [
+            {"id": "mb-uuid-1", "name": "Csillagrablók", "score": 0.83},
+        ]
+
+        candidates, source = await search_external_artists(
+            "Csillagrablok",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert source == "musicbrainz"
+        assert [c["name"] for c in candidates] == ["Csillagrablók"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_caches_match(self, mock_discogs_cache, mock_mb_pg):
+        candidates, source = await search_external_artists(
+            "ZZZ Nothing Here",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert candidates == []
+        assert source is None
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_caches_disabled(self):
+        """Both caches None — graceful degradation, no exception."""
+        candidates, source = await search_external_artists(
+            "Stereolab", discogs_cache=None, mb_pg=None
+        )
+
+        assert candidates == []
+        assert source is None
+
+    @pytest.mark.asyncio
+    async def test_skips_blank_skeleton(self, mock_discogs_cache, mock_mb_pg):
+        candidates, source = await search_external_artists(
+            "   ", discogs_cache=mock_discogs_cache, mb_pg=mock_mb_pg
+        )
+
+        assert candidates == []
+        assert source is None
+        mock_discogs_cache.search_artists_by_name.assert_not_called()
+        mock_mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discogs_unavailable_falls_through_to_musicbrainz(
+        self, mock_discogs_cache, mock_mb_pg
+    ):
+        """A discogs-cache outage must not block MB fallback."""
+        mock_discogs_cache.search_artists_by_name.side_effect = CacheUnavailableError("pool down")
+        mock_mb_pg.fetchall.return_value = [
+            {"id": "mb-uuid-1", "name": "Hermanos Gutiérrez", "score": 0.9},
+        ]
+
+        candidates, source = await search_external_artists(
+            "Hermanos Gutierrez",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert source == "musicbrainz"
+        assert candidates and candidates[0]["name"] == "Hermanos Gutiérrez"
+
+    @pytest.mark.asyncio
+    async def test_musicbrainz_error_returns_empty(self, mock_discogs_cache, mock_mb_pg):
+        mock_discogs_cache.search_artists_by_name.return_value = []
+        mock_mb_pg.fetchall.side_effect = RuntimeError("pg unreachable")
+
+        candidates, source = await search_external_artists(
+            "Whoever",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert candidates == []
+        assert source is None
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self, mock_discogs_cache, mock_mb_pg):
+        mock_discogs_cache.search_artists_by_name.return_value = [
+            {"id": i, "name": f"Artist {i}", "score": 0.7} for i in range(10)
+        ]
+
+        candidates, source = await search_external_artists(
+            "Artist",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+            limit=3,
+        )
+
+        assert source == "discogs"
+        # The cache layer is called with the limit; we trust it to slice.
+        mock_discogs_cache.search_artists_by_name.assert_awaited_once_with("Artist", limit=3)
+        # Result count comes from the cache; assert all candidates were preserved.
+        assert len(candidates) == 10

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1163,3 +1163,231 @@ class TestArtistAlbumPlusCompilation:
         assert response.found_on_compilation is True
         # Artist's own album should come first
         assert titles.index("London Zoo") < titles.index("The Sound of Dub")
+
+
+# ---------------------------------------------------------------------------
+# Tests: perform_lookup - external cache fallback (include_external_caches)
+# ---------------------------------------------------------------------------
+
+
+class TestPerformLookupExternalCacheFallback:
+    """include_external_caches=True falls back to discogs/MB when library is empty.
+
+    Used by the lossy-mojibake matcher in tubafrenzy to recover canonical artist
+    names that aren't in the WXYC library catalog (~99% of the lossy bucket).
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_off_does_not_query_external(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """Existing callers (no flag) see no behavior change and no external query."""
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(return_value=[])
+
+        request = LookupRequest(artist="Whoever", raw_message="Whoever")
+
+        response = await perform_lookup(
+            request,
+            mock_library_db,
+            mock_discogs_service,
+            telemetry,
+            discogs_cache=discogs_cache,
+            mb_pg=mb_pg,
+        )
+
+        assert response.results == []
+        assert response.external_source is None
+        discogs_cache.search_artists_by_name.assert_not_called()
+        mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_library_hit_marks_source_library_and_skips_external(
+        self,
+        mock_library_db,
+        mock_discogs_service,
+        telemetry,
+        stereolab_item,
+    ):
+        """When the library returns results, external_source='library' and external caches aren't queried."""
+        mock_library_db.search.return_value = [stereolab_item]
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Emperor Tomato Ketchup",
+            raw_message="Stereolab",
+            include_external_caches=True,
+        )
+
+        response = await perform_lookup(
+            request,
+            mock_library_db,
+            mock_discogs_service,
+            telemetry,
+            discogs_cache=discogs_cache,
+            mb_pg=mb_pg,
+        )
+
+        assert len(response.results) == 1
+        assert response.external_source == "library"
+        discogs_cache.search_artists_by_name.assert_not_called()
+        mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_discogs_when_library_empty(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """No library hit + flag set + discogs cache hit -> synthetic LookupResultItem."""
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(
+            return_value=[
+                {"id": 99, "name": "Astrid Øster Mortensen", "score": 0.71},
+            ]
+        )
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            artist="Astrid ster Mortenson",
+            raw_message="Astrid ster Mortenson",
+            include_external_caches=True,
+        )
+
+        response = await perform_lookup(
+            request,
+            mock_library_db,
+            mock_discogs_service,
+            telemetry,
+            discogs_cache=discogs_cache,
+            mb_pg=mb_pg,
+        )
+
+        assert response.external_source == "discogs"
+        assert len(response.results) == 1
+        assert response.results[0].library_item.artist == "Astrid Øster Mortensen"
+        # No artwork enrichment for external candidates
+        assert response.results[0].artwork is None
+        # MB never queried because discogs hit
+        mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_musicbrainz_when_discogs_empty(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(
+            return_value=[
+                {"id": "mb-uuid", "name": "Csillagrablók", "score": 0.83},
+            ]
+        )
+
+        request = LookupRequest(
+            artist="Csillagrablok",
+            raw_message="Csillagrablok",
+            include_external_caches=True,
+        )
+
+        response = await perform_lookup(
+            request,
+            mock_library_db,
+            mock_discogs_service,
+            telemetry,
+            discogs_cache=discogs_cache,
+            mb_pg=mb_pg,
+        )
+
+        assert response.external_source == "musicbrainz"
+        assert len(response.results) == 1
+        assert response.results[0].library_item.artist == "Csillagrablók"
+
+    @pytest.mark.asyncio
+    async def test_external_source_none_when_nothing_matches(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            artist="ZZZ Nothing",
+            raw_message="ZZZ Nothing",
+            include_external_caches=True,
+        )
+
+        response = await perform_lookup(
+            request,
+            mock_library_db,
+            mock_discogs_service,
+            telemetry,
+            discogs_cache=discogs_cache,
+            mb_pg=mb_pg,
+        )
+
+        assert response.results == []
+        assert response.external_source is None
+
+    @pytest.mark.asyncio
+    async def test_no_external_query_when_artist_field_missing(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """Phase 1.5 only handles artist-skeleton lookups — album/song-only requests skip the fallback."""
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            album="Some Album",
+            raw_message="Some Album",
+            include_external_caches=True,
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(
+                request,
+                mock_library_db,
+                mock_discogs_service,
+                telemetry,
+                discogs_cache=discogs_cache,
+                mb_pg=mb_pg,
+            )
+
+        assert response.external_source is None
+        discogs_cache.search_artists_by_name.assert_not_called()
+        mb_pg.fetchall.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds opt-in `include_external_caches` flag on `POST /api/v1/lookup`. When the WXYC library returns 0 results, the orchestrator falls back to fuzzy artist-name search against the `discogs-cache` PG DB, then the `musicbrainz-cache` PG DB.
- External candidates are synthesized into `LookupResultItem` shape (`call_number="(external)"`, `library_url=""`) so the lossy-mojibake matcher's skeleton-Levenshtein scoring applies unchanged.
- Adds top-level `external_source: 'library'|'discogs'|'musicbrainz'|null` for provenance. Default off — legacy callers see no behavior change.

## Implementation

- `lookup/external_search.py` (new) — orchestrates discogs → MB ordering with graceful per-leg degradation.
- `discogs/cache_service.py` — adds `search_artists_by_name()` using `pg_trgm` similarity over `artist.name` UNION `artist_name_variation.name`, both `f_unaccent`'d.
- MusicBrainz uses `similarity(lower(name), lower(\$1))` against `mb_artist`.
- `lookup/models.py` extends generated `LookupRequest`/`LookupResponse` via subclass override (avoids regenerating `wxyc-shared/api.yaml`).
- New env var: `DATABASE_URL_MUSICBRAINZ`. Optional; missing DSN silently disables the MB leg.
- Endpoint scoped to artist-bearing requests only.

## Test plan

- [x] Unit: `tests/unit/test_external_artist_search.py` — discogs hit, MB fallback, both empty, blank skeleton, discogs `CacheUnavailableError` falls through to MB, MB exception returns empty, respects limit (8 cases).
- [x] Unit: `tests/unit/test_orchestrator.py::TestPerformLookupExternalCacheFallback` — default off, library-source priority, falls back to discogs, falls back to MB, none-source on miss, no external query on artist-less requests (6 cases).
- [x] Integration: `tests/integration/test_external_cache_fallback.py` — end-to-end through FastAPI for legacy compat, library priority, discogs ordering, MB ordering (4 cases).
- [x] Full unit suite: 1504 passing.
- [x] `ruff check` + `ruff format` clean.

Closes #184
Refs WXYC/docs#6