### PR TITLE
Regenerate api_models.py + integrate typed CacheStats

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -970,6 +970,26 @@ class LookupResultItem(BaseModel):
     reconciled_identity: ReconciledIdentity | None = None
 
 
+class CacheStats(BaseModel):
+    memory_hits: conint(ge=0) = Field(
+        ..., description="Hits in LML's per-process in-memory TTL cache"
+    )
+    pg_hits: conint(ge=0) = Field(..., description="Hits in the discogs-cache PostgreSQL cache")
+    pg_misses: conint(ge=0) = Field(
+        ...,
+        description="Misses in the discogs-cache PostgreSQL cache (forced an API call or fallback)",
+    )
+    api_calls: conint(ge=0) = Field(
+        ..., description="Number of Discogs API calls made during the lookup"
+    )
+    pg_time_ms: confloat(ge=0.0) = Field(
+        ..., description="Total milliseconds spent in PostgreSQL cache lookups"
+    )
+    api_time_ms: confloat(ge=0.0) = Field(
+        ..., description="Total milliseconds spent in Discogs API calls"
+    )
+
+
 class SearchType(StrEnum):
     direct = "direct"
     fallback = "fallback"
@@ -998,9 +1018,7 @@ class LookupResponse(BaseModel):
     corrected_artist: str | None = Field(
         None, description="Fuzzy-corrected artist name if different from the original"
     )
-    cache_stats: dict[str, Any] | None = Field(
-        None, description="Cache hit/miss statistics from the lookup"
-    )
+    cache_stats: CacheStats | None = None
 
 
 class DiscogsTrackItem(BaseModel):

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -19,6 +19,7 @@ from core.telemetry import RequestTelemetry, get_cache_stats, init_cache_stats
 from discogs.cache_service import DiscogsCacheService
 from discogs.memory_cache import set_skip_cache
 from discogs.service import DiscogsService
+from generated.api_models import CacheStats
 from identity.dependencies import get_entity_store
 from library.db import LibraryDB
 from lookup.models import LookupRequest, LookupResponse
@@ -113,13 +114,12 @@ async def handle_lookup(
             http_client=http_client,
         )
 
-        # Attach cache stats. Read from the raw dict returned by
-        # get_cache_stats() before assignment to response.cache_stats: once
-        # wxyc-shared#86 ships a typed CacheStats Pydantic model, assigning
-        # the dict to response.cache_stats will auto-convert it into a model
-        # instance, and the projection (which calls `.items()`) would break.
+        # Attach cache stats. wxyc-shared#86 has shipped the typed CacheStats
+        # Pydantic model, so the response field is no longer dict-shaped —
+        # convert before assignment. Keep the raw dict around for the Sentry
+        # projection (which iterates via `.items()`).
         stats = get_cache_stats()
-        response.cache_stats = stats
+        response.cache_stats = CacheStats(**stats) if stats else None
 
         # Project cache_stats onto the active Sentry transaction so it joins
         # against the trace in Sentry's trace explorer (alongside latency,

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -12,6 +12,23 @@ from tests.factories import LOOKUP_BODY, make_catalog_item, make_match_result
 from tests.unit.conftest import override_deps
 
 
+def _full_cache_stats() -> dict:
+    """A fully-populated cache_stats dict matching the typed CacheStats schema.
+
+    `init_cache_stats()` populates every field in production; tests that mock
+    `get_cache_stats` need to do the same so the typed `CacheStats(**stats)`
+    conversion in the router doesn't raise on missing required fields.
+    """
+    return {
+        "memory_hits": 0,
+        "pg_hits": 0,
+        "pg_misses": 0,
+        "api_calls": 1,
+        "pg_time_ms": 0.0,
+        "api_time_ms": 0.0,
+    }
+
+
 @pytest.fixture
 def mock_db():
     return AsyncMock(spec=LibraryDB)
@@ -205,7 +222,7 @@ class TestHandleLookup:
 
         with (
             patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
-            patch("lookup.router.get_cache_stats", return_value={"api_calls": 1}),
+            patch("lookup.router.get_cache_stats", return_value=_full_cache_stats()),
             patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
         ):
             mock_lookup.return_value = response
@@ -216,39 +233,35 @@ class TestHandleLookup:
 
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
-    async def test_cache_stats_projection_skips_non_numeric(self, app_client):
-        """Non-numeric values in cache_stats are skipped (defensive — current shape is all numeric)."""
-        response = LookupResponse(results=[], search_type="direct")
+    def test_projection_skips_non_numeric_values(self):
+        """Direct unit test of `_project_cache_stats_to_transaction`'s defensive
+        behavior. The router-level typed CacheStats now guarantees all-numeric
+        fields, but the projection helper keeps the isinstance check as belt-
+        and-suspenders for any future caller that doesn't go through the router.
+        """
+        from lookup.router import _project_cache_stats_to_transaction
+
         stats = {"api_calls": 2, "weird_string": "nope", "weird_none": None}
         mock_transaction = Mock()
         mock_scope = Mock()
         mock_scope.transaction = mock_transaction
 
-        with (
-            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
-            patch("lookup.router.get_cache_stats", return_value=stats),
-            patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
-        ):
-            mock_lookup.return_value = response
-            async with AsyncClient(
-                transport=ASGITransport(app=app_client), base_url="http://test"
-            ) as client:
-                await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+        with patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope):
+            _project_cache_stats_to_transaction(stats)
 
         actual_calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
         assert actual_calls == {"lml.cache.api_calls": 2}
 
     @pytest.mark.asyncio
     async def test_cache_stats_projection_called_with_raw_get_cache_stats_return(self, app_client):
