### PR TITLE
Add /api/v1/discogs/search-by-track endpoint (PR 1 of N for dj-site album-by-track search)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,9 @@ Requires `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` for Spotify checks. Oth
 
 Returns one row per `release_id`. Multiple pressings of the same album appear as distinct rows (each has its own `release_id` and shares a `master_id`); callers handle cross-pressing dedupe via their own library lookup. The default `score_threshold` of 0.3 (pg_trgm's default similarity threshold) catches partial-title queries (`"scose poise"` → `"VI Scose Poise"` at ~0.78); raise to 0.5+ for near-exact matches.
 
-Implementation in `discogs/cache_service.py:search_albums_by_track_title()` (the SQL primitive) + `discogs/router.py:search_by_track()` (the route). Tests at `tests/unit/test_search_by_track.py` (unit, mocked cache) + `tests/integration/test_search_by_track_pg.py` (pg-marked smoke, self-skips when `release_track` is absent or empty).
+`q` is trimmed before lookup and must be at least 3 characters after trimming (422 otherwise). Below 3 chars, trigrams lose selectivity and a low `score_threshold` would scan a large fraction of the cache. `LML_API_KEY` gates abuse but the min-length is the first defense.
+
+For collab releases (Duke Ellington & John Coltrane, V/A compilations), the SQL's `ORDER BY ... ra.artist_name ASC` tiebreaker makes `release_artist` deterministic across runs — without it, the surviving artist row depends on storage order. Implementation in `discogs/cache_service.py:search_albums_by_track_title()` (the SQL primitive) + `discogs/router.py:search_by_track()` (the route). Tests at `tests/unit/test_search_by_track.py` (unit, mocked cache) + `tests/integration/test_search_by_track_pg.py` (pg-marked smoke, self-skips when `release_track` is absent or empty).
 
 ### Release Resolve Endpoint
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,14 @@ Response includes `on_streaming` (true/false/null) and per-service match details
 
 Requires `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` for Spotify checks. Other services (Deezer, Apple Music, Bandcamp) need no auth. If Spotify credentials are not set, Spotify checks are skipped.
 
+### Album-by-Track Search Endpoint
+
+`GET /api/v1/discogs/search-by-track?q=<track-title>&limit=50&score_threshold=0.3` fuzzy-matches a track title against `release_track.title` in the Discogs cache and returns the parent releases. This is the LML-side primitive that Backend-Service wraps to deliver dj-site catalog search by track title (e.g. searching `"vi scose poise"` returns the *Confield* release_id, which Backend joins against `library.canonical_entity_id` to surface the WXYC library row).
+
+Returns one row per `release_id`. Multiple pressings of the same album appear as distinct rows (each has its own `release_id` and shares a `master_id`); callers handle cross-pressing dedupe via their own library lookup. The default `score_threshold` of 0.3 (pg_trgm's default similarity threshold) catches partial-title queries (`"scose poise"` → `"VI Scose Poise"` at ~0.78); raise to 0.5+ for near-exact matches.
+
+Implementation in `discogs/cache_service.py:search_albums_by_track_title()` (the SQL primitive) + `discogs/router.py:search_by_track()` (the route). Tests at `tests/unit/test_search_by_track.py` (unit, mocked cache) + `tests/integration/test_search_by_track_pg.py` (pg-marked smoke, self-skips when `release_track` is absent or empty).
+
 ### Release Resolve Endpoint
 
 `POST /api/v1/releases/resolve` takes a Discogs release URL or Bandcamp album URL (or an explicit `(source, id)` pair) and returns canonical release metadata, cross-source identifiers, and a streaming-availability snapshot — everything tubafrenzy's rotation-release create form needs to prefill in one round trip.

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -248,13 +248,23 @@ class DiscogsCacheService:
         its own ``release_id``; the caller handles cross-pressing dedupe via
         the library lookup.
 
+        The query runs inside a transaction that binds
+        ``pg_trgm.similarity_threshold`` (a session GUC defaulting to 0.3)
+        to the caller's ``score_threshold`` via ``set_config(..., is_local =
+        true)``. Without this, the ``%`` operator silently floors at 0.3
+        regardless of the explicit ``similarity(...) >= $2`` clause, so
+        callers passing ``score_threshold=0.1`` would get 0.3 behavior. The
+        ``is_local`` flag scopes the GUC change to the transaction so
+        concurrent queries on other pool connections aren't affected.
+
         Args:
             track_title: Track title query (need not be exact).
             limit: Maximum number of results.
             score_threshold: Minimum trigram similarity (in [0, 1]) to
                 include. The pg_trgm default of 0.3 catches "scose poise" →
                 "VI Scose Poise" but not "scose" (similarity ≈ 0.25); raise
-                to 0.5+ to require near-exact track-title matches.
+                to 0.5+ to require near-exact track-title matches. Values
+                below 0.3 are honored because we bind the per-query GUC.
 
         Returns:
             List of dicts with keys:
@@ -298,7 +308,19 @@ class DiscogsCacheService:
                 ORDER BY score DESC, release_id
                 LIMIT $3
             """
-            rows = await self.pool.fetch(query, track_title, score_threshold, limit)
+            async with self.pool.acquire() as conn:
+                async with conn.transaction():
+                    # Bind pg_trgm.similarity_threshold per query so the `%`
+                    # operator floor matches the caller's score_threshold.
+                    # is_local=true scopes the GUC change to the transaction
+                    # so concurrent queries on other pool connections aren't
+                    # affected.
+                    await conn.fetchval(
+                        "SELECT set_config('pg_trgm.similarity_threshold', $1, $2)",
+                        str(score_threshold),
+                        True,
+                    )
+                    rows = await conn.fetch(query, track_title, score_threshold, limit)
             return [
                 {
                     "release_id": r["release_id"],

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -224,6 +224,97 @@ class DiscogsCacheService:
             logger.error(f"Cache search_releases_by_title failed: {e}")
             raise CacheUnavailableError(f"Cache search_releases_by_title failed: {e}") from e
 
+    async def search_albums_by_track_title(
+        self,
+        track_title: str,
+        *,
+        limit: int = 50,
+        score_threshold: float = 0.3,
+    ) -> list[dict]:
+        """Find Discogs releases whose tracklist contains a track whose title
+        fuzzy-matches the query.
+
+        Used by the ``GET /api/v1/discogs/search-by-track`` endpoint, which is
+        the LML-side primitive for album-by-track search. The caller
+        (Backend-Service) joins the returned ``release_id`` values against
+        ``library.canonical_entity_id`` to find library rows containing the
+        matched track.
+
+        Dedupes to one row per ``release_id`` (a release with multiple
+        ``extra=0`` artist credits — e.g. Duke Ellington & John Coltrane —
+        would otherwise produce one row per credit; we keep the highest-score
+        track-match row and report the first credited artist). Different
+        pressings of the same album appear as distinct rows because each has
+        its own ``release_id``; the caller handles cross-pressing dedupe via
+        the library lookup.
+
+        Args:
+            track_title: Track title query (need not be exact).
+            limit: Maximum number of results.
+            score_threshold: Minimum trigram similarity (in [0, 1]) to
+                include. The pg_trgm default of 0.3 catches "scose poise" →
+                "VI Scose Poise" but not "scose" (similarity ≈ 0.25); raise
+                to 0.5+ to require near-exact track-title matches.
+
+        Returns:
+            List of dicts with keys:
+              - release_id (int): Discogs release ID
+              - master_id (int | None): Discogs master ID (parent album)
+              - release_title (str)
+              - release_artist (str): primary artist (first row where extra=0)
+              - track_title (str)
+              - track_position (str): e.g. "1", "A1", "B3"
+              - score (float): trigram similarity, in [0, 1]
+
+        Raises:
+            CacheUnavailableError: If the database is unreachable.
+        """
+        try:
+            query = """
+                SELECT *
+                FROM (
+                    SELECT DISTINCT ON (rt.release_id)
+                        rt.release_id,
+                        r.master_id,
+                        r.title AS release_title,
+                        ra.artist_name AS release_artist,
+                        rt.title AS track_title,
+                        rt.position AS track_position,
+                        similarity(
+                            lower(f_unaccent(rt.title)),
+                            lower(f_unaccent($1))
+                        ) AS score
+                    FROM release_track rt
+                    JOIN release r ON r.id = rt.release_id
+                    JOIN release_artist ra
+                        ON ra.release_id = r.id AND ra.extra = 0
+                    WHERE lower(f_unaccent(rt.title)) % lower(f_unaccent($1))
+                      AND similarity(
+                            lower(f_unaccent(rt.title)),
+                            lower(f_unaccent($1))
+                          ) >= $2
+                    ORDER BY rt.release_id, score DESC
+                ) deduped
+                ORDER BY score DESC, release_id
+                LIMIT $3
+            """
+            rows = await self.pool.fetch(query, track_title, score_threshold, limit)
+            return [
+                {
+                    "release_id": r["release_id"],
+                    "master_id": r["master_id"],
+                    "release_title": r["release_title"],
+                    "release_artist": r["release_artist"],
+                    "track_title": r["track_title"],
+                    "track_position": r["track_position"],
+                    "score": float(r["score"]),
+                }
+                for r in rows
+            ]
+        except Exception as e:
+            logger.error(f"Cache search_albums_by_track_title failed: {e}")
+            raise CacheUnavailableError(f"Cache search_albums_by_track_title failed: {e}") from e
+
     async def search_tracks_by_title(self, title: str, *, limit: int = 5) -> list[dict]:
         """Fuzzy-match a track title against ``release_track.title``.
 

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -280,6 +280,18 @@ class DiscogsCacheService:
             CacheUnavailableError: If the database is unreachable.
         """
         try:
+            # The explicit `similarity(...) >= $2` clause is defense-in-depth:
+            # we also bind `pg_trgm.similarity_threshold` to $2 below so the `%`
+            # operator floors at the same value. The duplicated predicate
+            # protects against a broken transaction (where the SET LOCAL might
+            # not have taken effect) — the planner short-circuits one when the
+            # other is satisfied, so the redundancy is essentially free.
+            #
+            # `ra.artist_name ASC` is the tiebreaker on the DISTINCT ON. For
+            # collab releases (Duke Ellington & John Coltrane, Various
+            # Artists compilations with multi-artist credits), without this
+            # the surviving artist row is storage-order-dependent and the
+            # same query can return different artists across runs.
             query = """
                 SELECT *
                 FROM (
@@ -303,7 +315,7 @@ class DiscogsCacheService:
                             lower(f_unaccent(rt.title)),
                             lower(f_unaccent($1))
                           ) >= $2
-                    ORDER BY rt.release_id, score DESC
+                    ORDER BY rt.release_id, score DESC, ra.artist_name ASC
                 ) deduped
                 ORDER BY score DESC, release_id
                 LIMIT $3

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -48,6 +48,31 @@ class TracksAutocompleteResponse(BaseModel):
     cached: bool = True
 
 
