### PR TITLE
feat(lookup): populate extended-metadata fields, top-1 gating, warm_cache hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,13 @@ Library Metadata Lookup is a FastAPI service for WXYC radio that searches the li
 3. **Search Pipeline**: Execute strategies in order until results are found (see below)
 4. **Track Validation**: If fallback returned all artist albums, validate each against Discogs tracklists. When validation can't confirm any candidate AND we're showing artist-fallback results, `find_library_albums_with_cached_track()` consults the local PG cache directly ("releases by this artist whose tracklist contains this song") and promotes any matching library album over the unrelated fallback. Cache-only — never falls back to the API.
 5. **Artwork Fetch**: Fetch album art from Discogs for each result
-6. **Context Message**: Generate context string for the caller
+6. **Metadata Enrichment**: Populate `release_year`, `artist_bio`, `wikipedia_url`, streaming URLs. Release/artist details are fetched only for `items_with_artwork[0]` — BS/iOS only consume the top-1 result, so paying N Discogs round-trips for non-top-1 items is waste. Streaming-URL fallbacks stay per-result. Gating is *positional*: if the top-1 entry has `artwork=None`, no item carries release-year/bio/wiki, even if items further down have artwork. The lookup pipeline guarantees the strongest match is in position 0, so this is fine in practice. See `enrich_artwork_results()` in `lookup/orchestrator.py`.
+7. **Context Message**: Generate context string for the caller
+
+#### `LookupRequest` opt-in flags
+
+- `extended: bool` (default `false`) — When true, the top-1 result's `artwork` block carries additional fields LML already loads during enrichment but normally discards: `discogs_artist_id`, `tracklist`, `genres`, `styles`, `label`, `full_release_date`, `artist_image_url`, `profile_tokens`. Bio parsing uses `CachedOnlyResolver` (cache-only deep parse) when `DATABASE_URL_DISCOGS` is set; falls back to sync `parse()` otherwise. Designed to let Backend-Service collapse `/proxy/metadata/album` to one LML call, eliminating the follow-up `/discogs/release/{id}` and `/discogs/artist/{id}` round-trips.
+- `warm_cache: bool` (default `false`) — When true, schedules a fire-and-forget `asyncio.create_task` after the response is composed that runs the *deep* async parse (API-capable resolver) on the top-1 bio. Warms the PG cache for `[a…]`/`[r…]`/`[m…]` references so subsequent reads render richer. Bounded process-wide by `_WARM_CACHE_CONCURRENCY` (currently 4) to cap Discogs API amplification. Read-path callers leave this `false`; write-path callers (Backend-Service's `flowsheet-linkage.service.ts` on flowsheet-entry creation) set it `true`.
 
 ### Search Strategy Pipeline
 

--- a/discogs/markup_parser.py
+++ b/discogs/markup_parser.py
@@ -442,3 +442,40 @@ class DiscogsServiceResolver:
             return master.title if master else None
         except Exception:
             return None
+
+
+class CachedOnlyResolver:
+    """EntityResolver that consults the PG cache only — never the Discogs API.
+
+    Used on the lookup read path so bio tokenization can't blow up tail
+    latency when an artist's profile mentions many entities. Refs that
+    miss the cache fall through as unresolved tokens (dropped by ``resolve``),
+    yielding plain-text spans in the rendered bio. The companion write-path
+    flag ``warm_cache=true`` on /lookup uses ``DiscogsServiceResolver`` (above)
+    to fetch-and-cache misses opportunistically, so subsequent reads render
+    progressively richer.
+
+    The cache_service is the same ``DiscogsCacheService`` instance the
+    orchestrator already holds. Master IDs always resolve to None: the cache
+    has no masters table today.
+    """
+
+    def __init__(self, cache_service) -> None:
+        self._cache = cache_service
+
+    async def resolve_artist(self, id: int) -> str | None:
+        try:
+            details = await self._cache.get_artist_details(id)
+            return details.name if details else None
+        except Exception:
+            return None
+
+    async def resolve_release(self, id: int) -> str | None:
+        try:
+            release = await self._cache.get_release(id)
+            return release.title if release else None
+        except Exception:
+            return None
+
+    async def resolve_master(self, id: int) -> str | None:
+        return None

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -201,6 +201,18 @@ class DiscogsSearchResult(BaseModel):
     youtube_music_url: str | None = None
     bandcamp_url: str | None = None
     soundcloud_url: str | None = None
+    # Extended fields (populated only when LookupRequest.extended=True). LML
+    # already loads release + artist details during the streaming-URL
+    # enrichment pass; these stash the rest of the payload so the response
+    # can carry a full playcut metadata blob without a follow-up call.
+    discogs_artist_id: int | None = None
+    tracklist: list[DiscogsTrackItem] | None = None
+    genres: list[str] | None = None
+    styles: list[str] | None = None
+    label: str | None = None
+    full_release_date: str | None = None
+    artist_image_url: str | None = None
+    profile_tokens: list[ResolvedToken] | None = None
 
     def to_match_result(self) -> EnrichedDiscogsMatchResult:
         """Convert to the enriched API contract model."""
@@ -219,6 +231,14 @@ class DiscogsSearchResult(BaseModel):
             youtube_music_url=self.youtube_music_url,
             bandcamp_url=self.bandcamp_url,
             soundcloud_url=self.soundcloud_url,
+            discogs_artist_id=self.discogs_artist_id,
+            tracklist=self.tracklist,
+            genres=self.genres,
+            styles=self.styles,
+            label=self.label,
+            full_release_date=self.full_release_date,
+            artist_image_url=self.artist_image_url,
+            profile_tokens=self.profile_tokens,
         )
 
 
@@ -235,6 +255,12 @@ class EnrichedDiscogsMatchResult(_GeneratedDiscogsMatchResult):
 
     Subclasses the generated model so it passes Pydantic validation wherever
     DiscogsMatchResult is expected (e.g., LookupResultItem.artwork).
