### PR TITLE
[E2 step 0d 2/3] LML feature-flag documentation + grep-assert (cross-cache-identity)

### DIFF
--- a/.github/workflows/cross-cache-identity-flags.yml
+++ b/.github/workflows/cross-cache-identity-flags.yml
@@ -1,0 +1,29 @@
+name: Cross-cache-identity flag-doc consistency
+
+# Asserts that the LML-owned cross-cache-identity feature flags listed in
+# CLAUDE.md match the §4.2 locked inventory. Runs on every PR (including
+# doc-only ones — the existing ci.yml ignores `*.md` paths, but this check
+# specifically guards CLAUDE.md drift, so it must run unconditionally).
+#
+# Plan reference: WXYC/wiki plans/library-hook-canonicalization-plan.md §4.2.
+
+on:
+  pull_request:
+    paths:
+      - 'CLAUDE.md'
+      - 'scripts/check_cross_cache_identity_flags.sh'
+      - '.github/workflows/cross-cache-identity-flags.yml'
+  push:
+    branches: [main, prod]
+    paths:
+      - 'CLAUDE.md'
+      - 'scripts/check_cross_cache_identity_flags.sh'
+      - '.github/workflows/cross-cache-identity-flags.yml'
+
+jobs:
+  check:
+    name: Flag-doc consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check_cross_cache_identity_flags.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,24 @@ Optional:
 - `LML_API_KEY` -- Bearer token required from tubafrenzy / Backend-Service callers (see "Inbound Auth" below)
 - `LML_REQUIRE_AUTH` -- When `true`, enforce `LML_API_KEY` on protected endpoints. Default `false` (see rollout phasing in `core/auth.py`)
 
+### Cross-cache-identity feature flags
+
+Per-cache toggles for which `wxyc_library` hook table the matcher reads (legacy schema vs. new normalized schema), plus an emergency rollback flag for the §3.2.2.1 manual-override skip endpoint. All default `false`.
+
+The **canonical inventory** (with naming-convention rationale, phase state machine, rollout-checklist locations, and approval gates) lives in `WXYC/Backend-Service/CLAUDE.md` "Cross-cache-identity feature flags (canonical inventory)". When a flag is renamed or its default changes, both the canonical Backend section AND this list must update in the same PR; CI on this repo grep-asserts the names listed here match the §4.2 inventory.
+
+| Flag | Scope | Default | Set true when |
+|---|---|---|---|
+| `LML_USE_NEW_HOOK_DISCOGS` | per-cache (Docker discogs, port 5433) | `false` | Docker discogs cache parity-check passes 7 consecutive days |
+| `LML_USE_NEW_HOOK_DISCOGS_FULL` | per-cache (Homebrew full discogs) | `false` | Homebrew (full) discogs cache parity-check passes 7 consecutive days |
+| `LML_USE_NEW_HOOK_MUSICBRAINZ` | per-cache | `false` | musicbrainz cache parity-check passes 7 consecutive days |
+| `LML_USE_NEW_HOOK_WIKIDATA` | per-cache | `false` | wikidata cache parity-check passes 7 consecutive days |
+| `LML_MANUAL_OVERRIDE_CHECK_DISABLED` | global | `false` | Emergency rollback only — disables the §3.2.2.1 manual-override skip endpoint call. Backend's write rules still reject low-confidence reruns of manual rows correctly, just less efficiently. |
+
+Production location: Railway environment variables for the LML service. Updater is Jake via the Railway dashboard. The per-cache flags require 7 consecutive days of clean parity-check audit (E5 daily report); `LML_MANUAL_OVERRIDE_CHECK_DISABLED` is for unscheduled emergency rollback only.
+
+Plan reference: `WXYC/wiki/plans/library-hook-canonicalization-plan.md` §4.2.
+
 ### Inbound Auth (`LML_API_KEY`)
 
 `core/auth.py:require_lml_key` is a FastAPI dependency that validates `Authorization: Bearer <LML_API_KEY>` on every tubafrenzy / Backend-Service-facing endpoint. Wired in `main.py` via `app.include_router(..., dependencies=[Depends(require_lml_key)])` for the `lookup`, `library`, `discogs`, and `streaming` routers.

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from datetime import date as date_aliased
 from datetime import time as time_aliased
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import Any, Literal
 
 from pydantic import AwareDatetime, BaseModel, Field, RootModel, confloat, conint
@@ -920,6 +920,10 @@ class LookupRequest(BaseModel):
         None,
         description="Original request message (used for ambiguous format detection). Optional when structured fields (artist, album, song) are provided.\n",
     )
+    include_identity: bool | None = Field(
+        False,
+        description="Per cross-cache-identity plan §3.2.2 (E2-LML write contract). When true, the response carries an additional `identity` block (the §3.2.5 cascade's per-source resolution detail), and `api_version` is set to 2. When false (the default), the response is byte-identical to v0.5.0 — `identity` is absent and `api_version` is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets this to true on every call; other consumers (catalog search, dj-site proxy, iOS apps) leave it false.\n",
+    )
 
 
 class LibraryCatalogItem(BaseModel):
