### PR TITLE
Document deferred to_identity_match_form swap in reconciler (#262 outcome a)

### DIFF
--- a/discogs/matching.py
+++ b/discogs/matching.py
@@ -7,10 +7,30 @@ core/matching.py during the wxyc_etl migration.
 
 Generic text normalization (diacritics stripping, case folding, compilation
 detection) lives in wxyc_etl.text.
+
+Per WXYC/library-metadata-lookup#262 (E3 step 5f, 2026-05-11): the helpers
+in this module are **validation utilities**, NOT cross-cache identity
+matching. They normalize Discogs API tracklist strings against
+user-supplied / library-provided track titles and artist names so the
+"does this release contain this track?" check survives typographic noise
+(``Me & Mr. Jones`` vs ``Me And Mr Jones``, ``"Weird Al" Yankovic`` vs
+``Weird Al Yankovic``). They are NOT used to populate ``entity.identity``
+nor to query the discogs-cache tables that are stored under
+``lower(f_unaccent(...))``. The canonical identity-matching entry point
+is ``wxyc_etl.text.to_identity_match_form`` (or LML's
+``identity.normalize.canonicalize_for_identity_lookup`` wrapper); see the
+note on ``scripts/entity_resolution/discogs.py`` for the reconciler
+asymmetry that gates the swap on the Postgres analog landing.
 """
 
 import re
 
+# `to_match_form` (NFKD + diacritic-strip + lowercase + trim) is the
+# right base for validation comparisons here. Switching to
+# `to_identity_match_form` would silently drop parenthetical track
+# annotations (``(Live)``, ``(2024 Remaster)``) that legitimately
+# distinguish two tracks on the same release, and would also drop leading
+# articles, breaking ``The Way`` vs ``Way`` discrimination.
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 # Discogs disambiguation suffix: (2), (22), etc.
@@ -31,6 +51,14 @@ def strip_discogs_suffix(name: str) -> str:
 def normalize_for_track_comparison(text: str | None) -> str:
     """Normalize a track title for fuzzy comparison during validation.
 
+    NOT identity matching — this is the track-validation path called from
+    ``discogs/service.py`` to decide whether a Discogs release's tracklist
+    contains a user-supplied / library-provided song title. The layered
+    rules below (ampersand-to-and, full-punctuation strip, whitespace
+    collapse) are intentional LML shims that ``to_identity_match_form``
+    does NOT replicate (it preserves internal punctuation other than the
+    parenthetical-suffix strip).
+
     Extends normalize_for_comparison with additional steps:
     - Replaces ``&`` with ``and``
     - Strips punctuation (periods, apostrophes, quotes, etc.)
@@ -50,6 +78,13 @@ def normalize_for_track_comparison(text: str | None) -> str:
 
 def normalize_artist_for_validation(name: str) -> str:
     """Normalize an artist name for substring comparison during track validation.
+
+    NOT identity matching — this is the artist-substring path called from
+    ``discogs/service.py`` and ``tests/integration/test_lookup_pipeline.py``
+    to check whether a tracklist credit mentions the queried artist.
+    The Discogs-quoted-nickname strip (``"Weird Al" Yankovic``) and the
+    ``(2)``-suffix strip are intentional LML shims; ``to_identity_match_form``
+    does not handle either.
 
     Lowercases, strips quotes (Discogs uses quotes for nicknames, e.g.
     '"Weird Al" Yankovic'), and removes disambiguation suffixes like '(2)'.

--- a/discogs/matching.py
+++ b/discogs/matching.py
@@ -8,9 +8,8 @@ core/matching.py during the wxyc_etl migration.
 Generic text normalization (diacritics stripping, case folding, compilation
 detection) lives in wxyc_etl.text.
 
-Per WXYC/library-metadata-lookup#262 (E3 step 5f, 2026-05-11): the helpers
-in this module are **validation utilities**, NOT cross-cache identity
-matching. They normalize Discogs API tracklist strings against
+The helpers in this module are **validation utilities**, NOT cross-cache
+identity matching. They normalize Discogs API tracklist strings against
 user-supplied / library-provided track titles and artist names so the
 "does this release contain this track?" check survives typographic noise
 (``Me & Mr. Jones`` vs ``Me And Mr Jones``, ``"Weird Al" Yankovic`` vs

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -35,24 +35,23 @@ from dataclasses import dataclass
 
 from wxyc_etl.text import split_artist_name
 
-# NOTE(WXYC/library-metadata-lookup#262, E3 step 5f, re-verified 2026-05-11):
-# per `library-hook-canonicalization-plan` §3.3.1 step 5 the resolver path is
-# the canonical identity-matching consumer and should call
-# `to_identity_match_form`, but the swap is deferred until the PG column
-# expressions adopt a matching `wxyc_identity_match_artist()` analog (per
-# `wxyc-etl/docs/normalization.md` and plan §3.3.5 — still STILL REQUIRED /
-# pending as of 2026-05-11; see wiki §3.3.0 status update). Today the
-# discogs-cache column side uses `lower(f_unaccent(col))` (≈ `to_match_form`
-# semantics; see `discogs-etl/scripts/run_pipeline.py` GIN indexes on
-# `release_artist`, `release`, `release_track`, `release_track_artist`).
-# Switching the input alone strips leading articles asymmetrically (input
-# "The Beatles" → "beatles", col → "the beatles") and collapses the Stage 5
-# preprocessing variants into the canonical key, breaking exact matches for
-# Discogs rows with a "The " prefix. The Stage 5 cheap-derivation pipeline
-# (strip "The ", `&` → `and`, bracket-strip, multi-credit split) is the LML
-# replacement for those folds until the column side moves; flipping the
-# input alone would short-circuit those variants without symmetric column
-# support. The symmetric pair to watch:
+# NOTE(WXYC/library-metadata-lookup#262): the resolver path is the canonical
+# identity-matching consumer and should call `to_identity_match_form` per
+# `library-hook-canonicalization-plan` §3.3.1 step 5, but the swap is
+# deferred until the PG column expressions adopt a matching
+# `wxyc_identity_match_artist()` analog (plan §3.3.5 — pending; see wiki
+# §3.3.0 status). Today the discogs-cache column side uses
+# `lower(f_unaccent(col))` (≈ `to_match_form` semantics; see
+# `discogs-etl/scripts/run_pipeline.py` GIN indexes on `release_artist`,
+# `release`, `release_track`, `release_track_artist`). Switching the input
+# alone strips leading articles asymmetrically (input "The X" → "x", col →
+# "the x") and collapses the Stage 5 preprocessing variants into the
+# canonical key, breaking exact matches for Discogs rows with a "The "
+# prefix. The Stage 5 cheap-derivation pipeline (strip "The ", `&` → `and`,
+# bracket-strip, multi-credit split) is the LML replacement for those folds
+# until the column side moves; flipping the input alone would short-circuit
+# those variants without symmetric column support. The symmetric pair to
+# watch:
 #   - `identity/normalize.py:canonicalize_for_identity_lookup` already uses
 #     `to_identity_match_form` because its target column is
 #     `entity.identity.library_name` (LML-owned, stored verbatim), NOT a

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -35,16 +35,30 @@ from dataclasses import dataclass
 
 from wxyc_etl.text import split_artist_name
 
-# NOTE(WXYC/library-metadata-lookup#262): per `library-hook-canonicalization-plan`
-# §3.3.1 step 5 the resolver path is the canonical identity-matching consumer
-# and should call `to_identity_match_form`, but the swap is deferred until the
-# PG column expressions adopt a matching `wxyc_identity_match_artist()` analog
-# (per `wxyc-etl/docs/normalization.md`). Today the column side uses
-# `lower(f_unaccent(col))` (≈ `to_match_form` semantics); switching the input
-# alone strips leading articles asymmetrically (input "The Beatles" → "beatles",
-# col → "the beatles") and collapses the Stage 5 preprocessing variants into
-# the canonical key, breaking exact matches for Discogs rows with a "The "
-# prefix.
+# NOTE(WXYC/library-metadata-lookup#262, E3 step 5f, re-verified 2026-05-11):
+# per `library-hook-canonicalization-plan` §3.3.1 step 5 the resolver path is
+# the canonical identity-matching consumer and should call
+# `to_identity_match_form`, but the swap is deferred until the PG column
+# expressions adopt a matching `wxyc_identity_match_artist()` analog (per
+# `wxyc-etl/docs/normalization.md` and plan §3.3.5 — still STILL REQUIRED /
+# pending as of 2026-05-11; see wiki §3.3.0 status update). Today the
+# discogs-cache column side uses `lower(f_unaccent(col))` (≈ `to_match_form`
+# semantics; see `discogs-etl/scripts/run_pipeline.py` GIN indexes on
+# `release_artist`, `release`, `release_track`, `release_track_artist`).
+# Switching the input alone strips leading articles asymmetrically (input
+# "The Beatles" → "beatles", col → "the beatles") and collapses the Stage 5
+# preprocessing variants into the canonical key, breaking exact matches for
+# Discogs rows with a "The " prefix. The Stage 5 cheap-derivation pipeline
+# (strip "The ", `&` → `and`, bracket-strip, multi-credit split) is the LML
+# replacement for those folds until the column side moves; flipping the
+# input alone would short-circuit those variants without symmetric column
+# support. The symmetric pair to watch:
+#   - `identity/normalize.py:canonicalize_for_identity_lookup` already uses
+#     `to_identity_match_form` because its target column is
+#     `entity.identity.library_name` (LML-owned, stored verbatim), NOT a
+#     `lower(f_unaccent(...))` cache column.
+#   - This file's target columns ARE `lower(f_unaccent(...))`; flipping
+#     here requires the PG analog to ship first.
 from wxyc_etl.text import to_match_form as normalize_artist_name
 
 from scripts.entity_resolution.sources import PgSource

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -368,13 +368,20 @@ class TestNormalizationAsymmetryGuard:
         await reconciler.reconcile_batch(["The Microphones"])
         first_call_args = mock_pg.fetchall.await_args_list[0].args
         _, names_arg = first_call_args
-        assert "the microphones" in names_arg, (
+        # `names_arg` is a list of normalized name strings the reconciler
+        # passes to the SQL `ANY` clause. The `in` checks below assume
+        # list/set membership (each element is a full name), NOT substring
+        # match — if a future refactor flattens to a single joined string,
+        # these assertions break in a non-obvious way. `list(...)` makes
+        # the contract explicit.
+        names_list = list(names_arg)
+        assert "the microphones" in names_list, (
             "Stage 1 input must preserve the leading article so the input matches "
             "the discogs-cache column form. If this fails, the reconciler has been "
             "swapped to to_identity_match_form before the PG analog landed — "
             "see #262 deferred-swap note."
         )
-        assert "microphones" not in names_arg, (
+        assert "microphones" not in names_list, (
             "If 'microphones' (article-stripped) is in the input batch, the reconciler "
             "is using to_identity_match_form. Revert until the PG analog ships."
         )
@@ -390,11 +397,20 @@ class TestNormalizationAsymmetryGuard:
         await reconciler.reconcile_batch(["Stereolab (Live)"])
         first_call_args = mock_pg.fetchall.await_args_list[0].args
         _, names_arg = first_call_args
+        names_list = list(names_arg)
         # to_match_form lowercases but preserves the paren; the cache-side
         # `lower(f_unaccent("Stereolab (Live)"))` would equal "stereolab (live)".
-        assert "stereolab (live)" in names_arg, (
+        assert "stereolab (live)" in names_list, (
             "Stage 1 input must preserve the trailing paren suffix to stay symmetric "
             "with the discogs-cache column form. See #262 deferred-swap note."
+        )
+        # Negative-case symmetry with the leading-article test: if the
+        # paren-stripped form `"stereolab"` is in the input batch, the
+        # reconciler is using to_identity_match_form (which drops `(Live)`
+        # suffixes). Revert until the PG analog ships.
+        assert "stereolab" not in names_list, (
+            "If 'stereolab' (paren-stripped) is in the input batch, the reconciler "
+            "is using to_identity_match_form. Revert until the PG analog ships."
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -342,3 +342,73 @@ class TestDiacriticInsensitiveMatch:
         assert "Björk" in results
         # Original spelling preserved as the dict key for write-back to entity.identity.
         assert results["Björk"].discogs_artist_id == 7777
+
+
+class TestNormalizationAsymmetryGuard:
+    """Regression tests that pin the deferred-swap decision from
+    WXYC/library-metadata-lookup#262 (E3 step 5f).
+
+    The reconciler intentionally uses ``to_match_form`` (not
+    ``to_identity_match_form``) on the input side because the discogs-cache
+    column side stores ``lower(f_unaccent(...))`` and the matching Postgres
+    analog ``wxyc_identity_match_artist()`` has not shipped yet (plan §3.3.5
+    is still pending as of 2026-05-11). Flipping the input alone would
+    create asymmetry (leading-article drop, paren-suffix strip) and break
+    the Stage 5 preprocessing variants. These tests fail loudly if a
+    future drive-by edit swaps the alias before the column side moves.
+    """
+
+    @pytest.mark.asyncio
+    async def test_leading_article_preserved_on_input_side(self, reconciler, mock_pg):
+        """``to_match_form`` keeps leading "The "; ``to_identity_match_form`` would
+        drop it. The discogs-cache column stores ``lower(f_unaccent("The Beatles"))``
+        = ``"the beatles"`` — so the input must match that, not "beatles".
+        """
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        await reconciler.reconcile_batch(["The Beatles"])
+        first_call_args = mock_pg.fetchall.await_args_list[0].args
+        _, names_arg = first_call_args
+        assert "the beatles" in names_arg, (
+            "Stage 1 input must preserve the leading article so the input matches "
+            "the discogs-cache column form. If this fails, the reconciler has been "
+            "swapped to to_identity_match_form before the PG analog landed — "
+            "see #262 deferred-swap note."
+        )
+        assert "beatles" not in names_arg, (
+            "If 'beatles' (article-stripped) is in the input batch, the reconciler "
+            "is using to_identity_match_form. Revert until the PG analog ships."
+        )
+
+    @pytest.mark.asyncio
+    async def test_paren_suffix_preserved_on_input_side(self, reconciler, mock_pg):
+        """``to_match_form`` keeps trailing parens; ``to_identity_match_form`` drops
+        ``(Live)`` / ``(2024 Remaster)``-style suffixes. Asymmetric vs the
+        discogs-cache column form.
+        """
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        # Use a (Live) suffix shape — to_match_form preserves, to_identity_match_form drops.
+        await reconciler.reconcile_batch(["Stereolab (Live)"])
+        first_call_args = mock_pg.fetchall.await_args_list[0].args
+        _, names_arg = first_call_args
+        # to_match_form lowercases but preserves the paren; the cache-side
+        # `lower(f_unaccent("Stereolab (Live)"))` would equal "stereolab (live)".
+        assert "stereolab (live)" in names_arg, (
+            "Stage 1 input must preserve the trailing paren suffix to stay symmetric "
+            "with the discogs-cache column form. See #262 deferred-swap note."
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconciler_imports_to_match_form_not_identity_form(self):
+        """Static guard: the reconciler module's `normalize_artist_name` alias must
+        bind to ``wxyc_etl.text.to_match_form`` until the PG analog ships.
+        """
+        from wxyc_etl.text import to_identity_match_form, to_match_form
+
+        from scripts.entity_resolution import discogs as reconciler_module
+
+        assert reconciler_module.normalize_artist_name is to_match_form, (
+            "Reconciler must import `to_match_form as normalize_artist_name`. "
+            "Swapping to to_identity_match_form is gated on plan §3.3.5 (PG analog). "
+            "See WXYC/library-metadata-lookup#262 (E3 step 5f)."
+        )
+        assert reconciler_module.normalize_artist_name is not to_identity_match_form

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -346,36 +346,36 @@ class TestDiacriticInsensitiveMatch:
 
 class TestNormalizationAsymmetryGuard:
     """Regression tests that pin the deferred-swap decision from
-    WXYC/library-metadata-lookup#262 (E3 step 5f).
+    WXYC/library-metadata-lookup#262.
 
     The reconciler intentionally uses ``to_match_form`` (not
     ``to_identity_match_form``) on the input side because the discogs-cache
     column side stores ``lower(f_unaccent(...))`` and the matching Postgres
-    analog ``wxyc_identity_match_artist()`` has not shipped yet (plan §3.3.5
-    is still pending as of 2026-05-11). Flipping the input alone would
-    create asymmetry (leading-article drop, paren-suffix strip) and break
-    the Stage 5 preprocessing variants. These tests fail loudly if a
-    future drive-by edit swaps the alias before the column side moves.
+    analog ``wxyc_identity_match_artist()`` has not shipped (plan §3.3.5
+    pending). Flipping the input alone would create asymmetry (leading-article
+    drop, paren-suffix strip) and break the Stage 5 preprocessing variants.
+    These tests fail loudly if a future drive-by edit swaps the alias before
+    the column side moves.
     """
 
     @pytest.mark.asyncio
     async def test_leading_article_preserved_on_input_side(self, reconciler, mock_pg):
         """``to_match_form`` keeps leading "The "; ``to_identity_match_form`` would
-        drop it. The discogs-cache column stores ``lower(f_unaccent("The Beatles"))``
-        = ``"the beatles"`` — so the input must match that, not "beatles".
+        drop it. The discogs-cache column stores ``lower(f_unaccent("The Microphones"))``
+        = ``"the microphones"`` — so the input must match that, not "microphones".
         """
         mock_pg.fetchall = AsyncMock(return_value=[])
-        await reconciler.reconcile_batch(["The Beatles"])
+        await reconciler.reconcile_batch(["The Microphones"])
         first_call_args = mock_pg.fetchall.await_args_list[0].args
         _, names_arg = first_call_args
-        assert "the beatles" in names_arg, (
+        assert "the microphones" in names_arg, (
             "Stage 1 input must preserve the leading article so the input matches "
             "the discogs-cache column form. If this fails, the reconciler has been "
             "swapped to to_identity_match_form before the PG analog landed — "
             "see #262 deferred-swap note."
         )
-        assert "beatles" not in names_arg, (
-            "If 'beatles' (article-stripped) is in the input batch, the reconciler "
+        assert "microphones" not in names_arg, (
+            "If 'microphones' (article-stripped) is in the input batch, the reconciler "
             "is using to_identity_match_form. Revert until the PG analog ships."
         )
 
@@ -409,6 +409,6 @@ class TestNormalizationAsymmetryGuard:
         assert reconciler_module.normalize_artist_name is to_match_form, (
             "Reconciler must import `to_match_form as normalize_artist_name`. "
             "Swapping to to_identity_match_form is gated on plan §3.3.5 (PG analog). "
-            "See WXYC/library-metadata-lookup#262 (E3 step 5f)."
+            "See WXYC/library-metadata-lookup#262."
         )
         assert reconciler_module.normalize_artist_name is not to_identity_match_form


### PR DESCRIPTION
## Summary

E3 step 5f acceptance evaluation: the reconciler-side swap from `to_match_form` to `to_identity_match_form` (originally framed as a straightforward consumer migration) **must remain deferred** until the wiki §3.3.5 Postgres analog of `to_identity_match_form` ships. The swap is consumer-side only — without a matching column-side normalizer, the SELECT input and the stored data would use different normalization rules and the reconciler join would systematically miss matches.

Re-verified against `WXYC/wiki/plans/library-hook-canonicalization.md` §3.3.0 + §3.3.1: the Postgres analog is explicitly marked as "STILL REQUIRED. WX-2 ships Rust + Python only; no Postgres analog is in flight." The column-side normalization in `discogs-etl/scripts/run_pipeline.py` is `lower(f_unaccent(...))` across all four cascade tables (`release_artist`, `release`, `release_track`, `release_track_artist`) — that's `to_match_form` semantics, which is what the existing consumer-side import correctly pairs with.

## What this PR ships

- **`scripts/entity_resolution/discogs.py`**: expanded the existing deferred-swap NOTE with a pointer to wiki §3.3.0 status, the discogs-etl `lower(f_unaccent)` location, and a contrast against the symmetric pair already used in `identity/normalize.py`. Import alias `to_match_form as normalize_artist_name` is unchanged — that's the load-bearing decision.
- **`discogs/matching.py`**: added module-level + per-helper docstring notes labeling `normalize_for_track_comparison` and `normalize_artist_for_validation` as **validation utilities, NOT identity matching**. Their LML-specific rules (`&` → `and`, full-punctuation strip, `(2)`-suffix strip, "Weird Al" quote-strip) are deliberately NOT in `to_identity_match_form` and would either over- or under-collapse for tracklist validation. Documented these constraints rather than refactoring.
- **`tests/unit/test_discogs_reconciliation.py`**: new `TestNormalizationAsymmetryGuard` class with 3 tests that lock the input-side invariant — leading-article preserved (using "The Microphones"), trailing-paren preserved, alias binds to `to_match_form`. They fail loudly with `#262` in the failure messages if a future drive-by attempt swaps the alias without first landing the Postgres analog.

## Acceptance-checkbox note

The original issue body lists "`scripts/entity_resolution/discogs.py` uses `to_identity_match_form` for the resolver path" as a checkbox. The checkbox is aspirational and conflicts with the deferred-swap rationale captured in the same issue's prose. Outcome (a) does not satisfy that checkbox literally; it satisfies the spirit of the issue (validate the migration is safe, then defer until the asymmetry is resolved). The Postgres-analog work is tracked separately as a follow-up — see [WXYC/discogs-etl#194](https://github.com/WXYC/discogs-etl/issues/194).

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 247 files already formatted
- [x] `uv run mypy .` — no issues
- [x] `uv run pytest tests/unit/ -q` — 1683 passed (incl. 3 new asymmetry-guard tests)
- [x] `uv run pytest -m pg -q` — 75 passed, 5 skipped (the skips are the existing `release_artist` fixture pattern; unchanged from main)

Closes #262