### PR TITLE
#50 bump GitHub Actions for Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: 'pip'
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: 'pip'
@@ -57,8 +57,8 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: 'pip'
@@ -71,8 +71,8 @@ jobs:
     name: Default Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: 'pip'
@@ -82,9 +82,9 @@ jobs:
       # tests/e2e/. Infra-tagged tests run in their own jobs (`pg`, `external_api`).
       - run: pytest -v --cov=. --cov-report=xml
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -93,8 +93,8 @@ jobs:
     name: External API Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: 'pip'
@@ -125,8 +125,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: 'pip'
@@ -158,7 +158,7 @@ jobs:
     # deploy chain. See WXYC/library-metadata-lookup#208.
     needs: [lint, typecheck, test, pg]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Railway CLI
         run: npm install -g @railway/cli
       - name: Deploy to Railway
@@ -201,7 +201,7 @@ jobs:
     # external_api is intentionally NOT a deploy gate — see deploy-staging for the rationale.
     needs: [lint, typecheck, test, pg]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Railway CLI
         run: npm install -g @railway/cli
       - name: Deploy to Railway

--- a/.github/workflows/cross-cache-identity-flags.yml
+++ b/.github/workflows/cross-cache-identity-flags.yml
@@ -25,5 +25,5 @@ jobs:
     name: Flag-doc consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: bash scripts/check_cross_cache_identity_flags.sh

--- a/.github/workflows/refresh-streaming.yml
+++ b/.github/workflows/refresh-streaming.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Closes #50.

## Summary

- `actions/checkout@v4 → @v6` (current latest is v6.0.2; Node.js 24 landed in v5 and was carried forward)
- `actions/setup-python@v5 → @v6` (currently resolves to v6.2.0)
- `codecov/codecov-action@v4 → @v5` with the documented `file: → files:` input rename
- Incorporates the changes from #293, with `checkout` carried one major further to the current latest

## Why

CI emits the Node.js 20 deprecation warning on every run; GitHub forces Node.js 24 by default starting 2026-06-02. Bumping ahead of the forced flip keeps the deprecation log clean and lets us catch any incompatibility in a deliberate PR rather than an unrelated one.

## Verification

Verified each target major against the authoritative upstream repo:

| Action | Target | Current latest | Notes |
|---|---|---|---|
| `actions/checkout@v6` | `93cb6efe... → v6.0.2` | v6.0.2 (2026-01-09) | Node.js 24 introduced in v5.0.0 (2025-08-11); v6.0.0 added creds-file hardening; v6.0.2 added orchestration_id UA + tag-handling fixes. No input/output changes vs v5. |
| `actions/setup-python@v6` | `a309ff8b... → v6.2.0` | v6.2.0 (2026-01-22) | Node.js 24-compatible. |
| `codecov/codecov-action@v5` | `75cd1169... → v5.x` | v5.x | Release notes document the `file → files` rename, applied here. |

`actionlint` clean locally. The two remaining workflows (`charset-corpus-drift.yml`, `set-railway-var.yml`) don't reference any of these actions directly — `charset-corpus-drift.yml` consumes a reusable workflow at `WXYC/wxyc-shared` whose Node.js 24 update is owned there.

## Test plan

- [x] `actionlint` clean
- [x] YAML parses
- [ ] `Lint & Format`, `Type Check`, `Default Tests`, `External API Tests`, `PG Tests`, `Codegen Freshness`, `CI Marker Sync` jobs green on the new runner versions
- [ ] After merge, `Deploy to Staging` + `Smoke Test (Staging)` green on the next push to `main`