### PR TITLE
Gate album-title fallback on library results, not Discogs response

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -652,29 +652,6 @@ async def search_compilations_for_track(
                 for artist, album in tuples
             ]
 
-        # Album-title fallback (#319): when both artist-scoped probes returned
-        # nothing usable AND the request supplied an album AND the resolver
-        # pre-pass did not produce a high-confidence canonical (so the existing
-        # probes already exhausted what canonicalization can offer), retry with
-        # a title-only compilation search. Trio collaborations like the
-        # "Orcutt Shelley Miller" case from #237 are the motivating example.
-        fallback_release_ids: set[int] = set()
-        if discogs_service and not raw_releases and parsed.album and not outcome.swapped:
-            try:
-                fallback_response = await discogs_service.search_releases_by_album_title(
-                    parsed.album
-                )
-                fallback_releases = list(fallback_response.releases or [])
-                raw_releases.extend(fallback_releases)
-                fallback_release_ids = {r.release_id for r in fallback_releases}
-                if fallback_releases:
-                    logger.info(
-                        f"Album-title fallback returned {len(fallback_releases)} candidates "
-                        f"for '{parsed.album}'"
-                    )
-            except Exception as e:
-                logger.warning(f"Album-title fallback failed for '{parsed.album}': {e}")
-
         logger.info(f"Found {len(raw_releases)} releases with '{song_search}' on Discogs")
         discogs_found_releases = len(raw_releases) > 0
 
@@ -767,16 +744,7 @@ async def search_compilations_for_track(
             )
             return [(match, release_album) for match in matches]
 
-        all_release_results = await asyncio.gather(
-            *[
-                process_release(
-                    ri,
-                    skip_self_named_album=ri.release_id not in fallback_release_ids,
-                    skip_artist_match_filter=ri.release_id in fallback_release_ids,
-                )
-                for ri in raw_releases
-            ]
-        )
+        all_release_results = await asyncio.gather(*[process_release(ri) for ri in raw_releases])
 
         for release_matches in all_release_results:
             for match, discogs_album in release_matches:
