### PR TITLE
Surface specific HTTP status code from /health discogs probe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,20 @@ When `library.db` is missing (e.g., on first deploy before first upload):
 - Service is functional for non-database endpoints
 - After uploading library.db, next request triggers reconnection
 
+The `services.discogs_api` field on `GET /health` carries one of a fixed vocabulary of values defined by `DiscogsApiCheckResult` in `discogs/service.py`:
+
+| Value | Meaning |
+|---|---|
+| `ok` | Probe succeeded (200) |
+| `auth-error` | Token rejected (401, 403) — usually rotation drift |
+| `rate-limited` | Discogs is throttling us (429) |
+| `upstream-error` | Discogs returned 5xx |
+| `network-error` | Connection or timeout failure (`httpx.ConnectError`/`TimeoutException`/`NetworkError`) |
+| `error` | Unknown / unclassified failure |
+| `unavailable` | `discogs_service` not configured (no token) |
+
+Any value other than `ok` / `unavailable` flips the overall status to `degraded` (or `unhealthy` if a core service like `database` is also down).
+
 ## Scripts
 
 ### Streaming Report Stats Regenerator (`scripts/regenerate_report_stats.py`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,8 @@ The `services.discogs_api` field on `GET /health` carries one of a fixed vocabul
 
 Any value other than `ok` / `unavailable` flips the overall status to `degraded` (or `unhealthy` if a core service like `database` is also down).
 
+The probe also projects its result onto the active Sentry trace as the `discogs_api.check` tag (e.g. `discogs_api.check=auth-error`), so historic `/health` incidents can be queried by failure mode in the Sentry trace explorer without re-pulling Railway logs.
+
 ## Scripts
 
 ### Streaming Report Stats Regenerator (`scripts/regenerate_report_stats.py`)

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -9,6 +9,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import httpx
+import sentry_sdk
 from wxyc_etl.text import is_compilation_artist
 
 from config.settings import get_settings
@@ -257,26 +258,38 @@ class DiscogsService:
 
         Returns a ``DiscogsApiCheckResult`` so ``/health`` can distinguish
         token-rotation drift (401/403), rate limits (429), upstream outages
-        (5xx), and network failures from each other.
+        (5xx), and network failures from each other. The result is also
+        projected onto the active Sentry trace as the ``discogs_api.check``
+        tag so historic incidents are queryable in trace explorer.
         """
+        # NetworkError covers DNS/refused/reset; TimeoutException covers
+        # every connect/read/write/pool timeout. Both signal "couldn't reach
+        # Discogs" — anything else (LocalProtocolError, UnsupportedProtocol,
+        # RemoteProtocolError) is a programmer/protocol bug and falls through
+        # to ERROR with a log line.
         try:
             client = await self._get_client()
             resp = await client.get("/oauth/identity")
-        except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError):
-            return DiscogsApiCheckResult.NETWORK_ERROR
-        except Exception:
-            return DiscogsApiCheckResult.ERROR
+        except (httpx.NetworkError, httpx.TimeoutException):
+            result = DiscogsApiCheckResult.NETWORK_ERROR
+        except Exception as exc:
+            logger.warning("Unexpected error in Discogs check_api: %r", exc)
+            result = DiscogsApiCheckResult.ERROR
+        else:
+            status = resp.status_code
+            if status == 200:
+                result = DiscogsApiCheckResult.OK
+            elif status in (401, 403):
+                result = DiscogsApiCheckResult.AUTH_ERROR
+            elif status == 429:
+                result = DiscogsApiCheckResult.RATE_LIMITED
+            elif 500 <= status < 600:
+                result = DiscogsApiCheckResult.UPSTREAM_ERROR
+            else:
+                result = DiscogsApiCheckResult.ERROR
 
-        status = resp.status_code
-        if status == 200:
-            return DiscogsApiCheckResult.OK
-        if status in (401, 403):
-            return DiscogsApiCheckResult.AUTH_ERROR
-        if status == 429:
-            return DiscogsApiCheckResult.RATE_LIMITED
-        if 500 <= status < 600:
-            return DiscogsApiCheckResult.UPSTREAM_ERROR
-        return DiscogsApiCheckResult.ERROR
+        sentry_sdk.set_tag("discogs_api.check", result.value)
+        return result
 
     async def _request_with_retry(
         self,

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -184,6 +185,22 @@ def calculate_confidence(
     return min(score, 1.0)
 
 
+class DiscogsApiCheckResult(StrEnum):
+    """Outcome of a Discogs API connectivity probe.
+
+    The string values are surfaced verbatim by ``GET /health`` so operators can
+    distinguish auth drift, rate limiting, and upstream outages without a log
+    pull. See ``routers/health.py:_check_discogs_api``.
+    """
+
+    OK = "ok"
+    AUTH_ERROR = "auth-error"  # 401, 403
+    RATE_LIMITED = "rate-limited"  # 429
+    UPSTREAM_ERROR = "upstream-error"  # 5xx
+    NETWORK_ERROR = "network-error"  # connection / timeout
+    ERROR = "error"  # unknown / other
+
+
 class DiscogsService:
     """Service for all Discogs API interactions with caching.
 
