### PR TITLE
Pin entity-resolution tests to Wikidata QIDs, resolve to Discogs at runtime

### DIFF
--- a/scripts/entity_resolution/wikidata.py
+++ b/scripts/entity_resolution/wikidata.py
@@ -2,6 +2,7 @@
 
 Resolves:
 - Discogs artist ID -> Wikidata QID (via wikidata-cache P1953 mapping or SPARQL)
+- QID -> Discogs artist/master/release ID (via SPARQL P1953 / P1954 / P2206)
 - Artist name -> QID (via SPARQL name search for musicians/musical groups)
 - QID -> streaming platform IDs (Spotify P1902, Apple Music P2850, Bandcamp P3283)
 
@@ -12,10 +13,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import Literal
 
 from scripts.entity_resolution.sources import PgSource, SparqlSource
 
 logger = logging.getLogger(__name__)
+
+DiscogsKind = Literal["artist", "master", "release"]
 
 _CACHE_DISCOGS_TO_QID_SQL = """\
 SELECT discogs_artist_id, qid
@@ -32,6 +36,38 @@ SELECT ?item ?discogsId WHERE {
   ?item wdt:P1953 ?discogsId .
 }\
 """
+
+# Inverse direction of _SPARQL_DISCOGS_TO_QID. One template per Wikidata
+# property — the property is hard-coded rather than parameterized so that
+# query plans cache cleanly on the Wikidata Query Service and so the rendered
+# SPARQL stays readable in logs. Selection happens in
+# ``WikidataReconciler.resolve_discogs_ids_from_qids`` via the ``kind`` arg.
+_SPARQL_QID_TO_DISCOGS_ARTIST = """\
+SELECT ?item ?discogsId WHERE {
+  VALUES ?item { {values} }
+  ?item wdt:P1953 ?discogsId .
+}\
+"""
+
+_SPARQL_QID_TO_DISCOGS_MASTER = """\
+SELECT ?item ?discogsId WHERE {
+  VALUES ?item { {values} }
+  ?item wdt:P1954 ?discogsId .
+}\
+"""
+
+_SPARQL_QID_TO_DISCOGS_RELEASE = """\
+SELECT ?item ?discogsId WHERE {
+  VALUES ?item { {values} }
+  ?item wdt:P2206 ?discogsId .
+}\
+"""
+
+_SPARQL_TEMPLATE_BY_KIND: dict[DiscogsKind, str] = {
+    "artist": _SPARQL_QID_TO_DISCOGS_ARTIST,
+    "master": _SPARQL_QID_TO_DISCOGS_MASTER,
+    "release": _SPARQL_QID_TO_DISCOGS_RELEASE,
+}
 
 _SPARQL_NAME_SEARCH = """\
 SELECT ?item ?itemLabel WHERE {
@@ -131,6 +167,65 @@ class WikidataReconciler:
                     result[int(discogs_id_str)] = qid
                 except (ValueError, TypeError):
                     continue
+
+        return result
+
+    async def resolve_discogs_ids_from_qids(
+        self,
+        qids: set[str],
+        *,
+        kind: DiscogsKind = "artist",
+    ) -> dict[str, int]:
+        """Resolve Wikidata QIDs to current Discogs IDs via SPARQL.
+
+        Inverse of :meth:`resolve_qids_from_discogs_ids`. Use this when the
+        QID is the stable handle and you need the *current* Discogs ID — for
+        example, an integration test that wants to fetch the canonical Discogs
+        entity for a known Wikidata-pinned artist, or any code path that needs
+        to survive Discogs admin operations that re-assign numeric IDs (delete
+        + re-create, merge, etc.).
+
+        Args:
+            qids: Wikidata QIDs (e.g. ``"Q334652"``) to resolve.
+            kind: Selects the Wikidata property to follow:
+
+                - ``"artist"`` → P1953 (Discogs artist ID, default)
+                - ``"master"`` → P1954 (Discogs master release ID)
+                - ``"release"`` → P2206 (Discogs release ID)
+
+        Returns:
+            Dict mapping QID to current Discogs ID for QIDs that have the
+            requested property set in Wikidata. QIDs without the property —
+            or with non-integer values — are omitted from the result rather
+            than mapped to ``None``, matching the shape of
+            ``resolve_qids_from_discogs_ids``.
+
+        Raises:
+            ValueError: If ``kind`` is not one of the supported values.
+        """
+        if kind not in _SPARQL_TEMPLATE_BY_KIND:
+            raise ValueError(
+                f"unknown kind={kind!r}; expected one of {sorted(_SPARQL_TEMPLATE_BY_KIND)}"
+            )
+        if not qids:
+            return {}
+
+        # Prefix with ``wd:`` so the rendered ``VALUES ?item { ... }`` clause is
+        # syntactically valid SPARQL — bare ``Q334652`` is a parse error.
+        items = [f"wd:{qid}" for qid in qids]
+        bindings = await self._sparql.query_batched(_SPARQL_TEMPLATE_BY_KIND[kind], items)
+
+        result: dict[str, int] = {}
+        for binding in bindings:
+            item_uri = self._sparql.binding_value(binding, "item")
+            discogs_id_str = self._sparql.binding_value(binding, "discogsId")
+            if not item_uri or not discogs_id_str:
+                continue
+            qid = self._sparql.extract_qid(item_uri)
+            try:
+                result[qid] = int(discogs_id_str)
+            except (ValueError, TypeError):
+                continue
 
         return result
 

--- a/tests/integration/test_api_discogs.py
+++ b/tests/integration/test_api_discogs.py
@@ -3,9 +3,59 @@
 import os
 
 import pytest
+import pytest_asyncio
 
 from discogs.models import DiscogsSearchRequest
 from discogs.service import DiscogsService
+from scripts.entity_resolution.sources import SparqlSource
+from scripts.entity_resolution.wikidata import WikidataReconciler
+
+# Wikidata QIDs for entities used by ``TestEntityResolution``. QIDs are
+# substantially more stable than Discogs IDs (Discogs admin operations can
+# delete + re-create + re-assign IDs, see PR #204 for an incident); a QID is
+# resolved to its current Discogs ID via SPARQL P1953 / P1954 / P2206 at
+# fixture setup time so the tests survive Discogs reshuffling without a
+# human re-pinning IDs.
+#
+# Releases (P2206) very rarely have their own Wikidata entries — albums are
+# represented at the master level — so the release test stays pinned by
+# integer ID with a comment.
+_QID_STEREOLAB = "Q334652"
+_QID_DOTS_AND_LOOPS_ALBUM = "Q3037397"
+_PINNED_DOTS_AND_LOOPS_RELEASE_ID = 90416  # canonical vinyl LP, no Wikidata QID
+
+
+@pytest_asyncio.fixture(scope="module")
+async def canonical_discogs_ids() -> dict[str, int]:
+    """Resolve each test fixture QID to its current Discogs ID via Wikidata.
+
+    Runs once per pytest session (module scope) — two SPARQL round-trips
+    cached for the duration of the test run. Skips dependent tests rather
+    than passing a stale ID through on any of:
+    - Wikidata SPARQL endpoint unreachable / timing out
+    - The QID exists but the property (P1953 / P1954) was removed
+    - The Wikidata literal is non-numeric (defensive)
+    """
+    reconciler = WikidataReconciler(sparql=SparqlSource())
+    try:
+        artist_ids = await reconciler.resolve_discogs_ids_from_qids({_QID_STEREOLAB}, kind="artist")
+        master_ids = await reconciler.resolve_discogs_ids_from_qids(
+            {_QID_DOTS_AND_LOOPS_ALBUM}, kind="master"
+        )
+    except Exception as exc:
+        pytest.skip(f"Wikidata SPARQL unreachable ({type(exc).__name__}: {exc})")
+
+    artist_id = artist_ids.get(_QID_STEREOLAB)
+    master_id = master_ids.get(_QID_DOTS_AND_LOOPS_ALBUM)
+    if artist_id is None or master_id is None:
+        pytest.skip(
+            "Wikidata SPARQL did not return Discogs IDs for the pinned QIDs "
+            "(transient outage or property removed) — skipping ID-resolution tests."
+        )
+    return {
+        "stereolab_artist": artist_id,
+        "dots_and_loops_master": master_id,
+    }
 
 
 class TestDiscogsEndpoints:
@@ -67,14 +117,37 @@ class TestEntityResolution:
     """Integration tests for entity resolution using real Discogs API."""
 
     @pytest.mark.asyncio
-    async def test_resolve_artist(self):
-        """Resolve a known artist (Stereolab, ID 388) and verify name.
+    async def test_resolve_artist(self, canonical_discogs_ids):
+        """Resolve Stereolab (Wikidata Q334652) and verify name + ID round-trip.
 
-        IDs 2206 / 64977 / 17854 used to point at Stereolab + Dots And Loops
-        but Discogs reorganized the data behind those IDs around 2026-04-28.
-        Re-pinned to the canonical IDs verified via direct API probe and
-        cross-checked against LML's `entity.identity.discogs_artist_id` for
-        Stereolab.
+        The Discogs artist ID is resolved fresh from Wikidata P1953 at fixture
+        setup, so the test survives Discogs admin operations that re-assign
+        numeric IDs. See PR #204 for the incident this guard exists for.
+        """
+        token = os.environ.get("DISCOGS_TOKEN")
+        if not token:
+            pytest.skip("DISCOGS_TOKEN not set")
+
+        artist_id = canonical_discogs_ids["stereolab_artist"]
+        service = DiscogsService(token=token, cache_service=None)
+        try:
+            result = await service.get_artist_details(artist_id)
+        finally:
+            await service.close()
+
+        assert result is not None
+        assert result.name == "Stereolab"
+        assert result.artist_id == artist_id
+
+    @pytest.mark.asyncio
+    async def test_resolve_release(self):
+        """Resolve a known release (Dots And Loops, vinyl LP, ID 90416) and verify title.
+
+        Releases are not modeled at the entity level in Wikidata (only the
+        abstract album / master is — see ``test_resolve_master``), so this
+        test stays pinned to a numeric ID and will need manual re-pinning if
+        Discogs ever reorganizes this specific pressing. The pinned ID is the
+        canonical original Stereolab vinyl LP.
         """
         token = os.environ.get("DISCOGS_TOKEN")
         if not token:
