### PR TITLE
Honor Retry-After + jitter backoff on Discogs 429

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -102,7 +102,12 @@ class Settings(BaseSettings):
         default=5, description="Max concurrent Discogs API requests"
     )
     discogs_max_retries: int = Field(
-        default=2, description="Max retry attempts on 429 rate limit errors"
+        default=5,
+        description=(
+            "Max retry attempts on 429 rate limit errors. With jittered exponential backoff "
+            "capped at 60s, 5 retries spans roughly 0.5–62s of total wait — enough to ride "
+            "out a typical Discogs 60s rate-limit window without throwing away in-flight work."
+        ),
     )
 
     # Admin Configuration

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -64,6 +65,37 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 DISCOGS_API_BASE = "https://api.discogs.com"
+
+# Cap individual retry sleeps. Discogs's per-token rate-limit window is 60
+# seconds; once we cross that, the bucket has reset and there's no benefit to
+# waiting longer for the same 429.
+_MAX_RETRY_DELAY_SECONDS = 60.0
+
+
+def _compute_retry_delay(attempt: int, retry_after_header: str | None) -> float:
+    """Compute how long to sleep before the next retry of a 429-rate-limited request.
+
+    If Discogs sent a numeric ``Retry-After`` header, honor it (capped).
+    Otherwise, use exponential backoff with jitter so multiple parallel
+    backfill containers don't synchronize their retry waves into the next 429.
+
+    Args:
+        attempt: 0-indexed retry attempt number.
+        retry_after_header: Raw value of the ``Retry-After`` response header,
+            or None. RFC 9110 allows seconds (numeric) or HTTP-date; Discogs
+            sends seconds, so non-numeric values fall through to backoff.
+
+    Returns:
+        Delay in seconds, never exceeding ``_MAX_RETRY_DELAY_SECONDS``.
+    """
+    if retry_after_header is not None:
+        try:
+            return min(float(retry_after_header), _MAX_RETRY_DELAY_SECONDS)
+        except ValueError:
+            pass
+    base = 2**attempt
+    jitter = random.uniform(0.5, 1.5)
+    return min(base * jitter, _MAX_RETRY_DELAY_SECONDS)
 
 
 def calculate_confidence(
@@ -251,11 +283,12 @@ class DiscogsService:
 
                     if response.status_code == 429:
                         if attempt < max_retries:
-                            # Exponential backoff: 1s, 2s, 4s...
-                            delay = 2**attempt
+                            retry_after = response.headers.get("Retry-After")
+                            delay = _compute_retry_delay(attempt, retry_after)
                             logger.warning(
-                                f"Discogs rate limit hit, retrying in {delay}s "
-                                f"(attempt {attempt + 1}/{max_retries + 1})"
+                                f"Discogs rate limit hit, retrying in {delay:.2f}s "
+                                f"(attempt {attempt + 1}/{max_retries + 1}, "
+                                f"Retry-After={retry_after})"
                             )
                             await asyncio.sleep(delay)
                             continue

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -179,6 +179,87 @@ class TestRequestWithRetry:
         resp = await service._request_with_retry("GET", "/test", max_retries=0)
         assert resp is None
 
+    @pytest.mark.asyncio
+    async def test_429_honors_retry_after_header(self, service):
+        """When Discogs sends Retry-After, sleep that long instead of exponential backoff."""
+        mock_client = AsyncMock()
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+        resp_429.headers = {"Retry-After": "7"}
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        resp_200.headers = {}
+        mock_client.request = AsyncMock(side_effect=[resp_429, resp_200])
+        service._client = mock_client
+
+        with patch("discogs.service.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            resp = await service._request_with_retry("GET", "/test", max_retries=1)
+        assert resp.status_code == 200
+        mock_sleep.assert_awaited_once_with(7.0)
+
+    @pytest.mark.asyncio
+    async def test_429_retry_after_capped_at_max_delay(self, service):
+        """Retry-After values larger than the 60s cap are clamped."""
+        mock_client = AsyncMock()
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+        resp_429.headers = {"Retry-After": "300"}
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        resp_200.headers = {}
+        mock_client.request = AsyncMock(side_effect=[resp_429, resp_200])
+        service._client = mock_client
+
+        with patch("discogs.service.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await service._request_with_retry("GET", "/test", max_retries=1)
+        delay = mock_sleep.await_args_list[0].args[0]
+        assert delay == 60.0
+
+    @pytest.mark.asyncio
+    async def test_429_backoff_jittered(self, service):
+        """Without Retry-After, backoff calls random.uniform(0.5, 1.5) for jitter."""
+        mock_client = AsyncMock()
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+        resp_429.headers = {}
+        mock_client.request = AsyncMock(return_value=resp_429)
+        service._client = mock_client
+
+        with (
+            patch("discogs.service.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("discogs.service.random.uniform", return_value=1.25) as mock_uniform,
+        ):
+            await service._request_with_retry("GET", "/test", max_retries=3)
+        # 3 retries → 3 sleep calls + 3 jitter calls
+        assert mock_sleep.await_count == 3
+        assert mock_uniform.call_count == 3
+        # Each call to random.uniform should request the same jitter range.
+        for call in mock_uniform.call_args_list:
+            assert call.args == (0.5, 1.5)
+        # Attempts 0, 1, 2 → bases 1, 2, 4 → with jitter factor 1.25 → 1.25, 2.5, 5.0
+        delays = [c.args[0] for c in mock_sleep.await_args_list]
+        assert delays == [1.25, 2.5, 5.0]
+
+    @pytest.mark.asyncio
+    async def test_429_invalid_retry_after_falls_back_to_backoff(self, service):
+        """Non-numeric Retry-After (HTTP-date or junk) falls back to jittered backoff."""
+        mock_client = AsyncMock()
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+        resp_429.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        resp_200.headers = {}
+        mock_client.request = AsyncMock(side_effect=[resp_429, resp_200])
+        service._client = mock_client
+
+        with patch("discogs.service.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            resp = await service._request_with_retry("GET", "/test", max_retries=1)
+        assert resp.status_code == 200
+        delay = mock_sleep.await_args_list[0].args[0]
+        # Falls through to exponential at attempt 0: base 1s, jittered into [0.5, 1.5]
+        assert 0.5 <= delay <= 1.5
+
 
 # ---------------------------------------------------------------------------
 # _parse_title


### PR DESCRIPTION
Closes #201.

## Summary

When Discogs returns 429, the retry path now:

1. **Honors numeric `Retry-After`** header if present, capped at 60s (the rate-limit window).
2. **Falls back to jittered exponential backoff** when no header — `2**attempt * uniform(0.5, 1.5)`, capped at 60s.
3. **Default retry budget bumped 2 → 5 attempts.** Roughly 0.5–62s of total wait before giving up — enough to ride out a typical Discogs rate-limit window without throwing away in-flight backfill work.

## Why

The issue describes three options. (1) "Token-bucket pre-throttle" — already exists at the per-instance level (`discogs/ratelimit.py`, `AsyncLimiter(50, 60)`) and predates the issue. The issue's claim that LML "doesn't internally throttle" was stale at filing time. (2) "Smarter retry policy" — this PR. (3) "Multi-token rotation" — out of scope; deferred.

For the #631 metadata backfill at 1.86M rows, the previous behavior was:

```
2026-04-27 22:06:40,090 - WARNING - Discogs rate limit hit, retrying in 1s (attempt 1/3)
2026-04-27 22:06:41,289 - ERROR - Discogs rate limit hit, max retries exhausted
```

3 attempts × deterministic [1s, 2s, 4s] backoff = 7s total. Way too tight for a 60s rate-limit window. With this PR, the 5-attempt budget at jittered [1, 2, 4, 8, 16] × [0.5, 1.5] gives ~62s peak wait — most 429 cascades absorb without dropping work.

Jitter specifically matters when running multiple partitioned backfill containers: deterministic backoff would synchronize their retry waves into the next 429 wave. Jitter de-syncs them.

## Operator guidance for multi-container backfills

Multiple parallel backfill containers each hold a per-loop `AsyncLimiter` at `DISCOGS_RATE_LIMIT` (default 50/min). To stay under Discogs's 60/min ceiling, divide the env var by the partition count:

```
# 2 partitions:
DISCOGS_RATE_LIMIT=25
# 4 partitions:
DISCOGS_RATE_LIMIT=12
```

(Documented in the operator notes for #638 when that lands; not added to repo CLAUDE.md because it's specific to backfill orchestration.)

## Test plan

- [x] 4 new tests covering Retry-After honor, cap, jitter (via `random.uniform` patch), and malformed-header fallback.
- [x] Existing `TestRequestWithRetry` tests still pass (4 of them).
- [x] Full unit suite green (1557 tests).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy` clean.

## Out of scope

- Multi-token rotation (issue's option 3) — separate, larger change.
- Cross-container coordination (e.g. shared Redis-backed limiter) — not needed if operators divide `DISCOGS_RATE_LIMIT` per partition.
- Honoring `Retry-After` as an HTTP-date string (RFC 9110 allows this; Discogs doesn't send it). Falls back to backoff cleanly if encountered.