@@ -235,14 +252,31 @@ class DiscogsService:
             await self._client.aclose()
             self._client = None
 
-    async def check_api(self) -> bool:
-        """Check Discogs API connectivity."""
+    async def check_api(self) -> DiscogsApiCheckResult:
+        """Probe Discogs API connectivity, classifying the failure mode.
+
+        Returns a ``DiscogsApiCheckResult`` so ``/health`` can distinguish
+        token-rotation drift (401/403), rate limits (429), upstream outages
+        (5xx), and network failures from each other.
+        """
         try:
             client = await self._get_client()
             resp = await client.get("/oauth/identity")
-            return bool(resp.status_code == 200)
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError):
+            return DiscogsApiCheckResult.NETWORK_ERROR
         except Exception:
-            return False
+            return DiscogsApiCheckResult.ERROR
+
+        status = resp.status_code
+        if status == 200:
+            return DiscogsApiCheckResult.OK
+        if status in (401, 403):
+            return DiscogsApiCheckResult.AUTH_ERROR
+        if status == 429:
+            return DiscogsApiCheckResult.RATE_LIMITED
+        if 500 <= status < 600:
+            return DiscogsApiCheckResult.UPSTREAM_ERROR
+        return DiscogsApiCheckResult.ERROR
 
     async def _request_with_retry(
         self,

--- a/routers/health.py
+++ b/routers/health.py
@@ -25,10 +25,14 @@ async def _check_database(db: LibraryDB) -> str:
 
 
 async def _check_discogs_api(discogs_service: DiscogsService | None) -> str:
-    """Ping the Discogs API via the service's own client."""
+    """Ping the Discogs API via the service's own client.
+
+    Returns the ``DiscogsApiCheckResult`` enum's string value so operators can
+    distinguish auth drift, rate limits, and upstream outages from one another.
+    """
     if discogs_service is None:
         return "unavailable"
-    return "ok" if await discogs_service.check_api() else "error"
+    return (await discogs_service.check_api()).value
 
 
 async def _check_discogs_cache(discogs_service: DiscogsService | None) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from discogs.service import DiscogsApiCheckResult
 from services.parser import MessageType, ParsedRequest
 from tests.factories import make_library_item
 
@@ -27,7 +28,7 @@ def mock_discogs_service():
     service = AsyncMock()
     service.search = AsyncMock()
     service.validate_track_on_release = AsyncMock()
-    service.check_api = AsyncMock(return_value=True)
+    service.check_api = AsyncMock(return_value=DiscogsApiCheckResult.OK)
     service.cache_service = None
     return service
 

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -12,7 +12,7 @@ from discogs.models import (
     TrackItem,
     TrackReleasesResponse,
 )
-from discogs.service import DiscogsService
+from discogs.service import DiscogsApiCheckResult, DiscogsService
 
 
 @pytest.fixture
@@ -91,33 +91,83 @@ class TestDiscogsServiceInit:
 
 
 class TestCheckApi:
+    """check_api returns a DiscogsApiCheckResult discriminating failure modes."""
+
     @pytest.mark.asyncio
-    async def test_check_api_200(self, service):
+    async def test_check_api_200_returns_ok(self, service):
         mock_client = AsyncMock()
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_client.get = AsyncMock(return_value=mock_resp)
         service._client = mock_client
 
-        assert await service.check_api() is True
+        assert await service.check_api() == DiscogsApiCheckResult.OK
 
     @pytest.mark.asyncio
-    async def test_check_api_non_200(self, service):
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_check_api_auth_error(self, service, status):
         mock_client = AsyncMock()
         mock_resp = MagicMock()
-        mock_resp.status_code = 401
+        mock_resp.status_code = status
         mock_client.get = AsyncMock(return_value=mock_resp)
         service._client = mock_client
 
-        assert await service.check_api() is False
+        assert await service.check_api() == DiscogsApiCheckResult.AUTH_ERROR
 
     @pytest.mark.asyncio
-    async def test_check_api_exception(self, service):
+    async def test_check_api_rate_limited(self, service):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 429
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        service._client = mock_client
+
+        assert await service.check_api() == DiscogsApiCheckResult.RATE_LIMITED
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [500, 502, 503, 504])
+    async def test_check_api_upstream_error(self, service, status):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = status
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        service._client = mock_client
+
+        assert await service.check_api() == DiscogsApiCheckResult.UPSTREAM_ERROR
+
+    @pytest.mark.asyncio
+    async def test_check_api_unknown_status_falls_through_to_error(self, service):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 418
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        service._client = mock_client
+
+        assert await service.check_api() == DiscogsApiCheckResult.ERROR
+
+    @pytest.mark.asyncio
+    async def test_check_api_connect_error_is_network_error(self, service):
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=httpx.ConnectError("fail"))
         service._client = mock_client
 
