### PR TITLE
Pin datamodel-code-generator and ruff in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
         with:
           python-version: "3.12"
           cache: 'pip'
-      - run: pip install ruff
+      # Install the project's pinned ruff (see pyproject.toml dev deps) so a
+      # ruff release with new lint rules cannot silently fail this job on an
+      # unrelated PR. See WXYC/library-metadata-lookup#249.
+      - run: pip install -e ".[dev]"
       - run: ruff check .
       - run: ruff format --check .
 
@@ -40,7 +43,12 @@ jobs:
         with:
           python-version: "3.12"
           cache: 'pip'
-      - run: pip install "datamodel-code-generator[http]" ruff
+      # Install the project's pinned datamodel-code-generator + ruff (see
+      # pyproject.toml dev deps) so a new release with different generated-code
+      # formatting cannot silently fail this job on an unrelated PR. See
+      # WXYC/library-metadata-lookup#249. The script prefers .venv/bin/ then
+      # falls back to PATH, where the editable install lands the binaries.
+      - run: pip install -e ".[dev]"
       - run: bash scripts/generate_api_models.sh
       - name: Check for drift
         run: git diff --exit-code generated/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,14 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "pytest-httpx>=0.22.0",
     "pytest-cov>=4.0.0",
-    "ruff>=0.1.0",
+    # ruff, mypy, and datamodel-code-generator are pinned (not >=) so a new
+    # release that changes lint rules, type-check rules, or generated-code
+    # formatting cannot silently fail CI on an unrelated PR. Bumps should be
+    # deliberate, reviewable PRs. See WXYC/library-metadata-lookup#244 (mypy)
+    # and #249 (datamodel-codegen + ruff).
+    "ruff==0.15.6",
     "mypy==1.19.1",
-    "datamodel-code-generator[http]>=0.26.0",
+    "datamodel-code-generator[http]==0.56.1",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -343,7 +343,7 @@ wheels = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.55.0"
+version = "0.56.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -355,9 +355,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/36/ec505ce62c143c0f045e82e2bb0360e2ede765c0cfe3a70bf32c5661b8a2/datamodel_code_generator-0.55.0.tar.gz", hash = "sha256:20ae7a4fbbb12be380f0bd02544db4abae96c5b644d4b3f2b9c3fc0bc9ee1184", size = 833828, upload-time = "2026-03-10T20:41:15.796Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/9c/5379be8daf9ff2fbbb9a7efcf68c037b089e5b76f360c4f9ca730916e2ee/datamodel_code_generator-0.56.1.tar.gz", hash = "sha256:697abd90cc4eb2c65f130be79a83a24746c3f2d0e15e6eb9dbf17b96784449be", size = 840372, upload-time = "2026-04-16T17:09:53.537Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/c6/2abc9d11adbbf689b6b4dfb7a136d57b9ccaa3b3f1ba83504462109e8dbb/datamodel_code_generator-0.55.0-py3-none-any.whl", hash = "sha256:efa5a925288ca2a135fdc3361c7d774ae5b24b4fd632868363e249d55ea2f137", size = 256860, upload-time = "2026-03-10T20:41:13.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/cd/4a4a13f55069d88d8405aa325874b04c1b1dbc830f0d66c0e56cbd16aa12/datamodel_code_generator-0.56.1-py3-none-any.whl", hash = "sha256:cb2adc18a301f1a2cfcd56672037218eeaff0573669861c2b371eefe86753874", size = 256845, upload-time = "2026-04-16T17:09:51.81Z" },
 ]
 
 [package.optional-dependencies]
@@ -527,7 +527,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "cachetools", specifier = ">=5.0.0" },
-    { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'dev'", specifier = ">=0.26.0" },
+    { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'dev'", specifier = "==0.56.1" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
@@ -541,7 +541,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.6" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
     { name = "wxyc-etl", editable = "../wxyc-etl/wxyc-etl-python" },
@@ -962,6 +962,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1246,7 +1255,15 @@ wheels = [
 [[package]]
 name = "wxyc-etl"
 source = { editable = "../wxyc-etl/wxyc-etl-python" }
+dependencies = [
+    { name = "python-json-logger" },
+    { name = "sentry-sdk" },
+]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" }]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "python-json-logger", specifier = ">=2.0" },
+    { name = "sentry-sdk", specifier = ">=2.0" },
+]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

The Codegen Freshness and Lint jobs in `.github/workflows/ci.yml` were doing `pip install` with no version pin on `datamodel-code-generator` and `ruff`. CI silently picked up whatever release PyPI had marked latest at the moment the job ran, including releases that change the formatting of generated Pydantic v2 field defaults.

This bit on PR #248: local `uv` resolved `datamodel-code-generator==0.55.0` (per `uv.lock`), which emits `Field(default_factory=list)`; CI installed `0.56.1`, which emits `Field([], validate_default=True)`. The Codegen Freshness job's `git diff --exit-code generated/` then failed on a 9-line diff completely unrelated to the actual schema change. Recovery required a force-push.

This PR:

- Pins `datamodel-code-generator[http]==0.56.1` and `ruff==0.15.6` in `pyproject.toml` dev deps. 0.56.1 is the version that produces byte-identical output to the currently-committed `generated/api_models.py` (verified by regenerating against both 0.55.0 and 0.56.1 in clean venvs and diffing).
- Switches the Lint and Codegen Freshness jobs to install via `pip install -e ".[dev]"` so they pick up the project's pins. Single source of truth, matches the pattern PR #244 used for mypy in the Type Check job (which landed mid-rebase; combined the two pin sets in this PR).
- Updates `uv.lock` to match.

A future bump to either tool is now a deliberate, reviewable PR rather than a silent failure on an unrelated change.

## Versions chosen

| Tool | Version | Reason |
|---|---|---|
| `datamodel-code-generator[http]` | `0.56.1` | Latest as of 2026-05-04; matches output of currently-committed `generated/api_models.py` |
| `ruff` | `0.15.6` | Already what `uv.lock` and the committed code were formatted with |

## Test plan

- [x] `bash scripts/generate_api_models.sh` produces no diff on a clean checkout (`git diff --exit-code generated/`).
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass on touched files.
- [x] `uv run mypy . --ignore-missing-imports` passes (`Success: no issues found in 235 source files`).
- [x] `uv run pytest tests/unit/` passes (1608 passed).
- [ ] CI green on this branch.

Closes #249.