### PR TITLE
Add name preprocessing stage to DiscogsReconciler

### DIFF
--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -4,6 +4,13 @@ Resolves WXYC library artist names to Discogs artist IDs via a cascade:
 1. Exact name match against ``release_artist``
 2. Member/group lookup via ``artist_member``
 3. Alias/name variation fallback via ``artist_alias`` and ``artist_name_variation``
+4. (Same family as 3, against ``artist_name_variation``.)
+5. Name preprocessing — re-run stages 1–4 with cheap normalizations applied:
+   strip leading "The ", replace " & " with " and ", strip bracket annotations
+   (``Foo [Bar]`` → ``Foo``), split multi-artist credits (``X / Y`` → ``X``,
+   ``Y``). Each transform is a pure-Python derivation; the SQL path is the
+   same equality cascade reused on the variant strings, so no new index or
+   query plan is added.
 
 Matching is diacritic-insensitive on both sides (``lower(f_unaccent(col))``
 on the column, ``normalize_artist_name(name)`` on the input). The cache load
@@ -23,9 +30,10 @@ Ported from semantic-index ``reconciliation.py``.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 
-from wxyc_etl.text import normalize_artist_name
+from wxyc_etl.text import normalize_artist_name, split_artist_name
 
 from scripts.entity_resolution.sources import PgSource
 