-        assert await service.check_api() is False
+        assert await service.check_api() == DiscogsApiCheckResult.NETWORK_ERROR
+
+    @pytest.mark.asyncio
+    async def test_check_api_timeout_is_network_error(self, service):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+        service._client = mock_client
+
+        assert await service.check_api() == DiscogsApiCheckResult.NETWORK_ERROR
+
+    @pytest.mark.asyncio
+    async def test_check_api_unexpected_exception_is_error(self, service):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        service._client = mock_client
+
+        assert await service.check_api() == DiscogsApiCheckResult.ERROR
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -146,28 +146,72 @@ class TestCheckApi:
         assert await service.check_api() == DiscogsApiCheckResult.ERROR
 
     @pytest.mark.asyncio
-    async def test_check_api_connect_error_is_network_error(self, service):
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectError("dns fail"),
+            httpx.ReadError("peer reset"),
+            httpx.WriteError("write fail"),
+            httpx.ConnectTimeout("connect timeout"),
+            httpx.ReadTimeout("read timeout"),
+            httpx.WriteTimeout("write timeout"),
+            httpx.PoolTimeout("pool timeout"),
+        ],
+    )
+    async def test_check_api_transport_errors_are_network_error(self, service, exc):
         mock_client = AsyncMock()
-        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("fail"))
+        mock_client.get = AsyncMock(side_effect=exc)
         service._client = mock_client
 
         assert await service.check_api() == DiscogsApiCheckResult.NETWORK_ERROR
 
     @pytest.mark.asyncio
-    async def test_check_api_timeout_is_network_error(self, service):
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
-        service._client = mock_client
-
-        assert await service.check_api() == DiscogsApiCheckResult.NETWORK_ERROR
-
-    @pytest.mark.asyncio
-    async def test_check_api_unexpected_exception_is_error(self, service):
+    async def test_check_api_unexpected_exception_is_error_and_logs(self, service, caplog):
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=RuntimeError("boom"))
         service._client = mock_client
 
