### PR TITLE
Fuzzy fallback for trio-style artist validation in track-on-release check

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 import sentry_sdk
+from rapidfuzz import fuzz
 from wxyc_etl.text import is_compilation_artist
 
 from config.settings import get_settings
@@ -72,6 +73,15 @@ DISCOGS_API_BASE = "https://api.discogs.com"
 # seconds; once we cross that, the bucket has reset and there's no benefit to
 # waiting longer for the same 429.
 _MAX_RETRY_DELAY_SECONDS = 60.0
+
+# Fuzzy fallback for `validate_track_on_release` artist matching. Strict substring
+# matching loses on collaboration trios where neither name is a substring of the
+# other (e.g., request "Orcutt Shelley Miller" vs release artist
+# "Bill Orcutt, Tashi Shelley & Robbie Miller"). rapidfuzz token_set_ratio is
+# order- and stopword-tolerant; the threshold was chosen so that one shared
+# token across two short names ("Bill Orcutt" vs "Orcutt Shelley Miller") just
+# clears the bar (~70.6) while unrelated artists score well below 50. See LML#210.
+_ARTIST_FUZZY_MATCH_THRESHOLD = 70
 
 
 def _compute_retry_delay(attempt: int, retry_after_header: str | None) -> float:
@@ -1083,12 +1093,37 @@ class DiscogsService:
                             f"Validated: '{track}' by '{artist}' found on release {release_id}"
                         )
                         return True
+                # Fuzzy fallback: when no individual per-track artist substring-matches,
+                # compare against the joined credit string. Catches collaboration trios
+                # where each member is credited separately but the request uses the
+                # compact group name (LML#210).
+                joined = normalize_artist_for_validation(" ".join(item.artists))
+                if (
+                    joined
+                    and fuzz.token_set_ratio(artist_lower, joined) >= _ARTIST_FUZZY_MATCH_THRESHOLD
+                ):
+                    logger.info(
+                        f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}"
+                    )
+                    return True
             else:
                 # For single-artist releases, check release artist
                 release_artist = normalize_artist_for_validation(release.artist)
 
                 if artist_lower in release_artist or release_artist in artist_lower:
                     logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
+                    return True
+
+                # Fuzzy fallback for the same trio scenario (LML#210), but where
+                # all members are listed in the single release-artist string.
+                if (
+                    release_artist
+                    and fuzz.token_set_ratio(artist_lower, release_artist)
+                    >= _ARTIST_FUZZY_MATCH_THRESHOLD
+                ):
+                    logger.info(
+                        f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}"
+                    )
                     return True
 
         logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -1036,6 +1036,68 @@ class TestValidateTrackOnRelease:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_collaboration_trio_release_artist_matches_via_token_set(self, service):
+        """Trio collaboration: request artist tokens are a subset of the release artist string.
+
+        A release credited to "Bill Orcutt, Tashi Shelley & Robbie Miller" should validate
+        for a request with artist="Orcutt Shelley Miller" (the trio's compact name in WXYC's
+        flowsheet). Strict substring match fails because no individual member's name is a
+        substring of the trio name. token_set_ratio handles the overlap. See LML#210.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=34993109,
+            title="Orcutt Shelley Miller",
+            artist="Bill Orcutt, Tashi Shelley & Robbie Miller",
+            release_url="https://discogs.com/release/34993109",
+            tracklist=[
+                TrackItem(position="1", title="A Star Is Born"),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(
+                34993109, "A Star Is Born", "Orcutt Shelley Miller"
+            )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_collaboration_trio_per_track_artists_match_via_token_set(self, service):
+        """Same trio scenario, but each member is credited as a separate per-track artist."""
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Compilation",
+            artist="Various Artists",
+            release_url="https://discogs.com/release/1",
+            tracklist=[
+                TrackItem(
+                    position="1",
+                    title="A Star Is Born",
+                    artists=["Bill Orcutt", "Tashi Shelley", "Robbie Miller"],
+                ),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(
+                1, "A Star Is Born", "Orcutt Shelley Miller"
+            )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_token_set_fuzzy_does_not_match_unrelated_artist(self, service):
+        """The fuzzy fallback must still reject artists with no token overlap."""
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Some Album",
+            artist="Bill Orcutt, Tashi Shelley & Robbie Miller",
+            release_url="https://discogs.com/release/1",
+            tracklist=[
+                TrackItem(position="1", title="A Star Is Born"),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(1, "A Star Is Born", "Duke Ellington")
+        assert result is False
+
+    @pytest.mark.asyncio
     async def test_diacritics_in_track_title(self, service):
         """Track title with diacritics should match the unaccented search query.
 


### PR DESCRIPTION
## Summary

After the strict per-track-artist substring check in `validate_track_on_release()` fails, retry with `rapidfuzz.fuzz.token_set_ratio()` against the joined credit string. Catches the collaboration-trio scenario where the request artist (\"Orcutt Shelley Miller\") and the Discogs credit (\"Bill Orcutt, Tashi Shelley & Robbie Miller\" or per-track [\"Bill Orcutt\", \"Tashi Shelley\", \"Robbie Miller\"]) overlap token-wise but are not substrings of each other.

Threshold = 70 was probed empirically: a single shared token across two short names (e.g. \"Bill Orcutt\" ↔ \"Orcutt Shelley Miller\") just clears the bar at ~70.6, while unrelated artists score below 50.

## Scope — what this does and does not address

This fixes **Probe variation #4** from the issue body:

| artist | album | result before | result after |
|---|---|---|---|
| Bill Orcutt | Orcutt Shelley Miller | song_not_found, artwork=Y | song validates if release retrieved |

The release was already being retrieved in this variation (artwork=Y proves it); the validation was the gate. Now the fuzzy fallback accepts the trio credit.

This does **not** fix the original repro variation (artist=\"Orcutt Shelley Miller\" with all three exact tokens). In that case the failure happens *upstream* of `validate_track_on_release` — `search_releases_by_track` doesn't return release 34993109 as a candidate at all (10 Discogs API calls, 0 matches). That's a Discogs search-API behavior that needs its own investigation. I'll file a follow-up issue tracking the retrieval-side problem.

## Test plan

- [x] Unit: `test_collaboration_trio_release_artist_matches_via_token_set` — single-artist-style release with comma-joined credit.
- [x] Unit: `test_collaboration_trio_per_track_artists_match_via_token_set` — compilation-style with per-track-artist list.
- [x] Unit: `test_token_set_fuzzy_does_not_match_unrelated_artist` — \"Duke Ellington\" vs the trio still rejected.
- [x] Existing 11 `TestValidateTrackOnRelease` tests still pass — strict path is unchanged for the cases they cover.
- [x] Full unit suite: 1595 passed.
- [x] `ruff format --check` + `ruff check` clean.
- [x] `mypy --ignore-missing-imports` clean.
- [ ] After merge, re-run the issue's Probe variation #4 against staging and confirm the song validates.

## Out of scope (explicitly)

- Token-splitting heuristic for retrieval (issue Hypothesis option #2). Belongs to the follow-up.
- Adding `entity.identity` rows for the trio (Hypothesis option #3). Manual; one-off.
- Tightening the existing strict substring check (uncovered when writing tests: \"Queen\" matches \"Queens of the Stone Age\" via substring — pre-existing, separate concern).

Refs #210