### PR TITLE
Extend MB external-cache fuzzy fallback to UNION mb_artist_alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Set `DATABASE_URL_DISCOGS` to enable. The cache schema is defined in [WXYC/disco
 
 `POST /api/v1/lookup` accepts an opt-in `include_external_caches: bool` flag (default `false`). When the WXYC library catalog returns no results AND the request supplies an `artist` field AND the flag is set, the orchestrator runs a fuzzy artist-name search against the discogs-cache PostgreSQL DB; on miss it falls through to musicbrainz-cache. The matched canonical name is wrapped in a synthetic `LookupResultItem` (`library_item.id = 0`, `call_number = "(external)"`, `library_url = ""`) so the caller's existing scoring code applies as-is. The response carries an `external_source` field — `'library' | 'discogs' | 'musicbrainz' | null` — for provenance.
 
-Used by the lossy-mojibake matcher (`tubafrenzy/scripts/db/recovery/lossy_mojibake_recovery.py`) to recover canonical artist names for skeletons not in the WXYC physical catalog. Implementation in `lookup/external_search.py`; the discogs-cache trigram query lives in `discogs/cache_service.py:search_artists_by_name`.
+Used by the lossy-mojibake matcher (`tubafrenzy/scripts/db/recovery/lossy_mojibake_recovery.py`) to recover canonical artist names for skeletons not in the WXYC physical catalog. Implementation in `lookup/external_search.py`; the discogs-cache trigram query lives in `discogs/cache_service.py:search_artists_by_name`. Both legs UNION their primary artist table with the alias/variation table (discogs: `artist_name_variation`; musicbrainz: `mb_artist_alias`) so ASCII transliterations and alternate spellings hit, and the canonical primary name is what comes back.
 
 Wiring:
 - `DATABASE_URL_DISCOGS` (already required for the standard cache) covers the discogs leg.

--- a/lookup/external_search.py
+++ b/lookup/external_search.py
@@ -21,14 +21,29 @@ logger = logging.getLogger(__name__)
 
 ExternalSource = Literal["discogs", "musicbrainz"]
 
+# Trigram similarity over mb_artist.name UNION mb_artist_alias.name. Aliases
+# carry alternate spellings and ASCII transliterations of accented names
+# (e.g. 'Csillagrablok' -> 'Csillagrablók'); skipping them undercuts recall
+# on the lossy-mojibake matcher. The canonical mb_artist.name is returned
+# even when the trigram hit was against an alias row, so downstream skeleton
+# scoring operates on the canonical form.
 _MB_ARTIST_FUZZY_SQL = """\
-SELECT gid AS id, name,
-       similarity(lower(name), lower($1)) AS score
-FROM mb_artist
-WHERE lower(name) %% lower($1)
+SELECT id, name, max(score) AS score FROM (
+    SELECT a.gid AS id, a.name,
+           similarity(lower(a.name), lower($1)) AS score
+    FROM mb_artist a
+    WHERE lower(a.name) % lower($1)
+    UNION ALL
+    SELECT a.gid AS id, a.name,
+           similarity(lower(aa.name), lower($1)) AS score
+    FROM mb_artist a
+    JOIN mb_artist_alias aa ON aa.artist = a.id
+    WHERE lower(aa.name) % lower($1)
+) sub
+GROUP BY id, name
 ORDER BY score DESC
 LIMIT $2\
-""".replace("%%", "%")
+"""
 
 
 async def search_external_artists(

--- a/tests/integration/test_external_mb_alias_union.py
+++ b/tests/integration/test_external_mb_alias_union.py
@@ -1,0 +1,126 @@
+"""Integration test for the MB-cache alias UNION (Phase 1.6b).
+
+Asserts that ``_MB_ARTIST_FUZZY_SQL`` actually executes against PostgreSQL
+and returns the canonical mb_artist.name when the trigram match is against
+mb_artist_alias rather than mb_artist. This is the recall improvement
+that issue #191 ships -- a unit test that mocks ``fetchall`` cannot prove
+the SQL is well-formed or that the alias UNION resolves to the canonical
+parent name.
+
+Runs against the same Docker postgres service as the other ``pg``-marked
+tests (port 5433, ``DATABASE_URL_TEST``). Creates a small private
+``mb_artist`` + ``mb_artist_alias`` schema in a fresh test schema, drops
+it on teardown.
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from lookup.external_search import _MB_ARTIST_FUZZY_SQL
+from scripts.entity_resolution.sources import PgSource
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def mb_pg_source():
+    """PgSource pointing at a freshly seeded mb_artist / mb_artist_alias pair.
+
+    The standard MusicBrainz schema lives in the public schema, so this
+    fixture creates the two tables there with the expected shape, seeds
+    them, and drops them on teardown. ``pg_trgm`` is required for the ``%``
+    operator and ``similarity()``; the existing pg test container already
+    has discogs-cache extensions installed.
+    """
+    try:
+        conn = await asyncpg.connect(DATABASE_URL)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+
+    try:
+        await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        await conn.execute("DROP TABLE IF EXISTS mb_artist_alias CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS mb_artist CASCADE")
+        await conn.execute(
+            """
+            CREATE TABLE mb_artist (
+                id   integer PRIMARY KEY,
+                gid  uuid NOT NULL,
+                name text NOT NULL
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE mb_artist_alias (
+                id     integer PRIMARY KEY,
+                artist integer NOT NULL REFERENCES mb_artist(id) ON DELETE CASCADE,
+                name   text NOT NULL
+            )
+            """
+        )
+        # Csillagrablók: Hungarian band whose ASCII variant is in DJ flowsheets
+        # but not in mb_artist.name -- only in the alias table.
+        await conn.execute(
+            "INSERT INTO mb_artist (id, gid, name) VALUES "
+            "(1, '11111111-1111-1111-1111-111111111111', 'Csillagrablók'),"
+            "(2, '22222222-2222-2222-2222-222222222222', 'Stereolab')"
+        )
+        await conn.execute(
+            "INSERT INTO mb_artist_alias (id, artist, name) VALUES "
+            "(10, 1, 'Csillagrablok'),"
+            "(11, 1, 'Csillagrablók')"
+        )
+    finally:
+        await conn.close()
+
+    source = PgSource(DATABASE_URL)
+    yield source
+    await source.close()
+
+    cleanup = await asyncpg.connect(DATABASE_URL)
+    try:
+        await cleanup.execute("DROP TABLE IF EXISTS mb_artist_alias CASCADE")
+        await cleanup.execute("DROP TABLE IF EXISTS mb_artist CASCADE")
+    finally:
+        await cleanup.close()
+
+
+@pytest.mark.pg
+class TestMbArtistAliasUnion:
+    @pytest.mark.asyncio
+    async def test_alias_only_match_returns_canonical_name(self, mb_pg_source):
+        """ASCII skeleton matches mb_artist_alias.name; row carries the
+        accented mb_artist.name (canonical) so downstream scoring is right.
+        """
+        rows = await mb_pg_source.fetchall(_MB_ARTIST_FUZZY_SQL, "Csillagrablok", 5)
+        names = [r["name"] for r in rows]
+        assert "Csillagrablók" in names
+        # Returned id is mb_artist.gid (uuid), not the integer pk.
+        gids = {str(r["id"]) for r in rows}
+        assert "11111111-1111-1111-1111-111111111111" in gids
+
+    @pytest.mark.asyncio
+    async def test_primary_name_match_still_works(self, mb_pg_source):
+        """A name that exists in mb_artist.name (no alias needed) still hits."""
+        rows = await mb_pg_source.fetchall(_MB_ARTIST_FUZZY_SQL, "Stereolab", 5)
+        names = [r["name"] for r in rows]
+        assert "Stereolab" in names
+
+    @pytest.mark.asyncio
+    async def test_dedupes_when_match_hits_both_legs(self, mb_pg_source):
+        """Csillagrablók is in both mb_artist.name AND mb_artist_alias.name (id=11).
+        The query must collapse to one row per artist, not two.
+        """
+        rows = await mb_pg_source.fetchall(_MB_ARTIST_FUZZY_SQL, "Csillagrablók", 5)
+        canonical_rows = [r for r in rows if r["name"] == "Csillagrablók"]
+        assert len(canonical_rows) == 1

--- a/tests/unit/test_external_artist_search.py
+++ b/tests/unit/test_external_artist_search.py
@@ -149,3 +149,48 @@ class TestSearchExternalArtists:
         mock_discogs_cache.search_artists_by_name.assert_awaited_once_with("Artist", limit=3)
         # Result count comes from the cache; assert all candidates were preserved.
         assert len(candidates) == 10
+
+    @pytest.mark.asyncio
+    async def test_mb_query_unions_alias_table(self, mock_discogs_cache, mock_mb_pg):
+        """Phase 1.6b: MB fuzzy must search mb_artist AND mb_artist_alias.
+
+        Aliases live in mb_artist_alias (e.g. ASCII variant of a diacritic
+        name); querying only mb_artist undercuts recall on the lossy-mojibake
+        matcher. Asserts the SQL string references both tables so a future
+        refactor that drops the alias leg is caught here.
+        """
+        mock_discogs_cache.search_artists_by_name.return_value = []
+
+        await search_external_artists(
+            "Csillagrablok",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        mock_mb_pg.fetchall.assert_awaited_once()
+        sql = mock_mb_pg.fetchall.call_args.args[0]
+        assert "mb_artist_alias" in sql
+        assert "mb_artist" in sql
+
+    @pytest.mark.asyncio
+    async def test_mb_alias_match_returns_canonical_name(self, mock_discogs_cache, mock_mb_pg):
+        """When the match comes via mb_artist_alias, the row carries the
+        parent mb_artist.name so the matcher's skeleton-Levenshtein scoring
+        operates on the canonical form, not the alias.
+        """
+        mock_discogs_cache.search_artists_by_name.return_value = []
+        # Simulating a row that the SQL would emit when the trigram hit was
+        # against mb_artist_alias.name='Csillagrablok' but the SELECT pulls
+        # the canonical mb_artist.name.
+        mock_mb_pg.fetchall.return_value = [
+            {"id": "mb-uuid-csgr", "name": "Csillagrablók", "score": 0.71},
+        ]
+
+        candidates, source = await search_external_artists(
+            "Csillagrablok",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert source == "musicbrainz"
+        assert candidates == [{"id": "mb-uuid-csgr", "name": "Csillagrablók"}]


### PR DESCRIPTION
## Summary

- The musicbrainz-cache leg of `/api/v1/lookup`'s external-cache fallback (`include_external_caches=True`) only queried `mb_artist.name`. Alternate spellings and ASCII transliterations of accented names (e.g. `Csillagrablok` → `Csillagrablók`) live in `mb_artist_alias` and were silently skipped.
- This asymmetry hurt recall on the lossy-mojibake matcher relative to the discogs leg, which already UNIONs `artist` with `artist_name_variation`.
- New SQL mirrors the discogs pattern: `UNION ALL` over `mb_artist.name` and `mb_artist_alias.name`, grouped by canonical `mb_artist.gid`/`name` so the result always carries the parent canonical form regardless of which leg produced the trigram hit.

## Implementation

- `lookup/external_search.py` — replaces `_MB_ARTIST_FUZZY_SQL`. Uses `aa.artist = a.id` (matching the actual schema, per `scripts/musicbrainz_matching.py` and `musicbrainz-cache/schema/create_database.sql`).
- `tests/unit/test_external_artist_search.py` — adds two unit tests: SQL references both tables; alias-only canonical-name passthrough.
- `tests/integration/test_external_mb_alias_union.py` (new, `pg`-marked) — creates a small `mb_artist`/`mb_artist_alias` schema in the CI postgres service, seeds Csillagrablók with a `Csillagrablok` ASCII alias, and asserts the actual SQL returns the canonical name when the trigram hits the alias row. Also covers primary-name match and dedup when the same artist matches both legs.
- `CLAUDE.md` — notes the alias UNION on both legs.

## Test plan

- [x] Unit: 10/10 in `test_external_artist_search.py` pass (8 prior + 2 new).
- [x] Integration (default): 104 pass, no regressions.
- [x] Integration (pg): all 3 new `test_external_mb_alias_union` cases pass against a local `postgres:16-alpine` container.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy` clean.

Closes #191
Refs WXYC/docs#6