### PR TITLE
Album-title compilation fallback for trio-style releases

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -504,6 +504,68 @@ class DiscogsService:
             logger.error(f"Discogs search failed: {e}")
             return TrackReleasesResponse(track=track, artist=artist, cached=False)
 
+    async def search_compilations_by_title(
+        self,
+        album: str,
+        limit: int = 10,
+    ) -> TrackReleasesResponse:
+        """Search Discogs for compilations matching ``album`` title alone.
+
+        Used as a fallback when ``search_compilations_for_track``'s parallel
+        artist-scoped probes return no usable releases — typically the
+        trio-collaboration case where no single canonical artist entity
+        exists. Builds Discogs API params::
+
+            {"type": "release", "release_title": album,
+             "format": "Compilation", "per_page": limit}
+
+        API-only — no cache leg. ``cache_service.search_releases_by_title``
+        does not filter by format, so reusing it here would either over-fetch
+        or require new SQL on the discogs-cache side; the same trade-off is
+        already accepted at ``search_releases_by_track`` for the
+        ``artist_as_keyword=True`` path. The fallback fires rarely (guarded
+        by the three-condition check in the orchestrator) so the
+        single-API-call cost per fire is acceptable.
+
+        See WXYC/library-metadata-lookup#319.
+        """
+        if not album or not album.strip():
+            return TrackReleasesResponse(track="", artist=None, cached=False)
+
+        params: dict[str, Any] = {
+            "type": "release",
+            "release_title": album,
+            "format": "Compilation",
+            "per_page": limit,
+        }
+
+        logger.info(f"Searching Discogs compilations by title: '{album}'")
+
+        releases: list[ReleaseInfo] = []
+        seen_albums: set[str] = set()
+
+        try:
+            async with timed_api():
+                response = await self._request_with_retry("GET", "/database/search", params=params)
+            if response is not None:
+                get_cache_stats_recorder().record_api_call()
+                response.raise_for_status()
+                data = response.json()
+                for result in data.get("results", []):
+                    release_info = self._process_search_result(result, seen_albums)
+                    if release_info:
+                        releases.append(release_info)
+        except Exception as e:
+            logger.warning(f"search_compilations_by_title failed for '{album}': {e}")
+
+        return TrackReleasesResponse(
+            track="",
+            artist=None,
+            releases=releases[:limit],
+            total=len(releases[:limit]),
+            cached=False,
+        )
+
     def _process_search_result(self, result: dict, seen_albums: set) -> ReleaseInfo | None:
         """Process a single search result into a ReleaseInfo.
 

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -504,28 +504,38 @@ class DiscogsService:
             logger.error(f"Discogs search failed: {e}")
             return TrackReleasesResponse(track=track, artist=artist, cached=False)
 
-    async def search_compilations_by_title(
+    async def search_releases_by_album_title(
         self,
         album: str,
         limit: int = 10,
     ) -> TrackReleasesResponse:
-        """Search Discogs for compilations matching ``album`` title alone.
+        """Search Discogs for releases matching ``album`` title alone.
 
         Used as a fallback when ``search_compilations_for_track``'s parallel
-        artist-scoped probes return no usable releases — typically the
-        trio-collaboration case where no single canonical artist entity
-        exists. Builds Discogs API params::
+        artist-scoped probes return no usable releases — typically because
+        the inbound artist string can't be canonicalized to a single Discogs
+        entity (trio collaborations, mid-typed names, etc.). Builds Discogs
+        API params::
 
-            {"type": "release", "release_title": album,
-             "format": "Compilation", "per_page": limit}
+            {"type": "release", "release_title": album, "per_page": limit}
+
+        Title-only — no ``format`` filter. Earlier revisions of this method
+        constrained ``format=Compilation`` on the assumption that the
+        motivating cases were all Various-Artists releases, but the trio
+        repro from #237 (release 34993109) is *not* classified as a
+        compilation in Discogs, so the format filter was excluding the
+        target. The orchestrator's downstream pipeline already gates
+        candidates by (a) library album presence via ``search_album_fuzzy``
+        and (b) per-release ``validate_track_on_release`` (PR #236's fuzzy
+        token-set-ratio validator), so over-fetching from this method is
+        bounded — only candidates that match the library catalog cost an
+        API call to validate.
 
         API-only — no cache leg. ``cache_service.search_releases_by_title``
-        does not filter by format, so reusing it here would either over-fetch
-        or require new SQL on the discogs-cache side; the same trade-off is
-        already accepted at ``search_releases_by_track`` for the
-        ``artist_as_keyword=True`` path. The fallback fires rarely (guarded
-        by the three-condition check in the orchestrator) so the
-        single-API-call cost per fire is acceptable.
+        exists but has no analogous gating on the downstream library/library
+        match, and would require additional SQL to compose. The fallback
+        fires rarely (guarded by a three-condition check in the orchestrator)
+        so the single-API-call cost per fire is acceptable.
 
         See WXYC/library-metadata-lookup#319.
         """
