### PR TITLE
WX-3.B: strip U+0000 in EntityStore at PG TEXT write boundary

### DIFF
--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -15,6 +15,20 @@ from scripts.entity_resolution.sources import PgSource
 logger = logging.getLogger(__name__)
 
 
+def _strip_nul(value: str | None) -> str | None:
+    """Strip U+0000 from a string before sending it to a PostgreSQL TEXT column.
+
+    PostgreSQL TEXT cannot store U+0000 (psycopg/asyncpg raise
+    ``CharacterNotInRepertoireError``). Per WXYC/docs#18 the org-wide policy
+    is to strip at the write boundary. Preserves ``None`` so COALESCE-based
+    upserts continue to skip absent fields rather than overwriting them with
+    the empty string.
+    """
+    if value is None:
+        return None
+    return value.replace("\x00", "")
+
+
 @dataclass
 class Identity:
     """A row from ``entity.identity``."""
@@ -121,18 +135,25 @@ class EntityStore:
         Uses ``ON CONFLICT ... DO UPDATE`` with ``COALESCE`` so that populated
         fields are never overwritten with NULL.
 
+        Strips U+0000 from every TEXT-bound argument before INSERT. PostgreSQL
+        TEXT cannot store U+0000 (the SQL standard forbids it; psycopg/asyncpg
+        surface it as ``CharacterNotInRepertoireError``). Per WXYC/docs#18 the
+        org-wide policy is to strip at the write boundary — U+0000 in artist
+        metadata is always corruption, never intent. Idempotent and preserves
+        ``None`` semantics.
+
         Returns:
             The upserted Identity, or None if the query failed.
         """
         record = await self._pg.fetchone(
             _UPSERT_IDENTITY_SQL,
-            library_name,
+            _strip_nul(library_name),
             discogs_artist_id,
-            wikidata_qid,
-            musicbrainz_artist_id,
-            spotify_artist_id,
-            apple_music_artist_id,
-            bandcamp_id,
+            _strip_nul(wikidata_qid),
+            _strip_nul(musicbrainz_artist_id),
+            _strip_nul(spotify_artist_id),
+            _strip_nul(apple_music_artist_id),
+            _strip_nul(bandcamp_id),
         )
         if record is None:
             return None
@@ -141,10 +162,14 @@ class EntityStore:
     async def get_identity(self, library_name: str) -> Identity | None:
         """Look up an identity by library name.
 
+        ``library_name`` is U+0000-stripped before the query so a caller that
+        looked up a value it just upserted finds the same row, even if the
+        original input contained NUL bytes.
+
         Returns:
             The matching Identity, or None if not found.
         """
-        record = await self._pg.fetchone(_GET_IDENTITY_SQL, library_name)
+        record = await self._pg.fetchone(_GET_IDENTITY_SQL, _strip_nul(library_name))
         if record is None:
             return None
         return _record_to_identity(record)
@@ -158,7 +183,7 @@ class EntityStore:
         Returns:
             List of matching identities (empty list if none or on failure).
         """
-        records = await self._pg.fetchall(_GET_BY_STATUS_SQL, status)
+        records = await self._pg.fetchall(_GET_BY_STATUS_SQL, _strip_nul(status))
         if records is None:
             return []
         return [_record_to_identity(r) for r in records]
@@ -170,7 +195,7 @@ class EntityStore:
             identity_id: The ``entity.identity.id`` to update.
             status: New reconciliation status value.
         """
-        await self._pg.execute(_UPDATE_STATUS_SQL, identity_id, status)
+        await self._pg.execute(_UPDATE_STATUS_SQL, identity_id, _strip_nul(status))
 
     async def log_reconciliation(
         self,
@@ -192,8 +217,8 @@ class EntityStore:
         await self._pg.execute(
             _LOG_RECONCILIATION_SQL,
             identity_id,
-            source,
-            external_id,
+            _strip_nul(source),
+            _strip_nul(external_id),
             confidence,
-            method,
+            _strip_nul(method),
         )

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -16,13 +16,17 @@ logger = logging.getLogger(__name__)
 
 
 def _strip_nul(value: str | None) -> str | None:
-    """Strip U+0000 from a string before sending it to a PostgreSQL TEXT column.
+    """Strip U+0000 from a string before any PostgreSQL TEXT op.
 
-    PostgreSQL TEXT cannot store U+0000 (psycopg/asyncpg raise
-    ``CharacterNotInRepertoireError``). Per WXYC/docs#18 the org-wide policy
-    is to strip at the write boundary. Preserves ``None`` so COALESCE-based
-    upserts continue to skip absent fields rather than overwriting them with
-    the empty string.
+    PostgreSQL TEXT cannot carry U+0000 (the SQL standard forbids it;
+    psycopg/asyncpg surface it as ``CharacterNotInRepertoireError``). Per
+    WXYC/docs#18 the org-wide policy is to strip at every PG TEXT boundary —
+    U+0000 in artist metadata is always corruption, never intent. Applied to
+    INSERT/UPDATE writes AND to SELECT-by-name lookups so a caller looking
+    up a value it just upserted finds the stored row.
+
+    Preserves ``None`` so COALESCE-based upserts continue to skip absent
+    fields rather than overwriting them with the empty string. Idempotent.
     """
     if value is None:
         return None
