### PR TITLE
feat(discogs): GET /api/v1/discogs/resolve-release for album+artist -> release ID

### DIFF
--- a/discogs/models.py
+++ b/discogs/models.py
@@ -230,6 +230,23 @@ class DiscogsSearchResponse(BaseModel):
     cached: bool = False
 
 
+class DiscogsResolveReleaseResponse(BaseModel):
+    """Response for GET /api/v1/discogs/resolve-release.
+
+    A flat envelope around the top-confidence release match for an
+    (artist, album) pair. Replaces the legacy POST /api/v1/discogs/search
+    response (which wrapped the same data in a `results` array) for the
+    single-best-match use case driving tubafrenzy's library release tracklist
+    page (WXYC/tubafrenzy#546).
+    """
+
+    release_id: int
+    title: str | None = None
+    artist: str | None = None
+    release_url: str
+    confidence: float = 0.0
+
+
 class EnrichedDiscogsMatchResult(_GeneratedDiscogsMatchResult):
     """Extends the generated DiscogsMatchResult with enriched metadata fields.
 

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -9,6 +9,8 @@ from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 from discogs.markup_parser import DiscogsServiceResolver, parse_async
 from discogs.models import (
     ArtistDetails,
+    DiscogsResolveReleaseResponse,
+    DiscogsSearchRequest,
     EntityResolveResponse,
     EntityType,
     ReleaseMetadataResponse,
@@ -150,6 +152,60 @@ async def resolve_entity(
         if master is None:
             raise HTTPException(status_code=404, detail=f"Master {entity_id} not found")
         return EntityResolveResponse(name=master.title, type=entity_type, id=entity_id)
+
+
+@router.get(
+    "/resolve-release",
+    response_model=DiscogsResolveReleaseResponse,
+    summary="Resolve a Discogs release ID from (artist, album)",
+    responses={
+        200: {"description": "Top-confidence release match returned"},
+        404: {"description": "No matching release found"},
+        422: {"description": "Missing required album parameter"},
+        503: {"description": "Discogs service not configured"},
+    },
+)
+async def resolve_release(
+    album: str = Query(..., description="Album / release title (required)"),
+    artist: str | None = Query(
+        None,
+        description=(
+            "Artist name. Optional — omit for Various Artists / compilation releases "
+            "to avoid polluting fuzzy matching."
+        ),
+    ),
+    limit: int = Query(
+        5,
+        ge=1,
+        le=50,
+        description="Maximum number of underlying search results to rank (only the top one is returned).",
+    ),
+    service: DiscogsService | None = Depends(get_discogs_service),
+) -> DiscogsResolveReleaseResponse:
+    """Resolve an (artist, album) pair to a Discogs release ID.
+
+    Replaces the legacy POST /api/v1/discogs/search endpoint (removed in
+    c5f1e65) for the single-best-match use case driving tubafrenzy's library
+    release tracklist page (WXYC/tubafrenzy#546).
+    """
+    svc = _require_service(service)
+    request = DiscogsSearchRequest(artist=artist, album=album)
+    response = await svc.search(request, limit=limit)
+
+    if not response.results:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No matching release for artist={artist!r}, album={album!r}",
+        )
+
+    top = response.results[0]
+    return DiscogsResolveReleaseResponse(
+        release_id=top.release_id,
+        title=top.album,
+        artist=top.artist,
+        release_url=top.release_url,
+        confidence=top.confidence,
+    )
 
 
 @router.get(

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -850,6 +850,22 @@ class DiscogsSearchResult(BaseModel):
     type: Type
 
 
+class DiscogsResolveReleaseResponse(BaseModel):
+    release_id: int = Field(..., description="Discogs release ID of the best match.")
+    title: str | None = Field(
+        None,
+        description="Release title as returned by Discogs (may differ from the query).",
+    )
+    artist: str | None = Field(None, description="Primary artist name as returned by Discogs.")
+    release_url: str = Field(
+        ...,
+        description="Canonical Discogs URL, e.g. `https://www.discogs.com/release/12345`.",
+    )
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(
+        0, description="Match confidence from LML's ranker (0.0 - 1.0)."
+    )
+
+
 class DiscogsArtistRef(BaseModel):
     name: str
     id: int

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -136,6 +136,7 @@ class TestProtectedRouteRegistration:
         ("GET", "/api/v1/discogs/artist/{artist_id}"),
         ("GET", "/api/v1/discogs/entity/{entity_type}/{entity_id}"),
         ("GET", "/api/v1/discogs/tracks/autocomplete"),
+        ("GET", "/api/v1/discogs/resolve-release"),
     ]
 
     EXPECTED_UNPROTECTED = [

--- a/tests/unit/test_discogs_router.py
+++ b/tests/unit/test_discogs_router.py
@@ -9,6 +9,8 @@ from httpx import ASGITransport, AsyncClient
 from discogs.models import (
     ArtistDetails,
     ArtistRef,
+    DiscogsSearchResponse,
+    DiscogsSearchResult,
     MasterRelease,
     MemberRef,
     ReleaseMetadataResponse,
@@ -147,10 +149,14 @@ class TestGetRelease:
 
 
 class TestSearchReleasesRemoved:
-    """The /discogs/search endpoint has been removed. All callers use /lookup instead."""
+    """The legacy POST /discogs/search endpoint remains removed.
+
+    Replaced by GET /discogs/resolve-release (see TestResolveRelease below).
+    Kept as a guard against accidental re-introduction of the POST shape.
+    """
 
     @pytest.mark.asyncio
-    async def test_endpoint_returns_404(self, app_with_discogs):
+    async def test_post_endpoint_returns_404(self, app_with_discogs):
         async with AsyncClient(
             transport=ASGITransport(app=app_with_discogs), base_url="http://test"
         ) as client:
@@ -160,6 +166,163 @@ class TestSearchReleasesRemoved:
             )
 
         assert resp.status_code == 404 or resp.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# GET /discogs/resolve-release
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRelease:
+    """Tests for GET /api/v1/discogs/resolve-release.
+
+    Replaces the removed POST /api/v1/discogs/search for the (artist, album)
+    -> release_id resolution case used by tubafrenzy's library release
+    tracklist page (WXYC/tubafrenzy#546, WXYC/library-metadata-lookup#315).
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_top_result(self, app_with_discogs, mock_discogs):
+        mock_discogs.search = AsyncMock(
+            return_value=DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        album="Disco Not Disco, Vol. 2",
+                        artist="Various",
+                        release_id=12345,
+                        release_url="https://www.discogs.com/release/12345",
+                        confidence=0.91,
+                    ),
+                    DiscogsSearchResult(
+                        album="Disco Not Disco",
+                        artist="Various",
+                        release_id=999,
+                        release_url="https://www.discogs.com/release/999",
+                        confidence=0.62,
+                    ),
+                ],
+                total=2,
+                cached=True,
+            )
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/resolve-release",
+                params={"album": "Disco Not Disco, Vol. 2", "artist": "Various"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["release_id"] == 12345
+        assert data["title"] == "Disco Not Disco, Vol. 2"
+        assert data["artist"] == "Various"
+        assert data["release_url"] == "https://www.discogs.com/release/12345"
+        assert data["confidence"] == pytest.approx(0.91)
+
+    @pytest.mark.asyncio
+    async def test_empty_results_returns_404(self, app_with_discogs, mock_discogs):
+        mock_discogs.search = AsyncMock(
+            return_value=DiscogsSearchResponse(results=[], total=0, cached=False)
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/resolve-release",
+                params={"album": "Nonexistent Album", "artist": "Nobody"},
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_missing_album_returns_422(self, app_with_discogs):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/resolve-release", params={"artist": "Stereolab"}
+            )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_no_service_returns_503(self, app_without_discogs):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_without_discogs), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/resolve-release",
+                params={"album": "Some Album"},
+            )
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_artist_optional(self, app_with_discogs, mock_discogs):
+        """Artist is optional: tubafrenzy omits it for Various Artists releases."""
+        mock_discogs.search = AsyncMock(
+            return_value=DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        album="Disco Not Disco, Vol. 2",
+                        artist="Various",
+                        release_id=12345,
+                        release_url="https://www.discogs.com/release/12345",
+                        confidence=0.85,
+                    ),
+                ],
+                total=1,
+                cached=True,
+            )
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/resolve-release",
+                params={"album": "Disco Not Disco, Vol. 2"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["release_id"] == 12345
+        # The DiscogsSearchRequest passed to .search() should have artist=None.
+        call_args = mock_discogs.search.call_args
+        request = call_args.args[0] if call_args.args else call_args.kwargs["request"]
+        assert request.artist is None
+        assert request.album == "Disco Not Disco, Vol. 2"
+
+    @pytest.mark.asyncio
+    async def test_limit_passed_through(self, app_with_discogs, mock_discogs):
+        mock_discogs.search = AsyncMock(
+            return_value=DiscogsSearchResponse(
+                results=[
+                    DiscogsSearchResult(
+                        release_id=1,
+                        release_url="https://www.discogs.com/release/1",
+                        confidence=0.5,
+                    )
+                ],
+                total=1,
+                cached=True,
+            )
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/v1/discogs/resolve-release",
+                params={"album": "X", "limit": 10},
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_discogs.search.call_args.kwargs
+        assert call_kwargs.get("limit") == 10
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/discogs/resolve-release?album=...&artist=...` that returns the highest-confidence Discogs release ID for an `(artist, album)` pair (or 404 when no match). Replaces the resolution capability of the legacy `POST /api/v1/discogs/search` endpoint removed in c5f1e65 (2026-04-25). Closes #315.

The new shape matches the surrounding `/api/v1/discogs/*` conventions (`/track-releases`, `/release/{id}`, `/tracks/autocomplete`): GET, query string, identical auth surface, identical `_require_service` 503 check. `artist` is optional - tubafrenzy omits it for Various Artists / compilation releases to avoid polluting fuzzy matching.

The legacy POST shape stays deleted; `TestSearchReleasesRemoved` continues to lock it down.

## Why

Tubafrenzy's library release tracklist page (`/wxycdb/libraryRelease?id=...`) has been silently rendering "No tracklist available." for every release since 2026-04-25, because `LibrarySearchClient.searchDiscogsRelease` still calls the removed POST. See WXYC/tubafrenzy#546 for the front-end repro. This PR is the LML half of the fix; WXYC/tubafrenzy#PR-TBD is the tubafrenzy half.

## Endpoint contract

```
GET /api/v1/discogs/resolve-release?album=<title>&artist=<name>&limit=<int>
Authorization: Bearer <LML_API_KEY>   (when LML_REQUIRE_AUTH=true)

200 OK
{
  "release_id": 12345,
  "title": "Disco Not Disco, Vol. 2",
  "artist": "Various",
  "release_url": "https://www.discogs.com/release/12345",
  "confidence": 0.91
}

404 - No matching release
422 - Missing album
503 - DISCOGS_TOKEN not configured
401 - Missing/invalid bearer when LML_REQUIRE_AUTH=true
```

No new service code: the route just calls the existing `DiscogsService.search()` (which already does cache-first ranking) and returns the top result.

## Rollout order

1. **wxyc-shared PR (WXYC/wxyc-shared#122)** merges first - this PR's `generated/api_models.py` is regenerated from that `api.yaml` and should track it.
2. **This PR** merges to `main` - CI deploys to LML staging.
3. **Promote LML `main` -> `prod`** for the production deploy.
4. **Tubafrenzy PR (WXYC/tubafrenzy#PR-TBD)** merges to `main` - auto-deploys tubafrenzy to production.

Failure mode if step 3 lags step 4: tubafrenzy hits 404, `searchDiscogsRelease` returns `Optional.empty()`, UI shows "No tracklist available." - same broken state as today, no new harm.

## Test plan

- [x] `uv run pytest tests/unit/` - all 1660 unit tests pass; `TestResolveRelease` covers success (top of 2), empty -> 404, missing album -> 422, no service -> 503, artist-optional with mock assertion on `DiscogsSearchRequest.artist == None`, and limit passthrough
- [x] `TestProtectedRouteRegistration` covers auth-header enforcement on the new route via router-level dep inheritance
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy .` clean
- [ ] Smoke-test against staging after deploy: `curl -H "Authorization: Bearer $LML_API_KEY" "$LML_STAGING/api/v1/discogs/resolve-release?album=Disco%20Not%20Disco%2C%20Vol.%202"` returns 200 with a `release_id`
- [ ] Tubafrenzy PR's regression test (`LibraryReleaseTracksServletTest`) green against this endpoint

## Related

- Closes #315
- Refs WXYC/tubafrenzy#546 (the bug this enables fixing)
- Refs WXYC/wxyc-shared#122 (contract update; must merge first)
- Removed in: c5f1e65a378d82b8e49d544efb266ce6cc5af29e