### PR TITLE
Add POST /api/v1/identity/bulk-resolve-libraries (cross-cache-identity pivot)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ The service exposes REST endpoints for querying the `entity.identity` table in t
 
 - `GET /identity/resolve?name=Stereolab` -- Look up a single artist name. Returns 200 with external IDs or 404.
 - `POST /identity/bulk` with `{"names": ["Stereolab", "Autechre", ...]}` -- Resolve a batch of names. Returns `identities` (found) and `unresolved` (not found).
+- `POST /api/v1/identity/bulk-resolve-libraries` -- Cross-cache-identity contract endpoint per the 2026-05-09 pivot (BS#800). Backend POSTs library rows; LML composes per-source provenance via §3.4.1.1 Rules 2-6 and returns one verdict per row (`kind: single_artist | compilation | unresolved`). Implementation lives in `identity/bulk_resolve.py`; sits under `/api/v1/` so it inherits `LML_API_KEY` bearer auth.
 
 Both endpoints return 503 when `DATABASE_URL_DISCOGS` is not set or the entity schema is not applied.
 

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1065,6 +1065,73 @@ class LookupIdentityBlock(BaseModel):
     )
 
 
+class BulkResolveInput(BaseModel):
+    library_id: int = Field(..., description="Backend `wxyc_schema.library.id` (FK target).")
+    artist_name: str = Field(
+        ..., description="Hint — Backend's denormalized artist name for the row."
+    )
+    album_title: str = Field(
+        ..., description="Hint — Backend's denormalized album title for the row."
+    )
+
+
+class BulkResolveResultKind(StrEnum):
+    single_artist = "single_artist"
+    compilation = "compilation"
+    unresolved = "unresolved"
+
+
+class BulkResolveProvenanceEntry(BaseModel):
+    source: IdentitySource
+    method: IdentityMethod
+    confidence: confloat(ge=0.0, le=1.0) = Field(
+        ...,
+        description="Per-source confidence in [0, 1], within the source's locked method range from §3.4.1. NULL when `external_id` is NULL — the source ran but produced no candidate, so confidence is undefined (not zero). When non-null, equal to or greater than the top-level `confidence` (composition rules either MIN or boost, never lower a per-source row).\n",
+    )
+    external_id: str | None = Field(
+        None,
+        description="The external identifier this source resolved to (Discogs release ID, MusicBrainz MBID, Wikidata QID, Spotify URI suffix, etc.). NULL when the source ran but found no match (the row is still surfaced so consumers see the leg ran); `confidence` is also NULL in that case.\n",
+    )
+
+
+class BulkResolveTrackIdentity(BaseModel):
+    track_position: str = Field(..., description="Track position; matches the request input.")
+    sources: list[BulkResolveProvenanceEntry] = Field(
+        ...,
+        description="One per-source row per source LML composed the track from. Empty array means LML attempted resolution at track grain and found no matches.\n",
+    )
+
+
+class BulkResolveResult(BaseModel):
+    kind: BulkResolveResultKind
+    library_id: int = Field(..., description="Backend `library.id` for this result.")
+    main: ReconciledIdentity | None = Field(
+        None,
+        description="Composed external IDs for `kind: single_artist`. NULL for every other `kind`. URL construction is the consumer's job (see existing ReconciledIdentity contract).\n",
+    )
+    method: IdentityMethod | None = Field(
+        None,
+        description="The composed top-level method LML's bulk-resolve handler picked per §3.4.1.1 (typically the strongest leg's method, or `cross_source_agreement` when Rule 2 boosted). NULL for `kind: unresolved`.\n",
+    )
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(
+        None,
+        description="Composed top-level confidence in [0, 1] — the MIN of resolved sources' confidences after composition (§3.4.1.1 Rule 4), unless boosted by cross-source agreement (Rule 2). NULL for `kind: unresolved`.\n",
+    )
+    provenance: list[BulkResolveProvenanceEntry] = Field(
+        ...,
+        description="Per-source rows feeding LML's composition. Always present; empty array means LML attempted the cascade and no source produced a row above the §3.4.1.1 Rule 6 floor.\n",
+    )
+    tracks: list[BulkResolveTrackIdentity] | None = Field(
+        None,
+        description="Set only for `kind: compilation`; absent for every other `kind`. Empty array when LML has no per-track data for the V/A row yet. Two states (present-array or absent), not three.\n",
+    )
+
+
+class BulkResolveLibrariesResponse(BaseModel):
+    results: list[BulkResolveResult]
+    cache_stats: CacheStats | None = None
+
+
 class DiscogsTrackItem(BaseModel):
     position: str
     title: str
@@ -1328,3 +1395,12 @@ class LookupResponse(BaseModel):
     )
     cache_stats: CacheStats | None = None
     identity: LookupIdentityBlock | None = None
+
+
+class BulkResolveLibrariesRequest(BaseModel):
+    inputs: list[BulkResolveInput] = Field(
+        ...,
+        description="Inputs to resolve. Order preserved in `BulkResolveLibrariesResponse.results`.\n",
+        max_length=1000,
+        min_length=1,
+    )

--- a/identity/bulk_resolve.py
+++ b/identity/bulk_resolve.py
@@ -57,10 +57,15 @@ AGREEMENT_FLOOR = 0.95
 _INHERITED_METHOD = "inherited"
 
 # When the entity store has populated columns but no per-source provenance
-# log rows (legacy data), treat them as `exact_match` 1.00 — §3.4.1's
-# matrix lists `exact_match` as the "deterministic idempotent" tier and
-# this matches the pre-pivot semantics where any populated column was
-# considered authoritative.
+# log rows (legacy data), treat them as `exact_match` 1.00 on the wire —
+# §3.4.1's matrix lists `exact_match` as the "deterministic idempotent"
+# tier and this matches the pre-pivot semantics where any populated column
+# was considered authoritative. INTERNALLY we mark these rows
+# `is_inherited=True` so Rule 3 excludes them from the cross-source-agreement
+# detector — without that gate, two log-less legacy sources would always
+# trip Rule 2 and inflate composed confidence to ≥0.95. The wire format
+# stays honest (`exact_match` / 1.00); the boost path stays grounded in
+# positive matcher evidence.
 _LEGACY_DEFAULT_METHOD = IdentityMethod.exact_match
 _LEGACY_DEFAULT_CONFIDENCE = 1.00
 
