### PR TITLE
#280: flip reconciler to to_identity_match_form + symmetric SQL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "aiolimiter>=1.1.0",
     "sentry-sdk[fastapi]>=2.0.0",
     "python-multipart>=0.0.6",
-    "wxyc-etl>=0.3.0",
+    "wxyc-etl>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -12,17 +12,16 @@ Resolves WXYC library artist names to Discogs artist IDs via a cascade:
    same equality cascade reused on the variant strings, so no new index or
    query plan is added.
 
-Matching is diacritic-insensitive on both sides (``lower(f_unaccent(col))``
-on the column, ``normalize_artist_name(name)`` on the input). The cache load
-pipeline (``discogs-etl/scripts/filter_csv.py:normalize_artist``) strips
-diacritics when deciding which Discogs rows to retain, so reconciliation has
-to use the same normalization or any artist whose WXYC spelling differs in
-diacritics from the Discogs spelling silently goes unreconciled — which is
-the gap that produced the 17% reconciliation rate observed in prod.
-
-The ``lower(f_unaccent(...))`` column expression matches the existing GIN
-trigram index in the discogs-cache schema (see
-``discogs-etl/schema/create_indexes.sql``) so this remains an indexed lookup.
+Matching uses ``wxyc_identity_match_artist(col)`` on the column and
+``to_identity_match_form(name)`` (aliased here as ``normalize_artist_name``)
+on the input — the symmetric pair specified by wiki
+``plans/library-hook-canonicalization.md`` §3.3.5. The discogs-cache
+deploys ``wxyc_identity_match_artist`` as the Postgres analog of the Rust
+``to_identity_match_form`` (WXYC/discogs-etl#195), so the two sides
+collapse the same case + diacritic + leading-article + paren-suffix axes
+identically. The cache-side functional GIN trigram index rebuild over the
+new function expression is tracked separately; ``= ANY(...)`` exact lookups
+fall back to per-row evaluation in the meantime.
 
 Ported from semantic-index ``reconciliation.py``.
 """
@@ -35,59 +34,40 @@ from dataclasses import dataclass
 
 from wxyc_etl.text import split_artist_name
 
-# NOTE(WXYC/library-metadata-lookup#262): the resolver path is the canonical
-# identity-matching consumer and should call `to_identity_match_form` per
-# `library-hook-canonicalization-plan` §3.3.1 step 5, but the swap is
-# deferred until the PG column expressions adopt a matching
-# `wxyc_identity_match_artist()` analog (plan §3.3.5 — pending; see wiki
-# §3.3.0 status). Today the discogs-cache column side uses
-# `lower(f_unaccent(col))` (≈ `to_match_form` semantics; see
-# `discogs-etl/scripts/run_pipeline.py` GIN indexes on `release_artist`,
-# `release`, `release_track`, `release_track_artist`). Switching the input
-# alone strips leading articles asymmetrically (input "The X" → "x", col →
-# "the x") and collapses the Stage 5 preprocessing variants into the
-# canonical key, breaking exact matches for Discogs rows with a "The "
-# prefix. The Stage 5 cheap-derivation pipeline (strip "The ", `&` → `and`,
-# bracket-strip, multi-credit split) is the LML replacement for those folds
-# until the column side moves; flipping the input alone would short-circuit
-# those variants without symmetric column support. The symmetric pair to
-# watch:
-#   - `identity/normalize.py:canonicalize_for_identity_lookup` already uses
-#     `to_identity_match_form` because its target column is
-#     `entity.identity.library_name` (LML-owned, stored verbatim), NOT a
-#     `lower(f_unaccent(...))` cache column.
-#   - This file's target columns ARE `lower(f_unaccent(...))`; flipping
-#     here requires the PG analog to ship first.
-from wxyc_etl.text import to_match_form as normalize_artist_name
+# The reconciler is the canonical identity-matching consumer per wiki
+# `plans/library-hook-canonicalization.md` §3.3.1 step 5. Symmetric pair:
+# `to_identity_match_form` on the input side, `wxyc_identity_match_artist`
+# on the column side (deployed in WXYC/discogs-etl#195).
+from wxyc_etl.text import to_identity_match_form as normalize_artist_name
 
 from scripts.entity_resolution.sources import PgSource
 
 logger = logging.getLogger(__name__)
 
 _EXACT_MATCH_SQL = """\
-SELECT DISTINCT lower(f_unaccent(ra.artist_name)) AS artist_name, ra.artist_id
+SELECT DISTINCT wxyc_identity_match_artist(ra.artist_name) AS artist_name, ra.artist_id
 FROM release_artist ra
 WHERE ra.extra = 0
   AND ra.artist_id IS NOT NULL
-  AND lower(f_unaccent(ra.artist_name)) = ANY($1)\
+  AND wxyc_identity_match_artist(ra.artist_name) = ANY($1)\
 """
 
 _MEMBER_MATCH_SQL = """\
-SELECT DISTINCT lower(f_unaccent(am.member_name)) AS member_name, am.member_id
+SELECT DISTINCT wxyc_identity_match_artist(am.member_name) AS member_name, am.member_id
 FROM artist_member am
-WHERE lower(f_unaccent(am.member_name)) = ANY($1)\
+WHERE wxyc_identity_match_artist(am.member_name) = ANY($1)\
 """
 
 _ALIAS_MATCH_SQL = """\
-SELECT DISTINCT lower(f_unaccent(aa.alias_name)) AS alias_name, aa.artist_id
+SELECT DISTINCT wxyc_identity_match_artist(aa.alias_name) AS alias_name, aa.artist_id
 FROM artist_alias aa
-WHERE lower(f_unaccent(aa.alias_name)) = ANY($1)\
+WHERE wxyc_identity_match_artist(aa.alias_name) = ANY($1)\
 """
 
 _NAME_VARIATION_MATCH_SQL = """\
-SELECT DISTINCT lower(f_unaccent(nv.name)) AS name, nv.artist_id
+SELECT DISTINCT wxyc_identity_match_artist(nv.name) AS name, nv.artist_id
 FROM artist_name_variation nv
-WHERE lower(f_unaccent(nv.name)) = ANY($1)\
+WHERE wxyc_identity_match_artist(nv.name) = ANY($1)\
 """
 
 
@@ -196,12 +176,13 @@ class DiscogsReconciler:
 
         results: dict[str, ReconciliationMatch] = {}
 
-        # Build normalized (diacritic-stripped + lowercased) -> canonical mapping.
-        # The same normalization is applied to the column side via
-        # ``lower(f_unaccent(...))`` in each stage's SQL so the comparison is
-        # symmetric. Two canonicals that normalize to the same form (e.g.
-        # ``Björk`` and ``Bjork``) collapse to the same key — both resolve to
-        # the same Discogs ID, so dropping one is correct.
+        # Build normalized (identity-form) -> canonical mapping. The same
+        # normalization is applied to the column side via
+        # ``wxyc_identity_match_artist(...)`` in each stage's SQL so the
+        # comparison is symmetric (wiki §3.3.5). Two canonicals that normalize
+        # to the same form (e.g. ``Björk`` and ``Bjork``, or ``The Books`` and
+        # ``Books``) collapse to the same key — both resolve to the same
+        # Discogs ID, so dropping one is correct.
         normalized_to_canonical = {normalize_artist_name(n): n for n in effective_names}
 
         # Stage 1: Exact match

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -189,44 +189,46 @@ class TestNamePreprocessingStage:
     """
 
     @pytest.mark.asyncio
-    async def test_leading_the_strip_resolves_via_exact_match(self, reconciler, mock_pg):
-        """'The Microphones' has no exact match, but 'Microphones' (variant) does."""
+    async def test_leading_the_subsumed_by_baseline_normalization(self, reconciler, mock_pg):
+        """Post-#280 the article-strip is part of the locked-on baseline that
+        ``to_identity_match_form`` applies on the input side and
+        ``wxyc_identity_match_artist`` applies on the column side. ``The
+        Microphones`` therefore normalizes to ``microphones`` directly — Stage 1
+        exact match resolves it, and the Stage 5 preprocessing cascade never
+        runs for this case.
+        """
         mock_pg.fetchall = AsyncMock(
-            side_effect=[
-                [],  # Stage 1 exact match (canonical "the microphones") — miss
-                [],  # Stage 2 member — miss
-                [],  # Stage 3 alias — miss
-                [],  # Stage 4 name variation — miss
-                [
-                    {"artist_name": "microphones", "artist_id": 5050}
-                ],  # Stage 5 ⇒ exact match on variant
-            ]
+            return_value=[{"artist_name": "microphones", "artist_id": 5050}]
         )
         results = await reconciler.reconcile_batch(["The Microphones"])
         assert "The Microphones" in results
         assert results["The Microphones"].discogs_artist_id == 5050
-        assert results["The Microphones"].method == "name_preprocessing"
+        # Stage 1 (exact_match) hits, not name_preprocessing — the baseline
+        # already strips the leading article on both sides.
+        assert results["The Microphones"].method == "exact_match"
+        assert mock_pg.fetchall.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_bracket_strip_resolves(self, reconciler, mock_pg):
-        """'Adam X [DJ]' miss; 'Adam X' (bracket-stripped) hits exact match."""
-        mock_pg.fetchall = AsyncMock(
-            side_effect=[
-                [],  # Stage 1 — miss
-                [],  # Stage 2 — miss
-                [],  # Stage 3 — miss
-                [],  # Stage 4 — miss
-                [{"artist_name": "adam x", "artist_id": 8181}],  # Stage 5 ⇒ exact on stripped
-            ]
-        )
+    async def test_bracket_strip_subsumed_by_baseline_normalization(self, reconciler, mock_pg):
+        """Post-#280 the bracket-strip is part of the locked-on baseline.
+        ``Adam X [DJ]`` normalizes to ``adam x`` directly on both sides, so
+        Stage 1 resolves without needing the preprocessing cascade.
+        """
+        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "adam x", "artist_id": 8181}])
         results = await reconciler.reconcile_batch(["Adam X [DJ]"])
         assert "Adam X [DJ]" in results
         assert results["Adam X [DJ]"].discogs_artist_id == 8181
