### PR TITLE
#288 rank song-title match above primary album in artist+album branch

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -341,10 +341,25 @@ async def search_library_with_fallback(
 
         if all_results:
             primary_album_lower = albums[0].lower()
-            all_results.sort(
-                key=lambda r: primary_album_lower in (r.title or "").lower(),
-                reverse=True,
-            )
+            song_lower = (parsed.song or "").lower()
+
+            # When the request specifies a song, prefer a candidate whose title
+            # matches the song name (the title-album beats a same-artist
+            # compilation that also contains the track). albums[0] is whatever
+            # the upstream Discogs track-lookup returned first, which is
+            # non-deterministic when several releases tie on track-title
+            # similarity in the PG cache; the song key forces a deterministic,
+            # semantically correct order. albums[0] is kept as a secondary
+            # tiebreak so album-only requests (parsed.song unset) preserve the
+            # existing primary-album order.
+            def sort_key(r: LibraryItem) -> tuple[bool, bool]:
+                title_lower = (r.title or "").lower()
+                return (
+                    bool(song_lower) and song_lower in title_lower,
+                    primary_album_lower in title_lower,
+                )
+
+            all_results.sort(key=sort_key, reverse=True)
             return all_results, False
 
         # When Discogs found albums but none matched the library, fall through to

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,6 +87,21 @@ SEED_ITEMS = [
     (39, "Confield", "Autechre", "EL", 16, 1, "Electronic", "CD"),
     (40, "1st Class", "Large Professor", "HH", 1, 1, "Hiphop", "CD"),
     (41, "...Destroys The Space Invaders", "Prince Jammy", "RE", 1, 1, "Reggae", "Vinyl"),
+    # Junior Kimbrough: title-album and same-artist comp that both contain the
+    # song "Meet Me in the City". Exercises song-title-vs-primary-album
+    # ranking when several library candidates by the same artist all pass
+    # track validation against Discogs.
+    (51752, "Meet Me in the City", "Junior Kimbrough", "KI", 6, 4, "Blues", "CD"),
+    (
+        51753,
+        "You Better Run (The essential Junior Kimbrough)",
+        "Junior Kimbrough",
+        "KI",
+        6,
+        5,
+        "Blues",
+        "CD",
+    ),
     # Lee 'Scratch' Perry: cluster used by the cache-promotion regression test.
     # Five fallback albums with low-id slots, plus "Live at Maritime Hall" deeper
     # in the catalog -- mirrors the production layout where the song-bearing

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -217,6 +217,112 @@ class TestTrackValidationFiltering:
         assert body["song_not_found"] is False
 
 
+class TestSongTitleRanking:
+    """When several library candidates by the same artist all contain the
+    requested track, the album whose title matches the song name must rank
+    first — regardless of which album the upstream Discogs track-lookup
+    happened to return first."""
+
+    @pytest.mark.asyncio
+    async def test_title_album_beats_compilation_when_both_contain_song(self, library_db):
+        """'Meet Me in the City' by Junior Kimbrough should return the album
+        of that name (KI 6/4) ahead of the 'You Better Run' essentials comp
+        (KI 6/5), even when Discogs returned the comp first.
+
+        Seed data:
+        - (51752, "Meet Me in the City", "Junior Kimbrough")
+        - (51753, "You Better Run (The essential Junior Kimbrough)", "Junior Kimbrough")
+
+        Both albums contain "Meet Me in the City"; both pass track validation.
+        Sorting by `albums[0]` from the upstream Discogs track lookup is
+        non-deterministic when several releases tie on track-title similarity
+        in the PG cache, so the title-matching album must be promoted by the
+        song key.
+        """
+        from wxyc_fastapi.observability import init_cache_stats
+
+        from lookup.models import LookupRequest
+        from lookup.orchestrator import perform_lookup
+        from tests.conftest import make_lml_telemetry
+        from tests.factories import make_discogs_result
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(
+            spec_set=[
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "search",
+                "get_release",
+                "cache_service",
+            ]
+        )
+        mock_service.cache_service = None
+
+        meet_me_discogs = make_discogs_result(
+            release_id=8001, album="Meet Me in the City", artist="Junior Kimbrough"
+        )
+        you_better_run_discogs = make_discogs_result(
+            release_id=8002,
+            album="You Better Run: The Essential Junior Kimbrough",
+            artist="Junior Kimbrough",
+        )
+
+        async def mock_search(request):
+            album = (request.album if hasattr(request, "album") else "") or ""
+            album_lower = album.lower()
+            if "meet me in the city" in album_lower:
+                return DiscogsSearchResponse(results=[meet_me_discogs])
+            if "you better run" in album_lower or "essential" in album_lower:
+                return DiscogsSearchResponse(results=[you_better_run_discogs])
+            return DiscogsSearchResponse(results=[])
+
+        mock_service.search = AsyncMock(side_effect=mock_search)
+        # The track is genuinely on both releases — neither should be filtered.
+        mock_service.validate_track_on_release = AsyncMock(return_value=True)
+        mock_service.get_release = AsyncMock(return_value=None)
+        mock_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Meet Me in the City",
+                artist="Junior Kimbrough",
+                releases=[],
+                total=0,
+                cached=False,
+            )
+        )
+
+        request = LookupRequest(
+            artist="Junior Kimbrough",
+            song="Meet Me in the City",
+            raw_message="Meet Me in the City Junior Kimbrough",
+        )
+
+        # Bug-triggering Discogs order: comp first, title-match album second.
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[
+                ("Junior Kimbrough", "You Better Run: The Essential Junior Kimbrough"),
+                ("Junior Kimbrough", "Meet Me in the City"),
+            ],
+        ):
+            response = await perform_lookup(
+                request,
+                library_db,
+                mock_service,
+                make_lml_telemetry(),
+            )
+
+        titles = [r.library_item.title for r in response.results]
+        assert titles[0] == "Meet Me in the City", (
+            f"Title-matching album should rank first; got: {titles}"
+        )
+        assert "You Better Run (The essential Junior Kimbrough)" in titles, (
+            f"Comp should still appear (track is on it too); got: {titles}"
+        )
+        assert response.song_not_found is False
+
+
 class TestQuotedArtistNameValidation:
     """Test that Discogs-formatted quoted artist names don't cause false positives."""
 

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -627,6 +627,62 @@ class TestSearchLibraryWithFallback:
         assert mock_library_db.search.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_song_title_match_beats_primary_album_for_ranking(self, mock_library_db):