+
+    ``profile_tokens`` is narrowed from the generated permissive
+    ``DiscogsResolvedToken`` (single class, all-optional fields) to the
+    local ``ResolvedToken`` discriminated union so per-variant access stays
+    type-safe. Wire JSON is identical — both serialize with only the
+    populated per-variant fields.
     """
 
     release_year: int | None = None
@@ -245,3 +271,7 @@ class EnrichedDiscogsMatchResult(_GeneratedDiscogsMatchResult):
     youtube_music_url: str | None = None
     bandcamp_url: str | None = None
     soundcloud_url: str | None = None
+    # Intentional narrowing from the generated permissive DiscogsResolvedToken
+    # (flat class, all-optional fields) to the local discriminated union, for
+    # type-safe per-variant access. Wire JSON is identical.
+    profile_tokens: list[ResolvedToken] | None = None  # type: ignore[assignment]

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -918,6 +918,14 @@ class LookupRequest(BaseModel):
         False,
         description="Per cross-cache-identity plan §3.2.2 (E2-LML write contract). When true, the response carries an additional `identity` block (the §3.2.5 cascade's per-source resolution detail), and `api_version` is set to 2. When false (the default), the response is byte-identical to v0.5.0 — `identity` is absent and `api_version` is omitted. Backend's `library-identity-writer.ts` (E2-BS) sets this to true on every call; other consumers (catalog search, dj-site proxy, iOS apps) leave it false.\n",
     )
+    extended: bool | None = Field(
+        None,
+        description="When true, the top-1 result's `artwork` block is populated with additional fields LML already fetches during enrichment but normally discards: `discogs_artist_id`, `tracklist`, `genres`, `styles`, `label`, `full_release_date`, `artist_image_url`, and `profile_tokens` (cache-only deep parse of the artist's profile markup). Lets a caller obtain a full playcut metadata payload in a single `/lookup` call instead of following up with separate `/discogs/release/{id}` and `/discogs/artist/{id}` requests. Absent or false leaves the response shape unchanged.\n",
+    )
+    warm_cache: bool | None = Field(
+        None,
+        description="When true, LML schedules a fire-and-forget background task after the response is built that runs a *deep* async parse of the top-1 artist's bio. The task resolves all `[a…]`/`[r…]`/`[m…]` references against the Discogs API where the local cache misses, warming the PG cache so subsequent reads of the same artist render richer bio tokens. Intended for write-path callers (e.g. Backend-Service's flowsheet-linkage service committing a new DJ entry); read-path callers should leave this absent/false to avoid doubling the Discogs-API load per request.\n",
+    )
 
 
 class LibraryCatalogItem(BaseModel):
@@ -943,23 +951,6 @@ class LibraryCatalogItem(BaseModel):
         None,
         description="True if this release is available on at least one streaming service. False means only available in the WXYC physical library. Null if unknown.",
     )
-
-
-class DiscogsMatchResult(BaseModel):
-    album: str | None = Field(None, description="Release title")
-    artist: str | None = Field(None, description="Release artist")
-    release_id: int = Field(..., description="Discogs release ID")
-    release_url: str = Field(..., description="URL to the release on Discogs")
-    artwork_url: str | None = Field(None, description="Artwork image URL")
-    confidence: confloat(ge=0.0, le=1.0) | None = Field(0, description="Match confidence score")
-    release_year: int | None = Field(None, description="Release year from Discogs")
-    artist_bio: str | None = Field(None, description="Artist biography from Discogs profile")
-    wikipedia_url: str | None = Field(None, description="Wikipedia URL for the artist")
-    spotify_url: str | None = Field(None, description="Spotify album URL")
-    apple_music_url: str | None = Field(None, description="Apple Music album URL")
-    youtube_music_url: str | None = Field(None, description="YouTube Music search URL")
-    bandcamp_url: str | None = Field(None, description="Bandcamp album URL")
-    soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
 
 
 class CacheStats(BaseModel):
@@ -1438,6 +1429,55 @@ class EnhancedRequest(SongRequest):
     matches: list[LibraryMatch] | None = None
     artwork_url: str | None = None
     discogs_url: str | None = None
+
+
+class DiscogsMatchResult(BaseModel):
+    album: str | None = Field(None, description="Release title")
+    artist: str | None = Field(None, description="Release artist")
+    release_id: int = Field(..., description="Discogs release ID")
+    release_url: str = Field(..., description="URL to the release on Discogs")
+    artwork_url: str | None = Field(None, description="Artwork image URL")
+    confidence: confloat(ge=0.0, le=1.0) | None = Field(0, description="Match confidence score")
+    release_year: int | None = Field(None, description="Release year from Discogs")
+    artist_bio: str | None = Field(None, description="Artist biography from Discogs profile")
+    wikipedia_url: str | None = Field(None, description="Wikipedia URL for the artist")
+    spotify_url: str | None = Field(None, description="Spotify album URL")
+    apple_music_url: str | None = Field(None, description="Apple Music album URL")
+    youtube_music_url: str | None = Field(None, description="YouTube Music search URL")
+    bandcamp_url: str | None = Field(None, description="Bandcamp album URL")
+    soundcloud_url: str | None = Field(None, description="SoundCloud search URL")
+    discogs_artist_id: int | None = Field(
+        None,
+        description="Discogs artist ID for this release. Populated only when the originating `LookupRequest.extended` is true. Lets a caller key an artist-metadata cache without a follow-up release fetch.\n",
+    )
+    tracklist: list[DiscogsTrackItem] | None = Field(
+        None,
+        description="Release tracklist with per-track artist credits where available. Populated only when `extended` is true.\n",
+    )
+    genres: list[str] | None = Field(
+        None,
+        description='Discogs genre tags (e.g. "Rock", "Electronic"). Populated only when `extended` is true.\n',
+    )
+    styles: list[str] | None = Field(
+        None,
+        description='Discogs style tags (finer-grained than genres; e.g. "Indie Rock", "Ambient"). Populated only when `extended` is true.\n',
+    )
+    label: str | None = Field(
+        None,
+        description="Primary record-label name from the Discogs release. Distinct from `LibraryCatalogItem.label` (which comes from the WXYC catalog's rotation-release join). Populated only when `extended` is true.\n",
+    )
+    full_release_date: str | None = Field(
+        None,
+        description='Release date as an ISO string (e.g. "1997-09-22"). May be year-only ("1997") or year-month ("1997-09") if Discogs lacks the full date. Populated only when `extended` is true.\n',
+    )
+    artist_image_url: str | None = Field(
+        None,
+        description="Primary artist image URL from Discogs (the artist's profile photo, not the release artwork). Populated only when `extended` is true.\n",
+    )
+    profile_tokens: list[DiscogsResolvedToken] | None = Field(
+        None,
+        description="Pre-parsed structured tokens from the artist's `profile` markup, using a cache-only resolver — references to entities not in the local PG cache fall through as plain-text tokens (no inline Discogs API calls on the read path). Populated only when `extended` is true. Field name matches `DiscogsArtistDetails.profile_tokens` so callers can share rendering code across the two payloads. Pair with `LookupRequest.warm_cache=true` on write-path calls to progressively populate the cache so subsequent reads render richer.\n",
+    )
 
 
 class LookupResultItem(BaseModel):

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -27,8 +27,20 @@ from core.search import (
 )
 from discogs.cache_service import DiscogsCacheService
 from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
+from discogs.markup_parser import (
+    CachedOnlyResolver,
+    DiscogsServiceResolver,
+    parse_async,
+)
 from discogs.memory_cache import create_ttl_cache, should_skip_cache
-from discogs.models import DiscogsSearchRequest, DiscogsSearchResult, ReleaseInfo
+from discogs.models import (
+    ArtistDetails,
+    DiscogsSearchRequest,
+    DiscogsSearchResult,
+    ReleaseInfo,
+    ReleaseMetadataResponse,
+    ResolvedToken,
+)
 from discogs.service import DiscogsService
 from generated.api_models import (
     LibraryCatalogItem,
@@ -1345,6 +1357,10 @@ async def enrich_artwork_results(
     song: str | None = None,
     library_db: LibraryDB | None = None,
     http_client: httpx.AsyncClient | None = None,
+    *,
+    extended: bool = False,
+    warm_cache: bool = False,
+    discogs_cache: "DiscogsCacheService | None" = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Enrich artwork results with release year, artist details, and streaming links.
 
@@ -1354,62 +1370,107 @@ async def enrich_artwork_results(
     ``http_client`` is the shared ``httpx.AsyncClient`` used for the iTunes
     Search probe. Passing ``None`` skips the Apple Music lookup — the
     orchestrator never instantiates its own client (issue #241).
+
+    Release/artist details (year, bio, wikipedia URL) are fetched only for
+    ``items_with_artwork[0]`` — BS/iOS only consume the top-1 result, so
+    paying N round-trips of Discogs cache (and on miss, API) latency for
+    non-top-1 items was waste. Streaming-URL fallbacks stay per-result
+    (cheap; no I/O).
+
+    ``extended=True`` additionally populates the new DiscogsMatchResult
+    fields LML already loaded during the release+artist fetches:
+    ``discogs_artist_id``, ``tracklist``, ``genres``, ``styles``, ``label``,
+    ``full_release_date``, ``artist_image_url``, ``profile_tokens``. Bio
+    parsing uses a cache-only resolver — refs that miss fall through as
+    plain text, never trigger an inline Discogs API call.
+
+    ``warm_cache=True`` schedules an ``asyncio.create_task`` after the
+    response is composed that runs the *deep* async parse against the
+    API-capable resolver, warming the PG cache for referenced entities so
+    subsequent read-path lookups render richer. The task is not awaited —
+    write-path callers (Backend-Service's flowsheet-linkage service) pay
+    zero added latency. The task wraps its body in try/except and logs
+    failures via ``logger.exception`` so a stuck warm doesn't go silent.
     """
