### PR TITLE
ci: pin workflow-level GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -20,6 +20,13 @@ on:
     # Monday 08:17 UTC catches upstream bumps merged over the weekend.
     - cron: "17 8 * * 1"
 
+# Workflow-level GITHUB_TOKEN scope. The reusable workflow runs
+# `npm pack @wxyc/shared` against npm.pkg.github.com using the token
+# forwarded as `npm-token`, which needs packages:read.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   drift:
     uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ on:
       - "LICENSE"
       - ".gitignore"
 
+# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
+# comments on PRs, or creates releases; all writes to external services
+# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format

--- a/.github/workflows/cross-cache-identity-flags.yml
+++ b/.github/workflows/cross-cache-identity-flags.yml
@@ -20,6 +20,12 @@ on:
       - 'scripts/check_cross_cache_identity_flags.sh'
       - '.github/workflows/cross-cache-identity-flags.yml'
 
+# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
+# comments on PRs, or creates releases; all writes to external services
+# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Flag-doc consistency

--- a/.github/workflows/refresh-streaming.yml
+++ b/.github/workflows/refresh-streaming.yml
@@ -12,6 +12,12 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+# Workflow-level GITHUB_TOKEN scope. Jobs in this file write back to the
+# repository (create tags / upload release assets / push commits) via
+# GITHUB_TOKEN, so contents:write is required.
+permissions:
+  contents: write
+
 jobs:
   refresh:
     runs-on: ubuntu-latest

--- a/.github/workflows/set-railway-var.yml
+++ b/.github/workflows/set-railway-var.yml
@@ -45,6 +45,12 @@ on:
           - production
           - staging
 
+# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
+# comments on PRs, or creates releases; all writes to external services
+# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   apply:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #308.

Adds a top-level `permissions:` block to every workflow so the GITHUB_TOKEN runs with a least-privilege scope pinned in code, instead of inheriting whatever the repo-wide default happens to be.

- `ci.yml`: contents: read
- `charset-corpus-drift.yml`: contents: read + packages: read
- `cross-cache-identity-flags.yml`: contents: read
- `set-railway-var.yml`: contents: read
- `refresh-streaming.yml`: contents: write

Behavior-neutral today (no job writes via GITHUB_TOKEN beyond what the block grants) but pins the safe posture so future jobs can't silently inherit write scopes.

Part of the org-wide GitHub Actions hardening project (Phase 3).