-        assert results["Adam X [DJ]"].method == "name_preprocessing"
+        assert results["Adam X [DJ]"].method == "exact_match"
+        assert mock_pg.fetchall.await_count == 1
 
     @pytest.mark.asyncio
     async def test_split_resolves_via_first_part(self, reconciler, mock_pg):
-        """Multi-artist credit 'Juana Molina / Cat Power' resolves via 'Juana Molina'."""
+        """Multi-artist credit 'Juana Molina / Cat Power' resolves via 'Juana Molina'.
+
+        Multi-credit splitting is NOT in the locked-on baseline, so the canonical
+        ``juana molina / cat power`` still misses Stages 1-4 and the Stage 5
+        split variant ``juana molina`` is what produces the hit.
+        """
         mock_pg.fetchall = AsyncMock(
             side_effect=[
                 [],  # Stage 1 — miss
@@ -254,7 +256,10 @@ class TestNamePreprocessingStage:
     ):
         """An exact-match hit on the canonical short-circuits the cascade —
         Stage 5 does not run, no extra SQL is issued."""
-        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "the books", "artist_id": 4242}])
+        # Post-#280: `to_identity_match_form("The Books")` is `"books"` (article
+        # stripped by the locked-on baseline), so the mock returns the row whose
+        # `wxyc_identity_match_artist` form is `"books"`.
+        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "books", "artist_id": 4242}])
         await reconciler.reconcile_batch(["The Books"])
         # Exactly one SQL call: Stage 1 exact match. No cascade past it.
         assert mock_pg.fetchall.await_count == 1
