### PR TITLE
Prefer song-title album matches over sibling albums

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -340,9 +340,21 @@ async def search_library_with_fallback(
                     all_results.append(item)
 
         if all_results:
-            primary_album_lower = albums[0].lower()
+            song_normalized = normalize_for_comparison(parsed.song or "")
+            primary_album_normalized = normalize_for_comparison(albums[0])
+
+            def album_result_rank(item: LibraryItem) -> tuple[bool, bool]:
+                title_normalized = normalize_for_comparison(item.title or "")
+                return (
+                    bool(song_normalized and song_normalized in title_normalized),
+                    bool(
+                        primary_album_normalized
+                        and primary_album_normalized in title_normalized
+                    ),
+                )
+
             all_results.sort(
-                key=lambda r: primary_album_lower in (r.title or "").lower(),
+                key=album_result_rank,
                 reverse=True,
             )
             return all_results, False

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -297,6 +297,56 @@ class TestPerformLookupAlbumResolution:
         assert response.song_not_found is False
 
     @pytest.mark.asyncio
+    async def test_song_title_album_ranked_before_sibling_album(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """An album title matching the requested song should outrank sibling albums."""
+        sibling_album = make_library_item(
+            id=51753,
+            artist="Junior Kimbrough",
+            title="You Better Run (The Essential Junior Kimbrough)",
+            call_letters="KI",
+            release_call_number=5,
+        )
+        matching_album = make_library_item(
+            id=51752,
+            artist="Junior Kimbrough",
+            title="Meet Me in the City",
+            call_letters="KI",
+            release_call_number=4,
+        )
+        mock_library_db.find_similar_artist.return_value = None
+        mock_library_db.search.side_effect = [
+            [sibling_album],
+            [matching_album],
+        ]
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        request = LookupRequest(
+            artist="Junior Kimbrough",
+            song="Meet Me in the City",
+            raw_message="Meet Me in the City by Junior Kimbrough",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[
+                ("Junior Kimbrough", "You Better Run (The Essential Junior Kimbrough)"),
+                ("Junior Kimbrough", "Meet Me in the City"),
+            ],
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        assert [result.library_item.title for result in response.results] == [
+            "Meet Me in the City",
+            "You Better Run (The Essential Junior Kimbrough)",
+        ]
+        assert response.song_not_found is False
+
+    @pytest.mark.asyncio
     async def test_track_validation_filters_album_resolved_results(
         self,
         mock_library_db,


### PR DESCRIPTION
Fixes #288

## Summary
- Boost album results whose title matches the requested song when multiple Discogs album candidates are searched.
- Keep the existing primary Discogs album preference as a secondary ranking signal.
- Add a regression test for the Junior Kimbrough sibling-album case.

## Tests
- `uv run --frozen --extra dev pytest tests/unit/test_orchestrator.py::TestPerformLookupAlbumResolution::test_song_title_album_ranked_before_sibling_album -q`
- `uv run --frozen --extra dev pytest tests/unit/test_orchestrator.py tests/unit/test_orchestrator_helpers.py -q`
- `uv run --frozen --extra dev ruff check lookup/orchestrator.py tests/unit/test_orchestrator.py`