### PR TITLE
Make Discogs reconciler diacritic-insensitive to match the cache filter

### DIFF
--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -5,6 +5,18 @@ Resolves WXYC library artist names to Discogs artist IDs via a cascade:
 2. Member/group lookup via ``artist_member``
 3. Alias/name variation fallback via ``artist_alias`` and ``artist_name_variation``
 
+Matching is diacritic-insensitive on both sides (``lower(f_unaccent(col))``
+on the column, ``normalize_artist_name(name)`` on the input). The cache load
+pipeline (``discogs-etl/scripts/filter_csv.py:normalize_artist``) strips
+diacritics when deciding which Discogs rows to retain, so reconciliation has
+to use the same normalization or any artist whose WXYC spelling differs in
+diacritics from the Discogs spelling silently goes unreconciled — which is
+the gap that produced the 17% reconciliation rate observed in prod.
+
+The ``lower(f_unaccent(...))`` column expression matches the existing GIN
+trigram index in the discogs-cache schema (see
+``discogs-etl/schema/create_indexes.sql``) so this remains an indexed lookup.
+
 Ported from semantic-index ``reconciliation.py``.
 """
 
@@ -13,34 +25,36 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from wxyc_etl.text import normalize_artist_name
+
 from scripts.entity_resolution.sources import PgSource
 
 logger = logging.getLogger(__name__)
 
 _EXACT_MATCH_SQL = """\
-SELECT DISTINCT lower(ra.artist_name) AS artist_name, ra.artist_id
+SELECT DISTINCT lower(f_unaccent(ra.artist_name)) AS artist_name, ra.artist_id
 FROM release_artist ra
 WHERE ra.extra = 0
   AND ra.artist_id IS NOT NULL
-  AND lower(ra.artist_name) = ANY($1)\
+  AND lower(f_unaccent(ra.artist_name)) = ANY($1)\
 """
 
 _MEMBER_MATCH_SQL = """\
-SELECT DISTINCT lower(am.member_name) AS member_name, am.member_id
+SELECT DISTINCT lower(f_unaccent(am.member_name)) AS member_name, am.member_id
 FROM artist_member am
-WHERE lower(am.member_name) = ANY($1)\
+WHERE lower(f_unaccent(am.member_name)) = ANY($1)\
 """
 
 _ALIAS_MATCH_SQL = """\
-SELECT DISTINCT lower(aa.alias_name) AS alias_name, aa.artist_id
+SELECT DISTINCT lower(f_unaccent(aa.alias_name)) AS alias_name, aa.artist_id
 FROM artist_alias aa
-WHERE lower(aa.alias_name) = ANY($1)\
+WHERE lower(f_unaccent(aa.alias_name)) = ANY($1)\
 """
 
 _NAME_VARIATION_MATCH_SQL = """\
-SELECT DISTINCT lower(nv.name) AS name, nv.artist_id
+SELECT DISTINCT lower(f_unaccent(nv.name)) AS name, nv.artist_id
 FROM artist_name_variation nv
