### PR TITLE
Fix SparqlSource template substitution crashing on literal braces

### DIFF
--- a/scripts/entity_resolution/sources.py
+++ b/scripts/entity_resolution/sources.py
@@ -152,7 +152,12 @@ class SparqlSource:
         """Execute a SPARQL query in batches over a VALUES list.
 
         The template should contain a ``{values}`` placeholder that will be
-        replaced with space-separated items for each batch.
+        replaced with space-separated items for each batch. Substitution uses
+        :py:meth:`str.replace` rather than :py:meth:`str.format` because
+        SPARQL block syntax uses literal ``{`` and ``}`` everywhere — those
+        would crash ``str.format`` with ``ValueError: unexpected '{' in field
+        name``. Templates therefore stay readable as raw SPARQL with no brace
+        doubling.
 
         Args:
             sparql_template: SPARQL template with ``{values}`` placeholder.
@@ -165,7 +170,7 @@ class SparqlSource:
         for i in range(0, len(items), self._batch_size):
             batch = items[i : i + self._batch_size]
             values_str = " ".join(batch)
-            sparql = sparql_template.format(values=values_str)
+            sparql = sparql_template.replace("{values}", values_str)
             bindings = await self.query(sparql)
             all_bindings.extend(bindings)
         return all_bindings

--- a/scripts/entity_resolution/wikidata.py
+++ b/scripts/entity_resolution/wikidata.py
@@ -23,32 +23,35 @@ FROM discogs_mapping
 WHERE discogs_artist_id = ANY($1)\
 """
 
+# Templates use ``{values}`` / ``{name}`` placeholders substituted via
+# :py:meth:`str.replace`, NOT :py:meth:`str.format`, so literal SPARQL braces
+# need no doubling. See ``SparqlSource.query_batched``.
 _SPARQL_DISCOGS_TO_QID = """\
-SELECT ?item ?discogsId WHERE {{
-  VALUES ?discogsId {{ {values} }}
+SELECT ?item ?discogsId WHERE {
+  VALUES ?discogsId { {values} }
   ?item wdt:P1953 ?discogsId .
-}}\
+}\
 """
 
 _SPARQL_NAME_SEARCH = """\
-SELECT ?item ?itemLabel WHERE {{
+SELECT ?item ?itemLabel WHERE {
   ?item rdfs:label "{name}"@en .
-  {{ ?item wdt:P106/wdt:P279* wd:Q639669 . }}
+  { ?item wdt:P106/wdt:P279* wd:Q639669 . }
   UNION
-  {{ ?item wdt:P31 wd:Q215380 . }}
+  { ?item wdt:P31 wd:Q215380 . }
   UNION
-  {{ ?item wdt:P31 wd:Q5 . ?item wdt:P106 ?occ . ?occ wdt:P279* wd:Q639669 . }}
-  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en" . }}
-}} LIMIT 5\
+  { ?item wdt:P31 wd:Q5 . ?item wdt:P106 ?occ . ?occ wdt:P279* wd:Q639669 . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" . }
+} LIMIT 5\
 """
 
 _SPARQL_STREAMING_IDS = """\
-SELECT ?item ?spotifyId ?appleMusicId ?bandcampId WHERE {{
-  VALUES ?item {{ {values} }}
-  OPTIONAL {{ ?item wdt:P1902 ?spotifyId . }}
-  OPTIONAL {{ ?item wdt:P2850 ?appleMusicId . }}
-  OPTIONAL {{ ?item wdt:P3283 ?bandcampId . }}
-}}\
+SELECT ?item ?spotifyId ?appleMusicId ?bandcampId WHERE {
+  VALUES ?item { {values} }
+  OPTIONAL { ?item wdt:P1902 ?spotifyId . }
+  OPTIONAL { ?item wdt:P2850 ?appleMusicId . }
+  OPTIONAL { ?item wdt:P3283 ?bandcampId . }
+}\
 """
 
 
@@ -115,9 +118,8 @@ class WikidataReconciler:
 
     async def _resolve_qids_via_sparql(self, discogs_ids: set[int]) -> dict[int, str]:
         """Resolve Discogs IDs to QIDs via SPARQL P1953 property."""
