### PR TITLE
Omit null label sentinels from Discogs search

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -1015,7 +1015,9 @@ class DiscogsService:
             params["release_title"] = request.track
 
         if request.label:
-            params["label"] = request.label
+            label = request.label.strip()
+            if label and label.lower() != "null":
+                params["label"] = request.label
         if request.format:
             params["format"] = request.format
 

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -914,6 +914,13 @@ class TestBuildSearchParams:
         )
         assert "label" not in params
 
+    @pytest.mark.parametrize("label", ["NULL", "null", ""])
+    def test_omits_missing_label_sentinel_values(self, service, label):
+        params = service._build_search_params(
+            DiscogsSearchRequest(artist="Missy Elliott", album="Supa Dupa Fly", label=label)
+        )
+        assert "label" not in params
+
     def test_includes_format_when_provided(self, service):
         params = service._build_search_params(
             DiscogsSearchRequest(artist="Cat Power", album="Moon Pix", format="CD")


### PR DESCRIPTION
Fixes #197

## Summary
- omit missing-label sentinel values from Discogs strict search params
- treat `NULL`, `null`, and empty labels as absent labels
- add a regression test for the sentinel cases reported in the issue

## Tests
- `uv run --frozen --extra dev pytest tests/unit/test_discogs_service.py::TestBuildSearchParams::test_omits_missing_label_sentinel_values -q`
- `uv run --frozen --extra dev pytest tests/unit/test_discogs_service.py::TestBuildSearchParams -q`
- `uv run --frozen --extra dev pytest tests/unit/test_discogs_service.py -q`
- `uv run --frozen --extra dev ruff check discogs/service.py tests/unit/test_discogs_service.py`

## Notes
- Kept the change limited to Discogs search parameter construction.
- Real label values are still passed through unchanged.