### PR TITLE
fix(validate): fall back to release-level artist when per-track credits don't match

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -12,6 +12,8 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 import asyncio
 import logging
 
+from rapidfuzz import fuzz
+
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.models import (
     ArtistCredit,
@@ -32,6 +34,13 @@ class CacheUnavailableError(Exception):
     """Raised when the PostgreSQL cache is unreachable."""
 
     pass
+
+
+# Mirrors ``_ARTIST_FUZZY_MATCH_THRESHOLD`` in ``discogs/service.py`` — the
+# release-level fuzzy fallback used here must score the same way the API path
+# does so cache hits and cache misses can't disagree about whether a track is
+# on a release. Tied to that constant by intent, not duplicated by accident.
+_ARTIST_FUZZY_MATCH_THRESHOLD = 70
 
 
 class DiscogsCacheService:
@@ -985,6 +994,8 @@ class DiscogsCacheService:
             track_lower = normalize_for_track_comparison(track)
             artist_lower = normalize_artist_for_validation(artist)
 
+            release_artist_clean = normalize_artist_for_validation(primary_artist)
+
             for row in track_rows:
                 item_title = normalize_for_track_comparison(row["title"])
 
@@ -998,10 +1009,32 @@ class DiscogsCacheService:
                         track_artist_lower = normalize_artist_for_validation(track_artist)
                         if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
                             return True
-                else:
-                    release_artist_clean = normalize_artist_for_validation(primary_artist)
-                    if artist_lower in release_artist_clean or release_artist_clean in artist_lower:
+                    joined = normalize_artist_for_validation(" ".join(artists_for_track))
+                    if (
+                        joined
+                        and fuzz.token_set_ratio(artist_lower, joined)
+                        >= _ARTIST_FUZZY_MATCH_THRESHOLD
+                    ):
                         return True
+
+                # Release-level artist. Always consulted when per-track
+                # credits haven't matched — ``release_track_artist`` has no
+                # role column, so writer / producer / member credits land
+                # alongside main-artist credits (e.g., Live 93 by The Orb
+                # credits Paterson / Weston / Fehlmann on every track), and
+                # the release-level credit is the last word on "is this
+                # track by this artist." Mirrors the API path in
+                # ``discogs/service.py``.
+                if release_artist_clean and (
+                    artist_lower in release_artist_clean or release_artist_clean in artist_lower
+                ):
+                    return True
+                if (
+                    release_artist_clean
+                    and fuzz.token_set_ratio(artist_lower, release_artist_clean)
+                    >= _ARTIST_FUZZY_MATCH_THRESHOLD
+                ):
+                    return True
 
             return False
 

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -1162,7 +1162,8 @@ class DiscogsService:
             if track_lower not in item_title and item_title not in track_lower:
                 continue
 
-            # Check per-track artists first (for compilations)
+            # Per-track credits first (compilations, or tracks crediting the
+            # writers/performers). A positive hit short-circuits.
             if item.artists:
                 for track_artist in item.artists:
                     track_artist_lower = normalize_artist_for_validation(track_artist)
@@ -1184,25 +1185,26 @@ class DiscogsService:
                         f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}"
                     )
                     return True
-            else:
-                # For single-artist releases, check release artist
-                release_artist = normalize_artist_for_validation(release.artist)
 
-                if artist_lower in release_artist or release_artist in artist_lower:
-                    logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
-                    return True
-
-                # Fuzzy fallback for the same trio scenario (LML#210), but where
-                # all members are listed in the single release-artist string.
-                if (
-                    release_artist
-                    and fuzz.token_set_ratio(artist_lower, release_artist)
-                    >= _ARTIST_FUZZY_MATCH_THRESHOLD
-                ):
-                    logger.info(
-                        f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}"
-                    )
-                    return True
+            # Release-level artist. Always consulted when per-track credits
+            # haven't already matched — per-track credits often list band
+            # members / producers / writers rather than the band itself (e.g.,
+            # The Orb's "Towers Of Dub" on Live 93 is credited to Paterson /
+            # Weston / Fehlmann), so the release-level credit is the last
+            # word on "is this track by this artist."
+            release_artist = normalize_artist_for_validation(release.artist)
+            if release_artist and (
+                artist_lower in release_artist or release_artist in artist_lower
+            ):
+                logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
+                return True
+            if (
+                release_artist
+                and fuzz.token_set_ratio(artist_lower, release_artist)
+                >= _ARTIST_FUZZY_MATCH_THRESHOLD
+            ):
+                logger.info(f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}")
+                return True
 
         logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")
         return False

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1484,3 +1484,10 @@ class BulkResolveLibrariesRequest(BaseModel):
         max_length=1000,
         min_length=1,
     )