-        values_str = " ".join(f'"{did}"' for did in discogs_ids)
-        sparql = _SPARQL_DISCOGS_TO_QID.format(values=values_str)
-        bindings = await self._sparql.query_batched(sparql, [f"Q{did}" for did in discogs_ids])
+        items = [f'"{did}"' for did in discogs_ids]
+        bindings = await self._sparql.query_batched(_SPARQL_DISCOGS_TO_QID, items)
 
         result: dict[int, str] = {}
         for binding in bindings:
@@ -145,7 +147,7 @@ class WikidataReconciler:
             Wikidata QID of the best match, or None if not found.
         """
         escaped_name = name.replace('"', '\\"')
-        sparql = _SPARQL_NAME_SEARCH.format(name=escaped_name)
+        sparql = _SPARQL_NAME_SEARCH.replace("{name}", escaped_name)
         bindings = await self._sparql.query(sparql)
 
         if not bindings:

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -1,0 +1,97 @@
+"""Unit tests for entity_resolution source transports."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.entity_resolution.sources import SparqlSource
+
+
+class TestQueryBatchedTemplateSubstitution:
+    """``query_batched`` must substitute ``{values}`` without choking on the
+    literal ``{`` and ``}`` that appear in every SPARQL block."""
+
+    @pytest.mark.asyncio
+    async def test_template_with_literal_braces_is_substituted(self, monkeypatch):
+        """A raw SPARQL template (literal braces, single ``{values}`` placeholder)
+        must reach the underlying ``query()`` call with ``{values}`` replaced
+        and the literal SPARQL braces preserved.
+
+        Regression: WXYC/library-metadata-lookup#182. ``str.format`` raises
+        ``ValueError: unexpected '{' in field name`` on the first literal brace
+        after the placeholder.
+        """
+        sparql = SparqlSource(batch_size=10)
+        captured: list[str] = []
+
+        async def fake_query(query_str: str):
+            captured.append(query_str)
+            return []
+
+        monkeypatch.setattr(sparql, "query", fake_query)
+
+        template = (
+            "SELECT ?item ?discogsId WHERE {\n"
+            "  VALUES ?discogsId { {values} }\n"
+            "  ?item wdt:P1953 ?discogsId .\n"
+            "}"
+        )
+        await sparql.query_batched(template, ['"12"', '"34"'])
+
+        assert len(captured) == 1
+        rendered = captured[0]
+        assert '"12" "34"' in rendered
+        assert "{values}" not in rendered
+        # Literal SPARQL braces survive untouched.
+        assert "WHERE {" in rendered
+        assert "VALUES ?discogsId {" in rendered
+
+    @pytest.mark.asyncio
+    async def test_batches_split_by_batch_size(self, monkeypatch):
+        """Items longer than ``batch_size`` produce one ``query`` call per batch,
+        each carrying its own substituted VALUES list."""
+        sparql = SparqlSource(batch_size=2)
+        captured: list[str] = []
+
+        async def fake_query(query_str: str):
+            captured.append(query_str)
+            return []
+
+        monkeypatch.setattr(sparql, "query", fake_query)
+
+        template = "SELECT ?x WHERE { VALUES ?x { {values} } }"
+        await sparql.query_batched(template, ['"1"', '"2"', '"3"', '"4"', '"5"'])
+
+        assert len(captured) == 3
+        assert '"1" "2"' in captured[0]
+        assert '"3" "4"' in captured[1]
+        assert '"5"' in captured[2]
+
+    @pytest.mark.asyncio
+    async def test_combines_bindings_from_all_batches(self, monkeypatch):
+        """``query_batched`` returns the concatenated bindings from every batch."""
+        sparql = SparqlSource(batch_size=2)
+        call_count = {"n": 0}
+
+        async def fake_query(query_str: str):
+            call_count["n"] += 1
+            return [{"row": call_count["n"]}]
+
+        monkeypatch.setattr(sparql, "query", fake_query)
+
+        template = "SELECT ?x WHERE { VALUES ?x { {values} } }"
+        bindings = await sparql.query_batched(template, ["a", "b", "c"])
+
+        assert bindings == [{"row": 1}, {"row": 2}]
+
+    @pytest.mark.asyncio
+    async def test_empty_items_makes_no_queries(self, monkeypatch):
+        """Empty ``items`` list short-circuits without calling ``query``."""
+        sparql = SparqlSource()
+        query_mock = AsyncMock(return_value=[])
+        monkeypatch.setattr(sparql, "query", query_mock)
+
+        bindings = await sparql.query_batched("template", [])
+
+        assert bindings == []
+        query_mock.assert_not_called()

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from scripts.entity_resolution.wikidata import WikidataReconciler
+from scripts.entity_resolution.wikidata import (
+    _SPARQL_DISCOGS_TO_QID,
+    WikidataReconciler,
+)
 
 
 @pytest.fixture