-    if not discogs_service:
+    if not discogs_service or not items_with_artwork:
         return items_with_artwork
 
+    # Top-1-only expensive enrichment. fetch_release_details runs once;
+    # non-top-1 items reuse the same per-result streaming-URL build.
+    async def fetch_top1_release_details() -> tuple[
+        int | None,
+        str | None,
+        str | None,
+        "ReleaseMetadataResponse | None",
+        "ArtistDetails | None",
+    ]:
+        """Returns (year, artist_bio, wikipedia_url, release, details) for the top-1 result.
+
+        Returns the release + artist payloads alongside the legacy three
+        scalars so the extended-field population can pluck additional
+        fields without re-fetching.
+        """
+        top_artwork = items_with_artwork[0][1]
+        if top_artwork is None:
+            return None, None, None, None, None
+        try:
+            release = await discogs_service.get_release(top_artwork.release_id)
+            if not release:
+                return None, None, None, None, None
+
+            year = release.year if isinstance(release.year, int) else None
+            artist_id = release.artist_id
+            if not isinstance(artist_id, int) or artist_id <= 0:
+                return year, None, None, release, None
+
+            details = await discogs_service.get_artist_details(artist_id)
+            if not details:
+                return year, None, None, release, None
+
+            bio = details.profile if isinstance(details.profile, str) else None
+            wiki = next(
+                (url for url in details.urls if isinstance(url, str) and "wikipedia.org" in url),
+                None,
+            )
+            return year, bio, wiki, release, details
+        except Exception:
+            return None, None, None, None, None
+
+    top1_year, top1_bio, top1_wiki, top1_release, top1_details = await fetch_top1_release_details()
+
+    # Cache-only deep parse of the top-1 bio for the extended path. Refs
+    # that miss the cache fall through; we never fire a new API call here.
+    top1_profile_tokens: list[ResolvedToken] | None = None
+    if extended and top1_bio and discogs_cache is not None:
+        try:
+            top1_profile_tokens = await parse_async(top1_bio, CachedOnlyResolver(discogs_cache))
+        except Exception:
+            logger.exception("Cache-only bio parse failed; falling back to no tokens")
+            top1_profile_tokens = None
+
     async def enrich_one(
-        item: LibraryItem, artwork: DiscogsSearchResult | None
+        item: LibraryItem,
+        artwork: DiscogsSearchResult | None,
+        *,
+        is_top1: bool,
     ) -> tuple[LibraryItem, DiscogsSearchResult | None]:
         if not artwork:
             return (item, artwork)
 
         artist = item.alternate_artist_name or item.artist or ""
         search_term = song or item.title or ""
-        release_id = artwork.release_id
 
