### PR TITLE
Add staging environment support to set-railway-var workflow

### DIFF
--- a/.github/workflows/set-railway-var.yml
+++ b/.github/workflows/set-railway-var.yml
@@ -54,6 +54,21 @@ jobs:
       SERVICE: library-metadata-lookup
       HEALTH_URL: ${{ inputs.env == 'staging' && 'https://library-metadata-lookup-staging.up.railway.app/health' || 'https://library-metadata-lookup-production.up.railway.app/health' }}
     steps:
+      - name: Validate Railway token resolved for the requested environment
+        # GitHub's `&& X || Y` ternary returns the right operand when the left
+        # is empty/false. If RAILWAY_TOKEN_STAGING is unset (or someone deletes
+        # it), an `env=staging` invocation would silently fall back to
+        # RAILWAY_TOKEN_PRODUCTION and rotate the production secret instead —
+        # an invisible blast-radius escalation. Fail loud on resolved-empty.
+        env:
+          ENV_UPPER: ${{ inputs.env == 'staging' && 'STAGING' || 'PRODUCTION' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RAILWAY_TOKEN:-}" ]; then
+            echo "::error::RAILWAY_TOKEN resolved empty for env=${{ inputs.env }}. Verify RAILWAY_TOKEN_${ENV_UPPER} is set as a repo secret."
+            exit 1
+          fi
+
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 

--- a/.github/workflows/set-railway-var.yml
+++ b/.github/workflows/set-railway-var.yml
@@ -1,14 +1,14 @@
 name: Set Railway env var (manual)
 
-# One-shot ops workflow: upserts a single env var on the production Railway
-# service for library-metadata-lookup, then waits for the auto-redeploy and
-# probes /health. Used to rotate secrets (LML_API_KEY, ETL_NOTIFY_KEY, …)
-# without requiring a local Railway CLI session — the project-scoped
-# RAILWAY_TOKEN_PRODUCTION secret stays in GitHub.
+# One-shot ops workflow: upserts a single env var on the production or staging
+# Railway service for library-metadata-lookup, then waits for the auto-redeploy
+# and probes /health. Used to rotate secrets (LML_API_KEY, ETL_NOTIFY_KEY,
+# DISCOGS_TOKEN, …) without requiring a local Railway CLI session — the
+# project-scoped RAILWAY_TOKEN_{PRODUCTION,STAGING} secrets stay in GitHub.
 #
 # Usage:
 #   gh workflow run set-railway-var.yml --ref main -f key=LML_API_KEY
-#   gh workflow run set-railway-var.yml --ref main -f key=ETL_NOTIFY_KEY
+#   gh workflow run set-railway-var.yml --ref main -f key=DISCOGS_TOKEN -f env=staging
 #
 # The value is read from a same-named GH secret. Override with `secret_name`:
 #   gh workflow run set-railway-var.yml --ref main -f key=LML_API_KEY -f secret_name=LML_API_KEY_NEW
@@ -20,7 +20,8 @@ name: Set Railway env var (manual)
 # accidents.
 #
 # Required GH secrets:
-#   RAILWAY_TOKEN_PRODUCTION   project-scoped Railway token
+#   RAILWAY_TOKEN_PRODUCTION   project-scoped Railway token for production
+#   RAILWAY_TOKEN_STAGING      project-scoped Railway token for staging
 #   <key>                      the value to set (one per supported key —
 #                              add new ones to the resolve step's case)
 
@@ -35,14 +36,23 @@ on:
         description: 'GH secret name holding the value (defaults to `key`)'
         required: false
         type: string
+      env:
+        description: 'Railway environment to target'
+        required: false
+        type: choice
+        default: production
+        options:
+          - production
+          - staging
 
 jobs:
   apply:
     runs-on: ubuntu-latest
     env:
       # Project-scoped token. Setting once at the job level keeps it out of step echoes.
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_PRODUCTION }}
+      RAILWAY_TOKEN: ${{ inputs.env == 'staging' && secrets.RAILWAY_TOKEN_STAGING || secrets.RAILWAY_TOKEN_PRODUCTION }}
       SERVICE: library-metadata-lookup
+      HEALTH_URL: ${{ inputs.env == 'staging' && 'https://library-metadata-lookup-staging.up.railway.app/health' || 'https://library-metadata-lookup-production.up.railway.app/health' }}
     steps:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
@@ -112,7 +122,7 @@ jobs:
           echo "Sleeping 60s for redeploy..."
           sleep 60
           for i in 1 2 3 4 5 6; do
-            if curl -sf -m 10 https://library-metadata-lookup-production.up.railway.app/health > /tmp/health.json; then
+            if curl -sf -m 10 "$HEALTH_URL" > /tmp/health.json; then
               status=$(python3 -c "import json,sys;print(json.load(open('/tmp/health.json'))['status'])")
               echo "Health attempt $i: $status"
               if [ "$status" = "healthy" ] || [ "$status" = "degraded" ]; then
@@ -128,4 +138,4 @@ jobs:
 
       - name: Summary
         run: |
-          echo "Set ${{ env.KEY }} (${{ steps.resolve.outputs.length }} chars) on Railway service ${{ env.SERVICE }}."
+          echo "Set ${{ env.KEY }} (${{ steps.resolve.outputs.length }} chars) on Railway service ${{ env.SERVICE }} (${{ inputs.env }})."


### PR DESCRIPTION
Extends `set-railway-var.yml` with an optional `env` input (`production` | `staging`, defaults to `production`) so the same workflow can rotate secrets on either Railway environment. The `RAILWAY_TOKEN` and `/health` probe URL switch based on the input.

Existing invocations are unchanged because `production` is the default.

## Why

Originally a prerequisite for closing #209. That issue ended up being resolved by a manual rotation via the Railway dashboard, but the workflow extension is still useful for future rotations — keeps secrets in GitHub instead of requiring local Railway CLI sessions.

After this lands, staging rotations look like:

```
gh workflow run set-railway-var.yml --ref main -f key=DISCOGS_TOKEN -f env=staging
```

## Footgun caught in review (now fixed)

`${{ inputs.env == 'staging' && secrets.RAILWAY_TOKEN_STAGING || secrets.RAILWAY_TOKEN_PRODUCTION }}` is GitHub Actions' ternary idiom — it returns the right operand when the left is empty/false. If `RAILWAY_TOKEN_STAGING` were unset or deleted, an `env=staging` invocation would silently fall back to `RAILWAY_TOKEN_PRODUCTION` and rotate the production secret instead — invisible blast-radius escalation.

Fixed in 315af29 by adding a leading `Validate Railway token resolved` step that fails the workflow with a descriptive `::error::` pointing at the missing secret name, before any state is touched.

## Test plan

- [x] Validation step rejects empty `RAILWAY_TOKEN`.
- [x] Lint / typecheck pass (no Python changes, only YAML).
- [ ] **After merge: dry-run workflow against staging by re-rotating a known-cheap secret (`LML_API_KEY`)** — exercises the `env=staging` path end-to-end without putting `DISCOGS_TOKEN` at risk. If staging /health stays healthy after, the workflow path is verified.

## Follow-ups (separate issues, not blocking this merge)

- #227 — `set-railway-var` accepts `degraded` as success, which is the wrong criterion for `DISCOGS_TOKEN` rotations. Carryover bug from the original workflow; this PR doubles the surface to staging. Worth tightening before relying on automated DISCOGS_TOKEN rotations.
- #228 — Add static validation for workflow files (actionlint). The footgun in this PR was caught by code review, not by tooling — actionlint would have caught it in CI.

Refs #209 (closed), #219 (closed).