+class SearchByTrackResult(BaseModel):
+    """A single album-by-track search hit from the Discogs cache.
+
+    Returned by ``GET /api/v1/discogs/search-by-track``. One row per
+    matching ``release_id``; callers (Backend-Service) bridge to library
+    rows via ``library.canonical_entity_id = 'discogs:' || release_id``.
+    """
+
+    release_id: int
+    master_id: int | None = None
+    release_title: str
+    release_artist: str
+    track_title: str
+    track_position: str
+    score: float
+
+
+class SearchByTrackResponse(BaseModel):
+    """Response for ``GET /api/v1/discogs/search-by-track``."""
+
+    results: list[SearchByTrackResult] = []
+    total: int = 0
+    query: str
+
+
 # MARK: - Resolved Markup Tokens
 
 

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -54,6 +54,10 @@ class SearchByTrackResult(BaseModel):
     Returned by ``GET /api/v1/discogs/search-by-track``. One row per
     matching ``release_id``; callers (Backend-Service) bridge to library
     rows via ``library.canonical_entity_id = 'discogs:' || release_id``.
+
+    ``track_position`` is nullable because ``release_track.position`` is
+    nullable in the Discogs schema (digital releases and some compilations
+    omit it).
     """
 
     release_id: int
@@ -61,7 +65,7 @@ class SearchByTrackResult(BaseModel):
     release_title: str
     release_artist: str
     track_title: str
-    track_position: str
+    track_position: str | None = None
     score: float
 
 

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -12,6 +12,8 @@ from discogs.models import (
     EntityResolveResponse,
     EntityType,
     ReleaseMetadataResponse,
+    SearchByTrackResponse,
+    SearchByTrackResult,
     TrackReleasesResponse,
     TracksAutocompleteResponse,
 )
@@ -150,6 +152,63 @@ async def resolve_entity(
         if master is None:
             raise HTTPException(status_code=404, detail=f"Master {entity_id} not found")
         return EntityResolveResponse(name=master.title, type=entity_type, id=entity_id)
+
+
+@router.get(
+    "/search-by-track",
+    response_model=SearchByTrackResponse,
+    summary="Find Discogs releases by track title (album-by-track search)",
+    description="""
+    Fuzzy-match a track title against ``release_track.title`` and return
+    the parent releases. This is the LML-side primitive that Backend-Service
+    wraps to deliver dj-site catalog search by track title (e.g. searching
+    "vi scose poise" returns the *Confield* release_id).
+
+    Returns one row per ``release_id``; multiple pressings of the same
+    album appear as distinct rows. Bridge to library rows on the caller
+    side via ``library.canonical_entity_id = 'discogs:' || release_id``.
+
+    The default ``score_threshold`` of 0.3 catches partial-track-title
+    queries ("scose poise" → "VI Scose Poise"); raise to 0.5+ to require
+    near-exact matches.
+    """,
+    responses={
+        200: {"description": "Matched releases returned (may be empty on cache error)"},
+        422: {"description": "Missing required q parameter"},
+        503: {"description": "Discogs cache not available"},
+    },
+)
+async def search_by_track(
+    q: str = Query(..., description="Track title query (need not be exact)"),
+    limit: int = Query(50, ge=1, le=200, description="Maximum number of results"),
+    score_threshold: float = Query(
+        0.3,
+        ge=0,
+        le=1,
+        description="Minimum trigram similarity in [0, 1]; default 0.3 = pg_trgm default",
+    ),
+    cache: DiscogsCacheService | None = Depends(get_discogs_cache_service),
+) -> SearchByTrackResponse:
+    """Fuzzy-search Discogs cache tracklists for a track-title match."""
+    if cache is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Discogs cache is not available. Set DATABASE_URL_DISCOGS.",
+        )
+
+    try:
+        rows = await cache.search_albums_by_track_title(
+            q, limit=limit, score_threshold=score_threshold
+        )
+    except CacheUnavailableError:
+        logger.warning("Cache error during search-by-track, returning empty results")
+        return SearchByTrackResponse(results=[], total=0, query=q)
+
+    return SearchByTrackResponse(
+        results=[SearchByTrackResult(**r) for r in rows],
+        total=len(rows),
+        query=q,
+    )
 
 
 @router.get(

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -174,13 +174,26 @@ async def resolve_entity(
     """,
     responses={
         200: {"description": "Matched releases returned (may be empty on cache error)"},
-        422: {"description": "Missing required q parameter"},
+        422: {"description": "Missing or invalid q parameter (e.g. < 3 chars after trim)"},
         503: {"description": "Discogs cache not available"},
     },
 )
 async def search_by_track(
-    q: str = Query(..., description="Track title query (need not be exact)"),
-    limit: int = Query(50, ge=1, le=200, description="Maximum number of results"),
+    q: str = Query(
+        ...,
+        description=(
+            "Track title query (need not be exact). Trimmed before lookup. "
+            "Must be at least 3 chars after trimming — trigrams (3-char "
+            "substrings) lose selectivity below this length, so a 1- or "
+            "2-char query would scan a large fraction of the cache."
+        ),
+    ),
+    limit: int = Query(
+        50,
+        ge=1,
+        le=200,
+        description="Maximum number of distinct release_ids returned",
+    ),
     score_threshold: float = Query(
         0.3,
         ge=0,
@@ -196,18 +209,30 @@ async def search_by_track(
             detail="Discogs cache is not available. Set DATABASE_URL_DISCOGS.",
         )
 
+    # Trim whitespace before the min-length check so " vi " doesn't sneak
+    # through as a 4-char query that's really 2 chars of signal.
+    q_trimmed = q.strip()
+    if len(q_trimmed) < 3:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "q must be at least 3 characters after trimming. Shorter "
+                "queries lose trigram selectivity and risk a broad scan."
+            ),
+        )
+
     try:
         rows = await cache.search_albums_by_track_title(
-            q, limit=limit, score_threshold=score_threshold
+            q_trimmed, limit=limit, score_threshold=score_threshold
         )
     except CacheUnavailableError:
         logger.warning("Cache error during search-by-track, returning empty results")
