### PR TITLE
deps: bump wxyc-etl >=0.2.0 → >=0.3.0 (E3 step 5f, partial)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "aiolimiter>=1.1.0",
     "sentry-sdk[fastapi]>=2.0.0",
     "python-multipart>=0.0.6",
-    "wxyc-etl>=0.2.0",
+    "wxyc-etl>=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -34,6 +34,17 @@ import re
 from dataclasses import dataclass
 
 from wxyc_etl.text import split_artist_name
+
+# NOTE(WXYC/library-metadata-lookup#262): per `library-hook-canonicalization-plan`
+# §3.3.1 step 5 the resolver path is the canonical identity-matching consumer
+# and should call `to_identity_match_form`, but the swap is deferred until the
+# PG column expressions adopt a matching `wxyc_identity_match_artist()` analog
+# (per `wxyc-etl/docs/normalization.md`). Today the column side uses
+# `lower(f_unaccent(col))` (≈ `to_match_form` semantics); switching the input
+# alone strips leading articles asymmetrically (input "The Beatles" → "beatles",
+# col → "the beatles") and collapses the Stage 5 preprocessing variants into
+# the canonical key, breaking exact matches for Discogs rows with a "The "
+# prefix.
 from wxyc_etl.text import to_match_form as normalize_artist_name
 
 from scripts.entity_resolution.sources import PgSource


### PR DESCRIPTION
## Summary

Pin bump only — pulls in the cross-cache-identity normalizers (`to_identity_match_form` family) per [library-hook-canonicalization-plan §3.3.1 step 5](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md). The mechanical change for the rest of the matcher cascade is **deferred**; details below.

## Per-call-site identity vs match-form decision

| Call site | Use | Decision |
|---|---|---|
| `library/db.py` | FTS5 / library catalog search | `to_match_form` (search-style) — unchanged |
| `lookup/orchestrator.py` | Search-pipeline orchestrator | `to_match_form` (search-style) — unchanged |
| `discogs/matching.py:normalize_for_track_comparison` | Tracklist title fuzzy match | `to_match_form` + `&`→`and` + punctuation strip — intentional LML shim, unchanged |
| `discogs/matching.py:normalize_artist_for_validation` | Artist substring against tracklist credits | `to_match_form` + quote strip + Discogs `(2)` suffix strip — intentional LML shim, unchanged |
| `scripts/track_streaming/local_index.py` | Local index lookup | `to_match_form` — unchanged |
| `scripts/streaming_availability/matching.py` | Streaming-platform fuzzy match | `to_match_form` — unchanged |
| **`scripts/entity_resolution/discogs.py`** | **Identity reconciler** | **Should be `to_identity_match_form` per plan §3.2.5 — DEFERRED, see below** |

## Why the resolver alias swap is deferred

The resolver SQL queries (`_EXACT_MATCH_SQL`, `_MEMBER_MATCH_SQL`, `_ALIAS_MATCH_SQL`, `_NAME_VARIATION_MATCH_SQL`) all compare against `lower(f_unaccent(col))` on the column side. That expression has `to_match_form` semantics — it strips diacritics and lowercases, but does **not** strip leading articles or enclosing parens.

Switching the input alone to `to_identity_match_form` produces an asymmetric pair:
- Input `"The Beatles"` → `"beatles"`
- Column `"The Beatles"` via `lower(f_unaccent(...))` → `"the beatles"`
- Stage 1 exact match → MISS
- Stage 5 preprocessing variants strip `"The "` from the canonical, but the resulting variant is then re-normalized via the same `to_identity_match_form` and collapses into the canonical's normalized key, so it's filtered out by the existing `if v_norm in normalized_to_canonical: continue` guard.

Verified locally: switching the alias breaks 4 tests in `tests/unit/test_discogs_reconciliation.py::TestNamePreprocessingStage`. The full swap will land alongside a `wxyc_identity_match_artist()` Postgres analog (per [`wxyc-etl/docs/normalization.md`](https://github.com/WXYC/wxyc-etl/blob/main/docs/normalization.md)), which the plan's §3.3.2 step 4+5 require on the column side too.

A `NOTE(#262)` is added at the call site so the reasoning is preserved when the swap eventually lands.

## Test plan
- [x] `pytest tests/unit/` — 1622 passed (no regression vs main)
- [x] `ruff check` + `ruff format --check` clean
- [ ] PG tests + external-API tests (run via CI)

## Acceptance vs issue checklist
- [x] `pyproject.toml` reflects 0.3.0
- [ ] `scripts/entity_resolution/discogs.py` uses `to_identity_match_form` for the resolver path — **deferred (this PR adds NOTE; see "Why deferred")**
- [x] `discogs/matching.py` reviewed — layered helpers documented as intentional LML-specific shims (see table above)
- [x] Default tests pass; PG tests via CI
- [x] Per-call-site identity vs match-form decision documented (table above)

Issue #262 stays open after this PR merges; the resolver swap will land in a follow-up that bundles the PG-side function deployment.

Refs #262
Refs WXYC/wxyc-etl#73 (E3 step 5f, partial)