@@ -82,47 +155,31 @@ class TestEntityResolution:
 
         service = DiscogsService(token=token, cache_service=None)
         try:
-            result = await service.get_artist_details(388)
-        finally:
-            await service.close()
-
-        assert result is not None
-        assert result.name == "Stereolab"
-        assert result.artist_id == 388
-
-    @pytest.mark.asyncio
-    async def test_resolve_release(self):
-        """Resolve a known release (Dots And Loops, vinyl LP, ID 90416) and verify title."""
-        token = os.environ.get("DISCOGS_TOKEN")
-        if not token:
-            pytest.skip("DISCOGS_TOKEN not set")
-
-        service = DiscogsService(token=token, cache_service=None)
-        try:
-            result = await service.get_release(90416)
+            result = await service.get_release(_PINNED_DOTS_AND_LOOPS_RELEASE_ID)
         finally:
             await service.close()
 
         assert result is not None
         assert result.title == "Dots And Loops"
-        assert result.release_id == 90416
+        assert result.release_id == _PINNED_DOTS_AND_LOOPS_RELEASE_ID
 
     @pytest.mark.asyncio
-    async def test_resolve_master(self):
-        """Resolve a known master release (Dots And Loops, master ID 30682) and verify title."""
+    async def test_resolve_master(self, canonical_discogs_ids):
+        """Resolve Dots And Loops master (Wikidata Q3037397) via P1954 and verify title."""
         token = os.environ.get("DISCOGS_TOKEN")
         if not token:
             pytest.skip("DISCOGS_TOKEN not set")
 