+
+
+class LibraryQueryResponse(BaseModel):
+    results: list[AlbumSearchResult]
+    total: int
+    page: int
+    totalPages: int

--- a/tests/integration/test_validate_band_track_credits.py
+++ b/tests/integration/test_validate_band_track_credits.py
@@ -1,0 +1,51 @@
+"""Integration test for the band-vs-track-credits acceptance criterion.
+
+Motivating case: ``Towers Of Dub`` / ``The Orb`` / Live 93 (release 674529).
+On the Discogs API the track is credited to the band members
+(Alex Paterson, Kris Weston, Thomas Fehlmann) as per-track ``extraartists``
+in the XML, and the discogs-cache ETL stores all per-track credits in
+``release_track_artist`` without a role column. Both code paths must fall
+back to the release-level artist (``The Orb``) and validate the track.
+
+Marked ``external_api`` — hits the real Discogs API; self-skips if
+``DISCOGS_TOKEN`` is unset.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from discogs.service import DiscogsService
+
+DISCOGS_TOKEN = os.environ.get("DISCOGS_TOKEN")
+
+pytestmark = [
+    pytest.mark.external_api,
+    pytest.mark.skipif(not DISCOGS_TOKEN, reason="DISCOGS_TOKEN not set"),
+]
+
+
+@pytest.mark.asyncio
+async def test_validate_track_on_release_falls_back_to_band_credit():
+    """`Towers Of Dub` by `The Orb` validates against release 674529 (Live 93)
+    even though the per-track credits list band members, not the band itself.
+    """
+    service = DiscogsService(token=DISCOGS_TOKEN)
+    try:
+        result = await service.validate_track_on_release(674529, "Towers of Dub", "The Orb")
+    finally:
+        await service.close()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_validate_track_on_release_still_rejects_unrelated_artist():
+    """Same release must NOT validate for an unrelated artist."""
+    service = DiscogsService(token=DISCOGS_TOKEN)
+    try:
+        result = await service.validate_track_on_release(674529, "Towers of Dub", "Stereolab")
+    finally:
+        await service.close()
+    assert result is False

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -793,6 +793,58 @@ class TestValidateTrackOnRelease:
         with pytest.raises(CacheUnavailableError):
             await cache_service.validate_track_on_release(1, "Song", "Artist")
 
+    @pytest.mark.asyncio
+    async def test_per_track_credits_fall_back_to_release_artist(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Per-track credits list members/producers, not the band itself.
+
+        Live 93 by The Orb has Towers Of Dub credited to the band members
+        (Alex Paterson, Kris Weston, Thomas Fehlmann). The discogs-cache
+        release_track_artist table stores those credits without a role
+        distinction, so a request for "Towers Of Dub by The Orb" must
+        still validate by falling back to the release-level artist.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[
+                    {"track_sequence": 5, "artist_name": "Alex Paterson"},
+                    {"track_sequence": 5, "artist_name": "Kris Weston"},
+                    {"track_sequence": 5, "artist_name": "Thomas Fehlmann"},
+                ],
+                release_track=[{"sequence": 5, "title": "Towers Of Dub"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Orb"})
+        result = await cache_service.validate_track_on_release(13938, "Towers of Dub", "The Orb")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_per_track_credits_release_artist_fallback_still_rejects_unrelated(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Release-level fallback must not bleed into unrelated-artist matches.
+
+        Requesting "Towers Of Dub by Stereolab" against the same Live 93
+        cache row must return False even though we now consult the
+        release-level artist after per-track credits fail.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[
+                    {"track_sequence": 5, "artist_name": "Alex Paterson"},
+                    {"track_sequence": 5, "artist_name": "Kris Weston"},
+                    {"track_sequence": 5, "artist_name": "Thomas Fehlmann"},
+                ],
+                release_track=[{"sequence": 5, "title": "Towers Of Dub"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Orb"})
+        result = await cache_service.validate_track_on_release(13938, "Towers of Dub", "Stereolab")
+        assert result is False
+
 
 # ---------------------------------------------------------------------------
 # Artist detail caching

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -1236,6 +1236,53 @@ class TestValidateTrackOnRelease:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_per_track_credits_fall_back_to_release_artist(self, service):
+        """Per-track credits list members/producers, not the band itself.
+
+        Live 93 by The Orb has Towers Of Dub credited to the band members
+        (Alex Paterson, Kris Weston, Thomas Fehlmann). When the Discogs API
+        surfaces those names under ``track.artists`` (as the cache equivalent
+        ``release_track_artist`` does), the validator must still confirm the
+        track by falling back to the release-level artist.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=674529,
+            title="Live 93",
+            artist="The Orb",
+            release_url="https://discogs.com/release/674529",
+            tracklist=[
+                TrackItem(
+                    position="5",
+                    title="Towers Of Dub",
+                    artists=["Alex Paterson", "Kris Weston", "Thomas Fehlmann"],
+                ),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(674529, "Towers of Dub", "The Orb")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_per_track_credits_release_fallback_still_rejects_unrelated(self, service):
+        """The release-artist fallback must not match an unrelated artist."""
+        release = ReleaseMetadataResponse(
+            release_id=674529,
+            title="Live 93",
+            artist="The Orb",
+            release_url="https://discogs.com/release/674529",
+            tracklist=[
+                TrackItem(
+                    position="5",
+                    title="Towers Of Dub",
+                    artists=["Alex Paterson", "Kris Weston", "Thomas Fehlmann"],
+                ),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(674529, "Towers of Dub", "Stereolab")
+        assert result is False
+
+    @pytest.mark.asyncio
     async def test_cache_validated(self, service_with_cache):
         service_with_cache.cache_service.validate_track_on_release = AsyncMock(return_value=True)
 


### PR DESCRIPTION
Closes #327.

## Summary

- `validate_track_on_release` short-circuited to False whenever a tracklist row had per-track credits that didn't substring-match the requested artist. For The Orb's *Live 93*, every per-track row credits the band members (Paterson / Weston / Fehlmann), so the validator rejected the track and Live 93 dropped out of every recovery layer — TRACK_ON_COMPILATION, `filter_results_by_track_validation`, and `find_library_albums_with_cached_track`. The user got the 5-album artist-fallback instead.
- Both the cache (`discogs/cache_service.py`) and API (`discogs/service.py`) paths now consult the release-level artist after per-track credits fail. Substring then `fuzz.token_set_ratio >= 70`, mirroring the trio-collaboration fallback from LML#210. Per-track positive hits still short-circuit, so trio-and-VA behavior is preserved.

## Why the cache asymmetry

The discogs-cache `release_track_artist` table stores all per-track credits indiscriminately — writers, producers, and main artists all land in the same column with no `role` field. So per-track credits over-populate relative to the API's `track.artists` field. Either path could exhibit the bug; the cache hits it more often.

## Test plan

- [x] Added two unit tests in `tests/unit/test_cache_service.py` and `tests/unit/test_discogs_service.py` (band-credit fallback + unrelated-artist rejection). Both fail on `main`, both pass with the fix.
- [x] Added `tests/integration/test_validate_band_track_credits.py` (external_api) that exercises release 674529 against the real Discogs API.
- [x] All 23 existing `TestValidateTrackOnRelease` cases still green (compilations, "Weird Al" quote stripping, trio LML#210, ampersand/period normalization, diacritics).
- [x] End-to-end repro confirms `"Towers Of Dub" by "The Orb"` returns Live 93 as a direct match (search_type=direct, song_not_found=False).
- [x] `ruff check`, `ruff format --check`, `mypy` clean.
- [x] Full `pytest -m 'not pg and not external_api'` and `pytest -m external_api` runs are clean (the one event-loop test ordering flake repros on `main` unchanged).