@@ -786,6 +754,52 @@ async def search_compilations_for_track(
                     discogs_titles[match.id] = discogs_album
             if len(results) >= MAX_SEARCH_RESULTS:
                 break
+
+        # Album-title fallback (#319 + #237): when the artist-scoped probes
+        # produced no library results AND the request supplied an album AND
+        # the resolver pre-pass did not produce a high-confidence canonical,
+        # retry with a title-only Discogs search and process those candidates
+        # with the trio-aware kwargs (no self-named-album guard, no library-
+        # side artist filter — defer artist gating to validate_track_on_release).
+        #
+        # Earlier revisions gated this on ``not raw_releases``, but Discogs has
+        # since added a canonical entity for the motivating trio ("Orcutt
+        # Shelley Miller"), so the artist-scoped probes now return non-empty
+        # raw_releases that all get filtered out downstream. Gate on actual
+        # results, not Discogs response shape. See WXYC/library-metadata-lookup#237.
+        if discogs_service and not results and parsed.album and not outcome.swapped:
+            try:
+                fallback_response = await discogs_service.search_releases_by_album_title(
+                    parsed.album
+                )
+                fallback_releases = list(fallback_response.releases or [])
+                if fallback_releases:
+                    logger.info(
+                        f"Album-title fallback returned {len(fallback_releases)} candidates "
+                        f"for '{parsed.album}'"
+                    )
+                fallback_results = await asyncio.gather(
+                    *[
+                        process_release(
+                            ri,
+                            skip_self_named_album=False,
+                            skip_artist_match_filter=True,
+                        )
+                        for ri in fallback_releases
+                    ]
+                )
+                for release_matches in fallback_results:
+                    for match, discogs_album in release_matches:
+                        if match.id not in seen_ids:
+                            results.append(match)
+                            seen_ids.add(match.id)
+                            discogs_titles[match.id] = discogs_album
+                    if len(results) >= MAX_SEARCH_RESULTS:
+                        break
+                if fallback_releases:
+                    discogs_found_releases = True
+            except Exception as e:
+                logger.warning(f"Album-title fallback failed for '{parsed.album}': {e}")
     except Exception as e:
         logger.warning(f"Failed to search for track on other releases: {e}")
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -156,6 +156,44 @@ async def resolve_canonical_artist(
     return outcome
 
 
+def _log_album_title_fallback(
+    *,
+    album: str,
+    n_candidates: int,
+    surfaced_library_match: bool,
+    error: str | None = None,
+) -> None:
+    """Emit telemetry for the album-title fallback (#319 / #237).
+
+    Mirrors the ``_log_resolver_pre_pass`` shape. The fallback's firing
+    population grew significantly when the gate changed from ``not raw_releases``
+    to ``not results`` (see WXYC/library-metadata-lookup#322 review), so each
+    fire is recorded both as an INFO log line and as a Sentry transaction
+    ``data.album_title_fallback`` attribute. Sentry can answer "what
+    percentage of /lookup calls trigger this fallback, and what's the
+    surface rate?" without re-pulling Railway logs.
+
+    No-op when there's no active Sentry transaction. Any SDK error is
+    swallowed so observability never breaks /lookup.
+    """
+    payload: dict[str, Any] = {
+        "album": album,
+        "n_candidates": n_candidates,
+        "surfaced_library_match": surfaced_library_match,
+    }
+    if error is not None:
+        payload["error"] = error
+        logger.warning("album_title_fallback %s", payload)
+    else:
+        logger.info("album_title_fallback %s", payload)
+    try:
+        transaction = sentry_sdk.get_current_scope().transaction
+        if transaction is not None:
+            transaction.set_data("album_title_fallback", payload)
+    except Exception as e:
+        logger.warning("Failed to project album_title_fallback onto Sentry transaction: %s", e)
+
+
 def _log_resolver_pre_pass(outcome: ResolverOutcome, *, actual_swap: bool) -> None:
     """Emit shadow-mode telemetry for the resolver pre-pass.
 
@@ -767,6 +805,15 @@ async def search_compilations_for_track(
         # Shelley Miller"), so the artist-scoped probes now return non-empty
         # raw_releases that all get filtered out downstream. Gate on actual
         # results, not Discogs response shape. See WXYC/library-metadata-lookup#237.
+        #
+        # Trade-off: the gate is ``not results`` rather than
+        # ``len(results) < MAX_SEARCH_RESULTS``. A partial initial pass (e.g.
+        # one valid match) suppresses the fallback entirely, even when more
+        # spots are available. Conservative-by-design — the fallback's
+        # purpose is to backfill the zero-results case, not augment partial
+        # ones. Revisit if measurements show partial-result requests would
+        # benefit from supplementation.
+        pre_fallback_results_count = len(results)
         if discogs_service and not results and parsed.album and not outcome.swapped:
             try:
                 fallback_response = await discogs_service.search_releases_by_album_title(
@@ -798,8 +845,18 @@ async def search_compilations_for_track(
                         break
                 if fallback_releases:
                     discogs_found_releases = True
+                _log_album_title_fallback(
+                    album=parsed.album,
+                    n_candidates=len(fallback_releases),
+                    surfaced_library_match=len(results) > pre_fallback_results_count,
+                )
             except Exception as e:
-                logger.warning(f"Album-title fallback failed for '{parsed.album}': {e}")
+                _log_album_title_fallback(
+                    album=parsed.album,
+                    n_candidates=0,
+                    surfaced_library_match=False,
+                    error=str(e),
+                )
     except Exception as e:
         logger.warning(f"Failed to search for track on other releases: {e}")
 

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -149,9 +149,7 @@ class TestAlbumTitleFallback:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_fallback_fires_when_artist_probe_returns_releases_but_library_filters_them_all(
-        self,
-    ):
+    async def test_fallback_fires_after_initial_pass_filters_everything(self):
         """Staging regression from 2026-05-13 (#237 follow-up).
 
         Discogs has since added a canonical "Orcutt Shelley Miller" artist
@@ -231,10 +229,13 @@ class TestAlbumTitleFallback:
     @pytest.mark.asyncio
     async def test_fallback_skipped_when_library_match_already_found(self):
         """The gate fires on ``not results`` (no library matches were
-        produced), not ``not raw_releases``. When the artist-scoped probes'
-        candidates DO turn into a library match via the existing pipeline,
-        the fallback adds no value and should not fire — its cost is one
-        extra Discogs API call per fire."""
+        produced), not ``not raw_releases``. (The gate name changed in #322;
+        the prior incarnation tested the Discogs-response-empty condition,
+        which no longer matches reality after Discogs added a canonical
+        trio entity.) When the artist-scoped probes' candidates DO turn
+        into a library match via the existing pipeline, the fallback adds
+        no value and should not fire — its cost is one extra Discogs API
+        call per fire."""
         library_item = make_library_item(id=42, artist="A Real Artist", title="An Album")
         db = AsyncMock()
         db.search = AsyncMock(return_value=[library_item])

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -149,14 +149,99 @@ class TestAlbumTitleFallback:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_fallback_skipped_when_results_present(self):
+    async def test_fallback_fires_when_artist_probe_returns_releases_but_library_filters_them_all(
+        self,
+    ):
+        """Staging regression from 2026-05-13 (#237 follow-up).
+
+        Discogs has since added a canonical "Orcutt Shelley Miller" artist
+        entity, so the artist-scoped probe in search_releases_by_track now
+        DOES return the trio's 5 pressings. raw_releases is non-empty —
+        which silenced the original `not raw_releases` fallback gate — and
+        process_release rejects all 5 via the album==artist self-named
+        guard (the library row's title 'Orcutt-Shelley-Miller' has an
+        artist of 'Bill Orcutt', not the trio). End state: zero results.
+
+        After the fix the gate fires on "no library results produced" so
+        the fallback runs as a second pass with skip_self_named_album=False
+        and skip_artist_match_filter=True, finds the library row, and
+        validate_track_on_release confirms it.
+        """
+        # Library returns the trio album (matched by title — note the
+        # hyphens in the actual library title) for any of these queries.
+        library_item = make_library_item(
+            id=72142,
+            artist="Bill Orcutt",
+            title="Orcutt-Shelley-Miller",
+        )
         db = AsyncMock()
-        db.search = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[library_item])
+
+        # Five pressings of the trio release returned by both probes.
+        # is_compilation=False (Discogs lists this under format=Vinyl) and
+        # album == parsed.artist, which trips the self-named-album guard
+        # in the default process_release path.
+        trio_pressings_response = TrackReleasesResponse(
+            track="A Star Is Born",
+            artist="Orcutt Shelley Miller",
+            releases=[
+                ReleaseInfo(
+                    album="Orcutt Shelley Miller",
+                    artist="Orcutt Shelley Miller",
+                    release_id=rid,
+                    release_url=f"https://www.discogs.com/release/{rid}",
+                    is_compilation=False,
+                )
+                for rid in (35017901, 35220253, 34993109, 34998866, 34993607)
+            ],
+            total=5,
+        )
 
         service = AsyncMock()
         service.cache_service = AsyncMock()
         service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
-        # First probe returns a non-empty result so the fallback shouldn't fire.
+        service.search_releases_by_track = AsyncMock(return_value=trio_pressings_response)
+        service.search_releases_by_album_title = AsyncMock(return_value=_trio_response())
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="Orcutt Shelley Miller",
+            album="Orcutt Shelley Miller",
+            song="A Star Is Born",
+            raw_message="Orcutt Shelley Miller - A Star Is Born",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            results, _titles = await search_compilations_for_track(
+                db, parsed, discogs_service=service
+            )
+
+        service.search_releases_by_album_title.assert_awaited_once()
+        assert any(r.id == 72142 for r in results), (
+            "Expected library row 72142 to surface via the album-title fallback "
+            "after the artist-scoped probes' candidates were all filtered out by "
+            "process_release's default guards. Got: "
+            f"{[(r.id, r.title) for r in results]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_skipped_when_library_match_already_found(self):
+        """The gate fires on ``not results`` (no library matches were
+        produced), not ``not raw_releases``. When the artist-scoped probes'
+        candidates DO turn into a library match via the existing pipeline,
+        the fallback adds no value and should not fire — its cost is one
+        extra Discogs API call per fire."""
+        library_item = make_library_item(id=42, artist="A Real Artist", title="An Album")
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[library_item])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
         service.search_releases_by_track = AsyncMock(
             return_value=TrackReleasesResponse(
                 track="A Song",
@@ -187,8 +272,9 @@ class TestAlbumTitleFallback:
             new_callable=AsyncMock,
             return_value=[],
         ):
-            await search_compilations_for_track(db, parsed, discogs_service=service)
+            results, _ = await search_compilations_for_track(db, parsed, discogs_service=service)
 
+        assert any(r.id == 42 for r in results)
         service.search_releases_by_album_title.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #321. Reopens the close of #237.

## Problem

After #321 merged to staging, the #237 acceptance smoke still returned zero results:

\`\`\`
POST /api/v1/lookup
{"artist": "Orcutt Shelley Miller",
 "album": "Orcutt Shelley Miller",
 "song": "A Star Is Born"}
→ {"results": [], "song_not_found": true, ...}
\`\`\`

Root cause: Discogs has since added a canonical \`Orcutt Shelley Miller\` artist entity, so the artist-scoped probes in \`search_releases_by_track\` now DO return the trio's 5 pressings. \`raw_releases\` is non-empty — which silenced #321's \`not raw_releases\` fallback gate — but \`process_release\` rejects all 5 via the album==artist self-named guard. The library row (\`title='Orcutt-Shelley-Miller', artist='Bill Orcutt'\`) is real but never reached.

I verified this directly:

\`\`\`bash
curl ".../database/search?type=release&track=A+Star+Is+Born&artist=Orcutt+Shelley+Miller"
# Returns 5 pressings including 34993109 ← contradicts #237's original analysis
\`\`\`

## Fix

The fallback now gates on **library results**, not Discogs response shape. Runs as a second pass after the existing \`process_release\` loop, with \`skip_self_named_album=False\` and \`skip_artist_match_filter=True\`, so the trio case is handled regardless of which artist-scoped probes returned candidates.

Three-condition gate preserved (cost guard):
1. \`not results\` — the existing pipeline produced no library matches
2. \`parsed.album\` — we have a title to query with
3. \`not outcome.swapped\` — the resolver didn't already canonicalize the artist (which would have helped the existing probes)

## Test plan

- [x] New unit test (\`tests/unit/test_album_title_fallback.py\`) reproduces the staging shape: artist-scoped probes return the 5 trio pressings, library returns the actual WXYC row, gate fires, library row surfaces. Test fails on \`main\`, passes after the fix.
- [x] Renamed \`test_fallback_skipped_when_results_present\` → \`test_fallback_skipped_when_library_match_already_found\` and adjusted to set up an actual library match in \`db.search\` — the old version was testing the prior gate ("Discogs response non-empty") which no longer matches reality.
- [x] Existing trio surfacing test (\`test_trio_release_surfaces_through_fallback_with_mismatching_library_artist\`) still passes — same fallback, same kwargs, just invoked from the new gate.
- [x] Full unit suite: 1675 passed.
- [x] Lint + format + typecheck clean.
- [ ] Staging smoke (post-merge): the #237 acceptance POST returns the trio library item in \`results\`.

## Cost

Unchanged. The fallback still fires at most once per request, with the same three-condition guard and the same skip-most-of-the-time semantics. The only difference is that the gate now responds to actual behavior ("we didn't find anything") rather than a stale assumption about Discogs's response shape.

## What's NOT addressed in this PR

The calibration sweep is still pending. The local discogs-cache has \`artist_name_variation = 0 rows\` and no \`entity.identity\` schema, so the harness can't produce a meaningful sweep until the cache rebuild lands (blocked on WXYC/discogs-etl#188). The \`CANONICAL_ARTIST_SIMILARITY_FLOOR = 0.70\` provisional value stands. \`LML_RESOLVE_ARTIST_CANONICAL\` stays \`false\` in Railway.

Closes #237.