+        master_id = canonical_discogs_ids["dots_and_loops_master"]
         service = DiscogsService(token=token, cache_service=None)
         try:
-            result = await service.get_master(30682)
+            result = await service.get_master(master_id)
         finally:
             await service.close()
 
         assert result is not None
         assert result.title == "Dots And Loops"
-        assert result.master_id == 30682
+        assert result.master_id == master_id
 
     @pytest.mark.asyncio
     async def test_artist_not_found(self):

--- a/tests/integration/test_api_discogs.py
+++ b/tests/integration/test_api_discogs.py
@@ -2,6 +2,7 @@
 
 import os
 
+import httpx
 import pytest
 import pytest_asyncio
 
@@ -25,24 +26,39 @@ _QID_DOTS_AND_LOOPS_ALBUM = "Q3037397"
 _PINNED_DOTS_AND_LOOPS_RELEASE_ID = 90416  # canonical vinyl LP, no Wikidata QID
 
 
-@pytest_asyncio.fixture(scope="module")
+# Track how many times the resolver is invoked so the module-scoped fixture
+# can be tested for actually being module-scoped — not silently recreated by
+# pytest-asyncio's loop-scope handling.
+_resolver_call_count = 0
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
 async def canonical_discogs_ids() -> dict[str, int]:
     """Resolve each test fixture QID to its current Discogs ID via Wikidata.
 
-    Runs once per pytest session (module scope) — two SPARQL round-trips
-    cached for the duration of the test run. Skips dependent tests rather
-    than passing a stale ID through on any of:
-    - Wikidata SPARQL endpoint unreachable / timing out
+    Runs once per module (asserted via ``_resolver_call_count`` — see
+    ``test_fixture_runs_once_per_module``). The result is a plain dict with
+    no async resources held, so the value is safe to share across tests
+    even though each test gets its own event loop.
+
+    Skips dependent tests rather than passing a stale ID through on any of:
+    - Wikidata SPARQL endpoint unreachable / timing out (httpx.HTTPError)
+    - SPARQL response missing/malformed (asyncio.TimeoutError covers slow paths)
     - The QID exists but the property (P1953 / P1954) was removed
     - The Wikidata literal is non-numeric (defensive)
     """