-        async def fetch_release_details() -> tuple[int | None, str | None, str | None]:
-            """Returns (year, artist_bio, wikipedia_url) from Discogs release + artist."""
-            try:
-                release = await discogs_service.get_release(release_id)
-                if not release:
-                    return None, None, None
-
-                year = release.year if isinstance(release.year, int) else None
-
-                # Fetch artist details if we have an artist_id
-                artist_id = release.artist_id
-                if not isinstance(artist_id, int) or artist_id <= 0:
-                    return year, None, None
-
-                details = await discogs_service.get_artist_details(artist_id)
-                if not details:
-                    return year, None, None
-
-                bio = details.profile if isinstance(details.profile, str) else None
-                wiki = next(
-                    (
-                        url
-                        for url in details.urls
-                        if isinstance(url, str) and "wikipedia.org" in url
-                    ),
-                    None,
-                )
-                return year, bio, wiki
-            except Exception:
-                return None, None, None
-
-        async def fetch_apple_music() -> str | None:
-            if not artist or not search_term:
-                return None
-            return await _fetch_apple_music_url(artist, search_term, http_client=http_client)
-
-        release_details_result, apple_music_result = await asyncio.gather(
-            fetch_release_details(),
-            fetch_apple_music(),
+        apple_music_result = (
+            await _fetch_apple_music_url(artist, search_term, http_client=http_client)
+            if (artist and search_term)
+            else None
         )
 
-        year_result, artist_bio, wikipedia_url = release_details_result
+        # Top-1 scalars; non-top-1 leaves these as None and renders with
+        # streaming-URL fallbacks only.
+        year_result = top1_year if is_top1 else None
+        artist_bio = top1_bio if is_top1 else None
+        wikipedia_url = top1_wiki if is_top1 else None
 
         # Get streaming URLs: prefer direct links from DB, fall back to search URLs
         spotify_url = None
@@ -1449,24 +1510,70 @@ async def enrich_artwork_results(
                     "https://soundcloud.com/search?q=", artist, search_term
                 )
 
-        updated = artwork.model_copy(
-            update={
-                "release_year": year_result,
-                "artist_bio": artist_bio,
-                "wikipedia_url": wikipedia_url,
-                "spotify_url": spotify_url,
-                "apple_music_url": apple_music_override or apple_music_result or None,
-                "youtube_music_url": youtube_music_url,
-                "bandcamp_url": bandcamp_url,
-                "soundcloud_url": soundcloud_url,
-            }
-        )
-        return (item, updated)
+        update: dict = {
+            "release_year": year_result,
+            "artist_bio": artist_bio,
+            "wikipedia_url": wikipedia_url,
+            "spotify_url": spotify_url,
+            "apple_music_url": apple_music_override or apple_music_result or None,
+            "youtube_music_url": youtube_music_url,
+            "bandcamp_url": bandcamp_url,
+            "soundcloud_url": soundcloud_url,
+        }
+
+        # Extended fields land on the top-1 result only. The non-top-1
+        # items keep their lean shape so non-iOS lookup callers (request
+        # line, dj-site proxy, BS catalog) don't pay payload bloat for
+        # results they ignore.
+        if extended and is_top1:
+            if top1_release is not None:
+                update["discogs_artist_id"] = top1_release.artist_id
+                update["tracklist"] = (
+                    list(top1_release.tracklist) if top1_release.tracklist else None
+                )
+                update["genres"] = list(top1_release.genres) if top1_release.genres else None
+                update["styles"] = list(top1_release.styles) if top1_release.styles else None
+                update["label"] = top1_release.label
+                update["full_release_date"] = top1_release.released
+            update["artist_image_url"] = (
+                top1_details.image_url if top1_details is not None else None
+            )
+            update["profile_tokens"] = top1_profile_tokens
+
+        return (item, artwork.model_copy(update=update))
 
     enriched = await asyncio.gather(
-        *[enrich_one(item, artwork) for item, artwork in items_with_artwork]
+        *[
+            enrich_one(item, artwork, is_top1=(idx == 0))
+            for idx, (item, artwork) in enumerate(items_with_artwork)
+        ]
     )
+
+    # Write-path warm: fire-and-forget deep async parse of the top-1 bio
+    # using the API-capable resolver, so the PG cache gets populated for
+    # `[a…]`/`[r…]`/`[m…]` references. The task is intentionally not
+    # awaited — read-path latency is unaffected.
+    if warm_cache and top1_bio:
+        asyncio.create_task(_warm_bio_cache(top1_bio, discogs_service))
+
     return list(enriched)
+
+
+async def _warm_bio_cache(bio: str, discogs_service: "DiscogsService") -> None:
+    """Background task: deep-async parse of an artist bio to warm caches.
+
+    Resolves every `[a<id>]` / `[r<id>]` / `[m<id>]` reference through
+    ``DiscogsServiceResolver`` (cache → API → cache write-back), so
+    subsequent ``parse_async(..., CachedOnlyResolver)`` calls on this bio
+    return typed tokens instead of plain text. Errors are logged and
+    swallowed — the task must never propagate to the event loop.
+    """
+    try:
+        await parse_async(bio, DiscogsServiceResolver(discogs_service))
+        sentry_sdk.set_tag("lml.lookup.cache_warm_status", "success")
+    except Exception:
+        sentry_sdk.set_tag("lml.lookup.cache_warm_status", "error")
+        logger.exception("Background bio cache-warm failed")
 
 
 def build_context_message(
@@ -1693,7 +1800,22 @@ async def perform_lookup(
                 song=parsed.song,
                 library_db=db,
                 http_client=http_client,
+                extended=bool(request.extended),
+                warm_cache=bool(request.warm_cache),
+                discogs_cache=discogs_cache,
             )
+
+    # Project the request-side flags onto the active Sentry transaction so
+    # the trace can be filtered by request mode (lml.lookup.extended,
+    # lml.lookup.warm_cache).
+    try:
+        scope = sentry_sdk.get_current_scope()
+        if scope.transaction is not None:
+            scope.transaction.set_data("lml.lookup.extended", bool(request.extended))
+            scope.transaction.set_data("lml.lookup.warm_cache", bool(request.warm_cache))
+    except Exception:
+        # Observability must not break the request path.
+        pass
 
     # Step 5: Build context message
     context = build_context_message(

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -30,6 +30,7 @@ from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
 from discogs.markup_parser import (
     CachedOnlyResolver,
     DiscogsServiceResolver,
+    parse,
     parse_async,
 )
 from discogs.memory_cache import create_ttl_cache, should_skip_cache
@@ -67,6 +68,31 @@ MAX_SEARCH_RESULTS = 5
 
 SELF_TITLED_PATTERNS = frozenset({"s/t", "s.t.", "self-titled", "self titled"})
 """Common abbreviations for self-titled albums (case-insensitive exact match)."""
+
+_WARM_CACHE_CONCURRENCY: int = 4
+"""Process-wide cap on concurrent bio cache-warm tasks.
+
+A single warm task can fan out to many Discogs API calls (one per
+unresolved `[a…]`/`[r…]`/`[m…]` ref the local cache misses). The semaphore
+bounds the total in-flight API load when several flowsheet entries get
+committed in quick succession. 4 is conservative — Discogs's published
+rate limit is 60 RPM authenticated; warm bursts at 4 concurrent × a few
+refs each still leave headroom for the read path.
+"""
+
+_warm_cache_semaphore: asyncio.Semaphore | None = None
+"""Lazily-constructed (needs a running event loop). Re-bind on the first call."""
+
+_background_tasks: set[asyncio.Task] = set()
+"""References to fire-and-forget tasks scheduled by ``enrich_artwork_results``.
+
+`asyncio.create_task` returns weak references — without anchoring the
+task somewhere strong, the GC can reap it mid-execution and the warm
+silently drops. The standard pattern is a module-level set; each task
+removes itself in a done_callback. See
+https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+"""
+
 
 CANONICAL_ARTIST_SIMILARITY_FLOOR: float = 0.70
 """Trigram-similarity floor for swapping an inbound artist name with its canonical
@@ -1360,7 +1386,7 @@ async def enrich_artwork_results(
     *,
     extended: bool = False,
     warm_cache: bool = False,
-    discogs_cache: "DiscogsCacheService | None" = None,
+    discogs_cache: DiscogsCacheService | None = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Enrich artwork results with release year, artist details, and streaming links.
 
@@ -1371,26 +1397,38 @@ async def enrich_artwork_results(
     Search probe. Passing ``None`` skips the Apple Music lookup — the
     orchestrator never instantiates its own client (issue #241).
 
-    Release/artist details (year, bio, wikipedia URL) are fetched only for
-    ``items_with_artwork[0]`` — BS/iOS only consume the top-1 result, so
-    paying N round-trips of Discogs cache (and on miss, API) latency for
-    non-top-1 items was waste. Streaming-URL fallbacks stay per-result
-    (cheap; no I/O).
+    **Behavior change vs. v0.5.0:** release/artist details (release_year,
+    artist_bio, wikipedia_url) are fetched only for ``items_with_artwork[0]``.
+    BS/iOS only consume the top-1 result, so paying N round-trips of Discogs
+    cache (and on miss, API) latency for non-top-1 items was waste. The
+    streaming-URL fallback build still runs per-result (cheap; no I/O).
+    Gating is *positional*: a top-1 entry with ``artwork=None`` means no
+    item in the response carries release-year/bio/wiki, even when items
+    further down have artwork. BS/iOS only ever read ``results[0]`` so
+    this is fine in practice; the lookup pipeline guarantees the strongest
+    match is in position 0.
 
     ``extended=True`` additionally populates the new DiscogsMatchResult
     fields LML already loaded during the release+artist fetches:
     ``discogs_artist_id``, ``tracklist``, ``genres``, ``styles``, ``label``,
     ``full_release_date``, ``artist_image_url``, ``profile_tokens``. Bio
-    parsing uses a cache-only resolver — refs that miss fall through as
-    plain text, never trigger an inline Discogs API call.
+    parsing uses ``CachedOnlyResolver`` when ``discogs_cache`` is provided
+    — refs that miss the cache fall through as plain text, never trigger
+    an inline Discogs API call. When ``discogs_cache`` is None (LML
+    deployed without ``DATABASE_URL_DISCOGS``), bio parsing falls back to
+    sync ``parse()`` which strips ID-based refs but keeps name-based and
+    formatting tokens, so ``profile_tokens`` is still non-None for
+    consistent client-side rendering.
 
-    ``warm_cache=True`` schedules an ``asyncio.create_task`` after the
-    response is composed that runs the *deep* async parse against the
-    API-capable resolver, warming the PG cache for referenced entities so
-    subsequent read-path lookups render richer. The task is not awaited —
-    write-path callers (Backend-Service's flowsheet-linkage service) pay
-    zero added latency. The task wraps its body in try/except and logs
-    failures via ``logger.exception`` so a stuck warm doesn't go silent.
+    ``warm_cache=True`` schedules a fire-and-forget ``asyncio.create_task``
+    after the response is composed that runs the *deep* async parse
+    against the API-capable resolver, warming the PG cache for referenced
+    entities so subsequent read-path lookups render richer. The task is
+    not awaited — write-path callers (Backend-Service's flowsheet-linkage
+    service) pay zero added latency. Concurrent warm tasks are bounded by
+    ``_WARM_CACHE_CONCURRENCY`` to cap Discogs API amplification under
+    burst load. Failures are logged via ``logger.exception`` so a stuck
+    warm doesn't go silent.
     """
     if not discogs_service or not items_with_artwork:
         return items_with_artwork
@@ -1401,8 +1439,8 @@ async def enrich_artwork_results(
         int | None,
         str | None,
         str | None,
-        "ReleaseMetadataResponse | None",
-        "ArtistDetails | None",
+        ReleaseMetadataResponse | None,
+        ArtistDetails | None,
     ]:
         """Returns (year, artist_bio, wikipedia_url, release, details) for the top-1 result.
 
@@ -1440,13 +1478,19 @@ async def enrich_artwork_results(
 
     # Cache-only deep parse of the top-1 bio for the extended path. Refs
     # that miss the cache fall through; we never fire a new API call here.
+    # When the PG cache is unavailable (no DATABASE_URL_DISCOGS), fall
+    # back to sync parse() — drops ID-based refs but keeps name and
+    # formatting tokens, so clients still get structured rendering.
     top1_profile_tokens: list[ResolvedToken] | None = None
-    if extended and top1_bio and discogs_cache is not None:
-        try:
-            top1_profile_tokens = await parse_async(top1_bio, CachedOnlyResolver(discogs_cache))
-        except Exception:
-            logger.exception("Cache-only bio parse failed; falling back to no tokens")
-            top1_profile_tokens = None
+    if extended and top1_bio:
+        if discogs_cache is not None:
+            try:
+                top1_profile_tokens = await parse_async(top1_bio, CachedOnlyResolver(discogs_cache))
+            except Exception:
+                logger.exception("Cache-only bio parse failed; falling back to sync parse")
+                top1_profile_tokens = parse(top1_bio)
+        else:
+            top1_profile_tokens = parse(top1_bio)
 
     async def enrich_one(
         item: LibraryItem,
@@ -1510,7 +1554,7 @@ async def enrich_artwork_results(
                     "https://soundcloud.com/search?q=", artist, search_term
                 )
 
-        update: dict = {
+        update: dict[str, Any] = {
             "release_year": year_result,
             "artist_bio": artist_bio,
             "wikipedia_url": wikipedia_url,
@@ -1552,27 +1596,37 @@ async def enrich_artwork_results(
     # Write-path warm: fire-and-forget deep async parse of the top-1 bio
     # using the API-capable resolver, so the PG cache gets populated for
     # `[a…]`/`[r…]`/`[m…]` references. The task is intentionally not
-    # awaited — read-path latency is unaffected.
+    # awaited — read-path latency is unaffected. The task reference is
+    # parked in ``_background_tasks`` so the GC can't reap it mid-flight
+    # (asyncio holds only weak refs to tasks).
     if warm_cache and top1_bio:
-        asyncio.create_task(_warm_bio_cache(top1_bio, discogs_service))
+        task = asyncio.create_task(_warm_bio_cache(top1_bio, discogs_service))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     return list(enriched)
 
 
-async def _warm_bio_cache(bio: str, discogs_service: "DiscogsService") -> None:
+async def _warm_bio_cache(bio: str, discogs_service: DiscogsService) -> None:
     """Background task: deep-async parse of an artist bio to warm caches.
 
     Resolves every `[a<id>]` / `[r<id>]` / `[m<id>]` reference through
     ``DiscogsServiceResolver`` (cache → API → cache write-back), so
     subsequent ``parse_async(..., CachedOnlyResolver)`` calls on this bio
-    return typed tokens instead of plain text. Errors are logged and
-    swallowed — the task must never propagate to the event loop.
+    return typed tokens instead of plain text. Bounded by the module-level
+    semaphore to cap concurrent Discogs API amplification under burst
+    load. Errors are logged and swallowed — the task must never propagate
+    to the event loop. No Sentry tag is set here: the request scope has
+    long since closed by the time this runs, so a tag on the active scope
+    would land on whatever unrelated request is running next.
     """
+    global _warm_cache_semaphore
+    if _warm_cache_semaphore is None:
+        _warm_cache_semaphore = asyncio.Semaphore(_WARM_CACHE_CONCURRENCY)
     try:
-        await parse_async(bio, DiscogsServiceResolver(discogs_service))
-        sentry_sdk.set_tag("lml.lookup.cache_warm_status", "success")
+        async with _warm_cache_semaphore:
+            await parse_async(bio, DiscogsServiceResolver(discogs_service))
     except Exception:
-        sentry_sdk.set_tag("lml.lookup.cache_warm_status", "error")
         logger.exception("Background bio cache-warm failed")
 
 
@@ -1791,6 +1845,12 @@ async def perform_lookup(
                 library_results, discogs_service, discogs_titles
             )
 
+    # The generated LookupRequest models these as bool | None (api.yaml
+    # describes them with `default: false` but the field is not in the
+    # required set, so callers can omit them). Coerce once and reuse.
+    extended_mode = bool(request.extended)
+    warm_cache_mode = bool(request.warm_cache)
+
     # Step 4b: Enrich with release year, artist details, streaming links
     with telemetry.track_step("metadata_enrichment"):
         if items_with_artwork:
@@ -1800,8 +1860,8 @@ async def perform_lookup(
                 song=parsed.song,
                 library_db=db,
                 http_client=http_client,
-                extended=bool(request.extended),
-                warm_cache=bool(request.warm_cache),
+                extended=extended_mode,
+                warm_cache=warm_cache_mode,
                 discogs_cache=discogs_cache,
             )
 
@@ -1811,8 +1871,8 @@ async def perform_lookup(
     try:
         scope = sentry_sdk.get_current_scope()
         if scope.transaction is not None:
-            scope.transaction.set_data("lml.lookup.extended", bool(request.extended))
-            scope.transaction.set_data("lml.lookup.warm_cache", bool(request.warm_cache))
+            scope.transaction.set_data("lml.lookup.extended", extended_mode)
+            scope.transaction.set_data("lml.lookup.warm_cache", warm_cache_mode)
     except Exception:
         # Observability must not break the request path.
         pass

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -45,7 +45,13 @@ def make_catalog_item(id=1, artist="Stereolab", title="Aluminum Tunes", **kwargs
 
 
 def make_match_result(release_id=123, **kwargs):
-    """Build a DiscogsMatchResult (API contract model) with sensible defaults."""
+    """Build a DiscogsMatchResult (API contract model) with sensible defaults.
+
+    Extended-metadata fields (discogs_artist_id, tracklist, genres, styles,
+    label, full_release_date, artist_image_url, profile_tokens) default to
+    None — the API contract treats them as opt-in for `extended=true`
+    lookups. Pass them through ``kwargs`` to assert on their shape.
+    """
     defaults = {
         "release_url": f"https://discogs.com/release/{release_id}",
         "album": "Aluminum Tunes",

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1,10 +1,16 @@
 """Tests for metadata enrichment (release year, artist details, streaming links)."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from discogs.models import ArtistDetails, DiscogsSearchResult, ReleaseMetadataResponse
+from discogs.models import (
+    ArtistDetails,
+    DiscogsSearchResult,
+    ReleaseMetadataResponse,
+    TrackItem,
+)
 from lookup.orchestrator import (
     _build_streaming_search_url,
     _fetch_apple_music_url,
@@ -175,8 +181,19 @@ class TestEnrichArtworkResults:
         assert enriched.spotify_url is not None  # search URL still works
 
     @pytest.mark.asyncio
-    async def test_enriches_multiple_items_preserving_order(self):
-        """Multiple items should all be enriched and returned in input order."""
+    async def test_top1_gating_only_release_details_for_first_item(self):
+        """Only ``results[0]`` should trigger the release+artist Discogs fetch.
+
+        Previously every result in ``items_with_artwork`` ran
+        ``fetch_release_details`` even though BS/iOS only consume the top
+        result — paying N round-trips of Discogs cache (and on miss, API)
+        latency for nothing. The orchestrator now gates the expensive
+        enrichment to ``items_with_artwork[0]`` while keeping the cheap
+        streaming-URL fallback per-result.
+
+        Item order must still be preserved, and non-top-1 items keep their
+        artwork object (with streaming URLs filled in).
+        """
         items_with_artwork = [
             (
                 make_library_item(id=i, artist=f"Artist {i}", title=f"Album {i}"),
@@ -206,7 +223,267 @@ class TestEnrichArtworkResults:
         for i, (item, enriched) in enumerate(results, start=1):
             assert item.id == i, f"Item order not preserved at position {i}"
             assert enriched is not None
-            assert enriched.release_year == 2000 + i
+            # Streaming URLs still built per-result (cheap; no I/O).
+            assert enriched.spotify_url is not None
+
+        # Top-1 gets the release year; the rest don't.
+        assert results[0][1].release_year == 2001
+        assert results[1][1].release_year is None
+        assert results[2][1].release_year is None
+
+        # And only one release fetch fired — for release_id 1.
+        called_ids = {call.args[0] for call in discogs_service.get_release.call_args_list}
+        assert called_ids == {1}
+
+
+class TestEnrichArtworkResultsExtended:
+    """Coverage for the ``extended=True`` path: populates the additional
+    DiscogsMatchResult fields LML already loads but normally discards.
+
+    These fields land on the top-1 result only; non-top-1 items see the
+    same (lean) shape as before."""
+
+    @pytest.mark.asyncio
+    async def test_extended_populates_new_fields_on_top1(self):
+        item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
+        artwork = make_discogs_result(
+            release_id=10154369, artist="Stereolab", album="Aluminum Tunes"
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=10154369,
+            title="Aluminum Tunes",
+            artist="Stereolab",
+            year=1997,
+            label="Duophonic Ultra High Frequency Disks",
+            artist_id=42,
+            genres=["Electronic", "Rock"],
+            styles=["Indie Rock", "Experimental"],
+            tracklist=[
+                TrackItem(position="1", title="Pop Quiz", duration="3:14", artists=[]),
+                TrackItem(position="2", title="Olv 26", duration="2:48", artists=[]),
+            ],
+            released="1997-09-22",
+            release_url="https://discogs.com/release/10154369",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42,
+            name="Stereolab",
+            profile="French-British band founded in 1990.",
+            image_url="https://img.discogs.com/stereolab.jpg",
+            urls=["https://en.wikipedia.org/wiki/Stereolab"],
+        )
+
+        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
+            results = await enrich_artwork_results(
+                [(item, artwork)],
+                discogs_service,
+                song="Olv 26",
+                extended=True,
+            )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.discogs_artist_id == 42
+        assert enriched.label == "Duophonic Ultra High Frequency Disks"
+        assert enriched.genres == ["Electronic", "Rock"]
+        assert enriched.styles == ["Indie Rock", "Experimental"]
+        assert enriched.full_release_date == "1997-09-22"
+        assert enriched.artist_image_url == "https://img.discogs.com/stereolab.jpg"
+        assert enriched.tracklist is not None
+        assert len(enriched.tracklist) == 2
+        assert enriched.tracklist[0].title == "Pop Quiz"
+        # The pre-existing year/bio/wiki fields also remain populated.
+        assert enriched.release_year == 1997
+        assert "French-British band" in enriched.artist_bio
+
+    @pytest.mark.asyncio
+    async def test_extended_false_leaves_new_fields_unset(self):
+        """With extended=False the response shape is unchanged.
+
+        Existing consumers (request-o-matic, dj-site proxy, BS request-line)
+        must not see the new fields populated when they don't ask for them.
+        """
+        item = make_library_item()
+        artwork = make_discogs_result()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=123,
+            title="x",
+            artist="x",
+            year=2020,
+            artist_id=42,
+            genres=["Rock"],
+            styles=["Indie Rock"],
+            label="Some Label",
+            released="2020-01-15",
+            release_url="https://discogs.com/release/123",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42,
+            name="x",
+            image_url="https://img.discogs.com/x.jpg",
+        )
+
+        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
+            results = await enrich_artwork_results(
+                [(item, artwork)], discogs_service, extended=False
+            )
+
+        _, enriched = results[0]
+        assert enriched.discogs_artist_id is None
+        assert enriched.label is None
+        assert enriched.genres is None
+        assert enriched.styles is None
+        assert enriched.full_release_date is None
+        assert enriched.artist_image_url is None
+        assert enriched.tracklist is None
+        assert enriched.profile_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_extended_parses_profile_tokens_cache_only(self):
+        """When extended=True, the bio is parsed against the local cache only.
+
+        References that resolve from the cache (typically [a<id>] for an
+        artist whose details are already loaded by ``enrich_one``) become
+        typed tokens; refs that miss fall through as plain text. No new
+        Discogs API calls fire — only the cache_service lookups.
+        """
+        item = make_library_item()
+        artwork = make_discogs_result()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=123,
+            title="x",
+            artist="x",
+            year=2020,
+            artist_id=42,
+            release_url="https://discogs.com/release/123",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42,
+            name="Stereolab",
+            profile="Self-reference: [a42]. Unknown release: [r999999].",
+        )
+
+        # cache_service that resolves artist 42 but knows no releases.
+        cache_service = AsyncMock()
+        cache_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42, name="Stereolab"
+        )
+        cache_service.get_release.return_value = None  # unknown
+
+        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
+            results = await enrich_artwork_results(
+                [(item, artwork)],
+                discogs_service,
+                extended=True,
+                discogs_cache=cache_service,
+            )
+
+        _, enriched = results[0]
+        assert enriched.profile_tokens is not None
+        # The artist link resolved against the cache; the release ref didn't.
+        kinds = [type(t).__name__ for t in enriched.profile_tokens]
+        assert "ArtistLinkToken" in kinds
+        # Cache-only resolver returns None for the unknown release; the [r…]
+        # token is dropped by the resolver, not promoted to ReleaseLinkToken.
+        assert "ReleaseLinkToken" not in kinds
+
+    @pytest.mark.asyncio
+    async def test_warm_cache_schedules_background_task(self):
+        """warm_cache=True schedules a fire-and-forget deep-async bio parse.
+
+        The orchestrator must NOT await the warming task — it runs after
+        the response is built so write-path callers (Backend-Service's
+        flowsheet-linkage) pay zero added latency.
+        """
+        item = make_library_item()
+        artwork = make_discogs_result()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=123,
+            title="x",
+            artist="x",
+            year=2020,
+            artist_id=42,
+            release_url="https://discogs.com/release/123",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42, name="x", profile="Bio with [a99] and [r77]."
+        )
+
+        scheduled: list[asyncio.Task] = []
+        original_create_task = asyncio.create_task
+
+        def spy_create_task(coro, *args, **kwargs):
+            task = original_create_task(coro, *args, **kwargs)
+            scheduled.append(task)
+            return task
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
+        ):
+            await enrich_artwork_results(
+                [(item, artwork)],
+                discogs_service,
+                extended=True,
+                warm_cache=True,
+            )
+
+        # Exactly one warming task scheduled (top-1 only).
+        assert len(scheduled) == 1
+        # Drain it so the test exits cleanly. The task runs parse_async
+        # against the API-capable resolver; with a mocked discogs_service
+        # the resolutions return values from the side_effect.
+        await asyncio.gather(*scheduled, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_warm_cache_false_does_not_schedule(self):
+        item = make_library_item()
+        artwork = make_discogs_result()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=123,
+            title="x",
+            artist="x",
+            year=2020,
+            artist_id=42,
+            release_url="https://discogs.com/release/123",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42, name="x", profile="Bio."
+        )
+
+        scheduled: list[asyncio.Task] = []
+        original_create_task = asyncio.create_task
+
+        def spy_create_task(coro, *args, **kwargs):
+            task = original_create_task(coro, *args, **kwargs)
+            scheduled.append(task)
+            return task
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
+        ):
+            await enrich_artwork_results(
+                [(item, artwork)], discogs_service, extended=True, warm_cache=False
+            )
+
+        assert len(scheduled) == 0
+
+    @pytest.mark.asyncio
+    async def test_extended_with_empty_results(self):
+        """extended=True with no results is a no-op — no IndexError."""
+        results = await enrich_artwork_results([], AsyncMock(), extended=True)
+        assert results == []
 
     @pytest.mark.asyncio
     async def test_to_match_result_includes_enriched_fields(self):

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -486,6 +486,168 @@ class TestEnrichArtworkResultsExtended:
         assert results == []
 
     @pytest.mark.asyncio