-        """The projection helper must be invoked with the exact object returned by
-        get_cache_stats(), not with response.cache_stats. Once wxyc-shared#86 ships
-        a typed CacheStats Pydantic model, assigning a dict to response.cache_stats
-        will auto-convert it into a model instance (whose `.items()` method does not
-        exist), and the projection would AttributeError. Reading from the raw return
-        value of get_cache_stats() insulates the projection from that future shape change.
+        """The projection helper must be invoked with the exact dict returned by
+        get_cache_stats(), not with response.cache_stats. response.cache_stats is
+        now a typed CacheStats Pydantic model (wxyc-shared#86), whose `.items()`
+        method does not exist; the projection iterates via `.items()` so passing
+        the model would AttributeError. Reading from the raw return value of
+        get_cache_stats() keeps the projection working regardless.
         """
-        stats = {"api_calls": 4, "pg_hits": 2}
+        stats = _full_cache_stats()
         response = LookupResponse(results=[], search_type="direct")
 
         with (
@@ -269,8 +282,8 @@ class TestHandleLookup:
         passed_arg = mock_project.call_args.args[0]
         assert passed_arg is stats, (
             "_project_cache_stats_to_transaction must be called with the raw dict "
-            "returned by get_cache_stats(), not with response.cache_stats (which may "
-            "be coerced into a typed Pydantic model in the future)."
+            "returned by get_cache_stats(), not with response.cache_stats (which is "
+            "now a typed CacheStats Pydantic model)."
         )
 
     @pytest.mark.asyncio
@@ -286,41 +299,7 @@ class TestHandleLookup:
 
         with (
             patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
-            patch("lookup.router.get_cache_stats", return_value={"api_calls": 1}),
-            patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
-        ):
-            mock_lookup.return_value = response
-            async with AsyncClient(
-                transport=ASGITransport(app=app_client), base_url="http://test"
-            ) as client:
-                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
-
-        assert resp.status_code == 200
-
-    @pytest.mark.asyncio
-    async def test_cache_stats_projection_handles_non_dict_object_gracefully(self, app_client):
-        """End-to-end forward-compat: when get_cache_stats() returns a model-like
-        object (no `.items()`), the projection must not break the request. This is
-        the live-fire version of the future-bug from wxyc-shared#86: the projection's
-        try/except must catch the AttributeError so the request still 200s.
-        """
-        from dataclasses import dataclass
-
-        @dataclass
-        class FakeCacheStatsModel:
-            # Mimics a Pydantic v2 BaseModel: attribute access works, no `.items()`.
-            api_calls: int = 7
-            pg_hits: int = 3
-
-        fake_stats = FakeCacheStatsModel()
-        response = LookupResponse(results=[], search_type="direct")
-        mock_transaction = Mock()
-        mock_scope = Mock()
-        mock_scope.transaction = mock_transaction
-
-        with (
-            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
-            patch("lookup.router.get_cache_stats", return_value=fake_stats),
+            patch("lookup.router.get_cache_stats", return_value=_full_cache_stats()),
             patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope),
         ):
             mock_lookup.return_value = response


### PR DESCRIPTION
## Summary

Refresh `generated/api_models.py` against the latest `wxyc-shared/api.yaml`, which now ships a typed `CacheStats` schema (wxyc-shared#86: `Tighten cache_stats schema in api.yaml to a typed CacheStats object` + `Mark CacheStats inner fields as required`). Also makes the one consumer-side change required to keep CI green after the regen.

- `generated/api_models.py` — regenerated via `bash scripts/generate_api_models.sh`. Adds the `CacheStats` BaseModel; tightens `LookupResponse.cache_stats` from `dict[str, Any] | None` to `CacheStats | None`. Picks up a small unrelated codegen formatting tweak (`Field([], validate_default=True)` → `Field(default_factory=list)`) for `results`.
- `lookup/router.py` — convert the dict from `get_cache_stats()` to a `CacheStats` instance before assigning to `response.cache_stats`. Continue passing the raw dict (not the model) to `_project_cache_stats_to_transaction`, so the Sentry projection's `.items()` iteration keeps working. The existing comment block had explicitly anticipated this exact transition.
- `tests/unit/test_lookup_router.py` — four tests that mocked `get_cache_stats` with partial dicts now use a fully-populated dict via a new `_full_cache_stats()` helper (typed `CacheStats` requires all six fields; `init_cache_stats()` populates all six in production). `test_cache_stats_projection_skips_non_numeric` converts from an end-to-end router test (no longer reachable — typed CacheStats blocks weird input upstream) to a direct unit test of `_project_cache_stats_to_transaction`. `test_cache_stats_projection_handles_non_dict_object_gracefully` is removed: it was forward-compat scaffolding for exactly this PR's transition.

## Why bundled

A pure codegen refresh would fail the Type Check job — the typed `cache_stats` field rejects the raw-dict assignment. The router + test updates are the minimum complement to keep CI green after regenerating.

## Why this PR matters now

Codegen Freshness is currently failing on every open LML PR (the regen has been overdue since wxyc-shared#86 landed). Visible on PR #247.

## Test plan

- [x] `bash scripts/generate_api_models.sh` produces no further drift after this PR (`git diff --exit-code generated/`).
- [x] `uv run mypy . --ignore-missing-imports` — Success: no issues found in 235 source files.
- [x] `uv run ruff check` and `uv run ruff format --check` clean on touched files.
- [x] `uv run pytest tests/unit/` — 1608 passed.
- [ ] CI green on this branch.