### PR TITLE
Migrate to wxyc-etl 0.2.0 charter forms (to_match_form)

### DIFF
--- a/discogs/matching.py
+++ b/discogs/matching.py
@@ -11,7 +11,7 @@ detection) lives in wxyc_etl.text.
 
 import re
 
-from wxyc_etl.text import normalize_artist_name as normalize_for_comparison
+from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 # Discogs disambiguation suffix: (2), (22), etc.
 _DISCOGS_SUFFIX_RE = re.compile(r"\s*\(\d+\)$")

--- a/library/db.py
+++ b/library/db.py
@@ -6,7 +6,7 @@ import aiosqlite
 from cachetools import TTLCache  # type: ignore[import-untyped]
 from rapidfuzz import fuzz
 from wxyc_etl.schema import library_columns
-from wxyc_etl.text import normalize_artist_name as normalize_for_comparison
+from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from library.models import LibraryItem
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -14,7 +14,7 @@ from urllib.parse import quote
 
 import httpx
 from wxyc_etl.text import is_compilation_artist
-from wxyc_etl.text import normalize_artist_name as normalize_for_comparison
+from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from core.search import (
     build_strategies,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "aiolimiter>=1.1.0",
     "sentry-sdk[fastapi]>=2.0.0",
     "python-multipart>=0.0.6",
-    "wxyc-etl>=0.1.0",
+    "wxyc-etl>=0.2.0",
 ]
 
 [project.optional-dependencies]
@@ -41,9 +41,6 @@ dev = [
     "mypy==1.19.1",
     "datamodel-code-generator[http]==0.56.1",
 ]
-
-[tool.uv.sources]
-wxyc-etl = { path = "../wxyc-etl/wxyc-etl-python", editable = true }
 
 [build-system]
 requires = ["setuptools>=65.0", "wheel"]

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -33,7 +33,8 @@ import logging
 import re
 from dataclasses import dataclass
 
-from wxyc_etl.text import normalize_artist_name, split_artist_name
+from wxyc_etl.text import split_artist_name
+from wxyc_etl.text import to_match_form as normalize_artist_name
 
 from scripts.entity_resolution.sources import PgSource
 

--- a/scripts/streaming_availability/matching.py
+++ b/scripts/streaming_availability/matching.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Callable
 
 from rapidfuzz import fuzz
-from wxyc_etl.text import normalize_artist_name as normalize_for_comparison  # noqa: F401
+from wxyc_etl.text import to_match_form as normalize_for_comparison  # noqa: F401
 
 from discogs.matching import strip_discogs_suffix  # noqa: F401
 

--- a/scripts/track_streaming/local_index.py
+++ b/scripts/track_streaming/local_index.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import NamedTuple
 
-from wxyc_etl.text import normalize_artist_name as normalize_for_comparison
+from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from scripts.streaming_availability.matching import score_match
 

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -1,8 +1,8 @@
 """Unit tests for matching functions (relocated from core/matching.py)."""
 
 import pytest
