### PR TITLE
ci: pin @railway/cli to 4.58.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Railway CLI
-        run: npm install -g @railway/cli
+        run: npm install -g @railway/cli@4.58.0
       - name: Deploy to Railway
         run: railway up --service library-metadata-lookup
         env:
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Railway CLI
-        run: npm install -g @railway/cli
+        run: npm install -g @railway/cli@4.58.0
       - name: Deploy to Railway
         run: railway up --service library-metadata-lookup
         env:

--- a/.github/workflows/set-railway-var.yml
+++ b/.github/workflows/set-railway-var.yml
@@ -76,7 +76,7 @@ jobs:
           fi
 
       - name: Install Railway CLI
-        run: npm install -g @railway/cli
+        run: npm install -g @railway/cli@4.58.0
 
       - name: Show CLI version
         run: railway --version


### PR DESCRIPTION
## Summary

- Pins `npm install -g @railway/cli` to exact version `4.58.0` in three workflow invocations: `deploy-staging`, `deploy-production` (both in `ci.yml`), and the `set-railway-var.yml` secret-rotation workflow
- Trades floating npm `latest` for CI reproducibility — guards against silent CLI flag regressions breaking the deploy chain or var-set

Phase 5 of the WXYC org-wide GitHub Actions hardening project.

Closes #311.

## Test plan

- [ ] `deploy-staging` CI job succeeds on this PR (the install + `railway up --service library-metadata-lookup` is the live test)
- [ ] Post-merge staging deploy succeeds
- [ ] `set-railway-var.yml` is `workflow_dispatch`-only so it won't run on this PR; verified by review (one-token diff)