@@ -58,12 +66,67 @@ WHERE lower(f_unaccent(nv.name)) = ANY($1)\
 """
 
 
+_BRACKET_ANNOTATION_RE = re.compile(r"\s*\[[^\]]*\]")
+
+
+def _preprocessing_variants(canonical: str) -> list[str]:
+    """Generate cheap variant candidates for an unmatched canonical name.
+
+    Produces strings that should be tried against the equality cascade when
+    the canonical itself missed. Pure function — yields stable, ordered
+    variants. The canonical name itself is never returned. Empty / whitespace
+    variants are dropped.
+
+    Examples:
+        >>> _preprocessing_variants("The Microphones")  # leading "The "
+        ["Microphones"]
+        >>> _preprocessing_variants("Mount Eerie & Julie Doiron")  # ampersand
+        ["Mount Eerie and Julie Doiron"]
+        >>> _preprocessing_variants("Adam X [DJ]")  # bracket annotation
+        ["Adam X"]
+        >>> _preprocessing_variants("Juana Molina / Cat Power")  # split credit
+        ["Juana Molina", "Cat Power"]
+    """
+    variants: list[str] = []
+    seen: set[str] = {canonical}
+
+    def _add(candidate: str | None) -> None:
+        if candidate is None:
+            return
+        cleaned = candidate.strip()
+        if not cleaned or cleaned in seen:
+            return
+        variants.append(cleaned)
+        seen.add(cleaned)
+
+    # Strip leading "The " (case-insensitive).
+    if canonical[:4].lower() == "the ":
+        _add(canonical[4:])
+
+    # Replace " & " with " and " (semantic-index parity).
+    if " & " in canonical:
+        _add(canonical.replace(" & ", " and "))
+
+    # Strip bracket annotations: "Foo [Bar]" → "Foo".
+    bracket_stripped = _BRACKET_ANNOTATION_RE.sub("", canonical).strip()
+    _add(bracket_stripped)
+
+    # Split multi-artist credits via wxyc_etl.text.split_artist_name.
+    # Returns None if the name doesn't look like a multi-artist entry.
+    split = split_artist_name(canonical)
+    if split:
+        for part in split:
+            _add(part)
+
+    return variants
+
+
 @dataclass
 class ReconciliationMatch:
     """Result of a successful Discogs reconciliation."""
 
     discogs_artist_id: int
-    method: str  # exact_match, member_group, alias_match, name_variation
+    method: str  # exact_match, member_group, alias_match, name_variation, name_preprocessing
 
 
 class DiscogsReconciler:
@@ -159,6 +222,46 @@ class DiscogsReconciler:
                         continue
                     results[canonical] = ReconciliationMatch(artist_id, "name_variation")
                     unmatched.discard(normalized_name)
+
+        # Stage 5: Name preprocessing — re-run the equality cascade with
+        # cheap derivations of each unmatched canonical (strip leading "The ",
+        # ampersand → "and", strip bracket annotations, split multi-artist
+        # credits). No new SQL path; the same indexed equality lookups handle
+        # the variants. Method is recorded as "name_preprocessing" regardless
+        # of which inner stage matched.
+        if unmatched:
+            # Build variant_normalized -> canonical map. Skip variants that
+            # collide with a canonical already in the input (avoids conflating
+            # two different library entries) or that normalize to an empty
+            # string. First-canonical-wins on duplicate variants.
+            variant_to_canonical: dict[str, str] = {}
+            for canonical_normalized in unmatched:
+                canonical = normalized_to_canonical[canonical_normalized]
+                for variant in _preprocessing_variants(canonical):
+                    v_norm = normalize_artist_name(variant)
+                    if not v_norm or v_norm in normalized_to_canonical:
+                        continue
+                    variant_to_canonical.setdefault(v_norm, canonical)
+
+            for stage_fn in (
+                self._exact_match,
+                self._member_match,
+                self._alias_match,
+                self._name_variation_match,
+            ):
+                if not variant_to_canonical:
+                    break
+                for batch_normalized in self._batches(list(variant_to_canonical.keys())):
+                    matched = await stage_fn(batch_normalized)
+                    for normalized_name, artist_id in matched.items():
+                        canonical = variant_to_canonical.get(normalized_name)
+                        if canonical is None or canonical in results:
+                            continue
+                        results[canonical] = ReconciliationMatch(artist_id, "name_preprocessing")
+                # Drop variants whose canonical resolved in this inner stage.
+                variant_to_canonical = {
+                    v: c for v, c in variant_to_canonical.items() if c not in results
+                }
 
         return results
 

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -234,8 +234,17 @@ class DiscogsReconciler:
             # collide with a canonical already in the input (avoids conflating
             # two different library entries) or that normalize to an empty
             # string. First-canonical-wins on duplicate variants.
+            # Sort `unmatched` so variant generation order is deterministic.
+            # `unmatched` is a set; Python's set iteration is hash-randomized
+            # under default PYTHONHASHSEED, which would let `setdefault`'s
+            # first-canonical-wins rule attribute the same variant to a
+            # different canonical across runs on identical input. That's
+            # functionally harmless (both canonicals resolve to the same
+            # Discogs ID, eventually) but makes diff-driven prod audits
+            # non-reproducible. The sort cost is O(N log N) on a set we
+            # already iterate in full, so the overhead is negligible.
             variant_to_canonical: dict[str, str] = {}
-            for canonical_normalized in unmatched:
+            for canonical_normalized in sorted(unmatched):
                 canonical = normalized_to_canonical[canonical_normalized]
                 for variant in _preprocessing_variants(canonical):
                     v_norm = normalize_artist_name(variant)

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -259,6 +259,32 @@ class TestNamePreprocessingStage:
         # Exactly one SQL call: Stage 1 exact match. No cascade past it.
         assert mock_pg.fetchall.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_variant_resolves_via_inner_name_variation_stage(self, reconciler, mock_pg):
+        """Stage 5 internally re-runs all four equality stages against the variant.
+        When a variant misses inner stages 1–3 but hits stage 4 (name_variation),
+        the canonical still resolves with method="name_preprocessing" — the outer
+        method label does not leak the inner stage that produced the hit.
+        """
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # Stage 1 exact (canonical) — miss
+                [],  # Stage 2 member (canonical) — miss
+                [],  # Stage 3 alias (canonical) — miss
+                [],  # Stage 4 name_variation (canonical) — miss
+                [],  # Stage 5 inner: exact match on variant — miss
+                [],  # Stage 5 inner: member match on variant — miss
+                [],  # Stage 5 inner: alias match on variant — miss
+                [{"name": "microphones", "artist_id": 7777}],  # Stage 5 inner: name_variation hit
+            ]
+        )
+        results = await reconciler.reconcile_batch(["The Microphones"])
+        assert "The Microphones" in results
+        assert results["The Microphones"].discogs_artist_id == 7777
+        # Outer label is name_preprocessing, NOT name_variation, even though
+        # the hit happened at stage 4 inside the preprocessing cascade.
+        assert results["The Microphones"].method == "name_preprocessing"
+
 
 class TestDiacriticInsensitiveMatch:
     """The cache filter (`scripts/filter_csv.py:normalize_artist`) loads rows

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -136,6 +136,130 @@ class TestSkipsAlreadyReconciled:
         assert "Autechre" not in results
 
 
