### PR TITLE
identity/bulk-resolve-libraries: canonical-form lookup for entity.identity

### DIFF
--- a/identity/normalize.py
+++ b/identity/normalize.py
@@ -1,0 +1,77 @@
+"""Artist-name canonicalization for the cross-cache-identity bulk lookup.
+
+Issue WXYC/library-metadata-lookup#274 — `POST /api/v1/identity/bulk-resolve-libraries`
+looks up ``entity.identity.library_name`` via exact match. Backend posts
+``library.artist_name`` verbatim from its denormalized column, so any
+divergence from the stored canonical form would surface as a silent
+unresolved verdict.
+
+This module implements **approach 2** from the issue: pre-canonicalize the
+input in LML and exact-match against the stored canonical form. The bridge
+holds until the Postgres analog of ``wxyc_etl::text::to_identity_match_form``
+ships (plan §3.3 step 4), at which point the lookup can move to a
+``WHERE wxyc_norm_artist(library_name) = wxyc_norm_artist($1)`` functional
+index and the dependency on stored-row canonicality goes away.
+
+The canonical form layered here on top of
+``wxyc_etl.text.to_identity_match_form`` adds two extra folds that the
+shared normalizer does not yet do but the issue lists as observed
+divergence vectors:
+
+- Smart-quote / modifier-letter apostrophe folds (`’`, `‘`, `ʼ` → `'`).
+- Conjunction fold (``Sleater & Kinney`` ↔ ``Sleater and Kinney``).
+
+Whitespace runs collapse to a single ASCII space, and the result is
+lower-cased + leading/trailing-trimmed by ``to_identity_match_form``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from wxyc_etl.text import to_identity_match_form
+
+# Curly / modifier apostrophes that Backend's column may carry. Mapped to
+# ASCII apostrophe U+0027 so ``Don't`` and ``Don’t`` resolve to the same row.
+# Kept narrow on purpose — only apostrophe-shaped marks. Double-quote
+# variants would land in a different equivalence class and are not the
+# divergence vector the issue lists.
+_APOSTROPHE_FOLD = str.maketrans(
+    {
+        "‘": "'",  # LEFT SINGLE QUOTATION MARK
+        "’": "'",  # RIGHT SINGLE QUOTATION MARK
+        "ʼ": "'",  # MODIFIER LETTER APOSTROPHE
+        "ʹ": "'",  # MODIFIER LETTER PRIME
+    }
+)
+
+# ``&`` is the conjunction fold key when it sits between whitespace
+# (``Sleater & Kinney``). When it's glued to a token (``M&M``, ``A&E``)
+# it's typographic, not the conjunction, so we leave it alone.
+_AMPERSAND_CONJUNCTION_RE = re.compile(r"\s+&\s+")
+
+# Final whitespace pass. ``to_identity_match_form`` trims and lowercases,
+# but does not collapse interior runs introduced by upstream folds.
+_WHITESPACE_RUN_RE = re.compile(r"\s+")
+
+
+def canonicalize_for_identity_lookup(name: str) -> str:
+    """Return the canonical form of ``name`` for ``entity.identity`` lookups.
+
+    Layered transform:
+
+    1. Apostrophe fold (curly / modifier → ASCII).
+    2. Conjunction fold (`` & `` → `` and ``).
+    3. ``wxyc_etl.text.to_identity_match_form`` (NFKC, lowercase, diacritic
+       strip, trailing-paren strip, leading-article drop).
+    4. Whitespace-run collapse.
+
+    Accepts the empty string (returns ``""``) so callers don't need to guard
+    optional-string inputs. Idempotent.
+    """
+    if not name:
+        return ""
+    folded = name.translate(_APOSTROPHE_FOLD)
+    folded = _AMPERSAND_CONJUNCTION_RE.sub(" and ", folded)
+    normalized = to_identity_match_form(folded)
+    return _WHITESPACE_RUN_RE.sub(" ", normalized).strip()

--- a/identity/normalize.py
+++ b/identity/normalize.py
@@ -18,11 +18,25 @@ The canonical form layered here on top of
 shared normalizer does not yet do but the issue lists as observed
 divergence vectors:
 
-- Smart-quote / modifier-letter apostrophe folds (`’`, `‘`, `ʼ` → `'`).
+- Apostrophe-class fold (`’`, `‘`, `ʼ`, `ʹ` → `'`). Scope is single-quote
+  shapes only — double-quote pairs (`“ ”`), guillemets (`« »`), and
+  quotation-dash variants are not folded, on the assumption that they
+  don't appear as artist-name divergence vectors in the WXYC catalog.
+  If a future divergence audit (e.g., the BS#802 rollout report) surfaces
+  hits for those, widen the fold here.
 - Conjunction fold (``Sleater & Kinney`` ↔ ``Sleater and Kinney``).
+  Keyed on whitespace around ASCII ``&`` only. Fullwidth ``＆`` (U+FF06)
+  does **not** fold to ``and`` here — NFKC inside ``to_identity_match_form``
+  runs after this regex, so the fullwidth form normalizes to ASCII ``&``
+  too late to catch. The case is exotic enough for WXYC's catalog that we
+  lock the limitation rather than complicate the layering; see
+  ``tests/unit/test_identity_normalize.py::test_fullwidth_ampersand_not_folded``.
 
 Whitespace runs collapse to a single ASCII space, and the result is
 lower-cased + leading/trailing-trimmed by ``to_identity_match_form``.
+``\\s+`` matches Unicode whitespace (NBSP, thin space, etc.) — Backend's
+column has carried those when artist names were pasted from rich-text
+sources.
 """
 
 from __future__ import annotations

