### PR TITLE
Require Discogs health for token rotations

### DIFF
--- a/.github/workflows/set-railway-var.yml
+++ b/.github/workflows/set-railway-var.yml
@@ -24,6 +24,10 @@ name: Set Railway env var (manual)
 #   RAILWAY_TOKEN_STAGING      project-scoped Railway token for staging
 #   <key>                      the value to set (one per supported key —
 #                              add new ones to the resolve step's case)
+#
+# Health acceptance is key-aware: DISCOGS_TOKEN rotations must restore
+# services.discogs_api=ok, while other supported keys accept the existing
+# healthy/degraded service-level status.
 
 on:
   workflow_dispatch:
@@ -138,17 +142,25 @@ jobs:
           sleep 60
           for i in 1 2 3 4 5 6; do
             if curl -sf -m 10 "$HEALTH_URL" > /tmp/health.json; then
-              status=$(python3 -c "import json,sys;print(json.load(open('/tmp/health.json'))['status'])")
-              echo "Health attempt $i: $status"
-              if [ "$status" = "healthy" ] || [ "$status" = "degraded" ]; then
-                exit 0
+              if [ "$KEY" = "DISCOGS_TOKEN" ]; then
+                probe=$(python3 -c "import json; print(json.load(open('/tmp/health.json')).get('services', {}).get('discogs_api', 'missing'))")
+                echo "Health attempt $i: discogs_api=$probe"
+                if [ "$probe" = "ok" ]; then
+                  exit 0
+                fi
+              else
+                status=$(python3 -c "import json; print(json.load(open('/tmp/health.json'))['status'])")
+                echo "Health attempt $i: $status"
+                if [ "$status" = "healthy" ] || [ "$status" = "degraded" ]; then
+                  exit 0
+                fi
               fi
             else
               echo "Health attempt $i: HTTP error"
             fi
             sleep 10
           done
-          echo "::error::Service did not return healthy/degraded after 6 attempts"
+          echo "::error::Service did not return acceptable health after 6 attempts"
           exit 1
 
       - name: Summary


### PR DESCRIPTION
Fixes #227

## Summary
- make the post-rotation health probe key-aware for `DISCOGS_TOKEN`
- require `services.discogs_api == "ok"` for Discogs token rotations
- keep the existing `healthy`/`degraded` status acceptance for other supported keys
- document the per-key health acceptance rule in the workflow header

## Tests
- `..\..\tools\actionlint\actionlint.exe .github\workflows\set-railway-var.yml`
- bash predicate simulation for `DISCOGS_TOKEN` ok/error and non-Discogs degraded/error cases

## Notes
- No app code changes.
- The workflow continues to tolerate `degraded` for non-Discogs secret rotations.