-WHERE lower(nv.name) = ANY($1)\
+WHERE lower(f_unaccent(nv.name)) = ANY($1)\
 """
 
 
@@ -94,83 +108,88 @@ class DiscogsReconciler:
 
         results: dict[str, ReconciliationMatch] = {}
 
-        # Build lowercase -> canonical mapping
-        lower_to_canonical = {n.lower(): n for n in effective_names}
+        # Build normalized (diacritic-stripped + lowercased) -> canonical mapping.
+        # The same normalization is applied to the column side via
+        # ``lower(f_unaccent(...))`` in each stage's SQL so the comparison is
+        # symmetric. Two canonicals that normalize to the same form (e.g.
+        # ``Björk`` and ``Bjork``) collapse to the same key — both resolve to
+        # the same Discogs ID, so dropping one is correct.
+        normalized_to_canonical = {normalize_artist_name(n): n for n in effective_names}
 
         # Stage 1: Exact match
-        unmatched = set(lower_to_canonical.keys())
-        for batch_lower in self._batches(list(unmatched)):
-            matched = await self._exact_match(batch_lower)
-            for lower_name, artist_id in matched.items():
-                canonical = lower_to_canonical.get(lower_name)
+        unmatched = set(normalized_to_canonical.keys())
+        for batch_normalized in self._batches(list(unmatched)):
+            matched = await self._exact_match(batch_normalized)
+            for normalized_name, artist_id in matched.items():
+                canonical = normalized_to_canonical.get(normalized_name)
                 if canonical is None:
                     continue
                 results[canonical] = ReconciliationMatch(artist_id, "exact_match")
-                unmatched.discard(lower_name)
+                unmatched.discard(normalized_name)
 
         # Stage 2: Member/group match
         if unmatched:
-            for batch_lower in self._batches(list(unmatched)):
-                matched = await self._member_match(batch_lower)
-                for lower_name, artist_id in matched.items():
-                    canonical = lower_to_canonical.get(lower_name)
+            for batch_normalized in self._batches(list(unmatched)):
+                matched = await self._member_match(batch_normalized)
+                for normalized_name, artist_id in matched.items():
+                    canonical = normalized_to_canonical.get(normalized_name)
                     if canonical is None:
                         continue
                     results[canonical] = ReconciliationMatch(artist_id, "member_group")
-                    unmatched.discard(lower_name)
+                    unmatched.discard(normalized_name)
 
         # Stage 3: Alias match
         if unmatched:
-            for batch_lower in self._batches(list(unmatched)):
-                matched = await self._alias_match(batch_lower)
-                for lower_name, artist_id in matched.items():
-                    canonical = lower_to_canonical.get(lower_name)
+            for batch_normalized in self._batches(list(unmatched)):
+                matched = await self._alias_match(batch_normalized)
+                for normalized_name, artist_id in matched.items():
+                    canonical = normalized_to_canonical.get(normalized_name)
                     if canonical is None:
                         continue
                     results[canonical] = ReconciliationMatch(artist_id, "alias_match")
-                    unmatched.discard(lower_name)
+                    unmatched.discard(normalized_name)
 
         # Stage 4: Name variation fallback
         if unmatched:
-            for batch_lower in self._batches(list(unmatched)):
-                matched = await self._name_variation_match(batch_lower)
-                for lower_name, artist_id in matched.items():
-                    canonical = lower_to_canonical.get(lower_name)
+            for batch_normalized in self._batches(list(unmatched)):
+                matched = await self._name_variation_match(batch_normalized)
+                for normalized_name, artist_id in matched.items():
+                    canonical = normalized_to_canonical.get(normalized_name)
                     if canonical is None:
                         continue
                     results[canonical] = ReconciliationMatch(artist_id, "name_variation")
-                    unmatched.discard(lower_name)
+                    unmatched.discard(normalized_name)
 
         return results
 
-    async def _exact_match(self, lower_names: list[str]) -> dict[str, int]:
-        """Stage 1: Exact name match against release_artist."""
-        rows = await self._pg.fetchall(_EXACT_MATCH_SQL, lower_names)
+    async def _exact_match(self, normalized_names: list[str]) -> dict[str, int]:
+        """Stage 1: Diacritic-insensitive exact match against release_artist."""
+        rows = await self._pg.fetchall(_EXACT_MATCH_SQL, normalized_names)
         if not rows:
             return {}
         return {
             row["artist_name"]: row["artist_id"] for row in rows if row["artist_id"] is not None
         }
 
-    async def _member_match(self, lower_names: list[str]) -> dict[str, int]:
-        """Stage 2: Member/group lookup via artist_member."""
-        rows = await self._pg.fetchall(_MEMBER_MATCH_SQL, lower_names)
+    async def _member_match(self, normalized_names: list[str]) -> dict[str, int]:
+        """Stage 2: Diacritic-insensitive member/group lookup via artist_member."""
+        rows = await self._pg.fetchall(_MEMBER_MATCH_SQL, normalized_names)
         if not rows:
             return {}
         return {
             row["member_name"]: row["member_id"] for row in rows if row["member_id"] is not None
         }
 
-    async def _alias_match(self, lower_names: list[str]) -> dict[str, int]:
-        """Stage 3: Alias lookup via artist_alias."""
-        rows = await self._pg.fetchall(_ALIAS_MATCH_SQL, lower_names)
+    async def _alias_match(self, normalized_names: list[str]) -> dict[str, int]:
+        """Stage 3: Diacritic-insensitive alias lookup via artist_alias."""
+        rows = await self._pg.fetchall(_ALIAS_MATCH_SQL, normalized_names)
         if not rows:
             return {}
         return {row["alias_name"]: row["artist_id"] for row in rows if row["artist_id"] is not None}
 
-    async def _name_variation_match(self, lower_names: list[str]) -> dict[str, int]:
-        """Stage 4: Name variation lookup via artist_name_variation."""
-        rows = await self._pg.fetchall(_NAME_VARIATION_MATCH_SQL, lower_names)
+    async def _name_variation_match(self, normalized_names: list[str]) -> dict[str, int]:
+        """Stage 4: Diacritic-insensitive name variation lookup via artist_name_variation."""
+        rows = await self._pg.fetchall(_NAME_VARIATION_MATCH_SQL, normalized_names)
         if not rows:
             return {}
         return {row["name"]: row["artist_id"] for row in rows if row["artist_id"] is not None}

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -134,3 +134,61 @@ class TestSkipsAlreadyReconciled:
         )
         assert "Stereolab" in results
         assert "Autechre" not in results
+
+
+class TestDiacriticInsensitiveMatch:
+    """The cache filter (`scripts/filter_csv.py:normalize_artist`) loads rows
+    into the cache after stripping diacritics, so a Discogs row for "Björk" is
+    loaded if WXYC has "Bjork". The reconciler must match with the same
+    normalization or the load is wasted on every diacritic-different artist
+    (the prod 17% reconciliation rate vs ~99% LML coverage).
+    """
+
+    @pytest.mark.asyncio
+    async def test_wxyc_no_diacritics_matches_discogs_with_diacritics(self, reconciler, mock_pg):
+        """WXYC 'Bjork' (no umlaut) must match Discogs 'Björk' in release_artist."""
+        # Cache contains 'björk' (lowercased only); reconciler must strip
+        # diacritics on both sides so 'bjork' matches.
+        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "bjork", "artist_id": 7777}])
+        results = await reconciler.reconcile_batch(["Bjork"])
+        assert "Bjork" in results
+        assert results["Bjork"].discogs_artist_id == 7777
+        assert results["Bjork"].method == "exact_match"
+
+    @pytest.mark.asyncio
+    async def test_wxyc_with_diacritics_matches_diacritic_stripped_cache(self, reconciler, mock_pg):
+        """WXYC 'Hermanos Gutiérrez' must match a row whose normalized form is 'hermanos gutierrez'."""
+        mock_pg.fetchall = AsyncMock(
+            return_value=[{"artist_name": "hermanos gutierrez", "artist_id": 9001}]
+        )
+        results = await reconciler.reconcile_batch(["Hermanos Gutiérrez"])
+        assert "Hermanos Gutiérrez" in results
+        assert results["Hermanos Gutiérrez"].discogs_artist_id == 9001
+
+    @pytest.mark.asyncio
+    async def test_normalized_input_passed_to_sql(self, reconciler, mock_pg):
+        """The names sent to the SQL `ANY($1)` array must already be diacritic-stripped
+        and lowercased — matching the `lower(f_unaccent(...))` expression on the
+        column side (which is what the existing GIN index on release_artist uses)."""
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        await reconciler.reconcile_batch(["Björk", "Hermanos Gutiérrez", "Stereolab"])
+        # Inspect the ANY($1) parameter on the first call
+        first_call_args = mock_pg.fetchall.await_args_list[0].args
+        sql_arg, names_arg = first_call_args
+        assert "lower(f_unaccent(" in sql_arg, (
+            "EXACT_MATCH SQL must use lower(f_unaccent(...)) on the column side "
+            "to be diacritic-insensitive (matches the indexed expression)."
+        )
+        assert sorted(names_arg) == sorted(["bjork", "hermanos gutierrez", "stereolab"]), (
+            "Names sent to SQL must be diacritic-stripped + lowercased before being "
+            "compared against lower(f_unaccent(column))."
+        )
+
+    @pytest.mark.asyncio
+    async def test_canonical_preserved_in_result(self, reconciler, mock_pg):
+        """Even after normalization, the result keys are the original canonical names."""
+        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "bjork", "artist_id": 7777}])
+        results = await reconciler.reconcile_batch(["Björk"])
+        assert "Björk" in results
+        # Original spelling preserved as the dict key for write-back to entity.identity.
+        assert results["Björk"].discogs_artist_id == 7777


### PR DESCRIPTION
Closes #202

## Summary

The cache load pipeline in `discogs-etl` strips diacritics when deciding which Discogs rows to retain. The reconciler in this repo did not, so every WXYC artist whose name differed in diacritics from the Discogs spelling silently failed reconciliation. Measured impact in prod: only 17.3% of 24,062 WXYC artists are reconciled to a Discogs ID; sampling shows the unreconciled set is dominated by the diacritic mismatch (and the stale-cache class, which is a separate issue tracked in `discogs-etl`).

This change normalizes both sides of the comparison:

- Column: `lower(f_unaccent(col)) = ANY($1)` — matches the existing GIN trigram index expression on `release_artist`/`artist_member`/`artist_alias`/`artist_name_variation`, so the lookup stays index-driven.
- Input: `wxyc_etl.text.normalize_artist_name(name)` — strips combining marks and lowercases. Already a dependency.

The `normalized → canonical` map preserves the original WXYC spelling for write-back to `entity.identity`.

## Impact when deployed

Re-running entity resolution against the existing prod cache should close most of the 83% gap on its own (Björk, Hermanos Gutiérrez, Sigur Rós, Sigur Rós-class names, etc.). Cache rebuild remains a separate prerequisite for the rest.

## Test plan

- [x] 3 new failing unit tests added covering Bjork↔Björk symmetry, diacritic-bearing inputs, and the SQL/parameter-shape contract. Confirmed they fail on the unfixed reconciler.
- [x] All 12 reconciliation unit tests pass after the fix.
- [x] Full unit suite: 1525 passed.
- [x] `ruff check` clean, `ruff format --check` clean, `mypy` clean.
- [ ] Smoke test on staging: trigger a re-run of `python -m scripts.entity_resolution` and confirm reconciliation rate jumps significantly.