--- a/identity/router.py
+++ b/identity/router.py
@@ -222,7 +222,14 @@ async def bulk_resolve_libraries(
             continue
 
         try:
-            identity: Identity | None = await store.get_identity(input_row.artist_name)
+            # Canonical-form lookup (issue #274): Backend posts
+            # `library.artist_name` verbatim from its denormalized column, so
+            # diacritic / smart-quote / `&`-vs-`and` / case / whitespace drift
+            # from the stored canonical key would otherwise surface as silent
+            # unresolved verdicts. `get_identity_canonical` applies
+            # `identity.normalize.canonicalize_for_identity_lookup` before the
+            # exact-match SQL.
+            identity: Identity | None = await store.get_identity_canonical(input_row.artist_name)
         except (PostgresError, OSError):
             # Fail closed on partial PG failure — the caller cannot
             # distinguish "row had no identity" from "PG died before this

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -166,6 +166,16 @@ class EntityStore:
         query — same WX-3.B boundary policy as the read paths in this class
         (see ``_strip_nul`` for the rationale).
 
+        Asymmetry note (WXYC/library-metadata-lookup#274 follow-up): this
+        method writes ``library_name`` verbatim, but ``get_identity_canonical``
+        reads with a canonical-form lookup. The read-side bridge depends on
+        stored rows already being canonical (post-#207/#216/#217/#218
+        reconciliation). New ingestion runs that call this method directly
+        will re-introduce non-canonical rows unless callers canonicalize
+        upstream. Tracked under the planned plan §3.3 step 4 work, which
+        will move canonicalization into a Postgres functional-index and
+        moot the asymmetry.
+
         Returns:
             The upserted Identity, or None if the query failed.
         """
@@ -224,6 +234,10 @@ class EntityStore:
         # (semantic-index via /identity/bulk still gets the exact-match shape).
         from identity.normalize import canonicalize_for_identity_lookup
 
+        # `_strip_nul` returns `str | None`; the `or ""` is needed because
+        # `canonicalize_for_identity_lookup` expects `str`. The None branch is
+        # unreachable in practice (signature is `str`) but kept for type-checker
+        # symmetry with the rest of this class.
         canonical = canonicalize_for_identity_lookup(_strip_nul(library_name) or "")
         record = await self._pg.fetchone(_GET_IDENTITY_SQL, canonical)
         if record is None:

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -198,6 +198,38 @@ class EntityStore:
             return None
         return _record_to_identity(record)
 
+    async def get_identity_canonical(self, library_name: str) -> Identity | None:
+        """Look up an identity by a non-canonical artist name.
+
+        Pre-canonicalizes ``library_name`` via
+        ``identity.normalize.canonicalize_for_identity_lookup`` and exact-matches
+        the canonical form against ``entity.identity.library_name``. This is the
+        approach-2 bridge from WXYC/library-metadata-lookup#274: it collapses
+        the divergence vectors Backend's denormalized ``library.artist_name``
+        column carries (diacritics, smart quotes, ``&`` vs ``and``, case,
+        whitespace) into a single canonical key.
+
+        Correctness assumes the stored ``library_name`` is itself in the same
+        canonical form — true post-reconciliation runs #207/#216/#217/#218.
+        When the Postgres analog of ``to_identity_match_form`` lands
+        (plan §3.3 step 4), this method's SQL can be swapped for a
+        ``WHERE wxyc_norm_artist(library_name) = wxyc_norm_artist($1)``
+        functional-index query and the stored-canonicality assumption drops.
+
+        Returns:
+            The matching Identity, or None if no canonical row exists.
+        """
+        # Local import keeps the wxyc_etl Rust extension off the module-load
+        # path for store consumers that don't use the bulk-resolve handler
+        # (semantic-index via /identity/bulk still gets the exact-match shape).
+        from identity.normalize import canonicalize_for_identity_lookup
+
+        canonical = canonicalize_for_identity_lookup(_strip_nul(library_name) or "")
+        record = await self._pg.fetchone(_GET_IDENTITY_SQL, canonical)
+        if record is None:
+            return None
+        return _record_to_identity(record)
+
     async def get_identities_by_status(self, status: str) -> list[Identity]:
         """Return all identities with the given reconciliation status.
 

--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -66,12 +66,17 @@ async def set_up_entity_schema(pg_pool):
             )
         """)
         # Seed a couple of identities representative of WXYC's catalog.
+        # Per #274's approach-2 bridge: `library_name` is stored in canonical
+        # form (lowercase, no diacritics, ``and`` conjunction, ASCII quotes) —
+        # the same shape `identity.normalize.canonicalize_for_identity_lookup`
+        # emits — so the bulk-resolve-libraries handler's canonical lookup
+        # resolves whatever non-canonical variant Backend posts.
         await conn.execute(
             """
             INSERT INTO entity.identity (library_name, discogs_artist_id, wikidata_qid)
             VALUES
-                ('Stereolab', 2154, 'Q484464'),
-                ('Juana Molina', 305253, 'Q272615')
+                ('stereolab', 2154, 'Q484464'),
+                ('juana molina', 305253, 'Q272615')
             """
         )
     yield
@@ -158,6 +163,46 @@ class TestBulkResolveLibrariesEndpoint:
             "unresolved",
             "single_artist",
         ]
+
+    @pytest.mark.asyncio
+    async def test_canonical_lookup_collapses_divergence_vectors(self, app_client, pg_pool):
+        """Per #274: diverged inputs resolve to the same canonical-form row.
+
+        Seeds three identities in canonical form (lowercase, no diacritics,
+        ``and`` conjunction, ASCII apostrophe) and posts non-canonical
+        variants. Each should land on its canonical row instead of returning
+        ``unresolved`` — the silent miss-rate driver flagged by #273's review.
+        """
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO entity.identity (library_name, discogs_artist_id)
+                VALUES
+                    ('nilufer yanya', 5499521),
+                    ('sleater and kinney', 99999),
+                    ('don''t stop', 88888)
+                """
+            )
+
+        resp = await app_client.post(
+            "/api/v1/identity/bulk-resolve-libraries",
+            json={
+                "inputs": [
+                    {"library_id": 1, "artist_name": "Nilüfer Yanya", "album_title": "x"},
+                    {"library_id": 2, "artist_name": "Sleater & Kinney", "album_title": "x"},
+                    {"library_id": 3, "artist_name": "Don’t Stop", "album_title": "x"},
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        kinds = [r["kind"] for r in results]
+        # Pre-#274 every one of these would have been `unresolved`.
+        assert kinds == ["single_artist", "single_artist", "single_artist"]
+        assert results[0]["main"]["discogs_artist_id"] == 5499521
+        assert results[1]["main"]["discogs_artist_id"] == 99999
+        assert results[2]["main"]["discogs_artist_id"] == 88888
 
     @pytest.mark.asyncio
     async def test_413_for_oversized_request(self, app_client):

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -65,7 +65,7 @@ class TestBulkResolveLibrariesEndpoint:
     @pytest.mark.asyncio
     async def test_single_artist_returns_main_and_provenance(self, app_client, mock_entity_store):
         """A populated identity → kind=single_artist with ReconciledIdentity main."""
-        mock_entity_store.get_identity.return_value = _identity(
+        mock_entity_store.get_identity_canonical.return_value = _identity(
             "Stereolab", id=1, discogs_artist_id=2154, wikidata_qid="Q484464"
         )
         mock_entity_store.get_latest_provenance_by_source.return_value = {}
@@ -123,12 +123,12 @@ class TestBulkResolveLibrariesEndpoint:
         assert result["provenance"] == []
         assert result["tracks"] == []
         # V/A short-circuits the entity lookup — should never call get_identity.
-        mock_entity_store.get_identity.assert_not_awaited()
+        mock_entity_store.get_identity_canonical.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_unresolved_when_identity_missing(self, app_client, mock_entity_store):
         """No entity row for the artist → kind=unresolved."""
-        mock_entity_store.get_identity.return_value = None
+        mock_entity_store.get_identity_canonical.return_value = None
 
         async with AsyncClient(
             transport=ASGITransport(app=app_client), base_url="http://test"
@@ -163,7 +163,7 @@ class TestBulkResolveLibrariesEndpoint:
             mapping = {"Stereolab": _identity("Stereolab", id=1, discogs_artist_id=1)}
             return mapping.get(name)
 
-        mock_entity_store.get_identity.side_effect = get_identity
+        mock_entity_store.get_identity_canonical.side_effect = get_identity
         mock_entity_store.get_latest_provenance_by_source.return_value = {}
 
         async with AsyncClient(
@@ -204,7 +204,7 @@ class TestBulkResolveLibrariesEndpoint:
 
         assert resp.status_code == 413
         # Cap-check fires before any DB work.
-        mock_entity_store.get_identity.assert_not_awaited()
+        mock_entity_store.get_identity_canonical.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_503_when_entity_store_unavailable(self, mock_settings):
@@ -241,6 +241,49 @@ class TestBulkResolveLibrariesEndpoint:
         assert resp.status_code == 503
 
     @pytest.mark.asyncio
+    async def test_canonicalizes_artist_name_before_entity_lookup(
+        self, app_client, mock_entity_store
+    ):
+        """Per #274: diacritic / smart-quote / `&` divergence must not miss.
+
+        The handler must call ``get_identity_canonical`` (which pre-normalizes
+        via ``identity.normalize.canonicalize_for_identity_lookup``), NOT the
+        exact-match ``get_identity``. Backend posts ``library.artist_name``
+        verbatim from its denormalized column; any drift from
+        ``entity.identity.library_name``'s canonical form would otherwise
+        surface as a silent unresolved verdict.
+        """
+        mock_entity_store.get_identity_canonical.return_value = _identity(
+            "nilufer yanya", id=1, discogs_artist_id=5499521, wikidata_qid="Q21470020"
+        )
+        mock_entity_store.get_latest_provenance_by_source.return_value = {}
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={
+                    "inputs": [
+                        {
+                            "library_id": 42,
+                            "artist_name": "Nilüfer Yanya",
+                            "album_title": "Painless",
+                        }
+                    ]
+                },
+            )
+
+        assert resp.status_code == 200
+        result = resp.json()["results"][0]
+        assert result["kind"] == "single_artist"
+        assert result["main"]["discogs_artist_id"] == 5499521
+        mock_entity_store.get_identity_canonical.assert_awaited_once_with("Nilüfer Yanya")
+        # The legacy exact-match path must not be exercised — divergence
+        # vectors would otherwise leak past as silent unresolved verdicts.
+        mock_entity_store.get_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_422_for_validation_error(self, app_client, mock_entity_store):
         """Missing required field per-input → 422 (Pydantic validation)."""
         async with AsyncClient(
@@ -252,4 +295,4 @@ class TestBulkResolveLibrariesEndpoint:
             )
 
         assert resp.status_code == 422
-        mock_entity_store.get_identity.assert_not_awaited()
+        mock_entity_store.get_identity_canonical.assert_not_awaited()

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -131,6 +131,53 @@ class TestGetIdentity:
         assert identity is None
 
 
+class TestGetIdentityCanonical:
+    """Bridge implementation for WXYC/library-metadata-lookup#274.
+
+    ``get_identity_canonical()`` pre-normalizes the input via
+    ``identity.normalize.canonicalize_for_identity_lookup`` and then performs
+    the existing exact-match SQL. The stored ``library_name`` is assumed to be
+    in the same canonical form (post-#207/#216/#217/#218 reconciliation).
+    """
+
+    @pytest.mark.asyncio
+    async def test_passes_canonical_form_to_sql(self, store, mock_pg):
+        """A non-canonical input is canonicalized before the SQL bind param."""
+        mock_pg.fetchone = AsyncMock(return_value=None)
+        await store.get_identity_canonical("Nilüfer Yanya")
+        call_args = mock_pg.fetchone.call_args
+        # SQL bind parameter (positional arg #1 of fetchone) is the canonical
+        # form, not the raw input.
+        assert call_args[0][1] == "nilufer yanya"
+
+    @pytest.mark.asyncio
+    async def test_returns_identity_when_canonical_form_matches(self, store, mock_pg):
+        """Stored canonical row → returns Identity even when input is non-canonical."""
+        mock_pg.fetchone = AsyncMock(
+            return_value={
+                "id": 7,
+                "library_name": "nilufer yanya",
+                "discogs_artist_id": 5499521,
+                "wikidata_qid": "Q21470020",
+                "musicbrainz_artist_id": None,
+                "spotify_artist_id": None,
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "reconciled",
+            }
+        )
+        identity = await store.get_identity_canonical("Nilüfer Yanya")
+        assert identity is not None
+        assert identity.discogs_artist_id == 5499521
+        assert identity.wikidata_qid == "Q21470020"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_miss(self, store, mock_pg):
+        mock_pg.fetchone = AsyncMock(return_value=None)
+        identity = await store.get_identity_canonical("Some Artist")
+        assert identity is None
+
+
 class TestUpdateStatus:
     @pytest.mark.asyncio
     async def test_updates_reconciliation_status(self, store, mock_pg):

--- a/tests/unit/test_identity_normalize.py
+++ b/tests/unit/test_identity_normalize.py
@@ -53,13 +53,15 @@ class TestCanonicalizeForIdentityLookup:
         [
             "Sleater & Kinney",
             "Sleater and Kinney",
-            "Sleater  &  Kinney",
+            "Sleater  &  Kinney",  # padded spaces around `&`
+            "Sleater &  Kinney",  # asymmetric whitespace
             "sleater and kinney",
-            "Sleater & Kinney",  # explicit ampersand
+            "Sleater & Kinney",  # NBSP around `&` (rich-text paste)
+            "Sleater and Kinney",  # NBSP around `and`
         ],
     )
     def test_ampersand_and_and_collapse(self, variant: str) -> None:
-        """``&`` and ``and`` (with any surrounding whitespace) collapse to one form."""
+        """``&`` and ``and`` (with any surrounding whitespace, ASCII or NBSP) collapse."""
         assert canonicalize_for_identity_lookup(variant) == "sleater and kinney"
 
     def test_whitespace_collapses(self) -> None:
@@ -93,3 +95,34 @@ class TestCanonicalizeForIdentityLookup:
         assert "and" not in result, (
             f"Bare-glued ampersand should not be rewritten to 'and'; got {result!r}"
         )
+
+    def test_fullwidth_ampersand_not_folded(self) -> None:
+        """Fullwidth ``＆`` (U+FF06) is a documented limitation, not a bug.
+
+        The conjunction regex runs before ``to_identity_match_form``'s NFKC
+        pass, so by the time NFKC rewrites ``＆`` to ASCII ``&`` the fold
+        opportunity is gone. The case is exceptionally rare in WXYC's
+        catalog (Japanese typography on a US college-radio system) and the
+        module docstring locks the scope. This test pins the limitation so
+        a future refactor that moves NFKC up in the pipeline gets a
+        deliberate signal that it has changed contract.
+        """
+        # NFKC inside `to_identity_match_form` does still produce ASCII `&`,
+        # so the result keeps the literal ampersand rather than `and`.
+        assert canonicalize_for_identity_lookup("Sleater ＆ Kinney") == "sleater & kinney"
+
+    def test_inherits_trailing_paren_strip_from_wxyc_etl(self) -> None:
+        """`(Live)` / `(2024 Remaster)` suffixes drop via `to_identity_match_form`.
+
+        Pin the inheritance because the bulk-resolve handler depends on it:
+        a stored canonical row ``stereolab`` should resolve a Backend post of
+        ``Stereolab (Live)`` to the same identity.
+        """
+        assert canonicalize_for_identity_lookup("Stereolab (Live)") == "stereolab"
+        assert canonicalize_for_identity_lookup("Cat Power (2024 Remaster)") == "cat power"
+
+    def test_inherits_leading_article_drop_from_wxyc_etl(self) -> None:
+        """`The Beatles` and Discogs `Beatles, The` collapse to one form."""
+        canonical = canonicalize_for_identity_lookup("The Beatles")
+        assert canonical == canonicalize_for_identity_lookup("Beatles, The") == canonical
+        assert canonical == "beatles"

--- a/tests/unit/test_identity_normalize.py
+++ b/tests/unit/test_identity_normalize.py
@@ -1,0 +1,95 @@
+"""Unit tests for the identity-lookup canonicalization helper.
+
+The helper produces the canonical form used by
+``EntityStore.get_identity_canonical()`` (per WXYC/library-metadata-lookup#274
+bridge approach 2). It must collapse the divergence vectors Backend's
+``library.artist_name`` column can carry into the cross-cache-identity lookup:
+
+- Diacritics (Nilüfer Yanya vs Nilufer Yanya)
+- Curly vs straight quotes (Don't vs Don’t)
+- ``&`` vs ``and``
+- Trailing whitespace, doubled spaces
+- Casing
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from identity.normalize import canonicalize_for_identity_lookup
+
+
+class TestCanonicalizeForIdentityLookup:
+    """Every divergence vector listed in issue #274 must collapse to one form."""
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "Nilüfer Yanya",
+            "Nilufer Yanya",
+            "nilufer yanya",
+            "  NILÜFER  YANYA  ",
+        ],
+    )
+    def test_diacritics_and_casing_collapse(self, variant: str) -> None:
+        """All Niluefer-Yanya variants share one canonical form."""
+        assert canonicalize_for_identity_lookup(variant) == "nilufer yanya"
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "Don't Stop",  # ASCII apostrophe U+0027
+            "Don’t Stop",  # right single quotation mark U+2019
+            "Don‘t Stop",  # left single quotation mark U+2018
+            "Donʼt Stop",  # modifier letter apostrophe U+02BC
+        ],
+    )
+    def test_smart_quote_variants_collapse(self, variant: str) -> None:
+        """Curly / modifier-letter apostrophes fold to the ASCII straight form."""
+        assert canonicalize_for_identity_lookup(variant) == "don't stop"
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "Sleater & Kinney",
+            "Sleater and Kinney",
+            "Sleater  &  Kinney",
+            "sleater and kinney",
+            "Sleater & Kinney",  # explicit ampersand
+        ],
+    )
+    def test_ampersand_and_and_collapse(self, variant: str) -> None:
+        """``&`` and ``and`` (with any surrounding whitespace) collapse to one form."""
+        assert canonicalize_for_identity_lookup(variant) == "sleater and kinney"
+
+    def test_whitespace_collapses(self) -> None:
+        """Leading, trailing, and interior whitespace collapse to single spaces."""
+        assert canonicalize_for_identity_lookup("  Cat   Power  ") == "cat power"
+
+    def test_idempotent(self) -> None:
+        """Applying the function twice yields the same result as once."""
+        once = canonicalize_for_identity_lookup("Nilüfer Yanya")
+        twice = canonicalize_for_identity_lookup(once)
+        assert once == twice == "nilufer yanya"
+
+    def test_empty_string_passthrough(self) -> None:
+        assert canonicalize_for_identity_lookup("") == ""
+
+    def test_ampersand_inside_word_is_left_alone(self) -> None:
+        """``&`` only folds when it's a separator, not embedded in a token.
+
+        Discogs occasionally returns names like ``M&M`` where the ``&`` is a
+        token glue, not the conjunction. We do not over-rewrite those.
+        """
+        # Ampersand fold uses word boundaries; ``M&M`` stays as ``m&m``.
+        assert canonicalize_for_identity_lookup("M&M") == "m&m"
+
+    def test_ampersand_at_word_boundary_with_no_spaces_still_folds(self) -> None:
+        """``Foo&Bar`` (no spaces) → ``foo and bar`` only when spaces flank it."""
+        # We intentionally do NOT fold ``Foo&Bar`` — Discogs writes those as
+        # distinct compound tokens (e.g., ``A&E``). The fold key is whitespace
+        # around ``&``, which is the divergence vector the issue lists.
+        result = canonicalize_for_identity_lookup("Foo&Bar")
+        assert "and" not in result, (
+            f"Bare-glued ampersand should not be rewritten to 'and'; got {result!r}"
+        )


