### PR TITLE
Broaden external-cache fallback to album and song skeletons (Phase 1.7)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -178,6 +178,99 @@ class DiscogsCacheService:
             logger.error(f"Cache search_artists_by_name failed: {e}")
             raise CacheUnavailableError(f"Cache search_artists_by_name failed: {e}") from e
 
+    async def search_releases_by_title(self, title: str, *, limit: int = 5) -> list[dict]:
+        """Fuzzy-match an album/release title against ``release.title``.
+
+        Used by the Phase 1.7 mojibake-recovery fallback when the lossy
+        matcher sends a RELEASE_TITLE skeleton (no artist). Pairs each
+        matched release with its primary ``release_artist.artist_name`` so
+        the matcher's skeleton scoring has both the canonical title and
+        an artist context.
+
+        Args:
+            title: Release title (or skeleton) to search for.
+            limit: Maximum number of distinct releases to return.
+
+        Returns:
+            List of dicts with keys ``id``, ``title``, ``artist``, ``score``.
+
+        Raises:
+            CacheUnavailableError: If the database is unreachable.
+        """
+        try:
+            query = """
+                SELECT id, title, artist, max(score) AS score FROM (
+                    SELECT r.id, r.title, ra.artist_name AS artist,
+                        similarity(lower(f_unaccent(r.title)), lower(f_unaccent($1))) AS score
+                    FROM release r
+                    JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+                    WHERE lower(f_unaccent(r.title)) % lower(f_unaccent($1))
+                ) sub
+                GROUP BY id, title, artist
+                ORDER BY score DESC
+                LIMIT $2
+            """
+            rows = await self.pool.fetch(query, title, limit)
+            return [
+                {
+                    "id": r["id"],
+                    "title": r["title"],
+                    "artist": r["artist"],
+                    "score": float(r["score"]),
+                }
+                for r in rows
+            ]
+        except Exception as e:
+            logger.error(f"Cache search_releases_by_title failed: {e}")
+            raise CacheUnavailableError(f"Cache search_releases_by_title failed: {e}") from e
+
+    async def search_tracks_by_title(self, title: str, *, limit: int = 5) -> list[dict]:
+        """Fuzzy-match a track title against ``release_track.title``.
+
+        Used by the Phase 1.7 mojibake-recovery fallback when the lossy
+        matcher sends a SONG_TITLE skeleton. Returns the canonical track
+        title plus the parent release's primary artist so the matcher has
+        an artist context — the lossy bucket is dominated by song titles
+        (443 of 815 rows) and library has no song-level FTS.
+
+        Args:
+            title: Track title (or skeleton) to search for.
+            limit: Maximum number of distinct (track, artist) pairs to return.
+
+        Returns:
+            List of dicts with keys ``id`` (release_id), ``title``,
+            ``artist``, ``score``.
+
+        Raises:
+            CacheUnavailableError: If the database is unreachable.
+        """
+        try:
+            query = """
+                SELECT release_id AS id, title, artist, max(score) AS score FROM (
+                    SELECT rt.release_id, rt.title, ra.artist_name AS artist,
+                        similarity(lower(f_unaccent(rt.title)), lower(f_unaccent($1))) AS score
+                    FROM release_track rt
+                    JOIN release_artist ra ON ra.release_id = rt.release_id AND ra.extra = 0
+                    WHERE lower(f_unaccent(rt.title)) % lower(f_unaccent($1))
+                ) sub
+                GROUP BY release_id, title, artist
+                ORDER BY score DESC
+                LIMIT $2
+            """
+            rows = await self.pool.fetch(query, title, limit)
+            return [
+                {
+                    "id": r["id"],
+                    "title": r["title"],
+                    "artist": r["artist"],
+                    "score": float(r["score"]),
+                }
+                for r in rows
+            ]
+        except Exception as e:
+            logger.error(f"Cache search_tracks_by_title failed: {e}")
+            raise CacheUnavailableError(f"Cache search_tracks_by_title failed: {e}") from e
+
     async def autocomplete_tracks(
         self, artist: str, q: str, *, release: str | None = None, limit: int = 20
     ) -> list[str]:

--- a/lookup/external_search.py
+++ b/lookup/external_search.py
@@ -1,12 +1,17 @@
-"""External cache fallback for artist-name lookup.
+"""External cache fallback for artist / album / track lookup.
 
 When the WXYC library catalog returns no results, callers that opt in via
