### PR TITLE
#285 followup: address review feedback on identity-match flip

### DIFF
--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -186,6 +186,153 @@ class TestDiscogsReconciliationIntegration:
 
 
 @pytest.mark.pg
+class TestDiscogsReconciliationSQLSmoke:
+    """Smoke-test that each of the four reconciler SQL strings parses and
+    executes against a Postgres with the wxyc_identity_match_* functions
+    deployed (WXYC/discogs-etl#195, alembic 0004).
+
+    Why this test exists: the sibling ``test_reconcile_known_artists`` (above)
+    self-skips when ``release_artist`` is empty, which is the CI scenario.
+    Pre-#285 that meant CI never executed the
+    ``wxyc_identity_match_artist(col)`` SQL even after the flip — only prod
+    saw the symmetric pair under live traffic. This test closes that gap by
+    running each query with an empty ``ANY($1)`` array against stub tables,
+    asserting only that the SQL parses, the function call resolves, and the
+    rowset comes back empty.
+
+    Skip behavior: when ``wxyc_identity_match_artist`` is not present in
+    ``pg_proc`` (e.g. CI's vanilla ``postgres:16-alpine`` without alembic
+    0004 applied), this class self-skips. The function depends on the
+    ``unaccent`` extension and the ``wxyc_unaccent`` text-search dictionary
+    (which requires the rules file installed at the server's
+    ``$SHAREDIR/tsearch_data/``), neither of which is trivially provisioned
+    on the CI service container.
+
+    TODO(wxyc-etl): wxyc-etl 0.4.0 does not ship
+    ``wxyc_identity_match_functions.sql`` as package data — it lives only in
+    the wxyc-etl source tree at ``data/`` and is vendored byte-for-byte into
+    each cache repo. If a future release exposes the canonical SQL as
+    ``importlib.resources``-readable package data, the fixture below could
+    deploy the functions inline (idempotent ``CREATE OR REPLACE``) and the
+    smoke test would run on CI's plain postgres-16 service container — at
+    which point the skip becomes the exception rather than the rule. Until
+    then this test runs only on caches where alembic 0004 has been applied
+    (homebrew dev cache + Railway prod / staging).
+    """
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def ensure_reconciler_schema(self, pg_pool):
+        """Skip when ``wxyc_identity_match_artist`` isn't deployed, otherwise
+        create stub tables matching the columns each reconciler query reads.
+
+        Same skip pattern as ``test_reconcile_known_artists`` (which skips on
+        missing ``release_artist``) — keeps the test inert on fresh CI
+        postgres instances while still exercising the SQL on any
+        alembic-0004-applied cache.
+
+        Stub tables are idempotent (``IF NOT EXISTS``) so this is a no-op on a
+        real discogs-cache where the tables already exist with populated
+        data. The test queries always pass ``[]`` for ``ANY($1)``, so the
+        rowset is empty regardless of whether the underlying table is.
+        """
+        async with pg_pool.acquire() as conn:
+            exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = $1)",
+                "wxyc_identity_match_artist",
+            )
+            if not exists:
+                pytest.skip(
+                    "wxyc_identity_match_artist not deployed -- needs alembic 0004 "
+                    "from WXYC/discogs-etl. CI's plain postgres-16 service container "
+                    "doesn't have it. See class docstring for the TODO."
+                )
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS release_artist (
+                    release_id INTEGER,
+                    artist_id INTEGER,
+                    artist_name TEXT,
+                    extra INTEGER DEFAULT 0
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS artist_member (
+                    artist_id INTEGER,
+                    member_id INTEGER,
+                    member_name TEXT
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS artist_alias (
+                    artist_id INTEGER,
+                    alias_name TEXT
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS artist_name_variation (
+                    artist_id INTEGER,
+                    name TEXT
+                )
+            """)
+        yield
+
+    @pytest.mark.asyncio
+    async def test_exact_match_sql_parses_and_executes(self, pg_source):
+        from scripts.entity_resolution.discogs import _EXACT_MATCH_SQL
+
+        rows = await pg_source.fetchall(_EXACT_MATCH_SQL, [])
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_member_match_sql_parses_and_executes(self, pg_source):
+        from scripts.entity_resolution.discogs import _MEMBER_MATCH_SQL
+
+        rows = await pg_source.fetchall(_MEMBER_MATCH_SQL, [])
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_alias_match_sql_parses_and_executes(self, pg_source):
+        from scripts.entity_resolution.discogs import _ALIAS_MATCH_SQL
+
+        rows = await pg_source.fetchall(_ALIAS_MATCH_SQL, [])
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_name_variation_match_sql_parses_and_executes(self, pg_source):
+        from scripts.entity_resolution.discogs import _NAME_VARIATION_MATCH_SQL
+
+        rows = await pg_source.fetchall(_NAME_VARIATION_MATCH_SQL, [])
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_all_four_match_functions_exist(self, pg_pool):
+        """Confirm the full family of cross-cache-identity functions deploys
+        together. Pinned because LML's reconciler only currently uses the
+        ``_artist`` flavor, but the column-side flip in #285 was paired with
+        a function family deploy in discogs-etl#195; a future reconciler
+        change that reaches for ``_title`` / ``_with_punctuation`` /
+        ``_with_disambiguator_strip`` should fail loudly here rather than
+        at runtime if any sibling went missing.
+        """
+        expected = {
+            "wxyc_identity_match_artist",
+            "wxyc_identity_match_title",
+            "wxyc_identity_match_with_punctuation",
+            "wxyc_identity_match_with_disambiguator_strip",
+        }
+        async with pg_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT proname FROM pg_proc WHERE proname = ANY($1)",
+                list(expected),
+            )
+        present = {row["proname"] for row in rows}
+        missing = expected - present
+        assert not missing, (
+            f"Missing wxyc_identity_match_* functions: {sorted(missing)}. "
+            "Re-run alembic 0004 from WXYC/discogs-etl against this cache."
+        )
+
+
+@pytest.mark.pg
 class TestIdentityRouterEntityStoreUnavailable:
     """Identity routes return 503 — not 500 — when the entity schema is missing.
 

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -10,6 +10,7 @@ Requires: DATABASE_URL_TEST env var or Docker postgres on port 5433.
 from __future__ import annotations
 
 import os
+from typing import ClassVar
 
 import asyncpg
 import pytest
@@ -208,32 +209,34 @@ class TestDiscogsReconciliationSQLSmoke:
     ``$SHAREDIR/tsearch_data/``), neither of which is trivially provisioned
     on the CI service container.
 
-    TODO(wxyc-etl): wxyc-etl 0.4.0 does not ship
-    ``wxyc_identity_match_functions.sql`` as package data — it lives only in
-    the wxyc-etl source tree at ``data/`` and is vendored byte-for-byte into
-    each cache repo. If a future release exposes the canonical SQL as
-    ``importlib.resources``-readable package data, the fixture below could
-    deploy the functions inline (idempotent ``CREATE OR REPLACE``) and the
-    smoke test would run on CI's plain postgres-16 service container — at
-    which point the skip becomes the exception rather than the rule. Until
-    then this test runs only on caches where alembic 0004 has been applied
-    (homebrew dev cache + Railway prod / staging).
+    TODO(wxyc-etl): when wxyc-etl ships ``wxyc_identity_match_functions.sql``
+    as ``importlib.resources``-readable package data, the fixture below can
+    deploy the functions inline and this test will run on CI's plain
+    postgres-16 service container. Today the SQL only lives in the wxyc-etl
+    source tree and is vendored byte-for-byte into each cache repo.
     """
+
+    _STUB_TABLES: ClassVar[dict[str, str]] = {
+        "release_artist": (
+            "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0"
+        ),
+        "artist_member": "artist_id INTEGER, member_id INTEGER, member_name TEXT",
+        "artist_alias": "artist_id INTEGER, alias_name TEXT",
+        "artist_name_variation": "artist_id INTEGER, name TEXT",
+    }
 
     @pytest_asyncio.fixture(autouse=True)
     async def ensure_reconciler_schema(self, pg_pool):
         """Skip when ``wxyc_identity_match_artist`` isn't deployed, otherwise
-        create stub tables matching the columns each reconciler query reads.
+        ensure the four reconciler tables exist (stub them only if absent),
+        and drop any stubs we created on teardown.
 
         Same skip pattern as ``test_reconcile_known_artists`` (which skips on
-        missing ``release_artist``) — keeps the test inert on fresh CI
-        postgres instances while still exercising the SQL on any
-        alembic-0004-applied cache.
-
-        Stub tables are idempotent (``IF NOT EXISTS``) so this is a no-op on a
-        real discogs-cache where the tables already exist with populated
-        data. The test queries always pass ``[]`` for ``ANY($1)``, so the
-        rowset is empty regardless of whether the underlying table is.
+        missing ``release_artist``). On a real discogs-cache the tables exist
+        with data, so ``CREATE TABLE IF NOT EXISTS`` is a no-op and the
+        teardown's ``created_tables`` set is empty — real data survives. On a
+        fresh PG (currently unreachable: we skip before getting here) only the
+        stubs we created get dropped, so cross-test pollution can't accrete.
         """
         async with pg_pool.acquire() as conn:
             exists = await conn.fetchval(
@@ -246,34 +249,22 @@ class TestDiscogsReconciliationSQLSmoke:
                     "from WXYC/discogs-etl. CI's plain postgres-16 service container "
                     "doesn't have it. See class docstring for the TODO."
                 )
-            await conn.execute("""
-                CREATE TABLE IF NOT EXISTS release_artist (
-                    release_id INTEGER,
-                    artist_id INTEGER,
-                    artist_name TEXT,
-                    extra INTEGER DEFAULT 0
+            created_tables: set[str] = set()
+            for table_name, columns in self._STUB_TABLES.items():
+                pre_existing = await conn.fetchval(
+                    "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = current_schema() AND table_name = $1)",
+                    table_name,
                 )
-            """)
-            await conn.execute("""
-                CREATE TABLE IF NOT EXISTS artist_member (
-                    artist_id INTEGER,
-                    member_id INTEGER,
-                    member_name TEXT
-                )
-            """)
-            await conn.execute("""
-                CREATE TABLE IF NOT EXISTS artist_alias (
-                    artist_id INTEGER,
-                    alias_name TEXT
-                )
-            """)
-            await conn.execute("""
-                CREATE TABLE IF NOT EXISTS artist_name_variation (
-                    artist_id INTEGER,
-                    name TEXT
-                )
-            """)
-        yield
+                if not pre_existing:
+                    await conn.execute(f"CREATE TABLE {table_name} ({columns})")
+                    created_tables.add(table_name)
+        try:
+            yield
+        finally:
+            async with pg_pool.acquire() as conn:
+                for table_name in created_tables:
+                    await conn.execute(f"DROP TABLE IF EXISTS {table_name}")
 
     @pytest.mark.asyncio
     async def test_exact_match_sql_parses_and_executes(self, pg_source):
@@ -302,6 +293,28 @@ class TestDiscogsReconciliationSQLSmoke:
 
         rows = await pg_source.fetchall(_NAME_VARIATION_MATCH_SQL, [])
         assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_wxyc_identity_match_artist_strips_leading_article(self, pg_pool):
+        """Behavior-assertion: ``wxyc_identity_match_artist('The Microphones')``
+        must return ``'microphones'`` — same body shape as the Rust
+        ``to_identity_match_form`` (lowercase + leading-article strip).
+
+        The other tests in this class only prove the SQL parses and the
+        function symbol resolves. They'd still pass if a future alembic
+        revision redeployed the function with a no-op body. This test pins
+        the actual transformation behavior for one canonical case, so
+        drift between the PG function and the Rust reference fails loudly
+        here.
+        """
+        async with pg_pool.acquire() as conn:
+            result = await conn.fetchval("SELECT wxyc_identity_match_artist($1)", "The Microphones")
+        assert result == "microphones", (
+            f"wxyc_identity_match_artist('The Microphones') returned {result!r}; "
+            "expected 'microphones' (lowercase + leading-article strip). "
+            "Function body has drifted from the Rust to_identity_match_form. "
+            "See WXYC/wxyc-etl#112 + WXYC/discogs-etl#195."
+        )
 
     @pytest.mark.asyncio
     async def test_all_four_match_functions_exist(self, pg_pool):

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -182,10 +182,22 @@ class TestPreprocessingVariants:
         assert _preprocessing_variants("Stereolab") == []
 
 
-class TestNamePreprocessingStage:
-    """Stage 5 cascade: when an unmatched canonical's preprocessed variant
-    hits one of the four equality stages, the canonical resolves with
-    method="name_preprocessing".
+class TestBaselineSubsumesPreprocessingCases:
+    """Cases that USED to require Stage 5 name-preprocessing but are now
+    handled directly by Stage 1 exact match after #280.
+
+    Post-#280 the reconciler normalizes both sides with the locked-on
+    ``to_identity_match_form`` baseline (input) and ``wxyc_identity_match_artist``
+    (column). That baseline strips leading articles ("The ") and bracket
+    annotations ("[DJ]") on both sides, so canonicals that previously needed
+    the Stage 5 preprocessing variant to match now hit Stage 1 directly. These
+    tests pin that subsumption — if a future change loosens the baseline or
+    reverts to ``to_match_form``, Stage 1 will miss and these tests will start
+    seeing method="name_preprocessing" (or no match at all).
+
+    Distinct from ``TestNamePreprocessingStage`` below, which covers folds NOT
+    in the baseline (ampersand → "and", multi-artist credit splitting) — those
+    still genuinely require Stage 5.
     """
 
     @pytest.mark.asyncio
@@ -220,6 +232,21 @@ class TestNamePreprocessingStage:
         assert results["Adam X [DJ]"].discogs_artist_id == 8181
         assert results["Adam X [DJ]"].method == "exact_match"
         assert mock_pg.fetchall.await_count == 1
+
+
+class TestNamePreprocessingStage:
+    """Stage 5 cascade: when an unmatched canonical's preprocessed variant
+    hits one of the four equality stages, the canonical resolves with
+    method="name_preprocessing".
+
+    Post-#280 several folds that used to require Stage 5 (leading "The ",
+    bracket annotations, paren suffixes) are now subsumed by the locked-on
+    baseline applied symmetrically on both sides — see
+    ``TestBaselineSubsumesPreprocessingCases`` for the tests pinning that
+    subsumption. The cases in this class cover the folds that are NOT in
+    the baseline and therefore still need the Stage 5 cascade: ampersand →
+    "and" substitution and multi-artist credit splitting.
+    """
 
     @pytest.mark.asyncio
     async def test_split_resolves_via_first_part(self, reconciler, mock_pg):
@@ -327,9 +354,14 @@ class TestDiacriticInsensitiveMatch:
 
     @pytest.mark.asyncio
     async def test_normalized_input_passed_to_sql(self, reconciler, mock_pg):
-        """The names sent to the SQL `ANY($1)` array must already be diacritic-stripped
-        and lowercased — matching the `wxyc_identity_match_artist(...)` expression on
-        the column side (post-#280 symmetric pair)."""
+        """Names sent to the SQL `ANY($1)` array are normalized via
+        ``to_identity_match_form`` on the input side, symmetric with
+        ``wxyc_identity_match_artist`` on the column side (post-#280). The
+        baseline collapses case, diacritics, leading articles, paren suffixes,
+        and bracket annotations identically on both sides. The inputs used here
+        (Björk, Hermanos Gutiérrez, Stereolab) lack the other constructs, so the
+        observed batch is just the case+diacritic fold — the symmetry, not the
+        single-axis fold, is what this test pins."""
         mock_pg.fetchall = AsyncMock(return_value=[])
         await reconciler.reconcile_batch(["Björk", "Hermanos Gutiérrez", "Stereolab"])
         # Inspect the ANY($1) parameter on the first call


### PR DESCRIPTION
Follow-up to merged #285 ("flip reconciler to `to_identity_match_form` + symmetric SQL"). Three review items, each scoped to test-side changes — no production code, SQL, or symmetry guard touched.

## Review items

### 1. Medium: add a pg-marked SQL smoke test (`TestDiscogsReconciliationSQLSmoke`)

Reviewer flagged that the existing `tests/integration/test_entity_resolution.py::TestDiscogsReconciliationIntegration::test_reconcile_known_artists` self-skips when `release_artist` is empty — which is the CI scenario. So nothing in CI actually executed `wxyc_identity_match_artist(col)` even after #285's flip.

New class executes each of the four reconciler SQL strings (`_EXACT_MATCH_SQL`, `_MEMBER_MATCH_SQL`, `_ALIAS_MATCH_SQL`, `_NAME_VARIATION_MATCH_SQL`) against the live PG with `ANY($1) = []`, asserting only that the SQL parses and the function call resolves. A fifth test confirms the four-function family (`_artist`, `_title`, `_with_punctuation`, `_with_disambiguator_strip`) all deploy together — pinned because the reconciler currently only uses the `_artist` flavor but the column-side flip in #285 was paired with a family deploy in [discogs-etl#195](https://github.com/WXYC/discogs-etl/pull/195); a future reconciler change reaching for a sibling should fail loudly here rather than at runtime.

Class self-skips when `wxyc_identity_match_artist` is missing from `pg_proc`. CI's vanilla `postgres:16-alpine` service container doesn't ship the `unaccent` extension's `wxyc_unaccent` text-search dictionary (which requires the rules file installed at `$SHAREDIR/tsearch_data/`), and `wxyc-etl@v0.4.0` doesn't yet ship `wxyc_identity_match_functions.sql` as `importlib.resources`-readable package data — the SQL only lives in the source tree and is vendored byte-for-byte into each cache repo. A TODO comment in the class docstring flags this as the path to making the test run on CI in the future. Until then it runs against any cache where alembic 0004 has been applied (homebrew dev cache + Railway prod / staging).

Acknowledged tradeoff: with the current `postgres:16-alpine` service the smoke test will skip in CI, just like the sibling reconciliation integration test. It still adds value — it runs on the dev cache and on prod, will fail loudly if any of the four function definitions disappears, and is the obvious hook to flip on once wxyc-etl ships the SQL.

### 2. Medium: rehome `TestNamePreprocessingStage` tests that no longer test Stage 5

Class docstring claimed "Stage 5 cascade: when an unmatched canonical's preprocessed variant hits one of the four equality stages, the canonical resolves with method='name_preprocessing'." After #285, two of its tests — `test_leading_the_subsumed_by_baseline_normalization` and `test_bracket_strip_subsumed_by_baseline_normalization` — no longer exercise Stage 5. They exercise Stage 1 exact match against the locked-on baseline, which now strips leading articles and bracket annotations on both sides (`to_identity_match_form` input ↔ `wxyc_identity_match_artist` column).

Moved both into new class `TestBaselineSubsumesPreprocessingCases` with a docstring explaining the subsumption. Remaining `TestNamePreprocessingStage` tests stay in place — they cover folds NOT in the baseline (`&` → `and`, multi-artist credit splitting) which still genuinely need Stage 5. Class docstring on `TestNamePreprocessingStage` updated to cross-reference the new class.

### 3. Low: tighten `test_normalized_input_passed_to_sql` docstring

Previous docstring said "diacritic-stripped and lowercased". That undersells `to_identity_match_form` — it also strips leading articles, paren suffixes, and bracket annotations. Rewritten to describe the symmetric pair (`to_identity_match_form` input ↔ `wxyc_identity_match_artist` column, post-#280) and to call out that the chosen inputs (Björk, Hermanos Gutiérrez, Stereolab) lack the other constructs so the observed batch is the case+diacritic fold only — it is the symmetry, not the single-axis fold, that the test pins. Assertions unchanged.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy .` clean (`Success: no issues found in 247 source files`)
- [x] `uv run pytest tests/unit/` clean (1688 passed)
- [x] `uv run pytest tests/integration/test_entity_resolution.py -m pg` clean against local Docker PG (5433): 7 passed, 6 skipped — the 5 new smoke tests skip when `wxyc_identity_match_artist` is absent, matching the documented behavior
- [ ] CI green