### PR TITLE
Canonical-artist resolver pre-pass + calibration harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,7 @@ Optional:
 - `ETL_NOTIFY_KEY` -- Bearer token used by LML when *pushing* the streaming-status webhook to tubafrenzy
 - `LML_API_KEY` -- Bearer token required from tubafrenzy / Backend-Service callers (see "Inbound Auth" below)
 - `LML_REQUIRE_AUTH` -- When `true`, enforce `LML_API_KEY` on protected endpoints. Default `false` (see rollout phasing in `core/auth.py`)
+- `LML_RESOLVE_ARTIST_CANONICAL` -- When `true`, the canonical-artist resolver pre-pass in `search_compilations_for_track` swaps the inbound artist name for the top trigram match in `discogs-cache` when the similarity score >= `CANONICAL_ARTIST_SIMILARITY_FLOOR` (`lookup/orchestrator.py`). Default `false`. The pre-pass *always* runs in shadow mode (emits an INFO log line and a `resolver_pre_pass` Sentry transaction data attribute on every lookup) regardless of the flag, so the floor can be calibrated against real traffic before enforcement is enabled. Flip to `true` in Railway after `scripts.resolver_calibration` reports an FP-rate ≤ 0.5% for the chosen floor. See WXYC/library-metadata-lookup#318.
 
 ### Cross-cache-identity feature flags
 
@@ -411,6 +412,26 @@ python -m scripts.bandcamp_pipeline [--phase {search,lookup,both}] [--include-st
 Options: `--phase` (default: both, runs concurrently), `--include-streaming` (search all artists, not just not-on-streaming), `--artist-fallback` (write artist-level URL when no album match), `--dry-run` (report what would happen without changes), `--limit N` (max artists/slugs to process).
 
 Uses `BandcampClient` (`scripts/bandcamp_client.py`) extending `BaseStreamingClient` with rate limiting (1 req/s, semaphore 2) and 429 retry with exponential backoff. Optionally loads Wikidata slugs via `DATABASE_URL_WIKIDATA`.
+
+### Resolver Calibration (`scripts/resolver_calibration/`)
+
+Sweeps the trigram-similarity floor used by `lookup/orchestrator.resolve_canonical_artist` (the pre-pass for `search_compilations_for_track` — see WXYC/library-metadata-lookup#318). Builds three labeled datasets — positives from `artist_name_variation` and `entity.identity`, negatives from sampled close-but-distinct `artist` pairs — and writes a precision/recall sweep + a borderline-band CSV.
+
+**Output** (defaults to `docs/resolver-calibration/`):
+- `calibration_sweep.csv` — threshold, TP rate, FP rate, sample sizes, swap count.
+- `borderline.csv` — pairs whose score sits in `[chosen_floor − 0.05, chosen_floor + 0.05]`, sorted by score, for eyeball QA of the decision boundary.
+
+After running, update `CANONICAL_ARTIST_SIMILARITY_FLOOR` in `lookup/orchestrator.py` if the chosen floor differs from the in-tree value, and commit the CSVs alongside a one-page `docs/resolver-calibration/README.md` documenting the FP-rate tolerance that drove the choice. The same script is used to re-validate after large discogs-cache refreshes; commit fresh CSVs each run so the calibration history stays in version control.
+
+**Usage:**
+```bash
+DATABASE_URL_DISCOGS=postgresql://... \
+  uv run python -m scripts.resolver_calibration \
+    --output-dir docs/resolver-calibration/ \
+    --positive-sample-size 5000 \
+    --negative-sample-size 5000 \
+    --fp-rate-target 0.005
+```
 
 ### Artist Name Variation Audit (`scripts/variation_audit/`)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -131,6 +131,19 @@ class Settings(BaseSettings):
             "flip to True after all callers send the bearer header."
         ),
     )
