### PR TITLE
Drop source-build of wxyc-etl in CI; add pip cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
@@ -38,6 +39,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: pip install "datamodel-code-generator[http]" ruff
       - run: bash scripts/generate_api_models.sh
       - name: Check for drift
@@ -51,14 +53,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from source
-        run: |
-          pip install maturin
-          git clone --depth 1 https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python
-          maturin build --release
-          pip install /tmp/wxyc-etl/target/wheels/*.whl
+          cache: 'pip'
+      # wxyc-etl resolves from PyPI as a transitive dep of `pip install -e ".[dev]"`.
+      # `[tool.uv.sources]` in pyproject.toml is uv-only and doesn't apply to pip.
       - run: |
           pip install -e ".[dev]"
           pip install mypy
@@ -72,14 +69,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from source
-        run: |
-          pip install maturin
-          git clone --depth 1 https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python
-          maturin build --release
-          pip install /tmp/wxyc-etl/target/wheels/*.whl
+          cache: 'pip'
       - run: pip install -e ".[dev]"
       # Default `pytest` honours pyproject addopts (`-m 'not pg and not external_api'`),
       # so this job runs every unmarked test across tests/unit/, tests/integration/, and
@@ -101,14 +91,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from source
-        run: |
-          pip install maturin
-          git clone --depth 1 https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python
-          maturin build --release
-          pip install /tmp/wxyc-etl/target/wheels/*.whl
+          cache: 'pip'
       - run: pip install -e ".[dev]"
       - name: Run external_api tests
         # tests/e2e/discogs/* and the real-API classes in tests/integration/test_api_discogs.py
@@ -140,14 +123,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from source
-        run: |
-          pip install maturin
-          git clone --depth 1 https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python
-          maturin build --release
-          pip install /tmp/wxyc-etl/target/wheels/*.whl
+          cache: 'pip'
       - run: pip install -e ".[dev]"
       - name: Run PG tests
         # EntityStore CRUD runs end-to-end against a fresh schema. Reconciliation tests


### PR DESCRIPTION
## Summary

Two CI optimizations that together cut wall-clock per PR roughly in half (~4m20s → ~2m10s) and save ~6-8 minutes of total CI compute per PR:

1. **Stop building `wxyc-etl` from source.** All four long-running jobs (typecheck / test / external_api / pg) had a Rust toolchain + maturin release build step running on every CI run, taking ~90-120s each. wxyc-etl 0.1.0 has been on PyPI since the cross-repo migration; `pyproject.toml` already declares it as a normal dependency, and `pip install -e \".[dev]\"` resolves from PyPI just fine. The `[tool.uv.sources]` override in pyproject.toml is uv-specific and doesn't affect pip. The maturin path was simply leftover.

2. **`cache: 'pip'` on every setup-python step.** Cold cache: no-op. Warm cache: ~20-40s saved per job on the next pip install. Compounds across the 6 jobs that use Python.

## Diff

8 insertions, 32 deletions. One file: `.github/workflows/ci.yml`.

## Expected savings

| Job | Before | After (estimate) |
|---|---|---|
| Type Check | 173s | ~50s |
| External API Tests | 157s | ~30s |
| PG Tests | 174s | ~50s |
| Default Tests (wall-clock pole) | 259s | ~130s |

## Risk + verification

- **PR's own CI run is the canary.** If it goes green and all tests still pass, the optimization is verified end-to-end.
- **Easy revert.** If wxyc-etl resolution from PyPI ever breaks something subtle, this commit is a clean revert candidate.
- The PyPI wheel is what production already installs (via the same `pip install -e \".[dev]\"` call), so this change doesn't introduce a new code path — it just stops re-building what we already use.

## Out of scope

- pytest-xdist parallelism (Optimization #3 from the analysis): bigger change, needs verification of test isolation on the PG/external_api jobs.
- Skipping coverage on PR runs (#4): minor savings; lose per-PR coverage signal.

Both can land in follow-ups if the wall-clock improvement here doesn't satisfy.