@@ -265,6 +270,10 @@ class TestNamePreprocessingStage:
         When a variant misses inner stages 1–3 but hits stage 4 (name_variation),
         the canonical still resolves with method="name_preprocessing" — the outer
         method label does not leak the inner stage that produced the hit.
+
+        Uses an ampersand input because ``&`` → ``and`` is NOT in the locked-on
+        baseline; the preprocessing variant is still the only path that exercises
+        it.
         """
         mock_pg.fetchall = AsyncMock(
             side_effect=[
@@ -275,15 +284,16 @@ class TestNamePreprocessingStage:
                 [],  # Stage 5 inner: exact match on variant — miss
                 [],  # Stage 5 inner: member match on variant — miss
                 [],  # Stage 5 inner: alias match on variant — miss
-                [{"name": "microphones", "artist_id": 7777}],  # Stage 5 inner: name_variation hit
+                # Stage 5 inner: name_variation hit on `"mount eerie and julie doiron"`
+                [{"name": "mount eerie and julie doiron", "artist_id": 7777}],
             ]
         )
-        results = await reconciler.reconcile_batch(["The Microphones"])
-        assert "The Microphones" in results
-        assert results["The Microphones"].discogs_artist_id == 7777
+        results = await reconciler.reconcile_batch(["Mount Eerie & Julie Doiron"])
+        assert "Mount Eerie & Julie Doiron" in results
+        assert results["Mount Eerie & Julie Doiron"].discogs_artist_id == 7777
         # Outer label is name_preprocessing, NOT name_variation, even though
         # the hit happened at stage 4 inside the preprocessing cascade.
-        assert results["The Microphones"].method == "name_preprocessing"
+        assert results["Mount Eerie & Julie Doiron"].method == "name_preprocessing"
 
 
 class TestDiacriticInsensitiveMatch:
@@ -318,20 +328,21 @@ class TestDiacriticInsensitiveMatch:
     @pytest.mark.asyncio
     async def test_normalized_input_passed_to_sql(self, reconciler, mock_pg):
         """The names sent to the SQL `ANY($1)` array must already be diacritic-stripped
