### PR TITLE
Project cache_stats onto active Sentry transaction

### DIFF
--- a/lookup/router.py
+++ b/lookup/router.py
@@ -42,15 +42,22 @@ def _project_cache_stats_to_transaction(stats: dict | None) -> None:
     Non-numeric values (strings, None) are skipped — the cache_stats schema
     is all-numeric today, but keep the projection defensive in case that
     ever drifts.
+
+    Observability must not break the request path: any exception raised by
+    the Sentry SDK or by an unexpected stats shape is caught and logged at
+    WARNING. The request keeps going.
     """
     if not stats:
         return
-    transaction = sentry_sdk.get_current_scope().transaction
-    if transaction is None:
-        return
-    for key, value in stats.items():
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            transaction.set_data(f"lml.cache.{key}", value)
+    try:
+        transaction = sentry_sdk.get_current_scope().transaction
+        if transaction is None:
+            return
+        for key, value in stats.items():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                transaction.set_data(f"lml.cache.{key}", value)
+    except Exception as e:
+        logger.warning("Failed to project cache_stats onto Sentry transaction: %s", e)
 
 
 @router.post(

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -3,6 +3,7 @@
 import logging
 
 import httpx
+import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException
 from posthog import Posthog
 
@@ -28,6 +29,28 @@ from scripts.entity_resolution.store import EntityStore
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["lookup"])
+
+
+def _project_cache_stats_to_transaction(stats: dict | None) -> None:
+    """Attach numeric cache_stats fields to the current Sentry transaction.
+
+    Each field becomes a `lml.cache.<key>` data attribute on the transaction
+    so the data joins against the trace in Sentry's trace explorer. No-op
+    when there is no active transaction (Sentry not initialized, or call
+    happening outside a request span).
+
+    Non-numeric values (strings, None) are skipped — the cache_stats schema
+    is all-numeric today, but keep the projection defensive in case that
+    ever drifts.
+    """
+    if not stats:
+        return
+    transaction = sentry_sdk.get_current_scope().transaction
+    if transaction is None:
+        return
+    for key, value in stats.items():
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            transaction.set_data(f"lml.cache.{key}", value)
 
 
 @router.post(
@@ -85,6 +108,12 @@ async def handle_lookup(
 
         # Attach cache stats
         response.cache_stats = get_cache_stats()
+
+        # Project cache_stats onto the active Sentry transaction so it joins
+        # against the trace in Sentry's trace explorer (alongside latency,
+        # status, etc.). No-op when there is no active transaction (no
+        # SENTRY_DSN configured, or running outside a request span).
+        _project_cache_stats_to_transaction(response.cache_stats)
 
         # Send telemetry
         if posthog_client:

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -106,14 +106,19 @@ async def handle_lookup(
             http_client=http_client,
         )
 
-        # Attach cache stats
-        response.cache_stats = get_cache_stats()
+        # Attach cache stats. Read from the raw dict returned by
+        # get_cache_stats() before assignment to response.cache_stats: once
+        # wxyc-shared#86 ships a typed CacheStats Pydantic model, assigning
+        # the dict to response.cache_stats will auto-convert it into a model
+        # instance, and the projection (which calls `.items()`) would break.
+        stats = get_cache_stats()
+        response.cache_stats = stats
 
         # Project cache_stats onto the active Sentry transaction so it joins
         # against the trace in Sentry's trace explorer (alongside latency,
         # status, etc.). No-op when there is no active transaction (no
         # SENTRY_DSN configured, or running outside a request span).
-        _project_cache_stats_to_transaction(response.cache_stats)
+        _project_cache_stats_to_transaction(stats)
 
         # Send telemetry
         if posthog_client:

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -274,6 +274,64 @@ class TestHandleLookup:
         )
 
     @pytest.mark.asyncio
+    async def test_cache_stats_projection_failure_does_not_break_request(self, app_client):
+        """If the Sentry projection raises, the request must still succeed.
+        Observability mustn't break the request path.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+        mock_transaction = Mock()
+        mock_transaction.set_data = Mock(side_effect=RuntimeError("boom"))
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value={"api_calls": 1}),
+            patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_cache_stats_projection_handles_non_dict_object_gracefully(self, app_client):
+        """End-to-end forward-compat: when get_cache_stats() returns a model-like
+        object (no `.items()`), the projection must not break the request. This is
+        the live-fire version of the future-bug from wxyc-shared#86: the projection's
+        try/except must catch the AttributeError so the request still 200s.
+        """
+        from dataclasses import dataclass
+
+        @dataclass
+        class FakeCacheStatsModel:
+            # Mimics a Pydantic v2 BaseModel: attribute access works, no `.items()`.
+            api_calls: int = 7
+            pg_hits: int = 3
+
+        fake_stats = FakeCacheStatsModel()
+        response = LookupResponse(results=[], search_type="direct")
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value=fake_stats),
+            patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
     async def test_response_includes_call_number(self, app_client):
         """Regression: call_number must appear in the JSON response."""
         result_item = LookupResultItem(

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -155,6 +155,91 @@ class TestHandleLookup:
         mock_init.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_cache_stats_projected_onto_sentry_transaction(self, app_client):
+        """The numeric cache_stats fields are attached to the active Sentry transaction
+        as `lml.cache.*` data, so they appear in trace explorer alongside latency.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+        stats = {
+            "memory_hits": 2,
+            "pg_hits": 5,
+            "pg_misses": 1,
+            "api_calls": 3,
+            "pg_time_ms": 12.5,
+            "api_time_ms": 480.7,
+        }
+        mock_transaction = Mock()
+        mock_transaction.set_data = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value=stats),
+            patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        # Six numeric fields → six set_data calls
+        actual_calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert actual_calls == {
+            "lml.cache.memory_hits": 2,
+            "lml.cache.pg_hits": 5,
+            "lml.cache.pg_misses": 1,
+            "lml.cache.api_calls": 3,
+            "lml.cache.pg_time_ms": 12.5,
+            "lml.cache.api_time_ms": 480.7,
+        }
+
+    @pytest.mark.asyncio
+    async def test_cache_stats_projection_no_op_without_active_transaction(self, app_client):
+        """When there is no active Sentry transaction, projection is a no-op (no crash)."""
+        response = LookupResponse(results=[], search_type="direct")
+        mock_scope = Mock()
+        mock_scope.transaction = None  # no active transaction
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value={"api_calls": 1}),
+            patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_cache_stats_projection_skips_non_numeric(self, app_client):
+        """Non-numeric values in cache_stats are skipped (defensive — current shape is all numeric)."""
+        response = LookupResponse(results=[], search_type="direct")
+        stats = {"api_calls": 2, "weird_string": "nope", "weird_none": None}
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value=stats),
+            patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        actual_calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert actual_calls == {"lml.cache.api_calls": 2}
+
+    @pytest.mark.asyncio
     async def test_response_includes_call_number(self, app_client):
         """Regression: call_number must appear in the JSON response."""
         result_item = LookupResultItem(

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -240,6 +240,40 @@ class TestHandleLookup:
         assert actual_calls == {"lml.cache.api_calls": 2}
 
     @pytest.mark.asyncio
+    async def test_cache_stats_projection_called_with_raw_get_cache_stats_return(self, app_client):
+        """The projection helper must be invoked with the exact object returned by
+        get_cache_stats(), not with response.cache_stats. Once wxyc-shared#86 ships
+        a typed CacheStats Pydantic model, assigning a dict to response.cache_stats
+        will auto-convert it into a model instance (whose `.items()` method does not
+        exist), and the projection would AttributeError. Reading from the raw return
+        value of get_cache_stats() insulates the projection from that future shape change.
+        """
+        stats = {"api_calls": 4, "pg_hits": 2}
+        response = LookupResponse(results=[], search_type="direct")
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value=stats),
+            patch("lookup.router._project_cache_stats_to_transaction") as mock_project,
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        # Identity check: must be the exact dict from get_cache_stats(), not a
+        # copy that might have been routed through response.cache_stats.
+        mock_project.assert_called_once()
+        passed_arg = mock_project.call_args.args[0]
+        assert passed_arg is stats, (
+            "_project_cache_stats_to_transaction must be called with the raw dict "
+            "returned by get_cache_stats(), not with response.cache_stats (which may "
+            "be coerced into a typed Pydantic model in the future)."
+        )
+
+    @pytest.mark.asyncio
     async def test_response_includes_call_number(self, app_client):
         """Regression: call_number must appear in the JSON response."""
         result_item = LookupResultItem(


### PR DESCRIPTION
Closes #213.

## Summary

In `lookup/router.py:handle_lookup`, after `response.cache_stats = get_cache_stats()`, each numeric field is attached to the active Sentry transaction as `lml.cache.<key>` data. Once #646 (BS-side wrap) lands too, cache hit/miss visibility is on every BS callsite of LML without per-callsite instrumentation — readable from Sentry's trace explorer (e.g. filter `lml.cache.api_calls > 0`).

## Implementation

```py
def _project_cache_stats_to_transaction(stats: dict | None) -> None:
    if not stats:
        return
    transaction = sentry_sdk.get_current_scope().transaction
    if transaction is None:
        return
    for key, value in stats.items():
        if isinstance(value, (int, float)) and not isinstance(value, bool):
            transaction.set_data(f"lml.cache.{key}", value)
```

Two defenses:
- **No active transaction** → no-op. Covers Sentry-not-initialized (no DSN), and any code path that happens to run outside a request span.
- **Non-numeric value** → skipped (`bool` is excluded explicitly because Python's `isinstance(True, int)` returns True; we don't want booleans treated as numeric data).

## TDD

3 new tests in `tests/unit/test_lookup_router.py`:

- `test_cache_stats_projected_onto_sentry_transaction` — happy path; six numeric fields → six `set_data` calls with the expected keys/values.
- `test_cache_stats_projection_no_op_without_active_transaction` — `transaction=None` returns cleanly without raising.
- `test_cache_stats_projection_skips_non_numeric` — strings and Nones are filtered out; only `api_calls: 2` lands.

## Test plan

- [x] 3 new tests pass.
- [x] Existing 7 `TestHandleLookup` tests still pass.
- [x] Full unit suite green (1560 tests).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy` clean.
- [ ] **Manual sanity on staging post-deploy:** trigger a `/lookup` from BS, open the resulting LML transaction in Sentry, confirm the `lml.cache.*` data fields are visible.

## Sibling work

Part of the BS#656 epic (LML cache_stats E2E observability):
- WXYC/Backend-Service#646 — client-side companion: wrap `lookupMetadata` in `Sentry.startSpan` and project the same fields onto a child span. Independent of this PR — they earn full value as a unit but each can land in any order.
- WXYC/wxyc-shared#86 — typed `CacheStats` schema. Lands after #646 so the inline cast can be dropped in the same release.