+    global _resolver_call_count
+    _resolver_call_count += 1
+
     reconciler = WikidataReconciler(sparql=SparqlSource())
     try:
         artist_ids = await reconciler.resolve_discogs_ids_from_qids({_QID_STEREOLAB}, kind="artist")
         master_ids = await reconciler.resolve_discogs_ids_from_qids(
             {_QID_DOTS_AND_LOOPS_ALBUM}, kind="master"
         )
-    except Exception as exc:
+    # Narrow to network-shaped failures only — programmer errors (AttributeError
+    # etc.) should still fail loud rather than be swallowed into a skip.
+    except (httpx.HTTPError, TimeoutError) as exc:
         pytest.skip(f"Wikidata SPARQL unreachable ({type(exc).__name__}: {exc})")
 
     artist_id = artist_ids.get(_QID_STEREOLAB)
@@ -180,6 +196,26 @@ class TestEntityResolution:
         assert result is not None
         assert result.title == "Dots And Loops"
         assert result.master_id == master_id
+
+    @pytest.mark.asyncio
+    async def test_fixture_runs_once_per_module(self, canonical_discogs_ids):
+        """The module-scoped resolver fixture must not be silently recreated per test.
+
+        pytest-asyncio's interaction between ``scope="module"`` fixtures and
+        function-scoped event loops has historically caused fixtures to be
+        re-evaluated per test — wasting Wikidata SPARQL round-trips and
+        invalidating the docstring's "two SPARQL queries per session" claim.
+        ``loop_scope="module"`` on the fixture pins this. By the time this
+        test runs, the resolver should have been invoked exactly once across
+        every test in the class that consumed the fixture.
+        """
+        # `canonical_discogs_ids` is requested here only so the fixture is
+        # definitely live by the time we read the counter.
+        assert canonical_discogs_ids is not None
+        assert _resolver_call_count == 1, (
+            f"canonical_discogs_ids fixture was invoked {_resolver_call_count} times; "
+            "expected exactly 1 with module-scoped fixture + module-scoped loop."
+        )
 
     @pytest.mark.asyncio
     async def test_artist_not_found(self):

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -7,6 +7,9 @@ import pytest
 from scripts.entity_resolution.sources import SparqlSource
 from scripts.entity_resolution.wikidata import (
     _SPARQL_DISCOGS_TO_QID,
+    _SPARQL_QID_TO_DISCOGS_ARTIST,
+    _SPARQL_QID_TO_DISCOGS_MASTER,
+    _SPARQL_QID_TO_DISCOGS_RELEASE,
     _SPARQL_STREAMING_IDS,
     WikidataReconciler,
 )
@@ -219,3 +222,112 @@ class TestGracefulDegradation:
         result = await reconciler_no_cache.resolve_qids_from_discogs_ids({12})
         assert result[12] == "Q378288"
         mock_sparql.query_batched.assert_called_once()