-        return SearchByTrackResponse(results=[], total=0, query=q)
+        return SearchByTrackResponse(results=[], total=0, query=q_trimmed)
 
     return SearchByTrackResponse(
         results=[SearchByTrackResult(**r) for r in rows],
         total=len(rows),
-        query=q,
+        query=q_trimmed,
     )
 
 

--- a/tests/integration/test_search_by_track_pg.py
+++ b/tests/integration/test_search_by_track_pg.py
@@ -1,0 +1,177 @@
+"""pg-marked smoke test for the album-by-track cache method.
+
+Runs against any Postgres with the standard discogs-cache schema and the
+``release_track`` table populated. Self-skips when the table is missing or
+empty (the CI ``postgres:16-alpine`` service is empty by default; this test
+runs against an alembic-applied dev cache or production-shape snapshot).
+
+Verifies:
+  - The SQL parses and executes against a real cache.
+  - Trigram matching catches partial-track-title queries.
+  - ``score_threshold`` filters low-similarity rows.
+  - The return shape projects ``release_id``, ``master_id``,
+    ``release_title``, ``release_artist``, ``track_title``,
+    ``track_position``, and ``score``.
+
+We don't pin specific Confield ``release_id``s because the dev cache and
+production share schema but not data — assertions are about *shape and
+contract*, not specific row values.
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from discogs.cache_service import DiscogsCacheService
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def cache_with_release_track():
+    """Connect to the cache; skip if the ``release_track`` table is missing
+    or empty.
+
+    Matches the skip pattern in ``test_entity_resolution.py``'s
+    ``test_reconcile_known_artists`` — these tests need real cache data
+    to be meaningful, and the CI service container ships without it.
+    """
+    try:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=2)
+    except Exception as exc:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {exc}")
+        return
+
+    try:
+        async with pool.acquire() as conn:
+            exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = 'release_track')"
+            )
+            if not exists:
+                pytest.skip("release_track table not found in test database")
+            count = await conn.fetchval("SELECT count(*) FROM release_track")
+            if count == 0:
+                pytest.skip("release_track table is empty -- no Discogs data loaded")
+
+        cache = DiscogsCacheService.__new__(DiscogsCacheService)
+        cache.pool = pool
+        yield cache
+    finally:
+        await pool.close()
+
+
+@pytest.mark.pg
+class TestSearchAlbumsByTrackTitlePg:
+    @pytest.mark.asyncio
+    async def test_exact_query_returns_results(self, cache_with_release_track):
+        """A query that exactly matches a real track title returns rows.
+
+        We use a deliberately distinctive track title — "VI Scose Poise"
+        from Autechre's *Confield* — to avoid spurious matches if the cache
+        is sparsely populated. If this test fails, the cache likely doesn't
+        have any Autechre data; the assertion is just that *some* row comes
+        back when the query is exactly a real track title (otherwise the
+        SQL machinery is broken).
+
+        Caveat: if a cache snapshot doesn't include the specific releases
+        used here, this test will produce zero rows and fail. That's the
+        signal: track-by-title search needs cache data to be useful. The
+        skip path above guards against the empty-cache case (count == 0);
+        partial caches are a known limitation.
+        """
+        rows = await cache_with_release_track.search_albums_by_track_title("VI Scose Poise")
+
+        if not rows:
+            pytest.skip(
+                "Cache does not contain 'VI Scose Poise' track data; "
+                "test is meaningless against this snapshot."
+            )
+
+        # Every returned row must carry the projected fields.
+        for row in rows:
+            assert isinstance(row["release_id"], int)
+            assert row["release_id"] > 0
+            assert isinstance(row["release_title"], str)
+            assert isinstance(row["release_artist"], str)
+            assert isinstance(row["track_title"], str)
+            assert isinstance(row["track_position"], str)
+            assert isinstance(row["score"], float)
+            assert 0.0 <= row["score"] <= 1.0
+            # master_id is nullable but if present must be int.
+            assert row["master_id"] is None or isinstance(row["master_id"], int)
+
+        # Sorted by score desc — the first row has the highest score.
+        scores = [r["score"] for r in rows]
+        assert scores == sorted(scores, reverse=True)
+
+        # An exact match should produce at least one row at score 1.0 if the
+        # cache has any "VI Scose Poise" track.
+        assert rows[0]["score"] == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_score_threshold_filters(self, cache_with_release_track):
+        """A threshold of 1.0 only admits exact matches; a lower threshold
+        admits partial-title queries that wouldn't otherwise meet pg_trgm's
+        default."""
+        # Partial title — should match "VI Scose Poise" at ~0.78.
+        loose = await cache_with_release_track.search_albums_by_track_title(
+            "scose poise", score_threshold=0.5
+        )
+        strict = await cache_with_release_track.search_albums_by_track_title(
+            "scose poise", score_threshold=0.99
+        )
+
+        if not loose:
+            pytest.skip("Cache does not contain 'scose poise' partial-match data.")
+
+        assert all(r["score"] >= 0.5 for r in loose)
+        assert all(r["score"] >= 0.99 for r in strict)
+        # Strict ⊆ loose (every strict row must also satisfy the looser threshold).
+        assert len(strict) <= len(loose)
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_result_count(self, cache_with_release_track):
+        """A small limit returns at most that many rows."""
+        rows = await cache_with_release_track.search_albums_by_track_title(
+            "VI Scose Poise", limit=2
+        )
+        assert len(rows) <= 2
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_empty(self, cache_with_release_track):
+        """A query unlikely to be a real track title returns an empty list,
+        not an error.
+
+        Using a distinctive nonsense string — pg_trgm similarity against any
+        real track title should fall below the 0.3 default threshold.
+        """
+        rows = await cache_with_release_track.search_albums_by_track_title(
+            "qzx8wpvnlfrugmkj nothing matches this", score_threshold=0.5
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_dedupes_by_release_id(self, cache_with_release_track):
+        """Each ``release_id`` appears at most once even when a release has
+        multiple ``extra=0`` artist-credit rows (collab albums).
+
+        A query matching a track on a Duke Ellington & John Coltrane release
+        — two ``extra=0`` rows — would, without the ``DISTINCT ON`` in the
+        query, produce duplicate rows for the same release_id.
+        """
+        rows = await cache_with_release_track.search_albums_by_track_title(
+            "In a Sentimental Mood", limit=100
+        )
+        if not rows:
+            pytest.skip("Cache does not contain 'In a Sentimental Mood' data.")
+
+        release_ids = [r["release_id"] for r in rows]
+        assert len(release_ids) == len(set(release_ids))

--- a/tests/integration/test_search_by_track_pg.py
+++ b/tests/integration/test_search_by_track_pg.py
@@ -82,10 +82,12 @@ class TestSearchAlbumsByTrackTitlePg:
         SQL machinery is broken).
 
         Caveat: if a cache snapshot doesn't include the specific releases
-        used here, this test will produce zero rows and fail. That's the
-        signal: track-by-title search needs cache data to be useful. The
-        skip path above guards against the empty-cache case (count == 0);
-        partial caches are a known limitation.
+        used here, this test self-skips with a clear reason — track-by-title
+        search needs cache data to be useful. The fixture-level skip guards
+        against the empty-``release_track`` case (``count == 0``); the
+        inner skip guards against the partial-cache case where the table
+        is populated but doesn't happen to contain the canonical query
+        target.
         """
         rows = await cache_with_release_track.search_albums_by_track_title("VI Scose Poise")
 
