### PR TITLE
WX-3.D: Force UTF-8 decoding on Bandcamp HTML fetches

### DIFF
--- a/release/bandcamp_resolver.py
+++ b/release/bandcamp_resolver.py
@@ -160,6 +160,13 @@ async def fetch_bandcamp_album_html(client: BandcampClient, album_url: str) -> s
         return None
     if response is None or response.status_code != 200:
         return None
+    # Force UTF-8 decoding. Bandcamp serves UTF-8, but the Content-Type header
+    # sometimes omits `charset=`; httpx then either runs autodetect (if
+    # charset-normalizer is installed) or falls back to ISO-8859-1, both of
+    # which can mojibake diacritic-bearing artist/album names (e.g. "Sigur Rós"
+    # -> "Sigur RÃ³s") and land corrupt bytes in JSON-LD downstream.
+    # Reference: WXYC/library-metadata-lookup#260, WXYC/docs#17 (WX-3.D).
+    response.encoding = "utf-8"
     return response.text
 
 

--- a/tests/unit/release/test_bandcamp_resolver.py
+++ b/tests/unit/release/test_bandcamp_resolver.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from release.bandcamp_resolver import (
@@ -136,6 +137,47 @@ class TestFetchBandcampAlbumHtml:
         html = await fetch_bandcamp_album_html(client, "https://x.bandcamp.com/album/y")
 
         assert html is None
+
+    @pytest.mark.asyncio
+    async def test_forces_utf8_when_no_charset_in_content_type(self):
+        """Bandcamp serves UTF-8 but the response Content-Type may omit `charset=`.
+
+        When the charset is missing, httpx's autodetect can guess wrong (or fall
+        back to ISO-8859-1 if no detector is installed), producing mojibake on
+        diacritic-bearing artist/album names. The resolver must force UTF-8
+        decoding so the JSON-LD blob and downstream identity rows stay clean.
+
+        Reference: WXYC/library-metadata-lookup#260, WXYC/docs#17 (WX-3.D).
+        """
+        # Build a real httpx.Response with Content-Type lacking `charset=`.
+        # We pass `default_encoding="iso-8859-1"` to deterministically trigger
+        # the broken decode path the ticket describes — this is the byte-for-byte
+        # mojibake httpx produces on environments without charset-normalizer.
+        # A real Bandcamp page is mostly ASCII markup with a few diacritic bytes,
+        # which is exactly the shape autodetect struggles with.
+        artist = "Sigur Rós"
+        body = (
+            b'<html><head><script type="application/ld+json">{"@type":"MusicAlbum",'
+            b'"name":"( )","byArtist":{"name":"' + artist.encode("utf-8") + b'"}}'
+            b"</script></head><body>" + b"a" * 5000 + b"</body></html>"
+        )
+        response = httpx.Response(
+            200,
+            headers={"Content-Type": "text/html"},
+            content=body,
+            default_encoding="iso-8859-1",
+        )
+
+        client = MagicMock()
+        client._request_with_retry = AsyncMock(return_value=response)
+
+        html = await fetch_bandcamp_album_html(client, "https://sigurros.bandcamp.com/album/_")
+
+        assert html is not None
+        # Correctly decoded — the diacritic survived as a single Unicode codepoint.
+        assert "Sigur Rós" in html
+        # And the ISO-8859-1 mojibake form is absent.
+        assert "Sigur RÃ³s" not in html
 
 
 class TestResolveBandcampAlbum:


### PR DESCRIPTION
## Summary

`release/bandcamp_resolver.py:fetch_bandcamp_album_html` now forces `response.encoding = \"utf-8\"` before reading `.text`. Bandcamp serves UTF-8 but its responses sometimes omit the `charset=` attribute on `Content-Type: text/html`; in that case httpx either runs autodetect (charset-normalizer/chardet, results indeterministic and dependent on what's installed) or falls back to ISO-8859-1 — both of which can mojibake diacritic-bearing artist/album names (e.g. `Sigur Rós` -> `Sigur RÃ³s`) into the JSON-LD blob and downstream into `entity.identity` writes.

This is a write-boundary fix one layer upstream of the WX-2 charter — `to_storage_form` cannot reliably reverse this kind of mojibake, so we keep it from landing in the first place.

## Files changed

- `release/bandcamp_resolver.py` — single new line `response.encoding = \"utf-8\"` plus a comment referencing WXYC/docs#17 + this ticket.
- `tests/unit/release/test_bandcamp_resolver.py` — new test `test_forces_utf8_when_no_charset_in_content_type` reproducing the failure mode.

## Behavior diff

- **Before:** When Bandcamp serves `Content-Type: text/html` with no charset, `response.text` may be decoded as ISO-8859-1 (or autodetected to a different encoding), producing mojibake on non-ASCII bytes.
- **After:** UTF-8 is forced unconditionally; non-ASCII bytes round-trip as the correct Unicode codepoints.

No new dependencies. Existing integration tests for `release_resolve` continue to pass.

## Test approach

The new test builds a real `httpx.Response(200, headers={\"Content-Type\": \"text/html\"}, content=..., default_encoding=\"iso-8859-1\")` containing a JSON-LD MusicAlbum block whose `byArtist.name` is `\"Sigur Rós\"` encoded as UTF-8 bytes, plus 5KB of ASCII filler (mimicking a real Bandcamp page where autodetect has too little signal). `default_encoding=\"iso-8859-1\"` deterministically triggers the broken decode path the ticket describes. The test asserts:

- `\"Sigur Rós\"` is present in the returned text (correctly decoded), AND
- `\"Sigur RÃ³s\"` (the mojibake form) is NOT present.

Verified the test fails on `main` before the fix and passes after.

## Acceptance checklist

- [x] `fetch_bandcamp_album_html()` forces `response.encoding = \"utf-8\"` before returning `.text`.
- [x] Unit test feeds a fixture response with `Content-Type: text/html` (no charset) and a non-ASCII byte sequence; asserts the parsed text round-trips correctly.
- [x] No new dependency.
- [x] Existing integration tests for `release_resolve` continue to pass (full `tests/unit/` 1616 passed; full `tests/integration/` 217 passed, 83 deselected, 8 xfailed).

## Follow-ups (not in scope here)

- Existing `entity.identity` rows resolved through the broken path may carry mojibake'd labels. The ticket explicitly punts cleanup; the next pipeline pass overwrites via `EntityStore.upsert_identity` `COALESCE` semantics anyway.
- Other httpx call-sites in this repo (Discogs, Spotify, Deezer, Apple Music, MusicBrainz) were left alone — those are tracked under WX-3.F (WXYC/docs#19).

Closes #260