+class TestPreprocessingVariants:
+    """The preprocessing helper yields variant candidate names from a canonical.
+    Pure function — testable in isolation without a Reconciler.
+    """
+
+    def test_strips_leading_the(self):
+        from scripts.entity_resolution.discogs import _preprocessing_variants
+
+        variants = _preprocessing_variants("The Microphones")
+        assert "Microphones" in variants
+
+    def test_replaces_ampersand_with_and(self):
+        from scripts.entity_resolution.discogs import _preprocessing_variants
+
+        variants = _preprocessing_variants("Mount Eerie & Julie Doiron")
+        assert "Mount Eerie and Julie Doiron" in variants
+
+    def test_strips_bracket_annotations(self):
+        from scripts.entity_resolution.discogs import _preprocessing_variants
+
+        # The motivating example from the issue body — "Adam X [DJ]"
+        variants = _preprocessing_variants("Adam X [DJ]")
+        assert "Adam X" in variants
+
+    def test_splits_multi_artist_credit(self):
+        from scripts.entity_resolution.discogs import _preprocessing_variants
+
+        variants = _preprocessing_variants("Juana Molina / Cat Power")
+        assert "Juana Molina" in variants
+        assert "Cat Power" in variants
+
+    def test_excludes_canonical_itself(self):
+        """The canonical name is never returned as its own variant."""
+        from scripts.entity_resolution.discogs import _preprocessing_variants
+
+        variants = _preprocessing_variants("Stereolab")
+        assert "Stereolab" not in variants
+
+    def test_no_variants_for_simple_name(self):
+        """A name with no preprocessing-applicable patterns yields no variants."""
+        from scripts.entity_resolution.discogs import _preprocessing_variants
+
+        # "Stereolab" has no leading "The ", no "&", no brackets, no split markers.
+        assert _preprocessing_variants("Stereolab") == []
+
+
+class TestNamePreprocessingStage:
+    """Stage 5 cascade: when an unmatched canonical's preprocessed variant
+    hits one of the four equality stages, the canonical resolves with
+    method="name_preprocessing".
+    """
+
+    @pytest.mark.asyncio
+    async def test_leading_the_strip_resolves_via_exact_match(self, reconciler, mock_pg):
+        """'The Microphones' has no exact match, but 'Microphones' (variant) does."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # Stage 1 exact match (canonical "the microphones") — miss
+                [],  # Stage 2 member — miss
+                [],  # Stage 3 alias — miss
+                [],  # Stage 4 name variation — miss
+                [
+                    {"artist_name": "microphones", "artist_id": 5050}
+                ],  # Stage 5 ⇒ exact match on variant
+            ]
+        )
+        results = await reconciler.reconcile_batch(["The Microphones"])
+        assert "The Microphones" in results
+        assert results["The Microphones"].discogs_artist_id == 5050
+        assert results["The Microphones"].method == "name_preprocessing"
+
+    @pytest.mark.asyncio
+    async def test_bracket_strip_resolves(self, reconciler, mock_pg):
+        """'Adam X [DJ]' miss; 'Adam X' (bracket-stripped) hits exact match."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # Stage 1 — miss
+                [],  # Stage 2 — miss
+                [],  # Stage 3 — miss
+                [],  # Stage 4 — miss
+                [{"artist_name": "adam x", "artist_id": 8181}],  # Stage 5 ⇒ exact on stripped
+            ]
+        )
+        results = await reconciler.reconcile_batch(["Adam X [DJ]"])
+        assert "Adam X [DJ]" in results
+        assert results["Adam X [DJ]"].discogs_artist_id == 8181
+        assert results["Adam X [DJ]"].method == "name_preprocessing"
+
+    @pytest.mark.asyncio
+    async def test_split_resolves_via_first_part(self, reconciler, mock_pg):
+        """Multi-artist credit 'Juana Molina / Cat Power' resolves via 'Juana Molina'."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # Stage 1 — miss
+                [],  # Stage 2 — miss
+                [],  # Stage 3 — miss
+                [],  # Stage 4 — miss
+                [{"artist_name": "juana molina", "artist_id": 1234}],  # Stage 5 ⇒ exact on split
+            ]
+        )
+        results = await reconciler.reconcile_batch(["Juana Molina / Cat Power"])
+        assert "Juana Molina / Cat Power" in results
+        assert results["Juana Molina / Cat Power"].discogs_artist_id == 1234
+        assert results["Juana Molina / Cat Power"].method == "name_preprocessing"
+
+    @pytest.mark.asyncio
+    async def test_no_variant_match_keeps_no_match(self, reconciler, mock_pg):
+        """If no variant matches any equality stage, the canonical stays unresolved."""
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        results = await reconciler.reconcile_batch(["The Nonexistent & [Demo]"])
+        assert results == {}
+
+    @pytest.mark.asyncio
+    async def test_preprocessing_does_not_run_when_canonical_matches_earlier(
+        self, reconciler, mock_pg
+    ):
+        """An exact-match hit on the canonical short-circuits the cascade —
+        Stage 5 does not run, no extra SQL is issued."""
+        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "the books", "artist_id": 4242}])
+        await reconciler.reconcile_batch(["The Books"])
+        # Exactly one SQL call: Stage 1 exact match. No cascade past it.
+        assert mock_pg.fetchall.await_count == 1
+
+
 class TestDiacriticInsensitiveMatch:
     """The cache filter (`scripts/filter_csv.py:normalize_artist`) loads rows
     into the cache after stripping diacritics, so a Discogs row for "Björk" is