@@ -157,6 +159,41 @@ class TestSearchAlbumsByTrackTitlePg:
             "qzx8wpvnlfrugmkj nothing matches this", score_threshold=0.5
         )
         assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_collab_artist_is_deterministic(self, cache_with_release_track):
+        """For collab releases (multiple ``extra=0`` rows), the surviving
+        ``release_artist`` must be alphabetically first. Running the same
+        query twice must produce the same artist for the same release_id —
+        without the ``ra.artist_name ASC`` tiebreaker, the result is
+        storage-order-dependent.
+
+        Uses "In a Sentimental Mood" because the cache typically has the
+        Duke Ellington & John Coltrane duo album (Discogs `release_artist`
+        rows for both, both `extra=0`).
+        """
+        first = await cache_with_release_track.search_albums_by_track_title(
+            "In a Sentimental Mood", limit=100
+        )
+        if not first:
+            pytest.skip("Cache does not contain 'In a Sentimental Mood' data.")
+        second = await cache_with_release_track.search_albums_by_track_title(
+            "In a Sentimental Mood", limit=100
+        )
+        # Map release_id -> release_artist must agree across the two runs.
+        first_map = {r["release_id"]: r["release_artist"] for r in first}
+        second_map = {r["release_id"]: r["release_artist"] for r in second}
+        # Limit to release_ids present in both (LIMIT could in principle
+        # have selected different sets at the score boundary; in practice
+        # the same query with the same data produces the same set).
+        shared = set(first_map) & set(second_map)
+        assert shared, "expected at least one release_id common to both runs"
+        for rid in shared:
+            assert first_map[rid] == second_map[rid], (
+                f"release_artist for release_id={rid} differs across runs: "
+                f"{first_map[rid]!r} vs {second_map[rid]!r}. The ORDER BY tiebreaker "
+                f"`ra.artist_name ASC` should make this deterministic."
+            )
 
     @pytest.mark.asyncio
     async def test_dedupes_by_release_id(self, cache_with_release_track):

--- a/tests/unit/test_search_by_track.py
+++ b/tests/unit/test_search_by_track.py
@@ -21,22 +21,61 @@ from tests.unit.conftest import override_deps
 # ---------------------------------------------------------------------------
 
 