@@ -135,12 +139,9 @@ class EntityStore:
         Uses ``ON CONFLICT ... DO UPDATE`` with ``COALESCE`` so that populated
         fields are never overwritten with NULL.
 
-        Strips U+0000 from every TEXT-bound argument before INSERT. PostgreSQL
-        TEXT cannot store U+0000 (the SQL standard forbids it; psycopg/asyncpg
-        surface it as ``CharacterNotInRepertoireError``). Per WXYC/docs#18 the
-        org-wide policy is to strip at the write boundary — U+0000 in artist
-        metadata is always corruption, never intent. Idempotent and preserves
-        ``None`` semantics.
+        Every TEXT-bound argument is passed through ``_strip_nul`` before the
+        query — same WX-3.B boundary policy as the read paths in this class
+        (see ``_strip_nul`` for the rationale).
 
         Returns:
             The upserted Identity, or None if the query failed.

--- a/tests/integration/test_charset_torture_entity_identity.py
+++ b/tests/integration/test_charset_torture_entity_identity.py
@@ -32,13 +32,16 @@ DATABASE_URL = os.getenv(
 
 CORPUS_ENTRIES = list(iter_entries())
 
-# Inputs PostgreSQL TEXT cannot store. Keyed by (category, input). The SQL
-# standard forbids U+0000 in character types; psycopg/asyncpg both reject
-# it at protocol level. App-layer strip belongs to WX-3, not WX-1.
-PG_TEXT_XFAIL_INPUTS: dict[tuple[str, str], str] = {
-    ("quoting", "null\x00byte"): (
-        "[lml:pg-null-byte] PostgreSQL TEXT rejects U+0000 (SQL standard)"
-    ),
+# Inputs whose stored form differs from ``entry["input"]`` because
+# ``EntityStore`` strips them at the write boundary. PostgreSQL TEXT cannot
+# carry U+0000 (SQL standard 22021); per WXYC/docs#18 the org-wide policy is
+# to strip at every PG TEXT write boundary. The corpus keeps the original
+# input bytes — this map records what comes back out. The vendored
+# ``charset-torture.json`` is SHA-pinned to ``@wxyc/shared``; this override
+# lives in-repo because the strip is an LML-side decision and the corpus's
+# ``expected_storage`` field remains the upstream byte-preservation contract.
+PG_TEXT_STRIP_OVERRIDES: dict[tuple[str, str], str] = {
+    ("quoting", "null\x00byte"): "nullbyte",
 }
 
 
@@ -91,14 +94,18 @@ async def test_entity_identity_storage_roundtrip(
     entry: CharsetTortureEntry,
     request: pytest.FixtureRequest,
 ) -> None:
-    """upsert_identity → get_identity must preserve library_name byte-for-byte."""
-    xfail_reason = PG_TEXT_XFAIL_INPUTS.get((entry["category"], entry["input"]))
-    if xfail_reason is not None:
-        request.applymarker(pytest.mark.xfail(reason=xfail_reason, strict=True, raises=Exception))
+    """upsert_identity → get_identity must preserve library_name byte-for-byte.
+
+    Exception: inputs in ``PG_TEXT_STRIP_OVERRIDES`` are stripped at the write
+    boundary (see WXYC/docs#18) and read back in their stripped form.
+    """
+    expected_stored = PG_TEXT_STRIP_OVERRIDES.get(
+        (entry["category"], entry["input"]), entry["input"]
+    )
 
     upserted = await entity_store.upsert_identity(library_name=entry["input"])
     assert upserted is not None, f"{entry['category']}: upsert returned None"
-    assert upserted.library_name == entry["input"], (
+    assert upserted.library_name == expected_stored, (
         f"{entry['category']}: upsert lost bytes ({entry['notes']})"
     )
 
@@ -106,7 +113,7 @@ async def test_entity_identity_storage_roundtrip(
     assert fetched is not None, (
         f"{entry['category']}: get_identity could not locate row ({entry['notes']!r})"
     )
-    assert fetched.library_name == entry["input"], (
+    assert fetched.library_name == expected_stored, (
         f"{entry['category']}: read-back lost bytes ({entry['notes']})"
     )
     assert fetched.id == upserted.id

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -6,7 +6,32 @@ import pytest
 
 from scripts.entity_resolution.store import (
     EntityStore,
+    _strip_nul,
 )
+
+
+class TestStripNul:
+    """Locks the WX-3.B boundary contract on the private helper."""
+
+    def test_returns_none_for_none(self) -> None:
+        assert _strip_nul(None) is None
+
+    def test_returns_input_unchanged_when_no_nul(self) -> None:
+        assert _strip_nul("Stereolab") == "Stereolab"
+
+    def test_strips_single_nul(self) -> None:
+        assert _strip_nul("a\x00b") == "ab"
+
+    def test_strips_all_nuls(self) -> None:
+        assert _strip_nul("\x00a\x00b\x00") == "ab"
+
+    def test_empty_string_passthrough(self) -> None:
+        assert _strip_nul("") == ""
+
+    def test_idempotent(self) -> None:
+        once = _strip_nul("a\x00b\x00c")
+        twice = _strip_nul(once)
+        assert once == twice == "abc"
 
 
 @pytest.fixture


### PR DESCRIPTION
Implements WX-3.B per the org-wide policy ratified in WXYC/docs#18 (option 1: strip at boundary).

PostgreSQL TEXT cannot carry U+0000 (SQL standard 22021; psycopg/asyncpg surface it as `CharacterNotInRepertoireError`). U+0000 in artist metadata is always corruption, never intent — so `EntityStore` now strips it from every TEXT-bound argument before the INSERT/UPDATE/SELECT lands at PG.

## Files / callsites

- `scripts/entity_resolution/store.py`
  - New `_strip_nul(value: str | None) -> str | None` helper. Idempotent; preserves `None` so `COALESCE`-based upserts continue to skip absent fields rather than overwriting them with `""`.
  - `EntityStore.upsert_identity()` — strips `library_name`, `wikidata_qid`, `musicbrainz_artist_id`, `spotify_artist_id`, `apple_music_artist_id`, `bandcamp_id`. (Integer params untouched.)
  - `EntityStore.get_identity()` — strips `library_name` so a caller that looks up the value it just upserted finds the same row.
  - `EntityStore.get_identities_by_status()`, `update_status()`, `log_reconciliation()` — strip every TEXT param for consistency.
- `tests/integration/test_charset_torture_entity_identity.py`
  - Removed `[lml:pg-null-byte]` entry from `PG_TEXT_XFAIL_INPUTS` (renamed the dict to `PG_TEXT_STRIP_OVERRIDES` since its meaning flipped — it now records "expected-stored-form-after-strip" rather than "expected exception").
  - Test asserts read-back equals the override (when present) or the original input (otherwise); the strict-xfail mechanism is gone.

## Behavior diff observed

Before: 56 passed, 1 xfailed (`quoting:null\x00byte` raised `CharacterNotInRepertoireError` as expected under strict-xfail).
After: 57 passed — the null-byte case now upserts cleanly, stores `"nullbyte"`, and reads back identically. No regressions on the 56 previously-passing parametrize cases.

## None semantics preserved

`_strip_nul(None)` returns `None`, not `""`. Verified by inspection of `upsert_identity` callers — every optional `*_id` argument continues to flow through as `None` when omitted, so `COALESCE(EXCLUDED.<col>, entity.identity.<col>)` keeps existing values intact.

## Corpus pin untouched

The vendored `tests/fixtures/charset-torture.json` is SHA-pinned to `@wxyc/shared` via the `charset-corpus-drift` workflow. The strip is an LML-side decision; the corpus's `expected_storage` field remains the upstream byte-preservation contract. The local `PG_TEXT_STRIP_OVERRIDES` map records the divergence in-repo without bumping the pin.

## Acceptance checklist (from #252)

- [x] `EntityStore.upsert_identity()` strips `\x00` from every TEXT-bound argument before INSERT.
- [x] `[lml:pg-null-byte]` entry removed from `PG_TEXT_XFAIL_INPUTS` in the same commit.
- [x] No regressions on the 56 currently-passing parametrize cases (now 57 passing).

Closes #252