### PR TITLE
docs: add CI pin maintenance runbook subsection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,20 @@ Default `pytest` (no `-m`) runs every unmarked test across `tests/unit/`, `tests
 
 **CI Marker Sync** invokes the reusable workflow at `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml` to guarantee that every `@pytest.mark.<X>` actually used by a test is either re-selected by some CI `pytest -m` invocation or explicitly opted out via a `# ci-sync-skip: <marker> reason: <text>` comment in `pyproject.toml`. This guards against the silent-deselection bug pattern (WXYC/discogs-etl#103, WXYC/library-metadata-lookup#159).
 
+### CI pin maintenance
+
+Three classes of pin in `.github/workflows/*.yml` exist for supply-chain reasons (mirrors WXYC/request-o-matic#124's free-tier hardening; see WXYC/wiki#67 for the org-wide rollout). They will bit-rot and need occasional bumps:
+
+- **`@railway/cli@<version>`** in the `Install Railway CLI` step of `ci.yml` (`deploy-staging`, `deploy-production`) and `set-railway-var.yml`. Three lines total. Failure mode is loud (deploy step fails with a CLI error). Bump by checking `npm view @railway/cli version` and updating all three lines together; mismatched pins across these workflows would mean staging, production, and ops use different CLIs against the same Railway project. Railway ships fast (~40 versions in 60 days as of 2026-05); pin "current" rather than chasing every release. Last bump: 66d2eb4 (2026-05-13, pinned to 4.58.0).
+- **Workflow-level `permissions:`** scoped to the minimum each workflow needs:
+  - `ci.yml`, `cross-cache-identity-flags.yml`, `set-railway-var.yml`: `contents: read` (no GITHUB_TOKEN writes).
+  - `charset-corpus-drift.yml`: `contents: read` plus `packages: read` (the reusable workflow pulls `@wxyc/shared` from `npm.pkg.github.com`).
+  - `refresh-streaming.yml`: `contents: write` (creates / uploads to `streaming-data-v1` GitHub Release via `GH_TOKEN`).
+  Failure mode is silent — a job that needs a missing scope (e.g. `pull-requests: write`) fails its API call but the workflow stays green. When adding a step that needs to comment on PRs, push tags, mint releases, etc., explicitly grant the scope at the job level (or widen the workflow-level floor only if every job in the file needs it).
+- **Reusable-workflow refs pinned to `@gha/v1`**, not `@main` — `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@gha/v1` (in `ci.yml`) and `WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1` (in `charset-corpus-drift.yml`). The publishing repos treat `gha/v1` as a moving major tag — re-pointed forward on non-breaking changes, frozen on breaking changes (which get a fresh `gha/v2`). Don't downgrade either to `@main`; if a `gha/v2` migration arrives, follow the procedure at the top of the publishing repo's CLAUDE.md.
+
+Run `actionlint .github/workflows/*.yml` locally before pushing workflow changes; it validates `permissions:` syntax, action-version pins, and shell-script blocks (via shellcheck), and catches the silent-mistake class of errors above before CI does.
+
 ### Library Database Upload
 
 The `library.db` file lives on a Railway volume, not in git. It's uploaded via:


### PR DESCRIPTION
## Summary

- Adds a `### CI pin maintenance` subsection to `CLAUDE.md` under `## Deployment`, capturing the why/when-to-bump for the workflow pins already shipped.
- No workflow changes — the mechanical hardening was already in 2f297b2 / a6b0c48 (workflow-level `permissions:`), 66d2eb4 (`@railway/cli@4.58.0`), and 4b5815a (reusable-workflow refs pinned to `@gha/v1`).
- Mirrors the rom pattern from WXYC/request-o-matic#139, adapted to LML's actual workflow set: 5 workflows, 3 distinct permission profiles, Railway CLI in 3 call-sites across 2 workflows.

## Motivation

WXYC/wiki#67 tracks the org-wide replication of WXYC/request-o-matic#124's free-tier supply-chain hardening. LML was already mechanically ahead of rom (gha/v1 pins predate this work), but had no in-repo prose explaining the rationale. Without a runbook, a future maintainer touching the workflows has no signal that the under-scoped-`permissions:` failure mode is silent (job needs `pull-requests: write`, API call fails, workflow stays green) or that the three Railway-CLI call-sites need to bump in lockstep.

Closes #330. Part of WXYC/wiki#67.

## Test plan

- [x] `actionlint .github/workflows/*.yml` clean (no regressions).
- [ ] Markdown rendering: confirm the new subsection appears under `## Deployment` between `### CI/CD Pipeline` and `### Library Database Upload`.
- [ ] CI green (`Lint & Format`, `Type Check`, `Default Tests`, `External API Tests`, `PG Tests`, `Codegen Freshness`, `CI Marker Sync`).

## Related

- WXYC/wiki#67 — org-wide tracker
- WXYC/request-o-matic#124 — pattern source
- WXYC/request-o-matic#139 — rom-side runbook PR