@@ -127,13 +132,36 @@ def _build_per_source_rows(
     methods don't pollute the response).
     """
     external_ids = _identity_to_external_ids(identity)
+    # Defensive log: any per-source row that has a populated external_id but
+    # whose log key doesn't match the StrEnum value would fall through to the
+    # legacy path silently. If a future enum-value rename or casing drift
+    # breaks the lookup, this surfaces it before the rows hit production.
+    populated_sources = {s.value for s in external_ids}
+    log_keys = set(provenance.keys())
+    if populated_sources and log_keys and not (populated_sources & log_keys) and provenance:
+        logger.warning(
+            "bulk_resolve: identity %d has populated external_ids %s and "
+            "reconciliation_log entries %s but the keys don't intersect — "
+            "every source will fall to the legacy default. Check "
+            "IdentitySource enum vs reconciliation_log.source casing.",
+            identity.id,
+            sorted(populated_sources),
+            sorted(log_keys),
+        )
+
     rows: list[_ComposedRow] = []
     for source, external_id in external_ids.items():
         log_row = provenance.get(source.value)
         if log_row is None:
+            # Log-less identity. See _LEGACY_DEFAULT_METHOD docstring above:
+            # we report `exact_match` 1.00 on the wire (best approximation
+            # for a populated entity.identity column) but mark the row
+            # `is_inherited=True` so the cross-source-agreement detector
+            # (Rule 2 / Rule 3) excludes it. Without that gate, two legacy
+            # legs always boost composed confidence to ≥0.95.
             method = _LEGACY_DEFAULT_METHOD
             confidence = _LEGACY_DEFAULT_CONFIDENCE
-            is_inherited = False
+            is_inherited = True
         else:
             confidence = log_row.confidence if log_row.confidence is not None else 0.0
             if log_row.method == _INHERITED_METHOD:
@@ -264,6 +292,13 @@ async def compose_for_identity(
     the lookup found no row — we return `kind: unresolved`. When present,
     we read the per-source reconciliation log to assemble provenance and
     apply §3.4.1.1 composition.
+
+    TODO(WXYC/library-metadata-lookup#274): the caller of this function
+    looks up `identity` via exact `library_name = $1` against the
+    `entity.identity` table — Backend will pass `library.artist_name`
+    straight from its denormalized column, so diacritic / smart-quote /
+    `&` vs `and` divergence will surface as silent misses. #274 tracks
+    the canonical-form lookup that closes that gap.
     """
     if identity is None:
         return BulkResolveResult(

--- a/identity/bulk_resolve.py
+++ b/identity/bulk_resolve.py
@@ -1,0 +1,326 @@
+"""Composition logic for `POST /api/v1/identity/bulk-resolve-libraries`.
+
+Per the cross-cache-identity architecture pivot
+(WXYC/Backend-Service#800, 2026-05-09), LML — not Backend — is the sole
+composer of cross-cache identity. Backend POSTs library rows; LML returns one
+verdict per row. The handler shape is contract-locked in
+`wxyc-shared/api.yaml` (v1.2.0). The composition rules implemented here come
+from the wiki spec at `plans/library-hook-canonicalization.md` §3.4.1.1.
+
+Rule 1 (manual override) executes in Backend (per the pivot decision record),
+NOT here. Rules 2-6 execute here:
+
+- Rule 2: cross-source agreement boost (≥2 sources whose external IDs share
+  a known cross-reference, via wikidata-cache `discogs_mapping`).
+- Rule 3: inherited rows are excluded from the agreement detector.
+- Rule 4: main-row confidence is `MIN(per-source confidences)` unless Rule 2
+  applied.
+- Rule 5: documents the supersedure direction; not enforced at compose time.
+- Rule 6: per-source rows below 0.70 are dropped from the response provenance.
+
+V/A detection uses `wxyc_etl.text.is_compilation_artist`. For `kind:
+compilation` this PR returns `tracks: []` and `provenance: []` — full
+per-track resolution lands in WXYC/library-metadata-lookup#271.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from generated.api_models import (
+    BulkResolveProvenanceEntry,
+    BulkResolveResult,
+    BulkResolveResultKind,
+    IdentityMethod,
+    IdentitySource,
+    ReconciledIdentity,
+)
+from scripts.entity_resolution.store import EntityStore, Identity, ProvenanceRow
+
+logger = logging.getLogger(__name__)
+
+# Rule 6 — sub-floor sources don't appear in the sidecar (or in our
+# response provenance). Any per-source row whose confidence falls below
+# this floor is dropped from `BulkResolveResult.provenance`.
+SIDECAR_FLOOR = 0.70
+
+# Rule 2 — cross-source agreement floor. Composed `confidence` jumps to
+# `MAX(0.95, MIN(per-source))`.
+AGREEMENT_FLOOR = 0.95
+
+# Rule 3 — `inherited` rows do not participate in the agreement detector.
+# The string is intentional: §3.4.1's matrix lists `inherited` as a method
+# but the api.yaml `IdentityMethod` enum does not (it's an internal-only
+# state). We keep the comparison string-based to match what reconciliation
+# logs may carry.
+_INHERITED_METHOD = "inherited"
+
+# When the entity store has populated columns but no per-source provenance
+# log rows (legacy data), treat them as `exact_match` 1.00 — §3.4.1's
+# matrix lists `exact_match` as the "deterministic idempotent" tier and
+# this matches the pre-pivot semantics where any populated column was
+# considered authoritative.
+_LEGACY_DEFAULT_METHOD = IdentityMethod.exact_match
+_LEGACY_DEFAULT_CONFIDENCE = 1.00
+
+# Map `entity.identity` column names to (IdentitySource, getter) tuples so
+# we can build per-source rows from a populated identity row.
+_SOURCE_TO_COLUMN: list[tuple[IdentitySource, str]] = [
+    (IdentitySource.discogs, "discogs_artist_id"),
+    (IdentitySource.musicbrainz, "musicbrainz_artist_id"),
+    (IdentitySource.wikidata, "wikidata_qid"),
+    (IdentitySource.spotify, "spotify_artist_id"),
+    (IdentitySource.apple_music, "apple_music_artist_id"),
+    (IdentitySource.bandcamp, "bandcamp_id"),
+]
+
+
+def _identity_to_external_ids(identity: Identity) -> dict[IdentitySource, str]:
+    """Pluck non-null external IDs off an Identity row, keyed by source.
+
+    `discogs_artist_id` is an int in the DB; we stringify so the per-source
+    `external_id` field stays uniform per the api.yaml contract.
+    """
+    out: dict[IdentitySource, str] = {}
+    for source, column in _SOURCE_TO_COLUMN:
+        raw = getattr(identity, column)
+        if raw is not None and raw != "":
+            out[source] = str(raw)
+    return out
+
+
+@dataclass(frozen=True)
+class _ComposedRow:
+    """Per-source row, post Rule 6 floor and method/confidence resolution."""
+
+    source: IdentitySource
+    method: IdentityMethod
+    confidence: float
+    external_id: str
+    is_inherited: bool
+
+
+def _normalize_method(raw: str) -> IdentityMethod | None:
+    """Map a reconciliation_log `method` string to the api.yaml enum.
+
+    Returns None for unknown / non-enum values (e.g. `inherited`, which
+    §3.4.1 lists in the matrix but `api.yaml` does not). Callers route
+    `inherited` rows specially via `is_inherited`.
+    """
+    try:
+        return IdentityMethod(raw)
+    except ValueError:
+        return None
+
+
+def _build_per_source_rows(
+    identity: Identity,
+    provenance: dict[str, ProvenanceRow],
+) -> list[_ComposedRow]:
+    """Build per-source rows from an Identity + reconciliation_log provenance.
+
+    Rule 6 (sub-floor exclusion) is applied here: any source whose
+    confidence is below `SIDECAR_FLOOR` is dropped before composition. A
+    source listed in `provenance` whose method does not map to the api.yaml
+    enum is also dropped (preserving forward compatibility — unknown
+    methods don't pollute the response).
+    """
+    external_ids = _identity_to_external_ids(identity)
+    rows: list[_ComposedRow] = []
+    for source, external_id in external_ids.items():
+        log_row = provenance.get(source.value)
+        if log_row is None:
+            method = _LEGACY_DEFAULT_METHOD
+            confidence = _LEGACY_DEFAULT_CONFIDENCE
+            is_inherited = False
+        else:
+            confidence = log_row.confidence if log_row.confidence is not None else 0.0
+            if log_row.method == _INHERITED_METHOD:
+                # Rule 3 keys off this; method goes to a default so the
+                # row can still appear in provenance.
+                method = _LEGACY_DEFAULT_METHOD
+                is_inherited = True
+            else:
+                normalized = _normalize_method(log_row.method)
+                if normalized is None:
+                    logger.debug(
+                        "Skipping unknown method %r on identity %d source %s",
+                        log_row.method,
+                        identity.id,
+                        source.value,
+                    )
+                    continue
+                method = normalized
+                is_inherited = False
+            # Prefer the log's external_id — it's what the matcher actually
+            # resolved at the most recent attempt. Fall back to the column
+            # value if log row is missing one.
+            external_id = log_row.external_id or external_id
+        # Rule 6: sub-0.70 sources are omitted from the sidecar.
+        if confidence < SIDECAR_FLOOR:
+            continue
+        rows.append(
+            _ComposedRow(
+                source=source,
+                method=method,
+                confidence=confidence,
+                external_id=external_id,
+                is_inherited=is_inherited,
+            )
+        )
+    return rows
+
+
+def _has_cross_source_agreement(rows: list[_ComposedRow]) -> bool:
+    """Rule 2 + Rule 3 applied: agreement requires ≥2 *non-inherited* sources.
+
+    The full agreement detector (per §3.2.5) cross-references via
+    wikidata-cache `discogs_mapping`. For this PR we approximate with a
+    pragmatic proxy: the `entity.identity` row was already produced by
+    `scripts/entity_resolution/` which already cross-resolves IDs (Discogs
+    -> QID via `discogs_mapping`, MB -> Discogs via `mb_artist`). So if
+    ≥2 non-inherited per-source rows survived, we treat that as agreement.
+    Full per-pair cross-reference verification is a follow-up — the
+    contract is designed so the wire format is unchanged when the detector
+    becomes more discriminating.
+
+    TODO(WXYC/library-metadata-lookup#271 follow-up): pull a proper
+    `discogs_mapping` reader into `identity/` and verify the agreeing
+    rows actually point at entities that share a wikidata-cache
+    cross-reference. Until then this is permissive; downside is we may
+    boost some rows that should not boost.
+    """
+    independent = [r for r in rows if not r.is_inherited]
+    return len(independent) >= 2
+
+
+def _compose_main(
+    rows: list[_ComposedRow],
+) -> tuple[ReconciledIdentity | None, IdentityMethod | None, float | None]:
+    """Compose the top-level `main` identity, method, and confidence.
+
+    Returns (None, None, None) if no per-source rows survive — the caller
+    treats that as `kind: unresolved`.
+    """
+    if not rows:
+        return None, None, None
+
+    main = ReconciledIdentity()
+    for row in rows:
+        # Map source -> ReconciledIdentity field. The discogs_artist_id is
+        # the only int field; the rest are strings.
+        if row.source is IdentitySource.discogs:
+            main.discogs_artist_id = int(row.external_id) if row.external_id else None
+        elif row.source is IdentitySource.musicbrainz:
+            main.musicbrainz_artist_id = row.external_id
+        elif row.source is IdentitySource.wikidata:
+            main.wikidata_qid = row.external_id
+        elif row.source is IdentitySource.spotify:
+            main.spotify_artist_id = row.external_id
+        elif row.source is IdentitySource.apple_music:
+            main.apple_music_artist_id = row.external_id
+        elif row.source is IdentitySource.bandcamp:
+            main.bandcamp_id = row.external_id
+
+    confidences = [r.confidence for r in rows]
+    min_confidence = min(confidences)
+
+    # Rule 2: cross-source agreement boost. (Rule 1 — manual override —
+    # is Backend's responsibility per the pivot decision; not applied here.)
+    if _has_cross_source_agreement(rows):
+        composed_confidence = max(AGREEMENT_FLOOR, min_confidence)
+        composed_method = IdentityMethod.cross_source_agreement
+    else:
+        # Rule 4: MIN-of-confidences. The method is the per-source method
+        # of the row whose confidence is minimal — matches §3.4.1.1's
+        # worked example "Two sources, exact_match 1.00 + name_variation
+        # 0.92 -> name_variation 0.92".
+        composed_confidence = min_confidence
+        weakest = min(rows, key=lambda r: r.confidence)
+        composed_method = weakest.method
+
+    return main, composed_method, composed_confidence
+
+
+def _row_to_provenance(row: _ComposedRow) -> BulkResolveProvenanceEntry:
+    """Serialize a composed row to the api.yaml `BulkResolveProvenanceEntry`."""
+    return BulkResolveProvenanceEntry(
+        source=row.source,
+        method=row.method,
+        confidence=row.confidence,
+        external_id=row.external_id,
+    )
+
+
+async def compose_for_identity(
+    library_id: int,
+    identity: Identity | None,
+    entity_store: EntityStore,
+) -> BulkResolveResult:
+    """Compose a single-artist verdict for one library row.
+
+    `identity` is the entity_store row keyed by `library_name`. None means
+    the lookup found no row — we return `kind: unresolved`. When present,
+    we read the per-source reconciliation log to assemble provenance and
+    apply §3.4.1.1 composition.
+    """
+    if identity is None:
+        return BulkResolveResult(
+            kind=BulkResolveResultKind.unresolved,
+            library_id=library_id,
+            main=None,
+            method=None,
+            confidence=None,
+            provenance=[],
+            tracks=None,
+        )
+
+    provenance_rows = await entity_store.get_latest_provenance_by_source(identity.id)
+    composed = _build_per_source_rows(identity, provenance_rows)
+
+    if not composed:
+        # The identity row exists but every source failed Rule 6's floor
+        # (or had unknown method) — surface as `unresolved` per
+        # §3.4.1.1's "empty provenance means LML attempted the cascade
+        # and no source produced a row above the floor" semantics.
+        return BulkResolveResult(
+            kind=BulkResolveResultKind.unresolved,
+            library_id=library_id,
+            main=None,
+            method=None,
+            confidence=None,
+            provenance=[],
+            tracks=None,
+        )
+
+    main, method, confidence = _compose_main(composed)
+    provenance = [_row_to_provenance(r) for r in composed]
+
+    return BulkResolveResult(
+        kind=BulkResolveResultKind.single_artist,
+        library_id=library_id,
+        main=main,
+        method=method,
+        confidence=confidence,
+        provenance=provenance,
+        tracks=None,
+    )
+
+
+def compilation_result(library_id: int) -> BulkResolveResult:
+    """Build a `kind: compilation` verdict.
+
+    Per the spec for this PR (#272), V/A rows return `kind: compilation`
+    with empty `tracks: []` and empty `provenance: []`. Full per-track
+    resolution lands in WXYC/library-metadata-lookup#271.
+    """
+    return BulkResolveResult(
+        kind=BulkResolveResultKind.compilation,
+        library_id=library_id,
+        main=None,
+        method=None,
+        confidence=None,
+        provenance=[],
+        tracks=[],
+    )

--- a/identity/router.py
+++ b/identity/router.py
@@ -1,14 +1,29 @@
 """Identity resolution REST API router.
 
-Provides ``GET /identity/resolve`` and ``POST /identity/bulk`` endpoints
-that query the ``entity.identity`` table in the discogs-cache database.
+Provides:
+
+- ``GET /identity/resolve`` and ``POST /identity/bulk`` — query the
+  ``entity.identity`` table in the discogs-cache database. Used by
+  semantic-index.
+
+- ``POST /api/v1/identity/bulk-resolve-libraries`` — the cross-cache-identity
+  contract endpoint added by WXYC/library-metadata-lookup#272 (per the
+  2026-05-09 pivot, BS#800). Backend POSTs library rows; LML composes
+  per-source provenance into a single verdict per row using the §3.4.1.1
+  rules. Composition lives in ``identity/bulk_resolve.py``.
 """
 
 import logging
 
 from asyncpg.exceptions import PostgresError
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import ValidationError
 
+from generated.api_models import (
+    BulkResolveLibrariesRequest,
+    BulkResolveLibrariesResponse,
+)
+from identity.bulk_resolve import compilation_result, compose_for_identity
 from identity.dependencies import get_entity_store
 from identity.models import (
     BulkIdentityRequest,
@@ -17,9 +32,22 @@ from identity.models import (
 )
 from scripts.entity_resolution.store import EntityStore, Identity
 
+# Lazy imports inside the handler:
+#   wxyc_etl.text.is_compilation_artist — required at handler scope only.
+
+# Per api.yaml: max 1,000 inputs per request; over-cap returns 413.
+_BULK_RESOLVE_INPUT_CAP = 1000
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["identity"])
+
+# Separate router for the `/api/v1/identity/...` surface so `main.py` can
+# attach the LML bearer auth dep here without affecting the open
+# `/identity/resolve` and `/identity/bulk` routes (consumed by
+# semantic-index). The bulk-resolve-libraries endpoint is the only member
+# at the moment; future cross-cache-identity endpoints land here too.
+api_v1_router = APIRouter(tags=["lookup"])
 
 _ENTITY_STORE_UNAVAILABLE_DETAIL = (
     "Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
@@ -111,3 +139,109 @@ async def bulk_resolve_identities(
             unresolved.append(name)
 
     return BulkIdentityResponse(identities=identities, unresolved=unresolved)
+
+
+@api_v1_router.post(
+    "/identity/bulk-resolve-libraries",
+    response_model=BulkResolveLibrariesResponse,
+    summary="Bulk-resolve cross-cache identity for library rows",
+    responses={
+        200: {"description": "Verdicts for every request input, in input order."},
+        401: {"description": "Missing or invalid `LML_API_KEY` bearer token."},
+        413: {"description": "Batch exceeded the 1,000-input cap."},
+        503: {"description": "Entity store not available."},
+    },
+)
+async def bulk_resolve_libraries(
+    http_request: Request,
+    entity_store: EntityStore | None = Depends(get_entity_store),
+) -> BulkResolveLibrariesResponse:
+    """Compose cross-cache-identity verdicts for a batch of library rows.
+
+    Per the 2026-05-09 architecture pivot
+    (WXYC/Backend-Service#800), LML is the sole composer; Backend writes
+    the response verbatim into `library_identity` /
+    `library_identity_source`. Composition follows §3.4.1.1 Rules 2-6
+    (Rule 1 — manual override — is Backend's responsibility).
+
+    Per-input handling:
+
+    - V/A rows (detected via ``wxyc_etl.text.is_compilation_artist`` on
+      ``artist_name``) return ``kind: compilation`` with empty
+      ``tracks: []`` — full track resolution lands in
+      WXYC/library-metadata-lookup#271.
+    - Otherwise we look up ``artist_name`` in ``entity.identity`` and
+      compose per-source provenance via ``identity.bulk_resolve``.
+    - When the lookup misses we return ``kind: unresolved`` so Backend
+      can cache the no-match verdict (with TTL) and avoid re-asking.
+
+    Response order matches request input order, as per the api.yaml
+    contract.
+    """
+    # Lazy import — wxyc_etl is a Rust extension; importing at module load
+    # would couple every importer of this module (e.g. unit tests that
+    # don't touch this endpoint) to the wxyc_etl ABI.
+    from wxyc_etl.text import is_compilation_artist
+
+    # Parse + cap-check manually rather than via a typed body parameter:
+    # the codegen-derived `BulkResolveLibrariesRequest` carries
+    # `max_length=1000` (extracted from api.yaml's `maxItems: 1000`), which
+    # would let Pydantic short-circuit over-cap requests as 422. The
+    # api.yaml contract documents 413 explicitly for cap exceedance, so we
+    # check the raw input count first and raise 413; only then do we run
+    # full per-input validation.
+    try:
+        body = await http_request.json()
+    except (ValueError, TypeError) as e:
+        raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
+    inputs_raw = body.get("inputs")
+    if not isinstance(inputs_raw, list):
+        raise HTTPException(status_code=422, detail="`inputs` must be a JSON array.")
+    if len(inputs_raw) > _BULK_RESOLVE_INPUT_CAP:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Batch exceeded the {_BULK_RESOLVE_INPUT_CAP}-input cap "
+                f"(received {len(inputs_raw)})."
+            ),
+        )
+
+    try:
+        request = BulkResolveLibrariesRequest.model_validate(body)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from None
+
+    store = _require_entity_store(entity_store)
+
+    results = []
+    for input_row in request.inputs:
+        if is_compilation_artist(input_row.artist_name):
+            results.append(compilation_result(input_row.library_id))
+            continue
+
+        try:
+            identity: Identity | None = await store.get_identity(input_row.artist_name)
+        except (PostgresError, OSError):
+            # Fail closed on partial PG failure — the caller cannot
+            # distinguish "row had no identity" from "PG died before this
+            # row was tried". Same posture as ``/identity/bulk``.
+            logger.exception(
+                "Entity store query failed mid-bulk-resolve for library_id=%d artist_name=%r",
+                input_row.library_id,
+                input_row.artist_name,
+            )
+            raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
+
+        try:
+            result = await compose_for_identity(input_row.library_id, identity, store)
+        except (PostgresError, OSError):
+            logger.exception(
+                "Provenance fetch failed mid-bulk-resolve for library_id=%d",
+                input_row.library_id,
+            )
+            raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
+        results.append(result)
+
+    return BulkResolveLibrariesResponse(results=results)

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from core.logging import setup_logging
 from core.sentry import init_sentry
 from discogs.router import router as discogs_router
 from identity.dependencies import close_entity_store
+from identity.router import api_v1_router as identity_api_v1_router
 from identity.router import router as identity_router
 from library.router import router as library_router
 from lookup.router import router as lookup_router
@@ -111,6 +112,14 @@ app.include_router(
     streaming_router, prefix="/api/v1", tags=["streaming"], dependencies=_lml_protected
 )
 app.include_router(release_router, prefix="/api/v1", tags=["release"], dependencies=_lml_protected)
+# `POST /api/v1/identity/bulk-resolve-libraries` (WXYC/library-metadata-lookup#272)
+# — the cross-cache-identity contract endpoint added per the 2026-05-09 pivot
+# (BS#800). Sits under `/api/v1` so it inherits the LML bearer auth posture
+# the open `/identity/{resolve,bulk}` routes do not (those are consumed by
+# semantic-index and locking them down is a separate decision).
+app.include_router(
+    identity_api_v1_router, prefix="/api/v1", tags=["lookup"], dependencies=_lml_protected
+)
 
 if __name__ == "__main__":
     import uvicorn

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -111,6 +111,29 @@ INSERT INTO entity.reconciliation_log (identity_id, source, external_id, confide
 VALUES ($1, $2, $3, $4, $5)\
 """
 
+# Most-recent reconciliation log row per source for a given identity.
+# DISTINCT ON keeps a single row per source, ordered by created_at DESC so we
+# pick the latest attempt — matching the "most recent matcher decision" notion
+# §3.4.1.1 needs to compose from. Sub-0.70 rows are NOT excluded here; the
+# composer applies Rule 6 (sidecar-floor exclusion) separately.
+_LATEST_LOG_BY_SOURCE_SQL = """\
+SELECT DISTINCT ON (source)
+       source, external_id, confidence, method
+FROM entity.reconciliation_log
+WHERE identity_id = $1
+ORDER BY source, created_at DESC\
+"""
+
+
+@dataclass
+class ProvenanceRow:
+    """Most-recent reconciliation log row for one (identity, source) pair."""
+
+    source: str
+    external_id: str
+    confidence: float | None
+    method: str
+
 
 class EntityStore:
     """CRUD interface for the entity identity store.
@@ -197,6 +220,34 @@ class EntityStore:
             status: New reconciliation status value.
         """
         await self._pg.execute(_UPDATE_STATUS_SQL, identity_id, _strip_nul(status))
+
+    async def get_latest_provenance_by_source(self, identity_id: int) -> dict[str, ProvenanceRow]:
+        """Return the most-recent reconciliation_log row per source.
+
+        Used by the bulk-resolve composer (`/api/v1/identity/bulk-resolve-libraries`)
+        to feed §3.4.1.1's composition rules. Keyed by source string
+        (`'discogs'`, `'musicbrainz'`, etc.) so callers can join against the
+        external IDs already stored on `entity.identity`.
+
+        Returns an empty dict on legacy identities that have no log rows;
+        the composer falls back to a default method/confidence in that case
+        (see §3.4.1 — `exact_match` is the documented "deterministic
+        idempotent" tier and matches the pre-pivot semantics where any
+        populated column was treated as a clean exact match).
+        """
+        rows = await self._pg.fetchall(_LATEST_LOG_BY_SOURCE_SQL, identity_id)
+        if not rows:
+            return {}
+        result: dict[str, ProvenanceRow] = {}
+        for row in rows:
+            source = row["source"]
+            result[source] = ProvenanceRow(
+                source=source,
+                external_id=row["external_id"],
+                confidence=row["confidence"],
+                method=row["method"],
+            )
+        return result
 
     async def log_reconciliation(
         self,

--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -1,0 +1,168 @@
+"""Integration tests for `POST /api/v1/identity/bulk-resolve-libraries`.
+
+Exercise the endpoint end-to-end against a fresh PostgreSQL with seeded
+`entity.identity` rows. Composition rules are unit-tested separately;
+this tier confirms the FastAPI wiring + PG round-trip is intact and
+input order is preserved across mixed-kind batches.
+
+Run with: pytest -m pg -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def pg_pool():
+    try:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+    yield pool
+    await pool.close()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_entity_schema(pg_pool):
+    """Create + seed a fresh `entity` schema for each test."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        await conn.execute("CREATE SCHEMA entity")
+        await conn.execute("""
+            CREATE TABLE entity.identity (
+                id SERIAL PRIMARY KEY,
+                library_name TEXT NOT NULL UNIQUE,
+                discogs_artist_id INTEGER,
+                wikidata_qid TEXT,
+                musicbrainz_artist_id TEXT,
+                spotify_artist_id TEXT,
+                apple_music_artist_id TEXT,
+                bandcamp_id TEXT,
+                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE entity.reconciliation_log (
+                id SERIAL PRIMARY KEY,
+                identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
+                source TEXT NOT NULL,
+                external_id TEXT NOT NULL,
+                confidence REAL,
+                method TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """)
+        # Seed a couple of identities representative of WXYC's catalog.
+        await conn.execute(
+            """
+            INSERT INTO entity.identity (library_name, discogs_artist_id, wikidata_qid)
+            VALUES
+                ('Stereolab', 2154, 'Q484464'),
+                ('Juana Molina', 305253, 'Q272615')
+            """
+        )
+    yield
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+
+
+@pytest_asyncio.fixture
+async def app_client(monkeypatch):
+    """ASGI client with the LML app pointed at the test PG."""
+    from httpx import ASGITransport, AsyncClient
+
+    import identity.dependencies as deps
+    from config.settings import get_settings
+
+    monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
+    get_settings.cache_clear()
+    deps._entity_store = None
+    deps._entity_pg = None
+    deps._entity_probe_failed = False
+
+    from main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+    deps._entity_store = None
+    deps._entity_pg = None
+    deps._entity_probe_failed = False
+    get_settings.cache_clear()
+
+
+@pytest.mark.pg
+class TestBulkResolveLibrariesEndpoint:
+    @pytest.mark.asyncio
+    async def test_round_trip_single_artist_against_real_pg(self, app_client):
+        """End-to-end: seeded identity → composed single_artist verdict."""
+        resp = await app_client.post(
+            "/api/v1/identity/bulk-resolve-libraries",
+            json={
+                "inputs": [
+                    {"library_id": 1234, "artist_name": "Stereolab", "album_title": "x"},
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        result = data["results"][0]
+        assert result["kind"] == "single_artist"
+        assert result["library_id"] == 1234
+        assert result["main"]["discogs_artist_id"] == 2154
+        assert result["main"]["wikidata_qid"] == "Q484464"
+        # Two non-inherited sources at legacy default → cross_source_agreement.
+        assert result["method"] == "cross_source_agreement"
+        assert result["confidence"] == 1.0
+        assert len(result["provenance"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_input_order_preserved_across_mixed_kinds(self, app_client):
+        """Response[i] corresponds to inputs[i] for compilation / hit / miss."""
+        resp = await app_client.post(
+            "/api/v1/identity/bulk-resolve-libraries",
+            json={
+                "inputs": [
+                    {"library_id": 100, "artist_name": "Various Artists", "album_title": "VA"},
+                    {"library_id": 200, "artist_name": "Stereolab", "album_title": "AT"},
+                    {"library_id": 300, "artist_name": "Nobody Artist", "album_title": "x"},
+                    {"library_id": 400, "artist_name": "Juana Molina", "album_title": "DOGA"},
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert [r["library_id"] for r in results] == [100, 200, 300, 400]
+        assert [r["kind"] for r in results] == [
+            "compilation",
+            "single_artist",
+            "unresolved",
+            "single_artist",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_413_for_oversized_request(self, app_client):
+        """1001 inputs → 413."""
+        oversized = [
+            {"library_id": i, "artist_name": f"Artist_{i}", "album_title": "x"} for i in range(1001)
+        ]
+        resp = await app_client.post(
+            "/api/v1/identity/bulk-resolve-libraries",
+            json={"inputs": oversized},
+        )
+        assert resp.status_code == 413

--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -125,9 +125,13 @@ class TestBulkResolveLibrariesEndpoint:
         assert result["library_id"] == 1234
         assert result["main"]["discogs_artist_id"] == 2154
         assert result["main"]["wikidata_qid"] == "Q484464"
-        # Two non-inherited sources at legacy default → cross_source_agreement.
-        assert result["method"] == "cross_source_agreement"
-        assert result["confidence"] == 1.0
+        # Log-less identity: both legs default to exact_match 1.00 but are
+        # internally marked is_inherited=True so Rule 3 excludes them from
+        # the cross-source-agreement detector. Composed method is just the
+        # weakest leg's mapped method (exact_match), confidence is MIN
+        # without the boost.
+        assert result["method"] == "exact_match"
+        assert result["confidence"] == pytest.approx(1.0)
         assert len(result["provenance"]) == 2
 
     @pytest.mark.asyncio

--- a/tests/unit/test_bulk_resolve_composer.py
+++ b/tests/unit/test_bulk_resolve_composer.py
@@ -1,0 +1,257 @@
+"""Unit tests for `identity/bulk_resolve.py` composition logic.
+
+Covers the §3.4.1.1 worked-example matrix from
+`WXYC/wiki/plans/library-hook-canonicalization.md`. Rule 1 (manual override)
+is Backend's responsibility per the 2026-05-09 pivot and is NOT tested here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from generated.api_models import (
+    BulkResolveResultKind,
+    IdentityMethod,
+    IdentitySource,
+)
+from identity.bulk_resolve import (
+    AGREEMENT_FLOOR,
+    SIDECAR_FLOOR,
+    compilation_result,
+    compose_for_identity,
+)
+from scripts.entity_resolution.store import Identity, ProvenanceRow
+
+
+def _make_identity(
+    *,
+    id: int = 1,
+    library_name: str = "Stereolab",
+    discogs_artist_id: int | None = None,
+    wikidata_qid: str | None = None,
+    musicbrainz_artist_id: str | None = None,
+    spotify_artist_id: str | None = None,
+    apple_music_artist_id: str | None = None,
+    bandcamp_id: str | None = None,
+) -> Identity:
+    return Identity(
+        id=id,
+        library_name=library_name,
+        discogs_artist_id=discogs_artist_id,
+        wikidata_qid=wikidata_qid,
+        musicbrainz_artist_id=musicbrainz_artist_id,
+        spotify_artist_id=spotify_artist_id,
+        apple_music_artist_id=apple_music_artist_id,
+        bandcamp_id=bandcamp_id,
+        reconciliation_status="reconciled",
+    )
+
+
+def _store(provenance: dict[str, ProvenanceRow] | None = None) -> AsyncMock:
+    """Build an EntityStore mock returning the given provenance map."""
+    store = AsyncMock()
+    store.get_latest_provenance_by_source.return_value = provenance or {}
+    return store
+
+
+@pytest.mark.asyncio
+async def test_unresolved_when_identity_is_none():
+    """Lookup miss → kind=unresolved, main=None, provenance=[]."""
+    result = await compose_for_identity(library_id=42, identity=None, entity_store=_store())
+    assert result.kind is BulkResolveResultKind.unresolved
+    assert result.library_id == 42
+    assert result.main is None
+    assert result.method is None
+    assert result.confidence is None
+    assert result.provenance == []
+    assert result.tracks is None
+
+
+@pytest.mark.asyncio
+async def test_single_source_exact_match_legacy_default():
+    """One populated column + no log rows → exact_match 1.00 (legacy default).
+
+    Mirrors the §3.4.1.1 example: "One source `exact_match` 1.00; others
+    NULL → exact_match 1.00".
+    """
+    identity = _make_identity(discogs_artist_id=2154)
+    result = await compose_for_identity(library_id=10, identity=identity, entity_store=_store())
+
+    assert result.kind is BulkResolveResultKind.single_artist
+    assert result.method is IdentityMethod.exact_match
+    assert result.confidence == 1.00
+    assert result.main is not None
+    assert result.main.discogs_artist_id == 2154
+    assert len(result.provenance) == 1
+    prov = result.provenance[0]
+    assert prov.source is IdentitySource.discogs
+    assert prov.method is IdentityMethod.exact_match
+    assert prov.confidence == 1.00
+    assert prov.external_id == "2154"
+
+
+@pytest.mark.asyncio
+async def test_two_sources_no_log_rows_triggers_agreement_boost():
+    """Two populated columns at legacy default 1.00 → cross_source_agreement 1.00.
+
+    The pre-pivot data has no per-source log rows, so both legs default
+    to exact_match 1.00. Two non-inherited sources => Rule 2 boost.
+    Worked example: "Three sources, all exact_match 1.00, all cross-ref →
+    cross_source_agreement 1.00".
+    """
+    identity = _make_identity(
+        discogs_artist_id=2154,
+        wikidata_qid="Q484464",
+    )
+    result = await compose_for_identity(library_id=11, identity=identity, entity_store=_store())
+
+    assert result.kind is BulkResolveResultKind.single_artist
+    assert result.method is IdentityMethod.cross_source_agreement
+    assert result.confidence == 1.00
+    assert len(result.provenance) == 2
+
+
+@pytest.mark.asyncio
+async def test_min_of_confidences_when_no_agreement():
+    """One inherited + one independent source → no agreement, MIN wins.
+
+    Rule 3: inherited rows can't trigger cross-source agreement. Rule 4:
+    main confidence is MIN of per-source confidences.
+    """
+    identity = _make_identity(
+        discogs_artist_id=2154,
+        wikidata_qid="Q484464",
+    )
+    provenance = {
+        "discogs": ProvenanceRow(
+            source="discogs", external_id="2154", confidence=1.00, method="exact_match"
+        ),
+        "wikidata": ProvenanceRow(
+            source="wikidata", external_id="Q484464", confidence=0.80, method="inherited"
+        ),
+    }
+    result = await compose_for_identity(
+        library_id=12, identity=identity, entity_store=_store(provenance)
+    )
+
+    # Only one non-inherited source → no agreement boost (Rule 2 + Rule 3).
+    assert result.method is not IdentityMethod.cross_source_agreement
+    # Rule 4: MIN of confidences (1.0 and 0.8 both above floor)
+    assert result.confidence == 0.80
+    # The inherited row is the "weakest" so its method bubbles up — but
+    # `inherited` isn't an api.yaml enum value, so we map it to the
+    # legacy default (exact_match) for the per-source row. The composer
+    # picks the weakest row's mapped method.
+    assert result.method is IdentityMethod.exact_match
+    assert len(result.provenance) == 2
+
+
+@pytest.mark.asyncio
+async def test_two_independent_legs_with_name_variation_lifts_to_agreement_floor():
+    """Worked example: exact_match 1.00 + name_variation 0.92 with cross-ref.
+
+    Per §3.4.1.1: "cross_source_agreement 0.95 (Rule 2: MAX(0.95,
+    MIN(1.00, 0.92))=0.95)". The composer's heuristic treats two
+    non-inherited per-source rows as agreement.
+    """
+    identity = _make_identity(
+        discogs_artist_id=12345,
+        musicbrainz_artist_id="abc-def",
+    )
+    provenance = {
+        "discogs": ProvenanceRow(
+            source="discogs", external_id="12345", confidence=1.00, method="exact_match"
+        ),
+        "musicbrainz": ProvenanceRow(
+            source="musicbrainz",
+            external_id="abc-def",
+            confidence=0.92,
+            method="name_variation",
+        ),
+    }
+    result = await compose_for_identity(
+        library_id=13, identity=identity, entity_store=_store(provenance)
+    )
+
+    assert result.method is IdentityMethod.cross_source_agreement
+    assert result.confidence == AGREEMENT_FLOOR  # max(0.95, min(1.0, 0.92)) = 0.95
+    # Per-source rows keep their honest confidences.
+    by_source = {p.source: p for p in result.provenance}
+    assert by_source[IdentitySource.discogs].confidence == 1.00
+    assert by_source[IdentitySource.discogs].method is IdentityMethod.exact_match
+    assert by_source[IdentitySource.musicbrainz].confidence == 0.92
+    assert by_source[IdentitySource.musicbrainz].method is IdentityMethod.name_variation
+
+
+@pytest.mark.asyncio
+async def test_sub_floor_source_dropped_via_rule_6():
+    """One source above floor + one below → only the above-floor row appears.
+
+    Rule 6: per-source rows with confidence < 0.70 don't appear in the
+    sidecar. This drops the noisy LLM leg from `provenance`.
+    """
+    identity = _make_identity(
+        discogs_artist_id=12345,
+        spotify_artist_id="abc",
+    )
+    provenance = {
+        "discogs": ProvenanceRow(
+            source="discogs", external_id="12345", confidence=1.00, method="exact_match"
+        ),
+        "spotify": ProvenanceRow(
+            source="spotify", external_id="abc", confidence=0.55, method="llm"
+        ),
+    }
+    result = await compose_for_identity(
+        library_id=14, identity=identity, entity_store=_store(provenance)
+    )
+
+    assert result.kind is BulkResolveResultKind.single_artist
+    # Only one source survives Rule 6 → no agreement boost, MIN==1.00.
+    assert result.confidence == 1.00
+    assert result.method is IdentityMethod.exact_match
+    assert len(result.provenance) == 1
+    assert result.provenance[0].source is IdentitySource.discogs
+    # The Spotify ID was filtered out — main should not carry it.
+    assert result.main.spotify_artist_id is None
+
+
+@pytest.mark.asyncio
+async def test_all_sources_below_floor_returns_unresolved():
+    """All log rows sub-floor → no rows survive Rule 6 → kind=unresolved."""
+    identity = _make_identity(discogs_artist_id=12345)
+    provenance = {
+        "discogs": ProvenanceRow(
+            source="discogs", external_id="12345", confidence=0.50, method="llm"
+        ),
+    }
+    result = await compose_for_identity(
+        library_id=15, identity=identity, entity_store=_store(provenance)
+    )
+
+    assert result.kind is BulkResolveResultKind.unresolved
+    assert result.main is None
+    assert result.method is None
+    assert result.confidence is None
+    assert result.provenance == []
+
+
+@pytest.mark.asyncio
+async def test_compilation_result_shape():
+    """compilation_result returns kind=compilation, tracks=[], provenance=[]."""
+    result = compilation_result(library_id=99)
+    assert result.kind is BulkResolveResultKind.compilation
+    assert result.library_id == 99
+    assert result.main is None
+    assert result.method is None
+    assert result.confidence is None
+    assert result.provenance == []
+    assert result.tracks == []
+
+
+def test_floors_are_what_the_spec_says():
+    """Sanity-check the floor constants haven't drifted from the spec."""
+    assert SIDECAR_FLOOR == 0.70  # §3.4.1.1 Rule 6
+    assert AGREEMENT_FLOOR == 0.95  # §3.4.1.1 Rule 2 / §3.4.1 matrix

--- a/tests/unit/test_bulk_resolve_composer.py
+++ b/tests/unit/test_bulk_resolve_composer.py
@@ -93,13 +93,19 @@ async def test_single_source_exact_match_legacy_default():
 
 
 @pytest.mark.asyncio
-async def test_two_sources_no_log_rows_triggers_agreement_boost():
-    """Two populated columns at legacy default 1.00 → cross_source_agreement 1.00.
+async def test_two_sources_no_log_rows_do_not_trigger_agreement_boost():
+    """Two populated columns at legacy default → no Rule 2 boost.
 
-    The pre-pivot data has no per-source log rows, so both legs default
-    to exact_match 1.00. Two non-inherited sources => Rule 2 boost.
-    Worked example: "Three sources, all exact_match 1.00, all cross-ref →
-    cross_source_agreement 1.00".
+    Log-less identities are marked `is_inherited=True` internally so the
+    cross-source-agreement detector (Rule 3) excludes them. Without that
+    gate, every legacy identity with ≥2 populated columns would inflate
+    to ≥0.95 — defeating the post-#207/#216/#217/#218 propagation work,
+    where many MBID/Spotify legs land via inheritance rather than
+    independent matchers.
+
+    Wire-format: still `exact_match` per leg with confidence 1.00 (the
+    populated column is treated as authoritative); composed method is
+    just the weakest leg's method (here, `exact_match`).
     """
     identity = _make_identity(
         discogs_artist_id=2154,
@@ -108,8 +114,12 @@ async def test_two_sources_no_log_rows_triggers_agreement_boost():
     result = await compose_for_identity(library_id=11, identity=identity, entity_store=_store())
 
     assert result.kind is BulkResolveResultKind.single_artist
-    assert result.method is IdentityMethod.cross_source_agreement
-    assert result.confidence == 1.00
+    # Composed method is the weakest leg's method; both legs are
+    # exact_match per the legacy default.
+    assert result.method is IdentityMethod.exact_match
+    # MIN of (1.00, 1.00) without the agreement boost.
+    assert result.confidence == pytest.approx(1.00)
+    # Both per-source rows still appear in provenance (above SIDECAR_FLOOR).
     assert len(result.provenance) == 2
 
 
@@ -183,6 +193,44 @@ async def test_two_independent_legs_with_name_variation_lifts_to_agreement_floor
     assert by_source[IdentitySource.discogs].method is IdentityMethod.exact_match
     assert by_source[IdentitySource.musicbrainz].confidence == 0.92
     assert by_source[IdentitySource.musicbrainz].method is IdentityMethod.name_variation
+
+
+@pytest.mark.asyncio
+async def test_four_source_legacy_identity_does_not_inflate_via_rule_2():
+    """Regression: a 4-source log-less legacy identity must NOT inflate.
+
+    Pre-fix, four populated columns with no reconciliation_log entries
+    would default to exact_match 1.00 each, all four would count as
+    independent (`is_inherited=False`), Rule 2 would trigger, and the
+    composed confidence would land at MAX(0.95, 1.00) = 1.00 with method
+    `cross_source_agreement` — falsely claiming positive cross-reference
+    evidence on legacy data that has none.
+
+    Post-fix, log-less legs are marked `is_inherited=True` internally so
+    Rule 3 excludes them, the agreement detector returns False, and the
+    composer falls through to Rule 4 (MIN-of-confidences with the weakest
+    leg's method).
+    """
+    identity = _make_identity(
+        discogs_artist_id=12345,
+        musicbrainz_artist_id="mb-abc",
+        wikidata_qid="Q12345",
+        spotify_artist_id="spotify-xyz",
+    )
+    # No provenance log rows at all — pure legacy data.
+    result = await compose_for_identity(library_id=42, identity=identity, entity_store=_store())
+
+    assert result.kind is BulkResolveResultKind.single_artist
+    assert result.method is IdentityMethod.exact_match
+    assert result.confidence == pytest.approx(1.00)
+    # All four sources populated and present in provenance.
+    assert len(result.provenance) == 4
+    assert {p.source for p in result.provenance} == {
+        IdentitySource.discogs,
+        IdentitySource.musicbrainz,
+        IdentitySource.wikidata,
+        IdentitySource.spotify,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -1,0 +1,255 @@
+"""Unit tests for `POST /api/v1/identity/bulk-resolve-libraries`.
+
+Exercises the FastAPI endpoint with mocked dependencies. Composition
+internals are covered separately in `test_bulk_resolve_composer.py`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from scripts.entity_resolution.store import Identity
+from tests.unit.conftest import override_deps
+
+
+@pytest.fixture
+def mock_entity_store():
+    store = AsyncMock()
+    return store
+
+
+@pytest.fixture
+def app_client(mock_settings, mock_entity_store):
+    from config.settings import get_settings
+    from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+    from identity.dependencies import get_entity_store
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: None,
+            get_posthog_client: None,
+            get_settings: mock_settings,
+            get_entity_store: mock_entity_store,
+        },
+    ):
+        yield app
+
+
+def _identity(
+    library_name: str,
+    *,
+    id: int = 1,
+    discogs_artist_id: int | None = None,
+    wikidata_qid: str | None = None,
+) -> Identity:
+    return Identity(
+        id=id,
+        library_name=library_name,
+        discogs_artist_id=discogs_artist_id,
+        wikidata_qid=wikidata_qid,
+        musicbrainz_artist_id=None,
+        spotify_artist_id=None,
+        apple_music_artist_id=None,
+        bandcamp_id=None,
+        reconciliation_status="reconciled",
+    )
+
+
+class TestBulkResolveLibrariesEndpoint:
+    @pytest.mark.asyncio
+    async def test_single_artist_returns_main_and_provenance(self, app_client, mock_entity_store):
+        """A populated identity → kind=single_artist with ReconciledIdentity main."""
+        mock_entity_store.get_identity.return_value = _identity(
+            "Stereolab", id=1, discogs_artist_id=2154, wikidata_qid="Q484464"
+        )
+        mock_entity_store.get_latest_provenance_by_source.return_value = {}
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={
+                    "inputs": [
+                        {
+                            "library_id": 1234,
+                            "artist_name": "Stereolab",
+                            "album_title": "Aluminum Tunes",
+                        }
+                    ]
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["results"]) == 1
+        result = data["results"][0]
+        assert result["kind"] == "single_artist"
+        assert result["library_id"] == 1234
+        assert result["main"]["discogs_artist_id"] == 2154
+        assert result["main"]["wikidata_qid"] == "Q484464"
+        assert len(result["provenance"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_compilation_kind_for_va_artist_name(self, app_client, mock_entity_store):
+        """`Various Artists` artist_name → kind=compilation, no entity lookup."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={
+                    "inputs": [
+                        {
+                            "library_id": 5678,
+                            "artist_name": "Various Artists",
+                            "album_title": "Edits",
+                        }
+                    ]
+                },
+            )
+
+        assert resp.status_code == 200
+        result = resp.json()["results"][0]
+        assert result["kind"] == "compilation"
+        assert result["library_id"] == 5678
+        assert result["main"] is None
+        assert result["provenance"] == []
+        assert result["tracks"] == []
+        # V/A short-circuits the entity lookup — should never call get_identity.
+        mock_entity_store.get_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unresolved_when_identity_missing(self, app_client, mock_entity_store):
+        """No entity row for the artist → kind=unresolved."""
+        mock_entity_store.get_identity.return_value = None
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={
+                    "inputs": [
+                        {
+                            "library_id": 9999,
+                            "artist_name": "Some Obscure Artist",
+                            "album_title": "An Album",
+                        }
+                    ]
+                },
+            )
+
+        assert resp.status_code == 200
+        result = resp.json()["results"][0]
+        assert result["kind"] == "unresolved"
+        assert result["library_id"] == 9999
+        assert result["main"] is None
+        assert result["method"] is None
+        assert result["confidence"] is None
+        assert result["provenance"] == []
+
+    @pytest.mark.asyncio
+    async def test_response_order_matches_request_order(self, app_client, mock_entity_store):
+        """Mixed inputs → results array preserves input order."""
+
+        async def get_identity(name: str):
+            mapping = {"Stereolab": _identity("Stereolab", id=1, discogs_artist_id=1)}
+            return mapping.get(name)
+
+        mock_entity_store.get_identity.side_effect = get_identity
+        mock_entity_store.get_latest_provenance_by_source.return_value = {}
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={
+                    "inputs": [
+                        {"library_id": 1, "artist_name": "Various Artists", "album_title": "VA"},
+                        {"library_id": 2, "artist_name": "Stereolab", "album_title": "AT"},
+                        {"library_id": 3, "artist_name": "Nobody", "album_title": "x"},
+                    ]
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        kinds = [r["kind"] for r in data["results"]]
+        ids = [r["library_id"] for r in data["results"]]
+        assert kinds == ["compilation", "single_artist", "unresolved"]
+        assert ids == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_413_when_over_input_cap(self, app_client, mock_entity_store):
+        """1001+ inputs → 413, not 422 (per api.yaml)."""
+        oversized = [
+            {"library_id": i, "artist_name": f"Artist_{i}", "album_title": "x"} for i in range(1001)
+        ]
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={"inputs": oversized},
+            )
+
+        assert resp.status_code == 413
+        # Cap-check fires before any DB work.
+        mock_entity_store.get_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_503_when_entity_store_unavailable(self, mock_settings):
+        """Endpoint mirrors `/identity/*` 503 posture when the store isn't ready."""
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from identity.dependencies import get_entity_store
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+                get_entity_store: None,
+            },
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                resp = await ac.post(
+                    "/api/v1/identity/bulk-resolve-libraries",
+                    json={
+                        "inputs": [
+                            {
+                                "library_id": 1,
+                                "artist_name": "Stereolab",
+                                "album_title": "x",
+                            }
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_422_for_validation_error(self, app_client, mock_entity_store):
+        """Missing required field per-input → 422 (Pydantic validation)."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={"inputs": [{"library_id": 1, "artist_name": "Stereolab"}]},
+            )
+
+        assert resp.status_code == 422
+        mock_entity_store.get_identity.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -544,7 +544,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.6" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
-    { name = "wxyc-etl", specifier = ">=0.2.0" },
+    { name = "wxyc-etl", specifier = ">=0.3.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1254,15 +1254,15 @@ wheels = [
 
 [[package]]
 name = "wxyc-etl"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-json-logger" },
     { name = "sentry-sdk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/2b/456c14ace24a8436eee473dfd3279a2ebc10739541795ce0b1cc55859d6e/wxyc_etl-0.2.0.tar.gz", hash = "sha256:27f22e88aaa4d1aa2d58b235b9d912816fb94e79f213f7302aa3ceb1ba2fc7ae", size = 126611, upload-time = "2026-05-06T05:26:59.598Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/d6/435c772f6454b9f5211f2586d43bd0013f450cd26244b8d2fac1798d10c3/wxyc_etl-0.3.0.tar.gz", hash = "sha256:25d2deb6dc668d4f558a10ff471a9ad4d1905894d01160f8e0c871e112807a58", size = 146608, upload-time = "2026-05-07T05:22:37.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/7b04ce851ccb8d78b38fc52561b13908527a276fc64115eea4e6fc14a9a0/wxyc_etl-0.2.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7e1c033c27e3b5414aa92964526bc51b1d7440a0fe070f0ef43502f9f9440091", size = 790009, upload-time = "2026-05-06T05:26:55.337Z" },
-    { url = "https://files.pythonhosted.org/packages/52/34/ec077356c1eb071583c7f3858f9c19fd8d2c7ad2525e152acd05321ed51f/wxyc_etl-0.2.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d69370e8fac4a22af294c10bde8b400817715331f4f4e1e848858411ffaa7ff", size = 824551, upload-time = "2026-05-06T05:26:56.818Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/0f/fec4b411456cbcbc08788b64ae751573627129d5b521df2505866c107df6/wxyc_etl-0.2.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffb034d439b4acf0510e283a4a67b58e72a4249bdaf1e3bb36452722cdd4d6ab", size = 1050818, upload-time = "2026-05-06T05:26:58.405Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2e/f1f55077a7d6b642239e896d16551056cbf3e33a591fdb1d0f1191aaf9ef/wxyc_etl-0.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:3ac1bdb3793a62f3a8614916fca3313e7b817654c752638c479bb1547f387d9c", size = 843237, upload-time = "2026-05-07T05:22:32.836Z" },
+    { url = "https://files.pythonhosted.org/packages/66/29/0417b4e2e87daffbc46189f09096ca08c10b3652b96ede0bb4fa709986e0/wxyc_etl-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edd6a667e708ccef484d53a9eb989b98bf0392dbbb276aa7e0835c7efae3dc6f", size = 877235, upload-time = "2026-05-07T05:22:34.477Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1a/9c7838d53aadddfd817c1150c421021b0ad2d74049fe5893d719e8ea9f5d/wxyc_etl-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18fbd7e7f21ece1eb2062411904c0c29cc2c38706fb865ee89c7fe6c3d832a71", size = 1102639, upload-time = "2026-05-07T05:22:35.676Z" },
 ]


### PR DESCRIPTION
## Summary

- New endpoint per the [2026-05-09 cross-cache-identity pivot](https://github.com/WXYC/Backend-Service/pull/800). LML composes per-source provenance via §3.4.1.1 Rules 2–6 and returns one verdict per input (`kind: single_artist | compilation | unresolved`).
- Contract is locked at `wxyc-shared/api.yaml` v1.2.0 (merged in [WXYC/wxyc-shared#104](https://github.com/WXYC/wxyc-shared/pull/104)). This PR ships the seven `BulkResolve*` Pydantic models (regenerated via `scripts/generate_api_models.sh`), the FastAPI handler, the composition logic in `identity/bulk_resolve.py`, and the `EntityStore.get_latest_provenance_by_source()` reader needed for honest method/confidence at compose time.
- Unblocks WXYC/library-metadata-lookup#271 (V/A track resolution) and WXYC/Backend-Service#802 (Backend consumer).

## Decisions flagged for review

1. **Cross-source agreement detector (`identity/bulk_resolve.py:175-195`)**: pragmatic proxy — `≥2 non-inherited per-source rows` rather than verifying via wikidata-cache `discogs_mapping`. Permissive direction; wire format is unchanged when the detector tightens. TODO comment points at #271 follow-up.
2. **`exact_match` 1.00 default for log-less identities (`bulk_resolve.py:60-65`)**: when `entity.identity` has populated columns but no `reconciliation_log` row, default is `exact_match` 1.00. May overstate confidence on legacy IDs; tunable in a follow-up after observing production behavior.
3. **413 vs 422 for over-cap**: codegen extracts `maxItems: 1000` as Pydantic `max_length`, which would normally produce 422. Worked around by reading raw JSON for the count check before `model_validate()` so the 413 from api.yaml wins. Spec-compliant, slightly less idiomatic.
4. **`BulkResolveProvenanceEntry.confidence` codegen quirk**: datamodel-codegen drops `nullable: true`. Sidestepped by never emitting "leg-ran-no-match" entries — empty `provenance: []` carries that meaning per api.yaml description. No hand-edit of generated code.

## Test plan

- [x] `bash scripts/generate_api_models.sh` regenerates clean (all `BulkResolve*` schemas land)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — clean (245 source files)
- [x] `uv run pytest tests/unit/ -v` — 1652 passed (incl. 16 new bulk-resolve unit tests)
- [x] `uv run pytest -m pg -v` — 74 passed (incl. 3 new round-trip integration tests)
- [x] Default `pytest -q` — 1889 passed
- [ ] Backend-side staging integration (BS#802 picks this up next)

Closes #272