### PR TITLE
Prefix QIDs with wd: in fetch_streaming_ids SPARQL VALUES clause

### DIFF
--- a/scripts/entity_resolution/wikidata.py
+++ b/scripts/entity_resolution/wikidata.py
@@ -175,7 +175,10 @@ class WikidataReconciler:
         if not qids:
             return {}
 
-        bindings = await self._sparql.query_batched(_SPARQL_STREAMING_IDS, qids)
+        # Prefix with ``wd:`` so the rendered ``VALUES ?item { ... }`` clause is
+        # syntactically valid SPARQL — bare ``Q378288`` is a parse error.
+        items = [f"wd:{qid}" for qid in qids]
+        bindings = await self._sparql.query_batched(_SPARQL_STREAMING_IDS, items)
 
         result: dict[str, StreamingIds] = {}
         for binding in bindings:

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -4,8 +4,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from scripts.entity_resolution.sources import SparqlSource
 from scripts.entity_resolution.wikidata import (
     _SPARQL_DISCOGS_TO_QID,
+    _SPARQL_STREAMING_IDS,
     WikidataReconciler,
 )
 
@@ -138,6 +140,51 @@ class TestStreamingIdFetch:
         assert ids.spotify_artist_id == "2cGiltMnETMr482N3F3ILQK"
         assert ids.apple_music_artist_id == "1234567"
         assert ids.bandcamp_id == "autechre"
+
+    @pytest.mark.asyncio
+    async def test_passes_wd_prefixed_qids_to_query_batched(self, reconciler, mock_sparql):
+        """``fetch_streaming_ids`` must hand ``query_batched`` items already
+        prefixed with ``wd:`` so the rendered SPARQL ``VALUES`` clause is
+        syntactically valid (bare ``Q378288`` is a SPARQL parse error).
+
+        Regression: WXYC/library-metadata-lookup#187.
+        """
+        mock_sparql.query_batched = AsyncMock(return_value=[])
+
+        await reconciler.fetch_streaming_ids(["Q378288", "Q123"])
+
+        mock_sparql.query_batched.assert_called_once()
+        template_arg, items_arg = mock_sparql.query_batched.call_args.args
+        assert template_arg is _SPARQL_STREAMING_IDS
+        assert items_arg == ["wd:Q378288", "wd:Q123"]
+
+    @pytest.mark.asyncio
+    async def test_rendered_sparql_uses_wd_prefix(self, mock_wikidata_pg, monkeypatch):
+        """End-to-end through real ``SparqlSource``: capture the substituted
+        SPARQL and confirm the VALUES clause has ``wd:Q...``, not bare ``Q...``.
+
+        Regression: WXYC/library-metadata-lookup#187. Without the prefix,
+        Wikidata's SPARQL endpoint rejects the query at parse time.
+        """
+        sparql = SparqlSource(batch_size=10)
+        captured: list[str] = []
+
+        async def fake_query(query_str: str):
+            captured.append(query_str)
+            return []
+
+        monkeypatch.setattr(sparql, "query", fake_query)
+        reconciler = WikidataReconciler(sparql=sparql, wikidata_pg=mock_wikidata_pg)
+
+        await reconciler.fetch_streaming_ids(["Q378288", "Q123"])
+
+        assert len(captured) == 1
+        rendered = captured[0]
+        assert "wd:Q378288" in rendered
+        assert "wd:Q123" in rendered
+        # No bare QIDs anywhere in the VALUES clause.
+        assert "{ Q378288" not in rendered
+        assert " Q378288 " not in rendered
 
     @pytest.mark.asyncio
     async def test_partial_streaming_ids(self, reconciler, mock_sparql):


### PR DESCRIPTION
## Summary

- `WikidataReconciler.fetch_streaming_ids` passed raw QIDs (`["Q378288", ...]`) straight into `SparqlSource.query_batched`, which substituted them into `VALUES ?item { Q378288 Q123 }`. Bare `Q378288` is invalid SPARQL — `?item` is bound to entity URIs and needs the standard `wd:` prefix (or a full angle-bracketed URI). WDQS rejected the query at parse time, blocking the streaming-ID enrichment leg of the reconciliation pipeline after #182 unblocked the QID-resolution leg.
- Fixed by prefixing items with `wd:` at the call site, mirroring the shape `_resolve_qids_via_sparql` adopted in #186.

Closes #187.

## Test plan

- [x] `pytest tests/unit/test_wikidata_reconciliation.py` — two new regression tests:
  - `test_passes_wd_prefixed_qids_to_query_batched`: asserts the call site hands `query_batched` items like `"wd:Q378288"`, not `"Q378288"`.
  - `test_rendered_sparql_uses_wd_prefix`: end-to-end through a real `SparqlSource` with monkeypatched `query()` to capture the substituted SPARQL and confirm the VALUES clause has `wd:Q378288`, not bare `Q378288`.
- [x] `pytest tests/unit/` — full suite green (1519 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy . --ignore-missing-imports` clean