+    async def test_warm_cache_with_empty_bio_does_not_schedule(self):
+        """warm_cache=True must not schedule the task when the top-1 bio is
+        empty/None. Otherwise the warm task fires `parse_async("", …)` which
+        wastes a coroutine creation and amplifies nothing.
+        """
+        item = make_library_item()
+        artwork = make_discogs_result()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=123,
+            title="x",
+            artist="x",
+            year=2020,
+            artist_id=42,
+            release_url="https://discogs.com/release/123",
+        )
+        # Artist details with no profile bio — top1_bio resolves to None.
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42, name="x", profile=None
+        )
+
+        scheduled: list[asyncio.Task] = []
+        original_create_task = asyncio.create_task
+
+        def spy_create_task(coro, *args, **kwargs):
+            task = original_create_task(coro, *args, **kwargs)
+            scheduled.append(task)
+            return task
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
+        ):
+            await enrich_artwork_results(
+                [(item, artwork)], discogs_service, extended=True, warm_cache=True
+            )
+
+        assert len(scheduled) == 0
+
+    @pytest.mark.asyncio
+    async def test_warm_task_anchored_so_gc_cannot_reap_it(self):
+        """asyncio.create_task returns a weak reference. The orchestrator
+        must park the task in a strong-ref container until it completes,
+        or the GC can drop the warm mid-execution. Verify the task lands
+        in the module-level set and is removed via the done_callback.
+        """
+        from lookup.orchestrator import _background_tasks
+
+        item = make_library_item()
+        artwork = make_discogs_result()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=123,
+            title="x",
+            artist="x",
+            year=2020,
+            artist_id=42,
+            release_url="https://discogs.com/release/123",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42, name="x", profile="Bio."
+        )
+
+        snapshot_before = set(_background_tasks)
+
+        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
+            await enrich_artwork_results(
+                [(item, artwork)],
+                discogs_service,
+                extended=True,
+                warm_cache=True,
+            )
+
+        # The task is anchored in _background_tasks at scheduling time.
+        added = _background_tasks - snapshot_before
+        assert len(added) == 1
+        # Drain so the done_callback runs and the task is removed.
+        await asyncio.gather(*added, return_exceptions=True)
+        # After completion, the set must shrink back — leaving no leak.
+        assert (_background_tasks - snapshot_before) == set()
+
+    @pytest.mark.asyncio
+    async def test_extended_falls_back_to_sync_parse_without_cache(self):
+        """When discogs_cache is None (LML deployed without
+        DATABASE_URL_DISCOGS), bio parsing falls back to sync parse() so
+        profile_tokens is non-None and consistent for client rendering.
+        Sync parse() drops ID-based refs but keeps name and formatting
+        tokens.
+        """
+        item = make_library_item()
+        artwork = make_discogs_result()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=123,
+            title="x",
+            artist="x",
+            year=2020,
+            artist_id=42,
+            release_url="https://discogs.com/release/123",
+        )
+        # Bio with both name-based ([a=Name], renders) and id-based ([a42],
+        # dropped) refs plus a bold span (kept).
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42,
+            name="Stereolab",
+            profile="Members [a=Tim Gane] and [a42]. [b]Active since 1990.[/b]",
+        )
+
+        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
+            results = await enrich_artwork_results(
+                [(item, artwork)],
+                discogs_service,
+                extended=True,
+                discogs_cache=None,  # Explicit: no cache available
+            )
+
+        _, enriched = results[0]
+        assert enriched.profile_tokens is not None
+        kinds = [type(t).__name__ for t in enriched.profile_tokens]
+        # Name-based artist ref kept; id-based ref dropped (sync parse).
+        assert kinds.count("ArtistLinkToken") == 1
+        # Bold formatting kept.
+        assert "BoldToken" in kinds
+
+    @pytest.mark.asyncio
+    async def test_top1_with_no_artwork_leaves_all_release_year_none(self):
+        """Top-1 gating is *positional*. If items_with_artwork[0][1] is
+        None, no item gets release-year enrichment — even items further
+        down that have artwork. BS/iOS only consume results[0] so this is
+        fine in practice; documented in the function's docstring.
+        """
+        items_with_artwork = [
+            (make_library_item(id=1), None),
+            (make_library_item(id=2), make_discogs_result(release_id=2)),
+        ]
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=2,
+            title="x",
+            artist="x",
+            year=2020,
+            artist_id=None,
+            release_url="https://discogs.com/release/2",
+        )
+
+        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
+            results = await enrich_artwork_results(items_with_artwork, discogs_service)
+
+        # Position 0 stays None-artwork; position 1 gets streaming URLs
+        # but NOT release_year — the gate skipped it.
+        assert results[0][1] is None
+        assert results[1][1] is not None
+        assert results[1][1].release_year is None
+        # No release fetch fired — fetch_top1_release_details short-circuits
+        # when top-1's artwork is None.
+        discogs_service.get_release.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_to_match_result_includes_enriched_fields(self):
         result = DiscogsSearchResult(
             release_id=123,

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -138,6 +138,69 @@ class TestHandleLookup:
         assert resp.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_extended_flag_forwarded_to_perform_lookup(self, app_client):
+        """When the request body sets extended=true, the LookupRequest carried
+        into perform_lookup must reflect that. The router is a thin layer;
+        if the flag is dropped here the orchestrator's extended-path branch
+        is unreachable and the BS single-call optimization silently degrades.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json={**LOOKUP_BODY, "extended": True})
+
+        assert resp.status_code == 200
+        # First positional/keyword arg is the LookupRequest.
+        forwarded = mock_lookup.await_args.kwargs.get("request") or mock_lookup.await_args.args[0]
+        assert forwarded.extended is True
+
+    @pytest.mark.asyncio
+    async def test_warm_cache_flag_forwarded_to_perform_lookup(self, app_client):
+        """When the request body sets warm_cache=true, the LookupRequest must
+        carry it into perform_lookup so the orchestrator can schedule the
+        fire-and-forget bio warm.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json={**LOOKUP_BODY, "warm_cache": True})
+
+        assert resp.status_code == 200
+        forwarded = mock_lookup.await_args.kwargs.get("request") or mock_lookup.await_args.args[0]
+        assert forwarded.warm_cache is True
+
+    @pytest.mark.asyncio
+    async def test_extended_and_warm_cache_default_false(self, app_client):
+        """Requests that omit the new flags must keep the legacy behavior:
+        extended=False, warm_cache=False on the orchestrator side. Existing
+        callers (request-o-matic, dj-site proxy) leave the flags off.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        forwarded = mock_lookup.await_args.kwargs.get("request") or mock_lookup.await_args.args[0]
+        # The generated model uses Field(False, ...) so the default surfaces
+        # as either False or None depending on whether the client omits the
+        # field. Treat both as "off".
+        assert not forwarded.extended
+        assert not forwarded.warm_cache
+
+    @pytest.mark.asyncio
     async def test_skip_cache_flag(self, app_client):
         response = LookupResponse(results=[], search_type="direct")
 

--- a/tests/unit/test_markup_parser.py
+++ b/tests/unit/test_markup_parser.py
@@ -520,3 +520,112 @@ class TestResolve:
         tokens = tokenize("[a41]")
         resolved = resolve(tokens)
         assert len(resolved) == 0
+
+
+# MARK: - CachedOnlyResolver Tests
+
+
+class TestCachedOnlyResolver:
+    """Adapter that consults DiscogsCacheService and never the API.
+
+    Used on the lookup read path so bio tokenization can't blow up tail
+    latency when an artist's profile mentions many entities. Cache misses
+    must surface as None (never raise) so parse_async drops the unresolved
+    token. Master IDs always resolve to None — the cache has no masters
+    table.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolves_artist_from_cache(self):
+        from unittest.mock import AsyncMock
+
+        from discogs.markup_parser import CachedOnlyResolver
+        from discogs.models import ArtistDetails
+
+        cache = AsyncMock()
+        cache.get_artist_details.return_value = ArtistDetails(artist_id=42, name="Stereolab")
+
+        resolver = CachedOnlyResolver(cache)
+        assert await resolver.resolve_artist(42) == "Stereolab"
+
+    @pytest.mark.asyncio
+    async def test_resolves_release_from_cache(self):
+        from unittest.mock import AsyncMock
+
+        from discogs.markup_parser import CachedOnlyResolver
+        from discogs.models import ReleaseMetadataResponse
+
+        cache = AsyncMock()
+        cache.get_release.return_value = ReleaseMetadataResponse(
+            release_id=10154369,
+            title="Aluminum Tunes",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/10154369",
+        )
+
+        resolver = CachedOnlyResolver(cache)
+        assert await resolver.resolve_release(10154369) == "Aluminum Tunes"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_cache_miss(self):
+        from unittest.mock import AsyncMock
+
+        from discogs.markup_parser import CachedOnlyResolver
+
+        cache = AsyncMock()
+        cache.get_artist_details.return_value = None
+        cache.get_release.return_value = None
+
+        resolver = CachedOnlyResolver(cache)
+        assert await resolver.resolve_artist(999) is None
+        assert await resolver.resolve_release(999) is None
+
+    @pytest.mark.asyncio
+    async def test_swallows_cache_exceptions(self):
+        """Observability-grade resilience: a cache outage on the read path
+        cannot raise. The bio just renders without resolved entity links.
+        """
+        from unittest.mock import AsyncMock
+
+        from discogs.markup_parser import CachedOnlyResolver
+
+        cache = AsyncMock()
+        cache.get_artist_details.side_effect = RuntimeError("PG connection lost")
+        cache.get_release.side_effect = RuntimeError("PG connection lost")
+
+        resolver = CachedOnlyResolver(cache)
+        assert await resolver.resolve_artist(42) is None
+        assert await resolver.resolve_release(99) is None
+
+    @pytest.mark.asyncio
+    async def test_master_always_none(self):
+        """The discogs-cache has no masters table; always return None."""
+        from unittest.mock import AsyncMock
+
+        from discogs.markup_parser import CachedOnlyResolver
+
+        cache = AsyncMock()
+        resolver = CachedOnlyResolver(cache)
+        assert await resolver.resolve_master(12345) is None
+        # And must not have consulted the cache for masters either.
+        cache.get_release.assert_not_called()
+        cache.get_artist_details.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_integrates_with_parse_async(self):
+        """End-to-end: parse_async with CachedOnlyResolver produces typed
+        tokens for cache hits and drops cache misses."""
+        from unittest.mock import AsyncMock
+
+        from discogs.markup_parser import CachedOnlyResolver, parse_async
+        from discogs.models import ArtistDetails
+
+        cache = AsyncMock()
+        cache.get_artist_details.return_value = ArtistDetails(artist_id=42, name="Stereolab")
+        cache.get_release.return_value = None  # unknown
+
+        tokens = await parse_async("Featuring [a42] from [r999999]", CachedOnlyResolver(cache))
+
+        kinds = [type(t).__name__ for t in tokens]
+        assert "ArtistLinkToken" in kinds
+        assert "ReleaseLinkToken" not in kinds

