### PR TITLE
feat(search): SONG_AS_TRACK strategy + matched_via emission (E2-1)

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -383,8 +383,9 @@ async def execute_search_pipeline(
                 state.song_not_found = False
 
         elif strategy.name == SearchStrategyType.SONG_AS_TRACK:
-            # Cross-reference song against Discogs; match releases back to library.
-            # Returns (library_items, matched_via_by_id) — see plan §4.2.
+            # Two-value unpack (unlike other branches): the strategy returns
+            # matched_via_by_id alongside the library items so SearchState can
+            # carry provenance to perform_lookup. See plan §4.2.
             results, matched_via_by_id = await strategy.execute(db, parsed.song)
             if results:
                 state.results = results

--- a/core/search.py
+++ b/core/search.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from generated.api_models import TrackMatchHint
 from library.db import LibraryDB
 from library.models import LibraryItem
 from services.parser import ParsedRequest
@@ -78,6 +79,11 @@ class SearchStrategyType(StrEnum):
     SONG_AS_ARTIST = "song_as_artist"
     """Fallback: try parsed song as artist when no results and no artist parsed."""
 
+    SONG_AS_TRACK = "song_as_track"
+    """Fallback: cross-reference the parsed song against Discogs and match releases
+    back to the WXYC library. Fires for song-only inputs after SONG_AS_ARTIST returns
+    empty. Load-bearing for catalog-track-search (plan §4.2)."""
+
     KEYWORD_MATCH = "keyword_match"
     """Significant word extraction search."""
 
@@ -115,6 +121,14 @@ class SearchState:
     are preserved here so perform_lookup can validate them against Discogs tracklists
     and merge any confirmed matches (e.g., the artist's own album containing the track)
     back into the final results.
+    """
+
+    matched_via_by_id: dict[int, list[TrackMatchHint]] = field(default_factory=dict)
+    """Per-library-id provenance for track-driven matches (catalog-track-search §5.1).
+
+    Populated by SONG_AS_TRACK when a track-title cross-reference surfaces a library
+    row. perform_lookup() reads this when building LookupResultItem.matched_via so
+    the API contract carries the track→release linkage back to the caller.
     """
 
 
@@ -202,6 +216,24 @@ def no_results_and_song_but_no_artist(
     return not state.results and bool(parsed.song) and not parsed.artist
 
 
+def no_results_and_song_but_no_artist_track_fallback(
+    parsed: ParsedRequest, state: SearchState, raw_message: str
+) -> bool:
+    """Condition: SONG_AS_ARTIST already ran and produced nothing.
+
+    Fires after the song-as-artist interpretation has failed, then treats the
+    song as a *track* and cross-references against Discogs to find releases
+    that contain it. Strictly downstream of SONG_AS_ARTIST so the
+    parser-misread-artist case keeps first-crack ordering.
+    """
+    return (
+        not state.results
+        and bool(parsed.song)
+        and not parsed.artist
+        and SearchStrategyType.SONG_AS_ARTIST in state.strategies_tried
+    )
+
+
 # =============================================================================
 # Strategy Registry
 # =============================================================================
@@ -212,6 +244,7 @@ def build_strategies(
     search_alternative_func: ExecuteFunc,
     search_compilations_func: ExecuteFunc,
     search_song_as_artist_func: ExecuteFunc | None = None,
+    search_song_as_track_func: ExecuteFunc | None = None,
 ) -> list[SearchStrategy]:
     """Build the list of search strategies with injected execute functions.
 
@@ -223,6 +256,8 @@ def build_strategies(
         search_alternative_func: Function implementing SWAPPED_INTERPRETATION search
         search_compilations_func: Function implementing TRACK_ON_COMPILATION search
         search_song_as_artist_func: Function implementing SONG_AS_ARTIST search
+        search_song_as_track_func: Function implementing SONG_AS_TRACK search
+            (catalog-track-search §4.2). Fires strictly after SONG_AS_ARTIST.
 
     Returns:
         List of SearchStrategy objects in execution order
@@ -254,6 +289,17 @@ def build_strategies(
                 name=SearchStrategyType.SONG_AS_ARTIST,
                 condition=no_results_and_song_but_no_artist,
                 execute=search_song_as_artist_func,
+            )
+        )
+
+    # SONG_AS_TRACK must come AFTER SONG_AS_ARTIST — its condition checks that
+    # SONG_AS_ARTIST already ran and produced nothing.
+    if search_song_as_track_func is not None:
+        strategies.append(
+            SearchStrategy(
+                name=SearchStrategyType.SONG_AS_TRACK,
+                condition=no_results_and_song_but_no_artist_track_fallback,
+                execute=search_song_as_track_func,
             )
         )
 
@@ -336,6 +382,15 @@ async def execute_search_pipeline(
                 state.results = results
                 state.song_not_found = False
 
+        elif strategy.name == SearchStrategyType.SONG_AS_TRACK:
+            # Cross-reference song against Discogs; match releases back to library.
+            # Returns (library_items, matched_via_by_id) — see plan §4.2.
+            results, matched_via_by_id = await strategy.execute(db, parsed.song)
+            if results:
+                state.results = results
+                state.song_not_found = False
+                state.matched_via_by_id = matched_via_by_id or {}
+
         # Stop if we found results (unless we're doing compilation search which can replace results)
         if state.results and strategy.name != SearchStrategyType.TRACK_ON_COMPILATION:
             # For compilation search, we continue even if we have artist-only results
@@ -371,5 +426,10 @@ def get_search_type_from_state(state: SearchState) -> str:
         return "compilation"
     elif last_strategy == SearchStrategyType.SONG_AS_ARTIST:
         return "song_as_artist"
+    elif last_strategy == SearchStrategyType.SONG_AS_TRACK:
+        # api.yaml v1.3.0 SearchType has no `song_as_track` value. Precise
+        # provenance lives on matched_via.source per plan §5.1; from the
+        # caller's lens, track-driven matches are compilation-class.
+        return "compilation"
 
     return "none"

--- a/core/search.py
+++ b/core/search.py
@@ -390,7 +390,7 @@ async def execute_search_pipeline(
             if results:
                 state.results = results
                 state.song_not_found = False
-                state.matched_via_by_id = matched_via_by_id or {}
+                state.matched_via_by_id = matched_via_by_id
 
         # Stop if we found results (unless we're doing compilation search which can replace results)
         if state.results and strategy.name != SearchStrategyType.TRACK_ON_COMPILATION:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -30,7 +30,12 @@ from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
 from discogs.memory_cache import create_ttl_cache, should_skip_cache
 from discogs.models import DiscogsSearchRequest, DiscogsSearchResult, ReleaseInfo
 from discogs.service import DiscogsService
-from generated.api_models import LibraryCatalogItem, ReconciledIdentity
+from generated.api_models import (
+    LibraryCatalogItem,
+    ReconciledIdentity,
+    TrackMatchHint,
+    TrackMatchSource,
+)
 from library.db import STOPWORDS, LibraryDB
 from library.models import LibraryItem
 from lookup.external_search import (
@@ -459,6 +464,107 @@ async def search_song_as_artist(
         )
 
     return limit_results(results), None
+
+
+SONG_AS_TRACK_CONFIDENCE: float = 0.85
+"""Default confidence floor for SONG_AS_TRACK matches.
+
+Pinned at the master-cap value from catalog-track-search plan §5.2. The
+underlying ``search_releases_by_track`` cache path doesn't currently distinguish
+release- vs master-level matches, so we conservatively report the master cap.
+When LML graduates onto ``library_identity`` per cross-cache-identity (#25),
+this floor is replaced with ``library_identity.confidence`` per row.
+"""
+
+
+async def search_song_as_track(
+    db: LibraryDB,
+    song: str | None,
+    discogs_service: DiscogsService | None = None,
+) -> tuple[list[LibraryItem], dict[int, list[TrackMatchHint]]]:
+    """Cross-reference song against Discogs and match releases back to library.
+
+    Catalog-track-search §4.2 / LML#301: when SONG_AS_ARTIST returns empty for a
+    song-only query, treat the song as a *track* — find Discogs releases that
+    contain it, then fuzzy-match those releases against the WXYC library. Each
+    surviving row carries a TrackMatchHint recording the track→release linkage.
+
+    Args:
+        db: Library database for album fuzzy search.
+        song: The track title from the user query.
+        discogs_service: Required. Without it, this strategy no-ops.
+
+    Returns:
+        Tuple of (library_items, matched_via_by_id). matched_via_by_id maps
+        each library row's id to one-or-more TrackMatchHint entries — multiple
+        hints accumulate when the same WXYC row is referenced by multiple
+        Discogs releases (different pressings, etc.).
+    """
+    if not song or not discogs_service:
+        return [], {}
+
+    response = await discogs_service.search_releases_by_track(song, artist=None)
+    raw_releases = list(response.releases or [])
+    if not raw_releases:
+        logger.info(f"SONG_AS_TRACK: no Discogs releases for '{song}'")
+        return [], {}
+
+    logger.info(
+        f"SONG_AS_TRACK: {len(raw_releases)} Discogs releases for '{song}', "
+        "matching against library"
+    )
+
+    seen_ids: set[int] = set()
+    matched_items: list[LibraryItem] = []
+    matched_via_by_id: dict[int, list[TrackMatchHint]] = {}
+
+    for release in raw_releases:
+        if not release.album or len(release.album.strip()) < 3:
+            continue
+
+        matches = await search_album_fuzzy(db, release.album)
+        if not matches and release.is_compilation:
+            matches = await search_album_fuzzy(db, f"Various {release.album}")
+        if not matches:
+            continue
+
+        for item in matches:
+            if release.is_compilation and is_compilation_artist(item.artist or ""):
+                accept = True
+            elif item.artist and artist_matches_item(item, release.artist):
+                accept = True
+            else:
+                continue
+
+            if not accept:
+                continue
+
+            hint = TrackMatchHint(
+                title=song,
+                artist_credit=release.artist if release.is_compilation else None,
+                position=None,
+                confidence=SONG_AS_TRACK_CONFIDENCE,
+                source=TrackMatchSource.discogs_release,
+            )
+
+            if item.id in seen_ids:
+                matched_via_by_id[item.id].append(hint)
+                continue
+
+            seen_ids.add(item.id)
+            matched_items.append(item)
+            matched_via_by_id[item.id] = [hint]
+            logger.info(
+                f"SONG_AS_TRACK: matched '{item.artist} - {item.title}' "
+                f"via release '{release.album}'"
+            )
+
+            if len(matched_items) >= MAX_SEARCH_RESULTS:
+                break
+        if len(matched_items) >= MAX_SEARCH_RESULTS:
+            break
+
+    return matched_items, matched_via_by_id
 
 
 async def search_library_with_fallback(
@@ -1477,6 +1583,9 @@ async def perform_lookup(
             search_song_as_artist_func=partial(
                 search_song_as_artist, discogs_service=discogs_service
             ),
+            search_song_as_track_func=partial(
+                search_song_as_track, discogs_service=discogs_service
+            ),
         )
 
         search_state = await execute_search_pipeline(
@@ -1582,6 +1691,7 @@ async def perform_lookup(
         return identities_by_artist.get(item.artist)
 
     # Build response (convert internal models to API contract models)
+    matched_via_by_id = search_state.matched_via_by_id
     result_items = []
     if items_with_artwork:
         for item, artwork in items_with_artwork:
@@ -1590,6 +1700,7 @@ async def perform_lookup(
                     library_item=item.to_catalog_item(),
                     artwork=artwork.to_match_result() if artwork else None,
                     reconciled_identity=_identity_for(item),
+                    matched_via=matched_via_by_id.get(item.id),
                 )
             )
     elif library_results:
@@ -1598,6 +1709,7 @@ async def perform_lookup(
                 LookupResultItem(
                     library_item=item.to_catalog_item(),
                     reconciled_identity=_identity_for(item),
+                    matched_via=matched_via_by_id.get(item.id),
                 )
             )
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -530,13 +530,10 @@ async def search_song_as_track(
 
         for item in matches:
             if release.is_compilation and is_compilation_artist(item.artist or ""):
-                accept = True
+                pass
             elif item.artist and artist_matches_item(item, release.artist):
-                accept = True
+                pass
             else:
-                continue
-
-            if not accept:
                 continue
 
             hint = TrackMatchHint(

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -528,14 +528,24 @@ async def search_song_as_track(
         if not matches:
             continue
 
-        for item in matches:
-            if release.is_compilation and is_compilation_artist(item.artist or ""):
-                pass
-            elif item.artist and artist_matches_item(item, release.artist):
-                pass
-            else:
-                continue
+        eligible = [m for m in matches if _release_matches_library_row(release, m)]
+        if not eligible:
+            continue
 
+        # Validate the track actually appears on this release before surfacing
+        # — Discogs's release-search index is keyword-driven and returns hits
+        # that don't always contain the track on the tracklist. Deferred until
+        # after library matching so we only pay the API cost for releases we'd
+        # actually return, mirroring search_compilations_for_track.
+        if release.release_id and not await discogs_service.validate_track_on_release(
+            release.release_id, song, release.artist
+        ):
+            logger.debug(
+                f"SONG_AS_TRACK: skipping '{release.album}' — track not validated on release"
+            )
+            continue
+
+        for item in eligible:
             hint = TrackMatchHint(
                 title=song,
                 artist_credit=release.artist if release.is_compilation else None,
@@ -551,7 +561,7 @@ async def search_song_as_track(
             seen_ids.add(item.id)
             matched_items.append(item)
             matched_via_by_id[item.id] = [hint]
-            logger.info(
+            logger.debug(
                 f"SONG_AS_TRACK: matched '{item.artist} - {item.title}' "
                 f"via release '{release.album}'"
             )
@@ -562,6 +572,22 @@ async def search_song_as_track(
             break
 
     return matched_items, matched_via_by_id
+
+
+def _release_matches_library_row(release: ReleaseInfo, item: LibraryItem) -> bool:
+    """Predicate: does ``release``'s artist credit match ``item``'s library artist?
+
+    Compilation-aware: for VA releases (``release.is_compilation``), any library
+    row whose artist field is itself a compilation marker (e.g., "Various
+    Artists - Rock - D") qualifies. For non-compilations, the library row's
+    artist must prefix-match the Discogs release artist via the existing
+    ``artist_matches_item`` rules.
+    """
+    if release.is_compilation and is_compilation_artist(item.artist or ""):
+        return True
+    if item.artist and artist_matches_item(item, release.artist):
+        return True
+    return False
 
 
 async def search_library_with_fallback(

--- a/tests/integration/test_song_as_track.py
+++ b/tests/integration/test_song_as_track.py
@@ -1,0 +1,98 @@
+"""Integration test for the SONG_AS_TRACK strategy against the real discogs-cache.
+
+Verifies catalog-track-search §4.2 / LML#301 end-to-end: a song-only query
+resolves against the real discogs-cache PG, fuzzy-matches back to the seeded
+library row, and emits ``matched_via`` with the expected provenance shape.
+
+Run with::
+
+    DATABASE_URL_DISCOGS=postgresql://... pytest -m pg tests/integration/test_song_as_track.py -v
+
+Self-skips when:
+    - ``DATABASE_URL_DISCOGS`` is unset, or
+    - the connected cache lacks ``release_track`` (the discogs-fixture table is
+      too large to load in CI, matching ``test_va_discogs_lookup.py``'s
+      pattern).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from discogs.cache_service import DiscogsCacheService
+from discogs.service import DiscogsService
+from generated.api_models import TrackMatchSource
+from lookup.orchestrator import search_song_as_track
+
+DATABASE_URL = os.environ.get("DATABASE_URL_DISCOGS")
+pytestmark = [
+    pytest.mark.pg,
+    pytest.mark.skipif(not DATABASE_URL, reason="DATABASE_URL_DISCOGS not set"),
+]
+
+
+@pytest_asyncio.fixture
+async def discogs_service():
+    """Real DiscogsService backed by the cache; validation stubbed.
+
+    The acceptance criterion targets the cache-driven track search +
+    library-match plumbing. ``validate_track_on_release`` is unit-tested
+    separately (``test_validation_failure_skips_release``); stubbing it here
+    keeps this test focused on the integration with the real cache and
+    avoids the cache-miss → real-API fallback path on hosts whose cache
+    happens not to carry the tracklist row.
+
+    Skips when the cache lacks ``release_track``, mirroring
+    ``test_va_discogs_lookup.py``'s skip-on-missing-fixture pattern.
+    """
+    pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=2)
+    try:
+        async with pool.acquire() as conn:
+            has_release_track = await conn.fetchval(
+                "SELECT to_regclass('public.release_track') IS NOT NULL"
+            )
+        if not has_release_track:
+            pytest.skip("discogs-cache schema lacks `release_track` (too large for CI fixture)")
+
+        cache = DiscogsCacheService(pool=pool)
+        service = DiscogsService(token="not-used-cache-path-only", cache_service=cache)
+        service.validate_track_on_release = AsyncMock(return_value=True)
+        yield service
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+class TestSongAsTrackAgainstDiscogsCache:
+    async def test_vi_scose_poise_returns_confield(self, library_db, discogs_service):
+        """The motivating Confield case from LML#301.
+
+        "vi scose poise" is a track on Autechre's *Confield*. The cache's
+        ``search_releases_by_track`` should surface a Confield release, the
+        helper should fuzzy-match it against the seeded library row (id=39),
+        and the response should carry a TrackMatchHint with
+        ``source=discogs_release`` and the track title preserved.
+        """
+        results, matched_via = await search_song_as_track(
+            library_db, "vi scose poise", discogs_service=discogs_service
+        )
+
+        assert any(item.id == 39 for item in results), (
+            "Expected Confield (library_db id=39) in results, got "
+            f"{[(i.id, i.artist, i.title) for i in results]}"
+        )
+
+        confield_hints = matched_via[39]
+        assert len(confield_hints) >= 1
+        assert any(
+            hint.title.lower() == "vi scose poise"
+            and hint.source == TrackMatchSource.discogs_release
+            and hint.confidence is not None
+            and hint.confidence <= 0.85
+            for hint in confield_hints
+        ), f"Expected discogs_release-source hint for 'vi scose poise', got {confield_hints}"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -16,6 +16,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from discogs.models import DiscogsSearchResponse
+from generated.api_models import (
+    DiscogsReleaseInfo,
+    DiscogsTrackReleasesResponse,
+    TrackMatchSource,
+)
 from library.models import LibraryItem
 from lookup.models import LookupRequest, LookupResponse
 from lookup.orchestrator import perform_lookup
@@ -190,6 +195,79 @@ class TestPerformLookupBasic:
         assert len(response.results) == 1
         assert response.results[0].library_item.artist == "Queen"
         assert response.results[0].artwork is None
+
+    @pytest.mark.asyncio
+    async def test_song_as_track_emits_matched_via_on_result_item(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """Song-only query 'vi scose poise' surfaces Confield with matched_via populated.
+
+        Verifies the full wiring: SONG_AS_TRACK strategy runs after SONG_AS_ARTIST
+        returns empty, the result row's matched_via dict is plumbed through
+        SearchState into LookupResultItem.matched_via, and the TrackMatchHint
+        records source=discogs_release with the track title.
+        """
+        confield = make_library_item(id=60359, artist="Autechre", title="Confield")
+
+        # SONG_AS_ARTIST does: db.search(query=song) → []
+        # SONG_AS_TRACK does: db.search(query=album) → [confield]
+        async def search_side_effect(query, **kwargs):
+            return [confield] if query and "confield" in query.lower() else []
+
+        mock_library_db.search.side_effect = search_side_effect
+        mock_discogs_service.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="vi scose poise",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Confield",
+                    artist="Autechre",
+                    release_id=8434,
+                    release_url="https://discogs.com/release/8434",
+                    is_compilation=False,
+                )
+            ],
+            total=1,
+        )
+        # SONG_AS_ARTIST queries Discogs by artist; return empty so it falls through.
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+        mock_discogs_service.get_release = AsyncMock(return_value=None)
+
+        request = LookupRequest(song="vi scose poise", raw_message="vi scose poise")
+
+        response = await perform_lookup(request, mock_library_db, mock_discogs_service, telemetry)
+
+        assert len(response.results) == 1
+        item = response.results[0]
+        assert item.library_item.artist == "Autechre"
+        assert item.library_item.title == "Confield"
+        assert item.matched_via is not None
+        assert len(item.matched_via) == 1
+        hint = item.matched_via[0]
+        assert hint.title == "vi scose poise"
+        assert hint.source == TrackMatchSource.discogs_release
+
+    @pytest.mark.asyncio
+    async def test_matched_via_absent_on_non_track_match(
+        self, mock_library_db, mock_discogs_service, telemetry, queen_item
+    ):
+        """When the result came via ARTIST_PLUS_ALBUM, matched_via is None.
+
+        Guards against accidental population of matched_via on non-track-driven
+        results — the field is reserved for track-search provenance per plan §5.1.
+        """
+        mock_library_db.search.return_value = [queen_item]
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        request = LookupRequest(
+            artist="Queen",
+            album="A Night at the Opera",
+            raw_message="A Night at the Opera by Queen",
+        )
+
+        response = await perform_lookup(request, mock_library_db, mock_discogs_service, telemetry)
+
+        assert len(response.results) == 1
+        assert response.results[0].matched_via is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1421,3 +1421,115 @@ class TestSearchSongAsTrack:
 
         assert results == [va_album]
         assert matched_via[12345][0].artist_credit == "Adonis"
+
+    @pytest.mark.asyncio
+    async def test_validation_failure_skips_release(self):
+        """When validate_track_on_release returns False, the release is dropped.
+
+        Discogs's release-search index returns keyword hits that don't always
+        carry the song on their tracklist; validation rejects those before they
+        surface as false positives in the API response.
+        """
+        confield = make_library_item(id=60359, artist="Autechre", title="Confield")
+        db = AsyncMock()
+        db.search.return_value = [confield]
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="vi scose poise",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Confield",
+                    artist="Autechre",
+                    release_id=8434,
+                    release_url="https://discogs.com/release/8434",
+                    is_compilation=False,
+                )
+            ],
+            total=1,
+        )
+        svc.validate_track_on_release.return_value = False
+
+        results, matched_via = await search_song_as_track(db, "vi scose poise", discogs_service=svc)
+
+        assert results == []
+        assert matched_via == {}
+        svc.validate_track_on_release.assert_awaited_once_with(8434, "vi scose poise", "Autechre")
+
+    @pytest.mark.asyncio
+    async def test_multiple_releases_accumulate_hints_for_same_row(self):
+        """Two Discogs releases pointing at the same WXYC row accumulate hints.
+
+        A reissue/remaster pair shares the same library row but distinct
+        Discogs release IDs. matched_via_by_id[id] must list one hint per
+        release rather than collapsing to a single entry.
+        """
+        confield = make_library_item(id=60359, artist="Autechre", title="Confield")
+        db = AsyncMock()
+        db.search.return_value = [confield]
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="vi scose poise",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Confield",
+                    artist="Autechre",
+                    release_id=8434,
+                    release_url="https://discogs.com/release/8434",
+                    is_compilation=False,
+                ),
+                DiscogsReleaseInfo(
+                    album="Confield",
+                    artist="Autechre",
+                    release_id=999,
+                    release_url="https://discogs.com/release/999",
+                    is_compilation=False,
+                ),
+            ],
+            total=2,
+        )
+
+        results, matched_via = await search_song_as_track(db, "vi scose poise", discogs_service=svc)
+
+        assert results == [confield]
+        assert len(matched_via[60359]) == 2
+
+    @pytest.mark.asyncio
+    async def test_compilation_falls_back_to_various_prefix_search(self):
+        """When album-only fuzzy search misses for a compilation, retry with 'Various '.
+
+        FTS5 entries stored as "Various Artists — <title>" don't always match a
+        bare album-title query; prefixing with 'Various' helps the tokenizer.
+        """
+        va_album = make_library_item(
+            id=11111,
+            artist="Various Artists",
+            title="Trax Records 20th Anniversary Collection",
+        )
+        db = AsyncMock()
+
+        async def search_side_effect(query, **kwargs):
+            return [va_album] if query.startswith("Various ") else []
+
+        db.search.side_effect = search_side_effect
+
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="No Way Back",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Trax Records 20th Anniversary Collection",
+                    artist="Adonis",
+                    release_id=222,
+                    release_url="https://discogs.com/release/222",
+                    is_compilation=True,
+                )
+            ],
+            total=1,
+        )
+
+        results, matched_via = await search_song_as_track(db, "No Way Back", discogs_service=svc)
+
+        assert results == [va_album]
+        assert matched_via[11111][0].artist_credit == "Adonis"
+        queries = [call.kwargs["query"] for call in db.search.await_args_list]
+        assert any(q.startswith("Various ") for q in queries)

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -20,6 +20,11 @@ from discogs.models import (
     DiscogsSearchResponse,
     ReleaseMetadataResponse,
 )
+from generated.api_models import (
+    DiscogsReleaseInfo,
+    DiscogsTrackReleasesResponse,
+    TrackMatchSource,
+)
 from lookup.orchestrator import (
     artist_matches_item,
     build_context_message,
@@ -29,6 +34,7 @@ from lookup.orchestrator import (
     find_library_albums_with_cached_track,
     resolve_albums_for_track,
     search_library_with_fallback,
+    search_song_as_track,
     search_with_alternative_interpretation,
 )
 from services.parser import MessageType, ParsedRequest
@@ -1268,3 +1274,150 @@ class TestFetchArtworkFallback:
         assert len(results) == 1
         assert results[0][1] is not None
         assert results[0][1].artwork_url is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: search_song_as_track (catalog-track-search §4.2, LML#301)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSongAsTrack:
+    """SONG_AS_TRACK strategy: cross-reference song against Discogs, match
+    releases back to library, emit matched_via TrackMatchHint per row."""
+
+    @pytest.mark.asyncio
+    async def test_no_song_returns_empty(self):
+        db = AsyncMock()
+        results, matched_via = await search_song_as_track(db, None)
+        assert results == []
+        assert matched_via == {}
+        db.search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_blank_song_returns_empty(self):
+        db = AsyncMock()
+        results, matched_via = await search_song_as_track(db, "")
+        assert results == []
+        assert matched_via == {}
+
+    @pytest.mark.asyncio
+    async def test_no_discogs_service_returns_empty(self):
+        """Without a Discogs service, the strategy can't run and must no-op."""
+        db = AsyncMock()
+        results, matched_via = await search_song_as_track(
+            db, "vi scose poise", discogs_service=None
+        )
+        assert results == []
+        assert matched_via == {}
+        db.search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_discogs_releases_returns_empty(self):
+        db = AsyncMock()
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="vi scose poise", artist=None, releases=[], total=0
+        )
+
+        results, matched_via = await search_song_as_track(db, "vi scose poise", discogs_service=svc)
+
+        assert results == []
+        assert matched_via == {}
+        db.search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_library_miss_returns_empty(self):
+        """Discogs returns releases but none match in library — empty result."""
+        db = AsyncMock()
+        db.search.return_value = []
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="unknown song",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Some Album",
+                    artist="Some Artist",
+                    release_id=999,
+                    release_url="https://discogs.com/release/999",
+                    is_compilation=False,
+                )
+            ],
+            total=1,
+        )
+
+        results, matched_via = await search_song_as_track(db, "unknown song", discogs_service=svc)
+
+        assert results == []
+        assert matched_via == {}
+
+    @pytest.mark.asyncio
+    async def test_match_emits_track_match_hint(self):
+        """Confield case: 'vi scose poise' → Autechre's Confield.
+
+        The matched row gets a TrackMatchHint with the song as title,
+        source=discogs_release, confidence at the master-cap floor (≤ 0.85
+        per plan §5.2), and no per-track position (we don't fetch tracklists).
+        """
+        confield = make_library_item(id=60359, artist="Autechre", title="Confield")
+        db = AsyncMock()
+        db.search.return_value = [confield]
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="vi scose poise",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Confield",
+                    artist="Autechre",
+                    release_id=8434,
+                    release_url="https://discogs.com/release/8434",
+                    is_compilation=False,
+                )
+            ],
+            total=1,
+        )
+
+        results, matched_via = await search_song_as_track(db, "vi scose poise", discogs_service=svc)
+
+        assert results == [confield]
+        assert 60359 in matched_via
+        hints = matched_via[60359]
+        assert len(hints) == 1
+        hint = hints[0]
+        assert hint.title == "vi scose poise"
+        assert hint.source == TrackMatchSource.discogs_release
+        assert hint.confidence is not None and hint.confidence <= 0.85
+        assert hint.position is None
+
+    @pytest.mark.asyncio
+    async def test_compilation_match_carries_artist_credit(self):
+        """For VA compilations, the hint records the per-release artist credit.
+
+        Plan §5.1: artist_credit is the per-track artist for compilations;
+        null for non-comp tracks where the release-level artist applies.
+        """
+        va_album = make_library_item(
+            id=12345,
+            artist="Various Artists",
+            title="Trax Records 20th Anniversary Collection",
+        )
+        db = AsyncMock()
+        db.search.return_value = [va_album]
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="No Way Back",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Trax Records 20th Anniversary Collection",
+                    artist="Adonis",
+                    release_id=555,
+                    release_url="https://discogs.com/release/555",
+                    is_compilation=True,
+                )
+            ],
+            total=1,
+        )
+
+        results, matched_via = await search_song_as_track(db, "No Way Back", discogs_service=svc)
+
+        assert results == [va_album]
+        assert matched_via[12345][0].artist_credit == "Adonis"

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -13,8 +13,10 @@ from core.search import (
     has_artist_or_album_or_song,
     no_results_and_ambiguous_format,
     no_results_and_song_but_no_artist,
+    no_results_and_song_but_no_artist_track_fallback,
     song_not_found_with_artist_and_song,
 )
+from generated.api_models import TrackMatchHint, TrackMatchSource
 from services.parser import ParsedRequest
 from tests.factories import make_library_item as _item
 
@@ -64,6 +66,20 @@ class TestGetSearchTypeFromState:
         state.strategies_tried = [SearchStrategyType.SONG_AS_ARTIST]
         assert get_search_type_from_state(state) == "song_as_artist"
 
+    def test_song_as_track_maps_to_compilation(self):
+        """SONG_AS_TRACK reuses the existing 'compilation' search_type.
+
+        The api.yaml v1.3.0 SearchType enum has no `song_as_track` value;
+        the precise provenance lives on `matched_via.source` per plan §5.1.
+        Track-driven matches are compilation-class from the caller's lens.
+        """
+        state = SearchState()
+        state.strategies_tried = [
+            SearchStrategyType.SONG_AS_ARTIST,
+            SearchStrategyType.SONG_AS_TRACK,
+        ]
+        assert get_search_type_from_state(state) == "compilation"
+
 
 # ---------------------------------------------------------------------------
 # Condition functions
@@ -111,6 +127,49 @@ class TestConditions:
         state = SearchState()
         assert no_results_and_song_but_no_artist(parsed, state, "test") is False
 
+    # SONG_AS_TRACK condition — must fire only after SONG_AS_ARTIST returned empty.
+
+    def test_track_fallback_when_song_as_artist_failed(self):
+        """Condition fires after SONG_AS_ARTIST ran and produced nothing."""
+        parsed = ParsedRequest(song="vi scose poise", raw_message="vi scose poise")
+        state = SearchState(strategies_tried=[SearchStrategyType.SONG_AS_ARTIST])
+        assert (
+            no_results_and_song_but_no_artist_track_fallback(parsed, state, "vi scose poise")
+            is True
+        )
+
+    def test_track_fallback_blocked_when_song_as_artist_not_tried(self):
+        """Without SONG_AS_ARTIST in strategies_tried, the track fallback must wait.
+
+        This preserves the strategy cascade ordering: SONG_AS_ARTIST gets first
+        crack at song-only queries (it covers the parser-misread-artist case),
+        and SONG_AS_TRACK only steps in if that failed.
+        """
+        parsed = ParsedRequest(song="vi scose poise", raw_message="vi scose poise")
+        state = SearchState()
+        assert (
+            no_results_and_song_but_no_artist_track_fallback(parsed, state, "vi scose poise")
+            is False
+        )
+
+    def test_track_fallback_blocked_when_results_present(self):
+        parsed = ParsedRequest(song="X", raw_message="X")
+        state = SearchState(
+            results=[_item()],
+            strategies_tried=[SearchStrategyType.SONG_AS_ARTIST],
+        )
+        assert no_results_and_song_but_no_artist_track_fallback(parsed, state, "X") is False
+
+    def test_track_fallback_blocked_when_artist_parsed(self):
+        parsed = ParsedRequest(artist="Autechre", song="vi scose poise", raw_message="test")
+        state = SearchState(strategies_tried=[SearchStrategyType.SONG_AS_ARTIST])
+        assert no_results_and_song_but_no_artist_track_fallback(parsed, state, "test") is False
+
+    def test_track_fallback_blocked_when_no_song(self):
+        parsed = ParsedRequest(raw_message="test")
+        state = SearchState(strategies_tried=[SearchStrategyType.SONG_AS_ARTIST])
+        assert no_results_and_song_but_no_artist_track_fallback(parsed, state, "test") is False
+
 
 # ---------------------------------------------------------------------------
 # build_strategies
@@ -139,6 +198,36 @@ class TestBuildStrategies:
         )
         names = [s.name for s in strategies]
         assert SearchStrategyType.SONG_AS_ARTIST in names
+
+    def test_song_as_track_excluded_without_func(self):
+        strategies = build_strategies(
+            search_library_func=AsyncMock(),
+            search_alternative_func=AsyncMock(),
+            search_compilations_func=AsyncMock(),
+            search_song_as_artist_func=AsyncMock(),
+        )
+        names = [s.name for s in strategies]
+        assert SearchStrategyType.SONG_AS_TRACK not in names
+
+    def test_song_as_track_appended_after_song_as_artist(self):
+        """SONG_AS_TRACK must fire AFTER SONG_AS_ARTIST in the cascade.
+
+        Strategy execution order is array position, so SONG_AS_TRACK's index
+        must be strictly greater than SONG_AS_ARTIST's. This enforces the
+        condition's `SONG_AS_ARTIST in strategies_tried` precondition.
+        """
+        strategies = build_strategies(
+            search_library_func=AsyncMock(),
+            search_alternative_func=AsyncMock(),
+            search_compilations_func=AsyncMock(),
+            search_song_as_artist_func=AsyncMock(),
+            search_song_as_track_func=AsyncMock(),
+        )
+        names = [s.name for s in strategies]
+        assert SearchStrategyType.SONG_AS_TRACK in names
+        assert names.index(SearchStrategyType.SONG_AS_TRACK) > names.index(
+            SearchStrategyType.SONG_AS_ARTIST
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -323,3 +412,110 @@ class TestExecuteSearchPipeline:
         assert state.results == [adult_item]
         assert SearchStrategyType.SWAPPED_INTERPRETATION in state.strategies_tried
         search_song.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_song_as_track_runs_after_song_as_artist_empty(self):
+        """SONG_AS_TRACK fires for song-only queries after SONG_AS_ARTIST returns empty.
+
+        End-to-end pipeline: ARTIST_PLUS_ALBUM (empty), SONG_AS_ARTIST (empty),
+        SONG_AS_TRACK matches via Discogs cross-reference and populates
+        state.matched_via_by_id with a TrackMatchHint per matched row.
+        """
+        confield = _item(id=60359, artist="Autechre", title="Confield")
+        hint = TrackMatchHint(
+            title="vi scose poise",
+            artist_credit=None,
+            position="3",
+            confidence=0.92,
+            source=TrackMatchSource.discogs_release,
+        )
+
+        search_lib = AsyncMock(return_value=([], False))
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(return_value=([], {}))
+        search_song = AsyncMock(return_value=([], None))
+        search_track = AsyncMock(return_value=([confield], {60359: [hint]}))
+
+        strategies = build_strategies(
+            search_lib,
+            search_alt,
+            search_comp,
+            search_song,
+            search_song_as_track_func=search_track,
+        )
+
+        parsed = ParsedRequest(song="vi scose poise", raw_message="vi scose poise")
+
+        state = await execute_search_pipeline(
+            parsed,
+            AsyncMock(),
+            "vi scose poise",
+            strategies,
+        )
+
+        assert state.results == [confield]
+        assert SearchStrategyType.SONG_AS_ARTIST in state.strategies_tried
+        assert SearchStrategyType.SONG_AS_TRACK in state.strategies_tried
+        assert state.matched_via_by_id == {60359: [hint]}
+        search_track.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_song_as_track_skipped_when_song_as_artist_succeeds(self):
+        """SONG_AS_ARTIST winning short-circuits before SONG_AS_TRACK runs."""
+        item = _item(id=1, artist="Stereolab", title="Dots and Loops")
+
+        search_lib = AsyncMock(return_value=([], False))
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(return_value=([], {}))
+        search_song = AsyncMock(return_value=([item], None))
+        search_track = AsyncMock(return_value=([], {}))
+
+        strategies = build_strategies(
+            search_lib,
+            search_alt,
+            search_comp,
+            search_song,
+            search_song_as_track_func=search_track,
+        )
+
+        parsed = ParsedRequest(song="Stereolab", raw_message="Stereolab")
+
+        state = await execute_search_pipeline(
+            parsed,
+            AsyncMock(),
+            "Stereolab",
+            strategies,
+        )
+
+        assert state.results == [item]
+        search_track.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_song_as_track_empty_results_keeps_state_empty(self):
+        """When SONG_AS_TRACK also returns empty, state.results stays empty."""
+        search_lib = AsyncMock(return_value=([], False))
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(return_value=([], {}))
+        search_song = AsyncMock(return_value=([], None))
+        search_track = AsyncMock(return_value=([], {}))
+
+        strategies = build_strategies(
+            search_lib,
+            search_alt,
+            search_comp,
+            search_song,
+            search_song_as_track_func=search_track,
+        )
+
+        parsed = ParsedRequest(song="nonexistent track", raw_message="nonexistent track")
+
+        state = await execute_search_pipeline(
+            parsed,
+            AsyncMock(),
+            "nonexistent track",
+            strategies,
+        )
+
+        assert state.results == []
+        assert state.matched_via_by_id == {}
+        search_track.assert_awaited_once()


### PR DESCRIPTION
## Summary

Adds the `SONG_AS_TRACK` search strategy to the `/lookup` pipeline. When a song-only query falls through `SONG_AS_ARTIST` without results, the new strategy cross-references the track against Discogs and matches surfaced releases back to `library.db`, emitting a per-row `TrackMatchHint` on `LookupResultItem.matched_via`.

This is the **load-bearing upstream change of catalog-track-search v2** ([plan §4.2](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md)). Backend's 0-hit catalog queries will proxy to `/lookup` with `{song: query}` and this strategy is what handles the proxy.

## What changed

**`core/search.py`**
- `SearchStrategyType.SONG_AS_TRACK` enum value.
- `no_results_and_song_but_no_artist_track_fallback` condition — fires strictly after `SONG_AS_ARTIST` returns empty for song-only queries (so the parser-misread-artist case keeps first-crack ordering).
- `SearchState.matched_via_by_id: dict[int, list[TrackMatchHint]]` carries provenance from the strategy to `perform_lookup`.
- `build_strategies(search_song_as_track_func=...)` registers the new strategy after `SONG_AS_ARTIST`.
- `get_search_type_from_state` maps `SONG_AS_TRACK` to `"compilation"` — the api.yaml v1.3.0 `SearchType` enum has no `song_as_track` value; precise provenance lives on `matched_via.source` per [plan §5.1](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#51-additive-fields).

**`lookup/orchestrator.py`**
- `search_song_as_track()` helper. Calls `discogs_service.search_releases_by_track(song, artist=None)`, runs `search_album_fuzzy` on each result, accepts matches via the `_release_matches_library_row` predicate (compilation-aware), then calls `validate_track_on_release` after library matching narrows the candidate set — mirroring `search_compilations_for_track` so we only pay the API cost for releases we'd actually surface.
- Emits `TrackMatchHint(title=song, artist_credit=release.artist if comp else None, position=None, confidence=0.85, source=discogs_release)` per matched row. Confidence pinned at the master cap from plan §5.2. Multiple Discogs releases that point at the same WXYC row accumulate hints rather than dropping duplicates.
- Wired into `perform_lookup`'s `build_strategies` call; `matched_via_by_id` plumbed from `SearchState` onto `LookupResultItem.matched_via`.

## Acceptance criteria progress

From [#301](https://github.com/WXYC/library-metadata-lookup/issues/301):

- [x] `SONG_AS_TRACK` strategy registered with the spec'd condition
- [x] `search_song_as_track` implementation calls `search_releases_by_track` and matches against library.db
- [x] `LookupResultItem.matched_via` field populated; `source: discogs_release`
- [x] Confidence carried through (master-cap floor at 0.85 per §5.2)
- [x] Unit tests cover empty input, no-service, cache miss, library miss, validation failure, hint accumulation, "Various " retry, strategy-condition logic
- [x] PG-marker integration test against the populated discogs-cache (`tests/integration/test_song_as_track.py`); self-skips when cache lacks `release_track`, matching `test_va_discogs_lookup.py`'s convention
- [x] TDD: failing tests preceded implementation
- [x] **Staging smoke test green**: `POST /api/v1/lookup` with `{"song": "vi scose poise", "raw_message": "vi scose poise"}` returns Confield (library id=65880) by Autechre with `matched_via[0] = {title: "vi scose poise", source: "discogs_release", confidence: 0.85}` and `search_type: "compilation"`.
- [ ] Deploy to LML prod

## Test plan

- [x] `uv run pytest tests/unit/` — 1698 passed, no regressions
- [x] `DATABASE_URL_DISCOGS=... uv run pytest tests/integration/test_song_as_track.py -m pg` — passes against the populated homebrew :5432 cache (8.83s); skips against the docker :5433 dev cache (lacks `release_track`)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy .` clean
- [x] Staging `/api/v1/lookup` smoke test for `vi scose poise` returning Confield with `matched_via` populated (see acceptance criteria)
- [ ] Prod deploy

## Related

- Parent epic: WXYC/Backend-Service#815 (E2)
- Blocked by: WXYC/wxyc-shared#112 — closed (E7-1 / api.yaml v1.3.0 shipped 2026-05-13)
- Blocks: WXYC/Backend-Service#823 (E2-3, BS-side proxy)
- Supersedes the v1 design in WXYC/library-metadata-lookup#295 (closed, `POST /api/v1/discogs/releases/master-ids`)

Closes #301