### PR TITLE
Surface live-vs-cached Discogs tier as matched_via on release resolve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,12 @@ Response:
   "canonical": { "artist": "Juana Molina", "title": "DOGA", "label": "Sonamos", "catno": "SON-001", "year": 2024, "country": null, "formats": [] },
   "identifiers": { "discogs_release_id": 12345, "discogs_artist_id": 999, "spotify_album_id": "abc...", "bandcamp_album_url": null, ... },
   "streaming": { "on_streaming": true, "sources": { ... } },
+  "matched_via": "discogs_cache",
   "warnings": []
 }
 ```
+
+`matched_via` (per WXYC/library-metadata-lookup#329) tags the provenance tier for the canonical metadata so callers can label results "fresh from Discogs" vs "from cache". Values: `discogs_cache` (served from the local discogs-cache PG), `discogs_live_api` (local cache missed, fell through to the live Discogs API — the result is then written back to PG so the next request for the same release is free), or `null` (no canonical metadata was produced — rate-limit, not-found, non-Discogs source, or unrecognized URL). Live-tier hits also bump an ad-hoc `discogs_live_release_hit` counter on the request's cache_stats recorder so freshness-gap impact is visible in PostHog / Sentry. The cache write-back, rate-limit handling (60 req/min token bucket + concurrency semaphore in `discogs/ratelimit.py`), exponential backoff with jitter on 429s, and graceful degradation to `null` on quota exhaustion are all inherited from `DiscogsService.get_release`; the resolver is just a thin projection on top.
 
 Implementation lives in `release/`:
 - `url_parser.py` — pure URL → `(source, id)` parser. Supports Discogs `/release/<id>` and `/master/<id>` (with locale prefixes and slugs) and Bandcamp `<artist>.bandcamp.com/album/<slug>`.

--- a/release/discogs_resolver.py
+++ b/release/discogs_resolver.py
@@ -13,17 +13,37 @@ Discogs master URLs are not yet supported. Pasting a master URL returns a
 warning suggesting the user paste a release URL instead — masters require
 an extra API hop (``/masters/<id>`` → ``main_release``) that's not worth the
 rate-limit budget for v1 of this endpoint.
+
+Provenance (per #329): every successful resolution carries a ``matched_via``
+tag. ``discogs_cache`` means the row came from the local PostgreSQL cache;
+``discogs_live_api`` means the local cache missed and we fell through to
+the live Discogs API (which then writes the row back into the cache, so the
+next request for the same release is free). Live-tier hits also increment
+an ad-hoc ``discogs_live_release_hit`` counter on the request's cache_stats
+recorder so freshness-gap impact is visible in PostHog / Sentry.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import Literal
+
+from wxyc_fastapi.observability import get_cache_stats_recorder
 
 from discogs.service import DiscogsService
 from release.models import CanonicalRelease, ReleaseIdentifiers
 
 logger = logging.getLogger(__name__)
+
+# Per #329: the provenance tier values are a closed set. New tiers (e.g.
+# ``library_identity`` or ``musicbrainz_cache``) should be added here so
+# downstream consumers can switch on Literal exhaustiveness.
+MatchedVia = Literal["discogs_cache", "discogs_live_api"]
+
+# Cache-stats key for the live-tier counter. Defined here so tests can import
+# the same symbol the production code records under.
+LIVE_RELEASE_METRIC_KEY = "discogs_live_release_hit"
 
 
 @dataclass
@@ -33,6 +53,7 @@ class DiscogsResolveResult:
     canonical: CanonicalRelease | None
     identifiers: ReleaseIdentifiers
     warnings: list[str]
+    matched_via: MatchedVia | None = None
 
 
 async def resolve_discogs_release(service: DiscogsService, release_id: str) -> DiscogsResolveResult:
@@ -96,7 +117,30 @@ async def resolve_discogs_release(service: DiscogsService, release_id: str) -> D
         discogs_artist_id=release.artist_id,
     )
 
-    return DiscogsResolveResult(canonical=canonical, identifiers=identifiers, warnings=warnings)
+    # The cache_service.get_release() projection sets cached=True on a PG
+    # cache hit; the DiscogsService.get_release() API branch sets cached=False
+    # when it falls through to the live Discogs API and writes back into PG.
+    # That single bool is the source of truth for the live-vs-cached tier
+    # surfaced by #329. ``cached`` is ``bool | None`` in the generated schema —
+    # treat None the same as False (the API branch never produces None, only
+    # legacy fixtures might).
+    matched_via: MatchedVia = "discogs_cache" if release.cached else "discogs_live_api"
+    if matched_via == "discogs_live_api":
+        # Ad-hoc counter; the recorder permits undeclared keys (see
+        # wxyc-fastapi CacheStatsRecorder.record docstring). Wrapped in a
+        # try/except so a misconfigured request context never blocks the
+        # actual release lookup — the metric is observability, not contract.
+        try:
+            get_cache_stats_recorder().record(LIVE_RELEASE_METRIC_KEY)
+        except Exception:
+            logger.debug("Failed to record live-release metric", exc_info=True)
+
+    return DiscogsResolveResult(
+        canonical=canonical,
+        identifiers=identifiers,
+        warnings=warnings,
+        matched_via=matched_via,
+    )
 
 
 async def resolve_discogs_master(_service: DiscogsService, master_id: str) -> DiscogsResolveResult:

--- a/release/models.py
+++ b/release/models.py
@@ -102,6 +102,18 @@ class ReleaseResolveResponse(BaseModel):
             "configured services failed)."
         ),
     )
+    matched_via: Literal["discogs_cache", "discogs_live_api"] | None = Field(
+        None,
+        description=(
+            "Provenance tier for the canonical metadata (per #329). "
+            "``discogs_cache`` — served from the local discogs-cache PG. "
+            "``discogs_live_api`` — local cache missed, fell through to the "
+            "live Discogs API (and the result was written back to the cache so "
+            "the next request for the same release is free). Null when no "
+            "canonical metadata was produced (rate-limit / not-found / "
+            "non-Discogs source / unrecognized URL)."
+        ),
+    )
     warnings: list[str] = Field(
         default_factory=list,
         description=(

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Literal
 
 from discogs.service import DiscogsService
 from release.bandcamp_resolver import resolve_bandcamp_album
@@ -103,16 +104,22 @@ async def resolve_release(
         )
 
     # Dispatch to the right resolver.
+    # matched_via is the provenance tier for the canonical metadata (per #329):
+    # only Discogs sources populate it today. Bandcamp leaves it None — when /
+    # if we add a Bandcamp cache layer it can grow new tier values.
+    matched_via: Literal["discogs_cache", "discogs_live_api"] | None = None
     if parsed.source == "discogs_release":
         discogs_result = await resolve_discogs_release(deps.discogs, parsed.identifier)
         canonical = discogs_result.canonical
         identifiers = discogs_result.identifiers
         warnings = list(discogs_result.warnings)
+        matched_via = discogs_result.matched_via
     elif parsed.source == "discogs_master":
         master_result = await resolve_discogs_master(deps.discogs, parsed.identifier)
         canonical = master_result.canonical
         identifiers = master_result.identifiers
         warnings = list(master_result.warnings)
+        matched_via = master_result.matched_via
     else:  # bandcamp
         bandcamp_result = await resolve_bandcamp_album(deps.bandcamp, parsed.identifier)
         canonical = bandcamp_result.canonical
@@ -136,6 +143,7 @@ async def resolve_release(
         canonical=canonical or CanonicalRelease(artist="", title=""),
         identifiers=identifiers,
         streaming=streaming,
+        matched_via=matched_via,
         warnings=warnings,
     )
 

--- a/tests/unit/release/test_discogs_resolver.py
+++ b/tests/unit/release/test_discogs_resolver.py
@@ -3,7 +3,7 @@ output to CanonicalRelease + ReleaseIdentifiers, with warnings on failure."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -19,7 +19,11 @@ from release.discogs_resolver import (
 
 
 def _make_release(**overrides) -> DiscogsReleaseMetadata:
-    """Produce a minimal valid release for projection tests."""
+    """Produce a minimal valid release for projection tests.
+
+    ``cached`` defaults to True (the dominant production path); pass
+    ``cached=False`` to simulate a live-API miss.
+    """
     base = {
         "release_id": 12345,
         "title": "DOGA",
@@ -29,6 +33,7 @@ def _make_release(**overrides) -> DiscogsReleaseMetadata:
         "artist_id": 999,
         "labels": [DiscogsLabelCredit(label_id=42, name="Sonamos", catno="SON-001")],
         "release_url": "https://www.discogs.com/release/12345",
+        "cached": True,
     }
     base.update(overrides)
     return DiscogsReleaseMetadata.model_validate(base)
@@ -124,3 +129,82 @@ class TestResolveDiscogsMaster:
         assert len(result.warnings) == 1
         assert "master" in result.warnings[0].lower()
         mock_service.get_release.assert_not_called()
+
+
+class TestMatchedViaProvenance:
+    """Per #329: the resolver must surface a `matched_via` tier so consumers
+    can tell whether the release came from the local cache or the live
+    Discogs API. The bool ``ReleaseMetadataResponse.cached`` is the
+    authoritative signal — cache_service.get_release() sets cached=True,
+    DiscogsService.get_release()'s API branch sets cached=False.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_reports_discogs_cache(self, mock_service):
+        mock_service.get_release.return_value = _make_release(cached=True)
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        assert result.matched_via == "discogs_cache"
+
+    @pytest.mark.asyncio
+    async def test_live_api_hit_reports_discogs_live_api(self, mock_service):
+        mock_service.get_release.return_value = _make_release(cached=False)
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        assert result.matched_via == "discogs_live_api"
+
+    @pytest.mark.asyncio
+    async def test_miss_reports_none(self, mock_service):
+        # Cache miss + API failure: matched_via stays None.
+        mock_service.get_release.return_value = None
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        assert result.matched_via is None
+
+    @pytest.mark.asyncio
+    async def test_exception_reports_none(self, mock_service):
+        mock_service.get_release.side_effect = RuntimeError("network exploded")
+
+        result = await resolve_discogs_release(mock_service, "12345")
+
+        assert result.matched_via is None
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_id_reports_none(self, mock_service):
+        result = await resolve_discogs_release(mock_service, "not-a-number")
+
+        assert result.matched_via is None
+
+    @pytest.mark.asyncio
+    async def test_live_api_hit_records_metric(self, mock_service):
+        """The live-tier metric is the only way to see freshness gap impact."""
+        mock_service.get_release.return_value = _make_release(cached=False)
+
+        with patch("release.discogs_resolver.get_cache_stats_recorder") as recorder_factory:
+            recorder = recorder_factory.return_value
+            await resolve_discogs_release(mock_service, "12345")
+
+        recorder.record.assert_called_once_with("discogs_live_release_hit")
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_does_not_record_live_metric(self, mock_service):
+        mock_service.get_release.return_value = _make_release(cached=True)
+
+        with patch("release.discogs_resolver.get_cache_stats_recorder") as recorder_factory:
+            recorder = recorder_factory.return_value
+            await resolve_discogs_release(mock_service, "12345")
+
+        recorder.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_miss_does_not_record_live_metric(self, mock_service):
+        mock_service.get_release.return_value = None
+
+        with patch("release.discogs_resolver.get_cache_stats_recorder") as recorder_factory:
+            recorder = recorder_factory.return_value
+            await resolve_discogs_release(mock_service, "12345")
+
+        recorder.record.assert_not_called()

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -63,6 +63,7 @@ def _make_release(**overrides) -> DiscogsReleaseMetadata:
         "artist_id": 999,
         "labels": [DiscogsLabelCredit(label_id=42, name="Sonamos", catno="SON-001")],
         "release_url": "https://www.discogs.com/release/12345",
+        "cached": True,
     }
     base.update(overrides)
     return DiscogsReleaseMetadata.model_validate(base)
@@ -429,3 +430,103 @@ class TestIdentityWriteBack:
             )
 
         store.upsert_identity.assert_not_called()
+
+
+class TestMatchedViaPropagation:
+    """The orchestrator must surface ``matched_via`` on ``ReleaseResolveResponse``
+    so consumers can render a "fresh from Discogs" badge vs a "from cache"
+    badge (per #329 acceptance criteria).
+    """
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_propagates_discogs_cache(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release(cached=True)
+        deps = _deps(discogs=discogs)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        assert response.matched_via == "discogs_cache"
+
+    @pytest.mark.asyncio
+    async def test_live_api_hit_propagates_discogs_live_api(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release(cached=False)
+        deps = _deps(discogs=discogs)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        assert response.matched_via == "discogs_live_api"
+
+    @pytest.mark.asyncio
+    async def test_miss_leaves_matched_via_none(self):
+        discogs = AsyncMock()
+        discogs.get_release.return_value = None
+        deps = _deps(discogs=discogs)
+
+        response = await resolve_release(
+            ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+        )
+
+        assert response.matched_via is None
+
+    @pytest.mark.asyncio
+    async def test_master_url_leaves_matched_via_none(self):
+        discogs = AsyncMock()
+        deps = _deps(discogs=discogs)
+
+        response = await resolve_release(
+            ReleaseResolveRequest(url="https://www.discogs.com/master/789"), deps
+        )
+
+        assert response.matched_via is None
+
+    @pytest.mark.asyncio
+    async def test_bandcamp_branch_leaves_matched_via_none(self):
+        # Bandcamp resolution is not yet a Discogs tier; matched_via stays None.
+        bandcamp = MagicMock()
+        with (
+            patch(
+                "release.orchestrator.resolve_bandcamp_album",
+                new=AsyncMock(),
+            ) as mock_resolve,
+            patch(
+                "release.orchestrator.check_streaming_availability",
+                new=AsyncMock(return_value=_stream()),
+            ),
+        ):
+            from release.bandcamp_resolver import BandcampResolveResult
+            from release.models import CanonicalRelease, ReleaseIdentifiers
+
+            url = "https://juana-molina.bandcamp.com/album/doga"
+            mock_resolve.return_value = BandcampResolveResult(
+                canonical=CanonicalRelease(artist="Juana Molina", title="DOGA"),
+                identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
+                warnings=[],
+            )
+            response = await resolve_release(
+                ReleaseResolveRequest(url=url), _deps(bandcamp=bandcamp)
+            )
+
+        assert response.matched_via is None
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_url_leaves_matched_via_none(self):
+        deps = _deps()
+        with patch("release.orchestrator.check_streaming_availability"):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://example.com/foo"), deps
+            )
+        assert response.matched_via is None

--- a/tests/unit/release/test_router.py
+++ b/tests/unit/release/test_router.py
@@ -27,6 +27,7 @@ def _release(**overrides) -> DiscogsReleaseMetadata:
         "artist_id": 999,
         "labels": [DiscogsLabelCredit(label_id=42, name="Sonamos", catno="SON-001")],
         "release_url": "https://www.discogs.com/release/12345",
+        "cached": True,
     }
     base.update(overrides)
     return DiscogsReleaseMetadata.model_validate(base)
@@ -136,3 +137,52 @@ class TestResolveEndpoint:
         assert body["source"] == "discogs_release"
         assert body["streaming"]["on_streaming"] is True
         assert body["identifiers"]["spotify_album_id"] == "abc"
+
+    @pytest.mark.asyncio
+    async def test_matched_via_in_response_body_for_cache_hit(self, mock_settings, monkeypatch):
+        from main import app
+
+        async def fake_check(*args, **kwargs):
+            return StreamingCheckResponse(on_streaming=False, sources=StreamingCheckSources())
+
+        monkeypatch.setattr("release.orchestrator.check_streaming_availability", fake_check)
+
+        with override_deps(
+            app, {get_resolver_dependencies: _deps_with_discogs(_release(cached=True))}
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/releases/resolve",
+                    json={"url": "https://www.discogs.com/release/12345"},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["matched_via"] == "discogs_cache"
+
+    @pytest.mark.asyncio
+    async def test_matched_via_in_response_body_for_live_api(self, mock_settings, monkeypatch):
+        """Acceptance criterion (issue #329): the response carries a
+        ``matched_via`` field distinguishing the live-API tier from cached
+        tiers."""
+        from main import app
+
+        async def fake_check(*args, **kwargs):
+            return StreamingCheckResponse(on_streaming=False, sources=StreamingCheckSources())
+
+        monkeypatch.setattr("release.orchestrator.check_streaming_availability", fake_check)
+
+        with override_deps(
+            app, {get_resolver_dependencies: _deps_with_discogs(_release(cached=False))}
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/releases/resolve",
+                    json={"url": "https://www.discogs.com/release/12345"},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["matched_via"] == "discogs_live_api"


### PR DESCRIPTION
Closes #329.

## Summary

`/api/v1/releases/resolve` already cascaded release lookups through the local discogs-cache PG and on miss fell through to the live Discogs API (writing the result back into PG so the next request was free). What it didn't do was *tell anyone which leg won*. Consumers (dj-site Backend Results UI) couldn't render "fresh from Discogs" vs "from cache", and the org had no metric for live-tier hit rate so the freshness-gap impact called out in the ticket (e.g. the OOIOO / Lightning Bolt example, added to Discogs ~1 month before the local cache rebuild) was invisible.

This PR adds the missing provenance signal:

- New `matched_via` field on `ReleaseResolveResponse`. Closed Literal set: `"discogs_cache"` (PG hit), `"discogs_live_api"` (live-API fall-through), or `null` (no canonical metadata — rate-limit, not-found, non-Discogs source, or unrecognized URL).
- New ad-hoc `discogs_live_release_hit` counter on the request's cache_stats recorder, only incremented on live-tier hits. Joins the existing `pg_hits` / `pg_misses` / `api_calls` counters in PostHog events and the Sentry trace explorer.
- Documented the new field + counter in `CLAUDE.md`'s "Release Resolve Endpoint" section.

The signal piggybacks on the `cached: bool` field already set by `cache_service.get_release` (True) and `DiscogsService.get_release`'s API branch (False) — single source of truth, no new state. The metric record is wrapped in a defensive try/except so an unexpected recorder state never blocks the actual release lookup; observability must not break the request path.

## Acceptance criteria

- [x] Lookup for a release added to Discogs today returns canonical metadata + Discogs release_id. (Unchanged — `DiscogsService.get_release` already did this; we now surface the tier.)
- [x] Response carries a `matched_via` field distinguishing the live-API tier from cached tiers.
- [x] Live-API hits are cached back to discogs-cache (single round-trip per release org-wide). (Unchanged — inherited from `DiscogsService.get_release`'s write-back step.)
- [x] Rate-limit handling: bounded concurrency, exponential backoff, graceful degrade to empty on quota exhaustion. (Unchanged — inherited from `discogs/ratelimit.py`'s 60 req/min token bucket + concurrency semaphore and `_request_with_retry`'s 429 exponential-backoff-with-jitter; the resolver projects `None` to `matched_via=null` on exhaustion.)
- [x] Metric for live-tier hit rate. (`discogs_live_release_hit` counter.)

## Out of scope

#221 (live-Discogs-API artwork top-up for cached releases lacking `artwork_url`) is a separate one-shot script that backfills `release.artwork_url` directly via `SELECT id FROM release WHERE artwork_url IS NULL` + the existing `DiscogsService` rate-limit infra. It doesn't share this resolver path, so no shared `discogs_live_client` factoring was warranted today. The rate-limit primitives both would consume already live in `discogs/ratelimit.py` and `DiscogsService._request_with_retry`.

The `MatchedVia` Literal is a closed set so consumers can switch exhaustively; future tiers (`musicbrainz_cache`, `library_identity`) extend it as more cascade levels gain coverage.

## Test plan

- [x] Unit tests added in `tests/unit/release/test_discogs_resolver.py`: cache-hit reports `discogs_cache`, live-API hit reports `discogs_live_api`, miss / exception / non-numeric ID all report `None`, live-API hit records the metric, cache hit / miss do not.
- [x] Orchestrator-level tests in `tests/unit/release/test_orchestrator.py`: tier propagates through `resolve_release` for cache hit, live hit, miss, master URL, Bandcamp branch, and unrecognized URL.
- [x] HTTP-level tests in `tests/unit/release/test_router.py`: `matched_via` field appears in the response body for both cache and live tiers.
- [x] Full unit suite: 1718 passed locally.
- [x] Full default suite (`pytest -m "not pg and not external_api"`): 1956 passed, 108 deselected, 2 xfailed.
- [x] `ruff check .` clean. `ruff format --check .` clean.
- [x] `mypy . --ignore-missing-imports` clean.