### PR DESCRIPTION
## Summary

- Closes #274.
- `POST /api/v1/identity/bulk-resolve-libraries` now pre-canonicalizes `artist_name` at the LML boundary before exact-matching `entity.identity.library_name`, so diacritic / smart-quote / `&`-vs-`and` / case / whitespace drift between Backend's denormalized column and the stored canonical form no longer surfaces as silent unresolved verdicts (the miss-rate driver flagged in #273's review).
- Approach-2 bridge per the issue: layered on top of `wxyc_etl.text.to_identity_match_form` with smart-quote (curly + modifier apostrophe → ASCII) and conjunction (` & ` → ` and `) folds — the two divergence vectors the shared normalizer doesn't yet cover. Swap to the Postgres analog (§3.3 step 4) is a follow-up; the wire shape stays unchanged.

## Behaviour

- New `EntityStore.get_identity_canonical()` does the canonical lookup. Legacy `get_identity()` (exact-match) is untouched, so `/identity/{resolve,bulk}` (consumed by semantic-index, which pre-normalizes itself) sees no behaviour change.
- The bulk-resolve handler's existing PostgresError → 503 posture is preserved.

## Test plan

- [x] Unit: `tests/unit/test_identity_normalize.py` — 18 parametrized cases covering every divergence vector listed in the issue (Nilüfer/Nilufer, four apostrophe variants, `&` vs `and` with surrounding-whitespace gating, `M&M` glue-token preservation, whitespace collapse, idempotence, empty-string passthrough).
- [x] Unit: `tests/unit/test_entity_store.py::TestGetIdentityCanonical` — 3 tests asserting the canonical form is what reaches the SQL bind parameter and that miss/hit shapes match.
- [x] Unit: `tests/unit/test_bulk_resolve_libraries_endpoint.py` — new test asserts the handler calls `get_identity_canonical` and not the legacy exact-match `get_identity`.
- [x] PG integration: `tests/integration/test_bulk_resolve_libraries.py` — new test seeds canonical-form rows for `nilufer yanya`, `sleater and kinney`, `don't stop`, then posts the three diverged variants and asserts all three return `single_artist` with the correct `discogs_artist_id`. Pre-existing integration tests updated to seed canonical-form rows (consistent with the new endpoint contract).
- [x] Local pre-flight: `ruff check` + `ruff format --check` clean; `mypy identity scripts/entity_resolution` clean; `pytest tests/unit/` 1675 passed; `pytest -m pg` (test_bulk_resolve_libraries + test_entity_resolution) 11 passed.

## Notes

Correctness of approach 2 assumes `entity.identity.library_name` is stored in the same canonical form as the input normalizer emits — true post-reconciliation #207/#216/#217/#218. When the Postgres analog of `to_identity_match_form` ships, the SQL can move to a functional-index `WHERE wxyc_norm_artist(library_name) = wxyc_norm_artist(\$1)` query and the stored-canonicality assumption drops; the per-source / per-handler shape stays identical.