+        """When Discogs returns multiple albums for a track and one library
+        candidate's title matches the requested song, that candidate sorts
+        first regardless of which album Discogs returned first.
+
+        Reproducer: "Meet Me in the City by Junior Kimbrough". The PG cache
+        ranks both Discogs releases at similarity 1.0 (both contain a track
+        literally named "Meet Me in the City"); the physical-row tiebreak is
+        non-deterministic, so the compilation may arrive first in `albums`.
+        Sorting by `albums[0] in title` alone would let the compilation win
+        even though the library has an album whose title is the song name.
+        """
+        meet_me_album = make_library_item(
+            id=51752,
+            artist="Junior Kimbrough",
+            title="Meet Me in the City",
+            call_letters="KI",
+            artist_call_number=6,
+            release_call_number=4,
+        )
+        you_better_run = make_library_item(
+            id=51753,
+            artist="Junior Kimbrough",
+            title="You Better Run (The essential Junior Kimbrough)",
+            call_letters="KI",
+            artist_call_number=6,
+            release_call_number=5,
+        )
+        # albums[0] is the compilation: per-album search for "You Better Run..."
+        # returns the comp; per-album search for "Meet Me in the City" returns
+        # the title-match album. This is the bug-triggering arrival order.
+        mock_library_db.search.side_effect = [[you_better_run], [meet_me_album]]
+
+        parsed = ParsedRequest(
+            song="Meet Me in the City",
+            artist="Junior Kimbrough",
+            raw_message="Meet Me in the City Junior Kimbrough",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+        results, fallback = await search_library_with_fallback(
+            mock_library_db,
+            parsed,
+            [
+                "You Better Run (The essential Junior Kimbrough)",
+                "Meet Me in the City",
+            ],
+        )
+
+        assert [r.title for r in results] == [
+            "Meet Me in the City",
+            "You Better Run (The essential Junior Kimbrough)",
+        ]
+        assert fallback is False
+
+    @pytest.mark.asyncio
     async def test_album_only_search_when_no_artist(self, mock_library_db):
         """When parser extracts album but no artist, search by album title alone.
 


### PR DESCRIPTION
Closes #288.

## Summary

- `search_library_with_fallback` ranked candidates by `albums[0] in title` — whichever album `lookup_releases_by_track` returned first. That order is non-deterministic when several releases tie on track-title similarity in the PG cache (`ORDER BY similarity DESC` with sim=1.0 for both), so a same-artist comp could outrank the album whose title literally matches the song. "Meet Me in the City by Junior Kimbrough" returned the "You Better Run" comp (KI 6/5) ahead of the title-album (KI 6/4).
- Fix: add a primary sort key `parsed.song in title` so the title-matching album wins regardless of upstream order. `albums[0] in title` becomes the secondary tiebreak; Python's stable sort preserves the original parallel-fetch order beyond that.
- The two other sort sites in the same function (artist+song fallback at `orchestrator.py:365-369`, compilation search at `orchestrator.py:569-574`) already use this `song_lower in title` pattern. This change brings the artist+album branch in line.

## Why now

The code at `lookup/orchestrator.py:342-348` has been wrong since the LML scaffold (`ebcdc9e`, 2026-02-10) — `git log -S "primary_album_lower"` confirms no later commit modified the sort. What changed was upstream: the PG cache row order between the two Junior Kimbrough releases flipped on a re-ingest, and the bug surfaced. The earlier observed symptom ("Do the Rump" — yet another Kimbrough album) confirms this has flipped before. The fix removes the dependence on cache row order.

## Tests

- Unit: `tests/unit/test_orchestrator_helpers.py::TestSearchLibraryWithFallback::test_song_title_match_beats_primary_album_for_ranking` — mocks the bug-triggering Discogs arrival order (comp first) and asserts the title-album sorts first.
- Integration: `tests/integration/test_lookup_pipeline.py::TestSongTitleRanking` — uses the real SQLite-FTS5 `library_db` fixture with two new Kimbrough seed rows (51752/51753, `Blues cd KI 6/4` and `KI 6/5`) and runs `perform_lookup` end-to-end with both releases passing track validation.
- Both confirmed RED before the fix, GREEN after.
- Existing `test_multiple_albums_all_searched_and_deduplicated` (Stereolab/Percolator, where neither title contains the song) still passes — documents the secondary-sort case.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit/`)
- [x] Default suite passes (`uv run pytest` — 1887 passed, 1 skipped, 2 xfailed)
- [x] Lint clean (`uv run ruff check`)
- [x] Format clean (`uv run ruff format --check`)
- [x] mypy clean on `lookup/orchestrator.py`
- [ ] Staging deploys after merge and rom-side `test_meet_me_in_the_city_returns_correct_album` (external_api) passes against staging