### PR TITLE
scripts/bandcamp_*: force UTF-8 before reading resp.text

### DIFF
--- a/scripts/bandcamp_client.py
+++ b/scripts/bandcamp_client.py
@@ -136,6 +136,10 @@ class BandcampClient(BaseStreamingClient):
         if resp is None or resp.status_code != 200:
             return []
 
+        # Bandcamp serves UTF-8 but its Content-Type often omits `charset=`;
+        # force UTF-8 so diacritic-bearing album titles don't mojibake. See
+        # release/bandcamp_resolver.py for the same shape.
+        resp.encoding = "utf-8"
         html = resp.text
         seen_paths: set[str] = set()
         albums: list[dict] = []

--- a/scripts/bandcamp_lookup.py
+++ b/scripts/bandcamp_lookup.py
@@ -45,8 +45,7 @@ async def fetch_bandcamp_albums(
             if resp.status_code != 200:
                 return []
 
-            # Bandcamp omits `charset=` on most pages; force UTF-8 before
-            # reading resp.text so diacritics don't mojibake.
+            # Bandcamp omits charset= on most pages; force UTF-8 before resp.text.
             resp.encoding = "utf-8"
 
             # Extract album URLs and titles from the page

--- a/scripts/bandcamp_lookup.py
+++ b/scripts/bandcamp_lookup.py
@@ -45,6 +45,10 @@ async def fetch_bandcamp_albums(
             if resp.status_code != 200:
                 return []
 
+            # Bandcamp omits `charset=` on most pages; force UTF-8 before
+            # reading resp.text so diacritics don't mojibake.
+            resp.encoding = "utf-8"
+
             # Extract album URLs and titles from the page
             # Bandcamp album links: <a href="/album/album-name">
             albums = []

--- a/tests/unit/test_bandcamp_client.py
+++ b/tests/unit/test_bandcamp_client.py
@@ -263,3 +263,39 @@ class TestFetchArtistCatalog:
 
         albums = await client.fetch_artist_catalog("autechre")
         assert len(albums) == 1
+
+    @pytest.mark.asyncio
+    async def test_forces_utf8_when_no_charset_in_content_type(self):
+        """Bandcamp serves UTF-8 but the response Content-Type may omit `charset=`.
+
+        When the charset is missing, httpx falls back to its default encoding
+        (ISO-8859-1 unless `charset-normalizer` autodetects otherwise), producing
+        mojibake on diacritic-bearing album titles. The catalog fetch must force
+        UTF-8 decoding so titles like "Csillagrablók" survive the regex pass.
+
+        Reference: WXYC/library-metadata-lookup#265, WXYC/docs#19 (WX-3.F).
+        Mirrors the shape fixed in PR #263 for `release/bandcamp_resolver.py`.
+        """
+        title = "Csillagrablók"
+        body = (
+            b'<a href="/album/csillagrablok"><p class="title">'
+            + title.encode("utf-8")
+            + b"</p></a>"
+        )
+        response = httpx.Response(
+            200,
+            headers={"Content-Type": "text/html"},
+            content=body,
+            default_encoding="iso-8859-1",
+            request=httpx.Request("GET", "https://csillagrablok.bandcamp.com/music"),
+        )
+
+        client = BandcampClient()
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.request = AsyncMock(return_value=response)
+        client._http = mock_http
+
+        albums = await client.fetch_artist_catalog("csillagrablok")
+
+        assert len(albums) == 1
+        assert albums[0]["title"] == title

--- a/tests/unit/test_bandcamp_client.py
+++ b/tests/unit/test_bandcamp_client.py
@@ -266,16 +266,7 @@ class TestFetchArtistCatalog:
 
     @pytest.mark.asyncio
     async def test_forces_utf8_when_no_charset_in_content_type(self):
-        """Bandcamp serves UTF-8 but the response Content-Type may omit `charset=`.
-
-        When the charset is missing, httpx falls back to its default encoding
-        (ISO-8859-1 unless `charset-normalizer` autodetects otherwise), producing
-        mojibake on diacritic-bearing album titles. The catalog fetch must force
-        UTF-8 decoding so titles like "Csillagrablók" survive the regex pass.
-
-        Reference: WXYC/library-metadata-lookup#265, WXYC/docs#19 (WX-3.F).
-        Mirrors the shape fixed in PR #263 for `release/bandcamp_resolver.py`.
-        """
+        # httpx defaults to ISO-8859-1 when Content-Type omits charset=; force UTF-8.
         title = "Csillagrablók"
         body = (
             b'<a href="/album/csillagrablok"><p class="title">'

--- a/tests/unit/test_bandcamp_lookup.py
+++ b/tests/unit/test_bandcamp_lookup.py
@@ -1,0 +1,70 @@
+"""Unit tests for scripts/bandcamp_lookup.py."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from scripts.bandcamp_lookup import fetch_bandcamp_albums
+
+
+@pytest.mark.asyncio
+async def test_extracts_albums_with_titles():
+    html = (
+        '<a href="/album/confield"><p class="title">Confield</p></a>'
+        '<a href="/album/draft-7-30"><p class="title">Draft 7.30</p></a>'
+    )
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            text=html,
+            request=httpx.Request("GET", "https://autechre.bandcamp.com/music"),
+        )
+    )
+
+    albums = await fetch_bandcamp_albums(client, "autechre", asyncio.Semaphore(1))
+
+    assert len(albums) == 2
+    assert albums[0]["title"] == "Confield"
+    assert albums[0]["url"] == "https://autechre.bandcamp.com/album/confield"
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_on_404():
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(
+        return_value=httpx.Response(
+            404,
+            request=httpx.Request("GET", "https://nope.bandcamp.com/music"),
+        )
+    )
+
+    albums = await fetch_bandcamp_albums(client, "nope", asyncio.Semaphore(1))
+
+    assert albums == []
+
+
+@pytest.mark.asyncio
+async def test_forces_utf8_when_no_charset_in_content_type():
+    # httpx defaults to ISO-8859-1 when Content-Type omits charset=; force UTF-8.
+    title = "Csillagrablók"
+    body = b'<a href="/album/csillagrablok"><p class="title">' + title.encode("utf-8") + b"</p></a>"
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            headers={"Content-Type": "text/html"},
+            content=body,
+            default_encoding="iso-8859-1",
+            request=httpx.Request("GET", "https://csillagrablok.bandcamp.com/music"),
+        )
+    )
+
+    albums = await fetch_bandcamp_albums(client, "csillagrablok", asyncio.Semaphore(1))
+
+    assert len(albums) == 1
+    assert albums[0]["title"] == title


### PR DESCRIPTION
## Summary

- Mirror PR #263's `release/bandcamp_resolver.py` fix at the two remaining Bandcamp HTML-scrape sites surfaced by the WX-3.F audit (WXYC/docs#19): `scripts/bandcamp_client.py:139` (production pipeline class) and `scripts/bandcamp_lookup.py:44` (one-shot script).
- One line per site: `resp.encoding = "utf-8"` before `resp.text`. Bandcamp omits `charset=` on most responses, so httpx falls back to ISO-8859-1 and mojibakes diacritic-bearing album titles (e.g. "Csillagrablók" → "CsillagrablÃ³k").
- Deterministic unit tests for both call sites using `httpx.Response(..., default_encoding="iso-8859-1")` to trigger the broken decode path. Same shape as `release/test_bandcamp_resolver.py::test_forces_utf8_when_no_charset_in_content_type`.

Closes #265.

## Test plan

- [x] Failing tests added first (TDD red), confirmed to fail with `'CsillagrablÃ³k' == 'Csillagrablók'` mojibake on both `BandcampClient.fetch_artist_catalog` and `bandcamp_lookup.fetch_bandcamp_albums`.
- [x] After fix, both pass; full unit suite — 1626 passed.
- [x] `ruff check`, `ruff format --check`, `mypy` — all clean.