-        assert await service.check_api() == DiscogsApiCheckResult.ERROR
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="discogs.service"):
+            assert await service.check_api() == DiscogsApiCheckResult.ERROR
+
+        assert any("RuntimeError" in r.message or "boom" in r.message for r in caplog.records), (
+            f"expected unexpected-exception log breadcrumb, got: {[r.message for r in caplog.records]}"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            (200, "ok"),
+            (401, "auth-error"),
+            (429, "rate-limited"),
+            (503, "upstream-error"),
+        ],
+    )
+    async def test_check_api_sets_sentry_tag_for_each_outcome(self, service, status, expected):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = status
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        service._client = mock_client
+
+        with patch("discogs.service.sentry_sdk") as mock_sdk:
+            await service.check_api()
+
+        mock_sdk.set_tag.assert_called_once_with("discogs_api.check", expected)
+
+    @pytest.mark.asyncio
+    async def test_check_api_sets_sentry_tag_on_transport_error(self, service):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("fail"))
+        service._client = mock_client
+
+        with patch("discogs.service.sentry_sdk") as mock_sdk:
+            await service.check_api()
+
+        mock_sdk.set_tag.assert_called_once_with("discogs_api.check", "network-error")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_health_router.py
+++ b/tests/unit/test_health_router.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from discogs.service import DiscogsService
+from discogs.service import DiscogsApiCheckResult, DiscogsService
 from library.db import LibraryDB
 from routers.health import (
     _check_database,
@@ -35,17 +35,24 @@ class TestCheckDatabase:
 
 
 class TestCheckDiscogsApi:
-    @pytest.mark.asyncio
-    async def test_ok(self):
-        svc = AsyncMock(spec=DiscogsService)
-        svc.check_api = AsyncMock(return_value=True)
-        assert await _check_discogs_api(svc) == "ok"
+    """The probe surfaces the enum's string value verbatim into /health."""
 
     @pytest.mark.asyncio
-    async def test_error(self):
+    @pytest.mark.parametrize(
+        "result,expected",
+        [
+            (DiscogsApiCheckResult.OK, "ok"),
+            (DiscogsApiCheckResult.AUTH_ERROR, "auth-error"),
+            (DiscogsApiCheckResult.RATE_LIMITED, "rate-limited"),
+            (DiscogsApiCheckResult.UPSTREAM_ERROR, "upstream-error"),
+            (DiscogsApiCheckResult.NETWORK_ERROR, "network-error"),
+            (DiscogsApiCheckResult.ERROR, "error"),
+        ],
+    )
+    async def test_renders_each_enum_value(self, result, expected):
         svc = AsyncMock(spec=DiscogsService)
-        svc.check_api = AsyncMock(return_value=False)
-        assert await _check_discogs_api(svc) == "error"
+        svc.check_api = AsyncMock(return_value=result)
+        assert await _check_discogs_api(svc) == expected
 
     @pytest.mark.asyncio
     async def test_none_service(self):
@@ -114,7 +121,7 @@ class TestHealthEndpoint:
     @pytest.fixture
     def mock_discogs(self):
         svc = AsyncMock(spec=DiscogsService)
-        svc.check_api = AsyncMock(return_value=True)
+        svc.check_api = AsyncMock(return_value=DiscogsApiCheckResult.OK)
         svc.cache_service = AsyncMock()
         svc.cache_service.is_available = AsyncMock(return_value=True)
         return svc
@@ -153,7 +160,7 @@ class TestHealthEndpoint:
         from main import app
 
         svc = AsyncMock(spec=DiscogsService)
-        svc.check_api = AsyncMock(return_value=False)
+        svc.check_api = AsyncMock(return_value=DiscogsApiCheckResult.AUTH_ERROR)
         svc.cache_service = AsyncMock()
         svc.cache_service.is_available = AsyncMock(return_value=False)
 
@@ -174,6 +181,7 @@ class TestHealthEndpoint:
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] == "degraded"
+        assert body["services"]["discogs_api"] == "auth-error"
 
     @pytest.mark.asyncio
     async def test_unhealthy_returns_503(self, mock_settings):


### PR DESCRIPTION
## Summary

- `DiscogsService.check_api()` now returns a `DiscogsApiCheckResult` StrEnum that distinguishes auth drift (401/403), rate limiting (429), upstream outages (5xx), network failures, and unknown errors instead of collapsing everything to a bool.
- `routers/health.py:_check_discogs_api` renders the enum's string value verbatim into `services.discogs_api`, so the `GET /health` payload tells operators *why* the probe is failing.
- The response shape is unchanged — same string field per service, just a richer vocabulary (`ok | auth-error | rate-limited | upstream-error | network-error | error | unavailable`). The `degraded` vs `unhealthy` threshold logic is unchanged: any non-`ok` value still trips the status.

## Motivation

Diagnosing #209 on 2026-04-28 required a `railway logs` pull because `/health` reported only `discogs_api: "error"`. With this change, the same incident would have closed in seconds — `auth-error` says "rotate the token" directly.

## Test plan

- [x] Unit: `tests/unit/test_discogs_service.py::TestCheckApi` — parametrized coverage for 200/401/403/429/5xx/418/connect-error/timeout/unexpected-exception
- [x] Unit: `tests/unit/test_health_router.py::TestCheckDiscogsApi` — parametrized rendering of every enum value into the `/health` string
- [x] Unit: `test_degraded` strengthened to assert `services.discogs_api == "auth-error"` when `check_api` returns `AUTH_ERROR`
- [x] Full unit suite: 1570 passed
- [x] `ruff format --check` + `ruff check` clean
- [x] `mypy --ignore-missing-imports` clean on changed files
- [ ] After merge, hit staging `/health` and confirm the field renders one of the new vocabulary values

Closes #226