### PR TITLE
[A2] Fold album-title fallback into parallel gather

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -41,6 +41,7 @@ from discogs.models import (
     ReleaseInfo,
     ReleaseMetadataResponse,
     ResolvedToken,
+    TrackReleasesResponse,
 )
 from discogs.service import DiscogsService
 from generated.api_models import (
@@ -825,14 +826,45 @@ async def search_compilations_for_track(
         # We search the library first and only validate releases that match,
         # avoiding expensive API calls for releases not in our catalog.
         raw_releases: list[ReleaseInfo] = []
+        # The album-title fallback's preconditions (`parsed.album` set, no
+        # resolver swap) are decidable here, so its probe joins the same
+        # `asyncio.gather` as the two artist-scoped probes (WXYC/library-
+        # metadata-lookup#339). Cold-cache wall time drops from A+B+C to
+        # max(A,B,C); the cost is one speculative API call when Wave A
+        # already succeeds — that call warms the cache.
+        album_fallback_should_fire = (
+            discogs_service is not None and bool(parsed.album) and not outcome.swapped
+        )
+        album_fallback_response: TrackReleasesResponse | None = None
+        album_fallback_error: str | None = None
+
+        async def _album_title_probe_safe() -> tuple[TrackReleasesResponse | None, str | None]:
+            """Catch-and-return wrapper so a Discogs failure on the album-title
+            probe doesn't take down the artist-scoped probes in the same gather.
+            Mirrors the existing fallback's try/except, which logs via
+            `_log_album_title_fallback(..., error=str(e))`."""
+            assert discogs_service is not None  # narrow for type-checker
+            assert parsed.album is not None
+            try:
+                resp = await discogs_service.search_releases_by_album_title(parsed.album)
+                return resp, None
+            except Exception as exc:
+                return None, str(exc)
+
         if discogs_service:
-            # Fire both searches in parallel (speculative: VA search may not be needed)
-            response, va_response = await asyncio.gather(
+            probes: list[Any] = [
                 discogs_service.search_releases_by_track(song_search, artist_for_probes),
                 discogs_service.search_releases_by_track(
                     song_search, artist_for_probes, artist_as_keyword=True
                 ),
-            )
+            ]
+            if album_fallback_should_fire:
+                probes.append(_album_title_probe_safe())
+
+            gathered = await asyncio.gather(*probes)
+            response, va_response = gathered[0], gathered[1]
+            if album_fallback_should_fire:
+                album_fallback_response, album_fallback_error = gathered[2]
             raw_releases = list(response.releases or [])
 
             # Only merge VA results if the artist-scoped search found no compilations
@@ -963,15 +995,14 @@ async def search_compilations_for_track(
         # Album-title fallback (#319 + #237): when the artist-scoped probes
         # produced no library results AND the request supplied an album AND
         # the resolver pre-pass did not produce a high-confidence canonical,
-        # retry with a title-only Discogs search and process those candidates
-        # with the trio-aware kwargs (no self-named-album guard, no library-
-        # side artist filter — defer artist gating to validate_track_on_release).
+        # process the title-only Discogs candidates with the trio-aware
+        # kwargs (no self-named-album guard, no library-side artist filter —
+        # defer artist gating to validate_track_on_release).
         #
-        # Earlier revisions gated this on ``not raw_releases``, but Discogs has
-        # since added a canonical entity for the motivating trio ("Orcutt
-        # Shelley Miller"), so the artist-scoped probes now return non-empty
-        # raw_releases that all get filtered out downstream. Gate on actual
-        # results, not Discogs response shape. See WXYC/library-metadata-lookup#237.
+        # The probe itself was fired speculatively in the same `asyncio.gather`
+        # as the artist-scoped probes above (#339). When it returned results
+        # we already paid the Discogs API cost; here we just decide whether
+        # to *consume* those candidates, gated on `not results` from Wave A.
         #
         # Trade-off: the gate is ``not results`` rather than
         # ``len(results) < MAX_SEARCH_RESULTS``. A partial initial pass (e.g.
@@ -981,49 +1012,55 @@ async def search_compilations_for_track(
         # ones. Revisit if measurements show partial-result requests would
         # benefit from supplementation.
         pre_fallback_results_count = len(results)
-        if discogs_service and not results and parsed.album and not outcome.swapped:
-            try:
-                fallback_response = await discogs_service.search_releases_by_album_title(
-                    parsed.album
+        # `album_fallback_should_fire` implies `parsed.album is not None`
+        # (see the precondition where the flag is set); the `assert` here
+        # narrows the type for both branches below.
+        if album_fallback_should_fire:
+            assert parsed.album is not None
+
+        if album_fallback_should_fire and album_fallback_error is not None:
+            # The probe ran but raised; mirror the pre-#339 behavior of
+            # logging via `_log_album_title_fallback(..., error=...)`.
+            assert parsed.album is not None
+            _log_album_title_fallback(
+                album=parsed.album,
+                n_candidates=0,
+                surfaced_library_match=False,
+                error=album_fallback_error,
+            )
+        elif album_fallback_should_fire and not results and album_fallback_response is not None:
+            assert parsed.album is not None
+            fallback_releases = list(album_fallback_response.releases or [])
+            if fallback_releases:
+                logger.info(
+                    f"Album-title fallback returned {len(fallback_releases)} candidates "
+                    f"for '{parsed.album}'"
                 )
-                fallback_releases = list(fallback_response.releases or [])
-                if fallback_releases:
-                    logger.info(
-                        f"Album-title fallback returned {len(fallback_releases)} candidates "
-                        f"for '{parsed.album}'"
+            fallback_results = await asyncio.gather(
+                *[
+                    process_release(
+                        ri,
+                        skip_self_named_album=False,
+                        skip_artist_match_filter=True,
                     )
-                fallback_results = await asyncio.gather(
-                    *[
-                        process_release(
-                            ri,
-                            skip_self_named_album=False,
-                            skip_artist_match_filter=True,
-                        )
-                        for ri in fallback_releases
-                    ]
-                )
-                for release_matches in fallback_results:
-                    for match, discogs_album in release_matches:
-                        if match.id not in seen_ids:
-                            results.append(match)
-                            seen_ids.add(match.id)
-                            discogs_titles[match.id] = discogs_album
-                    if len(results) >= MAX_SEARCH_RESULTS:
-                        break
-                if fallback_releases:
-                    discogs_found_releases = True
-                _log_album_title_fallback(
-                    album=parsed.album,
-                    n_candidates=len(fallback_releases),
-                    surfaced_library_match=len(results) > pre_fallback_results_count,
-                )
-            except Exception as e:
-                _log_album_title_fallback(
-                    album=parsed.album,
-                    n_candidates=0,
-                    surfaced_library_match=False,
-                    error=str(e),
-                )
+                    for ri in fallback_releases
+                ]
+            )
+            for release_matches in fallback_results:
+                for match, discogs_album in release_matches:
+                    if match.id not in seen_ids:
+                        results.append(match)
+                        seen_ids.add(match.id)
+                        discogs_titles[match.id] = discogs_album
+                if len(results) >= MAX_SEARCH_RESULTS:
+                    break
+            if fallback_releases:
+                discogs_found_releases = True
+            _log_album_title_fallback(
+                album=parsed.album,
+                n_candidates=len(fallback_releases),
+                surfaced_library_match=len(results) > pre_fallback_results_count,
+            )
     except Exception as e:
         logger.warning(f"Failed to search for track on other releases: {e}")
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -8,6 +8,7 @@ track validation -> artwork fetch -> metadata enrichment -> context message.
 import asyncio
 import logging
 import re
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from functools import partial
 from typing import Any
@@ -83,6 +84,17 @@ refs each still leave headroom for the read path.
 
 _warm_cache_semaphore: asyncio.Semaphore | None = None
 """Lazily-constructed (needs a running event loop). Re-bind on the first call."""
+
+_ProbeResult = TrackReleasesResponse | tuple[TrackReleasesResponse | None, str | None]
+"""Heterogeneous return type for the gathered probes in ``search_compilations_for_track``.
+
+The two artist-scoped probes return ``TrackReleasesResponse`` directly; the
+optional album-title probe returns ``tuple[TrackReleasesResponse | None,
+str | None]`` (response, error_str) via its catch-and-return wrapper. The
+gather sees the union; element-by-element narrowing happens via isinstance
+asserts at the call site.
+"""
+
 
 _background_tasks: set[asyncio.Task] = set()
 """References to fire-and-forget tasks scheduled by ``enrich_artwork_results``.
@@ -852,7 +864,10 @@ async def search_compilations_for_track(
                 return None, str(exc)
 
         if discogs_service:
-            probes: list[Any] = [
+            # Two artist-scoped probes return TrackReleasesResponse; the optional
+            # album-title probe returns tuple[TrackReleasesResponse | None, str | None].
+            # _ProbeResult (module-scope alias) captures the heterogeneous shape.
+            probes: list[Coroutine[Any, Any, _ProbeResult]] = [
                 discogs_service.search_releases_by_track(song_search, artist_for_probes),
                 discogs_service.search_releases_by_track(
                     song_search, artist_for_probes, artist_as_keyword=True
@@ -862,9 +877,15 @@ async def search_compilations_for_track(
                 probes.append(_album_title_probe_safe())
 
             gathered = await asyncio.gather(*probes)
+            # gathered[0] / gathered[1] are TrackReleasesResponse by construction
+            # (the order matches the `probes` list above); narrow via assert.
+            assert isinstance(gathered[0], TrackReleasesResponse)
+            assert isinstance(gathered[1], TrackReleasesResponse)
             response, va_response = gathered[0], gathered[1]
             if album_fallback_should_fire:
-                album_fallback_response, album_fallback_error = gathered[2]
+                probe_tuple = gathered[2]
+                assert isinstance(probe_tuple, tuple)
+                album_fallback_response, album_fallback_error = probe_tuple
             raw_releases = list(response.releases or [])
 
             # Only merge VA results if the artist-scoped search found no compilations
@@ -1013,11 +1034,8 @@ async def search_compilations_for_track(
         # benefit from supplementation.
         pre_fallback_results_count = len(results)
         # `album_fallback_should_fire` implies `parsed.album is not None`
-        # (see the precondition where the flag is set); the `assert` here
-        # narrows the type for both branches below.
-        if album_fallback_should_fire:
-            assert parsed.album is not None
-
+        # (see the precondition where the flag is set); each branch below
+        # re-asserts to narrow the type locally for the type-checker.
         if album_fallback_should_fire and album_fallback_error is not None:
             # The probe ran but raised; mirror the pre-#339 behavior of
             # logging via `_log_album_title_fallback(..., error=...)`.

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -15,6 +15,7 @@ intentionally has matching artist and album strings.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -227,15 +228,14 @@ class TestAlbumTitleFallback:
         )
 
     @pytest.mark.asyncio
-    async def test_fallback_skipped_when_library_match_already_found(self):
-        """The gate fires on ``not results`` (no library matches were
-        produced), not ``not raw_releases``. (The gate name changed in #322;
-        the prior incarnation tested the Discogs-response-empty condition,
-        which no longer matches reality after Discogs added a canonical
-        trio entity.) When the artist-scoped probes' candidates DO turn
-        into a library match via the existing pipeline, the fallback adds
-        no value and should not fire — its cost is one extra Discogs API
-        call per fire."""
+    async def test_fallback_not_consumed_when_library_match_already_found(self):
+        """The consume-gate fires on ``not results`` (no library matches were
+        produced from the artist-scoped probes). Since #339 the album-title
+        probe runs *speculatively* in the same `asyncio.gather` as the
+        artist-scoped probes — paying its API cost up front to save the
+        sequential-wait latency. The library match here is found by Wave A,
+        so the fallback's *results* must not surface, even though its API
+        call was made."""
         library_item = make_library_item(id=42, artist="A Real Artist", title="An Album")
         db = AsyncMock()
         db.search = AsyncMock(return_value=[library_item])
@@ -276,7 +276,9 @@ class TestAlbumTitleFallback:
             results, _ = await search_compilations_for_track(db, parsed, discogs_service=service)
 
         assert any(r.id == 42 for r in results)
-        service.search_releases_by_album_title.assert_not_called()
+        # The probe IS called speculatively (#339); the consume-gate, not the
+        # fire-gate, is what prevents its (empty) result from surfacing.
+        service.search_releases_by_album_title.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_trio_release_surfaces_through_fallback_with_mismatching_library_artist(
@@ -369,3 +371,110 @@ class TestAlbumTitleFallback:
             )
 
         assert not any(r.id == 34993109 for r in results)
+
+
+class TestAlbumTitleProbeConcurrency:
+    """Acceptance check for WXYC/library-metadata-lookup#339 (A2).
+
+    The album-title probe must fire in the same ``asyncio.gather`` as the
+    two artist-scoped probes when its preconditions (``parsed.album`` set
+    and resolver did not swap) are met — otherwise cold-cache wall time
+    is ``A + B + C`` instead of ``max(A, B, C)``. The trade-off is one
+    speculative API call when Wave A succeeds; that call warms LML's
+    cache and is counted as cheap.
+    """
+
+    @pytest.mark.asyncio
+    async def test_album_title_probe_runs_in_parallel_with_track_probes(self):
+        """All three Discogs probes are in-flight concurrently."""
+        active = {"count": 0, "peak": 0}
+
+        def make_probe_mock(response: TrackReleasesResponse):
+            async def _probe(*_args, **_kwargs):
+                active["count"] += 1
+                active["peak"] = max(active["peak"], active["count"])
+                # Yield twice so the other gathered coroutines get scheduled
+                # before this one returns. One ``sleep(0)`` is enough for the
+                # second sibling to enter; the second ``sleep(0)`` covers the
+                # third (the album-title probe).
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                active["count"] -= 1
+                return response
+
+            return _probe
+
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        service.search_releases_by_track = AsyncMock(side_effect=make_probe_mock(_empty_response()))
+        service.search_releases_by_album_title = AsyncMock(
+            side_effect=make_probe_mock(_empty_response())
+        )
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="Obscure Artist",
+            album="An Album",
+            song="A Song",
+            raw_message="Obscure Artist - A Song",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        assert active["peak"] == 3, (
+            "Expected all three probes (two artist-scoped + album-title fallback) "
+            f"to be in-flight concurrently, but peak concurrency was {active['peak']}. "
+            "If this is 2, the album-title probe is still sequential and the "
+            "A2 optimization didn't land."
+        )
+
+    @pytest.mark.asyncio
+    async def test_album_title_probe_does_not_run_when_album_missing(self):
+        """When ``parsed.album`` is None, peak concurrency is 2 — the album-title
+        probe must not fire (no album to search by) and must not appear in the
+        gather."""
+        active = {"count": 0, "peak": 0}
+
+        async def _probe(*_args, **_kwargs):
+            active["count"] += 1
+            active["peak"] = max(active["peak"], active["count"])
+            await asyncio.sleep(0)
+            active["count"] -= 1
+            return _empty_response()
+
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        service.search_releases_by_track = AsyncMock(side_effect=_probe)
+        service.search_releases_by_album_title = AsyncMock(side_effect=_probe)
+
+        parsed = ParsedRequest(
+            artist="Obscure Artist",
+            song="A Song",
+            raw_message="Obscure Artist - A Song",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        assert active["peak"] == 2, (
+            "When parsed.album is missing, only the two artist-scoped probes "
+            f"should fire (peak == 2), but observed peak {active['peak']}."
+        )
+        service.search_releases_by_album_title.assert_not_called()

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -438,6 +438,75 @@ class TestAlbumTitleProbeConcurrency:
         )
 
     @pytest.mark.asyncio
+    async def test_speculative_probe_error_logged_even_when_wave_a_succeeds(self):
+        """New behavior introduced by #339: because the album-title probe now
+        fires speculatively in the same `asyncio.gather` as the artist-scoped
+        probes, a Discogs failure on the speculative probe is now observable
+        even when Wave A succeeded and the consume-gate would have skipped it.
+
+        Pre-#339 the fallback never ran in this scenario (the `not results`
+        gate suppressed both fire and log), so no error was visible. Post-#339
+        the probe DID run and DID raise, so the error path must call
+        `_log_album_title_fallback(..., error=...)` to surface it.
+        """
+        library_item = make_library_item(id=42, artist="A Real Artist", title="An Album")
+        db = AsyncMock()
+        db.search = AsyncMock(return_value=[library_item])
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        # Wave A succeeds — the library row id=42 is surfaced.
+        service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="A Song",
+                artist="A Real Artist",
+                releases=[
+                    ReleaseInfo(
+                        album="An Album",
+                        artist="A Real Artist",
+                        release_id=42,
+                        release_url="https://www.discogs.com/release/42",
+                    )
+                ],
+                total=1,
+            )
+        )
+        # The speculative album-title probe raises mid-gather.
+        service.search_releases_by_album_title = AsyncMock(
+            side_effect=RuntimeError("simulated Discogs failure")
+        )
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="A Real Artist",
+            album="An Album",
+            song="A Song",
+            raw_message="A Real Artist - A Song",
+        )
+
+        with (
+            patch(
+                "lookup.orchestrator.lookup_releases_by_track",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("lookup.orchestrator._log_album_title_fallback") as mock_log,
+        ):
+            results, _ = await search_compilations_for_track(db, parsed, discogs_service=service)
+
+        # Wave A's library row still surfaces (the speculative-probe failure
+        # must not affect the artist-scoped path).
+        assert any(r.id == 42 for r in results)
+        # The error path fires `_log_album_title_fallback(..., error=...)`.
+        mock_log.assert_called_once()
+        call_kwargs = mock_log.call_args.kwargs
+        assert call_kwargs["album"] == "An Album"
+        assert call_kwargs["n_candidates"] == 0
+        assert call_kwargs["surfaced_library_match"] is False
+        assert "simulated Discogs failure" in call_kwargs["error"]
+
+    @pytest.mark.asyncio
     async def test_album_title_probe_does_not_run_when_album_missing(self):
         """When ``parsed.album`` is None, peak concurrency is 2 — the album-title
         probe must not fire (no album to search by) and must not appear in the


### PR DESCRIPTION
## Summary

- Fires the album-title compilation fallback's Discogs probe in the **same** `asyncio.gather` as the two existing artist-scoped probes in `search_compilations_for_track` (`lookup/orchestrator.py`). Cold-cache wall time drops from `A + B + C` to `max(A, B, C)` — the project's biggest single perf win per #338, worth ~3 s per cold lookup on the six obscure-artist queries in #337.
- Preconditions (`parsed.album` set, no resolver swap) are decidable before the gather, so they're checked up front and used to size the probe list (2 or 3). The probe is wrapped in a catch-and-return helper so a Discogs failure on it doesn't take down the sibling track probes; the existing `_log_album_title_fallback(..., error=...)` path is preserved.
- The **consume-gate** is unchanged: title-only probe results surface only when the artist-scoped probes produced no library matches (`not results`). The trade-off is one speculative API call when Wave A succeeds — that call warms LML's PG cache for the next request and is counted as cheap.

## Trade-off

Worst case: one extra Discogs API call per `search_compilations_for_track` invocation that has `parsed.album` set and no resolver swap but where Wave A already succeeds. The call is async-cached in `cache_service` for the next request, matching the proposal in #339.

## Test plan

- [x] New `TestAlbumTitleProbeConcurrency::test_album_title_probe_runs_in_parallel_with_track_probes` — asserts all three probes are in-flight concurrently (peak == 3) when preconditions are met (matches #339's acceptance criterion).
- [x] New `TestAlbumTitleProbeConcurrency::test_album_title_probe_does_not_run_when_album_missing` — asserts only 2 probes fire and `search_releases_by_album_title` is never called.
- [x] Existing `TestAlbumTitleFallback` cases still pass; `test_fallback_skipped_when_library_match_already_found` was renamed to `test_fallback_not_consumed_when_library_match_already_found` and its assertion flipped from `assert_not_called` to `assert_awaited_once` to reflect the new speculative-fire / lazy-consume contract.
- [x] Full unit suite green: 1747/1747.
- [x] `ruff check` + `ruff format --check` + `mypy lookup/orchestrator.py` all clean.
- [ ] **Operator follow-up:** re-measure #337's six obscure-artist queries cold against staging. The acceptance criterion is "median wall time drops by ≥ 30%."

## Related

- Parent: WXYC/library-metadata-lookup#338 (Epic A — LML lookup cascade performance)
- WXYC/library-metadata-lookup#319 — original PR that added the album-title fallback. This PR preserves *what* it does (`process_release` kwargs unchanged: `skip_self_named_album=False, skip_artist_match_filter=True`); only *when* it fires changed.

Closes #339