### PR TITLE
Add GET /admin/download-streaming-db symmetric with upload endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,17 @@ atomically replaces the file, and returns `{"status": "ok", "row_count": <int>}`
 
 The ETL script in [discogs-cache](https://github.com/WXYC/discogs-etl) (`scripts/sync-library.sh`) handles daily uploads to both staging and production.
 
+### Streaming Database Backup (Upload + Download)
+
+`streaming_availability.db` is the analysis database for streaming-availability search results. It's a sibling of `library.db` on the Railway volume. Two symmetric admin endpoints, both gated by `ADMIN_TOKEN`:
+
+```
+POST /admin/upload-streaming-db    # multipart upload, validates `albums` table
+GET  /admin/download-streaming-db  # FileResponse stream of the volume copy (404 if missing)
+```
+
+The download endpoint lets the daily library-sync pipeline (WXYC/discogs-etl) read the file directly from the Railway volume instead of round-tripping it through a GitHub Release, making the volume the canonical source.
+
 ### Health Check Behavior
 
 When `library.db` is missing (e.g., on first deploy before first upload):

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -18,9 +18,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["admin"])
 
+STREAMING_DB_FILENAME = "streaming_availability.db"
+
 # Strong references to background tasks to prevent GC before completion.
 # See https://docs.python.org/3/library/asyncio-task.html#creating-tasks
 _background_tasks: set[asyncio.Task] = set()
+
+
+def _streaming_db_path(settings: Settings) -> Path:
+    """Sibling of library.db on the Railway volume."""
+    return settings.resolved_library_db_path.parent / STREAMING_DB_FILENAME
 
 
 def _get_streaming_ids(db_path: Path) -> set[int]:
@@ -227,9 +234,8 @@ async def upload_streaming_db(
     """
     _validate_auth(settings, authorization)
 
-    db_dir = settings.resolved_library_db_path.parent
-    db_path = db_dir / "streaming_availability.db"
-    tmp_path = db_dir / "streaming_availability.db.tmp"
+    db_path = _streaming_db_path(settings)
+    tmp_path = db_path.with_suffix(db_path.suffix + ".tmp")
 
     try:
         content = await file.read()
@@ -286,15 +292,15 @@ async def download_streaming_db(
     """
     _validate_auth(settings, authorization)
 
-    db_path = settings.resolved_library_db_path.parent / "streaming_availability.db"
+    db_path = _streaming_db_path(settings)
     if not db_path.exists():
         raise HTTPException(
             status_code=404,
-            detail="streaming_availability.db not found on volume",
+            detail=f"{STREAMING_DB_FILENAME} not found on volume",
         )
 
     return FileResponse(
         path=db_path,
         media_type="application/octet-stream",
-        filename="streaming_availability.db",
+        filename=STREAMING_DB_FILENAME,
     )

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, UploadFile
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 
 from config.settings import Settings, get_settings
 from core.dependencies import close_library_db
@@ -258,4 +258,43 @@ async def upload_streaming_db(
             "row_count": row_count,
             "timestamp": datetime.now(UTC).isoformat(),
         }
+    )
+
+
+@router.get(
+    "/download-streaming-db",
+    summary="Download the current streaming_availability.db backup",
+    responses={
+        200: {
+            "description": "Streaming database file",
+            "content": {"application/octet-stream": {}},
+        },
+        401: {"description": "Missing authorization"},
+        403: {"description": "Invalid or missing token"},
+        404: {"description": "streaming_availability.db not present on the volume"},
+    },
+)
+async def download_streaming_db(
+    settings: Settings = Depends(get_settings),
+    authorization: str | None = Header(None),
+):
+    """Stream the current streaming_availability.db from the Railway volume.
+
+    Symmetric with `POST /admin/upload-streaming-db`. Lets the daily
+    library-sync pipeline (WXYC/discogs-etl) read the file directly from the
+    volume instead of round-tripping it through a GitHub Release.
+    """
+    _validate_auth(settings, authorization)
+
+    db_path = settings.resolved_library_db_path.parent / "streaming_availability.db"
+    if not db_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail="streaming_availability.db not found on volume",
+        )
+
+    return FileResponse(
+        path=db_path,
+        media_type="application/octet-stream",
+        filename="streaming_availability.db",
     )