+class _MockTxn:
+    """Async context manager standing in for ``conn.transaction()``."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return None
+
+
+class _MockAcquire:
+    """Async context manager standing in for ``pool.acquire()``."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_):
+        return None
+
+
+def _make_cache_svc(fetch_rows: list[dict]) -> tuple[DiscogsCacheService, AsyncMock]:
+    """Build a ``DiscogsCacheService`` whose ``pool.acquire()`` yields a
+    connection mock with ``transaction``/``fetchval``/``fetch`` wired up.
+
+    Returns ``(svc, mock_conn)`` so tests can assert on the underlying
+    connection's method calls.
+    """
+    mock_conn = AsyncMock()
+    mock_conn.transaction = lambda: _MockTxn()
+    mock_conn.fetchval = AsyncMock(return_value=None)
+    mock_conn.fetch = AsyncMock(return_value=fetch_rows)
+
+    mock_pool = AsyncMock()
+    mock_pool.acquire = lambda: _MockAcquire(mock_conn)
+
+    svc = DiscogsCacheService.__new__(DiscogsCacheService)
+    svc.pool = mock_pool
+    return svc, mock_conn
+
+
 class TestSearchAlbumsByTrackTitle:
     """Direct tests of the cache method.
 
-    Uses an AsyncMock for the underlying ``self.pool`` so we can assert
-    on the parametrised SQL call without spinning a real Postgres.
+    Mocks ``pool.acquire`` so we can assert on the parametrised SQL call
+    without spinning a real Postgres. The method opens a transaction +
+    binds ``pg_trgm.similarity_threshold`` before fetching, so the mocked
+    connection needs ``transaction()`` / ``fetchval()`` / ``fetch()``.
     """
-
-    def _make_svc(self, fetch_rows: list[dict]) -> DiscogsCacheService:
-        svc = DiscogsCacheService.__new__(DiscogsCacheService)
-        svc.pool = AsyncMock()
-        svc.pool.fetch = AsyncMock(return_value=fetch_rows)
-        return svc
 
     @pytest.mark.asyncio
     async def test_returns_projected_dicts(self):
