### PR TITLE
Allow set-railway-var workflow to upsert DISCOGS_TOKEN

### DIFF
--- a/.github/workflows/set-railway-var.yml
+++ b/.github/workflows/set-railway-var.yml
@@ -58,6 +58,7 @@ jobs:
           # supports has to be listed here.
           LML_API_KEY: ${{ secrets.LML_API_KEY }}
           ETL_NOTIFY_KEY: ${{ secrets.ETL_NOTIFY_KEY }}
+          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
         run: |
           set -euo pipefail
           KEY="${{ inputs.key }}"
@@ -65,6 +66,7 @@ jobs:
           case "$SECRET_NAME" in
             LML_API_KEY)    VALUE="$LML_API_KEY" ;;
             ETL_NOTIFY_KEY) VALUE="$ETL_NOTIFY_KEY" ;;
+            DISCOGS_TOKEN)  VALUE="$DISCOGS_TOKEN" ;;
             *)
               echo "::error::Unsupported secret_name '$SECRET_NAME'. Add it to the resolve step's env block + case statement."
               exit 1


### PR DESCRIPTION
Closes part of #196.

## Summary

Adds \`DISCOGS_TOKEN\` to the secrets allowlist in \`.github/workflows/set-railway-var.yml\` so it can be rotated on Railway via:

\`\`\`
gh workflow run set-railway-var.yml -f key=DISCOGS_TOKEN
\`\`\`

Same pattern as \`LML_API_KEY\` and \`ETL_NOTIFY_KEY\` — the resolve step needs the env binding plus a case arm.

## Why now

Production LML's Discogs auth is broken (#196). Rotating \`DISCOGS_TOKEN\` is the immediate fix but the rotation tooling didn't accept this key. Two-line workflow change unblocks it.

## Follow-up

After merge:
1. Add a \`DISCOGS_TOKEN\` repo secret with a working Discogs personal access token.
2. \`gh workflow run set-railway-var.yml -f key=DISCOGS_TOKEN\`.
3. Verify \`/health\` returns \`status: healthy\` (not degraded).