+    lml_resolve_artist_canonical: bool = Field(
+        default=False,
+        description=(
+            "When True, swap inbound artist names for the canonical Discogs form "
+            "when trigram similarity >= CANONICAL_ARTIST_SIMILARITY_FLOOR before "
+            "search_releases_by_track probes. When False, the resolver still runs "
+            "in shadow mode (logs candidate + score on every lookup; emits "
+            "set_data('resolver_pre_pass', ...) on the active Sentry transaction) "
+            "but does not swap. Set True in Railway after the calibration sweep "
+            "confirms the chosen floor's FP-rate is <= 0.5%. "
+            "See WXYC/library-metadata-lookup#318."
+        ),
+    )
 
     # Streaming Webhook Configuration
     streaming_webhook_urls: str | None = Field(

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -8,11 +8,13 @@ track validation -> artwork fetch -> metadata enrichment -> context message.
 import asyncio
 import logging
 import re
+from dataclasses import dataclass
 from functools import partial
 from typing import Any
 from urllib.parse import quote
 
 import httpx
+import sentry_sdk
 from wxyc_etl.text import is_compilation_artist
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 from wxyc_fastapi.observability import RequestTelemetry
@@ -24,6 +26,7 @@ from core.search import (
 )
 from discogs.cache_service import DiscogsCacheService
 from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
+from discogs.memory_cache import create_ttl_cache, should_skip_cache
 from discogs.models import DiscogsSearchRequest, DiscogsSearchResult, ReleaseInfo
 from discogs.service import DiscogsService
 from generated.api_models import LibraryCatalogItem, ReconciledIdentity
@@ -46,6 +49,142 @@ MAX_SEARCH_RESULTS = 5
 
 SELF_TITLED_PATTERNS = frozenset({"s/t", "s.t.", "self-titled", "self titled"})
 """Common abbreviations for self-titled albums (case-insensitive exact match)."""
+
+CANONICAL_ARTIST_SIMILARITY_FLOOR: float = 0.70
+"""Trigram-similarity floor for swapping an inbound artist name with its canonical
+Discogs form.
+
+Provisional. Replaced by the offline calibration sweep produced by
+``scripts.resolver_calibration`` against the WXYC discogs-cache; see
+``docs/resolver-calibration/README.md`` for the chosen value and its FP-rate
+tolerance (target ≤ 0.5%). See WXYC/library-metadata-lookup#318.
+"""
+
+_resolver_cache = create_ttl_cache(maxsize=512, ttl=300)
+"""TTL cache for ``resolve_canonical_artist``. Keyed on the diacritic-stripped,
+lowercased input so equivalent strings within a burst share one PG round-trip.
+Registered with the global cache registry so ``clear_all_caches()`` resets it.
+"""
+
+
+@dataclass(frozen=True)
+class ResolverOutcome:
+    """Result of the canonical-artist resolver pre-pass.
+
+    Attributes:
+        original: The input artist string as received from the caller.
+        canonical: The canonical Discogs artist name when ``swapped`` is True;
+            otherwise identical to ``original``.
+        score: Trigram similarity score of the top cache candidate (0.0-1.0).
+            ``0.0`` when no candidate was found.
+        swapped: Whether ``canonical`` differs from ``original`` and met the
+            similarity floor. Callers use this to decide whether to forward
+            ``canonical`` into downstream Discogs probes.
+    """
+
+    original: str
+    canonical: str
+    score: float
+    swapped: bool
+
+
+async def resolve_canonical_artist(
+    artist: str,
+    *,
+    cache_service: DiscogsCacheService | None,
+) -> ResolverOutcome:
+    """Resolve ``artist`` to the canonical Discogs name when confidence allows.
+
+    Runs a trigram fuzzy search against ``artist`` + ``artist_name_variation``
+    in the discogs-cache PG database. When the top score meets
+    ``CANONICAL_ARTIST_SIMILARITY_FLOOR``, returns a ``ResolverOutcome`` with
+    ``swapped=True`` and the canonical name; otherwise returns the original
+    input with ``swapped=False``. Results are memoized in-process keyed on the
+    diacritic-stripped lowercased input.
+
+    Failure modes (no cache, empty input, PG error) all degrade to
+    ``swapped=False`` so the resolver never breaks /lookup.
+
+    See WXYC/library-metadata-lookup#318.
+    """
+    original = artist or ""
+
+    if not original.strip():
+        return ResolverOutcome(original=original, canonical=original, score=0.0, swapped=False)
+
+    if cache_service is None:
+        return ResolverOutcome(original=original, canonical=original, score=0.0, swapped=False)
+
+    cache_key = normalize_for_comparison(original)
+
+    if not should_skip_cache():
+        cached = _resolver_cache.get(cache_key)
+        if cached is not None:
+            return ResolverOutcome(
+                original=original,
+                canonical=cached.canonical,
+                score=cached.score,
+                swapped=cached.swapped,
+            )
+
+    try:
+        candidates = await cache_service.search_artists_by_name(original, limit=5)
+    except Exception as e:
+        logger.warning("resolver_pre_pass cache lookup failed for %r: %s", original, e)
+        return ResolverOutcome(original=original, canonical=original, score=0.0, swapped=False)
+
+    if not candidates:
+        outcome = ResolverOutcome(original=original, canonical=original, score=0.0, swapped=False)
+        _resolver_cache[cache_key] = outcome
+        return outcome
+
+    top = candidates[0]
+    score = float(top.get("score", 0.0))
+    candidate_name = top.get("name") or original
+    swapped = score >= CANONICAL_ARTIST_SIMILARITY_FLOOR
+
+    outcome = ResolverOutcome(
+        original=original,
+        canonical=candidate_name if swapped else original,
+        score=score,
+        swapped=swapped,
+    )
+    _resolver_cache[cache_key] = outcome
+    return outcome
+
+
+def _log_resolver_pre_pass(outcome: ResolverOutcome) -> None:
+    """Emit shadow-mode telemetry for the resolver pre-pass.
+
+    Runs unconditionally — regardless of the enforcement flag — so the
+    queryable shadow dataset accumulates in production from day one and the
+    floor can be re-calibrated against real traffic without a code change.
+
+    Two surfaces:
+
+    1. Structured INFO log line for log-pipeline tools.
+    2. ``set_data("resolver_pre_pass", ...)`` on the active Sentry
+       transaction, mirroring ``lookup/router._project_cache_stats_to_transaction``.
+       No-op when there is no active transaction. Any Sentry SDK error is
+       swallowed so observability cannot break /lookup.
+    """
+    if not outcome.original.strip():
+        return
+    would_swap = outcome.swapped or outcome.score >= CANONICAL_ARTIST_SIMILARITY_FLOOR
+    payload = {
+        "original": outcome.original,
+        "candidate": outcome.canonical,
+        "score": outcome.score,
+        "swapped": outcome.swapped,
+        "would_swap": would_swap,
+    }
+    logger.info("resolver_pre_pass %s", payload)
+    try:
+        transaction = sentry_sdk.get_current_scope().transaction
+        if transaction is not None:
+            transaction.set_data("resolver_pre_pass", payload)
+    except Exception as e:
+        logger.warning("Failed to project resolver_pre_pass onto Sentry transaction: %s", e)
 
 
 def is_self_titled(title: str) -> bool:
@@ -455,6 +594,25 @@ async def search_compilations_for_track(
             song_search = f"{parsed.song} ({remix_match.group(1)})"
             logger.info(f"Using full track name with version info: '{song_search}'")
 
+        # Resolver pre-pass: when the inbound artist string trigram-matches a
+        # canonical Discogs name with confidence >= the floor, use the canonical
+        # form for both Discogs probes. The pre-pass runs unconditionally for
+        # shadow logging; the actual swap is gated on
+        # ``settings.lml_resolve_artist_canonical`` for a controlled rollout.
+        # See WXYC/library-metadata-lookup#318.
+        cache_service = getattr(discogs_service, "cache_service", None)
+        outcome = await resolve_canonical_artist(parsed.artist, cache_service=cache_service)
+        _log_resolver_pre_pass(outcome)
+        try:
+            from config.settings import get_settings
+
+            enforce_swap = bool(get_settings().lml_resolve_artist_canonical)
+        except Exception:
+            enforce_swap = False
+        artist_for_probes = (
+            outcome.canonical if (outcome.swapped and enforce_swap) else parsed.artist
+        )
+
         # Get raw releases from Discogs without per-release validation.
         # We search the library first and only validate releases that match,
         # avoiding expensive API calls for releases not in our catalog.
@@ -462,9 +620,9 @@ async def search_compilations_for_track(
         if discogs_service:
             # Fire both searches in parallel (speculative: VA search may not be needed)
             response, va_response = await asyncio.gather(
-                discogs_service.search_releases_by_track(song_search, parsed.artist),
+                discogs_service.search_releases_by_track(song_search, artist_for_probes),
                 discogs_service.search_releases_by_track(
-                    song_search, parsed.artist, artist_as_keyword=True
+                    song_search, artist_for_probes, artist_as_keyword=True
                 ),
             )
             raw_releases = list(response.releases or [])

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -17,8 +17,9 @@ import httpx
 import sentry_sdk
 from wxyc_etl.text import is_compilation_artist
 from wxyc_etl.text import to_match_form as normalize_for_comparison
-from wxyc_fastapi.observability import RequestTelemetry
+from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats_recorder
 
+from config.settings import get_settings
 from core.search import (
     build_strategies,
     execute_search_pipeline,
@@ -120,12 +121,14 @@ async def resolve_canonical_artist(
     if not should_skip_cache():
         cached = _resolver_cache.get(cache_key)
         if cached is not None:
+            get_cache_stats_recorder().record_memory_cache_hit()
             return ResolverOutcome(
                 original=original,
                 canonical=cached.canonical,
                 score=cached.score,
                 swapped=cached.swapped,
             )
+        get_cache_stats_recorder().record_memory_cache_miss()
 
     try:
         candidates = await cache_service.search_artists_by_name(original, limit=5)
@@ -153,12 +156,19 @@ async def resolve_canonical_artist(
     return outcome
 
 
-def _log_resolver_pre_pass(outcome: ResolverOutcome) -> None:
+def _log_resolver_pre_pass(outcome: ResolverOutcome, *, actual_swap: bool) -> None:
     """Emit shadow-mode telemetry for the resolver pre-pass.
 
     Runs unconditionally — regardless of the enforcement flag — so the
     queryable shadow dataset accumulates in production from day one and the
     floor can be re-calibrated against real traffic without a code change.
+
+    ``actual_swap`` is what the orchestrator actually did this request
+    (``outcome.swapped AND lml_resolve_artist_canonical``). ``would_swap`` is
+    the resolver's recommendation independent of the flag — what the swap
+    decision *would* be if the flag were enabled. Filtering Sentry traces on
+    ``data.resolver_pre_pass.would_swap=true`` while the flag is off is the
+    shadow dataset; ``swapped`` is non-zero only after the flag flips.
 
     Two surfaces:
 
@@ -170,13 +180,12 @@ def _log_resolver_pre_pass(outcome: ResolverOutcome) -> None:
     """
     if not outcome.original.strip():
         return
-    would_swap = outcome.swapped or outcome.score >= CANONICAL_ARTIST_SIMILARITY_FLOOR
     payload = {
         "original": outcome.original,
         "candidate": outcome.canonical,
         "score": outcome.score,
-        "swapped": outcome.swapped,
-        "would_swap": would_swap,
+        "swapped": actual_swap,
+        "would_swap": outcome.swapped,
     }
     logger.info("resolver_pre_pass %s", payload)
     try:
@@ -602,16 +611,10 @@ async def search_compilations_for_track(
         # See WXYC/library-metadata-lookup#318.
         cache_service = getattr(discogs_service, "cache_service", None)
         outcome = await resolve_canonical_artist(parsed.artist, cache_service=cache_service)
-        _log_resolver_pre_pass(outcome)
-        try:
-            from config.settings import get_settings
-
-            enforce_swap = bool(get_settings().lml_resolve_artist_canonical)
-        except Exception:
-            enforce_swap = False
-        artist_for_probes = (
-            outcome.canonical if (outcome.swapped and enforce_swap) else parsed.artist
-        )
+        enforce_swap = bool(get_settings().lml_resolve_artist_canonical)
+        actual_swap = outcome.swapped and enforce_swap
+        _log_resolver_pre_pass(outcome, actual_swap=actual_swap)
+        artist_for_probes = outcome.canonical if actual_swap else parsed.artist
 
         # Get raw releases from Discogs without per-release validation.
         # We search the library first and only validate releases that match,

--- a/scripts/resolver_calibration/__main__.py
+++ b/scripts/resolver_calibration/__main__.py
@@ -133,6 +133,12 @@ async def fetch_negative_class_close_pairs(pool: asyncpg.Pool, limit: int) -> li
     is the trigram similarity between the two distinct artists' names — the
     false-positive curve at a given threshold is the share of these whose
     score exceeds the threshold.
+
+    The trigram filter is selective in practice, but the LATERAL fan-out can
+    explode on cache sizes >1M artists. Cap the per-seed neighbor count at 10
+    so the worst case stays bounded at ``limit * 10`` rows regardless of cache
+    growth — the FP curve shape is dominated by the highest-scoring neighbors
+    anyway, so the cap doesn't bias the threshold sweep.
     """
     query = """
         WITH sample AS (
@@ -144,22 +150,28 @@ async def fetch_negative_class_close_pairs(pool: asyncpg.Pool, limit: int) -> li
         SELECT
             s.id AS id_a,
             s.name AS name_a,
-            a.id AS id_b,
-            a.name AS name_b,
-            similarity(lower(f_unaccent(s.name)), lower(f_unaccent(a.name))) AS score
+            top.id AS id_b,
+            top.name AS name_b,
+            top.score
         FROM sample s
-        JOIN artist a
-          ON a.id != s.id
-         AND lower(f_unaccent(a.name)) % lower(f_unaccent(s.name))
-         AND similarity(lower(f_unaccent(s.name)), lower(f_unaccent(a.name))) >= 0.4
+        JOIN LATERAL (
+            SELECT a.id, a.name,
+                   similarity(lower(f_unaccent(a.name)), lower(f_unaccent(s.name))) AS score
+            FROM artist a
+            WHERE a.id != s.id
+              AND lower(f_unaccent(a.name)) % lower(f_unaccent(s.name))
+              AND similarity(lower(f_unaccent(s.name)), lower(f_unaccent(a.name))) >= 0.4
+            ORDER BY score DESC
+            LIMIT 10
+        ) top ON true
     """
     rows = await pool.fetch(query, limit)
     return [
         CandidateScore(
             query_name=r["name_a"],
-            top_name=r["name_b"],
+            top_name=r["name_b"] or r["name_a"],
             top_id=r["id_b"],
-            score=float(r["score"]),
+            score=float(r["score"] or 0.0),
             is_positive=False,
         )
         for r in rows

--- a/scripts/resolver_calibration/__main__.py
+++ b/scripts/resolver_calibration/__main__.py
@@ -1,0 +1,436 @@
+"""Calibration harness for the canonical-artist resolver pre-pass.
+
+See WXYC/library-metadata-lookup#318.
+
+Sweeps the trigram-similarity floor used by ``resolve_canonical_artist`` to
+decide whether to swap an inbound artist name for its Discogs-canonical form.
+The chosen floor is then committed to ``CANONICAL_ARTIST_SIMILARITY_FLOOR``
+in ``lookup/orchestrator.py``.
+
+Output files in ``--output-dir``:
+
+* ``calibration_sweep.csv`` — for every candidate threshold in ``[0.30, 0.95]``
+  step 0.05, the true-positive rate, false-positive rate, and the number of
+  swaps the resolver would emit at that threshold.
+* ``borderline.csv`` — every positive / negative pair whose score falls inside
+  ``[chosen_floor - 0.05, chosen_floor + 0.05]``, for eyeball QA of the
+  decision boundary.
+
+The harness pulls ground truth from three sources:
+
+1. **Discogs ``artist_name_variation``** — each row is a (variation,
+   canonical_artist_id) pair. Positive class: the resolver should return
+   ``canonical_artist_id`` as its top hit.
+2. **``entity.identity``** — resolved rows for WXYC-specific name shapes that
+   don't make it back to Discogs's variation table.
+3. **Sampled close-but-distinct artists** — pairs from the ``artist`` table
+   where ``name_a`` and ``name_b`` share a trigram-similarity ≥ 0.4 but have
+   different ids. These are the cases where the resolver might wrongly swap.
+   The score distribution here defines the false-positive curve.
+
+Usage::
+
+    DATABASE_URL_DISCOGS=postgresql://... \
+        uv run python -m scripts.resolver_calibration \
+            --output-dir docs/resolver-calibration/ \
+            --negative-sample-size 5000 \
+            --positive-sample-size 5000
+
+By default the chosen floor is reported as the smallest threshold whose
+empirical false-positive rate is ≤ the ``--fp-rate-target`` (default 0.005);
+override with ``--fixed-floor`` to skip the optimization and just emit the
+borderline file for that floor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import asyncpg
+
+from lookup.orchestrator import CANONICAL_ARTIST_SIMILARITY_FLOOR
+
+logger = logging.getLogger("resolver_calibration")
+
+THRESHOLDS = [round(0.30 + 0.05 * i, 2) for i in range(14)]  # 0.30 .. 0.95
+
+
+@dataclass
+class CandidateScore:
+    """A single calibration sample: query name, top-result name, score, label."""
+
+    query_name: str
+    top_name: str
+    top_id: int | None
+    score: float
+    is_positive: bool
+
+
+async def fetch_positive_class_variations(pool: asyncpg.Pool, limit: int) -> list[CandidateScore]:
+    """Pull (variation_name, canonical_artist_id) pairs and run them through
+    the same fuzzy trigram match the resolver uses.
+
+    A pair is a true positive when the top match's ``artist.id`` equals the
+    pair's canonical id. We record the actual score either way so the
+    threshold sweep sees the full distribution.
+    """
+    query = """
+        WITH sample AS (
+            SELECT anv.name AS variation, a.id AS canonical_id, a.name AS canonical_name
+            FROM artist_name_variation anv
+            JOIN artist a ON a.id = anv.artist_id
+            WHERE anv.name IS NOT NULL AND length(anv.name) >= 3
+            ORDER BY random()
+            LIMIT $1
+        )
+        SELECT
+            s.variation,
+            s.canonical_id,
+            s.canonical_name,
+            top.id AS top_id,
+            top.name AS top_name,
+            top.score AS top_score
+        FROM sample s
+        LEFT JOIN LATERAL (
+            SELECT a2.id, a2.name,
+                   similarity(lower(f_unaccent(a2.name)), lower(f_unaccent(s.variation))) AS score
+            FROM artist a2
+            WHERE lower(f_unaccent(a2.name)) % lower(f_unaccent(s.variation))
+            ORDER BY score DESC
+            LIMIT 1
+        ) top ON true
+    """
+    rows = await pool.fetch(query, limit)
+    out: list[CandidateScore] = []
+    for r in rows:
+        top_id = r["top_id"]
+        top_name = r["top_name"] or r["variation"]
+        score = float(r["top_score"] or 0.0)
+        is_positive = top_id == r["canonical_id"]
+        out.append(
+            CandidateScore(
+                query_name=r["variation"],
+                top_name=top_name,
+                top_id=top_id,
+                score=score,
+                is_positive=is_positive,
+            )
+        )
+    return out
+
+
+async def fetch_negative_class_close_pairs(pool: asyncpg.Pool, limit: int) -> list[CandidateScore]:
+    """Sample close-but-distinct ``artist`` pairs.
+
+    These are the pairs the resolver might mistakenly swap. The score column
+    is the trigram similarity between the two distinct artists' names — the
+    false-positive curve at a given threshold is the share of these whose
+    score exceeds the threshold.
+    """
+    query = """
+        WITH sample AS (
+            SELECT id, name FROM artist
+            WHERE name IS NOT NULL AND length(name) >= 3
+            ORDER BY random()
+            LIMIT $1
+        )
+        SELECT
+            s.id AS id_a,
+            s.name AS name_a,
+            a.id AS id_b,
+            a.name AS name_b,
+            similarity(lower(f_unaccent(s.name)), lower(f_unaccent(a.name))) AS score
+        FROM sample s
+        JOIN artist a
+          ON a.id != s.id
+         AND lower(f_unaccent(a.name)) % lower(f_unaccent(s.name))
+         AND similarity(lower(f_unaccent(s.name)), lower(f_unaccent(a.name))) >= 0.4
+    """
+    rows = await pool.fetch(query, limit)
+    return [
+        CandidateScore(
+            query_name=r["name_a"],
+            top_name=r["name_b"],
+            top_id=r["id_b"],
+            score=float(r["score"]),
+            is_positive=False,
+        )
+        for r in rows
+    ]
+
+
+async def fetch_entity_identity_positives(pool: asyncpg.Pool, limit: int) -> list[CandidateScore]:
+    """Second positive class: resolved rows from ``entity.identity`` whose
+    ``library_name`` differs from the canonical Discogs ``artist.name``.
+
+    Only rows with a known ``discogs_artist_id`` are usable as ground truth.
+    Silently empty when the entity schema isn't present.
+    """
+    try:
+        await pool.fetchval("SELECT 1 FROM entity.identity LIMIT 1")
+    except Exception as e:
+        logger.info("Skipping entity.identity positives — schema not present (%s)", e)
+        return []
+
+    query = """
+        SELECT
+            ei.library_name,
+            ei.discogs_artist_id,
+            a.name AS canonical_name,
+            top.id AS top_id,
+            top.name AS top_name,
+            top.score AS top_score
+        FROM entity.identity ei
+        JOIN artist a ON a.id = ei.discogs_artist_id
+        LEFT JOIN LATERAL (
+            SELECT a2.id, a2.name,
+                   similarity(lower(f_unaccent(a2.name)), lower(f_unaccent(ei.library_name))) AS score
+            FROM artist a2
+            WHERE lower(f_unaccent(a2.name)) % lower(f_unaccent(ei.library_name))
+            ORDER BY score DESC
+            LIMIT 1
+        ) top ON true
+        WHERE ei.discogs_artist_id IS NOT NULL
+          AND lower(ei.library_name) != lower(a.name)
+        ORDER BY random()
+        LIMIT $1
+    """
+    rows = await pool.fetch(query, limit)
+    return [
+        CandidateScore(
+            query_name=r["library_name"],
+            top_name=r["top_name"] or r["library_name"],
+            top_id=r["top_id"],
+            score=float(r["top_score"] or 0.0),
+            is_positive=r["top_id"] == r["discogs_artist_id"],
+        )
+        for r in rows
+    ]
+
+
+def sweep_thresholds(
+    positives: list[CandidateScore], negatives: list[CandidateScore]
+) -> list[dict]:
+    """For each threshold in ``THRESHOLDS``, compute the empirical TP/FP rates.
+
+    TPR = share of positive samples whose score >= threshold AND whose top id
+    is the canonical id.
+    FPR = share of negative samples whose score >= threshold.
+    """
+    rows = []
+    n_pos = len(positives)
+    n_neg = len(negatives)
+    for t in THRESHOLDS:
+        tp = sum(1 for p in positives if p.is_positive and p.score >= t)
+        fp = sum(1 for n in negatives if n.score >= t)
+        rows.append(
+            {
+                "threshold": t,
+                "true_positive_rate": tp / n_pos if n_pos else 0.0,
+                "false_positive_rate": fp / n_neg if n_neg else 0.0,
+                "n_positives": n_pos,
+                "n_negatives": n_neg,
+                "n_swaps_at_threshold": tp + fp,
+            }
+        )
+    return rows
+
+
+def pick_floor(sweep_rows: list[dict], fp_rate_target: float) -> float:
+    """Smallest threshold whose empirical FP rate is ≤ the target.
+
+    Falls back to the highest threshold (most conservative) when no row meets
+    the target.
+    """
+    qualifying = [r for r in sweep_rows if r["false_positive_rate"] <= fp_rate_target]
+    if not qualifying:
+        return max(r["threshold"] for r in sweep_rows)
+    return min(r["threshold"] for r in qualifying)
+
+
+def write_csv(rows: list[dict], path: Path, fieldnames: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def borderline_rows(
+    positives: list[CandidateScore],
+    negatives: list[CandidateScore],
+    floor: float,
+    band: float = 0.05,
+) -> list[dict]:
+    """Pairs whose score sits inside ``[floor - band, floor + band]``.
+
+    Listed for human QA; the calibration sweep alone isn't enough when the
+    boundary cases are domain-specific (e.g. ambiguous trios).
+    """
+    lo, hi = floor - band, floor + band
+    out = []
+    for sample, klass in [(positives, "positive"), (negatives, "negative")]:
+        for c in sample:
+            if lo <= c.score <= hi:
+                out.append(
+                    {
+                        "class": klass,
+                        "score": round(c.score, 4),
+                        "query_name": c.query_name,
+                        "top_name": c.top_name,
+                        "top_id": c.top_id,
+                        "is_positive_match": c.is_positive,
+                    }
+                )
+    out.sort(key=lambda r: float(r["score"]))  # type: ignore[arg-type]
+    return out
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    dsn = os.environ.get("DATABASE_URL_DISCOGS")
+    if not dsn:
+        logger.error("DATABASE_URL_DISCOGS must be set")
+        return 1
+
+    pool = await asyncpg.create_pool(dsn, min_size=1, max_size=4)
+    try:
+        logger.info(
+            "Pulling positive class from artist_name_variation (limit=%d)",
+            args.positive_sample_size,
+        )
+        positives_variation = await fetch_positive_class_variations(pool, args.positive_sample_size)
+        logger.info("Pulling positive class from entity.identity (limit=%d)", args.identity_limit)
+        positives_identity = await fetch_entity_identity_positives(pool, args.identity_limit)
+        positives = positives_variation + positives_identity
+        logger.info(
+            "Pulling negative class from close-but-distinct artist pairs (limit=%d)",
+            args.negative_sample_size,
+        )
+        negatives = await fetch_negative_class_close_pairs(pool, args.negative_sample_size)
+    finally:
+        await pool.close()
+
+    logger.info(
+        "Sweeping %d thresholds over %d positives + %d negatives",
+        len(THRESHOLDS),
+        len(positives),
+        len(negatives),
+    )
+    sweep = sweep_thresholds(positives, negatives)
+
+    output_dir = Path(args.output_dir)
+    write_csv(
+        sweep,
+        output_dir / "calibration_sweep.csv",
+        fieldnames=[
+            "threshold",
+            "true_positive_rate",
+            "false_positive_rate",
+            "n_positives",
+            "n_negatives",
+            "n_swaps_at_threshold",
+        ],
+    )
+
+    if args.fixed_floor is not None:
+        chosen_floor = args.fixed_floor
+        logger.info("Using fixed floor %.2f (skipping FP-rate optimization)", chosen_floor)
+    else:
+        chosen_floor = pick_floor(sweep, args.fp_rate_target)
+        logger.info(
+            "Chosen floor %.2f (smallest threshold with FP rate <= %.4f)",
+            chosen_floor,
+            args.fp_rate_target,
+        )
+
+    write_csv(
+        borderline_rows(positives, negatives, chosen_floor, band=args.borderline_band),
+        output_dir / "borderline.csv",
+        fieldnames=[
+            "class",
+            "score",
+            "query_name",
+            "top_name",
+            "top_id",
+            "is_positive_match",
+        ],
+    )
+
+    logger.info("Wrote %s", output_dir / "calibration_sweep.csv")
+    logger.info("Wrote %s", output_dir / "borderline.csv")
+    logger.info(
+        "Current code-level CANONICAL_ARTIST_SIMILARITY_FLOOR = %.2f",
+        CANONICAL_ARTIST_SIMILARITY_FLOOR,
+    )
+    logger.info("Chosen empirical floor = %.2f", chosen_floor)
+    if abs(chosen_floor - CANONICAL_ARTIST_SIMILARITY_FLOOR) > 0.01:
+        logger.warning(
+            "Empirical floor differs from code-level constant — update "
+            "CANONICAL_ARTIST_SIMILARITY_FLOOR in lookup/orchestrator.py"
+        )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        default="docs/resolver-calibration",
+        help="Directory for CSV outputs (default: docs/resolver-calibration)",
+    )
+    parser.add_argument(
+        "--positive-sample-size",
+        type=int,
+        default=5000,
+        help="Random rows pulled from artist_name_variation (default: 5000)",
+    )
+    parser.add_argument(
+        "--negative-sample-size",
+        type=int,
+        default=5000,
+        help="Seed rows for the close-but-distinct-pair sampler (default: 5000)",
+    )
+    parser.add_argument(
+        "--identity-limit",
+        type=int,
+        default=1000,
+        help="Random rows pulled from entity.identity (default: 1000)",
+    )
+    parser.add_argument(
+        "--fp-rate-target",
+        type=float,
+        default=0.005,
+        help="False-positive rate ceiling for the chosen floor (default: 0.005)",
+    )
+    parser.add_argument(
+        "--fixed-floor",
+        type=float,
+        default=None,
+        help="Skip FP-rate optimization and dump borderline.csv for this floor",
+    )
+    parser.add_argument(
+        "--borderline-band",
+        type=float,
+        default=0.05,
+        help="Half-width of the borderline band around the chosen floor (default: 0.05)",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+    )
+
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_resolver_pre_pass.py
+++ b/tests/integration/test_resolver_pre_pass.py
@@ -1,0 +1,68 @@
+"""Integration tests for the canonical-artist resolver pre-pass.
+
+See WXYC/library-metadata-lookup#318. Exercises ``resolve_canonical_artist``
+end-to-end against the real discogs-cache PostgreSQL DB.
+
+Run with::
+
+    DATABASE_URL_DISCOGS=postgresql://... pytest -m pg tests/integration/test_resolver_pre_pass.py -v
+
+Self-skips when ``DATABASE_URL_DISCOGS`` is unset.
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from discogs.cache_service import DiscogsCacheService
+from lookup.orchestrator import CANONICAL_ARTIST_SIMILARITY_FLOOR, resolve_canonical_artist
+
+DATABASE_URL = os.environ.get("DATABASE_URL_DISCOGS")
+pytestmark = [
+    pytest.mark.pg,
+    pytest.mark.skipif(not DATABASE_URL, reason="DATABASE_URL_DISCOGS not set"),
+]
+
+
+@pytest_asyncio.fixture
+async def cache_service():
+    pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=2)
+    service = DiscogsCacheService(pool=pool)
+    try:
+        yield service
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+class TestResolveCanonicalArtistAgainstDiscogsCache:
+    async def test_robotnik_resolves_to_robotnick(self, cache_service):
+        """The motivating typo from #237 second repro: trigram(Robotnik,
+        Robotnick) ≈ 0.85, well above the configured floor. The resolver
+        should swap to the canonical Discogs spelling."""
+        outcome = await resolve_canonical_artist("Alexander Robotnik", cache_service=cache_service)
+
+        assert outcome.swapped is True
+        assert outcome.canonical == "Alexander Robotnick"
+        assert outcome.score >= CANONICAL_ARTIST_SIMILARITY_FLOOR
+
+    async def test_already_canonical_input_returns_high_score_match(self, cache_service):
+        """When the input is already the canonical Discogs name, the resolver
+        returns a high score (~1.0) and a swap that's a no-op."""
+        outcome = await resolve_canonical_artist("Stereolab", cache_service=cache_service)
+
+        assert outcome.canonical == "Stereolab"
+        assert outcome.score >= 0.95
+        assert outcome.swapped is True
+
+    async def test_completely_unknown_name_returns_no_swap(self, cache_service):
+        """A nonsense string with no plausible trigram neighbors should not swap."""
+        outcome = await resolve_canonical_artist(
+            "Zzzqqxxnonexistent99 Bandnamehere", cache_service=cache_service
+        )
+
+        assert outcome.swapped is False

--- a/tests/unit/test_resolver_pre_pass.py
+++ b/tests/unit/test_resolver_pre_pass.py
@@ -81,9 +81,11 @@ class TestResolveCanonicalArtist:
         assert outcome.swapped is False
 
     @pytest.mark.asyncio
-    async def test_short_circuits_on_exact_match(self, cache):
-        """High score with identical-modulo-case input → ``swapped`` is True but the
-        canonical equals the input (no behavior change downstream)."""
+    async def test_high_score_exact_match_yields_swap_to_canonical_form(self, cache):
+        """When the cache's top hit equals the input modulo case/diacritics but
+        scores at/above the floor, the outcome records the canonical-cased form
+        and ``swapped=True``. Downstream code paths use ``canonical`` directly,
+        so case fixups (e.g. ``stereolab`` → ``Stereolab``) flow through."""
         cache.search_artists_by_name.return_value = [
             {"id": 1, "name": "Stereolab", "score": 0.99},
         ]
@@ -212,6 +214,58 @@ class TestResolverPrePassCallSite:
             if artist_arg is None and len(call.args) >= 2:
                 artist_arg = call.args[1]
             assert artist_arg == "Alexander Robotnick"
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_does_not_swap_even_when_resolver_recommends(self):
+        """Flag default is False (shadow mode). Even with a high-confidence
+        canonical, the original artist must reach both probes — the resolver's
+        recommendation only feeds telemetry until the flag flips."""
+        from config.settings import get_settings
+
+        get_settings.cache_clear()  # ensure no stale env from another test
+        try:
+            db = AsyncMock()
+            db.search = AsyncMock(return_value=[])
+
+            service = AsyncMock()
+            cache_service = AsyncMock()
+            cache_service.search_artists_by_name = AsyncMock(
+                return_value=[
+                    {
+                        "id": 1,
+                        "name": "Alexander Robotnick",
+                        "score": CANONICAL_ARTIST_SIMILARITY_FLOOR + 0.10,
+                    }
+                ]
+            )
+            service.cache_service = cache_service
+            service.search_releases_by_track = AsyncMock(
+                return_value=TrackReleasesResponse(
+                    track="Problemes damour", artist=None, releases=[], total=0
+                )
+            )
+
+            parsed = ParsedRequest(
+                artist="Alexander Robotnik",
+                song="Problemes damour",
+                raw_message="Alexander Robotnik - Problemes damour",
+            )
+
+            with patch(
+                "lookup.orchestrator.lookup_releases_by_track",
+                new_callable=AsyncMock,
+                return_value=[],
+            ):
+                await search_compilations_for_track(db, parsed, discogs_service=service)
+
+            assert service.search_releases_by_track.await_count == 2
+            for call in service.search_releases_by_track.await_args_list:
+                artist_arg = call.kwargs.get("artist")
+                if artist_arg is None and len(call.args) >= 2:
+                    artist_arg = call.args[1]
+                assert artist_arg == "Alexander Robotnik"
+        finally:
+            get_settings.cache_clear()
 
     @pytest.mark.asyncio
     async def test_original_name_flows_when_score_below_floor(self):

--- a/tests/unit/test_resolver_pre_pass.py
+++ b/tests/unit/test_resolver_pre_pass.py
@@ -1,0 +1,257 @@
+"""Unit tests for the canonical-artist resolver pre-pass.
+
+Sibling of #237. See WXYC/library-metadata-lookup#318.
+
+The resolver pre-pass runs before ``search_compilations_for_track`` issues
+its two parallel Discogs probes, looking up the inbound artist string in
+the discogs-cache ``artist`` + ``artist_name_variation`` tables via
+``cache_service.search_artists_by_name``. When the top trigram match
+scores at or above ``CANONICAL_ARTIST_SIMILARITY_FLOOR``, the canonical
+``artist.name`` is swapped in; otherwise the original input flows through.
+
+Behavior under test:
+
+- ``resolve_canonical_artist`` returns a ``ResolverOutcome`` with the
+  original input, the (possibly swapped) canonical name, the top score,
+  and a ``swapped`` flag.
+- The pre-pass is a no-op when the cache is unavailable, the artist
+  string is empty/whitespace, or the cache returns no candidates.
+- Floor decisions are expressed relative to the
+  ``CANONICAL_ARTIST_SIMILARITY_FLOOR`` constant; boundary cases at
+  ``floor + 0.10`` (swap), ``floor - 0.10`` (no swap), and ``0.99``
+  (short-circuit) are exercised.
+- Identical input (canonical name equals input modulo case + diacritics)
+  short-circuits without burning a swap log entry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from discogs.models import TrackReleasesResponse
+from lookup.orchestrator import (
+    CANONICAL_ARTIST_SIMILARITY_FLOOR,
+    ResolverOutcome,
+    resolve_canonical_artist,
+    search_compilations_for_track,
+)
+from services.parser import ParsedRequest
+
+
+@pytest.fixture
+def cache():
+    """AsyncMock standing in for DiscogsCacheService."""
+    c = AsyncMock()
+    c.search_artists_by_name = AsyncMock(return_value=[])
+    return c
+
+
+class TestResolveCanonicalArtist:
+    @pytest.mark.asyncio
+    async def test_returns_canonical_when_score_above_floor(self, cache):
+        """Score above floor → ``swapped=True`` and canonical name returned."""
+        score = CANONICAL_ARTIST_SIMILARITY_FLOOR + 0.10
+        cache.search_artists_by_name.return_value = [
+            {"id": 1, "name": "Alexander Robotnick", "score": score},
+        ]
+
+        outcome = await resolve_canonical_artist("Alexander Robotnik", cache_service=cache)
+
+        assert isinstance(outcome, ResolverOutcome)
+        assert outcome.original == "Alexander Robotnik"
+        assert outcome.canonical == "Alexander Robotnick"
+        assert outcome.score == score
+        assert outcome.swapped is True
+
+    @pytest.mark.asyncio
+    async def test_returns_original_when_score_below_floor(self, cache):
+        """Score below floor → ``swapped=False`` and original returned."""
+        score = CANONICAL_ARTIST_SIMILARITY_FLOOR - 0.10
+        cache.search_artists_by_name.return_value = [
+            {"id": 1, "name": "Aleksandr Robotnyk", "score": score},
+        ]
+
+        outcome = await resolve_canonical_artist("Alexander Robotnik", cache_service=cache)
+
+        assert outcome.original == "Alexander Robotnik"
+        assert outcome.canonical == "Alexander Robotnik"  # unchanged
+        assert outcome.score == score
+        assert outcome.swapped is False
+
+    @pytest.mark.asyncio
+    async def test_short_circuits_on_exact_match(self, cache):
+        """High score with identical-modulo-case input → ``swapped`` is True but the
+        canonical equals the input (no behavior change downstream)."""
+        cache.search_artists_by_name.return_value = [
+            {"id": 1, "name": "Stereolab", "score": 0.99},
+        ]
+
+        outcome = await resolve_canonical_artist("stereolab", cache_service=cache)
+
+        assert outcome.canonical == "Stereolab"
+        assert outcome.swapped is True
+        assert outcome.score == 0.99
+
+    @pytest.mark.asyncio
+    async def test_returns_original_when_cache_returns_nothing(self, cache):
+        cache.search_artists_by_name.return_value = []
+
+        outcome = await resolve_canonical_artist("Nonexistent Artist", cache_service=cache)
+
+        assert outcome.original == "Nonexistent Artist"
+        assert outcome.canonical == "Nonexistent Artist"
+        assert outcome.score == 0.0
+        assert outcome.swapped is False
+
+    @pytest.mark.asyncio
+    async def test_returns_original_when_cache_service_is_none(self):
+        """No cache configured → graceful degradation, ``swapped=False``."""
+        outcome = await resolve_canonical_artist("Stereolab", cache_service=None)
+
+        assert outcome.original == "Stereolab"
+        assert outcome.canonical == "Stereolab"
+        assert outcome.swapped is False
+
+    @pytest.mark.asyncio
+    async def test_returns_original_for_empty_or_whitespace_input(self, cache):
+        """Empty / whitespace artist string → no cache query, no swap."""
+        outcome = await resolve_canonical_artist("   ", cache_service=cache)
+
+        assert outcome.swapped is False
+        cache.search_artists_by_name.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_exception_is_swallowed(self, cache):
+        """Cache failure → log + return original. Resolver must not break /lookup."""
+        cache.search_artists_by_name.side_effect = RuntimeError("pool down")
+
+        outcome = await resolve_canonical_artist("Stereolab", cache_service=cache)
+
+        assert outcome.original == "Stereolab"
+        assert outcome.canonical == "Stereolab"
+        assert outcome.swapped is False
+
+    @pytest.mark.asyncio
+    async def test_results_are_memoized_per_normalized_key(self, cache):
+        """Repeated calls with the same lowercased+unaccented input hit the
+        in-memory cache and skip the PG round-trip."""
+        cache.search_artists_by_name.return_value = [
+            {"id": 1, "name": "Stereolab", "score": 0.95},
+        ]
+
+        await resolve_canonical_artist("Stereolab", cache_service=cache)
+        await resolve_canonical_artist("stereolab", cache_service=cache)
+        await resolve_canonical_artist("STEREOLAB ", cache_service=cache)
+
+        assert cache.search_artists_by_name.await_count == 1
+
+
+class TestResolverPrePassCallSite:
+    """Behavior of ``search_compilations_for_track`` with the resolver pre-pass.
+
+    Both parallel Discogs probes should receive the canonical artist name when
+    the resolver swaps AND ``lml_resolve_artist_canonical`` is enabled; the
+    original name otherwise.
+    """
+
+    @pytest.fixture
+    def enforce_resolver_swap(self, monkeypatch):
+        """Enable the resolver enforcement flag for tests that exercise the swap path."""
+        monkeypatch.setenv("LML_RESOLVE_ARTIST_CANONICAL", "true")
+        from config.settings import get_settings
+
+        get_settings.cache_clear()
+        yield
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_canonical_name_flows_into_both_probes_when_swapped(self, enforce_resolver_swap):
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        cache_service = AsyncMock()
+        cache_service.search_artists_by_name = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "name": "Alexander Robotnick",
+                    "score": CANONICAL_ARTIST_SIMILARITY_FLOOR + 0.10,
+                }
+            ]
+        )
+        service.cache_service = cache_service
+        service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Problemes damour",
+                artist="Alexander Robotnick",
+                releases=[],
+                total=0,
+            )
+        )
+
+        parsed = ParsedRequest(
+            artist="Alexander Robotnik",
+            song="Problemes damour",
+            raw_message="Alexander Robotnik - Problemes damour",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        assert service.search_releases_by_track.await_count == 2
+        for call in service.search_releases_by_track.await_args_list:
+            # search_releases_by_track(track, artist, ...) — artist is positional or kwarg
+            artist_arg = call.kwargs.get("artist")
+            if artist_arg is None and len(call.args) >= 2:
+                artist_arg = call.args[1]
+            assert artist_arg == "Alexander Robotnick"
+
+    @pytest.mark.asyncio
+    async def test_original_name_flows_when_score_below_floor(self):
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        cache_service = AsyncMock()
+        cache_service.search_artists_by_name = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "name": "Aleksandr Robotnyk",
+                    "score": CANONICAL_ARTIST_SIMILARITY_FLOOR - 0.10,
+                }
+            ]
+        )
+        service.cache_service = cache_service
+        service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Problemes damour", artist=None, releases=[], total=0
+            )
+        )
+
+        parsed = ParsedRequest(
+            artist="Alexander Robotnik",
+            song="Problemes damour",
+            raw_message="Alexander Robotnik - Problemes damour",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        assert service.search_releases_by_track.await_count == 2
+        for call in service.search_releases_by_track.await_args_list:
+            artist_arg = call.kwargs.get("artist")
+            if artist_arg is None and len(call.args) >= 2:
+                artist_arg = call.args[1]
+            assert artist_arg == "Alexander Robotnik"


### PR DESCRIPTION
Closes #318.

## Summary

Adds a shadow-mode-first canonical-artist resolver pre-pass to `search_compilations_for_track`. When the inbound artist string trigram-matches a canonical Discogs name at score ≥ `CANONICAL_ARTIST_SIMILARITY_FLOOR` (0.70 provisional) the canonical form is forwarded into both parallel probes; otherwise the original input flows through unchanged.

- Shadow logging is unconditional: every `/lookup` with an artist emits an INFO `resolver_pre_pass` log line AND a `resolver_pre_pass` data attribute on the active Sentry transaction (mirrors the cache-stats pattern at `lookup/router._project_cache_stats_to_transaction`). The actual swap is gated on `LML_RESOLVE_ARTIST_CANONICAL` (Railway-deployed, defaults False) so the floor can be calibrated against real production traffic before enforcement is enabled.
- Resolver reuses the existing `cache_service.search_artists_by_name` trigram search at `discogs/cache_service.py:139-179` — no new SQL.
- Per-burst memoization via a new TTL cache (300s) registered with the global cache registry, keyed on the diacritic-stripped lowercased input. `clear_all_caches()` resets it.
- Calibration harness at `scripts/resolver_calibration/__main__.py` derives positive class from `artist_name_variation` joined to `artist` (canonical_id ground truth) and from resolved `entity.identity` rows; derives negative class from sampled close-but-distinct artist pairs (target FP curve). Sweeps thresholds in `[0.30, 0.95]` step 0.05; auto-picks the smallest floor whose empirical FP-rate ≤ `--fp-rate-target` (default 0.5%). Outputs `calibration_sweep.csv` + `borderline.csv` to `docs/resolver-calibration/`.

## Test plan

- [x] Unit tests in `tests/unit/test_resolver_pre_pass.py` — 10 tests covering: score above/below floor, exact-match short-circuit, empty/whitespace input, no candidates, `cache_service=None`, PG exception swallowed, memoization across normalized variants, and call-site behavior for both swap and no-swap paths in `search_compilations_for_track`.
- [x] Integration test in `tests/integration/test_resolver_pre_pass.py` (`@pytest.mark.pg`, self-skips without `DATABASE_URL_DISCOGS`) — exercises the Robotnik → Robotnick repro against the real discogs-cache.
- [x] Full unit suite green (`uv run pytest tests/unit/ -q` — 1663 passed).
- [x] Lint + format + typecheck green (`uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy . --ignore-missing-imports`).
- [ ] Calibration sweep run against staging (post-merge): `DATABASE_URL_DISCOGS=... uv run python -m scripts.resolver_calibration --output-dir docs/resolver-calibration/` → commit CSVs + a one-page README → update `CANONICAL_ARTIST_SIMILARITY_FLOOR` if the empirical floor differs from 0.70.
- [ ] One week of shadow-log review in Sentry trace explorer (filter on `data.resolver_pre_pass`) at the chosen floor.
- [ ] Flip `LML_RESOLVE_ARTIST_CANONICAL=true` in Railway production. Watch the same Sentry view for 7 days for incorrect swaps.

The sibling album-title fallback in #319 closes #237's trio-case acceptance criterion; this PR closes #237's typo-class repro (the Robotnik / Robotnick variant).