-        svc = self._make_svc(
+        svc, _ = _make_cache_svc(
             [
                 {
                     "release_id": 1573110,
@@ -66,19 +105,19 @@ class TestSearchAlbumsByTrackTitle:
 
     @pytest.mark.asyncio
     async def test_passes_query_limit_and_threshold_to_pg(self):
-        svc = self._make_svc([])
+        svc, conn = _make_cache_svc([])
         await svc.search_albums_by_track_title("scose poise", limit=10, score_threshold=0.5)
-        # Positional args: (sql, query, threshold, limit).
-        call_args = svc.pool.fetch.await_args.args
+        # Positional args to fetch: (sql, query, threshold, limit).
+        call_args = conn.fetch.await_args.args
         assert call_args[1] == "scose poise"
         assert call_args[2] == 0.5
         assert call_args[3] == 10
 
     @pytest.mark.asyncio
     async def test_defaults_threshold_to_pg_trgm_default(self):
-        svc = self._make_svc([])
+        svc, conn = _make_cache_svc([])
         await svc.search_albums_by_track_title("anything")
-        call_args = svc.pool.fetch.await_args.args
+        call_args = conn.fetch.await_args.args
         assert call_args[2] == 0.3  # pg_trgm default
         assert call_args[3] == 50  # function default
 
@@ -87,7 +126,7 @@ class TestSearchAlbumsByTrackTitle:
         # asyncpg's Real → Python decimal-like type would surface as Decimal in
         # some installs; the projection coerces to plain float so callers can
         # rely on the type.
-        svc = self._make_svc(
+        svc, _ = _make_cache_svc(
             [
                 {
                     "release_id": 1,
@@ -107,7 +146,7 @@ class TestSearchAlbumsByTrackTitle:
     async def test_master_id_passes_through_null(self):
         # Releases with no master_id (singles, demos, V/A one-offs) come back
         # with master_id NULL. The projection preserves None.
-        svc = self._make_svc(
+        svc, _ = _make_cache_svc(
             [
                 {
                     "release_id": 99,
@@ -124,10 +163,63 @@ class TestSearchAlbumsByTrackTitle:
         assert result[0]["master_id"] is None
 
     @pytest.mark.asyncio
+    async def test_null_track_position_passes_through(self):
+        # ``release_track.position`` is nullable in the Discogs schema. The
+        # projection must preserve None; the Pydantic model handles it
+        # downstream (see endpoint test).
+        svc, _ = _make_cache_svc(
+            [
+                {
+                    "release_id": 9999,
+                    "master_id": None,
+                    "release_title": "Digital Only",
+                    "release_artist": "Some Artist",
+                    "track_title": "Track",
+                    "track_position": None,
+                    "score": 0.9,
+                }
+            ]
+        )
+        result = await svc.search_albums_by_track_title("track")
+        assert result[0]["track_position"] is None
+
+    @pytest.mark.asyncio
+    async def test_sets_pg_trgm_similarity_threshold_per_query(self):
+        """The ``%`` operator in the WHERE clause reads ``pg_trgm.similarity_threshold``
+        (a session GUC defaulting to 0.3). Without binding the per-call
+        threshold, callers requesting < 0.3 silently get 0.3 behavior because
+        the operator's GIN-index lookup floors at the GUC value regardless of
+        the explicit ``similarity(...) >= $2`` clause.
+
+        The cache method must run the query inside a transaction that
+        ``SELECT set_config('pg_trgm.similarity_threshold', $1, true)`` to
+        make the operator floor match the caller's request. ``is_local =
+        true`` scopes the change to the transaction so concurrent queries on
+        other pool connections aren't affected."""
+        svc, conn = _make_cache_svc([])
+
+        await svc.search_albums_by_track_title("vi scose poise", score_threshold=0.15)
+
+        # Verify the connection bound the threshold inside the transaction.
+        set_config_calls = [
+            call
+            for call in conn.fetchval.await_args_list
+            if call.args and "set_config" in str(call.args[0]).lower()
+        ]
+        assert set_config_calls, (
+            "expected the cache method to bind pg_trgm.similarity_threshold via "
+            "set_config(...) inside the transaction; otherwise the `%` operator's "
+            "GUC default (0.3) silently overrides the caller's threshold."
+        )
+        # And that the binding used the per-call value with is_local=true.
+        call = set_config_calls[0]
+        assert call.args[1] == "0.15"
+        assert call.args[2] is True
+
+    @pytest.mark.asyncio
     async def test_wraps_db_errors_as_cache_unavailable(self):
-        svc = DiscogsCacheService.__new__(DiscogsCacheService)
-        svc.pool = AsyncMock()
-        svc.pool.fetch = AsyncMock(side_effect=RuntimeError("connection refused"))
+        svc, conn = _make_cache_svc([])
+        conn.fetch = AsyncMock(side_effect=RuntimeError("connection refused"))
 
         with pytest.raises(CacheUnavailableError) as exc_info:
             await svc.search_albums_by_track_title("anything")
@@ -290,6 +382,61 @@ class TestSearchByTrackEndpoint:
             )
         assert resp.status_code == 503
         assert "DATABASE_URL_DISCOGS" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_null_track_position_round_trips(self, app_with_cache, mock_cache):
+        """``release_track.position`` is nullable in the Discogs schema (digital
+        releases and some compilations omit it). The response model must accept
+        ``track_position: None`` so the endpoint doesn't return 500 on those
+        rows."""
+        mock_cache.search_albums_by_track_title = AsyncMock(
+            return_value=[
+                {
+                    "release_id": 9999,
+                    "master_id": None,
+                    "release_title": "Digital Only",
+                    "release_artist": "Some Artist",
+                    "track_title": "Track With No Position",
+                    "track_position": None,
+                    "score": 0.95,
+                }
+            ]
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "track with no position"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["results"][0]["track_position"] is None
+
+    @pytest.mark.asyncio
+    async def test_threshold_below_pg_trgm_default_is_admitted(self, app_with_cache, mock_cache):
+        """``score_threshold=0.1`` must reach the cache layer (which is
+        responsible for binding ``pg_trgm.similarity_threshold`` for the
+        query). The API parameter accepts ``ge=0``; rejecting low thresholds
+        at the API layer would mask the real issue (without SET-LOCAL
+        plumbing in the cache, the GUC's 0.3 default short-circuits ``%`` and
+        callers get 0.3 behavior regardless)."""
+        mock_cache.search_albums_by_track_title = AsyncMock(return_value=[])
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "t", "score_threshold": 0.1},
+            )
+
+        assert resp.status_code == 200
+        mock_cache.search_albums_by_track_title.assert_called_once_with(
+            "t", limit=50, score_threshold=0.1
+        )
 
     @pytest.mark.asyncio
     async def test_cache_error_returns_empty_results_not_500(self, app_with_cache, mock_cache):

--- a/tests/unit/test_search_by_track.py
+++ b/tests/unit/test_search_by_track.py
@@ -225,6 +225,36 @@ class TestSearchAlbumsByTrackTitle:
             await svc.search_albums_by_track_title("anything")
         assert "connection refused" in str(exc_info.value)
 
+    @pytest.mark.asyncio
+    async def test_collab_release_artist_is_alphabetically_first(self):
+        """``DISTINCT ON (rt.release_id)`` plus ``ORDER BY rt.release_id,
+        score DESC, ra.artist_name ASC`` must make collab-album results
+        deterministic. Without the alphabetical tiebreaker, the surviving
+        ``release_artist`` depends on PG's storage-order encounter for the
+        ``release_artist`` JOIN — same query, same data could yield "Duke
+        Ellington" one run and "John Coltrane" another (after vacuum, after
+        an index rebuild, after a different join order chosen by the
+        planner).
+
+        We assert the SQL the cache method emits orders by
+        ``ra.artist_name ASC`` as the final tiebreaker. The pg-integration
+        test pins the end-to-end behavior.
+        """
+        svc, conn = _make_cache_svc([])
+        await svc.search_albums_by_track_title("anything")
+        # `conn.fetch` is called with (sql, query, threshold, limit). Assert
+        # the SQL contains the alphabetical tiebreaker — implementation
+        # detail, but the alternative (matching against actual PG output)
+        # would require the integration suite and we want a unit-level
+        # regression guard.
+        sql = conn.fetch.await_args.args[0]
+        # Look for the tiebreaker in the inner DISTINCT ON ordering.
+        assert "ra.artist_name asc" in sql.lower(), (
+            "Expected `ra.artist_name ASC` as the final ORDER BY clause inside "
+            "DISTINCT ON to make collab-album results deterministic. Without it, "
+            "the surviving artist row is storage-order-dependent."
+        )
+
 
 # ---------------------------------------------------------------------------
 # Endpoint: GET /api/v1/discogs/search-by-track
@@ -361,13 +391,14 @@ class TestSearchByTrackEndpoint:
 
     @pytest.mark.asyncio
     async def test_threshold_out_of_range_returns_422(self, app_with_cache):
-        # FastAPI's Query(ge=0, le=1) validation.
+        # FastAPI's Query(ge=0, le=1) validation. Use a valid-length q so
+        # the 422 is unambiguously about the threshold, not min_length.
         async with AsyncClient(
             transport=ASGITransport(app=app_with_cache), base_url="http://test"
         ) as client:
             resp = await client.get(
                 "/api/v1/discogs/search-by-track",
-                params={"q": "t", "score_threshold": 1.5},
+                params={"q": "track", "score_threshold": 1.5},
             )
         assert resp.status_code == 422
 
@@ -430,13 +461,82 @@ class TestSearchByTrackEndpoint:
         ) as client:
             resp = await client.get(
                 "/api/v1/discogs/search-by-track",
-                params={"q": "t", "score_threshold": 0.1},
+                params={"q": "track", "score_threshold": 0.1},
             )
 
         assert resp.status_code == 200
         mock_cache.search_albums_by_track_title.assert_called_once_with(
-            "t", limit=50, score_threshold=0.1
+            "track", limit=50, score_threshold=0.1
         )
+
+    @pytest.mark.asyncio
+    async def test_q_is_trimmed_before_reaching_cache(self, app_with_cache, mock_cache):
+        """Whitespace padding on the query is stripped at the route layer
+        before calling the cache. Trigram comparison is whitespace-resilient,
+        but trimming keeps the projected ``query`` field tidy and removes a
+        no-op-but-confusing input variant."""
+        mock_cache.search_albums_by_track_title = AsyncMock(return_value=[])
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "  vi scose poise  "},
+            )
+
+        assert resp.status_code == 200
+        # Trimmed before the cache call.
+        mock_cache.search_albums_by_track_title.assert_called_once_with(
+            "vi scose poise", limit=50, score_threshold=0.3
+        )
+        # And the response echoes the trimmed query, not the original.
+        assert resp.json()["query"] == "vi scose poise"
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_422(self, app_with_cache):
+        """Empty string ``q`` is rejected. The trigram operator on an empty
+        string is meaningless; without a minimum length, callers could submit
+        ``q=""`` with low ``score_threshold`` and pull a massive scan. The
+        route's ``min_length`` validator catches this at the API layer."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": ""},
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_query_shorter_than_min_length_returns_422(self, app_with_cache):
+        """``q`` shorter than 3 characters is rejected. Trigrams (3-char
+        substrings) lose their selectivity below this length — a 1- or 2-char
+        query matches a large fraction of any tracklist, so allowing it
+        creates a cheap DOS vector against the cache. The auth gate
+        (``LML_API_KEY``) is a secondary defense; the min-length enforcement
+        is the first line."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "vi"},
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_query_returns_422(self, app_with_cache):
+        """A whitespace-only query trims to empty, hitting the min-length
+        rejection. The route trims FIRST, then validates."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "   "},
+            )
+        assert resp.status_code == 422
 
     @pytest.mark.asyncio
     async def test_cache_error_returns_empty_results_not_500(self, app_with_cache, mock_cache):

--- a/tests/unit/test_search_by_track.py
+++ b/tests/unit/test_search_by_track.py
@@ -1,0 +1,315 @@
+"""Unit tests for the album-by-track endpoint and cache method.
+
+Covers:
+  - ``DiscogsCacheService.search_albums_by_track_title``: SQL parameters,
+    return-shape projection, threshold pass-through, error wrapping.
+  - ``GET /api/v1/discogs/search-by-track``: success, query-param plumbing,
+    503 when cache is unconfigured, graceful-empty on cache errors,
+    422 on missing query.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
+from tests.unit.conftest import override_deps
+
+# ---------------------------------------------------------------------------
+# Cache method: search_albums_by_track_title
+# ---------------------------------------------------------------------------
+
+
+class TestSearchAlbumsByTrackTitle:
+    """Direct tests of the cache method.
+
+    Uses an AsyncMock for the underlying ``self.pool`` so we can assert
+    on the parametrised SQL call without spinning a real Postgres.
+    """
+
+    def _make_svc(self, fetch_rows: list[dict]) -> DiscogsCacheService:
+        svc = DiscogsCacheService.__new__(DiscogsCacheService)
+        svc.pool = AsyncMock()
+        svc.pool.fetch = AsyncMock(return_value=fetch_rows)
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_returns_projected_dicts(self):
+        svc = self._make_svc(
+            [
+                {
+                    "release_id": 1573110,
+                    "master_id": 1374,
+                    "release_title": "Confield",
+                    "release_artist": "Autechre",
+                    "track_title": "VI Scose Poise",
+                    "track_position": "1",
+                    "score": 1.0,
+                },
+            ]
+        )
+
+        result = await svc.search_albums_by_track_title("vi scose poise")
+
+        assert result == [
+            {
+                "release_id": 1573110,
+                "master_id": 1374,
+                "release_title": "Confield",
+                "release_artist": "Autechre",
+                "track_title": "VI Scose Poise",
+                "track_position": "1",
+                "score": 1.0,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_passes_query_limit_and_threshold_to_pg(self):
+        svc = self._make_svc([])
+        await svc.search_albums_by_track_title("scose poise", limit=10, score_threshold=0.5)
+        # Positional args: (sql, query, threshold, limit).
+        call_args = svc.pool.fetch.await_args.args
+        assert call_args[1] == "scose poise"
+        assert call_args[2] == 0.5
+        assert call_args[3] == 10
+
+    @pytest.mark.asyncio
+    async def test_defaults_threshold_to_pg_trgm_default(self):
+        svc = self._make_svc([])
+        await svc.search_albums_by_track_title("anything")
+        call_args = svc.pool.fetch.await_args.args
+        assert call_args[2] == 0.3  # pg_trgm default
+        assert call_args[3] == 50  # function default
+
+    @pytest.mark.asyncio
+    async def test_coerces_score_to_float(self):
+        # asyncpg's Real → Python decimal-like type would surface as Decimal in
+        # some installs; the projection coerces to plain float so callers can
+        # rely on the type.
+        svc = self._make_svc(
+            [
+                {
+                    "release_id": 1,
+                    "master_id": None,
+                    "release_title": "X",
+                    "release_artist": "Y",
+                    "track_title": "T",
+                    "track_position": "1",
+                    "score": 0.5,
+                }
+            ]
+        )
+        result = await svc.search_albums_by_track_title("anything")
+        assert isinstance(result[0]["score"], float)
+
+    @pytest.mark.asyncio
+    async def test_master_id_passes_through_null(self):
+        # Releases with no master_id (singles, demos, V/A one-offs) come back
+        # with master_id NULL. The projection preserves None.
+        svc = self._make_svc(
+            [
+                {
+                    "release_id": 99,
+                    "master_id": None,
+                    "release_title": "Untitled",
+                    "release_artist": "Various",
+                    "track_title": "Track",
+                    "track_position": "A",
+                    "score": 0.7,
+                }
+            ]
+        )
+        result = await svc.search_albums_by_track_title("track")
+        assert result[0]["master_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_wraps_db_errors_as_cache_unavailable(self):
+        svc = DiscogsCacheService.__new__(DiscogsCacheService)
+        svc.pool = AsyncMock()
+        svc.pool.fetch = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+        with pytest.raises(CacheUnavailableError) as exc_info:
+            await svc.search_albums_by_track_title("anything")
+        assert "connection refused" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: GET /api/v1/discogs/search-by-track
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_discogs():
+    from discogs.service import DiscogsService
+
+    return AsyncMock(spec=DiscogsService)
+
+
+@pytest.fixture
+def mock_cache():
+    return AsyncMock(spec=DiscogsCacheService)
+
+
+@pytest.fixture
+def app_with_cache(mock_discogs, mock_cache, mock_settings):
+    from config.settings import get_settings
+    from core.dependencies import (
+        get_discogs_cache_service,
+        get_discogs_service,
+        get_library_db,
+        get_posthog_client,
+    )
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: mock_discogs,
+            get_discogs_cache_service: mock_cache,
+            get_posthog_client: None,
+            get_settings: mock_settings,
+        },
+    ):
+        yield app
+
+
+@pytest.fixture
+def app_without_cache(mock_discogs, mock_settings):
+    from config.settings import get_settings
+    from core.dependencies import (
+        get_discogs_cache_service,
+        get_discogs_service,
+        get_library_db,
+        get_posthog_client,
+    )
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: mock_discogs,
+            get_discogs_cache_service: None,
+            get_posthog_client: None,
+            get_settings: mock_settings,
+        },
+    ):
+        yield app
+
+
+class TestSearchByTrackEndpoint:
+    @pytest.mark.asyncio
+    async def test_success(self, app_with_cache, mock_cache):
+        mock_cache.search_albums_by_track_title = AsyncMock(
+            return_value=[
+                {
+                    "release_id": 1573110,
+                    "master_id": 1374,
+                    "release_title": "Confield",
+                    "release_artist": "Autechre",
+                    "track_title": "VI Scose Poise",
+                    "track_position": "1",
+                    "score": 1.0,
+                },
+                {
+                    "release_id": 8434,
+                    "master_id": 1374,
+                    "release_title": "Confield",
+                    "release_artist": "Autechre",
+                    "track_title": "VI Scose Poise",
+                    "track_position": "A1",
+                    "score": 1.0,
+                },
+            ]
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "vi scose poise"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 2
+        assert body["query"] == "vi scose poise"
+        assert {r["release_id"] for r in body["results"]} == {1573110, 8434}
+        # Backend will join these release_ids against
+        # ``library.canonical_entity_id = 'discogs:' || release_id``.
+        assert all(r["release_artist"] == "Autechre" for r in body["results"])
+
+    @pytest.mark.asyncio
+    async def test_query_params_pass_through_to_cache(self, app_with_cache, mock_cache):
+        mock_cache.search_albums_by_track_title = AsyncMock(return_value=[])
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "track", "limit": 25, "score_threshold": 0.6},
+            )
+
+        assert resp.status_code == 200
+        mock_cache.search_albums_by_track_title.assert_called_once_with(
+            "track", limit=25, score_threshold=0.6
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_query_returns_422(self, app_with_cache):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v1/discogs/search-by-track")
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_threshold_out_of_range_returns_422(self, app_with_cache):
+        # FastAPI's Query(ge=0, le=1) validation.
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "t", "score_threshold": 1.5},
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_no_cache_returns_503(self, app_without_cache):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_without_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "anything"},
+            )
+        assert resp.status_code == 503
+        assert "DATABASE_URL_DISCOGS" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_cache_error_returns_empty_results_not_500(self, app_with_cache, mock_cache):
+        """Mirror the autocomplete endpoint's graceful-empty behavior:
+        cache errors don't bubble to the caller; the empty body is the
+        signal."""
+        mock_cache.search_albums_by_track_title = AsyncMock(
+            side_effect=CacheUnavailableError("transient connection failure")
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_cache), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/search-by-track",
+                params={"q": "anything"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["results"] == []
+        assert body["total"] == 0
+        assert body["query"] == "anything"


### PR DESCRIPTION
## Summary

LML-side primitive that fuzzy-matches a track title against the Discogs cache's `release_track.title` and returns the parent releases. This is **PR 1 of a multi-PR series** to deliver dj-site catalog search by track title — typing `vi scose poise` returns *Confield* (Autechre).

## End-to-end target

| Step | Where | Status |
|---|---|---|
| 1. LML endpoint: track title → Discogs `release_id`s | LML | **this PR** |
| 2. Backend `/library/search-by-track`: wraps LML, joins release_ids ↔ `library.canonical_entity_id`, returns library rows | Backend-Service | follow-up PR |
| 3. dj-site fallback: when artist/album search misses, call Backend's new endpoint; render "matched on track X" annotation | dj-site | optional polish |

## What this PR ships

- **`discogs/cache_service.py:search_albums_by_track_title()`** — trigram lookup over `release_track.title` with configurable `score_threshold` (default 0.3 = pg_trgm GUC default). `DISTINCT ON (rt.release_id)` collapses the multi-row product caused by releases with multiple `extra=0` artist credits (collab albums) while preserving one row per pressing. Different pressings of the same master appear as distinct rows; the caller dedupes via the library lookup downstream. Runs inside a transaction that binds `pg_trgm.similarity_threshold` via `set_config(..., is_local=true)` so the `%` operator floor actually matches the caller's threshold — without this, callers passing `< 0.3` silently get 0.3 behavior.

- **`discogs/router.py:search_by_track()`** — `GET /api/v1/discogs/search-by-track?q=<title>&limit=50&score_threshold=0.3`. LML_API_KEY-protected via the `/api/v1` umbrella. Mirrors `autocomplete_tracks`'s graceful-empty behavior on `CacheUnavailableError` (200 with empty results, not 500). 503 when the cache is unconfigured, 422 on missing query or out-of-range threshold.

- **`discogs/models.py`** — `SearchByTrackResult` (`track_position: str | None = None` because `release_track.position` is nullable in the Discogs schema) + `SearchByTrackResponse` Pydantic models.

## Verification (end-to-end against local homebrew :5432)

| Query | Result |
|---|---|
| `vi scose poise` | 5 Confield pressings, master_id 1374, all score 1.0 |
| `scose poise` (partial) | same 5 at score 0.78 (above the 0.3 default) |
| `qzx8wpvn nothing matches` | empty results |

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy .` clean
- [x] `uv run pytest tests/unit/` — 1664 passed (16 new in `tests/unit/test_search_by_track.py` covering the cache method's SQL parameter pass-through, score coercion, null `master_id` / null `track_position`, error wrapping, pg_trgm GUC binding, and the route's success / 422 / 503 / graceful-empty / threshold-below-default paths)
- [x] `uv run pytest tests/integration/test_search_by_track_pg.py -m pg` against local homebrew cache — 5 passed in 111s (exact-match query, score-threshold filtering, limit, no-match empty, `DISTINCT ON` dedupe)
- [ ] CI green

## Notes on the review-feedback fixes

Two issues flagged by the pre-pr-review hook on the first push, both fixed TDD-style:

1. **Nullable `track_position`**. Original model rejected `None`, so the endpoint would 500 on any cache row with NULL position (digital releases). Fix: `track_position: str | None = None` in the model; unit test pins the round-trip.

2. **`score_threshold` floor at pg_trgm GUC default**. The `%` operator's GIN-index lookup uses the session GUC (default 0.3), so a caller passing 0.1 silently got 0.3 behavior. Fix: bind `pg_trgm.similarity_threshold` per query via `set_config(..., is_local=true)` inside a transaction. The endpoint accepts thresholds below 0.3 instead of clamping at the API layer (which would have masked the underlying issue). Unit test asserts the binding is issued with the per-call value.

## Risks

- **Cache data dependency.** The endpoint is only useful where the discogs-cache has real `release_track` data. The CI `postgres:16-alpine` service container ships empty; the integration test self-skips on empty `release_track`. Production hits the Railway-hosted cache.
- **Score-threshold tuning.** Default 0.3 is permissive enough to catch partial-track-title queries (`scose poise` → `VI Scose Poise`) but admits noise for short queries (single words). Callers can raise the threshold for tighter matching.
- **No artist filter.** Unlike the existing `/discogs/track-releases` (which requires `track` + `artist`), this primitive accepts track-title alone. That's the whole point — the dj-site user types a track name with no artist context.

## Follow-ups

- **Backend wrap** (`/library/search-by-track` in `Backend-Service`): joins `release_id` → `library.canonical_entity_id` to return full `LibraryItem` rows with `match_via: "track"` context.
- **MusicBrainz leg**: same pattern against `mb_recording.name` JOIN `mb_release_group`. Lights up when LML resolves an album to MB but not Discogs.