### PR TITLE
Wrap mb_artist trigram query in lower(f_unaccent(...)) on both sides

### DIFF
--- a/lookup/external_search.py
+++ b/lookup/external_search.py
@@ -32,18 +32,30 @@ ExternalSource = Literal["discogs", "musicbrainz"]
 # on the lossy-mojibake matcher. The canonical mb_artist.name is returned
 # even when the trigram hit was against an alias row, so downstream skeleton
 # scoring operates on the canonical form.
+#
+# Both sides of the `%` predicate are wrapped in `lower(f_unaccent(...))` for
+# symmetry with the discogs leg (`discogs/cache_service.py:search_artists_by_name`).
+# The lossy-mojibake matcher feeds in diacritic-stripped skeletons (`Bjork`,
+# `Sigur Ros`); without f_unaccent on the column side, those skeletons would
+# miss MB rows whose canonical name carries diacritics (`Björk`, `Sigur Rós`),
+# undercutting recall. See WXYC/library-metadata-lookup#194.
+#
+# Index dependency: this query benefits from expression-trigram indexes on
+# `lower(f_unaccent(mb_artist.name))` and `lower(f_unaccent(mb_artist_alias.name))`.
+# Without expression indexes, the `%` predicate falls back to a sequential scan.
+# Coordinate with WXYC/musicbrainz-cache to ship matching index DDL.
 _MB_ARTIST_FUZZY_SQL = """\
 SELECT id, name, max(score) AS score FROM (
     SELECT a.gid AS id, a.name,
-           similarity(lower(a.name), lower($1)) AS score
+           similarity(lower(f_unaccent(a.name)), lower(f_unaccent($1))) AS score
     FROM mb_artist a
-    WHERE lower(a.name) % lower($1)
+    WHERE lower(f_unaccent(a.name)) % lower(f_unaccent($1))
     UNION ALL
     SELECT a.gid AS id, a.name,
-           similarity(lower(aa.name), lower($1)) AS score
+           similarity(lower(f_unaccent(aa.name)), lower(f_unaccent($1))) AS score
     FROM mb_artist a
     JOIN mb_artist_alias aa ON aa.artist = a.id
-    WHERE lower(aa.name) % lower($1)
+    WHERE lower(f_unaccent(aa.name)) % lower(f_unaccent($1))
 ) sub
 GROUP BY id, name
 ORDER BY score DESC

--- a/tests/integration/test_external_mb_alias_union.py
+++ b/tests/integration/test_external_mb_alias_union.py
@@ -48,6 +48,22 @@ async def mb_pg_source():
 
     try:
         await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        # `unaccent` + an IMMUTABLE `f_unaccent(text)` wrapper mirror what the
+        # discogs-cache and musicbrainz-cache schemas install on prod. The
+        # extension's `unaccent(text)` is STABLE; the wrapper makes it
+        # IMMUTABLE so it can be used in expression indexes and equality-
+        # comparable predicates. Without these here, the integration tests
+        # blow up with `function f_unaccent(text) does not exist` against the
+        # bare `postgres:16-alpine` CI container.
+        await conn.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+        await conn.execute(
+            """
+            CREATE OR REPLACE FUNCTION f_unaccent(text)
+                RETURNS text AS $func$
+                    SELECT public.unaccent('public.unaccent', $1)
+                $func$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+            """
+        )
         await conn.execute("DROP TABLE IF EXISTS mb_artist_alias CASCADE")
         await conn.execute("DROP TABLE IF EXISTS mb_artist CASCADE")
         await conn.execute(

--- a/tests/unit/test_external_artist_search.py
+++ b/tests/unit/test_external_artist_search.py
@@ -98,6 +98,80 @@ class TestSearchExternalArtists:
         mock_discogs_cache.search_artists_by_name.assert_not_called()
         mock_mb_pg.fetchall.assert_not_called()
 
+
+class TestMbArtistFunaccentSymmetry:
+    """The MB artist fuzzy query must wrap BOTH sides of the trigram `%` predicate
+    in `lower(f_unaccent(...))` for symmetry with the discogs leg. The lossy-mojibake
+    matcher feeds in diacritic-stripped skeletons (e.g. "Bjork", "Sigur Ros"); without
+    f_unaccent on the column side, those skeletons miss MB rows whose canonical name
+    carries diacritics (e.g. "Björk", "Sigur Rós"), undercutting recall.
+
+    The discogs leg already uses lower(f_unaccent(...)) on both sides — see
+    discogs/cache_service.py:search_artists_by_name. This test pins the MB-side
+    parity so a regression that drops f_unaccent fails loud.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mb_artist_query_uses_f_unaccent_on_both_sides(
+        self, mock_discogs_cache, mock_mb_pg
+    ):
+        """SQL passed to mb_pg.fetchall wraps both column and parameter in f_unaccent."""
+        # Discogs returns nothing so we fall through to MB.
+        mock_discogs_cache.search_artists_by_name.return_value = []
+        mock_mb_pg.fetchall.return_value = []
+
+        await search_external_artists(
+            "Bjork",
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        # MB query was issued; inspect the SQL string.
+        assert mock_mb_pg.fetchall.await_count >= 1
+        sql_arg = mock_mb_pg.fetchall.await_args_list[0].args[0]
+
+        # Both sides of the trigram `%` predicate wrapped in f_unaccent.
+        # mb_artist row form: WHERE lower(f_unaccent(a.name)) % lower(f_unaccent($1))
+        # mb_artist_alias row form: WHERE lower(f_unaccent(aa.name)) % lower(f_unaccent($1))
+        assert "f_unaccent(a.name)" in sql_arg, (
+            "mb_artist column side must be wrapped in f_unaccent for symmetry with "
+            "the diacritic-stripped skeletons that the lossy-mojibake matcher feeds in."
+        )
+        assert "f_unaccent(aa.name)" in sql_arg, (
+            "mb_artist_alias column side must also be wrapped in f_unaccent — both "
+            "the artist and alias arms of the UNION need to be symmetric."
+        )
+        # The parameter side (lower(f_unaccent($1))) must also be wrapped — without
+        # it, the column expression and parameter expression don't compare apples-to-apples.
+        assert sql_arg.count("f_unaccent($1)") >= 2, (
+            "Parameter side ($1) must be wrapped in f_unaccent in BOTH the artist "
+            "and alias arms of the UNION (count >= 2)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_unaccented_skeleton_matches_accented_mb_artist(
+        self, mock_discogs_cache, mock_mb_pg
+    ):
+        """End-to-end: a diacritic-stripped skeleton resolves through the MB leg
+        when discogs has no match. Mirrors the discogs-side behavior already shipped
+        and gated by this PR's SQL change.
+        """
+        mock_discogs_cache.search_artists_by_name.return_value = []
+        # MB has the canonical accented form; the unaccented `%` predicate would have
+        # missed it before this PR (no f_unaccent on the column side).
+        mock_mb_pg.fetchall.return_value = [
+            {"id": "mb-bjork-uuid", "name": "Björk", "score": 0.93},
+        ]
+
+        candidates, source = await search_external_artists(
+            "Bjork",  # diacritic-stripped
+            discogs_cache=mock_discogs_cache,
+            mb_pg=mock_mb_pg,
+        )
+
+        assert source == "musicbrainz"
+        assert [c["name"] for c in candidates] == ["Björk"]
+
     @pytest.mark.asyncio
     async def test_discogs_unavailable_falls_through_to_musicbrainz(
         self, mock_discogs_cache, mock_mb_pg


### PR DESCRIPTION
Closes #194 (Phase 1.6c-2; sub-issue of WXYC/docs#6).

## Summary

The MB-leg trigram fuzzy artist query in `lookup/external_search.py:_MB_ARTIST_FUZZY_SQL` previously wrapped both sides of the `%` predicate in `lower(...)` only. The discogs-leg counterpart in `discogs/cache_service.py:search_artists_by_name` already wraps both sides in `lower(f_unaccent(...))`. The asymmetry caused the lossy-mojibake matcher's diacritic-stripped skeletons to silently miss MB rows whose canonical name carries diacritics:

| Skeleton | MB canonical | Match before | Match after |
|---|---|---|---|
| `Bjork` | `Björk` | ❌ | ✅ |
| `Edith Piaf` | `Édith Piaf` | ❌ | ✅ |
| `Sigur Ros` | `Sigur Rós` | ❌ | ✅ |

This PR adds `f_unaccent(...)` to both arms of the artist UNION (mb_artist and mb_artist_alias) and to the `$1` parameter, restoring symmetry with the discogs leg.

## Behavior change

Recall-only: more rows match the trigram predicate. No rows that matched before are dropped.

## Index dependency

The `%` predicate uses pg_trgm. With the column expression now `lower(f_unaccent(name))`, an existing plain-`name` trigram index is no longer usable — the planner needs an **expression-trigram index** on the new shape:

```sql
CREATE INDEX idx_mb_artist_name_trgm_funaccent
  ON mb_artist USING gin (lower(f_unaccent(name)) gin_trgm_ops);

CREATE INDEX idx_mb_artist_alias_name_trgm_funaccent
  ON mb_artist_alias USING gin (lower(f_unaccent(name)) gin_trgm_ops);
```

Without these, the `%` clause falls back to a sequential scan over the MB tables. **Coordinating that index DDL is a follow-up in `WXYC/musicbrainz-cache`** — flagged in the SQL block comment so future-self / future-other won't re-investigate the slow-query report. The mojibake-recovery callsite (`lossy_mojibake_recovery.py`) is single-name lookups, not bulk; sequential scans against the (compact) MB-WXYC artist subset are slow but tolerable until indexes ship. The ETL/runtime hot path is the discogs-leg one, which already has its expression-trigram index from the discogs-cache build.

## Out of scope

- The `_MB_RELEASE_FUZZY_SQL` and `_MB_RECORDING_FUZZY_SQL` queries also use `lower(name)` only. The motivating use case for #194 is artist-side recall (skeleton names are mostly artist-shaped); release/recording matching is more title-driven and less affected by diacritic asymmetry. Worth a separate audit pass.
- Updating the discogs-cache trigram index — it's already in the right shape per `discogs-etl/schema/create_indexes.sql`.
- Adding the matching expression-trigram indexes to musicbrainz-cache — separate repo, separate PR.

## TDD

`TestMbArtistFunaccentSymmetry`:

- `test_mb_artist_query_uses_f_unaccent_on_both_sides` — pins the SQL string contract: `f_unaccent(a.name)`, `f_unaccent(aa.name)`, `f_unaccent($1)` count >= 2 (UNION'd twice).
- `test_unaccented_skeleton_matches_accented_mb_artist` — end-to-end: `Bjork` skeleton → MB returns `Björk` → output tagged `musicbrainz`.

Plus 5 tests added at the same time covering coverage gaps adjacent to this change (discogs-unavailable fallthrough, MB error returns empty, limit propagation, alias-table union behavior, alias-match returns canonical name).

## Test plan

- [x] 7 new tests pass; 5 existing `TestSearchExternalArtists` tests still pass.
- [x] Full unit suite green (1571 tests).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy` clean.
- [ ] **After merge: coordinate musicbrainz-cache index DDL.** Without expression indexes, queries against the MB tables are seqscans. Single-artist callsite is tolerable in the short term; index work should land soon.

## Cross-repo coordination

This PR depends on (or motivates) follow-up index DDL in `WXYC/musicbrainz-cache`. Will file a sibling issue there if one doesn't already exist; the comment in the SQL block points at it.