### PR TITLE
Decouple deploy jobs from External API Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,11 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [lint, typecheck, test, external_api, pg]
+    # external_api is intentionally NOT a deploy gate — Discogs drift is an external
+    # availability signal, not a precondition for shipping our own code. The job
+    # still runs and reports per-PR; a red status is visible without blocking the
+    # deploy chain. See WXYC/library-metadata-lookup#208.
+    needs: [lint, typecheck, test, pg]
     steps:
       - uses: actions/checkout@v4
       - name: Install Railway CLI
@@ -212,7 +216,8 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/prod'
-    needs: [lint, typecheck, test, external_api, pg]
+    # external_api is intentionally NOT a deploy gate — see deploy-staging for the rationale.
+    needs: [lint, typecheck, test, pg]
     steps:
       - uses: actions/checkout@v4
       - name: Install Railway CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,9 +250,9 @@ Untouched: `/health`, `/identity/resolve`, `/identity/bulk`. Identity routes are
 | External API Tests | All pushes + PRs | -- |
 | PG Tests | All pushes + PRs | -- |
 | CI Marker Sync | All pushes + PRs | -- |
-| Deploy to Staging | Push to `main` | lint, typecheck, test, external_api, pg |
+| Deploy to Staging | Push to `main` | lint, typecheck, test, pg |
 | Smoke Test (Staging) | Push to `main` | deploy-staging |
-| Deploy to Production | Push to `prod` | lint, typecheck, test, external_api, pg |
+| Deploy to Production | Push to `prod` | lint, typecheck, test, pg |
 | Smoke Test (Production) | Push to `prod` | deploy-production |
 
 ### Pytest markers (architecture A)


### PR DESCRIPTION
Closes #208.

## Summary

Removes `external_api` from the `needs:` lists of `deploy-staging` and `deploy-production`. Discogs availability and ID-pinning stability are properties of an external system we don't control; gating deploys on them turns every Discogs drift into a self-inflicted incident.

The triggering case: 2026-04-28's Discogs ID reorganization left `External API Tests` red for ~14 hours and blocked the staging deploy of the diacritic-insensitive reconciler fix in #203 until #204 re-pinned the tests, even though nothing in the deploy itself was Discogs-related.

## What it does

- `deploy-staging.needs`: `[lint, typecheck, test, external_api, pg]` → `[lint, typecheck, test, pg]`
- `deploy-production.needs`: same.
- Brief comment block above `deploy-staging` documenting the omission so a future maintainer doesn't add it back.
- `CLAUDE.md` table updated to match.

## What still works

- `External API Tests` still runs on every push and on every PR for visibility. A red status remains a per-PR signal — it just doesn't refuse to deploy.
- All other gates (`lint`, `typecheck`, `test`, `pg`) are unchanged.
- The smoke-test and deploy-production chain are unchanged otherwise.

## Out of scope

- Adding a Slack/Sentry notification on red `external_api` (acceptance bullet 3 in #208). The existing per-PR status check is sufficient signal in the short term; a dedicated notification channel can layer on later without re-introducing the gate.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`).
- [ ] CI on this PR passes.
- [ ] After merge: a push to `main` with intentionally-red `external_api` (next time Discogs drifts) deploys to staging anyway.