### PR TITLE
Share httpx client + lock pool init to stop FD leak (closes #241)

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -1,8 +1,10 @@
 """FastAPI dependency injection providers."""
 
+import asyncio
 import logging
 
 import asyncpg
+import httpx
 from fastapi import Depends
 from posthog import Posthog
 
@@ -19,8 +21,11 @@ logger = logging.getLogger(__name__)
 _library_db: LibraryDB | None = None
 _discogs_service: DiscogsService | None = None
 _discogs_pool: asyncpg.Pool | None = None
+_discogs_init_lock: asyncio.Lock = asyncio.Lock()
 _posthog_client: Posthog | None = None
 _musicbrainz_pg: PgSource | None = None
+_apple_music_http_client: httpx.AsyncClient | None = None
+_apple_music_http_client_lock: asyncio.Lock = asyncio.Lock()
 
 
 async def get_library_db(settings: Settings = Depends(get_settings)) -> LibraryDB:
@@ -88,7 +93,17 @@ async def get_discogs_service(
         logger.debug("No Discogs credentials set - Discogs service disabled")
         return None
 
-    if _discogs_service is None:
+    if _discogs_service is not None:
+        return _discogs_service
+
+    # Serialize concurrent first-callers so only one creates the cache pool.
+    # Without this lock, each caller passes the `is None` check, each awaits
+    # ``asyncpg.create_pool``, and all but one pool is orphaned with up to 5
+    # open connections (FDs). See issue #241.
+    async with _discogs_init_lock:
+        if _discogs_service is not None:
+            return _discogs_service
+
         cache_service = None
 
         if settings.database_url_discogs and _discogs_pool is None:
@@ -121,7 +136,7 @@ async def get_discogs_service(
             f"Discogs service initialized (cache: {'enabled' if cache_service else 'disabled'})"
         )
 
-    return _discogs_service
+        return _discogs_service
 
 
 async def close_discogs_service() -> None:
@@ -193,6 +208,34 @@ async def close_musicbrainz_pg() -> None:
     if _musicbrainz_pg is not None:
         await _musicbrainz_pg.close()
         _musicbrainz_pg = None
+
+
+async def get_apple_music_http_client() -> httpx.AsyncClient:
+    """Process-lifetime ``httpx.AsyncClient`` for the iTunes Search probe.
+
+    The lookup orchestrator probes ``itunes.apple.com/search`` once per
+    enriched result item. Constructing a fresh ``httpx.AsyncClient`` per
+    probe (the previous behavior) leaked file descriptors under sustained
+    /api/v1/lookup traffic and exhausted the container's FD limit on
+    2026-05-01 (issue #241). A shared client is returned instead and
+    closed on app shutdown via ``close_apple_music_http_client``.
+    """
+    global _apple_music_http_client
+    if _apple_music_http_client is not None:
+        return _apple_music_http_client
+    async with _apple_music_http_client_lock:
+        if _apple_music_http_client is None:
+            _apple_music_http_client = httpx.AsyncClient(timeout=5.0)
+            logger.info("Apple Music shared HTTP client initialized")
+        return _apple_music_http_client
+
+
+async def close_apple_music_http_client() -> None:
+    """Close the shared Apple Music HTTP client on app shutdown."""
+    global _apple_music_http_client
+    if _apple_music_http_client is not None:
+        await _apple_music_http_client.aclose()
+        _apple_music_http_client = None
 
 
 def get_posthog_client(settings: Settings = Depends(get_settings)) -> Posthog | None:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -834,15 +834,19 @@ def _build_streaming_search_url(base: str, artist: str, term: str) -> str:
 async def _fetch_apple_music_url(
     artist: str, song: str, http_client: httpx.AsyncClient | None = None
 ) -> str | None:
-    """Search the iTunes API for an Apple Music link. Free, no auth required."""
+    """Search the iTunes API for an Apple Music link. Free, no auth required.
+
+    Requires a shared ``http_client``; returns ``None`` when one isn't
+    provided so callers can degrade gracefully. Constructing a fresh
+    ``httpx.AsyncClient`` per probe is what leaked FDs in the 2026-05-01
+    LML outage (issue #241), so the per-call fallback was removed.
+    """
+    if http_client is None:
+        return None
     try:
         query = quote(f"{artist} {song}")
         url = f"https://itunes.apple.com/search?term={query}&entity=song&media=music&limit=1"
-        if http_client:
-            resp = await http_client.get(url)
-        else:
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                resp = await client.get(url)
+        resp = await http_client.get(url)
         if resp.status_code != 200:
             return None
         data = resp.json()
@@ -857,11 +861,16 @@ async def enrich_artwork_results(
     discogs_service: DiscogsService | None,
     song: str | None = None,
     library_db: LibraryDB | None = None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Enrich artwork results with release year, artist details, and streaming links.
 
     When library_db has a streaming_links table, uses direct URLs from the database.
     Falls back to search URLs when direct links are not available.
+
+    ``http_client`` is the shared ``httpx.AsyncClient`` used for the iTunes
+    Search probe. Passing ``None`` skips the Apple Music lookup — the
+    orchestrator never instantiates its own client (issue #241).
     """
     if not discogs_service:
         return items_with_artwork
@@ -910,7 +919,7 @@ async def enrich_artwork_results(
         async def fetch_apple_music() -> str | None:
             if not artist or not search_term:
                 return None
-            return await _fetch_apple_music_url(artist, search_term)
+            return await _fetch_apple_music_url(artist, search_term, http_client=http_client)
 
         release_details_result, apple_music_result = await asyncio.gather(
             fetch_release_details(),
@@ -1054,6 +1063,7 @@ async def perform_lookup(
     entity_store: EntityStore | None = None,
     discogs_cache: DiscogsCacheService | None = None,
     mb_pg: PgSourceProtocol | None = None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> LookupResponse:
     """Orchestrate the full lookup pipeline.
 
@@ -1184,6 +1194,7 @@ async def perform_lookup(
                 discogs_service,
                 song=parsed.song,
                 library_db=db,
+                http_client=http_client,
             )
 
     # Step 5: Build context message

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -2,10 +2,12 @@
 
 import logging
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from posthog import Posthog
 
 from core.dependencies import (
+    get_apple_music_http_client,
     get_discogs_cache_service,
     get_discogs_service,
     get_library_db,
@@ -59,6 +61,7 @@ async def handle_lookup(
     mb_pg: PgSource | None = Depends(get_musicbrainz_pg),
     entity_store: EntityStore | None = Depends(get_entity_store),
     posthog_client: Posthog | None = Depends(get_posthog_client),
+    http_client: httpx.AsyncClient = Depends(get_apple_music_http_client),
     skip_cache: bool = False,
 ):
     """Process a lookup request."""
@@ -77,6 +80,7 @@ async def handle_lookup(
             entity_store=entity_store,
             discogs_cache=discogs_cache,
             mb_pg=mb_pg,
+            http_client=http_client,
         )
 
         # Attach cache stats

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from config.settings import get_settings
 from core.auth import require_lml_key
 from core.dependencies import (
+    close_apple_music_http_client,
     close_discogs_service,
     close_library_db,
     close_musicbrainz_pg,
@@ -65,6 +66,7 @@ async def lifespan(app: FastAPI):
     await close_entity_store()
     await close_musicbrainz_pg()
     await close_streaming_clients()
+    await close_apple_music_http_client()
     logger.info("All services shut down")
 
 

--- a/scripts/entity_resolution/sources.py
+++ b/scripts/entity_resolution/sources.py
@@ -57,11 +57,19 @@ class PgSource:
     def __init__(self, dsn: str) -> None:
         self._dsn = dsn
         self._pool: asyncpg.Pool | None = None
+        # Serializes concurrent first-callers to ``_get_pool``. Without it,
+        # both callers pass the ``self._pool is None`` check and each await
+        # ``asyncpg.create_pool``, orphaning all but one pool with up to 5
+        # open connections (FDs). See issue #241.
+        self._pool_lock: asyncio.Lock = asyncio.Lock()
 
     async def _get_pool(self) -> asyncpg.Pool:
-        if self._pool is None:
-            self._pool = await asyncpg.create_pool(self._dsn, min_size=1, max_size=5)
-        return self._pool
+        if self._pool is not None:
+            return self._pool
+        async with self._pool_lock:
+            if self._pool is None:
+                self._pool = await asyncpg.create_pool(self._dsn, min_size=1, max_size=5)
+            return self._pool
 
     async def fetchall(self, query: str, *args: Any) -> list[dict[str, Any]]:
         """Execute a query and return all rows as dicts."""

--- a/tests/unit/test_fd_leak_regression_241.py
+++ b/tests/unit/test_fd_leak_regression_241.py
@@ -1,0 +1,225 @@
+"""Regression tests for issue #241 — FD exhaustion on LML prod 2026-05-01.
+
+Around 21:44 UTC the production container hit ``OSError: [Errno 24] Too many
+open files`` and stopped accepting connections, taking down /api/v1/lookup
+and the iOS request feature. The recovery was a no-op redeploy that swapped
+the container; the leak source survives until something changes.
+
+These tests encode the two prime hypotheses identified during incident
+investigation as concrete contracts the code should satisfy:
+
+1. ``_fetch_apple_music_url`` is on the request hot path and must NOT
+   construct a fresh ``httpx.AsyncClient`` per call. Every other outbound
+   client in the service (Discogs, Spotify, Deezer, Bandcamp, AppleMusicClient)
+   is a process-lifetime singleton with explicit ``close()`` on shutdown;
+   this one slipped through. Each instantiation opens a fresh transport
+   (DNS resolver socket + connection pool) — under sustained traffic from
+   request-o-matic ``/health/ready`` polls + real iOS DJ requests, those
+   accumulate FDs faster than they can be cleaned up.
+
+2. Two lazy-init asyncpg pools have a TOCTOU race:
+   ``scripts/entity_resolution/sources.py:PgSource._get_pool`` and
+   ``core/dependencies.py:get_discogs_service``. Both check ``self._pool is
+   None`` then ``await asyncpg.create_pool(...)`` without a lock. Concurrent
+   first-callers each pass the check, each create a pool, and all but one
+   pool is orphaned with no reference to ``close()`` it. Each orphaned pool
+   holds up to 5 connections (FDs).
+
+These tests fail today; they should pass after fixes ship.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from discogs.models import ReleaseMetadataResponse
+
+
+class TestFetchAppleMusicUrlNoLeak:
+    """Hypothesis #1: the artwork-enrichment hot path must not instantiate
+    ``httpx.AsyncClient`` per call.
+
+    The desired contract: ``enrich_artwork_results`` accepts (or sources from
+    DI) a shared ``httpx.AsyncClient`` / ``AppleMusicClient`` and threads it
+    down to ``_fetch_apple_music_url``. The orchestrator owns no transient
+    clients of its own.
+    """
+
+    @pytest.mark.asyncio
+    async def test_enrich_artwork_results_does_not_construct_httpx_client(self):
+        """A full enrich pass over multiple items must not instantiate any
+        ``httpx.AsyncClient`` inside the orchestrator. Every instantiation
+        on the hot path is a leaked-FD risk (issue #241).
+        """
+        from lookup.orchestrator import enrich_artwork_results
+        from tests.factories import make_discogs_result, make_library_item
+
+        items_with_artwork = [
+            (
+                make_library_item(id=i, artist=f"Artist {i}", title=f"Album {i}"),
+                make_discogs_result(release_id=i, artist=f"Artist {i}", album=f"Album {i}"),
+            )
+            for i in range(1, 4)
+        ]
+
+        discogs_service = AsyncMock()
+
+        def make_release(release_id: int) -> ReleaseMetadataResponse:
+            return ReleaseMetadataResponse(
+                release_id=release_id,
+                title=f"Album {release_id}",
+                artist=f"Artist {release_id}",
+                year=2000 + release_id,
+                artist_id=None,
+                release_url=f"https://discogs.com/release/{release_id}",
+            )
+
+        discogs_service.get_release.side_effect = lambda rid: make_release(rid)
+
+        instantiations: list[tuple] = []
+
+        class TrackingAsyncClient:
+            """Stand-in for ``httpx.AsyncClient`` that records construction
+            and yields a get-stub returning an empty iTunes response.
+            """
+
+            def __init__(self, *args, **kwargs):
+                instantiations.append((args, kwargs))
+
+            async def __aenter__(self):
+                stub = AsyncMock()
+                stub.get = AsyncMock(
+                    return_value=httpx.Response(
+                        200,
+                        json={"results": []},
+                        request=httpx.Request("GET", "https://itunes.apple.com/search"),
+                    )
+                )
+                return stub
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+        with patch("lookup.orchestrator.httpx.AsyncClient", TrackingAsyncClient):
+            await enrich_artwork_results(items_with_artwork, discogs_service, song="Song")
+
+        assert instantiations == [], (
+            f"lookup.orchestrator constructed {len(instantiations)} "
+            f"httpx.AsyncClient(s) during a single enrich pass over "
+            f"{len(items_with_artwork)} items. Each instantiation opens a "
+            "fresh transport (DNS + connection pool); under sustained "
+            "/api/v1/lookup traffic this leaks FDs (issue #241). "
+            "enrich_artwork_results should accept a shared client and "
+            "thread it through to _fetch_apple_music_url."
+        )
+
+
+class TestPgSourcePoolRace:
+    """Hypothesis #2a: ``PgSource._get_pool`` is racy.
+
+    Two concurrent first-callers each pass the ``self._pool is None`` check,
+    each ``await asyncpg.create_pool(...)``, then both assign ``self._pool``
+    in turn. The loser orphans its pool — up to 5 connections (FDs) with no
+    reference to close them.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_pool_calls_create_pool_once(self):
+        """Concurrent ``_get_pool`` callers must share a single pool. The
+        lazy init needs an asyncio.Lock around the check-and-set.
+        """
+        from scripts.entity_resolution.sources import PgSource
+
+        create_calls: list[tuple] = []
+        release_event = asyncio.Event()
+
+        async def fake_create_pool(*args, **kwargs):
+            create_calls.append((args, kwargs))
+            # Yield long enough for every concurrent caller to pass
+            # the ``is None`` check before any of us assigns ``self._pool``.
+            await release_event.wait()
+            return AsyncMock(name="pool")
+
+        with patch(
+            "scripts.entity_resolution.sources.asyncpg.create_pool",
+            side_effect=fake_create_pool,
+        ):
+            src = PgSource("postgres://fake/db")
+            tasks = [asyncio.create_task(src._get_pool()) for _ in range(8)]
+            # Let every task progress to the create_pool await.
+            for _ in range(4):
+                await asyncio.sleep(0)
+            release_event.set()
+            await asyncio.gather(*tasks)
+
+        assert len(create_calls) == 1, (
+            f"asyncpg.create_pool was called {len(create_calls)} times for "
+            "the same PgSource. Concurrent first-callers race between the "
+            "`if self._pool is None` check and the assignment, orphaning "
+            "all but one pool — each orphan holds up to 5 connections. "
+            "_get_pool needs an asyncio.Lock around the lazy init "
+            "(issue #241)."
+        )
+
+
+class TestGetDiscogsServicePoolRace:
+    """Hypothesis #2b: ``core.dependencies.get_discogs_service`` is racy.
+
+    Same shape as PgSource: concurrent cold-start callers each enter the
+    ``_discogs_pool is None`` branch, each ``await asyncpg.create_pool(...)``,
+    and orphan all but one pool.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_discogs_service_creates_one_pool(self):
+        """Concurrent first-callers in ``get_discogs_service`` must
+        produce a single shared discogs-cache pool.
+        """
+        from config.settings import Settings
+        from core import dependencies
+
+        # Reset module globals so we exercise cold-start init.
+        dependencies._discogs_service = None
+        dependencies._discogs_pool = None
+
+        settings = Settings(
+            discogs_token="test-token",
+            database_url_discogs="postgres://fake-discogs/db",
+        )
+
+        create_calls: list[tuple] = []
+        release_event = asyncio.Event()
+
+        async def fake_create_pool(*args, **kwargs):
+            create_calls.append((args, kwargs))
+            await release_event.wait()
+            return AsyncMock(name="discogs-pool")
+
+        try:
+            with patch(
+                "core.dependencies.asyncpg.create_pool",
+                side_effect=fake_create_pool,
+            ):
+                tasks = [
+                    asyncio.create_task(dependencies.get_discogs_service(settings))
+                    for _ in range(8)
+                ]
+                for _ in range(4):
+                    await asyncio.sleep(0)
+                release_event.set()
+                await asyncio.gather(*tasks)
+        finally:
+            dependencies._discogs_service = None
+            dependencies._discogs_pool = None
+
+        assert len(create_calls) == 1, (
+            f"asyncpg.create_pool was called {len(create_calls)} times for "
+            "the discogs cache. Concurrent cold-start callers race in "
+            "get_discogs_service, orphaning all but one pool — each orphan "
+            "holds up to 5 connections. Wrap the lazy init in an "
+            "asyncio.Lock (issue #241)."
+        )


### PR DESCRIPTION
## Summary

- Diagnoses and fixes the FD-exhaustion leak that took down LML prod on 2026-05-01 (#241): `OSError: [Errno 24] Too many open files` in the request-accept loop.
- Adds a process-lifetime `httpx.AsyncClient` for the iTunes Search probe in `_fetch_apple_music_url` (previously instantiated per result item, on every `/api/v1/lookup`).
- Wraps two racy lazy-pool initializers (`PgSource._get_pool`, `core/dependencies.get_discogs_service`) in `asyncio.Lock` so concurrent first-callers don't orphan extra `asyncpg` pools.

## Diagnosis

`_fetch_apple_music_url` constructed a fresh `httpx.AsyncClient` on every artwork-enriched result. Every other outbound client in the service (Discogs, Spotify, Deezer, Bandcamp, `AppleMusicClient`) is a process-lifetime singleton with explicit `close()` on shutdown — this one slipped through. Each instantiation opens a fresh DNS resolver socket and connection pool; `async with` cleanup couldn't keep up under sustained traffic from request-o-matic `/health/ready` polls + iOS DJ requests.

The two lazy `asyncpg.create_pool` sites had a TOCTOU race: each checked `self._pool is None` then `await asyncpg.create_pool(...)` without serialization. Concurrent first-callers each passed the check, each created a pool, and all but one was orphaned with up to 5 open connections and no reference to close them.

## Changes

- **`core/dependencies.py`** — adds `get_apple_music_http_client()` / `close_apple_music_http_client()` (lock-protected lazy init); wraps the `get_discogs_service` cold-start pool creation in a module-level `asyncio.Lock`.
- **`lookup/orchestrator.py`** — drops the per-call `httpx.AsyncClient` fallback in `_fetch_apple_music_url`; threads `http_client` through `enrich_artwork_results` and `perform_lookup`. When no client is plumbed through, the Apple Music probe is skipped.
- **`lookup/router.py`** — wires the shared client into the lookup endpoint via FastAPI DI.
- **`main.py`** — registers `close_apple_music_http_client()` in the lifespan shutdown.
- **`scripts/entity_resolution/sources.py`** — per-instance `asyncio.Lock` around `PgSource._get_pool`.
- **`tests/unit/test_fd_leak_regression_241.py`** — three regression tests, one per contract. Each fails at parent `2cc1656` (3 AsyncClients per 3-item enrich; 8 `create_pool` calls per 8 concurrent first-callers) and passes after the fixes.

## Test plan

- [x] `uv run pytest tests/unit/` — 1597 passed
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — no errors (notes are informational)
- [x] New regression tests verified red at parent commit, green at this commit
- [ ] Smoke `/api/v1/lookup` against staging after deploy; confirm Apple Music URL still populates on results
- [ ] Watch staging FD count over a soak window (request-o-matic `/health/ready` polls hit lookup every minute)

## Follow-ups (deferred — not in this PR)

- The issue's suggested `/admin/fd-count` debug endpoint + Sentry FD-count tag would let us confirm the fix lands in graphs over time. Worth filing as its own ticket.
- The Dockerfile FD soft-limit bump as a backstop is also worth filing separately — it doesn't replace this fix.
- `BaseStreamingClient._get_client` has the *shape* of the racy pattern but no `await` between the check and the assignment, so it isn't actually racy under cooperative scheduling. Left as-is.

Closes #241