+
+
+class TestQidToDiscogsId:
+    """The inverse direction of resolve_qids_from_discogs_ids.
+
+    Wikidata QIDs are substantially more stable than Discogs IDs (which
+    Discogs admins can reorganize / merge / re-assign). When a caller has a
+    QID and needs the *current* Discogs ID — for example, an integration
+    test that wants to fetch the canonical Discogs entity for a known
+    Wikidata-pinned artist — this is the lookup direction that survives
+    Discogs reshuffling.
+    """
+
+    @pytest.mark.asyncio
+    async def test_artist_kind_uses_p1953(self, reconciler_no_cache, mock_sparql):
+        """kind='artist' resolves QID -> P1953 (Discogs artist ID)."""
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q334652"},
+                    "discogsId": {"type": "literal", "value": "388"},
+                }
+            ]
+        )
+        result = await reconciler_no_cache.resolve_discogs_ids_from_qids({"Q334652"}, kind="artist")
+        assert result == {"Q334652": 388}
+        # Confirm the SPARQL template that was rendered targets P1953.
+        template_arg = mock_sparql.query_batched.await_args.args[0]
+        assert template_arg is _SPARQL_QID_TO_DISCOGS_ARTIST
+        assert "wdt:P1953" in template_arg
+
+    @pytest.mark.asyncio
+    async def test_master_kind_uses_p1954(self, reconciler_no_cache, mock_sparql):
+        """kind='master' resolves QID -> P1954 (Discogs master release ID)."""
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q3037397"},
+                    "discogsId": {"type": "literal", "value": "30682"},
+                }
+            ]
+        )
+        result = await reconciler_no_cache.resolve_discogs_ids_from_qids(
+            {"Q3037397"}, kind="master"
+        )
+        assert result == {"Q3037397": 30682}
+        template_arg = mock_sparql.query_batched.await_args.args[0]
+        assert template_arg is _SPARQL_QID_TO_DISCOGS_MASTER
+        assert "wdt:P1954" in template_arg
+
+    @pytest.mark.asyncio
+    async def test_release_kind_uses_p2206(self, reconciler_no_cache, mock_sparql):
+        """kind='release' resolves QID -> P2206 (Discogs release ID)."""
+        mock_sparql.query_batched = AsyncMock(return_value=[])
+        await reconciler_no_cache.resolve_discogs_ids_from_qids({"Q123"}, kind="release")
+        template_arg = mock_sparql.query_batched.await_args.args[0]
+        assert template_arg is _SPARQL_QID_TO_DISCOGS_RELEASE
+        assert "wdt:P2206" in template_arg
+
+    @pytest.mark.asyncio
+    async def test_invalid_kind_raises(self, reconciler_no_cache):
+        """Unknown ``kind`` raises rather than silently picking a property."""
+        with pytest.raises(ValueError, match="kind"):
+            await reconciler_no_cache.resolve_discogs_ids_from_qids({"Q1"}, kind="label")
+
+    @pytest.mark.asyncio
+    async def test_qids_passed_with_wd_prefix(self, reconciler_no_cache, mock_sparql):
+        """SPARQL VALUES clause needs `wd:` prefix on each QID; bare `Q...` is a parse error."""
+        mock_sparql.query_batched = AsyncMock(return_value=[])
+        await reconciler_no_cache.resolve_discogs_ids_from_qids({"Q334652"}, kind="artist")
+        items_arg = mock_sparql.query_batched.await_args.args[1]
+        assert items_arg == ["wd:Q334652"]
+
+    @pytest.mark.asyncio
+    async def test_empty_qids_short_circuits(self, reconciler_no_cache, mock_sparql):
+        """Empty input does no SPARQL request."""
+        result = await reconciler_no_cache.resolve_discogs_ids_from_qids(set(), kind="artist")
+        assert result == {}
+        mock_sparql.query_batched.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_property_skipped(self, reconciler_no_cache, mock_sparql):
+        """A QID that has no P1953 value (e.g. obscure artist) is omitted from the result, not None-valued."""
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q1"},
+                    # discogsId binding intentionally absent — Wikidata returns no row
+                    # at all in this case, but mirroring the defensive parsing in
+                    # resolve_qids_from_discogs_ids is the right shape.
+                }
+            ]
+        )
+        result = await reconciler_no_cache.resolve_discogs_ids_from_qids({"Q1"}, kind="artist")
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_non_integer_discogs_id_skipped(self, reconciler_no_cache, mock_sparql):
+        """Defensive: a malformed Wikidata literal that does not parse as int is skipped."""
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q1"},
+                    "discogsId": {"type": "literal", "value": "not-a-number"},
+                }
+            ]
+        )
+        result = await reconciler_no_cache.resolve_discogs_ids_from_qids({"Q1"}, kind="artist")
+        assert result == {}

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -331,3 +331,36 @@ class TestQidToDiscogsId:
         )
         result = await reconciler_no_cache.resolve_discogs_ids_from_qids({"Q1"}, kind="artist")
         assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_rendered_sparql_uses_wd_prefix(self, mock_wikidata_pg, monkeypatch):
