### PR TITLE
Fire streaming webhooks in background

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -92,7 +92,14 @@ async def _send_streaming_webhooks(
     """Send streaming changes to all comma-separated webhook URLs concurrently."""
     urls = [u.strip() for u in webhook_urls.split(",") if u.strip()]
     tasks = [_send_streaming_webhook(url, notify_key, changes) for url in urls]
-    return list(await asyncio.gather(*tasks))
+    results = list(await asyncio.gather(*tasks))
+    logger.info(
+        "Streaming webhook complete: %d changes to %d URLs: %s",
+        len(changes),
+        len(results),
+        ", ".join(f"{r['url']} -> {r['status']}" for r in results),
+    )
+    return results
 
 
 def _validate_auth(
@@ -171,18 +178,14 @@ async def upload_library_db(
     os.replace(str(tmp_path), str(db_path))
     logger.info(f"Library database replaced: {db_path} ({row_count} rows)")
 
-    # Send streaming webhook after successful swap
-    webhook_result = None
+    # Fire streaming webhooks in the background (don't block the upload response)
     if settings.streaming_webhook_urls and changes:
-        webhook_result = await _send_streaming_webhooks(
-            settings.streaming_webhook_urls,
-            settings.etl_notify_key,
-            changes,
-        )
-        logger.info(
-            "Streaming webhook sent: %d changes to %d URLs",
-            len(changes),
-            len(webhook_result),
+        asyncio.create_task(
+            _send_streaming_webhooks(
+                settings.streaming_webhook_urls,
+                settings.etl_notify_key,
+                changes,
+            )
         )
 
     response: dict = {
@@ -190,8 +193,8 @@ async def upload_library_db(
         "row_count": row_count,
         "timestamp": datetime.now(UTC).isoformat(),
     }
-    if webhook_result is not None:
-        response["webhook"] = webhook_result
+    if settings.streaming_webhook_urls and changes:
+        response["webhook"] = {"status": "pending", "changes_count": len(changes)}
     return JSONResponse(content=response)
 
 

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["admin"])
 
+# Strong references to background tasks to prevent GC before completion.
+# See https://docs.python.org/3/library/asyncio-task.html#creating-tasks
+_background_tasks: set[asyncio.Task] = set()
+
 
 def _get_streaming_ids(db_path: Path) -> set[int]:
     """Read the set of library_ids from streaming_links in a SQLite file.
@@ -180,13 +184,15 @@ async def upload_library_db(
 
     # Fire streaming webhooks in the background (don't block the upload response)
     if settings.streaming_webhook_urls and changes:
-        asyncio.create_task(
+        task = asyncio.create_task(
             _send_streaming_webhooks(
                 settings.streaming_webhook_urls,
                 settings.etl_notify_key,
                 changes,
             )
         )
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     response: dict = {
         "status": "ok",

--- a/tests/unit/test_admin_router.py
+++ b/tests/unit/test_admin_router.py
@@ -10,7 +10,14 @@ from httpx import ASGITransport, AsyncClient
 
 from config.settings import Settings, get_settings
 from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+from routers.admin import _background_tasks
 from tests.unit.conftest import override_deps
+
+
+async def _drain_background_tasks():
+    """Await all pending background webhook tasks so assertions can verify their effects."""
+    while _background_tasks:
+        await asyncio.gather(*_background_tasks)
 
 
 def _make_valid_sqlite_db(path, streaming_ids=None) -> int:
@@ -578,7 +585,7 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
-            await asyncio.sleep(0)  # let background task run
+            await _drain_background_tasks()
 
         assert resp.status_code == 200
         body = resp.json()
@@ -642,7 +649,7 @@ class TestUploadWebhookIntegration:
         patcher, _ = _mock_httpx_client(side_effect=httpx.ConnectError("refused"))
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
-            await asyncio.sleep(0)  # let background task run (and fail)
+            await _drain_background_tasks()
 
         assert resp.status_code == 200
         body = resp.json()
@@ -661,7 +668,7 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
-            await asyncio.sleep(0)
+            await _drain_background_tasks()
 
         assert resp.status_code == 200
         payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
@@ -682,7 +689,7 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
-            await asyncio.sleep(0)
+            await _drain_background_tasks()
 
         assert resp.status_code == 200
         payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
@@ -703,7 +710,7 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
-            await asyncio.sleep(0)
+            await _drain_background_tasks()
 
         assert resp.status_code == 200
         payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
@@ -724,7 +731,7 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, multi_webhook_settings, upload_file)
-            await asyncio.sleep(0)
+            await _drain_background_tasks()
 
         assert resp.status_code == 200
         body = resp.json()

--- a/tests/unit/test_admin_router.py
+++ b/tests/unit/test_admin_router.py
@@ -1,5 +1,6 @@
 """Unit tests for routers/admin.py -- library.db upload endpoint."""
 
+import asyncio
 import sqlite3
 from unittest.mock import AsyncMock, patch
 
@@ -564,7 +565,7 @@ class TestUploadWebhookIntegration:
 
     @pytest.mark.asyncio
     async def test_sends_streaming_diff(self, tmp_path, webhook_settings):
-        """Upload with streaming changes triggers webhook with correct diff."""
+        """Upload with streaming changes triggers background webhook with correct diff."""
         from main import app
 
         # Old DB at the configured path with streaming_ids [1, 2, 3]
@@ -577,12 +578,14 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
+            await asyncio.sleep(0)  # let background task run
 
         assert resp.status_code == 200
         body = resp.json()
-        assert "webhook" in body
+        assert body["webhook"]["status"] == "pending"
+        assert body["webhook"]["changes_count"] == 2
 
-        # Verify the POST payload
+        # Verify the POST payload sent in background
         call_kwargs = mock_post.call_args
         payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
         changes = payload["changes"]
@@ -628,7 +631,7 @@ class TestUploadWebhookIntegration:
 
     @pytest.mark.asyncio
     async def test_webhook_failure_returns_200(self, tmp_path, webhook_settings):
-        """Webhook failure does not fail the upload."""
+        """Webhook failure does not fail the upload (fires in background)."""
         from main import app
 
         _make_valid_sqlite_db(webhook_settings.library_db_path, streaming_ids=[1])
@@ -639,11 +642,12 @@ class TestUploadWebhookIntegration:
         patcher, _ = _mock_httpx_client(side_effect=httpx.ConnectError("refused"))
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
+            await asyncio.sleep(0)  # let background task run (and fail)
 
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] == "ok"
-        assert body["webhook"][0]["status"] == "failed"
+        assert body["webhook"]["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_first_ever_upload(self, tmp_path, webhook_settings):
@@ -657,6 +661,7 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
+            await asyncio.sleep(0)
 
         assert resp.status_code == 200
         payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
@@ -677,6 +682,7 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
+            await asyncio.sleep(0)
 
         assert resp.status_code == 200
         payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
@@ -697,6 +703,7 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, webhook_settings, upload_file)
+            await asyncio.sleep(0)
 
         assert resp.status_code == 200
         payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
@@ -717,8 +724,9 @@ class TestUploadWebhookIntegration:
         patcher, mock_post = _mock_httpx_client(200)
         with patcher:
             resp = await self._upload(app, multi_webhook_settings, upload_file)
+            await asyncio.sleep(0)
 
         assert resp.status_code == 200
         body = resp.json()
-        assert len(body["webhook"]) == 2
-        assert all(r["status"] == "sent" for r in body["webhook"])
+        assert body["webhook"]["status"] == "pending"
+        assert body["webhook"]["changes_count"] == 1


### PR DESCRIPTION
## Summary

- Switch webhook delivery from synchronous (blocking the upload response) to background via `asyncio.create_task`
- Fixes Railway 502 timeouts caused by slow downstream receivers (tubafrenzy Lucene reindex takes ~2s per change)
- Upload response now returns `"webhook": {"status": "pending", "changes_count": N}` instead of per-URL results
- Webhook results are logged via `logger.info` for operational visibility
- Tasks held in a module-level `set` to prevent GC before completion

## Test plan

- [x] All 29 admin router tests pass (updated to use `_drain_background_tasks()`)
- [x] Full unit suite (1553 tests) passes
- [x] ruff lint + format clean