-from wxyc_etl.text import is_compilation_artist, strip_diacritics
-from wxyc_etl.text import normalize_artist_name as normalize_for_comparison
+from wxyc_etl.text import is_compilation_artist
+from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from core.search import detect_ambiguous_format
 from discogs.matching import (
@@ -12,43 +12,6 @@ from discogs.matching import (
 )
 from discogs.service import calculate_confidence
 from lookup.orchestrator import is_self_titled, map_library_format_to_discogs
-
-# ---------------------------------------------------------------------------
-# strip_diacritics
-# ---------------------------------------------------------------------------
-
-
-class TestStripDiacritics:
-    """Tests for Unicode diacritics removal."""
-
-    @pytest.mark.parametrize(
-        "input_text, expected",
-        [
-            ("Björk", "Bjork"),
-            ("Sigur Rós", "Sigur Ros"),
-            ("Zoé", "Zoe"),
-            ("Motörhead", "Motorhead"),
-            ("Godspeed You! Black Emperor", "Godspeed You! Black Emperor"),
-            ("Bjork", "Bjork"),
-            ("", ""),
-            ("Hüsker Dü", "Husker Du"),
-            ("Café Tacvba", "Cafe Tacvba"),
-        ],
-        ids=[
-            "bjork",
-            "sigur_ros",
-            "zoe",
-            "motorhead",
-            "punctuation_preserved",
-            "ascii_unchanged",
-            "empty_string",
-            "husker_du",
-            "cafe_tacvba",
-        ],
-    )
-    def test_strip_diacritics(self, input_text, expected):
-        assert strip_diacritics(input_text) == expected
-
 
 # ---------------------------------------------------------------------------
 # strip_discogs_suffix
@@ -113,17 +76,25 @@ class TestNormalizeForComparison:
             ("Björk", "bjork"),
             ("SIGUR RÓS", "sigur ros"),
             ("Motörhead", "motorhead"),
-            (None, ""),
             ("", ""),
             ("  Björk  ", "bjork"),
+            # Charter forms (wxyc-etl 0.2.0): Greek final-form sigma folds to medial,
+            # Cf code points (e.g. soft-hyphen U+00AD) are stripped, but ZWJ U+200D
+            # is preserved. Regression coverage for LML#168 (Στella) and the broader
+            # WX-2 normalizer charter migration.
+            ("Οδυσσεύς", "οδυσσευσ"),
+            ("Bjö­rk", "bjork"),
+            ("Bjö‍rk", "bjo‍rk"),
         ],
         ids=[
             "bjork_lowercase",
             "sigur_ros_uppercase",
             "motorhead",
-            "none_input",
             "empty_string",
             "trims_whitespace",
+            "greek_final_sigma_folds",
+            "soft_hyphen_stripped",
+            "zwj_preserved",
         ],
     )
     def test_normalize_for_comparison(self, input_text, expected):

--- a/uv.lock
+++ b/uv.lock
@@ -544,7 +544,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.6" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
-    { name = "wxyc-etl", editable = "../wxyc-etl/wxyc-etl-python" },
+    { name = "wxyc-etl", specifier = ">=0.2.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1254,16 +1254,15 @@ wheels = [
 
 [[package]]
 name = "wxyc-etl"
-source = { editable = "../wxyc-etl/wxyc-etl-python" }
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-json-logger" },
     { name = "sentry-sdk" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "python-json-logger", specifier = ">=2.0" },
-    { name = "sentry-sdk", specifier = ">=2.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/01/2b/456c14ace24a8436eee473dfd3279a2ebc10739541795ce0b1cc55859d6e/wxyc_etl-0.2.0.tar.gz", hash = "sha256:27f22e88aaa4d1aa2d58b235b9d912816fb94e79f213f7302aa3ceb1ba2fc7ae", size = 126611, upload-time = "2026-05-06T05:26:59.598Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/7b04ce851ccb8d78b38fc52561b13908527a276fc64115eea4e6fc14a9a0/wxyc_etl-0.2.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7e1c033c27e3b5414aa92964526bc51b1d7440a0fe070f0ef43502f9f9440091", size = 790009, upload-time = "2026-05-06T05:26:55.337Z" },
+    { url = "https://files.pythonhosted.org/packages/52/34/ec077356c1eb071583c7f3858f9c19fd8d2c7ad2525e152acd05321ed51f/wxyc_etl-0.2.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d69370e8fac4a22af294c10bde8b400817715331f4f4e1e848858411ffaa7ff", size = 824551, upload-time = "2026-05-06T05:26:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0f/fec4b411456cbcbc08788b64ae751573627129d5b521df2505866c107df6/wxyc_etl-0.2.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffb034d439b4acf0510e283a4a67b58e72a4249bdaf1e3bb36452722cdd4d6ab", size = 1050818, upload-time = "2026-05-06T05:26:58.405Z" },
 ]
-provides-extras = ["dev"]


### PR DESCRIPTION
Closes #255. Durably resolves #168 — the upstream Greek final-sigma fold landed in wxyc-etl 0.1.x via `normalize_artist_name`, and is now wired through every LML callsite via the WX-2 charter `to_match_form`.

## Summary

Bumps `wxyc-etl` to `>=0.2.0` and swaps every callsite of the deprecated legacy normalizers (`normalize_artist_name`, `strip_diacritics`) to the WX-2 Normalizer Charter form. All callsites in this repo are comparison/lookup sites (FTS keys, hash-index keys, equality checks, fuzzy match prep) — none store the normalized result, so `to_match_form` is the right form for all of them.

