### PR TITLE
Cache-driven safety net for artist-only fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Library Metadata Lookup is a FastAPI service for WXYC radio that searches the li
 1. **Artist Correction**: Fuzzy match artist against library catalog to fix typos
 2. **Album Resolution**: If song provided without album, query Discogs for album names
 3. **Search Pipeline**: Execute strategies in order until results are found (see below)
-4. **Track Validation**: If fallback returned all artist albums, validate each against Discogs tracklists
+4. **Track Validation**: If fallback returned all artist albums, validate each against Discogs tracklists. When validation can't confirm any candidate AND we're showing artist-fallback results, `find_library_albums_with_cached_track()` consults the local PG cache directly ("releases by this artist whose tracklist contains this song") and promotes any matching library album over the unrelated fallback. Cache-only — never falls back to the API.
 5. **Artwork Fetch**: Fetch album art from Discogs for each result
 6. **Context Message**: Generate context string for the caller
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -756,6 +756,59 @@ async def filter_results_by_track_validation(
     return None
 
 
+async def find_library_albums_with_cached_track(
+    db: LibraryDB,
+    song: str | None,
+    artist: str | None,
+    discogs_service: DiscogsService | None,
+    limit: int = MAX_SEARCH_RESULTS,
+) -> list[LibraryItem]:
+    """Find WXYC library albums whose Discogs cache entry lists ``song`` by ``artist``.
+
+    Used as a safety net after ``filter_results_by_track_validation`` fails to
+    confirm any artist-fallback candidate. The PG cache holds full Discogs
+    tracklist data with trigram-indexed track titles, so a single lookup can
+    answer "which releases by this artist contain this track?" in milliseconds —
+    even when the upstream ``resolve_albums_for_track`` / API path missed it.
+
+    Cache-only by design: skips any API fallback path. Returns ``[]`` cleanly
+    when the cache is unavailable, fails, or has nothing for the query.
+    """
+    if not discogs_service or not song or not artist:
+        return []
+    cache_service = getattr(discogs_service, "cache_service", None)
+    if cache_service is None:
+        return []
+
+    try:
+        cached_releases = await cache_service.search_releases_by_track(
+            track=song, artist=artist, limit=20
+        )
+    except Exception as e:
+        logger.warning(f"Cache lookup for track-album promotion failed: {e}")
+        return []
+
+    if not cached_releases:
+        return []
+
+    matches: list[LibraryItem] = []
+    seen_ids: set[int] = set()
+
+    for release in cached_releases:
+        candidate_items = await search_album_fuzzy(db, release.album)
+        for item in candidate_items:
+            if item.id in seen_ids:
+                continue
+            if not artist_matches_item(item, artist):
+                continue
+            matches.append(item)
+            seen_ids.add(item.id)
+            if len(matches) >= limit:
+                return matches
+
+    return matches
+
+
 async def _resolve_fallback_artwork(discogs_service: DiscogsService, release_id: int) -> str | None:
     """Try artist image, then label image, for a release with no cover art."""
     release = await discogs_service.get_release(release_id)
@@ -1154,6 +1207,18 @@ async def perform_lookup(
                 if validated:
                     library_results = validated
                     song_not_found = False
+                elif song_not_found:
+                    # Per-result validation confirmed nothing. Ask the local
+                    # PG cache directly: "any release by this artist whose
+                    # tracklist contains this song?" — and promote the matching
+                    # library album. Catches the case where the upstream
+                    # track→releases lookup missed a release the cache holds.
+                    promoted = await find_library_albums_with_cached_track(
+                        db, parsed.song, parsed.artist, discogs_service
+                    )
+                    if promoted:
+                        library_results = promoted
+                        song_not_found = False
         elif search_state.artist_fallback_results:
             # Compilation found, but the artist's own album may also contain the track.
             # Validate the artist fallback results (saved before compilation search

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,6 +87,16 @@ SEED_ITEMS = [
     (39, "Confield", "Autechre", "EL", 16, 1, "Electronic", "CD"),
     (40, "1st Class", "Large Professor", "HH", 1, 1, "Hiphop", "CD"),
     (41, "...Destroys The Space Invaders", "Prince Jammy", "RE", 1, 1, "Reggae", "Vinyl"),
+    # Lee 'Scratch' Perry: cluster used by the cache-promotion regression test.
+    # Five fallback albums with low-id slots, plus "Live at Maritime Hall" deeper
+    # in the catalog -- mirrors the production layout where the song-bearing
+    # album sits past the artist-only FTS5 top-N slice.
+    (12663, "Chicken Scratch", "Lee 'Scratch' Perry", "Pe", 1, 1, "Reggae", "Vinyl"),
+    (12664, 'Ooh! Wah! 12"', "Lee 'Scratch' Perry", "Pe", 1, 2, "Reggae", "Vinyl"),
+    (12665, "History Mystery Prophecy", "Lee 'Scratch' Perry", "Pe", 1, 3, "Reggae", "Vinyl"),
+    (12680, "Arkology", "Lee 'Scratch' Perry", "Pe", 1, 17, "Reggae", "CD"),
+    (12684, "Dub Fire", "Lee 'Scratch' Perry", "Pe", 1, 21, "Reggae", "CD"),
+    (12682, "Live at Maritime Hall", "Lee 'Scratch' Perry", "Pe", 1, 20, "Reggae", "CD"),
 ]
 
 

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -498,3 +498,158 @@ class TestTrackOnArtistAlbumAndCompilation:
         assert response.found_on_compilation is True
         # Artist's own album should come before the compilation
         assert titles.index("London Zoo") < titles.index("The Sound of Dub")
+
+
+class TestPromoteAlbumFromCachedTrackData:
+    """Cache-driven safety net for the artist-only fallback.
+
+    When the artist-only FTS5 fallback returns N albums by ID order, none of
+    which can be validated against the requested track, but the local Discogs
+    PG cache holds the answer — promote the cache-known album.
+
+    Reproduces "bucky skank by lee scratch perry": fallback returned 5 unrelated
+    Lee Perry albums, validator couldn't confirm Bucky Skank on any, while the
+    cache knew it was on "Live at Maritime Hall" all along.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cache_promotes_song_bearing_album_over_unrelated_fallback(self, library_db):
+        """Library has 6 Lee Perry albums; FTS-by-ID returns 5 that don't have
+        "Bucky Skank"; cache says it's on "Live at Maritime Hall" → promotion
+        should surface Maritime Hall and clear `song_not_found`.
+        """
+        from core.telemetry import RequestTelemetry, init_cache_stats
+        from discogs.models import (
+            DiscogsSearchResponse,
+            ReleaseInfo,
+            TrackReleasesResponse,
+        )
+        from lookup.models import LookupRequest
+        from lookup.orchestrator import perform_lookup
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(
+            spec_set=[
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "search",
+                "get_release",
+                "cache_service",
+            ]
+        )
+
+        # Compilation/artist-keyword Discogs lookups return nothing (mirrors prod).
+        mock_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Bucky Skank",
+                artist="Lee 'Scratch' Perry",
+                releases=[],
+                total=0,
+                cached=False,
+            )
+        )
+
+        # Per-result Discogs.search returns nothing for the validator either, so
+        # `filter_results_by_track_validation` cannot confirm any fallback album.
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        mock_service.validate_track_on_release = AsyncMock(return_value=False)
+        mock_service.get_release = AsyncMock(return_value=None)
+
+        # The PG cache holds the answer.
+        mock_service.cache_service = AsyncMock()
+        mock_service.cache_service.search_releases_by_track = AsyncMock(
+            return_value=[
+                ReleaseInfo(
+                    album="Lee Scratch Perry Live At Maritime Hall",
+                    artist="Lee 'Scratch' Perry",
+                    release_id=2865555,
+                    release_url="https://www.discogs.com/release/2865555",
+                    is_compilation=False,
+                ),
+            ]
+        )
+
+        request = LookupRequest(
+            artist="Lee 'Scratch' Perry",
+            song="Bucky Skank",
+            raw_message="bucky skank by lee scratch perry",
+        )
+
+        # Patch the upstream track→releases lookup to return nothing — this is
+        # exactly the production failure mode the safety net is designed for.
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(request, library_db, mock_service, RequestTelemetry())
+
+        titles = [r.library_item.title for r in response.results]
+        assert "Live at Maritime Hall" in titles, (
+            f"Cache-known song-bearing album should be promoted; got: {titles}"
+        )
+        # Promotion replaces the unrelated fallback set
+        for noise in ("Chicken Scratch", "Arkology", "Dub Fire"):
+            assert noise not in titles, (
+                f"{noise!r} doesn't contain the song; should be replaced, got: {titles}"
+            )
+        assert response.song_not_found is False, (
+            "song_not_found should clear once a track-bearing album is confirmed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_promotion_when_cache_has_no_matching_release(self, library_db):
+        """Cache empty → existing artist-fallback behavior is preserved."""
+        from core.telemetry import RequestTelemetry, init_cache_stats
+        from discogs.models import DiscogsSearchResponse, TrackReleasesResponse
+        from lookup.models import LookupRequest
+        from lookup.orchestrator import perform_lookup
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(
+            spec_set=[
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "search",
+                "get_release",
+                "cache_service",
+            ]
+        )
+        mock_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Bucky Skank",
+                artist="Lee 'Scratch' Perry",
+                releases=[],
+                total=0,
+                cached=False,
+            )
+        )
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        mock_service.validate_track_on_release = AsyncMock(return_value=False)
+        mock_service.get_release = AsyncMock(return_value=None)
+
+        # Cache has no answer either
+        mock_service.cache_service = AsyncMock()
+        mock_service.cache_service.search_releases_by_track = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            artist="Lee 'Scratch' Perry",
+            song="Bucky Skank",
+            raw_message="bucky skank by lee scratch perry",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(request, library_db, mock_service, RequestTelemetry())
+
+        # Without a cache answer we keep the artist-fallback behavior:
+        # the user still gets albums by the artist, and song_not_found stays True.
+        assert response.song_not_found is True
+        assert len(response.results) >= 1
+        for r in response.results:
+            assert "Perry" in (r.library_item.artist or "")

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -454,6 +454,127 @@ class TestPerformLookupFallback:
         assert len(response.results) == 1
         assert response.results[0].library_item.title == "A Night at the Opera"
 
+    @pytest.mark.asyncio
+    async def test_promotes_album_known_to_contain_track_from_local_cache(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """When per-result Discogs validation can't confirm any artist-fallback
+        candidate, the orchestrator should consult the local Discogs PG cache
+        for "releases by this artist containing this track" and promote the
+        matching library album.
+
+        Reproduces "bucky skank by lee scratch perry": the artist-only fallback
+        returned 5 unrelated Lee Perry albums, all failed validation, and the
+        library album that actually contains the song ("Live at Maritime Hall")
+        was never surfaced — even though the local cache had the answer.
+        """
+        # Five fallback albums that don't contain the track
+        fallback_items = [
+            LibraryItem(
+                id=12663,
+                artist="Lee 'Scratch' Perry",
+                title="Chicken Scratch",
+                call_letters="Pe",
+                artist_call_number=1,
+                release_call_number=1,
+                genre="Reggae",
+                format="vinyl",
+            ),
+            LibraryItem(
+                id=12664,
+                artist="Lee 'Scratch' Perry",
+                title='Ooh! Wah! 12"',
+                call_letters="Pe",
+                artist_call_number=1,
+                release_call_number=2,
+                genre="Reggae",
+                format="vinyl",
+            ),
+        ]
+        # The actual answer (in the library, but not in the fallback's top-N FTS slice)
+        maritime = LibraryItem(
+            id=12682,
+            artist="Lee 'Scratch' Perry",
+            title="Live at Maritime Hall",
+            call_letters="Pe",
+            artist_call_number=1,
+            release_call_number=20,
+            genre="Reggae",
+            format="cd",
+        )
+
+        mock_library_db.find_similar_artist.return_value = None
+
+        # Mirror the production FTS5 behavior: queries containing the song words
+        # ("bucky"/"skank") match nothing because no album *title* contains
+        # those tokens. Only the artist-only and album-title-based queries hit.
+        async def fake_search(query=None, **kwargs):
+            q = (query or "").lower()
+            if "bucky" in q or "skank" in q:
+                return []
+            if "maritime" in q:
+                return [maritime]
+            if "scratch" in q or "perry" in q:
+                return fallback_items
+            return []
+
+        mock_library_db.search.side_effect = fake_search
+
+        # Per-result validation fails for all fallback items (none contain the track)
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+        mock_discogs_service.validate_track_on_release.return_value = False
+
+        from discogs.models import ReleaseInfo, TrackReleasesResponse
+
+        # Compilation strategy's two API calls return nothing (mirrors prod where
+        # the artist-only fallback isn't replaced by a compilation hit)
+        mock_discogs_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Bucky Skank",
+                artist="Lee 'Scratch' Perry",
+                releases=[],
+                total=0,
+                cached=False,
+            )
+        )
+
+        # The local PG cache holds the answer — Maritime Hall has Bucky Skank
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+            return_value=[
+                ReleaseInfo(
+                    album="Lee Scratch Perry Live At Maritime Hall",
+                    artist="Lee 'Scratch' Perry",
+                    release_id=2865555,
+                    release_url="https://discogs.com/release/2865555",
+                    is_compilation=False,
+                ),
+            ]
+        )
+
+        request = LookupRequest(
+            artist="Lee 'Scratch' Perry",
+            song="Bucky Skank",
+            raw_message="bucky skank by lee scratch perry",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        titles = [r.library_item.title for r in response.results]
+        assert "Live at Maritime Hall" in titles, (
+            f"Cache-known album should be promoted; got: {titles}"
+        )
+        assert response.song_not_found is False, (
+            "Promoting a confirmed track-bearing album should clear song_not_found"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: perform_lookup - compilation search

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -26,6 +26,7 @@ from lookup.orchestrator import (
     fetch_artwork_for_items,
     filter_results_by_artist,
     filter_results_by_track_validation,
+    find_library_albums_with_cached_track,
     resolve_albums_for_track,
     search_library_with_fallback,
     search_with_alternative_interpretation,
@@ -773,6 +774,195 @@ class TestFilterResultsByTrackValidation:
             items, "Flow Coma", "808 State", mock_discogs_service
         )
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: find_library_albums_with_cached_track
+# ---------------------------------------------------------------------------
+
+
+class TestFindLibraryAlbumsWithCachedTrack:
+    """Tests for the cache-driven promotion safety net.
+
+    When the artist-only fallback returned albums that all fail track validation,
+    this helper consults the local Discogs PG cache directly: "give me releases
+    by this artist that contain this track" — and surfaces the matching WXYC
+    library albums. Catches the case where the upstream Discogs query in
+    `resolve_albums_for_track` missed the answer that the local cache holds.
+
+    Reproduces: "bucky skank by lee scratch perry" returned 5 unrelated Lee Perry
+    albums while skipping "Live at Maritime Hall", which the cache knows contains
+    that track.
+    """
+
+    def _cache_releases(self, *titles_and_artists):
+        from discogs.models import ReleaseInfo
+
+        return [
+            ReleaseInfo(
+                album=album,
+                artist=artist,
+                release_id=1000 + i,
+                release_url=f"https://discogs.com/release/{1000 + i}",
+                is_compilation=False,
+            )
+            for i, (album, artist) in enumerate(titles_and_artists)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_returns_library_album_when_cache_links_track_to_release(
+        self, mock_library_db, mock_discogs_service
+    ):
+        """Cache says 'Bucky Skank' is on a release whose title matches a WXYC
+        library album by the same artist → that album is returned."""
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+            return_value=self._cache_releases(
+                ("Lee Scratch Perry Live At Maritime Hall", "Lee 'Scratch' Perry")
+            )
+        )
+
+        maritime = make_library_item(
+            id=12682,
+            artist="Lee 'Scratch' Perry",
+            title="Live at Maritime Hall",
+        )
+        mock_library_db.search.return_value = [maritime]
+
+        result = await find_library_albums_with_cached_track(
+            mock_library_db,
+            "Bucky Skank",
+            "Lee 'Scratch' Perry",
+            mock_discogs_service,
+        )
+
+        assert len(result) == 1
+        assert result[0].id == 12682
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_discogs_service(self, mock_library_db):
+        result = await find_library_albums_with_cached_track(
+            mock_library_db, "Song", "Artist", None
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_cache_service(self, mock_library_db, mock_discogs_service):
+        """No PG cache attached → helper is a no-op (we don't fall back to the API)."""
+        mock_discogs_service.cache_service = None
+        result = await find_library_albums_with_cached_track(
+            mock_library_db, "Song", "Artist", mock_discogs_service
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_song_or_artist_missing(
+        self, mock_library_db, mock_discogs_service
+    ):
+        mock_discogs_service.cache_service = AsyncMock()
+        assert (
+            await find_library_albums_with_cached_track(
+                mock_library_db, None, "Artist", mock_discogs_service
+            )
+            == []
+        )
+        assert (
+            await find_library_albums_with_cached_track(
+                mock_library_db, "Song", None, mock_discogs_service
+            )
+            == []
+        )
+        # Cache should never be consulted when inputs are insufficient
+        mock_discogs_service.cache_service.search_releases_by_track.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_cache_has_no_matching_releases(
+        self, mock_library_db, mock_discogs_service
+    ):
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(return_value=[])
+        result = await find_library_albums_with_cached_track(
+            mock_library_db, "Song", "Artist", mock_discogs_service
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_skips_releases_with_no_library_match(
+        self, mock_library_db, mock_discogs_service
+    ):
+        """Cache returns a release the WXYC library doesn't carry."""
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+            return_value=self._cache_releases(("Some Bootleg Compilation", "Lee Perry"))
+        )
+        mock_library_db.search.return_value = []
+
+        result = await find_library_albums_with_cached_track(
+            mock_library_db, "Song", "Lee Perry", mock_discogs_service
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_filters_out_library_rows_with_wrong_artist(
+        self, mock_library_db, mock_discogs_service
+    ):
+        """FTS returns an album with a matching title but a different artist."""
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+            return_value=self._cache_releases(("Live at Maritime Hall", "Lee Perry"))
+        )
+        wrong_artist = make_library_item(
+            id=99, artist="Some Other Band", title="Live at Maritime Hall"
+        )
+        mock_library_db.search.return_value = [wrong_artist]
+
+        result = await find_library_albums_with_cached_track(
+            mock_library_db, "Bucky Skank", "Lee 'Scratch' Perry", mock_discogs_service
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_dedupes_when_multiple_releases_resolve_to_same_library_row(
+        self, mock_library_db, mock_discogs_service
+    ):
+        """Two cache releases for the same album (different pressings) → one row."""
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+            return_value=self._cache_releases(
+                ("Live at Maritime Hall", "Lee 'Scratch' Perry"),
+                ("Lee Scratch Perry Live At Maritime Hall", "Lee 'Scratch' Perry"),
+            )
+        )
+        maritime = make_library_item(
+            id=12682, artist="Lee 'Scratch' Perry", title="Live at Maritime Hall"
+        )
+        mock_library_db.search.return_value = [maritime]
+
+        result = await find_library_albums_with_cached_track(
+            mock_library_db,
+            "Bucky Skank",
+            "Lee 'Scratch' Perry",
+            mock_discogs_service,
+        )
+        assert len(result) == 1
+        assert result[0].id == 12682
+
+    @pytest.mark.asyncio
+    async def test_cache_failure_returns_empty_does_not_raise(
+        self, mock_library_db, mock_discogs_service
+    ):
+        """Cache exceptions degrade gracefully — caller still gets a usable answer."""
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+            side_effect=RuntimeError("cache offline")
+        )
+        result = await find_library_albums_with_cached_track(
+            mock_library_db,
+            "Song",
+            "Artist",
+            mock_discogs_service,
+        )
+        assert result == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #267.

## Summary

Adds `find_library_albums_with_cached_track()` in `lookup/orchestrator.py`: when the per-result Discogs validator can't confirm any artist-fallback candidate AND `song_not_found` is still set, ask the local Discogs PG cache directly — \"any release by this artist whose tracklist contains this song?\" — and promote any matching WXYC library album over the unrelated fallback noise.

Cache-only by design (no API fallback). Returns `[]` cleanly when the cache is unavailable, empty, or errors. Happy paths untouched: the promotion lives in an `elif` after the existing validator.

## Why the existing pipeline misses

Walked the four code paths that *should* surface the answer in `lookup/orchestrator.py`; each one drops `Live at Maritime Hall` for a different reason:

| Step | Function | Why it loses the answer |
|---|---|---|
| 1 | `resolve_albums_for_track` → `lookup_releases_by_track` | Re-validates each cache hit via `validate_track_on_release`; rejects the row the cache just told us contained the track (cache miss / API rate-limited / 401). |
| 2 | `search_library_with_fallback` | Artist-only FTS5 fallback returns first 5 Lee Perry rows by primary-key order; Maritime Hall (id 12682) is the 21st row. |
| 3 | `search_compilations_for_track` | Same upstream as step 1, same rejection. |
| 4 | `filter_results_by_track_validation` | Purely subtractive — can only kill candidates already in `library_results`. Maritime Hall was never *in* the candidate set, so it can never be promoted. |

The new helper closes the gap with a single trigram-indexed PG query, mapped back to library rows via the existing `search_album_fuzzy` + `artist_matches_item` pipeline (so the same album-title and artist-prefix gates the rest of the codebase trusts apply here too).

## TDD

| Layer | File | Tests |
|---|---|---|
| Helper unit | `tests/unit/test_orchestrator_helpers.py::TestFindLibraryAlbumsWithCachedTrack` | 9 — happy path, missing service/cache, missing inputs, no library match, wrong-artist row, cache-rank dedup, cache exception |
| Pipeline unit | `tests/unit/test_orchestrator.py::TestPerformLookupFallback::test_promotes_album_known_to_contain_track_from_local_cache` | Full `perform_lookup` reproduction of the Lee Perry bug |
| Integration | `tests/integration/test_lookup_pipeline.py::TestPromoteAlbumFromCachedTrackData` | 2 — promotion fires against a real in-memory LibraryDB seeded with 6 Lee Perry albums; cache-empty path leaves existing artist-fallback behavior intact |

Each test was written red first, then made green.

Lee Perry seed cluster added to `tests/integration/conftest.py` so the integration tests have a multi-album artist whose song-bearing album sits past the FTS5 top-N slice — mirrors the production layout.

## Test plan

- [x] `uv run pytest tests/unit/ tests/integration/` → 1861 passed, 0 failed
- [x] `uv run ruff check . && uv run ruff format --check .` → clean
- [x] `uv run mypy . --ignore-missing-imports` → Success: no issues found in 241 source files
- [ ] Staging smoke after deploy: `lookup -s \"bucky skank by lee scratch perry\"` → expect `Live at Maritime Hall` in results, `song_not_found=false`

## Out of scope

- Issues #210 / #237 (collaboration-trio artist normalization). The new helper relies on the cache's own artist-trigram match, which already handles single-artist names but not unsplit trios.
- Parallelizing the per-release library lookup loop. The promotion runs in the cold path; SQLite-connection serialization caps the wall-clock win at a few ms, and we lose early-exit. Worth revisiting only if telemetry shows promotion latency mattering.