-        and lowercased — matching the `lower(f_unaccent(...))` expression on the
-        column side (which is what the existing GIN index on release_artist uses)."""
+        and lowercased — matching the `wxyc_identity_match_artist(...)` expression on
+        the column side (post-#280 symmetric pair)."""
         mock_pg.fetchall = AsyncMock(return_value=[])
         await reconciler.reconcile_batch(["Björk", "Hermanos Gutiérrez", "Stereolab"])
         # Inspect the ANY($1) parameter on the first call
         first_call_args = mock_pg.fetchall.await_args_list[0].args
         sql_arg, names_arg = first_call_args
-        assert "lower(f_unaccent(" in sql_arg, (
-            "EXACT_MATCH SQL must use lower(f_unaccent(...)) on the column side "
-            "to be diacritic-insensitive (matches the indexed expression)."
+        assert "wxyc_identity_match_artist(" in sql_arg, (
+            "EXACT_MATCH SQL must use wxyc_identity_match_artist(...) on the column "
+            "side to be symmetric with to_identity_match_form on the input side. "
+            "See WXYC/library-metadata-lookup#280."
         )
         assert sorted(names_arg) == sorted(["bjork", "hermanos gutierrez", "stereolab"]), (
-            "Names sent to SQL must be diacritic-stripped + lowercased before being "
-            "compared against lower(f_unaccent(column))."
+            "Names sent to SQL must be normalized via to_identity_match_form before "
+            "being compared against wxyc_identity_match_artist(column)."
         )
 
     @pytest.mark.asyncio
@@ -344,25 +355,23 @@ class TestDiacriticInsensitiveMatch:
         assert results["Björk"].discogs_artist_id == 7777
 
 
-class TestNormalizationAsymmetryGuard:
-    """Regression tests that pin the deferred-swap decision from
-    WXYC/library-metadata-lookup#262.
+class TestNormalizationSymmetryGuard:
+    """Regression tests that pin the post-flip symmetric pair from
+    WXYC/library-metadata-lookup#280.
 
-    The reconciler intentionally uses ``to_match_form`` (not
-    ``to_identity_match_form``) on the input side because the discogs-cache
-    column side stores ``lower(f_unaccent(...))`` and the matching Postgres
-    analog ``wxyc_identity_match_artist()`` has not shipped (plan §3.3.5
-    pending). Flipping the input alone would create asymmetry (leading-article
-    drop, paren-suffix strip) and break the Stage 5 preprocessing variants.
-    These tests fail loudly if a future drive-by edit swaps the alias before
-    the column side moves.
+    The reconciler uses ``to_identity_match_form`` on the input side and
+    ``wxyc_identity_match_artist(col)`` on the column side (deployed in
+    WXYC/discogs-etl#195). Both sides strip leading articles, paren
+    suffixes, and bracket annotations identically. These tests fail loudly
+    if a future drive-by edit reverts the alias to ``to_match_form`` or
+    leaves the SQL using ``lower(f_unaccent(col))``.
     """
 
     @pytest.mark.asyncio
-    async def test_leading_article_preserved_on_input_side(self, reconciler, mock_pg):
-        """``to_match_form`` keeps leading "The "; ``to_identity_match_form`` would
-        drop it. The discogs-cache column stores ``lower(f_unaccent("The Microphones"))``
-        = ``"the microphones"`` — so the input must match that, not "microphones".
+    async def test_leading_article_stripped_on_input_side(self, reconciler, mock_pg):
+        """``to_identity_match_form`` drops leading "The "; the
+        ``wxyc_identity_match_artist`` column side strips it the same way, so
+        the input batch must carry the stripped form.
         """
         mock_pg.fetchall = AsyncMock(return_value=[])
         await reconciler.reconcile_batch(["The Microphones"])
@@ -375,56 +384,49 @@ class TestNormalizationAsymmetryGuard:
         # these assertions break in a non-obvious way. `list(...)` makes
         # the contract explicit.
         names_list = list(names_arg)
-        assert "the microphones" in names_list, (
-            "Stage 1 input must preserve the leading article so the input matches "
-            "the discogs-cache column form. If this fails, the reconciler has been "
-            "swapped to to_identity_match_form before the PG analog landed — "
-            "see #262 deferred-swap note."
+        assert "microphones" in names_list, (
+            "Stage 1 input must carry the article-stripped form so the input "
+            "matches the wxyc_identity_match_artist column form. If this fails, "
+            "the reconciler has been reverted to to_match_form — see #280."
         )
-        assert "microphones" not in names_list, (
-            "If 'microphones' (article-stripped) is in the input batch, the reconciler "
-            "is using to_identity_match_form. Revert until the PG analog ships."
+        assert "the microphones" not in names_list, (
+            "If 'the microphones' (article-preserving) is in the input batch, "
+            "the reconciler has been reverted to to_match_form. Restore "
+            "to_identity_match_form per WXYC/library-metadata-lookup#280."
         )
 
     @pytest.mark.asyncio
-    async def test_paren_suffix_preserved_on_input_side(self, reconciler, mock_pg):
-        """``to_match_form`` keeps trailing parens; ``to_identity_match_form`` drops
-        ``(Live)`` / ``(2024 Remaster)``-style suffixes. Asymmetric vs the
-        discogs-cache column form.
+    async def test_paren_suffix_stripped_on_input_side(self, reconciler, mock_pg):
+        """``to_identity_match_form`` drops ``(Live)`` / ``(2024 Remaster)``
+        suffixes; the ``wxyc_identity_match_artist`` column side does the same.
         """
         mock_pg.fetchall = AsyncMock(return_value=[])
-        # Use a (Live) suffix shape — to_match_form preserves, to_identity_match_form drops.
         await reconciler.reconcile_batch(["Stereolab (Live)"])
         first_call_args = mock_pg.fetchall.await_args_list[0].args
         _, names_arg = first_call_args
         names_list = list(names_arg)
-        # to_match_form lowercases but preserves the paren; the cache-side
-        # `lower(f_unaccent("Stereolab (Live)"))` would equal "stereolab (live)".
-        assert "stereolab (live)" in names_list, (
-            "Stage 1 input must preserve the trailing paren suffix to stay symmetric "
-            "with the discogs-cache column form. See #262 deferred-swap note."
+        assert "stereolab" in names_list, (
+            "Stage 1 input must carry the paren-stripped form to stay symmetric "
+            "with the wxyc_identity_match_artist column form. See #280."
         )
-        # Negative-case symmetry with the leading-article test: if the
-        # paren-stripped form `"stereolab"` is in the input batch, the
-        # reconciler is using to_identity_match_form (which drops `(Live)`
-        # suffixes). Revert until the PG analog ships.
-        assert "stereolab" not in names_list, (
-            "If 'stereolab' (paren-stripped) is in the input batch, the reconciler "
-            "is using to_identity_match_form. Revert until the PG analog ships."
+        assert "stereolab (live)" not in names_list, (
+            "If 'stereolab (live)' (paren-preserving) is in the input batch, the "
+            "reconciler has been reverted to to_match_form. Restore "
+            "to_identity_match_form per WXYC/library-metadata-lookup#280."
         )
 
     @pytest.mark.asyncio
-    async def test_reconciler_imports_to_match_form_not_identity_form(self):
-        """Static guard: the reconciler module's `normalize_artist_name` alias must
-        bind to ``wxyc_etl.text.to_match_form`` until the PG analog ships.
+    async def test_reconciler_imports_to_identity_match_form(self):
+        """Static guard: the reconciler module's `normalize_artist_name` alias
+        must bind to ``wxyc_etl.text.to_identity_match_form`` post-#280.
         """
         from wxyc_etl.text import to_identity_match_form, to_match_form
 
         from scripts.entity_resolution import discogs as reconciler_module
 
-        assert reconciler_module.normalize_artist_name is to_match_form, (
-            "Reconciler must import `to_match_form as normalize_artist_name`. "
-            "Swapping to to_identity_match_form is gated on plan §3.3.5 (PG analog). "
-            "See WXYC/library-metadata-lookup#262."
+        assert reconciler_module.normalize_artist_name is to_identity_match_form, (
+            "Reconciler must import `to_identity_match_form as normalize_artist_name`. "
+            "Reverting to to_match_form re-introduces the asymmetry that #280 closed. "
+            "See WXYC/library-metadata-lookup#280."
         )
-        assert reconciler_module.normalize_artist_name is not to_identity_match_form
+        assert reconciler_module.normalize_artist_name is not to_match_form

--- a/uv.lock
+++ b/uv.lock
@@ -544,7 +544,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.6" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
-    { name = "wxyc-etl", specifier = ">=0.3.0" },
+    { name = "wxyc-etl", specifier = ">=0.4.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1254,15 +1254,15 @@ wheels = [
 
 [[package]]
 name = "wxyc-etl"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-json-logger" },
     { name = "sentry-sdk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/d6/435c772f6454b9f5211f2586d43bd0013f450cd26244b8d2fac1798d10c3/wxyc_etl-0.3.0.tar.gz", hash = "sha256:25d2deb6dc668d4f558a10ff471a9ad4d1905894d01160f8e0c871e112807a58", size = 146608, upload-time = "2026-05-07T05:22:37.138Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/21/11d20c97a21153c64fbc26e4b5a8be66b269c0dbce48c6e1648346797323/wxyc_etl-0.4.0.tar.gz", hash = "sha256:962c95adaa11932866422756651ea1debcee085243db53d87b740be9ba210919", size = 151119, upload-time = "2026-05-11T16:26:15.264Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/2e/f1f55077a7d6b642239e896d16551056cbf3e33a591fdb1d0f1191aaf9ef/wxyc_etl-0.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:3ac1bdb3793a62f3a8614916fca3313e7b817654c752638c479bb1547f387d9c", size = 843237, upload-time = "2026-05-07T05:22:32.836Z" },
-    { url = "https://files.pythonhosted.org/packages/66/29/0417b4e2e87daffbc46189f09096ca08c10b3652b96ede0bb4fa709986e0/wxyc_etl-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edd6a667e708ccef484d53a9eb989b98bf0392dbbb276aa7e0835c7efae3dc6f", size = 877235, upload-time = "2026-05-07T05:22:34.477Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/1a/9c7838d53aadddfd817c1150c421021b0ad2d74049fe5893d719e8ea9f5d/wxyc_etl-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18fbd7e7f21ece1eb2062411904c0c29cc2c38706fb865ee89c7fe6c3d832a71", size = 1102639, upload-time = "2026-05-07T05:22:35.676Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/da/a8a1abee60641b50bf1842ff01972492912cf32d819b1a8c3dd6fd1a31ca/wxyc_etl-0.4.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4adcab8c8860cc407972bf10b238536cf870816051b8d6d743311d1ad2e17b33", size = 843142, upload-time = "2026-05-11T16:26:10.849Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/45/76d4411e443de7030b68ce28ad3e875e474fa329265444cf11da723b3fd6/wxyc_etl-0.4.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1edfbb1e9db4b82eb7a731a9f5295edc8050b1a857867b7f6e55b47c6bd6e899", size = 877222, upload-time = "2026-05-11T16:26:12.397Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d9/f173ae9633a45b56a7c176ecc878217708c93a34a8ed9217c6478243e406/wxyc_etl-0.4.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b75f7847b3decdb4f127f33540f2ee0f40cc12fd61d1ef97f82396b6f4965e1", size = 1102479, upload-time = "2026-05-11T16:26:13.97Z" },
 ]


### PR DESCRIPTION
## Summary

Closes the deferred-swap pinned by #262 / PR #279 now that WXYC/discogs-etl#195 has deployed `wxyc_identity_match_artist()` to the discogs-cache. Reconciler's input side and the column side now collapse the same axes — case + diacritics + leading-article + paren-suffix + bracket annotations — per the locked-on baseline in wiki [`plans/library-hook-canonicalization.md` §3.3.5](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization.md#335-postgres-analog-implementation-specification).

## Changes

- **`scripts/entity_resolution/discogs.py`** — alias flip + SQL flip:
  - Replace the 23-line deferred-swap NOTE block with a 3-line pointer at the symmetric pair.
  - `from wxyc_etl.text import to_match_form as normalize_artist_name` → `to_identity_match_form as normalize_artist_name`.
  - All four SQL queries flip `lower(f_unaccent(col))` → `wxyc_identity_match_artist(col)` (`release_artist.artist_name`, `artist_member.member_name`, `artist_alias.alias_name`, `artist_name_variation.name`).
  - Module + `reconcile_batch` docstrings updated.

- **`tests/unit/test_discogs_reconciliation.py`** — invert the asymmetry guard:
  - `TestNormalizationAsymmetryGuard` → `TestNormalizationSymmetryGuard`; all three assertions inverted (article-stripped form expected in input batch, paren-stripped form expected, alias bound to `to_identity_match_form`).
  - `TestDiacriticInsensitiveMatch.test_normalized_input_passed_to_sql` updated to assert the new column-side form.
  - Preprocessing-stage tests whose canonical now normalizes directly under the locked-on baseline (`The Microphones` → `microphones`; `Adam X [DJ]` → `adam x`) are repurposed to demonstrate that Stage 1 resolves them — they no longer require the Stage 5 preprocessing cascade. `test_variant_resolves_via_inner_name_variation_stage` moves to a `Mount Eerie & Julie Doiron` example because `& → and` is **not** in the locked-on baseline and is still the only path that exercises Stage 5 inner cascade.

- **`pyproject.toml`** — bump `wxyc-etl >=0.3.0` → `>=0.4.0` so `to_identity_match_form` is importable.

## Symmetry trace

With wxyc-etl 0.4.0 + discogs-etl alembic 0004 deployed:

| Input | `to_identity_match_form(input)` | `wxyc_identity_match_artist(col)` | match |
|---|---|---|---|
| `The Microphones` | `microphones` | `microphones` | ✓ |
| `Stereolab (Live)` | `stereolab` | `stereolab` | ✓ |
| `Hermanos Gutiérrez` | `hermanos gutierrez` | `hermanos gutierrez` | ✓ |
| `Adam X [DJ]` | `adam x` | `adam x` | ✓ |

Pre-flip, the input side stripped articles/parens but the column side didn't — silent under-matching on Discogs rows with `The ` prefixes or `(Live)` suffixes.

## Test plan

- [x] `uv run ruff check .` (clean)
- [x] `uv run ruff format --check .` (247 files formatted)
- [x] `uv run mypy .` (no issues, 247 source files)
- [x] `uv run pytest tests/unit/` — 1688 passed
- [ ] CI `pg` job: pg-marked integration tests query columns expected to be normalized by `wxyc_identity_match_artist` — exercises the new functions deployed by discogs-etl alembic 0004 against the `postgres:16-alpine` service container.

## Related

- Closes #280
- Built on WXYC/discogs-etl#195 (function deploy, merged 2026-05-11)
- Vendors `to_identity_match_form` from WXYC/wxyc-etl 0.4.0 (PyPI)
- Sibling deploys: WXYC/musicbrainz-cache#52, WXYC/wikidata-cache#38 (both merged 2026-05-11)
- Parent epic: WXYC/wxyc-etl#73 (E3)
- Prior work: #262 / PR #279 (locked the deferred-swap)

The deferred index/cache-load flip in discogs-etl (the `idx_release_*_trgm` rebuild over `wxyc_identity_match_artist(col)`) is a perf optimization tracked separately; the `= ANY(...)` exact-equality lookups in this reconciler don't use the trigram index either way, so its absence doesn't block correctness.