### PR TITLE
Annotate create_ttl_cache local to unblock CI Type Check

### DIFF
--- a/discogs/memory_cache.py
+++ b/discogs/memory_cache.py
@@ -74,7 +74,7 @@ def create_ttl_cache(maxsize: int, ttl: int) -> TTLCache:
     Returns:
         TTLCache instance
     """
-    cache = TTLCache(maxsize=maxsize, ttl=ttl)
+    cache: TTLCache = TTLCache(maxsize=maxsize, ttl=ttl)
     _cache_registry.append(cache)
     return cache
 


### PR DESCRIPTION
## Summary

CI's Type Check job runs an unpinned `pip install mypy` and gets the latest available release. Mypy 1.20+ requires an explicit annotation on `cache = TTLCache(maxsize=..., ttl=...)` in `discogs/memory_cache.py:77` (the inferred type from the cachetools stubs has changed). Local mypy 1.19.1 still accepts the bare assignment, so the regression slipped past pre-push checks.

The Type Check failure on commit d9db8f0 (#242, the FD-leak fix for #241) skipped both `Deploy to Staging` and `Deploy to Production`, so the fix is sitting in main but not running anywhere yet. This PR annotates the one offending line; CI should go green and the deploy chain should run.

## Follow-up

Worth filing a small ticket for: pin `mypy` in the workflow (or in dev deps) so this can't happen again silently. Not done in this PR to keep the unblock minimal.

## Test plan

- [x] `uv run mypy . --ignore-missing-imports` — clean locally
- [x] `uv run pytest tests/unit/test_memory_cache.py` — 25 passed
- [x] `uv run ruff check .` — clean
- [ ] CI Type Check goes green and Deploy to Staging actually runs