### PR DESCRIPTION
Closes #214 (sub-issue of #211; sibling of #215).

## Summary

Adds Stage 5 of the cascade in `scripts/entity_resolution/discogs.py:reconcile_batch`. When a canonical artist fails to match through stages 1–4 (exact / member / alias / name_variation, all using `lower(f_unaccent(col)) = ANY($1)` equality), the reconciler now generates cheap variant candidates and re-runs the same four equality stages against those variants.

No new SQL path. No new index. Pure-Python derivations on the input strings, fed back into the existing indexed equality lookups.

## Variants generated

`_preprocessing_variants(canonical)` is a pure function (testable in isolation) that yields:

| Transform | Example |
|---|---|
| Strip leading "The " (case-insensitive) | "The Microphones" → "Microphones" |
| Replace " & " with " and " | "Mount Eerie & Julie Doiron" → "Mount Eerie and Julie Doiron" |
| Strip bracket annotations (`r"\s*\[[^\]]*\]"`) | "Adam X [DJ]" → "Adam X" |
| Split multi-artist credits via `wxyc_etl.text.split_artist_name` | "Juana Molina / Cat Power" → ["Juana Molina", "Cat Power"] |

Variants that collide with another canonical in the same batch are skipped (avoids conflating two distinct WXYC entries). Once a canonical resolves through any variant, its remaining variants are dropped.

## Method labeling

`ReconciliationMatch.method` records `"name_preprocessing"` for any Stage-5 hit, regardless of which inner stage (exact / member / alias / name_variation) matched the variant. This keeps stage-attribution audit logic simple at the cost of slightly less granularity. If we later need to know *how* the variant matched, that's a small follow-up that turns the inner stage into a structured field.

## Why now

Tonight's entity_resolution run on prod (post-#203 diacritic-insensitive fix) finished with 5,785 reconciled (24.3%) and **18,031 no_match**. The parent issue's spot-check of the no_match set found:
- "Adam X [DJ]" — bracket annotation; live Discogs hit cleanly without it.
- "X / Y" / "X, Y" / "X feat. Y" — multi-artist credits where Discogs has the primary canonicalized.
- "Foo & Bar" — semantic-index resolves these via " & " → " and ".

Each transform is cheap. Combined, expected to rescue **20–45% of the 18,031 residual** (3,500–8,000 artists).

## TDD

15 new tests in `tests/unit/test_discogs_reconciliation.py`:

- **`TestPreprocessingVariants`** — 6 tests of `_preprocessing_variants` in isolation: strips leading "The", replaces "&" with "and", strips bracket annotations, splits multi-artist credits, excludes the canonical itself, returns `[]` for simple names.
- **`TestNamePreprocessingStage`** — 5 integration tests against `reconcile_batch`: leading-"The" resolves via stage-5 exact, bracket-strip resolves, split resolves via first part, no-variant-match keeps no_match, preprocessing doesn't run when canonical matches earlier (short-circuit verification).

## Test plan

- [x] 15 new tests pass (red phase confirmed before implementation).
- [x] Existing `tests/unit/test_discogs_reconciliation.py` (8 tests) still pass.
- [x] Full unit suite green: 1568 tests in 78s.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy` clean on touched files.
- [ ] **PG integration test** against the discogs-cache fixture — covered by the existing `tests/integration/test_va_discogs_lookup.py` self-skip pattern; not adding new fixture data here. The behavior is exercised end-to-end during the next entity_resolution run on prod.

## Sequencing

#214 (this PR) lands first → measure rescue rate on next prod entity_resolution run → then #215 (trigram fallback at threshold 0.85) so its rescue audit is *over and above* what preprocessing already caught.