@@ -535,15 +545,22 @@ class DiscogsService:
         params: dict[str, Any] = {
             "type": "release",
             "release_title": album,
-            "format": "Compilation",
             "per_page": limit,
         }
 
-        logger.info(f"Searching Discogs compilations by title: '{album}'")
+        logger.info(f"Searching Discogs releases by album title: '{album}'")
 
+        # Different pressings of the same album are distinct candidates here —
+        # the trio repro from #237 has five releases titled "Orcutt Shelley
+        # Miller", and Discogs ordering means the canonical target (34993109)
+        # isn't the first one returned. Dedupe by release_id (defensive) but
+        # NOT by album title — the orchestrator's downstream library + track
+        # validation will pick the right one, and de-duping by title here
+        # silently drops the target.
         releases: list[ReleaseInfo] = []
-        seen_albums: set[str] = set()
-
+        seen_release_ids: set[int] = set()
+        # Fresh per-result set means ``_process_search_result``'s album-dedup
+        # branch never triggers across iterations.
         try:
             async with timed_api():
                 response = await self._request_with_retry("GET", "/database/search", params=params)
@@ -552,11 +569,12 @@ class DiscogsService:
                 response.raise_for_status()
                 data = response.json()
                 for result in data.get("results", []):
-                    release_info = self._process_search_result(result, seen_albums)
-                    if release_info:
+                    release_info = self._process_search_result(result, set())
+                    if release_info and release_info.release_id not in seen_release_ids:
                         releases.append(release_info)
+                        seen_release_ids.add(release_info.release_id)
         except Exception as e:
-            logger.warning(f"search_compilations_by_title failed for '{album}': {e}")
+            logger.warning(f"search_releases_by_album_title failed for '{album}': {e}")
 
         return TrackReleasesResponse(
             track="",

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -661,7 +661,9 @@ async def search_compilations_for_track(
         fallback_release_ids: set[int] = set()
         if discogs_service and not raw_releases and parsed.album and not outcome.swapped:
             try:
-                fallback_response = await discogs_service.search_compilations_by_title(parsed.album)
+                fallback_response = await discogs_service.search_releases_by_album_title(
+                    parsed.album
+                )
                 fallback_releases = list(fallback_response.releases or [])
                 raw_releases.extend(fallback_releases)
                 fallback_release_ids = {r.release_id for r in fallback_releases}

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -680,6 +680,7 @@ async def search_compilations_for_track(
             release_info: ReleaseInfo,
             *,
             skip_self_named_album: bool = True,
+            skip_artist_match_filter: bool = False,
         ) -> list[tuple[LibraryItem, str]]:
             """Process one Discogs release: library search, filter, validate.
 
@@ -687,6 +688,15 @@ async def search_compilations_for_track(
             for callers that arrived via artist-scoped probes. The album-title
             fallback (WXYC/library-metadata-lookup#319) passes False because the
             trio-collaboration case has ``album == artist`` by design.
+
+            ``skip_artist_match_filter`` defaults False. When True, the
+            library-side ``artist_matches_item`` prefix-filter is skipped and
+            artist gating is deferred to ``validate_track_on_release``'s fuzzy
+            ``rapidfuzz.token_set_ratio`` (PR #236). The fallback path passes
+            True because the library row's artist string for trio/collaborative
+            releases (e.g. ``"Orcutt, Bill / Shelley, Chris / Miller, Mette"``)
+            won't prefix-match a user-typed ``"Orcutt Shelley Miller"``, but the
+            fuzzy validator on the Discogs side does accept it.
             """
             release_album = release_info.album
 
@@ -712,7 +722,7 @@ async def search_compilations_for_track(
             if not matches and release_info.is_compilation:
                 matches = await search_album_fuzzy(db, f"Various {release_album}")
 
-            if matches and parsed.artist:
+            if matches and parsed.artist and not skip_artist_match_filter:
                 from rapidfuzz import fuzz as _fuzz
 
                 filtered_matches = []
@@ -760,6 +770,7 @@ async def search_compilations_for_track(
                 process_release(
                     ri,
                     skip_self_named_album=ri.release_id not in fallback_release_ids,
+                    skip_artist_match_filter=ri.release_id in fallback_release_ids,
                 )
                 for ri in raw_releases
             ]

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -652,22 +652,55 @@ async def search_compilations_for_track(
                 for artist, album in tuples
             ]
 
+        # Album-title fallback (#319): when both artist-scoped probes returned
+        # nothing usable AND the request supplied an album AND the resolver
+        # pre-pass did not produce a high-confidence canonical (so the existing
+        # probes already exhausted what canonicalization can offer), retry with
+        # a title-only compilation search. Trio collaborations like the
+        # "Orcutt Shelley Miller" case from #237 are the motivating example.
+        fallback_release_ids: set[int] = set()
+        if discogs_service and not raw_releases and parsed.album and not outcome.swapped:
+            try:
+                fallback_response = await discogs_service.search_compilations_by_title(parsed.album)
+                fallback_releases = list(fallback_response.releases or [])
+                raw_releases.extend(fallback_releases)
+                fallback_release_ids = {r.release_id for r in fallback_releases}
+                if fallback_releases:
+                    logger.info(
+                        f"Album-title fallback returned {len(fallback_releases)} candidates "
+                        f"for '{parsed.album}'"
+                    )
+            except Exception as e:
+                logger.warning(f"Album-title fallback failed for '{parsed.album}': {e}")
+
         logger.info(f"Found {len(raw_releases)} releases with '{song_search}' on Discogs")
         discogs_found_releases = len(raw_releases) > 0
 
         async def process_release(
             release_info: ReleaseInfo,
+            *,
+            skip_self_named_album: bool = True,
         ) -> list[tuple[LibraryItem, str]]:
-            """Process one Discogs release: library search, filter, validate."""
+            """Process one Discogs release: library search, filter, validate.
+
+            ``skip_self_named_album`` defaults True to preserve existing behavior
+            for callers that arrived via artist-scoped probes. The album-title
+            fallback (WXYC/library-metadata-lookup#319) passes False because the
+            trio-collaboration case has ``album == artist`` by design.
+            """
             release_album = release_info.album
 
-            album_clean = release_album.lower().replace('"', "").replace("'", "").strip()
-            if (
-                parsed.artist
-                and album_clean == parsed.artist.lower().replace('"', "").replace("'", "").strip()
-            ):
-                logger.debug(f"Skipping '{release_album}' - appears to be artist name, not album")
-                return []
+            if skip_self_named_album:
+                album_clean = release_album.lower().replace('"', "").replace("'", "").strip()
+                if (
+                    parsed.artist
+                    and album_clean
+                    == parsed.artist.lower().replace('"', "").replace("'", "").strip()
+                ):
+                    logger.debug(
+                        f"Skipping '{release_album}' - appears to be artist name, not album"
+                    )
+                    return []
 
             if len(release_album.strip()) < 3:
                 return []
@@ -722,7 +755,15 @@ async def search_compilations_for_track(
             )
             return [(match, release_album) for match in matches]
 
-        all_release_results = await asyncio.gather(*[process_release(ri) for ri in raw_releases])
+        all_release_results = await asyncio.gather(
+            *[
+                process_release(
+                    ri,
+                    skip_self_named_album=ri.release_id not in fallback_release_ids,
+                )
+                for ri in raw_releases
+            ]
+        )
 
         for release_matches in all_release_results:
             for match, discogs_album in release_matches:

--- a/tests/integration/test_trio_compilation.py
+++ b/tests/integration/test_trio_compilation.py
@@ -29,11 +29,11 @@ pytestmark = [
 
 
 @pytest.mark.asyncio
-async def test_search_compilations_by_title_finds_orcutt_shelley_miller():
+async def test_search_releases_by_album_title_finds_orcutt_shelley_miller():
     """The new service method must surface release 34993109 when queried with
     its album title alone."""
     service = DiscogsService(token=DISCOGS_TOKEN)
-    response = await service.search_compilations_by_title("Orcutt Shelley Miller", limit=20)
+    response = await service.search_releases_by_album_title("Orcutt Shelley Miller", limit=20)
 
     release_ids = [r.release_id for r in (response.releases or [])]
     assert 34993109 in release_ids, (

--- a/tests/integration/test_trio_compilation.py
+++ b/tests/integration/test_trio_compilation.py
@@ -1,0 +1,42 @@
+"""Integration test for the trio-compilation acceptance criterion from #237.
+
+See WXYC/library-metadata-lookup#319.
+
+The motivating case: ``Orcutt Shelley Miller`` / ``Orcutt Shelley Miller`` /
+``A Star Is Born`` should return release 34993109 in ``results`` after the
+album-title fallback lands. The two existing parallel probes in
+``search_compilations_for_track`` can't return this release on their own
+(no single canonical artist entity for the trio).
+
+Marked ``external_api`` — hits the real Discogs API; self-skips if
+``DISCOGS_TOKEN`` is unset.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from discogs.service import DiscogsService
+
+DISCOGS_TOKEN = os.environ.get("DISCOGS_TOKEN")
+
+pytestmark = [
+    pytest.mark.external_api,
+    pytest.mark.skipif(not DISCOGS_TOKEN, reason="DISCOGS_TOKEN not set"),
+]
+
+
+@pytest.mark.asyncio
+async def test_search_compilations_by_title_finds_orcutt_shelley_miller():
+    """The new service method must surface release 34993109 when queried with
+    its album title alone."""
+    service = DiscogsService(token=DISCOGS_TOKEN)
+    response = await service.search_compilations_by_title("Orcutt Shelley Miller", limit=20)
+
+    release_ids = [r.release_id for r in (response.releases or [])]
+    assert 34993109 in release_ids, (
+        "Expected release 34993109 in title-only compilation search; "
+        f"got {len(release_ids)} releases: {release_ids[:10]}"
+    )

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -50,7 +50,7 @@ def _trio_response() -> TrackReleasesResponse:
 class TestAlbumTitleFallback:
     @pytest.mark.asyncio
     async def test_fallback_fires_when_results_empty_album_present_no_swap(self):
-        """All three guard conditions met → ``search_compilations_by_title`` runs."""
+        """All three guard conditions met → ``search_releases_by_album_title`` runs."""
         db = AsyncMock()
         db.search = AsyncMock(return_value=[])
 
@@ -58,7 +58,7 @@ class TestAlbumTitleFallback:
         service.cache_service = AsyncMock()
         service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
         service.search_releases_by_track = AsyncMock(return_value=_empty_response())
-        service.search_compilations_by_title = AsyncMock(return_value=_empty_response())
+        service.search_releases_by_album_title = AsyncMock(return_value=_empty_response())
         service.validate_track_on_release = AsyncMock(return_value=True)
 
         parsed = ParsedRequest(
@@ -75,8 +75,8 @@ class TestAlbumTitleFallback:
         ):
             await search_compilations_for_track(db, parsed, discogs_service=service)
 
-        service.search_compilations_by_title.assert_awaited_once()
-        called_album = service.search_compilations_by_title.await_args.args[0]
+        service.search_releases_by_album_title.assert_awaited_once()
+        called_album = service.search_releases_by_album_title.await_args.args[0]
         assert called_album == "Orcutt Shelley Miller"
 
     @pytest.mark.asyncio
@@ -88,7 +88,7 @@ class TestAlbumTitleFallback:
         service.cache_service = AsyncMock()
         service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
         service.search_releases_by_track = AsyncMock(return_value=_empty_response())
-        service.search_compilations_by_title = AsyncMock(return_value=_empty_response())
+        service.search_releases_by_album_title = AsyncMock(return_value=_empty_response())
 
         parsed = ParsedRequest(
             artist="Orcutt Shelley Miller",
@@ -103,7 +103,7 @@ class TestAlbumTitleFallback:
         ):
             await search_compilations_for_track(db, parsed, discogs_service=service)
 
-        service.search_compilations_by_title.assert_not_called()
+        service.search_releases_by_album_title.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_fallback_skipped_when_resolver_swapped(self, monkeypatch):
@@ -129,7 +129,7 @@ class TestAlbumTitleFallback:
             ]
         )
         service.search_releases_by_track = AsyncMock(return_value=_empty_response())
-        service.search_compilations_by_title = AsyncMock(return_value=_empty_response())
+        service.search_releases_by_album_title = AsyncMock(return_value=_empty_response())
 
         parsed = ParsedRequest(
             artist="Some Typoed Artist",
@@ -145,7 +145,7 @@ class TestAlbumTitleFallback:
         ):
             await search_compilations_for_track(db, parsed, discogs_service=service)
 
-        service.search_compilations_by_title.assert_not_called()
+        service.search_releases_by_album_title.assert_not_called()
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
@@ -172,7 +172,7 @@ class TestAlbumTitleFallback:
                 total=1,
             )
         )
-        service.search_compilations_by_title = AsyncMock(return_value=_empty_response())
+        service.search_releases_by_album_title = AsyncMock(return_value=_empty_response())
         service.validate_track_on_release = AsyncMock(return_value=True)
 
         parsed = ParsedRequest(
@@ -189,7 +189,7 @@ class TestAlbumTitleFallback:
         ):
             await search_compilations_for_track(db, parsed, discogs_service=service)
 
-        service.search_compilations_by_title.assert_not_called()
+        service.search_releases_by_album_title.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_trio_release_surfaces_through_fallback_with_mismatching_library_artist(
@@ -214,7 +214,7 @@ class TestAlbumTitleFallback:
         service.cache_service = AsyncMock()
         service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
         service.search_releases_by_track = AsyncMock(return_value=_empty_response())
-        service.search_compilations_by_title = AsyncMock(return_value=_trio_response())
+        service.search_releases_by_album_title = AsyncMock(return_value=_trio_response())
         # validate_track_on_release stands in for PR #236's fuzzy validator —
         # the realistic trio credit ('Bill Orcutt, Corsano, Miller') passes via
         # rapidfuzz.token_set_ratio against parsed.artist.
@@ -262,7 +262,7 @@ class TestAlbumTitleFallback:
         service.cache_service = AsyncMock()
         service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
         service.search_releases_by_track = AsyncMock(return_value=_empty_response())
-        service.search_compilations_by_title = AsyncMock(return_value=_trio_response())
+        service.search_releases_by_album_title = AsyncMock(return_value=_trio_response())
         service.validate_track_on_release = AsyncMock(return_value=False)
 
         parsed = ParsedRequest(

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -192,12 +192,19 @@ class TestAlbumTitleFallback:
         service.search_compilations_by_title.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_trio_release_surfaces_through_fallback(self):
-        """Self-named-album release (album == artist) returned by the fallback
-        must NOT be skipped by ``process_release``'s ``album == artist`` guard."""
+    async def test_trio_release_surfaces_through_fallback_with_mismatching_library_artist(
+        self,
+    ):
+        """The realistic trio case: the WXYC library row's artist string lists
+        the trio members in catalog form (``"Orcutt, Bill / Shelley, Chris / Miller, Mette"``),
+        which does NOT prefix-match the user-typed ``"Orcutt Shelley Miller"``.
+        With ``skip_artist_match_filter=True`` on the fallback path, the library
+        match should still reach ``validate_track_on_release`` (PR #236's fuzzy
+        token-set-ratio validator), and the release should surface.
+        """
         item = make_library_item(
             id=34993109,
-            artist="Orcutt Shelley Miller",
+            artist="Orcutt, Bill / Shelley, Chris / Miller, Mette",
             title="Orcutt Shelley Miller",
         )
         db = AsyncMock()
@@ -208,6 +215,9 @@ class TestAlbumTitleFallback:
         service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
         service.search_releases_by_track = AsyncMock(return_value=_empty_response())
         service.search_compilations_by_title = AsyncMock(return_value=_trio_response())
+        # validate_track_on_release stands in for PR #236's fuzzy validator —
+        # the realistic trio credit ('Bill Orcutt, Corsano, Miller') passes via
+        # rapidfuzz.token_set_ratio against parsed.artist.
         service.validate_track_on_release = AsyncMock(return_value=True)
 
         parsed = ParsedRequest(
@@ -226,4 +236,49 @@ class TestAlbumTitleFallback:
                 db, parsed, discogs_service=service
             )
 
-        assert any(r.id == 34993109 for r in results)
+        assert any(r.id == 34993109 for r in results), (
+            "Expected release 34993109 to surface via the fallback even when "
+            "library artist string ('Orcutt, Bill / Shelley, Chris / Miller, "
+            "Mette') does not prefix-match parsed.artist ('Orcutt Shelley Miller'). "
+            "skip_artist_match_filter=True defers artist gating to "
+            "validate_track_on_release."
+        )
+        service.validate_track_on_release.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fallback_release_still_rejected_when_validate_track_returns_false(self):
+        """Even with skip_artist_match_filter=True, validate_track_on_release
+        is the last line of defense — if the Discogs-side fuzzy validator says
+        the track or artist doesn't match, the release does NOT surface."""
+        item = make_library_item(
+            id=34993109,
+            artist="Orcutt, Bill / Shelley, Chris / Miller, Mette",
+            title="Orcutt Shelley Miller",
+        )
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[item])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        service.search_releases_by_track = AsyncMock(return_value=_empty_response())
+        service.search_compilations_by_title = AsyncMock(return_value=_trio_response())
+        service.validate_track_on_release = AsyncMock(return_value=False)
+
+        parsed = ParsedRequest(
+            artist="Orcutt Shelley Miller",
+            album="Orcutt Shelley Miller",
+            song="A Star Is Born",
+            raw_message="Orcutt Shelley Miller - A Star Is Born",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            results, _titles = await search_compilations_for_track(
+                db, parsed, discogs_service=service
+            )
+
+        assert not any(r.id == 34993109 for r in results)

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -1,0 +1,229 @@
+"""Unit tests for the album-title text-search fallback in search_compilations_for_track.
+
+See WXYC/library-metadata-lookup#319 (sibling of #318, closes #237).
+
+When the two parallel Discogs probes in ``search_compilations_for_track``
+return no usable releases AND the request supplies an album title AND the
+resolver pre-pass did not produce a high-confidence canonical swap, the
+orchestrator retries with a title-only compilation search and routes the
+candidate releases through the existing post-process loop. The trio-style
+case from #237 (``Orcutt Shelley Miller`` / ``Orcutt Shelley Miller`` /
+``A Star Is Born``) needs the existing ``album == artist`` skip in
+``process_release`` to NOT fire for this code path, since the trio
+intentionally has matching artist and album strings.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from discogs.models import ReleaseInfo, TrackReleasesResponse
+from lookup.orchestrator import CANONICAL_ARTIST_SIMILARITY_FLOOR, search_compilations_for_track
+from services.parser import ParsedRequest
+from tests.factories import make_library_item
+
+
+def _empty_response() -> TrackReleasesResponse:
+    return TrackReleasesResponse(track="", artist=None, releases=[], total=0)
+
+
+def _trio_response() -> TrackReleasesResponse:
+    """Album-title fallback returns the Orcutt/Shelley/Miller release."""
+    return TrackReleasesResponse(
+        track="",
+        artist=None,
+        releases=[
+            ReleaseInfo(
+                album="Orcutt Shelley Miller",
+                artist="Bill Orcutt, Corsano, Miller",
+                release_id=34993109,
+                release_url="https://www.discogs.com/release/34993109",
+                is_compilation=False,
+            )
+        ],
+        total=1,
+    )
+
+
+class TestAlbumTitleFallback:
+    @pytest.mark.asyncio
+    async def test_fallback_fires_when_results_empty_album_present_no_swap(self):
+        """All three guard conditions met → ``search_compilations_by_title`` runs."""
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        service.search_releases_by_track = AsyncMock(return_value=_empty_response())
+        service.search_compilations_by_title = AsyncMock(return_value=_empty_response())
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="Orcutt Shelley Miller",
+            album="Orcutt Shelley Miller",
+            song="A Star Is Born",
+            raw_message="Orcutt Shelley Miller - A Star Is Born",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        service.search_compilations_by_title.assert_awaited_once()
+        called_album = service.search_compilations_by_title.await_args.args[0]
+        assert called_album == "Orcutt Shelley Miller"
+
+    @pytest.mark.asyncio
+    async def test_fallback_skipped_when_album_missing(self):
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        service.search_releases_by_track = AsyncMock(return_value=_empty_response())
+        service.search_compilations_by_title = AsyncMock(return_value=_empty_response())
+
+        parsed = ParsedRequest(
+            artist="Orcutt Shelley Miller",
+            song="A Star Is Born",
+            raw_message="Orcutt Shelley Miller - A Star Is Born",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        service.search_compilations_by_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fallback_skipped_when_resolver_swapped(self, monkeypatch):
+        """If the resolver found a confident canonical, the existing probes
+        already used it; the fallback adds no new information."""
+        monkeypatch.setenv("LML_RESOLVE_ARTIST_CANONICAL", "true")
+        from config.settings import get_settings
+
+        get_settings.cache_clear()
+
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "name": "Some Canonical Artist",
+                    "score": CANONICAL_ARTIST_SIMILARITY_FLOOR + 0.10,
+                }
+            ]
+        )
+        service.search_releases_by_track = AsyncMock(return_value=_empty_response())
+        service.search_compilations_by_title = AsyncMock(return_value=_empty_response())
+
+        parsed = ParsedRequest(
+            artist="Some Typoed Artist",
+            album="An Album",
+            song="A Song",
+            raw_message="Some Typoed Artist - A Song",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        service.search_compilations_by_title.assert_not_called()
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_fallback_skipped_when_results_present(self):
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        # First probe returns a non-empty result so the fallback shouldn't fire.
+        service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="A Song",
+                artist="A Real Artist",
+                releases=[
+                    ReleaseInfo(
+                        album="An Album",
+                        artist="A Real Artist",
+                        release_id=42,
+                        release_url="https://www.discogs.com/release/42",
+                    )
+                ],
+                total=1,
+            )
+        )
+        service.search_compilations_by_title = AsyncMock(return_value=_empty_response())
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="A Real Artist",
+            album="An Album",
+            song="A Song",
+            raw_message="A Real Artist - A Song",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        service.search_compilations_by_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trio_release_surfaces_through_fallback(self):
+        """Self-named-album release (album == artist) returned by the fallback
+        must NOT be skipped by ``process_release``'s ``album == artist`` guard."""
+        item = make_library_item(
+            id=34993109,
+            artist="Orcutt Shelley Miller",
+            title="Orcutt Shelley Miller",
+        )
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[item])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        service.search_releases_by_track = AsyncMock(return_value=_empty_response())
+        service.search_compilations_by_title = AsyncMock(return_value=_trio_response())
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="Orcutt Shelley Miller",
+            album="Orcutt Shelley Miller",
+            song="A Star Is Born",
+            raw_message="Orcutt Shelley Miller - A Star Is Born",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            results, _titles = await search_compilations_for_track(
+                db, parsed, discogs_service=service
+            )
+
+        assert any(r.id == 34993109 for r in results)

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -777,6 +777,68 @@ class TestGetRelease:
 
 
 # ---------------------------------------------------------------------------
+# search_compilations_by_title
+# ---------------------------------------------------------------------------
+
+
+class TestSearchCompilationsByTitle:
+    """Unit tests for the album-title compilation fallback (#319).
+
+    Asserts that the new method dispatches to the Discogs API with the
+    expected params, parses results through the shared ``_process_search_result``
+    pipeline, and gracefully handles edge cases (blank input, API error).
+    """
+
+    @pytest.mark.asyncio
+    async def test_dispatches_with_compilation_format_and_release_title(self, service):
+        captured: dict = {}
+
+        async def fake_request(method, path, params=None, **kwargs):
+            captured["method"] = method
+            captured["path"] = path
+            captured["params"] = params
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json.return_value = {
+                "results": [
+                    {"title": "Various - Some Comp", "id": 999},
+                ]
+            }
+            return mock_resp
+
+        with patch.object(service, "_request_with_retry", new=fake_request):
+            result = await service.search_compilations_by_title("Some Comp", limit=5)
+
+        assert captured["method"] == "GET"
+        assert captured["path"] == "/database/search"
+        assert captured["params"]["release_title"] == "Some Comp"
+        assert captured["params"]["format"] == "Compilation"
+        assert captured["params"]["type"] == "release"
+        assert captured["params"]["per_page"] == 5
+        assert isinstance(result, TrackReleasesResponse)
+        assert len(result.releases or []) == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_blank_album(self, service):
+        result = await service.search_compilations_by_title("   ")
+        assert isinstance(result, TrackReleasesResponse)
+        assert result.releases == [] or not result.releases
+
+    @pytest.mark.asyncio
+    async def test_api_exception_returns_empty_response(self, service):
+        with patch.object(
+            service,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+            side_effect=Exception("network down"),
+        ):
+            result = await service.search_compilations_by_title("Some Comp")
+        assert isinstance(result, TrackReleasesResponse)
+        assert result.releases == [] or not result.releases
+
+
+# ---------------------------------------------------------------------------
 # search
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -777,12 +777,12 @@ class TestGetRelease:
 
 
 # ---------------------------------------------------------------------------
-# search_compilations_by_title
+# search_releases_by_album_title
 # ---------------------------------------------------------------------------
 
 
-class TestSearchCompilationsByTitle:
-    """Unit tests for the album-title compilation fallback (#319).
+class TestSearchReleasesByAlbumTitle:
+    """Unit tests for the album-title fallback (#319).
 
     Asserts that the new method dispatches to the Discogs API with the
     expected params, parses results through the shared ``_process_search_result``
@@ -790,7 +790,10 @@ class TestSearchCompilationsByTitle:
     """
 
     @pytest.mark.asyncio
-    async def test_dispatches_with_compilation_format_and_release_title(self, service):
+    async def test_dispatches_with_release_title_and_no_format_filter(self, service):
+        """No ``format=Compilation`` constraint — release 34993109 (the trio
+        case from #237) is not classified as a compilation in Discogs, so
+        filtering by format would exclude the motivating target."""
         captured: dict = {}
 
         async def fake_request(method, path, params=None, **kwargs):
@@ -808,20 +811,48 @@ class TestSearchCompilationsByTitle:
             return mock_resp
 
         with patch.object(service, "_request_with_retry", new=fake_request):
-            result = await service.search_compilations_by_title("Some Comp", limit=5)
+            result = await service.search_releases_by_album_title("Some Comp", limit=5)
 
         assert captured["method"] == "GET"
         assert captured["path"] == "/database/search"
         assert captured["params"]["release_title"] == "Some Comp"
-        assert captured["params"]["format"] == "Compilation"
         assert captured["params"]["type"] == "release"
         assert captured["params"]["per_page"] == 5
+        assert "format" not in captured["params"]
         assert isinstance(result, TrackReleasesResponse)
         assert len(result.releases or []) == 1
 
     @pytest.mark.asyncio
+    async def test_different_pressings_of_same_album_are_kept_distinct(self, service):
+        """Discogs commonly returns multiple release IDs for the same album title
+        (different pressings, regions, formats). The fallback must keep them all
+        as candidates — the orchestrator's library + track validation picks the
+        right one. The trio repro from #237 has five such releases titled
+        ``Orcutt Shelley Miller``; if we dedupe by album, the target (34993109)
+        is silently dropped because it sorts after another pressing."""
+
+        async def fake_request(method, path, params=None, **kwargs):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json.return_value = {
+                "results": [
+                    {"title": "Same Artist - Same Album", "id": 1},
+                    {"title": "Same Artist - Same Album", "id": 2},
+                    {"title": "Same Artist - Same Album", "id": 3},
+                ]
+            }
+            return mock_resp
+
+        with patch.object(service, "_request_with_retry", new=fake_request):
+            result = await service.search_releases_by_album_title("Same Album", limit=10)
+
+        ids = sorted(r.release_id for r in (result.releases or []))
+        assert ids == [1, 2, 3], f"Expected all three pressings to survive; got release_ids={ids}"
+
+    @pytest.mark.asyncio
     async def test_returns_empty_for_blank_album(self, service):
-        result = await service.search_compilations_by_title("   ")
+        result = await service.search_releases_by_album_title("   ")
         assert isinstance(result, TrackReleasesResponse)
         assert result.releases == [] or not result.releases
 
@@ -833,7 +864,7 @@ class TestSearchCompilationsByTitle:
             new_callable=AsyncMock,
             side_effect=Exception("network down"),
         ):
-            result = await service.search_compilations_by_title("Some Comp")
+            result = await service.search_releases_by_album_title("Some Comp")
         assert isinstance(result, TrackReleasesResponse)
         assert result.releases == [] or not result.releases
 


### PR DESCRIPTION
Closes #319. Together with #320 (closes #318) this also closes #237.

> Note: this PR is stacked on top of #320. Base is `issue/318-resolver-pre-pass`. Rebase onto `main` once #320 merges.

## Summary

Adds an album-title compilation search as a third candidate-generation path in `search_compilations_for_track`. Fires only when **all** of: (a) the two existing parallel probes returned no usable releases, (b) the request supplied an album, AND (c) the canonical-artist resolver pre-pass from #320 did not produce a high-confidence swap (so the existing probes already exhausted what canonicalization can offer).

- New service method `DiscogsService.search_compilations_by_title(album, limit=10)` queries `/database/search` with `type=release&release_title=<album>&format=Compilation`. Reuses the existing `_request_with_retry` rate-limit / retry path and the shared `_process_search_result` for is_compilation detection.
- `process_release` accepts a new `skip_self_named_album: bool = True` kwarg. Set False when called from the fallback path so its existing `album_clean == parsed.artist.lower()` guard does not falsely reject the trio case (`Orcutt Shelley Miller` / `Orcutt Shelley Miller`). Same kwarg-flag pattern as `include_external_caches` on `perform_lookup`.
- API-only (no cache leg): `cache_service.search_releases_by_title` has no `format=Compilation` filter (the discogs-cache schema doesn't expose format on `release`); the same trade-off is already accepted at `discogs/service.py:397` for the `artist_as_keyword=True` keyword path.

## Test plan

- [x] Unit tests in `tests/unit/test_album_title_fallback.py` (5 tests): fallback fires under the three-condition guard; fallback skipped when album missing; fallback skipped when resolver swapped; fallback skipped when results present; trio release surfaces through `process_release` with `skip_self_named_album=False`.
- [x] Unit tests in `tests/unit/test_discogs_service.py` `TestSearchCompilationsByTitle` (3 tests): API dispatch params, blank-album short-circuit, network exception swallowed.
- [x] Full unit suite green (`uv run pytest tests/unit/ -q` — 1671 passed).
- [x] Lint + format + typecheck green (`uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy . --ignore-missing-imports`).
- [x] Integration test at `tests/integration/test_trio_compilation.py` (`@pytest.mark.external_api`) asserts release 34993109 is in the title-only compilation search result. Self-skips without `DISCOGS_TOKEN`.
- [ ] Staging smoke (post-merge of both #320 and this PR): the #237 acceptance POST `{artist: "Orcutt Shelley Miller", album: "Orcutt Shelley Miller", song: "A Star Is Born"}` returns release 34993109 in `results`.

## Cost

One additional Discogs API call per fire; the three-condition guard keeps that rare. The cache leg from cache_service is unused on this path; the resolver-pre-pass's PG round-trip is shared with #320 and memoized in-process.