+        """End-to-end through real ``SparqlSource``: capture the substituted SPARQL
+        and confirm the VALUES clause has ``wd:Q...`` and the right ``wdt:P...``
+        property for each ``kind``.
+
+        Mirrors the same defensive shape as ``test_rendered_sparql_uses_wd_prefix``
+        for ``fetch_streaming_ids`` (regression: WXYC/library-metadata-lookup#187).
+        Without the prefix, Wikidata's SPARQL endpoint rejects the query at parse time.
+        """
+        sparql = SparqlSource(batch_size=10)
+        captured: list[str] = []
+
+        async def fake_query(query_str: str):
+            captured.append(query_str)
+            return []
+
+        monkeypatch.setattr(sparql, "query", fake_query)
+        reconciler = WikidataReconciler(sparql=sparql, wikidata_pg=mock_wikidata_pg)
+
+        await reconciler.resolve_discogs_ids_from_qids({"Q334652"}, kind="artist")
+        await reconciler.resolve_discogs_ids_from_qids({"Q3037397"}, kind="master")
+        await reconciler.resolve_discogs_ids_from_qids({"Q1"}, kind="release")
+
+        assert len(captured) == 3
+        artist_q, master_q, release_q = captured
+        assert "wd:Q334652" in artist_q and "wdt:P1953" in artist_q
+        assert "wd:Q3037397" in master_q and "wdt:P1954" in master_q
+        assert "wd:Q1" in release_q and "wdt:P2206" in release_q
+        # No bare QIDs anywhere in the rendered VALUES clauses.
+        for q in captured:
+            assert "{ Q" not in q, f"bare QID leaked into SPARQL: {q!r}"


### PR DESCRIPTION
Closes #205

## Summary

Replaces the hand-pinned Discogs IDs in `TestEntityResolution` (re-pinned in PR #204) with Wikidata QIDs that get resolved to the *current* Discogs ID at fixture setup. Discogs admins can reorganize numeric IDs; Wikidata QIDs do not move that way (Stereolab has been Q334652 since at least 2003), so the next time Discogs reshuffles the test self-heals.

Adds `WikidataReconciler.resolve_discogs_ids_from_qids(qids, *, kind)` — the inverse direction of the existing `resolve_qids_from_discogs_ids`. `kind` is `\"artist\"` (P1953), `\"master\"` (P1954), or `\"release\"` (P2206). The release test stays integer-pinned because P2206 is sparse on Wikidata (only masters have entries reliably) — documented in a docstring.

## Reliability shift

Failure mode comparison vs the current re-pin:

| Scenario | After #204 (current) | After this PR |
|---|---|---|
| Discogs reshuffles an ID | ❌ test fails, human re-pins | ✅ self-heals via P1953/P1954 |
| Wikidata SPARQL outage | ✅ unaffected | ⚠️ test self-*skips* (not fails) — fixture catches and `pytest.skip`s |
| Wikidata QID changes (very rare) | n/a | ❌ test fails (correct signal) |
| Wikidata removes the property | n/a | ⚠️ test self-skips |

Wikimedia's SPARQL endpoint runs ~99.9% uptime; outages are minutes-scale.

## Investigated blast radius

- Across all WXYC repos, only `TestEntityResolution` (3 tests) pins live Discogs IDs to specific entities.
- The e2e tests in `tests/e2e/discogs/test_endpoints.py` already use canonical IDs (388, 90416) and survived the 2026-04-28 reorganization unchanged — evidence that canonical IDs are markedly more stable.
- LML already has production-grade SPARQL plumbing in `scripts/entity_resolution/sources.py:SparqlSource` (rate-limited, retries on 429/403, proper User-Agent). Reused as-is.
- No new secrets, no new dependencies. CI keeps the existing `external_api` marker; `query.wikidata.org` is publicly reachable from GitHub runners.
- Two extra SPARQL round-trips per pytest session (~150–500ms each). Negligible against the existing job runtime.

## Test plan

- [x] 8 new unit tests for `resolve_discogs_ids_from_qids` (kind dispatch, invalid kind rejection, `wd:` prefix encoding, empty-input short-circuit, missing-property defensive path, non-numeric defensive path). Run as part of the default suite — no infra needed.
- [x] Full unit suite locally: 1552 passed.
- [x] `TestEntityResolution` against live Discogs + Wikidata: 6/6 passed.
- [x] `ruff check` clean, `ruff format --check` clean, `mypy` clean.
- [ ] CI green on PR (default + external_api jobs).

## Out of scope

- Decoupling `Deploy to Staging` from `External API Tests` — the systemic deploy-gate problem flagged in PR #204's review. Separate, larger change.
- The third (release) test stays integer-pinned. P2206 is sparse on Wikidata.