-``LookupRequest.include_external_caches`` get a fuzzy artist-name search
-against the discogs-cache PostgreSQL DB and, on miss, the musicbrainz-cache
-PostgreSQL DB. Used by the lossy-mojibake matcher
-(tubafrenzy/scripts/db/recovery/lossy_mojibake_recovery.py) to recover
-canonical artist names for skeletons that don't appear in the WXYC physical
-catalog.
+``LookupRequest.include_external_caches`` fall back to fuzzy search against
+the discogs-cache PostgreSQL DB and, on miss, the musicbrainz-cache PG DB.
+
+Phase 1.5 covered artist skeletons; Phase 1.7 broadens the fallback so
+RELEASE_TITLE / SONG_TITLE skeletons (which dominate the lossy-mojibake
+bucket — 631 of the 815 unmatched rows) also get a fair shot.
+
+Each branch returns a sequence of result dicts plus the ``ExternalSource``
+that produced them. The orchestrator wraps these into synthetic
+``LookupResultItem`` rows so the matcher's existing scoring code applies
+unchanged.
 """
 
 from __future__ import annotations
@@ -45,6 +50,43 @@ ORDER BY score DESC
 LIMIT $2\
 """
 
+# Trigram similarity on mb_release.name with the canonical artist credit
+# pulled from mb_artist_credit. Returns the full credit string (e.g.
+# "Lupe Fiasco feat. Skylar Grey") rather than picking a single artist —
+# the matcher's skeleton scoring uses this as artist context.
+_MB_RELEASE_FUZZY_SQL = """\
+SELECT id, title, artist, max(score) AS score FROM (
+    SELECT r.id AS id, r.name AS title, ac.name AS artist,
+           similarity(lower(r.name), lower($1)) AS score
+    FROM mb_release r
+    JOIN mb_artist_credit ac ON ac.id = r.artist_credit
+    WHERE lower(r.name) % lower($1)
+) sub
+GROUP BY id, title, artist
+ORDER BY score DESC
+LIMIT $2\
+"""
+
+# Trigram similarity on mb_recording.name. Recordings are MB's track-level
+# entity; mb_track is per-medium-position and produces duplicates for the
+# same recording on multiple releases.
+_MB_RECORDING_FUZZY_SQL = """\
+SELECT id, title, artist, max(score) AS score FROM (
+    SELECT rec.id AS id, rec.name AS title, ac.name AS artist,
+           similarity(lower(rec.name), lower($1)) AS score
+    FROM mb_recording rec
+    JOIN mb_artist_credit ac ON ac.id = rec.artist_credit
+    WHERE lower(rec.name) % lower($1)
+) sub
+GROUP BY id, title, artist
+ORDER BY score DESC
+LIMIT $2\
+"""
+
+
+def _is_blank(value: str | None) -> bool:
+    return value is None or not value.strip()
+
 
 async def search_external_artists(
     skeleton: str,
@@ -63,7 +105,7 @@ async def search_external_artists(
     them, or ``([], None)`` if neither cache returned a hit. Errors against
     one cache do not block the next.
     """
-    if not skeleton or not skeleton.strip():
+    if _is_blank(skeleton):
         return [], None
 
     if discogs_cache is not None:
@@ -93,5 +135,112 @@ async def search_external_artists(
                 return [{"id": r["id"], "name": r["name"]} for r in rows], "musicbrainz"
         except Exception as e:
             logger.warning("MusicBrainz external-fallback query failed: %s", e)
+
+    return [], None
+
+
+async def search_external_albums(
+    skeleton: str,
+    *,
+    discogs_cache: DiscogsCacheService | None,
+    mb_pg: PgSourceProtocol | None,
+    limit: int = 5,
+) -> tuple[list[dict[str, Any]], ExternalSource | None]:
+    """Fuzzy-match a release-title ``skeleton`` against external caches.
+
+    Returns ``[{"id", "artist", "title"}, ...]`` plus the source — the
+    ``artist`` is the release's primary credit pulled from the same query,
+    so the matcher's skeleton scoring has an artist context even for a
+    bare RELEASE_TITLE input.
+    """
+    if _is_blank(skeleton):
+        return [], None
+
+    if discogs_cache is not None:
+        try:
+            rows = await discogs_cache.search_releases_by_title(skeleton, limit=limit)
+            if rows:
+                logger.info(
+                    "External fallback: discogs cache returned %d releases for %r",
+                    len(rows),
+                    skeleton,
+                )
+                return (
+                    [{"id": r["id"], "artist": r["artist"], "title": r["title"]} for r in rows],
+                    "discogs",
+                )
+        except CacheUnavailableError as e:
+            logger.warning("Discogs cache unavailable for release fallback: %s", e)
+        except Exception as e:
+            logger.warning("Discogs release fallback query failed: %s", e)
+
+    if mb_pg is not None:
+        try:
+            rows = await mb_pg.fetchall(_MB_RELEASE_FUZZY_SQL, skeleton, limit)
+            if rows:
+                logger.info(
+                    "External fallback: musicbrainz cache returned %d releases for %r",
+                    len(rows),
+                    skeleton,
+                )
+                return (
+                    [{"id": r["id"], "artist": r["artist"], "title": r["title"]} for r in rows],
+                    "musicbrainz",
+                )
+        except Exception as e:
+            logger.warning("MusicBrainz release fallback query failed: %s", e)
+
+    return [], None
+
+
+async def search_external_tracks(
+    skeleton: str,
+    *,
+    discogs_cache: DiscogsCacheService | None,
+    mb_pg: PgSourceProtocol | None,
+    limit: int = 5,
+) -> tuple[list[dict[str, Any]], ExternalSource | None]:
+    """Fuzzy-match a track-title ``skeleton`` against external caches.
+
+    The lossy bucket is 54% song titles (443 of 815) and the WXYC library
+    has no song-level FTS, so this branch is the highest-recall use case
+    for the Phase 1.7 widening.
+    """
+    if _is_blank(skeleton):
+        return [], None
+
+    if discogs_cache is not None:
+        try:
+            rows = await discogs_cache.search_tracks_by_title(skeleton, limit=limit)
+            if rows:
+                logger.info(
+                    "External fallback: discogs cache returned %d tracks for %r",
+                    len(rows),
+                    skeleton,
+                )
+                return (
+                    [{"id": r["id"], "artist": r["artist"], "title": r["title"]} for r in rows],
+                    "discogs",
+                )
+        except CacheUnavailableError as e:
+            logger.warning("Discogs cache unavailable for track fallback: %s", e)
+        except Exception as e:
+            logger.warning("Discogs track fallback query failed: %s", e)
+
+    if mb_pg is not None:
+        try:
+            rows = await mb_pg.fetchall(_MB_RECORDING_FUZZY_SQL, skeleton, limit)
+            if rows:
+                logger.info(
+                    "External fallback: musicbrainz cache returned %d recordings for %r",
+                    len(rows),
+                    skeleton,
+                )
+                return (
+                    [{"id": r["id"], "artist": r["artist"], "title": r["title"]} for r in rows],
+                    "musicbrainz",
+                )
+        except Exception as e:
+            logger.warning("MusicBrainz recording fallback query failed: %s", e)
 
     return [], None

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import re
 from functools import partial
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -28,7 +29,11 @@ from discogs.service import DiscogsService
 from generated.api_models import LibraryCatalogItem, ReconciledIdentity
 from library.db import STOPWORDS, LibraryDB
 from library.models import LibraryItem
-from lookup.external_search import search_external_artists
+from lookup.external_search import (
+    search_external_albums,
+    search_external_artists,
+    search_external_tracks,
+)
 from lookup.models import LookupRequest, LookupResponse, LookupResultItem
 from scripts.entity_resolution.sources import PgSourceProtocol
 from scripts.entity_resolution.store import EntityStore, Identity
@@ -1219,17 +1224,41 @@ async def perform_lookup(
                 )
             )
 
-    # Step 7: External-cache fallback (Phase 1.5 mojibake recovery).
-    # Opt-in via include_external_caches; only artist-keyed requests trigger
-    # the fallback today (the lossy bucket is dominated by artist skeletons).
+    # Step 7: External-cache fallback (Phase 1.5 + 1.7 mojibake recovery).
+    # Opt-in via include_external_caches. The lossy-mojibake matcher sends
+    # column-typed bodies, so we dispatch by which skeleton field is set:
+    # artist takes precedence (highest-precision lookup), then album, then
+    # song. A bare raw_message with no typed field skips the fallback —
+    # LABEL_NAME is too noisy to be useful here.
     external_source: str | None = "library" if result_items else None
-    if not result_items and request.include_external_caches and parsed.artist:
-        with telemetry.track_step("external_cache_fallback"):
-            candidates, source = await search_external_artists(
-                parsed.artist,
-                discogs_cache=discogs_cache,
-                mb_pg=mb_pg,
-            )
+    if not result_items and request.include_external_caches:
+        candidates: list[dict[str, Any]] = []
+        source: str | None = None
+        if parsed.artist:
+            with telemetry.track_step("external_cache_fallback"):
+                rows, source = await search_external_artists(
+                    parsed.artist,
+                    discogs_cache=discogs_cache,
+                    mb_pg=mb_pg,
+                )
+            candidates = [{"artist": r["name"], "title": ""} for r in rows]
+        elif parsed.album:
+            with telemetry.track_step("external_cache_fallback"):
+                rows, source = await search_external_albums(
+                    parsed.album,
+                    discogs_cache=discogs_cache,
+                    mb_pg=mb_pg,
+                )
+            candidates = [{"artist": r["artist"], "title": r["title"]} for r in rows]
+        elif parsed.song:
+            with telemetry.track_step("external_cache_fallback"):
+                rows, source = await search_external_tracks(
+                    parsed.song,
+                    discogs_cache=discogs_cache,
+                    mb_pg=mb_pg,
+                )
+            candidates = [{"artist": r["artist"], "title": r["title"]} for r in rows]
+
         if candidates:
             external_source = source
             for candidate in candidates:
@@ -1237,7 +1266,8 @@ async def perform_lookup(
                     LookupResultItem(
                         library_item=LibraryCatalogItem(
                             id=0,
-                            artist=candidate["name"],
+                            artist=candidate["artist"],
+                            title=candidate["title"] or None,
                             call_number="(external)",
                             library_url="",
                         ),

--- a/tests/integration/test_external_cache_fallback.py
+++ b/tests/integration/test_external_cache_fallback.py
@@ -28,6 +28,8 @@ async def app_client_with_external_caches(library_db, test_settings):
 
     discogs_cache = AsyncMock()
     discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+    discogs_cache.search_releases_by_title = AsyncMock(return_value=[])
+    discogs_cache.search_tracks_by_title = AsyncMock(return_value=[])
 
     mb_pg = AsyncMock()
     mb_pg.fetchall = AsyncMock(return_value=[])
@@ -131,3 +133,80 @@ class TestExternalCacheFallback:
         assert body["external_source"] == "musicbrainz"
         assert len(body["results"]) == 1
         assert body["results"][0]["library_item"]["artist"] == "Csillagrablók"
+
+    @pytest.mark.asyncio
+    async def test_album_skeleton_falls_back_to_discogs_releases(
+        self, app_client_with_external_caches
+    ):
+        """Phase 1.7: a RELEASE_TITLE skeleton (album, no artist) hits the release leg."""
+        client = app_client_with_external_caches
+        client.discogs_cache.search_releases_by_title.return_value = [
+            {"id": 12345, "title": "DOGA", "artist": "Juana Molina", "score": 0.81},
+        ]
+
+        resp = await client.post(
+            "/api/v1/lookup",
+            json={
+                "album": "ZZZNotInLibraryAlbum",
+                "raw_message": "ZZZNotInLibraryAlbum",
+                "include_external_caches": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["external_source"] == "discogs"
+        assert len(body["results"]) == 1
+        item = body["results"][0]["library_item"]
+        assert item["artist"] == "Juana Molina"
+        assert item["title"] == "DOGA"
+        # Artist branch must NOT have fired.
+        client.discogs_cache.search_artists_by_name.assert_not_called()
+        client.discogs_cache.search_tracks_by_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_song_skeleton_falls_back_to_mb_recording(self, app_client_with_external_caches):
+        """Phase 1.7: a SONG_TITLE skeleton with discogs miss + MB recording hit."""
+        client = app_client_with_external_caches
+        client.discogs_cache.search_tracks_by_title.return_value = []
+        client.mb_pg.fetchall.return_value = [
+            {"id": 42, "title": "la paradoja", "artist": "Juana Molina", "score": 0.85},
+        ]
+
+        resp = await client.post(
+            "/api/v1/lookup",
+            json={
+                "song": "la paradja",
+                "raw_message": "la paradja",
+                "include_external_caches": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["external_source"] == "musicbrainz"
+        assert len(body["results"]) == 1
+        item = body["results"][0]["library_item"]
+        assert item["artist"] == "Juana Molina"
+        assert item["title"] == "la paradoja"
+        # MB query SQL must reference mb_recording, not mb_release / mb_artist.
+        sql = client.mb_pg.fetchall.call_args.args[0]
+        assert "mb_recording" in sql
+
+    @pytest.mark.asyncio
+    async def test_label_only_request_skips_fallback(self, app_client_with_external_caches):
+        """A bare raw_message (no typed field, e.g. LABEL_NAME case) skips the fallback."""
+        client = app_client_with_external_caches
+
+        resp = await client.post(
+            "/api/v1/lookup",
+            json={
+                "raw_message": "ESP Disk'",
+                "include_external_caches": True,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("external_source") is None
+        client.discogs_cache.search_artists_by_name.assert_not_called()
+        client.discogs_cache.search_releases_by_title.assert_not_called()
+        client.discogs_cache.search_tracks_by_title.assert_not_called()
+        client.mb_pg.fetchall.assert_not_called()

--- a/tests/integration/test_external_mb_release_recording.py
+++ b/tests/integration/test_external_mb_release_recording.py
@@ -1,0 +1,140 @@
+"""Integration test for the MB-cache release + recording fuzzy SQL (Phase 1.7).
+
+Asserts that ``_MB_RELEASE_FUZZY_SQL`` and ``_MB_RECORDING_FUZZY_SQL``
+execute against PostgreSQL and return canonical title + artist credit,
+mirroring the alias-UNION integration test for the artist branch. A
+unit test that mocks ``fetchall`` cannot prove the SQL is well-formed.
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from lookup.external_search import (
+    _MB_RECORDING_FUZZY_SQL,
+    _MB_RELEASE_FUZZY_SQL,
+)
+from scripts.entity_resolution.sources import PgSource
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def mb_pg_source():
+    """PgSource pointing at freshly seeded mb_artist_credit / mb_release / mb_recording.
+
+    Same approach as ``test_external_mb_alias_union``: build the minimum
+    schema needed in the test DB, seed a couple of representative WXYC
+    rows, drop on teardown.
+    """
+    try:
+        conn = await asyncpg.connect(DATABASE_URL)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+
+    try:
+        await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        await conn.execute("DROP TABLE IF EXISTS mb_recording CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS mb_release CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS mb_artist_credit CASCADE")
+        await conn.execute(
+            """
+            CREATE TABLE mb_artist_credit (
+                id integer PRIMARY KEY,
+                name text NOT NULL
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE mb_release (
+                id integer PRIMARY KEY,
+                gid uuid NOT NULL,
+                name text NOT NULL,
+                artist_credit integer NOT NULL REFERENCES mb_artist_credit(id),
+                release_group integer
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE mb_recording (
+                id integer PRIMARY KEY,
+                gid uuid NOT NULL,
+                name text NOT NULL,
+                artist_credit integer REFERENCES mb_artist_credit(id),
+                length integer
+            )
+            """
+        )
+        await conn.execute(
+            "INSERT INTO mb_artist_credit (id, name) VALUES "
+            "(1, 'Stereolab'),"
+            "(2, 'Juana Molina'),"
+            "(3, 'Jessica Pratt')"
+        )
+        await conn.execute(
+            "INSERT INTO mb_release (id, gid, name, artist_credit, release_group) VALUES "
+            "(100, '00000000-0000-0000-0000-000000000100', 'Aluminum Tunes', 1, 1),"
+            "(101, '00000000-0000-0000-0000-000000000101', 'DOGA', 2, 2)"
+        )
+        await conn.execute(
+            "INSERT INTO mb_recording (id, gid, name, artist_credit, length) VALUES "
+            "(200, '00000000-0000-0000-0000-000000000200', 'la paradoja', 2, 240000),"
+            "(201, '00000000-0000-0000-0000-000000000201', 'Back, Baby', 3, 200000)"
+        )
+    finally:
+        await conn.close()
+
+    source = PgSource(DATABASE_URL)
+    yield source
+    await source.close()
+
+    cleanup = await asyncpg.connect(DATABASE_URL)
+    try:
+        await cleanup.execute("DROP TABLE IF EXISTS mb_recording CASCADE")
+        await cleanup.execute("DROP TABLE IF EXISTS mb_release CASCADE")
+        await cleanup.execute("DROP TABLE IF EXISTS mb_artist_credit CASCADE")
+    finally:
+        await cleanup.close()
+
+
+@pytest.mark.pg
+class TestMbReleaseFuzzy:
+    @pytest.mark.asyncio
+    async def test_fuzzy_release_title_returns_canonical(self, mb_pg_source):
+        rows = await mb_pg_source.fetchall(_MB_RELEASE_FUZZY_SQL, "Aluminum Tnes", 5)
+        titles = [r["title"] for r in rows]
+        artists = [r["artist"] for r in rows]
+        assert "Aluminum Tunes" in titles
+        assert "Stereolab" in artists
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_empty(self, mb_pg_source):
+        rows = await mb_pg_source.fetchall(_MB_RELEASE_FUZZY_SQL, "ZZZNOTHING", 5)
+        assert rows == []
+
+
+@pytest.mark.pg
+class TestMbRecordingFuzzy:
+    @pytest.mark.asyncio
+    async def test_fuzzy_recording_title_returns_canonical(self, mb_pg_source):
+        rows = await mb_pg_source.fetchall(_MB_RECORDING_FUZZY_SQL, "la paradja", 5)
+        titles = [r["title"] for r in rows]
+        artists = [r["artist"] for r in rows]
+        assert "la paradoja" in titles
+        assert "Juana Molina" in artists
+
+    @pytest.mark.asyncio
+    async def test_recording_match_carries_canonical_credit(self, mb_pg_source):
+        rows = await mb_pg_source.fetchall(_MB_RECORDING_FUZZY_SQL, "Back Baby", 5)
+        match = next(r for r in rows if r["title"] == "Back, Baby")
+        assert match["artist"] == "Jessica Pratt"

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -867,3 +867,76 @@ class TestWriteArtistDetails:
         assert any("artist_name_variation" in sql for sql in all_sql)
         assert any("artist_member" in sql for sql in all_sql)
         assert any("artist_url" in sql for sql in all_sql)
+
+
+class TestSearchReleasesByTitle:
+    @pytest.mark.asyncio
+    async def test_returns_release_with_canonical_artist(self, cache_service, mock_asyncpg_pool):
+        """Phase 1.7: fuzzy release-title hit returns canonical title + primary artist."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {"id": 12345, "title": "DOGA", "artist": "Juana Molina", "score": 0.81},
+            ]
+        )
+        results = await cache_service.search_releases_by_title("DOG")
+        assert results == [
+            {"id": 12345, "title": "DOGA", "artist": "Juana Molina", "score": 0.81},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_query_targets_release_title_trigram_with_extra_zero(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """The SQL must use the trigram operator on release.title and pin extra=0."""
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.search_releases_by_title("Aluminum Tunes", limit=3)
+        call = mock_asyncpg_pool.fetch.call_args
+        sql = call.args[0]
+        assert "release_artist" in sql
+        assert "extra = 0" in sql
+        assert "f_unaccent" in sql
+        assert "%" in sql  # trigram operator
+        assert call.args[1] == "Aluminum Tunes"
+        assert call.args[2] == 3
+
+    @pytest.mark.asyncio
+    async def test_raises_cache_unavailable_on_pool_error(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=RuntimeError("conn lost"))
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.search_releases_by_title("anything")
+
+
+class TestSearchTracksByTitle:
+    @pytest.mark.asyncio
+    async def test_returns_track_with_release_artist(self, cache_service, mock_asyncpg_pool):
+        """Phase 1.7: fuzzy track-title hit returns canonical title + parent release artist."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {"id": 555, "title": "Back, Baby", "artist": "Jessica Pratt", "score": 0.92},
+            ]
+        )
+        results = await cache_service.search_tracks_by_title("Back Baby")
+        assert results == [
+            {"id": 555, "title": "Back, Baby", "artist": "Jessica Pratt", "score": 0.92},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_query_targets_release_track_title_trigram(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.search_tracks_by_title("la paradoja", limit=2)
+        call = mock_asyncpg_pool.fetch.call_args
+        sql = call.args[0]
+        assert "release_track" in sql
+        assert "release_artist" in sql
+        assert "f_unaccent" in sql
+        assert "%" in sql
+        assert call.args[1] == "la paradoja"
+        assert call.args[2] == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_cache_unavailable_on_pool_error(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=RuntimeError("conn lost"))
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.search_tracks_by_title("anything")

--- a/tests/unit/test_external_release_search.py
+++ b/tests/unit/test_external_release_search.py
@@ -1,0 +1,178 @@
+"""Unit tests for the album + track external-cache fallback branches.
+
+Phase 1.7 of the mojibake-cleanup project (WXYC/library-metadata-lookup#195).
+The lossy-mojibake matcher sends column-typed lookup bodies — a SONG_TITLE
+skeleton becomes ``{song: ...}``, a RELEASE_TITLE skeleton becomes
+``{album: ...}``. Phase 1.5 only handled artist-keyed bodies; this phase
+broadens the fallback so SONG_TITLE / RELEASE_TITLE skeletons get a fair
+shot at the discogs-cache + musicbrainz-cache PostgreSQL DBs.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.cache_service import CacheUnavailableError
+from lookup.external_search import (
+    search_external_albums,
+    search_external_tracks,
+)
+
+
+@pytest.fixture
+def mock_discogs_cache():
+    cache = AsyncMock()
+    cache.search_releases_by_title = AsyncMock(return_value=[])
+    cache.search_tracks_by_title = AsyncMock(return_value=[])
+    return cache
+
+
+@pytest.fixture
+def mock_mb_pg():
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    return pg
+
+
+class TestSearchExternalAlbums:
+    @pytest.mark.asyncio
+    async def test_returns_discogs_album_hit(self, mock_discogs_cache, mock_mb_pg):
+        """Discogs release hit returns canonical artist + release title."""
+        mock_discogs_cache.search_releases_by_title.return_value = [
+            {"id": 12345, "title": "DOGA", "artist": "Juana Molina", "score": 0.81},
+        ]
+
+        items, source = await search_external_albums(
+            "DOG",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert source == "discogs"
+        assert items == [{"id": 12345, "artist": "Juana Molina", "title": "DOGA"}]
+        mock_mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_musicbrainz_release(self, mock_discogs_cache, mock_mb_pg):
+        """Discogs miss -> MB ``mb_release`` query returns canonical artist credit."""
+        mock_discogs_cache.search_releases_by_title.return_value = []
+        mock_mb_pg.fetchall.return_value = [
+            {"id": 7, "title": "Aluminum Tunes", "artist": "Stereolab", "score": 0.78},
+        ]
+
+        items, source = await search_external_albums(
+            "Aluminum Tnes",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert source == "musicbrainz"
+        assert items == [{"id": 7, "artist": "Stereolab", "title": "Aluminum Tunes"}]
+        # MB query must hit mb_release + mb_artist_credit
+        sql = mock_mb_pg.fetchall.call_args.args[0]
+        assert "mb_release" in sql
+        assert "mb_artist_credit" in sql
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_double_miss(self, mock_discogs_cache, mock_mb_pg):
+        items, source = await search_external_albums(
+            "ZZZNothingHere",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+        assert items == []
+        assert source is None
+
+    @pytest.mark.asyncio
+    async def test_skips_blank_skeleton(self, mock_discogs_cache, mock_mb_pg):
+        items, source = await search_external_albums(
+            "   ",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+        assert items == []
+        assert source is None
+        mock_discogs_cache.search_releases_by_title.assert_not_called()
+        mock_mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caches_disabled(self):
+        items, source = await search_external_albums("DOGA", discogs_cache=None, mb_pg=None)
+        assert items == []
+        assert source is None
+
+    @pytest.mark.asyncio
+    async def test_discogs_unavailable_falls_through_to_mb(self, mock_discogs_cache, mock_mb_pg):
+        mock_discogs_cache.search_releases_by_title.side_effect = CacheUnavailableError("pool down")
+        mock_mb_pg.fetchall.return_value = [
+            {"id": 1, "title": "Edits", "artist": "Chuquimamani-Condori", "score": 0.9},
+        ]
+        items, source = await search_external_albums(
+            "Edits",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+        assert source == "musicbrainz"
+        assert items[0]["title"] == "Edits"
+
+
+class TestSearchExternalTracks:
+    @pytest.mark.asyncio
+    async def test_returns_discogs_track_hit(self, mock_discogs_cache, mock_mb_pg):
+        """Discogs ``release_track`` hit returns track title + parent release artist."""
+        mock_discogs_cache.search_tracks_by_title.return_value = [
+            {
+                "id": 555,
+                "title": "Back, Baby",
+                "artist": "Jessica Pratt",
+                "score": 0.92,
+            },
+        ]
+        items, source = await search_external_tracks(
+            "Back Baby",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+        assert source == "discogs"
+        assert items == [{"id": 555, "artist": "Jessica Pratt", "title": "Back, Baby"}]
+        mock_mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_mb_recording(self, mock_discogs_cache, mock_mb_pg):
+        """Discogs miss -> MB ``mb_recording`` query returns canonical artist credit."""
+        mock_discogs_cache.search_tracks_by_title.return_value = []
+        mock_mb_pg.fetchall.return_value = [
+            {"id": 42, "title": "la paradoja", "artist": "Juana Molina", "score": 0.85},
+        ]
+        items, source = await search_external_tracks(
+            "la paradja",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+        assert source == "musicbrainz"
+        assert items == [{"id": 42, "artist": "Juana Molina", "title": "la paradoja"}]
+        sql = mock_mb_pg.fetchall.call_args.args[0]
+        assert "mb_recording" in sql
+        assert "mb_artist_credit" in sql
+
+    @pytest.mark.asyncio
+    async def test_skips_blank_skeleton(self, mock_discogs_cache, mock_mb_pg):
+        items, source = await search_external_tracks(
+            "",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+        assert items == []
+        assert source is None
+        mock_discogs_cache.search_tracks_by_title.assert_not_called()
+        mock_mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_double_miss(self, mock_discogs_cache, mock_mb_pg):
+        items, source = await search_external_tracks(
+            "ZZZNotARealSong",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+        assert items == []
+        assert source is None

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1355,22 +1355,64 @@ class TestPerformLookupExternalCacheFallback:
         assert response.external_source is None
 
     @pytest.mark.asyncio
-    async def test_no_external_query_when_artist_field_missing(
+    async def test_no_external_query_when_no_typed_field(
         self, mock_library_db, mock_discogs_service, telemetry
     ):
-        """Phase 1.5 only handles artist-skeleton lookups — album/song-only requests skip the fallback."""
+        """Phase 1.7: a bare raw_message with no typed field (LABEL_NAME case) skips fallback."""
         mock_library_db.search.return_value = []
         mock_library_db.find_similar_artist.return_value = None
         mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
 
         discogs_cache = AsyncMock()
         discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+        discogs_cache.search_releases_by_title = AsyncMock(return_value=[])
+        discogs_cache.search_tracks_by_title = AsyncMock(return_value=[])
         mb_pg = AsyncMock()
         mb_pg.fetchall = AsyncMock(return_value=[])
 
         request = LookupRequest(
-            album="Some Album",
-            raw_message="Some Album",
+            raw_message="ESP Disk'",
+            include_external_caches=True,
+        )
+
+        response = await perform_lookup(
+            request,
+            mock_library_db,
+            mock_discogs_service,
+            telemetry,
+            discogs_cache=discogs_cache,
+            mb_pg=mb_pg,
+        )
+
+        assert response.external_source is None
+        discogs_cache.search_artists_by_name.assert_not_called()
+        discogs_cache.search_releases_by_title.assert_not_called()
+        discogs_cache.search_tracks_by_title.assert_not_called()
+        mb_pg.fetchall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_album_skeleton_falls_back_to_discogs_releases(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """Phase 1.7: RELEASE_TITLE skeleton -> discogs release fuzzy hit -> synthetic result."""
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+        discogs_cache.search_releases_by_title = AsyncMock(
+            return_value=[
+                {"id": 12345, "title": "DOGA", "artist": "Juana Molina", "score": 0.81},
+            ]
+        )
+        discogs_cache.search_tracks_by_title = AsyncMock(return_value=[])
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            album="DOG",
+            raw_message="DOG",
             include_external_caches=True,
         )
 
@@ -1388,6 +1430,110 @@ class TestPerformLookupExternalCacheFallback:
                 mb_pg=mb_pg,
             )
 
-        assert response.external_source is None
+        assert response.external_source == "discogs"
+        assert len(response.results) == 1
+        item = response.results[0].library_item
+        assert item.artist == "Juana Molina"
+        assert item.title == "DOGA"
+        # Artist branch must NOT have fired; only release branch.
         discogs_cache.search_artists_by_name.assert_not_called()
-        mb_pg.fetchall.assert_not_called()
+        discogs_cache.search_tracks_by_title.assert_not_called()
+        discogs_cache.search_releases_by_title.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_song_skeleton_falls_back_to_discogs_tracks(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """Phase 1.7: SONG_TITLE skeleton -> discogs track fuzzy hit -> synthetic result."""
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(return_value=[])
+        discogs_cache.search_releases_by_title = AsyncMock(return_value=[])
+        discogs_cache.search_tracks_by_title = AsyncMock(
+            return_value=[
+                {
+                    "id": 555,
+                    "title": "Back, Baby",
+                    "artist": "Jessica Pratt",
+                    "score": 0.92,
+                },
+            ]
+        )
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            song="Back Baby",
+            raw_message="Back Baby",
+            include_external_caches=True,
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(
+                request,
+                mock_library_db,
+                mock_discogs_service,
+                telemetry,
+                discogs_cache=discogs_cache,
+                mb_pg=mb_pg,
+            )
+
+        assert response.external_source == "discogs"
+        assert len(response.results) == 1
+        item = response.results[0].library_item
+        assert item.artist == "Jessica Pratt"
+        assert item.title == "Back, Baby"
+        discogs_cache.search_artists_by_name.assert_not_called()
+        discogs_cache.search_releases_by_title.assert_not_called()
+        discogs_cache.search_tracks_by_title.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_artist_takes_precedence_over_album_when_both_present(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """When the request supplies both artist AND album, artist branch runs first."""
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        discogs_cache = AsyncMock()
+        discogs_cache.search_artists_by_name = AsyncMock(
+            return_value=[{"id": 1, "name": "Stereolab", "score": 0.9}]
+        )
+        discogs_cache.search_releases_by_title = AsyncMock(return_value=[])
+        discogs_cache.search_tracks_by_title = AsyncMock(return_value=[])
+        mb_pg = AsyncMock()
+        mb_pg.fetchall = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Aluminum Tunes",
+            raw_message="Stereolab Aluminum Tunes",
+            include_external_caches=True,
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(
+                request,
+                mock_library_db,
+                mock_discogs_service,
+                telemetry,
+                discogs_cache=discogs_cache,
+                mb_pg=mb_pg,
+            )
+
+        assert response.external_source == "discogs"
+        discogs_cache.search_artists_by_name.assert_awaited_once()
+        discogs_cache.search_releases_by_title.assert_not_called()
+        discogs_cache.search_tracks_by_title.assert_not_called()


### PR DESCRIPTION
## Summary

- Widens `include_external_caches` fallback in `POST /api/v1/lookup` so RELEASE_TITLE and SONG_TITLE skeletons (the 631-of-815 majority of the lossy-mojibake bucket) get the same fallback path as ARTIST_NAME — previously a silent no-op for those fields.
- Album branch: discogs `release_title` (existing trigram index) → MB `mb_release.name`. Song branch: discogs `release_track.title` (existing trigram index) → MB `mb_recording.name`. Both branches return canonical artist context from the cache (release/recording joined to `mb_artist_credit` / discogs `release_artist`) so the matcher's skeleton scoring works for bare title-only inputs.
- Existing artist behavior unchanged; default `include_external_caches` remains `false`. Precedence in the orchestrator is artist > album > song; LABEL_NAME (bare `raw_message`) skips fallback entirely.

## Implementation

- `lookup/external_search.py` — adds `search_external_albums` and `search_external_tracks`; new `_MB_RELEASE_FUZZY_SQL` and `_MB_RECORDING_FUZZY_SQL` joining `mb_artist_credit`.
- `discogs/cache_service.py` — adds `search_releases_by_title` and `search_tracks_by_title` using the `f_unaccent` + `%` pattern from `search_artists_by_name`.
- `lookup/orchestrator.py` — Step 7 dispatches by skeleton field; result shape is `library_item.{artist=primary_credit, title=release_or_recording_title}` for album/track matches.

## Follow-up

The MB cache currently has trigram GIN indexes on `mb_artist.name` / `mb_artist_alias.name` (added in Phase 1.6) but **not** on `mb_release.name` or `mb_recording.name`. The new SQL still works (seq-scan with `%`), which is acceptable for the one-shot 815-row recovery batch. A migration to add those indexes belongs in `WXYC/musicbrainz-cache` as a separate PR.

Closes #195. Refs WXYC/docs#6.

## Test plan

- [x] Unit: `tests/unit/test_external_release_search.py` (album + track branches; cache miss/unavailable fall-through)
- [x] Unit: `tests/unit/test_cache_service.py::TestSearchReleasesByTitle` and `TestSearchTracksByTitle`
- [x] Unit: `tests/unit/test_orchestrator.py` precedence + per-skeleton fallback
- [x] Integration: `tests/integration/test_external_cache_fallback.py` end-to-end via `POST /api/v1/lookup` with mocked caches
- [x] PG-marked integration: `tests/integration/test_external_mb_release_recording.py` exercises the new MB SQL against a live Postgres
- [x] All 1540 unit tests green; `ruff check` + `ruff format --check` + `mypy` clean