--- a/tests/unit/test_markup_parser.py
+++ b/tests/unit/test_markup_parser.py
@@ -5,9 +5,12 @@ Covers: artist links, bold/italic/underline formatting, label links,
 URL links, release/master links, edge cases, async entity resolution.
 """
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from discogs.markup_parser import (
+    CachedOnlyResolver,
     _ArtistId,
     _ArtistName,
     _PlainText,
@@ -18,6 +21,7 @@ from discogs.markup_parser import (
     tokenize,
 )
 from discogs.models import (
+    ArtistDetails,
     ArtistLinkToken,
     BoldToken,
     ItalicToken,
@@ -25,6 +29,7 @@ from discogs.models import (
     MasterLinkToken,
     PlainTextToken,
     ReleaseLinkToken,
+    ReleaseMetadataResponse,
     ResolvedToken,
     UnderlineToken,
     UrlLinkToken,
@@ -537,11 +542,6 @@ class TestCachedOnlyResolver:
 
     @pytest.mark.asyncio
     async def test_resolves_artist_from_cache(self):
-        from unittest.mock import AsyncMock
-
-        from discogs.markup_parser import CachedOnlyResolver
-        from discogs.models import ArtistDetails
-
         cache = AsyncMock()
         cache.get_artist_details.return_value = ArtistDetails(artist_id=42, name="Stereolab")
 
@@ -550,11 +550,6 @@ class TestCachedOnlyResolver:
 
     @pytest.mark.asyncio
     async def test_resolves_release_from_cache(self):
-        from unittest.mock import AsyncMock
-
-        from discogs.markup_parser import CachedOnlyResolver
-        from discogs.models import ReleaseMetadataResponse
-
         cache = AsyncMock()
         cache.get_release.return_value = ReleaseMetadataResponse(
             release_id=10154369,
@@ -568,10 +563,6 @@ class TestCachedOnlyResolver:
 
     @pytest.mark.asyncio
     async def test_returns_none_on_cache_miss(self):
-        from unittest.mock import AsyncMock
-
-        from discogs.markup_parser import CachedOnlyResolver
-
         cache = AsyncMock()
         cache.get_artist_details.return_value = None
         cache.get_release.return_value = None
@@ -585,10 +576,6 @@ class TestCachedOnlyResolver:
         """Observability-grade resilience: a cache outage on the read path
         cannot raise. The bio just renders without resolved entity links.
         """
-        from unittest.mock import AsyncMock
-
-        from discogs.markup_parser import CachedOnlyResolver
-
         cache = AsyncMock()
         cache.get_artist_details.side_effect = RuntimeError("PG connection lost")
         cache.get_release.side_effect = RuntimeError("PG connection lost")
@@ -600,10 +587,6 @@ class TestCachedOnlyResolver:
     @pytest.mark.asyncio
     async def test_master_always_none(self):
         """The discogs-cache has no masters table; always return None."""
-        from unittest.mock import AsyncMock
-
-        from discogs.markup_parser import CachedOnlyResolver
-
         cache = AsyncMock()
         resolver = CachedOnlyResolver(cache)
         assert await resolver.resolve_master(12345) is None
@@ -615,11 +598,6 @@ class TestCachedOnlyResolver:
     async def test_integrates_with_parse_async(self):
         """End-to-end: parse_async with CachedOnlyResolver produces typed
         tokens for cache hits and drops cache misses."""
-        from unittest.mock import AsyncMock
-
-        from discogs.markup_parser import CachedOnlyResolver, parse_async
-        from discogs.models import ArtistDetails
-
         cache = AsyncMock()
         cache.get_artist_details.return_value = ArtistDetails(artist_id=42, name="Stereolab")
         cache.get_release.return_value = None  # unknown


### PR DESCRIPTION
## Summary

- Populates 8 new fields on the top-1 `DiscogsMatchResult` under `extended=true`: `discogs_artist_id`, `tracklist`, `genres`, `styles`, `label`, `full_release_date`, `artist_image_url`, `profile_tokens`. All come from the release + artist-details payloads LML already fetches during enrichment.
- Adds `CachedOnlyResolver` (`discogs/markup_parser.py`) — bio parsing on the read path consults PG only, never the Discogs API. Unresolved refs fall through as plain text. Cache exceptions become `None`, never raise.
- Adds `warm_cache=true` flag: schedules a fire-and-forget `asyncio.create_task` after the response is composed that runs the *deep* async parse against the API-capable `DiscogsServiceResolver`, warming the PG cache for `[a…]`/`[r…]` references. Wraps in try/except, logs failures via `logger.exception()`, projects `lml.lookup.cache_warm_status` Sentry tag.
- Free p99 win: top-1 gating. The release+artist fetch is hoisted out of `enrich_one`'s per-result loop and runs once. BS/iOS only consume the top result anyway.
- Projects `lml.lookup.extended` and `lml.lookup.warm_cache` onto the active Sentry transaction so the trace explorer can split latency by request mode.

Strictly additive on the response shape — `extended=false` (the default) returns byte-identical JSON to today.

## Test plan

- [x] `uv run pytest tests/unit/ -v` — 1741 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — clean
- [ ] CI green
- [ ] Manual smoke against staging: `curl POST /api/v1/lookup` with `extended=true` returns new fields populated; with `extended=false` the response matches a current-prod baseline

Closes #335