## Callsites changed (8 imports across 7 files)

| File | Use | New import |
|---|---|---|
| `lookup/orchestrator.py` | artist/album equality in lookup pipeline | `to_match_form as normalize_for_comparison` |
| `library/db.py` | SQLite FTS5 lookup key (transient, regex-stripped) | `to_match_form as normalize_for_comparison` |
| `discogs/matching.py` | Discogs result vs library candidate | `to_match_form as normalize_for_comparison` |
| `scripts/track_streaming/local_index.py` | in-memory hash-index of tracks | `to_match_form as normalize_for_comparison` |
| `scripts/streaming_availability/matching.py` | streaming match scoring | `to_match_form as normalize_for_comparison` |
| `scripts/entity_resolution/discogs.py` | Discogs reconciliation against `lower(f_unaccent(...))` columns | `to_match_form as normalize_artist_name` |
| `tests/unit/test_matching.py` | parity helper | `to_match_form as normalize_for_comparison` |

`pyproject.toml`: dropped the local `[tool.uv.sources]` editable override (the local sibling at `../wxyc-etl/wxyc-etl-python` is still on 0.1.0 and wouldn't expose `to_match_form`); CI was already pulling `wxyc-etl` from PyPI via `pip install -e ".[dev]"`, so this aligns local and CI behavior.

`discogs/matching.py:normalize_artist_for_validation` — kept. Its semantics (lowercase + strip quotes + strip Discogs `(N)` suffix) are *not* covered by `to_match_form`; the existing tests (`'\"Weird Al\" Yankovic'` → `'weird al yankovic'`, `'Koo Nimo (2)'` → `'koo nimo'`) document the divergence.

## Behavior diffs observed

`to_match_form` differs from the legacy `normalize_artist_name` in two well-scoped ways, both verified locally:

1. **Cf code-point strip (excluding U+200D ZWJ).** `to_match_form('Bjö\\xADrk')` → `'bjork'`; legacy left the soft-hyphen in. `to_match_form('Bjö\\u200drk')` → `'bjo\\u200drk'` (ZWJ preserved by design — emoji ZWJ sequences are real text).
2. **Greek final-sigma fold (ς → σ).** Already shipped in legacy via `wxyc-etl@0ebba41`, so no observable diff at this layer; the LML#168 root-cause fix was purely upstream and is now durably wired through.
3. **Stricter `None` handling.** `to_match_form` raises `TypeError` on `None` (legacy returned `''`). Every runtime callsite already guards (`if not text:` / `if parsed.artist`), so the only fallout was a `(None, '')` parametrize row in `test_normalize_for_comparison` — dropped, not papered over.

New regression coverage in `test_matching.py::TestNormalizeForComparison`: `greek_final_sigma_folds`, `soft_hyphen_stripped`, `zwj_preserved`.

`TestStripDiacritics` removed — those assertions were case-preserving by design and tested an upstream function that's now deprecated; case preservation isn't anything LML relies on, and equivalent semantics for our consumers are covered upstream in wxyc-etl's own test suite.

## Acceptance criteria

- [x] `pyproject.toml` pins `wxyc-etl>=0.2.0`
- [x] No remaining import of `normalize_artist_name` / `strip_diacritics` / `normalize_title` / `batch_normalize` from `wxyc_etl.text` (`grep` clean — only the local `as normalize_artist_name` alias remains, importing `to_match_form`)
- [x] `pytest tests/unit/` green (1612 passed); behavior diffs explained above; `pytest -W error::DeprecationWarning` also green
- [x] LML#168 referenced as durably resolved
- [x] Optional regression coverage for the Στella case (and broader sigma / Cf-strip / ZWJ semantics) added in `test_matching.py`

## Test plan

- [x] `uv run pytest tests/unit/ -v` (1612 passed)
- [x] `uv run pytest tests/unit/ -W error::DeprecationWarning` (zero deprecation warnings remain)
- [x] `uv run ruff check . && uv run ruff format --check .` (clean)
- [x] `uv run mypy . --ignore-missing-imports` (Success: no issues found in 240 source files)
- [ ] CI: lint, typecheck, default tests, pg tests, marker sync