### PR TITLE
docs(CLAUDE.md): note the prod-merge autoclose gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,8 @@ uvicorn main:app --reload
 - **`main`** -- Development. Push here to deploy to **staging**.
 - **`prod`** -- Production. Push here to deploy to **production**.
 
+**Autoclose gotcha:** GitHub's `Closes #N` / `Fixes #N` keyword in a PR body only triggers issue-autoclose when the PR merges into the repo's **default branch**. LML's default is `main`, but most feature/fix PRs target `prod` (the deploy branch), so referenced issues stay open after merge. Close them manually with `gh issue close N --reason completed --comment "shipped via #PR"` when merging into `prod`. We've discussed flipping the default to `prod` or wiring a tiny "close issues on prod merge" workflow; neither has shipped yet. Until then: close by hand.
+
 ## Testing
 
 ### Unit Tests


### PR DESCRIPTION
Documentation-only diff explaining why `Closes #N` in LML PR bodies doesn't autoclose referenced issues — GitHub only autocloses on merges to the repo's default branch (`main` here), and most LML PRs target `prod`. We hit this on #332 (had to close #329 by hand).

Adds a note under `### Branches` so the next person who notices a stuck-open issue has the explanation without re-deriving it. Two future-fix options mentioned (flip default to `prod`, or add a workflow that watches prod merges) but neither shipped here.