### PR TITLE
fix(identity): return 503 instead of 500 when entity store is unavailable

### DIFF
--- a/audit/lml_capability_matrix.md
+++ b/audit/lml_capability_matrix.md
@@ -70,8 +70,8 @@ Cache: TTLCache for `find_similar_artist` and `search` results, cleared on `/adm
 | `POST /lookup {artist:"µ-Ziq", album:"Lunatic Harness"}` | `/lookup` | `search_type=direct`, hit. ✅ |
 | `POST /lookup {artist:"μ-Ziq"}` (no album) | `/lookup` | `search_type=fallback`, 5 hits. ✅ |
 | `POST /lookup {artist:"Σtella"}` | `/lookup` | 0 hits — artist not in WXYC catalog (not a fuzzy bug). |
-| `GET /identity/resolve?name=Stereolab` | `/identity/resolve` | **HTTP 500** in both staging and production. Should be 503 when `DATABASE_URL_DISCOGS` is unset, per `CLAUDE.md`. ⚠️ |
-| `POST /identity/bulk` | `/identity/bulk` | **HTTP 500**. Same issue. ⚠️ |
+| `GET /identity/resolve?name=Stereolab` | `/identity/resolve` | 200 / 404 normally; **503** when `DATABASE_URL_DISCOGS` is unset or the `entity` schema is missing (fixed in #169). |
+| `POST /identity/bulk` | `/identity/bulk` | 200 normally; **503** when entity store is unavailable, including mid-request `asyncpg.PostgresError` (fail-closed; fixed in #169). |
 
 ## Codepoint subtlety: U+00B5 vs U+03BC
 

--- a/identity/dependencies.py
+++ b/identity/dependencies.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from asyncpg.exceptions import PostgresError
 from fastapi import Depends
 
 from config.settings import Settings, get_settings
@@ -12,6 +13,10 @@ logger = logging.getLogger(__name__)
 
 _entity_store: EntityStore | None = None
 _entity_pg: PgSource | None = None
+_entity_probe_failed: bool = False
+
+# Lightweight probe: confirms the schema is applied without scanning rows.
+_PROBE_SQL = "SELECT 1 FROM entity.identity LIMIT 0"
 
 
 async def get_entity_store(
@@ -22,33 +27,59 @@ async def get_entity_store(
     The entity store reuses the ``DATABASE_URL_DISCOGS`` connection since
     the ``entity`` schema lives in the discogs-cache PostgreSQL database.
 
-    Returns:
-        EntityStore if the database is configured, None otherwise.
+    Returns ``None`` — which the router renders as 503 — when
+    ``DATABASE_URL_DISCOGS`` is unset, the DSN is unreachable, or the
+    ``entity.identity`` table is missing. A failed probe is cached for
+    the process lifetime; Railway redeploys are the recovery path.
     """
-    global _entity_store, _entity_pg
+    global _entity_store, _entity_pg, _entity_probe_failed
 
     if _entity_store is not None:
         return _entity_store
+    if _entity_probe_failed:
+        return None
 
     dsn = settings.database_url_discogs
     if not dsn:
         logger.debug("DATABASE_URL_DISCOGS not set -- entity store disabled")
         return None
 
+    pg = PgSource(dsn)
     try:
-        _entity_pg = PgSource(dsn)
-        _entity_store = EntityStore(_entity_pg)
-        logger.info("Entity store initialized")
-        return _entity_store
-    except Exception as e:
-        logger.warning("Failed to initialize entity store: %s: %s", type(e).__name__, e)
+        await pg.fetchone(_PROBE_SQL)
+    except (PostgresError, OSError) as e:
+        logger.warning(
+            "Entity store probe failed; disabling identity routes: %s: %s",
+            type(e).__name__,
+            e,
+        )
+        _entity_probe_failed = True
+        await _safe_close(pg)
         return None
+    except Exception as e:
+        logger.warning("Unexpected error initializing entity store: %s: %s", type(e).__name__, e)
+        _entity_probe_failed = True
+        await _safe_close(pg)
+        return None
+
+    _entity_pg = pg
+    _entity_store = EntityStore(pg)
+    logger.info("Entity store initialized")
+    return _entity_store
+
+
+async def _safe_close(pg: PgSource) -> None:
+    try:
+        await pg.close()
+    except Exception:
+        pass
 
 
 async def close_entity_store() -> None:
     """Close the entity store PgSource connection."""
-    global _entity_store, _entity_pg
+    global _entity_store, _entity_pg, _entity_probe_failed
     if _entity_pg is not None:
         await _entity_pg.close()
         _entity_pg = None
     _entity_store = None
+    _entity_probe_failed = False

--- a/identity/router.py
+++ b/identity/router.py
@@ -6,6 +6,7 @@ that query the ``entity.identity`` table in the discogs-cache database.
 
 import logging
 
+from asyncpg.exceptions import PostgresError
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from identity.dependencies import get_entity_store
@@ -19,6 +20,11 @@ from scripts.entity_resolution.store import EntityStore, Identity
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["identity"])
+
+_ENTITY_STORE_UNAVAILABLE_DETAIL = (
+    "Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
+    "and the entity schema has been applied."
+)
 
 
 def _identity_to_response(identity: Identity) -> IdentityResponse:
@@ -38,11 +44,7 @@ def _identity_to_response(identity: Identity) -> IdentityResponse:
 def _require_entity_store(store: EntityStore | None) -> EntityStore:
     """Raise 503 if the entity store is not available."""
     if store is None:
-        raise HTTPException(
-            status_code=503,
-            detail="Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
-            "and the entity schema has been applied.",
-        )
+        raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
     return store
 
 
@@ -62,7 +64,11 @@ async def resolve_identity(
 ) -> IdentityResponse:
     """Look up a single artist name in the entity identity store."""
     store = _require_entity_store(entity_store)
-    identity = await store.get_identity(name)
+    try:
+        identity = await store.get_identity(name)
+    except (PostgresError, OSError):
+        logger.exception("Entity store query failed for name=%r", name)
+        raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
     if identity is None:
         raise HTTPException(status_code=404, detail=f"No identity found for '{name}'")
     return _identity_to_response(identity)
@@ -92,7 +98,13 @@ async def bulk_resolve_identities(
     unresolved: list[str] = []
 
     for name in request.names:
-        identity = await store.get_identity(name)
+        try:
+            identity = await store.get_identity(name)
+        except (PostgresError, OSError):
+            # Fail closed on partial PG failure: the caller cannot distinguish
+            # "name had no identity" from "PG died before this name was tried".
+            logger.exception("Entity store query failed mid-bulk for name=%r", name)
+            raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
         if identity is not None:
             identities.append(_identity_to_response(identity))
         else:

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -186,6 +186,68 @@ class TestDiscogsReconciliationIntegration:
 
 
 @pytest.mark.pg
+class TestIdentityRouterEntityStoreUnavailable:
+    """Identity routes return 503 — not 500 — when the entity schema is missing.
+
+    Regression for #169: a misconfigured deploy (no DATABASE_URL_DISCOGS, or DSN
+    pointing at a DB without the entity schema applied) used to leak a 500.
+    """
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def set_up_entity_schema(self, pg_pool):
+        """Override the module-level autouse fixture: keep the schema *missing*."""
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        yield
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+
+    @pytest_asyncio.fixture
+    async def app_with_pg_dsn(self, monkeypatch):
+        """Reset the dep cache and point Settings at the test DSN."""
+        import identity.dependencies as deps
+        from config.settings import get_settings
+
+        monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
+        get_settings.cache_clear()
+        deps._entity_store = None
+        deps._entity_pg = None
+        deps._entity_probe_failed = False
+
+        from main import app
+
+        yield app
+
+        deps._entity_store = None
+        deps._entity_pg = None
+        deps._entity_probe_failed = False
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_503_when_entity_schema_missing(self, app_with_pg_dsn):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_pg_dsn), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
+
+        assert resp.status_code == 503
+        assert "entity store" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_bulk_returns_503_when_entity_schema_missing(self, app_with_pg_dsn):
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_pg_dsn), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/identity/bulk", json={"names": ["Stereolab"]})
+
+        assert resp.status_code == 503
+
+
+@pytest.mark.pg
 class TestDeduplicationIntegration:
     """Test deduplication against real PostgreSQL."""
 

--- a/tests/unit/test_identity_dependencies.py
+++ b/tests/unit/test_identity_dependencies.py
@@ -1,0 +1,103 @@
+"""Unit tests for identity/dependencies.py — get_entity_store probe behaviour."""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+import identity.dependencies as deps
+from config.settings import Settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_dep_state():
+    """Ensure each test sees a fresh dependency cache."""
+    deps._entity_store = None
+    deps._entity_pg = None
+    deps._entity_probe_failed = False
+    yield
+    deps._entity_store = None
+    deps._entity_pg = None
+    deps._entity_probe_failed = False
+
+
+def _settings(dsn: str | None) -> Settings:
+    return Settings(
+        discogs_token=None,
+        database_url_discogs=dsn,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+        library_db_path="test_library.db",
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_dsn_unset():
+    assert await deps.get_entity_store(_settings(None)) is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_probe_raises_undefined_table(monkeypatch):
+    """Probe failure (entity schema not applied) → store disabled."""
+
+    async def boom(self, query, *args):
+        raise asyncpg.UndefinedTableError('relation "entity.identity" does not exist')
+
+    monkeypatch.setattr("scripts.entity_resolution.sources.PgSource.fetchone", boom)
+    monkeypatch.setattr(
+        "scripts.entity_resolution.sources.PgSource.close",
+        _noop_close,
+    )
+
+    result = await deps.get_entity_store(_settings("postgresql://x:y@127.0.0.1:1/z"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_probe_raises_oserror(monkeypatch):
+    """Probe failure (PG host unreachable) → store disabled."""
+
+    async def boom(self, query, *args):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("scripts.entity_resolution.sources.PgSource.fetchone", boom)
+    monkeypatch.setattr("scripts.entity_resolution.sources.PgSource.close", _noop_close)
+
+    result = await deps.get_entity_store(_settings("postgresql://x:y@127.0.0.1:1/z"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_is_cached(monkeypatch):
+    """A failed probe is not retried on subsequent calls (process-lifetime cache)."""
+    call_count = 0
+
+    async def boom(self, query, *args):
+        nonlocal call_count
+        call_count += 1
+        raise asyncpg.UndefinedTableError("nope")
+
+    monkeypatch.setattr("scripts.entity_resolution.sources.PgSource.fetchone", boom)
+    monkeypatch.setattr("scripts.entity_resolution.sources.PgSource.close", _noop_close)
+
+    settings = _settings("postgresql://x:y@127.0.0.1:1/z")
+    assert await deps.get_entity_store(settings) is None
+    assert await deps.get_entity_store(settings) is None
+    assert await deps.get_entity_store(settings) is None
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_returns_store_when_probe_succeeds(monkeypatch):
+    async def ok(self, query, *args):
+        return None  # SELECT ... LIMIT 0 returns no rows
+
+    monkeypatch.setattr("scripts.entity_resolution.sources.PgSource.fetchone", ok)
+
+    result = await deps.get_entity_store(_settings("postgresql://x:y@127.0.0.1:1/z"))
+    assert result is not None
+
+
+async def _noop_close(self):
+    return None

--- a/tests/unit/test_identity_router.py
+++ b/tests/unit/test_identity_router.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+import asyncpg
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -206,6 +207,63 @@ class TestEntityStoreUnavailable:
         ):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
+
+        assert resp.status_code == 503
+        assert "entity store" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_503_when_pg_raises_undefined_table(
+        self, app_client, mock_entity_store
+    ):
+        """A mid-request asyncpg.UndefinedTableError maps to 503, not 500."""
+        mock_entity_store.get_identity.side_effect = asyncpg.UndefinedTableError(
+            'relation "entity.identity" does not exist'
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
+
+        assert resp.status_code == 503
+        assert "entity store" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_503_when_pg_unreachable(self, app_client, mock_entity_store):
+        """A mid-request OSError (PG host unreachable) maps to 503, not 500."""
+        mock_entity_store.get_identity.side_effect = OSError("connection refused")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_bulk_returns_503_when_pg_fails_midway(self, app_client, mock_entity_store):
+        """Bulk endpoint returns 503 (not partial 200) when PG dies mid-request.
+
+        Distinguishing 'this name had no identity' (correctly in unresolved[]) from
+        'this name was never tried because PG died' is impossible from a partial
+        response — fail closed instead.
+        """
+        good = _make_identity_record("Autechre", id=1, discogs_artist_id=12)
+
+        async def flaky_get_identity(name: str):
+            if name == "Autechre":
+                return good
+            raise asyncpg.PostgresConnectionError("server closed the connection unexpectedly")
+
+        mock_entity_store.get_identity.side_effect = flaky_get_identity
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/identity/bulk",
+                json={"names": ["Autechre", "Stereolab"]},
+            )
 
         assert resp.status_code == 503
         assert "entity store" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

- `/identity/resolve` and `/identity/bulk` previously leaked HTTP 500 when `DATABASE_URL_DISCOGS` was unset, the DSN was unreachable, or the `entity.identity` table was missing. Documented contract (CLAUDE.md, OpenAPI `responses` block) is 503 in all those cases.
- `get_entity_store` now runs a one-shot `SELECT 1 FROM entity.identity LIMIT 0` probe and returns `None` on any `asyncpg.PostgresError` / `OSError`, caching the failure for the process lifetime so requests don't re-probe.
- `resolve_identity` and `bulk_resolve_identities` catch mid-request PG/OS errors and convert to 503 with `logger.exception`. Bulk fails closed on partial PG failure rather than returning a misleading partial 200.
- Audit doc `audit/lml_capability_matrix.md` updated to reflect the corrected behaviour.

Closes #169

## Test plan

- [x] `pytest tests/unit/test_identity_dependencies.py tests/unit/test_identity_router.py -v` — 16 passed (5 new dep probe tests + 3 new router 503 tests + existing)
- [x] `pytest tests/unit/ -q` — 1498 passed, no regressions
- [x] `pytest -m pg tests/integration/test_entity_resolution.py -v` — 7 passed, 1 skipped (release_artist fixture missing locally, expected); includes 2 new router-level 503 tests against a Postgres without the entity schema
- [x] `ruff check` and `ruff format --check` clean
- [x] `mypy identity/ --ignore-missing-imports` clean
- [ ] After staging deploy: toggle `DATABASE_URL_DISCOGS` off, hit `/identity/resolve?name=Stereolab`, expect 503; toggle back on, expect 200