--- a/tests/integration/test_admin_streaming_db.py
+++ b/tests/integration/test_admin_streaming_db.py
@@ -1,0 +1,98 @@
+"""Integration tests for /admin/upload-streaming-db + /admin/download-streaming-db.
+
+Verifies the volume round-trip: upload bytes, fetch them back, assert byte-equal.
+This is the contract the discogs-etl daily sync depends on once it stops going
+through the GitHub Release transport.
+"""
+
+import sqlite3
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import Settings, get_settings
+from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+from tests.unit.conftest import override_deps
+
+
+def _make_streaming_db(path, album_count: int = 3) -> bytes:
+    """Create a minimal valid streaming_availability.db with an `albums` table.
+
+    Returns the file's bytes so the caller can compare against the downloaded
+    payload. The file is closed before bytes are read so SQLite has flushed.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE albums ("
+        "id INTEGER PRIMARY KEY, artist TEXT, title TEXT, on_streaming INTEGER)"
+    )
+    for i in range(album_count):
+        conn.execute(
+            "INSERT INTO albums (id, artist, title, on_streaming) VALUES (?, ?, ?, ?)",
+            (i + 1, f"Artist {i}", f"Album {i}", 1),
+        )
+    conn.commit()
+    conn.close()
+    return path.read_bytes()
+
+
+@pytest.fixture
+def admin_settings(tmp_path):
+    """Settings with a writable volume directory and a configured admin token."""
+    return Settings(
+        admin_token="round-trip-token",
+        library_db_path=tmp_path / "library.db",
+        discogs_token=None,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+    )
+
+
+class TestUploadDownloadRoundTrip:
+    @pytest.mark.asyncio
+    async def test_upload_then_download_byte_equal(self, tmp_path, admin_settings):
+        """POST upload, GET download -> downloaded bytes equal uploaded bytes."""
+        from main import app
+
+        source_path = tmp_path / "source_streaming.db"
+        original_bytes = _make_streaming_db(source_path, album_count=5)
+
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: admin_settings,
+            },
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                with open(source_path, "rb") as f:
+                    upload_resp = await client.post(
+                        "/admin/upload-streaming-db",
+                        headers={"Authorization": "Bearer round-trip-token"},
+                        files={
+                            "file": (
+                                "streaming_availability.db",
+                                f,
+                                "application/octet-stream",
+                            )
+                        },
+                    )
+                assert upload_resp.status_code == 200
+                assert upload_resp.json()["status"] == "ok"
+                assert upload_resp.json()["row_count"] == 5
+
+                download_resp = await client.get(
+                    "/admin/download-streaming-db",
+                    headers={"Authorization": "Bearer round-trip-token"},
+                )
+
+        assert download_resp.status_code == 200
+        assert download_resp.content == original_bytes
+        assert download_resp.headers["content-type"] == "application/octet-stream"

--- a/tests/unit/test_admin_router.py
+++ b/tests/unit/test_admin_router.py
@@ -1,4 +1,4 @@
-"""Unit tests for routers/admin.py -- library.db upload endpoint."""
+"""Unit tests for routers/admin.py -- library.db upload + streaming-db endpoints."""
 
 import asyncio
 import sqlite3
@@ -737,3 +737,98 @@ class TestUploadWebhookIntegration:
         body = resp.json()
         assert body["webhook"]["status"] == "pending"
         assert body["webhook"]["changes_count"] == 1
+
+
+class TestDownloadStreamingDB:
+    """Tests for GET /admin/download-streaming-db."""
+
+    async def _get(self, app, settings, headers=None):
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: settings,
+            },
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                return await client.get("/admin/download-streaming-db", headers=headers or {})
+
+    @pytest.mark.asyncio
+    async def test_missing_auth_header(self, admin_settings):
+        """No Authorization header -> 401."""
+        from main import app
+
+        resp = await self._get(app, admin_settings)
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Missing authorization"
+
+    @pytest.mark.asyncio
+    async def test_malformed_auth_header(self, admin_settings):
+        """Authorization header without 'Bearer ' prefix -> 403."""
+        from main import app
+
+        resp = await self._get(app, admin_settings, headers={"Authorization": "test-secret-token"})
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Invalid token"
+
+    @pytest.mark.asyncio
+    async def test_wrong_bearer_token(self, admin_settings):
+        """Wrong token -> 403."""
+        from main import app
+
+        resp = await self._get(app, admin_settings, headers={"Authorization": "Bearer wrong-token"})
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Invalid token"
+
+    @pytest.mark.asyncio
+    async def test_no_admin_token_configured(self, no_token_settings):
+        """ADMIN_TOKEN not set -> 403."""
+        from main import app
+
+        resp = await self._get(app, no_token_settings, headers={"Authorization": "Bearer anything"})
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(self, admin_settings):
+        """Valid token but streaming_availability.db missing on the volume -> 404."""
+        from main import app
+
+        # admin_settings.library_db_path lives in tmp_path; sibling streaming
+        # file does not exist.
+        assert not (
+            admin_settings.resolved_library_db_path.parent / "streaming_availability.db"
+        ).exists()
+
+        resp = await self._get(
+            app, admin_settings, headers={"Authorization": "Bearer test-secret-token"}
+        )
+        assert resp.status_code == 404
+        assert "streaming_availability.db" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_successful_download(self, admin_settings):
+        """Valid token + file present -> 200 with byte-for-byte payload."""
+        from main import app
+
+        streaming_path = (
+            admin_settings.resolved_library_db_path.parent / "streaming_availability.db"
+        )
+        # SQLite file header bytes ("SQLite format 3\0") plus arbitrary trailing bytes
+        # are sufficient for streaming the file -- the download endpoint does not
+        # validate contents, only reads + streams them back.
+        payload = b"SQLite format 3\x00" + b"streaming-db-test-payload" * 100
+        streaming_path.write_bytes(payload)
+
+        resp = await self._get(
+            app, admin_settings, headers={"Authorization": "Bearer test-secret-token"}
+        )
+
+        assert resp.status_code == 200
+        assert resp.content == payload
+        assert resp.headers["content-type"] == "application/octet-stream"
+        # FileResponse sets Content-Disposition: attachment with the filename
+        assert "streaming_availability.db" in resp.headers.get("content-disposition", "")

--- a/tests/unit/test_admin_router.py
+++ b/tests/unit/test_admin_router.py
@@ -830,5 +830,4 @@ class TestDownloadStreamingDB:
         assert resp.status_code == 200
         assert resp.content == payload
         assert resp.headers["content-type"] == "application/octet-stream"
-        # FileResponse sets Content-Disposition: attachment with the filename
         assert "streaming_availability.db" in resp.headers.get("content-disposition", "")


### PR DESCRIPTION
## Summary
- New `GET /admin/download-streaming-db` returns `streaming_availability.db` from the Railway volume via FastAPI's `FileResponse`, gated by the same `ADMIN_TOKEN` bearer check as the upload endpoints.
- Returns 404 when the file isn't on the volume yet (e.g., before the first upload).
- CLAUDE.md updated with a "Streaming Database Backup (Upload + Download)" section pairing the two endpoints.

The daily library-sync pipeline (WXYC/discogs-etl) can now pull the volume copy directly instead of round-tripping the file through a GitHub Release, making the volume the canonical source.

Closes #238.

## Test plan
- [x] `uv run pytest tests/unit/test_admin_router.py::TestDownloadStreamingDB -v` — 6 new unit tests covering missing/malformed/wrong/no-config tokens, 404 on missing file, and 200 with byte-equal payload + correct headers.
- [x] `uv run pytest tests/integration/test_admin_streaming_db.py -v` — round-trips upload → download and asserts byte-for-byte equality plus `application/octet-stream` Content-Type.
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy . --ignore-missing-imports`
- [x] `uv run pytest tests/` — 1721 passed.