@@ -67,6 +70,29 @@ class TestDiscogsIdToQidViaCache:
         result = await reconciler.resolve_qids_from_discogs_ids({12})
         assert result[12] == "Q378288"
         mock_sparql.query_batched.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sparql_fallback_passes_template_and_quoted_ids(
+        self, reconciler, mock_wikidata_pg, mock_sparql
+    ):
+        """The SPARQL fallback must hand ``query_batched`` the *unformatted*
+        template and the SPARQL-quoted Discogs IDs as items, so batching
+        actually splits the work and the literal SPARQL braces survive.
+
+        Regression: WXYC/library-metadata-lookup#182. Previously the call
+        site pre-substituted ``{values}`` (defeating batching) and then passed
+        ``Q``-prefixed strings as items (wrong format and never used).
+        """
+        mock_wikidata_pg.fetchall = AsyncMock(return_value=[])
+        mock_sparql.query_batched = AsyncMock(return_value=[])
+
+        await reconciler.resolve_qids_from_discogs_ids({12, 34})
+
+        mock_sparql.query_batched.assert_called_once()
+        template_arg, items_arg = mock_sparql.query_batched.call_args.args
+        assert template_arg is _SPARQL_DISCOGS_TO_QID
+        assert "{values}" in template_arg
+        assert set(items_arg) == {'"12"', '"34"'}
 
 
 class TestNameSearch:


### PR DESCRIPTION
## Summary

- `SparqlSource.query_batched` used `str.format(values=...)` against templates that contain literal SPARQL `{` / `}` for every block, raising `ValueError: unexpected '{' in field name` at the start of the Wikidata reconciliation stage. Switched to `str.replace("{values}", ...)` so substitution is robust and templates stay readable as raw SPARQL.
- `WikidataReconciler._resolve_qids_via_sparql` had a secondary bug surfaced by the crash: it pre-substituted the template before calling `query_batched` (defeating batching) and passed `Q`-prefixed strings as items (wrong format and never used). Cleaned up to hand `query_batched` the raw template plus quoted Discogs IDs as items, mirroring the working `fetch_streaming_ids` shape.
- Undid the now-unnecessary `{{` / `}}` doubling across all three SPARQL templates and switched the `_SPARQL_NAME_SEARCH` call site to `.replace()` for consistency.

Until this lands, the Wikidata / Spotify / Apple Music / Bandcamp stages of the reconciliation pipeline cannot run, so `entity.identity` rows only carry `discogs_artist_id` populated. Downstream consumers (notably Backend-Service's `artist-identity-etl` and any client reading `reconciled_identity` from `/library/info`) only see a Discogs ID.

Closes #182.

## Test plan

- [x] `pytest tests/unit/test_sources.py` — 4 new tests covering `query_batched` substitution, batching, binding aggregation, and empty-input short-circuit
- [x] `pytest tests/unit/test_wikidata_reconciliation.py` — added regression test asserting the SPARQL fallback hands the raw template plus `'"<id>"'` items to `query_batched`
- [x] `pytest tests/unit/` — full suite green (1495 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy . --ignore-missing-imports` clean