### PR TITLE
bulk-resolve-libraries: three-leg fall-through (exact → LOWER → canonical)

### DIFF
--- a/identity/router.py
+++ b/identity/router.py
@@ -222,14 +222,14 @@ async def bulk_resolve_libraries(
             continue
 
         try:
-            # Canonical-form lookup (issue #274): Backend posts
-            # `library.artist_name` verbatim from its denormalized column, so
-            # diacritic / smart-quote / `&`-vs-`and` / case / whitespace drift
-            # from the stored canonical key would otherwise surface as silent
-            # unresolved verdicts. `get_identity_canonical` applies
-            # `identity.normalize.canonicalize_for_identity_lookup` before the
-            # exact-match SQL.
-            identity: Identity | None = await store.get_identity_canonical(input_row.artist_name)
+            # Three-leg fall-through lookup (issues #274 / #276): exact match
+            # first (handles the 99.8% dominant case where Backend's
+            # `library.artist_name` shape equals storage), then case-
+            # insensitive `LOWER()` (catches pure case drift), then canonical
+            # form (catches diacritic / `&`-vs-`and` / smart-quote / etc.
+            # divergence when storage happens to be canonical). Strictly ≥
+            # legacy `get_identity()` hit rate.
+            identity: Identity | None = await store.resolve_library_name(input_row.artist_name)
         except (PostgresError, OSError):
             # Fail closed on partial PG failure — the caller cannot
             # distinguish "row had no identity" from "PG died before this

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -95,12 +95,19 @@ WHERE library_name = $1\
 # without a functional `(LOWER(library_name))` index, but the table is
 # ~24K rows so a seq scan stays sub-millisecond and the leg only fires on
 # leg-1 miss.
+#
+# `ORDER BY id ASC` makes the pick deterministic when two stored rows
+# lower-match (e.g., both ``'Stereolab'`` and ``'stereolab'`` exist — the
+# UNIQUE constraint on `library_name` is case-sensitive, so this is
+# allowed). The oldest row wins; without the ordering the row PG returns
+# could flip between deploys / connection pools.
 _GET_IDENTITY_LOWER_SQL = """\
 SELECT id, library_name, discogs_artist_id, wikidata_qid,
        musicbrainz_artist_id, spotify_artist_id,
        apple_music_artist_id, bandcamp_id, reconciliation_status
 FROM entity.identity
 WHERE LOWER(library_name) = LOWER($1)
+ORDER BY id ASC
 LIMIT 1\
 """
 
@@ -277,6 +284,13 @@ class EntityStore:
         # canonical == verbatim.lower(), leg 2's `LOWER(library_name) =
         # LOWER(verbatim)` set is a superset of leg 3's `library_name =
         # canonical` set, so leg 3 brings nothing new.
+        #
+        # Assumption: Python ``str.lower()`` and PG ``LOWER()`` agree for
+        # the inputs we care about (ASCII + Latin-script Unicode). They can
+        # diverge on long-tail cases (Turkish dotted I, Greek final sigma)
+        # depending on the database's collation; for WXYC's catalog the 3
+        # non-ASCII rows (Beyoncé, etc.) don't exercise that edge. If a
+        # future divergence audit surfaces hits, narrow the short-circuit.
         canonical = canonicalize_for_identity_lookup(verbatim)
         if canonical and canonical != verbatim and canonical != verbatim.lower():
             record = await self._pg.fetchone(_GET_IDENTITY_SQL, canonical)

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -91,6 +91,19 @@ FROM entity.identity
 WHERE library_name = $1\
 """
 
+# Case-insensitive leg of `resolve_library_name` (#276). Not index-backed
+# without a functional `(LOWER(library_name))` index, but the table is
+# ~24K rows so a seq scan stays sub-millisecond and the leg only fires on
+# leg-1 miss.
+_GET_IDENTITY_LOWER_SQL = """\
+SELECT id, library_name, discogs_artist_id, wikidata_qid,
+       musicbrainz_artist_id, spotify_artist_id,
+       apple_music_artist_id, bandcamp_id, reconciliation_status
+FROM entity.identity
+WHERE LOWER(library_name) = LOWER($1)
+LIMIT 1\
+"""
+
 _GET_BY_STATUS_SQL = """\
 SELECT id, library_name, discogs_artist_id, wikidata_qid,
        musicbrainz_artist_id, spotify_artist_id,
@@ -166,15 +179,13 @@ class EntityStore:
         query — same WX-3.B boundary policy as the read paths in this class
         (see ``_strip_nul`` for the rationale).
 
-        Asymmetry note (WXYC/library-metadata-lookup#274 follow-up): this
-        method writes ``library_name`` verbatim, but ``get_identity_canonical``
-        reads with a canonical-form lookup. The read-side bridge depends on
-        stored rows already being canonical (post-#207/#216/#217/#218
-        reconciliation). New ingestion runs that call this method directly
-        will re-introduce non-canonical rows unless callers canonicalize
-        upstream. Tracked under the planned plan §3.3 step 4 work, which
-        will move canonicalization into a Postgres functional-index and
-        moot the asymmetry.
+        Storage note: this method writes ``library_name`` verbatim. The
+        bulk-resolve-libraries handler reads via the three-leg
+        ``resolve_library_name`` fall-through (exact → LOWER → canonical),
+        so verbatim writes resolve correctly on Backend's verbatim posts.
+        Once plan §3.3 step 4 lands the Postgres analog of
+        ``to_identity_match_form``, the read can move to a functional-index
+        canonical lookup and the storage shape stops mattering.
 
         Returns:
             The upserted Identity, or None if the query failed.
@@ -208,41 +219,71 @@ class EntityStore:
             return None
         return _record_to_identity(record)
 
-    async def get_identity_canonical(self, library_name: str) -> Identity | None:
-        """Look up an identity by a non-canonical artist name.
+    async def resolve_library_name(self, library_name: str) -> Identity | None:
+        """Look up an identity for a non-canonical artist name, with fall-through.
 
-        Pre-canonicalizes ``library_name`` via
-        ``identity.normalize.canonicalize_for_identity_lookup`` and exact-matches
-        the canonical form against ``entity.identity.library_name``. This is the
-        approach-2 bridge from WXYC/library-metadata-lookup#274: it collapses
-        the divergence vectors Backend's denormalized ``library.artist_name``
-        column carries (diacritics, smart quotes, ``&`` vs ``and``, case,
-        whitespace) into a single canonical key.
+        Three-leg lookup per WXYC/library-metadata-lookup#276. Replaces the
+        canonical-only ``get_identity_canonical`` from #275, which regressed
+        the hit rate against the verbatim-cased production data the audit
+        surfaced (99.8% of stored rows are mixed-case).
 
-        Correctness assumes the stored ``library_name`` is itself in the same
-        canonical form — true post-reconciliation runs #207/#216/#217/#218.
-        When the Postgres analog of ``to_identity_match_form`` lands
-        (plan §3.3 step 4), this method's SQL can be swapped for a
-        ``WHERE wxyc_norm_artist(library_name) = wxyc_norm_artist($1)``
-        functional-index query and the stored-canonicality assumption drops.
+        Legs run sequentially and return the first hit:
+
+        1. **Exact match** — ``WHERE library_name = $1`` against the verbatim
+           (NUL-stripped) input. Uses the unique index. Handles the dominant
+           production path where Backend's input shape equals storage.
+        2. **Case-insensitive match** — ``WHERE LOWER(library_name) = LOWER($1)``.
+           Catches pure case-drift between Backend and storage. Seq-scans
+           ~24K rows but stays sub-millisecond at that size.
+        3. **Canonical match** — ``WHERE library_name = $canonical($1)`` against
+           the ``canonicalize_for_identity_lookup`` form. Catches inputs whose
+           canonical form equals a stored row (rare in current production —
+           ~0.2% per the #276 audit — but free correctness for those rows
+           and the eventual full-canonical backfill).
+
+        Legs 2 and 3 are skipped when their bind value duplicates an earlier
+        leg's, keeping the hot path at one query for the dominant exact-hit
+        case. Per-call worst case is three sequential index/seq-scan queries;
+        for a 1,000-row bulk request that's ~3,000 queries on miss, all on
+        the same PG connection — well within the per-handler latency budget.
+
+        ``library_name`` is U+0000-stripped (WX-3.B boundary policy) before
+        every leg.
 
         Returns:
-            The matching Identity, or None if no canonical row exists.
+            The matching Identity, or None if all legs miss.
         """
         # Local import keeps the wxyc_etl Rust extension off the module-load
-        # path for store consumers that don't use the bulk-resolve handler
-        # (semantic-index via /identity/bulk still gets the exact-match shape).
+        # path for store consumers that don't use this method.
         from identity.normalize import canonicalize_for_identity_lookup
 
-        # `_strip_nul` returns `str | None`; the `or ""` is needed because
-        # `canonicalize_for_identity_lookup` expects `str`. The None branch is
-        # unreachable in practice (signature is `str`) but kept for type-checker
-        # symmetry with the rest of this class.
-        canonical = canonicalize_for_identity_lookup(_strip_nul(library_name) or "")
-        record = await self._pg.fetchone(_GET_IDENTITY_SQL, canonical)
-        if record is None:
-            return None
-        return _record_to_identity(record)
+        verbatim = _strip_nul(library_name) or ""
+
+        # Leg 1: exact match (verbatim, uses unique index).
+        record = await self._pg.fetchone(_GET_IDENTITY_SQL, verbatim)
+        if record is not None:
+            return _record_to_identity(record)
+
+        # Leg 2: case-insensitive match (lowers the *stored* side). Always
+        # runs on leg 1 miss — input casing doesn't matter, since LOWER()
+        # applies to the stored column.
+        record = await self._pg.fetchone(_GET_IDENTITY_LOWER_SQL, verbatim)
+        if record is not None:
+            return _record_to_identity(record)
+
+        # Leg 3: canonical form (diacritic strip, article drop, etc.). Skip
+        # when the canonical bind would duplicate a previous leg's result
+        # set: if canonical == verbatim, leg 1 already covered it; if
+        # canonical == verbatim.lower(), leg 2's `LOWER(library_name) =
+        # LOWER(verbatim)` set is a superset of leg 3's `library_name =
+        # canonical` set, so leg 3 brings nothing new.
+        canonical = canonicalize_for_identity_lookup(verbatim)
+        if canonical and canonical != verbatim and canonical != verbatim.lower():
+            record = await self._pg.fetchone(_GET_IDENTITY_SQL, canonical)
+            if record is not None:
+                return _record_to_identity(record)
+
+        return None
 
     async def get_identities_by_status(self, status: str) -> list[Identity]:
         """Return all identities with the given reconciliation status.

--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -230,6 +230,99 @@ class TestBulkResolveLibrariesEndpoint:
         assert results[2]["main"]["discogs_artist_id"] == 88888
 
     @pytest.mark.asyncio
+    async def test_all_three_legs_resolve_in_one_batch(self, app_client, pg_pool):
+        """Mixed-shape stored rows + mixed-shape inputs all resolve in one call.
+
+        Locks the full chain end-to-end. Seeds three rows in three different
+        shapes (verbatim mixed-case, canonical, canonical) and posts inputs
+        that each trigger a different leg, plus one miss.
+
+        Layout:
+
+        | input                | matches via         | stored row             |
+        |---------------------|---------------------|------------------------|
+        | ``"Stereolab"``      | leg 1 (verbatim)    | ``'Stereolab'``        |
+        | ``"sTeReOlAb"``      | leg 2 (LOWER)       | ``'Stereolab'``        |
+        | ``"Nilüfer Yanya"``  | leg 3 (canonical)   | ``'nilufer yanya'``    |
+        | ``"Sleater & Kinney"`` | leg 3 (canonical) | ``'sleater and kinney'`` |
+        | ``"Nobody Knows"``   | (all legs miss)     | —                       |
+        """
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO entity.identity (library_name, discogs_artist_id)
+                VALUES
+                    ('nilufer yanya', 5499521),
+                    ('sleater and kinney', 99999)
+                """
+            )
+            # Note: 'Stereolab' is already seeded with discogs_artist_id=2154
+            # by the schema fixture.
+
+        resp = await app_client.post(
+            "/api/v1/identity/bulk-resolve-libraries",
+            json={
+                "inputs": [
+                    {"library_id": 1, "artist_name": "Stereolab", "album_title": "x"},
+                    {"library_id": 2, "artist_name": "sTeReOlAb", "album_title": "x"},
+                    {"library_id": 3, "artist_name": "Nilüfer Yanya", "album_title": "x"},
+                    {"library_id": 4, "artist_name": "Sleater & Kinney", "album_title": "x"},
+                    {"library_id": 5, "artist_name": "Nobody Knows", "album_title": "x"},
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert [r["kind"] for r in results] == [
+            "single_artist",
+            "single_artist",
+            "single_artist",
+            "single_artist",
+            "unresolved",
+        ]
+        # Same identity reached via two different legs (1 and 2) → same row.
+        assert results[0]["main"]["discogs_artist_id"] == 2154
+        assert results[1]["main"]["discogs_artist_id"] == 2154
+        assert results[2]["main"]["discogs_artist_id"] == 5499521
+        assert results[3]["main"]["discogs_artist_id"] == 99999
+        assert results[4]["main"] is None
+
+    @pytest.mark.asyncio
+    async def test_leg_2_picks_lowest_id_when_two_rows_lower_match(self, app_client, pg_pool):
+        """`library_name` is case-sensitive-UNIQUE; two case-variants can co-exist.
+
+        Seed two rows whose lower-form is identical (``'Stereolab'`` already
+        in fixture; add ``'stereolab'``). Post a third case variant
+        (``"sTeReOlAb"``) so leg 1 misses but leg 2's `LOWER(...)` matches
+        both stored rows. The `ORDER BY id ASC` tie-break must pick the
+        oldest (the fixture's ``'Stereolab'``, id 1).
+        """
+        async with pg_pool.acquire() as conn:
+            # Insert a second case-variant. Discogs id is intentionally
+            # different so we can tell which row leg 2 picked.
+            await conn.execute(
+                "INSERT INTO entity.identity (library_name, discogs_artist_id) "
+                "VALUES ('stereolab', 99999)"
+            )
+
+        resp = await app_client.post(
+            "/api/v1/identity/bulk-resolve-libraries",
+            json={
+                "inputs": [
+                    {"library_id": 1, "artist_name": "sTeReOlAb", "album_title": "x"},
+                ]
+            },
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["results"][0]
+        assert result["kind"] == "single_artist"
+        # Oldest row wins (the fixture's `'Stereolab'`, discogs_artist_id=2154),
+        # not the freshly-inserted `'stereolab'` (id=99999).
+        assert result["main"]["discogs_artist_id"] == 2154
+
+    @pytest.mark.asyncio
     async def test_413_for_oversized_request(self, app_client):
         """1001 inputs → 413."""
         oversized = [

--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -65,18 +65,17 @@ async def set_up_entity_schema(pg_pool):
                 created_at TIMESTAMPTZ NOT NULL DEFAULT now()
             )
         """)
-        # Seed a couple of identities representative of WXYC's catalog.
-        # Per #274's approach-2 bridge: `library_name` is stored in canonical
-        # form (lowercase, no diacritics, ``and`` conjunction, ASCII quotes) —
-        # the same shape `identity.normalize.canonicalize_for_identity_lookup`
-        # emits — so the bulk-resolve-libraries handler's canonical lookup
-        # resolves whatever non-canonical variant Backend posts.
+        # Seed in verbatim Backend casing — matches the production shape
+        # surfaced by the #276 audit (99.8% of entity.identity rows are
+        # mixed-case verbatim, not canonical). The handler's three-leg
+        # fall-through (#276) handles both verbatim hits and canonical-form
+        # divergence on top of this shape.
         await conn.execute(
             """
             INSERT INTO entity.identity (library_name, discogs_artist_id, wikidata_qid)
             VALUES
-                ('stereolab', 2154, 'Q484464'),
-                ('juana molina', 305253, 'Q272615')
+                ('Stereolab', 2154, 'Q484464'),
+                ('Juana Molina', 305253, 'Q272615')
             """
         )
     yield
@@ -165,13 +164,39 @@ class TestBulkResolveLibrariesEndpoint:
         ]
 
     @pytest.mark.asyncio
+    async def test_case_drift_resolves_via_lower_fall_through(self, app_client, pg_pool):
+        """Per #276: case drift between Backend input and verbatim-cased storage hits.
+
+        Seeds verbatim mixed-case rows (the production shape per the #276
+        audit — 99.8% of `entity.identity.library_name` is mixed-case
+        verbatim). Posts the *lowercase* variant and asserts the LOWER fall-
+        through leg resolves both rows. This is the regression test for the
+        #275 ship: that PR canonicalized the input to lowercase and would
+        have missed the verbatim-stored row entirely.
+        """
+        resp = await app_client.post(
+            "/api/v1/identity/bulk-resolve-libraries",
+            json={
+                "inputs": [
+                    {"library_id": 1, "artist_name": "stereolab", "album_title": "x"},
+                    {"library_id": 2, "artist_name": "JUANA MOLINA", "album_title": "x"},
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert [r["kind"] for r in results] == ["single_artist", "single_artist"]
+        assert results[0]["main"]["discogs_artist_id"] == 2154
+        assert results[1]["main"]["discogs_artist_id"] == 305253
+
+    @pytest.mark.asyncio
     async def test_canonical_lookup_collapses_divergence_vectors(self, app_client, pg_pool):
         """Per #274: diverged inputs resolve to the same canonical-form row.
 
         Seeds three identities in canonical form (lowercase, no diacritics,
         ``and`` conjunction, ASCII apostrophe) and posts non-canonical
-        variants. Each should land on its canonical row instead of returning
-        ``unresolved`` — the silent miss-rate driver flagged by #273's review.
+        variants. Each should land on its canonical row via the canonical
+        leg of the #276 three-leg fall-through.
         """
         async with pg_pool.acquire() as conn:
             await conn.execute(

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -65,7 +65,7 @@ class TestBulkResolveLibrariesEndpoint:
     @pytest.mark.asyncio
     async def test_single_artist_returns_main_and_provenance(self, app_client, mock_entity_store):
         """A populated identity → kind=single_artist with ReconciledIdentity main."""
-        mock_entity_store.get_identity_canonical.return_value = _identity(
+        mock_entity_store.resolve_library_name.return_value = _identity(
             "Stereolab", id=1, discogs_artist_id=2154, wikidata_qid="Q484464"
         )
         mock_entity_store.get_latest_provenance_by_source.return_value = {}
@@ -123,12 +123,12 @@ class TestBulkResolveLibrariesEndpoint:
         assert result["provenance"] == []
         assert result["tracks"] == []
         # V/A short-circuits the entity lookup — should never call get_identity.
-        mock_entity_store.get_identity_canonical.assert_not_awaited()
+        mock_entity_store.resolve_library_name.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_unresolved_when_identity_missing(self, app_client, mock_entity_store):
         """No entity row for the artist → kind=unresolved."""
-        mock_entity_store.get_identity_canonical.return_value = None
+        mock_entity_store.resolve_library_name.return_value = None
 
         async with AsyncClient(
             transport=ASGITransport(app=app_client), base_url="http://test"
@@ -163,7 +163,7 @@ class TestBulkResolveLibrariesEndpoint:
             mapping = {"Stereolab": _identity("Stereolab", id=1, discogs_artist_id=1)}
             return mapping.get(name)
 
-        mock_entity_store.get_identity_canonical.side_effect = get_identity
+        mock_entity_store.resolve_library_name.side_effect = get_identity
         mock_entity_store.get_latest_provenance_by_source.return_value = {}
 
         async with AsyncClient(
@@ -204,7 +204,7 @@ class TestBulkResolveLibrariesEndpoint:
 
         assert resp.status_code == 413
         # Cap-check fires before any DB work.
-        mock_entity_store.get_identity_canonical.assert_not_awaited()
+        mock_entity_store.resolve_library_name.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_503_when_entity_store_unavailable(self, mock_settings):
@@ -241,19 +241,17 @@ class TestBulkResolveLibrariesEndpoint:
         assert resp.status_code == 503
 
     @pytest.mark.asyncio
-    async def test_canonicalizes_artist_name_before_entity_lookup(
+    async def test_uses_fall_through_lookup_not_legacy_exact_match(
         self, app_client, mock_entity_store
     ):
-        """Per #274: diacritic / smart-quote / `&` divergence must not miss.
+        """Per #274/#276: handler must use the three-leg fall-through method.
 
-        The handler must call ``get_identity_canonical`` (which pre-normalizes
-        via ``identity.normalize.canonicalize_for_identity_lookup``), NOT the
-        exact-match ``get_identity``. Backend posts ``library.artist_name``
-        verbatim from its denormalized column; any drift from
-        ``entity.identity.library_name``'s canonical form would otherwise
-        surface as a silent unresolved verdict.
+        The handler must call ``resolve_library_name`` (exact → LOWER →
+        canonical fall-through), NOT the legacy exact-match ``get_identity``.
+        The legacy method would miss any input that differs from storage even
+        by case — the exact regression the #276 production audit surfaced.
         """
-        mock_entity_store.get_identity_canonical.return_value = _identity(
+        mock_entity_store.resolve_library_name.return_value = _identity(
             "nilufer yanya", id=1, discogs_artist_id=5499521, wikidata_qid="Q21470020"
         )
         mock_entity_store.get_latest_provenance_by_source.return_value = {}
@@ -278,7 +276,7 @@ class TestBulkResolveLibrariesEndpoint:
         result = resp.json()["results"][0]
         assert result["kind"] == "single_artist"
         assert result["main"]["discogs_artist_id"] == 5499521
-        mock_entity_store.get_identity_canonical.assert_awaited_once_with("Nilüfer Yanya")
+        mock_entity_store.resolve_library_name.assert_awaited_once_with("Nilüfer Yanya")
         # The legacy exact-match path must not be exercised — divergence
         # vectors would otherwise leak past as silent unresolved verdicts.
         mock_entity_store.get_identity.assert_not_awaited()
@@ -295,4 +293,4 @@ class TestBulkResolveLibrariesEndpoint:
             )
 
         assert resp.status_code == 422
-        mock_entity_store.get_identity_canonical.assert_not_awaited()
+        mock_entity_store.resolve_library_name.assert_not_awaited()

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from scripts.entity_resolution.store import (
+    _GET_IDENTITY_LOWER_SQL,
     EntityStore,
     _strip_nul,
 )
@@ -215,10 +216,11 @@ class TestResolveLibraryName:
         assert identity is not None
         assert identity.id == 42
         assert mock_pg.fetchone.await_count == 2
-        # Leg 2 SQL contains LOWER(...) — assert via the SQL string itself,
-        # not the bind value (the bind is still the verbatim input).
+        # Assert against the SQL constant rather than substring-matching the
+        # SQL text — keeps the test sensitive to the right thing (which
+        # query ran) without breaking on whitespace / formatting changes.
         leg_2_sql = mock_pg.fetchone.await_args_list[1][0][0]
-        assert "lower(library_name)" in leg_2_sql.lower()
+        assert leg_2_sql == _GET_IDENTITY_LOWER_SQL
         # Canonical leg is skipped (canonical(input) equals input).
         # No third query.
 
@@ -280,6 +282,42 @@ class TestResolveLibraryName:
         mock_pg.fetchone = AsyncMock(return_value=None)
         await store.resolve_library_name("Stereolab")
         assert mock_pg.fetchone.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_string_input_returns_none_cleanly(self, store, mock_pg):
+        """Empty input must not raise and must not exercise leg 3.
+
+        Leg 1 binds the empty string and misses; leg 2 the same; leg 3's
+        canonical form is also empty, so the `if canonical and ...` guard
+        skips it. Net: 2 queries, None returned.
+        """
+        mock_pg.fetchone = AsyncMock(return_value=None)
+        identity = await store.resolve_library_name("")
+        assert identity is None
+        assert mock_pg.fetchone.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_leg_2_lower_sql_includes_order_by_id_for_determinism(self, store, mock_pg):
+        """Locks the deterministic tie-break.
+
+        When two stored rows lower-match (e.g., both ``'Stereolab'`` and
+        ``'stereolab'`` exist — `library_name`'s UNIQUE constraint is
+        case-sensitive, so this is allowed), `ORDER BY id ASC` guarantees
+        the oldest row wins. Without it the row PG returns can flip between
+        deploys / connection pools.
+        """
+        mock_pg.fetchone = AsyncMock(
+            side_effect=[
+                None,  # leg 1 miss
+                self._row("Stereolab", id=42, discogs_artist_id=2154),
+            ]
+        )
+        await store.resolve_library_name("stereolab")
+        leg_2_sql = mock_pg.fetchone.await_args_list[1][0][0]
+        # Both clauses must be present — `LIMIT 1` without `ORDER BY` would
+        # be non-deterministic on ambiguous case.
+        assert "ORDER BY id ASC" in leg_2_sql
+        assert "LIMIT 1" in leg_2_sql
 
 
 class TestUpdateStatus:

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -131,51 +131,155 @@ class TestGetIdentity:
         assert identity is None
 
 
-class TestGetIdentityCanonical:
-    """Bridge implementation for WXYC/library-metadata-lookup#274.
+class TestResolveLibraryName:
+    """Three-leg fall-through lookup per WXYC/library-metadata-lookup#276.
 
-    ``get_identity_canonical()`` pre-normalizes the input via
-    ``identity.normalize.canonicalize_for_identity_lookup`` and then performs
-    the existing exact-match SQL. The stored ``library_name`` is assumed to be
-    in the same canonical form (post-#207/#216/#217/#218 reconciliation).
+    `resolve_library_name()` is the bulk-resolve-libraries handler's lookup
+    path. The #276 production audit found `entity.identity.library_name` rows
+    are stored in verbatim Backend casing (99.8% mixed-case, articles
+    preserved, `&` preserved). A canonical-only lookup misses almost
+    everything; the legacy exact-match handles the dominant path.
+
+    The method tries three legs in order, returning the first hit:
+
+    1. **Exact match** — `WHERE library_name = $verbatim_input`. Catches
+       the 99.8% dominant case where Backend's input shape equals the
+       stored shape. Uses the unique index.
+    2. **Case-insensitive match** — `WHERE LOWER(library_name) = LOWER($verbatim_input)`.
+       Catches pure case-drift (Backend posts ``"stereolab"`` against stored
+       ``"Stereolab"``, or vice-versa). Seq-scans ~23K rows without a
+       functional index but stays sub-millisecond at that size.
+    3. **Canonical match** — `WHERE library_name = $canonical_input`.
+       Catches inputs whose canonical form happens to equal a stored
+       canonical row (only ~0.2% of stored rows per the #276 audit are
+       already canonical, but it's free correctness for those rows and
+       the eventual full backfill).
+
+    Short-circuits: legs 2 and 3 are skipped when their bind value
+    duplicates an earlier leg's (e.g., input ``"stereolab"`` is its own
+    lower-form, so leg 2 is redundant). The exact-match leg always runs.
+
+    Net hit rate is strictly ≥ legacy `get_identity()` exact-match; the
+    additional legs are pure additive coverage.
     """
 
-    @pytest.mark.asyncio
-    async def test_passes_canonical_form_to_sql(self, store, mock_pg):
-        """A non-canonical input is canonicalized before the SQL bind param."""
-        mock_pg.fetchone = AsyncMock(return_value=None)
-        await store.get_identity_canonical("Nilüfer Yanya")
-        call_args = mock_pg.fetchone.call_args
-        # SQL bind parameter (positional arg #1 of fetchone) is the canonical
-        # form, not the raw input.
-        assert call_args[0][1] == "nilufer yanya"
+    @staticmethod
+    def _row(library_name: str, **overrides: object) -> dict[str, object]:
+        return {
+            "id": 1,
+            "library_name": library_name,
+            "discogs_artist_id": None,
+            "wikidata_qid": None,
+            "musicbrainz_artist_id": None,
+            "spotify_artist_id": None,
+            "apple_music_artist_id": None,
+            "bandcamp_id": None,
+            "reconciliation_status": "reconciled",
+            **overrides,
+        }
 
     @pytest.mark.asyncio
-    async def test_returns_identity_when_canonical_form_matches(self, store, mock_pg):
-        """Stored canonical row → returns Identity even when input is non-canonical."""
+    async def test_exact_match_short_circuits_other_legs(self, store, mock_pg):
+        """Verbatim input hits row on leg 1 → no further queries.
+
+        This is the dominant production path: 99.8% of stored rows are in
+        verbatim casing, so the exact-match leg handles them in one query.
+        """
         mock_pg.fetchone = AsyncMock(
-            return_value={
-                "id": 7,
-                "library_name": "nilufer yanya",
-                "discogs_artist_id": 5499521,
-                "wikidata_qid": "Q21470020",
-                "musicbrainz_artist_id": None,
-                "spotify_artist_id": None,
-                "apple_music_artist_id": None,
-                "bandcamp_id": None,
-                "reconciliation_status": "reconciled",
-            }
+            return_value=self._row("Stereolab", id=42, discogs_artist_id=2154)
         )
-        identity = await store.get_identity_canonical("Nilüfer Yanya")
+        identity = await store.resolve_library_name("Stereolab")
         assert identity is not None
-        assert identity.discogs_artist_id == 5499521
-        assert identity.wikidata_qid == "Q21470020"
+        assert identity.id == 42
+        assert identity.discogs_artist_id == 2154
+        # One query — leg 1 alone.
+        assert mock_pg.fetchone.await_count == 1
+        # First leg uses the verbatim input (NUL-stripped, otherwise unchanged).
+        assert mock_pg.fetchone.await_args_list[0][0][1] == "Stereolab"
 
     @pytest.mark.asyncio
-    async def test_returns_none_for_miss(self, store, mock_pg):
+    async def test_falls_through_to_case_insensitive_leg(self, store, mock_pg):
+        """Leg 1 misses, leg 2 (LOWER both sides) hits via case-insensitive match.
+
+        Backend posts ``"stereolab"``; stored is ``"Stereolab"``. Leg 1 misses
+        because the bind is the verbatim lowercase input. Leg 2 queries
+        ``WHERE LOWER(library_name) = LOWER('stereolab')`` and hits.
+        """
+        mock_pg.fetchone = AsyncMock(
+            side_effect=[
+                None,  # leg 1 miss
+                self._row("Stereolab", id=42, discogs_artist_id=2154),
+            ]
+        )
+        identity = await store.resolve_library_name("stereolab")
+        assert identity is not None
+        assert identity.id == 42
+        assert mock_pg.fetchone.await_count == 2
+        # Leg 2 SQL contains LOWER(...) — assert via the SQL string itself,
+        # not the bind value (the bind is still the verbatim input).
+        leg_2_sql = mock_pg.fetchone.await_args_list[1][0][0]
+        assert "lower(library_name)" in leg_2_sql.lower()
+        # Canonical leg is skipped (canonical(input) equals input).
+        # No third query.
+
+    @pytest.mark.asyncio
+    async def test_falls_through_to_canonical_leg(self, store, mock_pg):
+        """All three legs fire when the input diverges beyond case alone.
+
+        Input ``"Nilüfer Yanya"`` (diacritic) against a stored canonical
+        row ``"nilufer yanya"``:
+        - Leg 1 (verbatim ``"Nilüfer Yanya"``) misses
+        - Leg 2 (`LOWER(library_name) = LOWER("Nilüfer Yanya")`) misses
+          (`"Nilüfer Yanya".lower()` keeps the umlaut)
+        - Leg 3 (canonical ``"nilufer yanya"``) hits
+        """
+        mock_pg.fetchone = AsyncMock(
+            side_effect=[
+                None,  # leg 1
+                None,  # leg 2
+                self._row("nilufer yanya", id=7, discogs_artist_id=5499521),
+            ]
+        )
+        identity = await store.resolve_library_name("Nilüfer Yanya")
+        assert identity is not None
+        assert identity.id == 7
+        assert mock_pg.fetchone.await_count == 3
+        # Leg 3 uses the canonical form.
+        assert mock_pg.fetchone.await_args_list[2][0][1] == "nilufer yanya"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_all_legs_miss(self, store, mock_pg):
+        """Input with diacritic forces all three legs (canonical ≠ verbatim.lower)."""
         mock_pg.fetchone = AsyncMock(return_value=None)
-        identity = await store.get_identity_canonical("Some Artist")
+        identity = await store.resolve_library_name("Nilüfer Yanya")
         assert identity is None
+        assert mock_pg.fetchone.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_lowercase_input_runs_legs_1_and_2_only(self, store, mock_pg):
+        """Already-lowercase input → leg 1 (verbatim) + leg 2 (LOWER) only.
+
+        Backend posts ``"stereolab"``. Leg 1's `WHERE library_name =
+        'stereolab'` misses if storage is mixed-case; leg 2's
+        `WHERE LOWER(library_name) = LOWER('stereolab')` catches it. Leg 3's
+        canonical form is also ``"stereolab"`` — that bind equals
+        ``verbatim.lower()`` so leg 2's superset already covered it. Skip.
+        """
+        mock_pg.fetchone = AsyncMock(return_value=None)
+        await store.resolve_library_name("stereolab")
+        assert mock_pg.fetchone.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_mixed_case_ascii_skips_canonical_leg(self, store, mock_pg):
+        """Mixed-case ASCII input with no normalization differences → 2 queries.
+
+        Input ``"Stereolab"``: leg 1 verbatim, leg 2 case-insensitive,
+        leg 3 canonical form is ``"stereolab"`` which equals
+        ``verbatim.lower()`` — leg 2 already covers it.
+        """
+        mock_pg.fetchone = AsyncMock(return_value=None)
+        await store.resolve_library_name("Stereolab")
+        assert mock_pg.fetchone.await_count == 2
 
 
 class TestUpdateStatus:

--- a/tests/unit/test_identity_normalize.py
+++ b/tests/unit/test_identity_normalize.py
@@ -1,9 +1,10 @@
 """Unit tests for the identity-lookup canonicalization helper.
 
-The helper produces the canonical form used by
-``EntityStore.get_identity_canonical()`` (per WXYC/library-metadata-lookup#274
-bridge approach 2). It must collapse the divergence vectors Backend's
-``library.artist_name`` column can carry into the cross-cache-identity lookup:
+The helper produces the canonical form used by the third leg of
+``EntityStore.resolve_library_name()`` (the bulk-resolve-libraries lookup
+path, per WXYC/library-metadata-lookup#274 / #276). It must collapse the
+divergence vectors Backend's ``library.artist_name`` column can carry into
+the cross-cache-identity lookup:
 
 - Diacritics (Nilüfer Yanya vs Nilufer Yanya)
 - Curly vs straight quotes (Don't vs Don’t)


### PR DESCRIPTION
## Summary

- Closes #276 — the regression that #275 introduced when it canonicalized inputs against verbatim-cased storage.
- Production audit on `entity.identity`: 23,764 of 23,816 rows (99.8%) are mixed-case verbatim (`'Stereolab'`, `'The Frumpies'`, `'Skip & Die'`, `'Beyoncé'`). #275's canonical-only lookup would miss them all. This PR restores the legacy hit rate and adds two strictly-additive coverage legs on top.
- Replaces `EntityStore.get_identity_canonical()` with `resolve_library_name()`:
  - **Leg 1**: `WHERE library_name = $verbatim` (unique index). Dominant path.
  - **Leg 2**: `WHERE LOWER(library_name) = LOWER($verbatim)`. Catches case drift.
  - **Leg 3**: `WHERE library_name = $canonicalize($verbatim)`. Catches normalization differences when storage happens to be canonical (rare today, transparent after a future backfill).
- Handler swaps `get_identity_canonical` → `resolve_library_name`. Legacy `get_identity()` untouched; semantic-index's consumption of `/identity/{resolve,bulk}` is unchanged.

## Audit findings that drove the design

| Bucket | Count | % |
|---|---|---|
| Total rows | 23,816 | — |
| **NOT lowercase** | **23,764** | **99.8%** |
| Has `&` conjunction | 312 | 1.3% |
| Has trailing parens | 45 | 0.2% |
| Has leading article | 1,542 | 6.5% |
| Has non-ASCII (diacritics) | 3 | <0.1% |
| Already canonical-ish | 51 | 0.2% |

The exact-match leg covers the dominant 99.8% (when Backend's column and storage match shape). The `LOWER()` leg adds case-insensitivity for the ~99% of remaining cases that diverge only by case. The canonical leg catches the long-tail (diacritics, `&`/`and`, smart quotes, articles, parens) — currently <0.2% of stored rows but unlocks once the §3.3-step-4 Postgres analog backfill ships.

## Behaviour

- Per-call: 1 query on the dominant hit, 2 on case-drift hit, 3 on miss. For a 1,000-row bulk request that's ~3,000 sequential queries worst case, all on one PG connection — comfortably within the per-handler latency budget.
- Short-circuits: leg 3 is skipped when its bind would duplicate leg 1 (canonical == verbatim) or be a strict subset of leg 2's match set (canonical == verbatim.lower()). Leg 2 always runs on leg 1 miss — `LOWER()` applies to the stored side, so the input's own case doesn't matter.
- Same `PostgresError` → 503 posture as before; no contract change on the wire.

## Test plan

- [x] **Unit**: 6 new tests in `tests/unit/test_entity_store.py::TestResolveLibraryName` lock each leg and each short-circuit (exact hit, lower-leg hit, canonical-leg hit, all-miss, lowercase-input two-query path, mixed-case-ASCII two-query path).
- [x] **Unit**: endpoint test renamed and reframed to assert the handler uses `resolve_library_name` and not the legacy `get_identity`.
- [x] **Integration (PG)**: seed reverted to verbatim mixed-case (`'Stereolab'`, `'Juana Molina'`) — matches the production shape from the #276 audit. New `test_case_drift_resolves_via_lower_fall_through` posts lowercase / uppercase inputs against mixed-case storage to lock the regression that #275 introduced. Existing `test_canonical_lookup_collapses_divergence_vectors` continues to cover diacritic / `&`-vs-`and` / smart-quote vectors via the canonical leg.
- [x] **Pre-flight local**: ruff check + ruff format clean; mypy clean; 1,683 unit tests pass; 12 PG integration tests pass.

## Follow-ups

- A functional index on `LOWER(library_name)` would move leg 2 from seq-scan to index-lookup. At ~24K rows it's already fast enough to not matter, but the cost is one CREATE INDEX. Worth filing if/when bulk-resolve traffic grows.
- Backfilling stored `library_name` to canonical form would let leg 3 carry more weight and would moot the whole fall-through once the §3.3-step-4 Postgres analog ships. Tracked under the existing canonicalization-plan workstream.