### PR TITLE
Re-pin entity-resolution Discogs tests to canonical IDs

### DIFF
--- a/tests/integration/test_api_discogs.py
+++ b/tests/integration/test_api_discogs.py
@@ -68,54 +68,61 @@ class TestEntityResolution:
 
     @pytest.mark.asyncio
     async def test_resolve_artist(self):
-        """Resolve a known artist (Stereolab, ID 2206) and verify name."""
+        """Resolve a known artist (Stereolab, ID 388) and verify name.
+
+        IDs 2206 / 64977 / 17854 used to point at Stereolab + Dots And Loops
+        but Discogs reorganized the data behind those IDs around 2026-04-28.
+        Re-pinned to the canonical IDs verified via direct API probe and
+        cross-checked against LML's `entity.identity.discogs_artist_id` for
+        Stereolab.
+        """
         token = os.environ.get("DISCOGS_TOKEN")
         if not token:
             pytest.skip("DISCOGS_TOKEN not set")
 
         service = DiscogsService(token=token, cache_service=None)
         try:
-            result = await service.get_artist_details(2206)
+            result = await service.get_artist_details(388)
         finally:
             await service.close()
 
         assert result is not None
         assert result.name == "Stereolab"
-        assert result.artist_id == 2206
+        assert result.artist_id == 388
 
     @pytest.mark.asyncio
     async def test_resolve_release(self):
-        """Resolve a known release (Dots and Loops, ID 64977) and verify title."""
+        """Resolve a known release (Dots And Loops, vinyl LP, ID 90416) and verify title."""
         token = os.environ.get("DISCOGS_TOKEN")
         if not token:
             pytest.skip("DISCOGS_TOKEN not set")
 
         service = DiscogsService(token=token, cache_service=None)
         try:
-            result = await service.get_release(64977)
+            result = await service.get_release(90416)
         finally:
             await service.close()
 
         assert result is not None
         assert result.title == "Dots And Loops"
-        assert result.release_id == 64977
+        assert result.release_id == 90416
 
     @pytest.mark.asyncio
     async def test_resolve_master(self):
-        """Resolve a known master release (Dots and Loops, master ID 17854) and verify title."""
+        """Resolve a known master release (Dots And Loops, master ID 30682) and verify title."""
         token = os.environ.get("DISCOGS_TOKEN")
         if not token:
             pytest.skip("DISCOGS_TOKEN not set")
 
         service = DiscogsService(token=token, cache_service=None)
         try:
-            result = await service.get_master(17854)
+            result = await service.get_master(30682)
         finally:
             await service.close()
 
         assert result is not None
         assert result.title == "Dots And Loops"
-        assert result.master_id == 17854
+        assert result.master_id == 30682
 
     @pytest.mark.asyncio
     async def test_artist_not_found(self):


### PR DESCRIPTION
## Why

`External API Tests` has been red on main since ~2026-04-28 02:18 UTC because Discogs reorganized the data behind the pinned IDs:

| Old ID | Old expectation | What Discogs serves now |
|---|---|---|
| `/artists/2206` | Stereolab | Benjamin |
| `/releases/64977` | Dots And Loops | Sunshine |
| `/masters/17854` | Dots And Loops | See You |

`Deploy to Staging` depends on `External API Tests` per ci.yml, so the failure has blocked the staging Railway deploy of every main commit since (including #203, the reconciler diacritic fix).

## Fix

Re-pin to canonical IDs verified by direct API probe and cross-checked against LML's own `entity.identity.discogs_artist_id` for Stereolab:

- artist 388
- master 30682
- release 90416 (vinyl LP)

Locally:
```
DISCOGS_TOKEN=… uv run pytest tests/integration/test_api_discogs.py::TestEntityResolution -m external_api
======================================== 6 passed in 1.39s
```

Docstring note added for the next reviewer.

## Test plan

- [x] Local pytest against live Discogs: 6/6 pass.
- [x] Ruff check + format clean.
- [ ] CI green on PR.
- [ ] After merge, confirm Railway staging deploy fires (the dependency we've been blocked on).