@@ -990,6 +994,10 @@ class CacheStats(BaseModel):
     )
 
 
+class ApiVersion(IntEnum):
+    integer_2 = 2
+
+
 class SearchType(StrEnum):
     direct = "direct"
     fallback = "fallback"
@@ -999,26 +1007,62 @@ class SearchType(StrEnum):
     none = "none"
 
 
-class LookupResponse(BaseModel):
-    results: list[LookupResultItem] | None = Field([], validate_default=True)
-    search_type: SearchType | None = Field(
-        "none",
-        description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",
+class IdentitySource(StrEnum):
+    discogs = "discogs"
+    musicbrainz = "musicbrainz"
+    wikidata = "wikidata"
+    spotify = "spotify"
+    apple_music = "apple_music"
+    bandcamp = "bandcamp"
+
+
+class IdentityMethod(StrEnum):
+    manual = "manual"
+    cross_source_agreement = "cross_source_agreement"
+    exact_match = "exact_match"
+    name_variation = "name_variation"
+    member_group = "member_group"
+    alias_match = "alias_match"
+    trigram = "trigram"
+    llm = "llm"
+
+
+class IdentitySkipReason(StrEnum):
+    error = "error"
+    manual_override_protected = "manual_override_protected"
+    disabled = "disabled"
+    prerequisite_failed = "prerequisite_failed"
+
+
+class IdentityResolution(BaseModel):
+    source: IdentitySource
+    attempted: bool = Field(
+        ...,
+        description="True when this source's leg actually ran (whether or not it found a match). False when it was skipped — `reason` is populated, `external_id`/`method`/`confidence` are NULL.\n",
     )
-    song_not_found: bool | None = Field(
-        False,
-        description="True if search fell back to artist-only (track not confirmed on results)",
+    external_id: str | None = Field(
+        None,
+        description="The external identifier this leg resolved to (Discogs release ID, MusicBrainz MBID, Wikidata QID, Spotify URI suffix, Apple Music ID, Bandcamp slug). Stored as a string regardless of the source's native type so the API surface is uniform; Backend casts to the per-source column type when writing `library_identity_source`. NULL when `attempted: false`, or when the leg ran but found no match.\n",
     )
-    found_on_compilation: bool | None = Field(
-        False, description="True if the track was found on a compilation album"
+    method: IdentityMethod | None = Field(
+        None,
+        description="The matcher method that produced the resolution. NULL when `attempted: false` or when the leg ran but found no match.\n",
     )
-    context_message: str | None = Field(
-        None, description="Human-readable context string for display"
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(
+        None,
+        description="Confidence in [0, 1]. Must fall within the method's locked range from plan §3.4.1 — Backend's writer rejects rows where confidence is out of range. NULL when `attempted: false` or when the leg ran but found no match.\n",
     )
-    corrected_artist: str | None = Field(
-        None, description="Fuzzy-corrected artist name if different from the original"
+    reason: IdentitySkipReason | None = Field(
+        None,
+        description="Required when `attempted: false`; absent or NULL otherwise.\n",
     )
-    cache_stats: CacheStats | None = None
+
+
+class LookupIdentityBlock(BaseModel):
+    resolved: list[IdentityResolution] = Field(
+        ...,
+        description="One entry per known source. Order is stable (matches the `IdentitySource` enum order). Always populated even when no source resolved — the array carries `attempted: false` entries in that case.\n",
+    )
 
 
 class DiscogsTrackItem(BaseModel):
@@ -1257,3 +1301,30 @@ class SpotifyTrackResponse(BaseModel):
     artist: str = Field(..., description="Primary artist name")
     album: str = Field(..., description="Album name")
     artworkUrl: str | None = Field(None, description="Album artwork URL from Spotify")
+
+
+class LookupResponse(BaseModel):
+    api_version: ApiVersion | None = Field(
+        None,
+        description="Present and equal to 2 only when the request set `include_identity: true`. Absent for the v1-compatible shape so existing consumers see byte-identical responses.\n",
+    )
+    results: list[LookupResultItem] | None = Field([], validate_default=True)
+    search_type: SearchType | None = Field(
+        "none",
+        description="The search strategy that produced results: direct, fallback, alternative, compilation, song_as_artist, or none\n",
+    )
+    song_not_found: bool | None = Field(
+        False,
+        description="True if search fell back to artist-only (track not confirmed on results)",
+    )
+    found_on_compilation: bool | None = Field(
+        False, description="True if the track was found on a compilation album"
+    )
+    context_message: str | None = Field(
+        None, description="Human-readable context string for display"
+    )
+    corrected_artist: str | None = Field(
+        None, description="Fuzzy-corrected artist name if different from the original"
+    )
+    cache_stats: CacheStats | None = None
+    identity: LookupIdentityBlock | None = None

--- a/scripts/check_cross_cache_identity_flags.sh
+++ b/scripts/check_cross_cache_identity_flags.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Asserts that the LML-owned cross-cache-identity feature flags listed in
+# CLAUDE.md's "Cross-cache-identity feature flags" subsection match the §4.2
+# locked inventory.
+#
+# Tier 1 (this PR, BS#667): doc-vs-expected-list.
+# Tier 2 (E2-LML cascade PR): adds a check that flag names referenced in code
+# match the doc; this script will be extended at that time.
+#
+# Plan reference: WXYC/wiki plans/library-hook-canonicalization-plan.md §4.2.
+# Canonical: WXYC/Backend-Service/CLAUDE.md "Cross-cache-identity feature flags (canonical inventory)".
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+
+if [[ ! -f "$CLAUDE_MD" ]]; then
+  echo "FAIL: $CLAUDE_MD not found." >&2
+  exit 1
+fi
+
+# Locked LML-owned flag names per §4.2.
+expected=(
+  "LML_USE_NEW_HOOK_DISCOGS"
+  "LML_USE_NEW_HOOK_DISCOGS_FULL"
+  "LML_USE_NEW_HOOK_MUSICBRAINZ"
+  "LML_USE_NEW_HOOK_WIKIDATA"
+  "LML_MANUAL_OVERRIDE_CHECK_DISABLED"
+)
+
+# Extract LML_* flag names from the "### Cross-cache-identity feature flags"
+# subsection (until the next ### header or EOF).
+documented=$(
+  awk '
+    /^### Cross-cache-identity feature flags/ { in_section = 1; next }
+    /^### / && in_section { in_section = 0 }
+    in_section { print }
+  ' "$CLAUDE_MD" | grep -oE '`(LML_[A-Z_]+)`' | tr -d '`' | sort -u
+)
+
+if [[ -z "$documented" ]]; then
+  echo "FAIL: no LML_* flags found under the '### Cross-cache-identity feature flags' subsection in CLAUDE.md." >&2
+  exit 1
+fi
+
+expected_sorted=$(printf '%s\n' "${expected[@]}" | sort -u)
+
+missing=$(comm -23 <(printf '%s\n' "$expected_sorted") <(printf '%s\n' "$documented"))
+extra=$(comm -13 <(printf '%s\n' "$expected_sorted") <(printf '%s\n' "$documented"))
+
+failed=0
+if [[ -n "$missing" ]]; then
+  echo "FAIL: §4.2 LML-owned flags missing from CLAUDE.md:" >&2
+  echo "$missing" | sed 's/^/  - /' >&2
+  failed=1
+fi
+if [[ -n "$extra" ]]; then
+  echo "FAIL: CLAUDE.md lists LML_* flags not in §4.2:" >&2
+  echo "$extra" | sed 's/^/  - /' >&2
+  echo "  If a new LML cross-cache-identity flag is being introduced, update §4.2 first." >&2
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "" >&2
+  echo "Canonical inventory: WXYC/Backend-Service/CLAUDE.md 'Cross-cache-identity feature flags (canonical inventory)'." >&2
+  exit 1
+fi
+
+count=$(printf '%s\n' "$expected_sorted" | wc -l | tr -d ' ')
+echo "PASS: $count LML-owned cross-cache-identity flag(s) consistent with §4.2."


### PR DESCRIPTION
## Summary

LML half of WXYC/Backend-Service#667 (E2 step 0d, part 2 of 3). Adds the LML-owned cross-cache-identity feature flags from §4.2's locked inventory to CLAUDE.md and a CI grep-assert that the documented set matches the canonical inventory in WXYC/Backend-Service.

## Changes

- `CLAUDE.md` — new "Cross-cache-identity feature flags" subsection under "Environment Variables". Lists the 4 per-cache `LML_USE_NEW_HOOK_*` flags + the global `LML_MANUAL_OVERRIDE_CHECK_DISABLED` emergency-rollback flag with their defaults, scopes, and approval gates. Cross-references the canonical Backend-side section.
- `scripts/check_cross_cache_identity_flags.sh` — tier-1 grep-assert. Tier-2 (every flag named in code matches the doc) ships with the E2-LML cascade PR; the code references don't exist yet.
- `.github/workflows/cross-cache-identity-flags.yml` — dedicated workflow that runs the grep-assert on every PR touching CLAUDE.md, the script, or the workflow itself. Necessary because the existing `ci.yml` ignores `*.md` paths and this check specifically guards CLAUDE.md drift.

## .env.example divergence (calling out)

The BS#667 issue body groups LML with Backend and semantic-index under "amend `.env.example` (verified to exist in those repos at PR-open time)". LML does not actually have a checked-in `.env.example` — only a local `.env`. Documenting in CLAUDE.md is consistent with the issue body's CLAUDE.md-Configuration treatment of repos without `.env.example`. If a `.env.example` is added later, the flags should be mirrored there with cross-references back to this section.

## Test plan

- [x] `bash scripts/check_cross_cache_identity_flags.sh` PASS locally (5 LML-owned flags consistent with §4.2).
- [ ] Cross-cache-identity flag-doc consistency CI green on push.

## Plan reference

`WXYC/wiki/plans/library-hook-canonicalization-plan.md` §4.2.

## Related

- Parent issue: WXYC/Backend-Service#667 (closes when parts 1/3 + 2/3 + 3/3 all merge)
- Canonical inventory PR (1/3): WXYC/Backend-Service#740
- Epic parent: WXYC/Backend-Service#663 (E2)