### PR TITLE
Pin reusable workflow refs to gha/v1

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -22,9 +22,10 @@ on:
 
 jobs:
   drift:
-    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
+    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1
     with:
       pinned-sha256: 75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a
       package-version: "0.10.0"
+      wxyc-shared-ref: gha/v1
     secrets:
       npm-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,12 @@ jobs:
 
   marker-sync:
     name: CI Marker Sync
-    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@gha/v1
     with:
       repo-path: "."
       workflows-dir: ".github/workflows"
       tests-dir: "tests"
+      wxyc-etl-ref: gha/v1
 
   deploy-staging:
     name: Deploy to Staging


### PR DESCRIPTION
## Summary

- Pin `WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml` from `@main` → `@gha/v1`
- Pin `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml` from `@main` → `@gha/v1`
- Pass `wxyc-shared-ref: gha/v1` / `wxyc-etl-ref: gha/v1` so the inner script-checkout in each reusable workflow stays pinned (default was `main`).

## Why

Before this PR, a push to `wxyc-shared/main` or `wxyc-etl/main` would cascade into this repo's CI with this repo's secrets. The new `gha/v1` stability tags upstream provide an immutable-by-policy ref to pin against.

## Project

Part of the org-level [GitHub Actions Supply-Chain Hardening](https://github.com/orgs/WXYC/projects/31) project, Phase 2.

## Test plan

- [ ] CI Marker Sync job still passes (validates wxyc-etl reusable workflow runs at gha/v1)
- [ ] Charset Corpus Drift job still passes on next scheduled / push run (validates wxyc-shared reusable workflow runs at gha/v1)