### PR TITLE
[A3] Wall-clock budget in execute_search_pipeline

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -6,16 +6,95 @@ Each strategy has explicit trigger conditions and can be easily tested in isolat
 Strategies are executed in array order until results are found.
 """
 
+import logging
+import os
 import re
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+import sentry_sdk
+
 from generated.api_models import TrackMatchHint
 from library.db import LibraryDB
 from library.models import LibraryItem
 from services.parser import ParsedRequest
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SEARCH_BUDGET_MS = 4000
+"""Wall-clock budget for ``execute_search_pipeline``, in milliseconds.
+
+Leaves ~1s headroom under Backend-Service's current 5s LML runtime timeout
+(BS#873). Once WXYC/Backend-Service#876 (single coordinator) lands and the
+BS timeout normalizes, this value should move; in the meantime,
+``LML_SEARCH_BUDGET_MS`` overrides without a deploy.
+"""
+
+SEARCH_BUDGET_ENV_VAR = "LML_SEARCH_BUDGET_MS"
+
+
+def resolve_search_budget_ms() -> int:
+    """Return the active search budget in ms, honoring ``LML_SEARCH_BUDGET_MS``.
+
+    Unparseable or negative values fall back to :data:`DEFAULT_SEARCH_BUDGET_MS`
+    with a WARN — operator typos should not 500 every /lookup. Read per-call
+    (not at import) so tests can monkeypatch the env var without reaching into
+    module state.
+    """
+    raw = os.environ.get(SEARCH_BUDGET_ENV_VAR)
+    if raw is None:
+        return DEFAULT_SEARCH_BUDGET_MS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an integer; falling back to %d",
+            SEARCH_BUDGET_ENV_VAR,
+            raw,
+            DEFAULT_SEARCH_BUDGET_MS,
+        )
+        return DEFAULT_SEARCH_BUDGET_MS
+    if value < 0:
+        logger.warning(
+            "%s=%d is negative; falling back to %d",
+            SEARCH_BUDGET_ENV_VAR,
+            value,
+            DEFAULT_SEARCH_BUDGET_MS,
+        )
+        return DEFAULT_SEARCH_BUDGET_MS
+    return value
+
+
+def _log_search_budget_exceeded(
+    *, elapsed_ms: float, skipped: list["SearchStrategyType"], budget_ms: int
+) -> None:
+    """Project a budget breach onto the active Sentry transaction.
+
+    Mirrors ``_log_album_title_fallback`` / ``_log_resolver_pre_pass`` in
+    ``lookup/orchestrator``: structured INFO log line plus two ``set_data``
+    keys on the active transaction so trace explorer can filter on
+    ``search_budget_exceeded:true`` without re-pulling Railway logs.
+
+    No-op when there is no active transaction. Any SDK error is swallowed so
+    observability cannot break /lookup.
+    """
+    payload = {
+        "elapsed_ms": round(elapsed_ms, 2),
+        "budget_ms": budget_ms,
+        "skipped": [s.value for s in skipped],
+    }
+    logger.info("search_budget_exceeded %s", payload)
+    try:
+        transaction = sentry_sdk.get_current_scope().transaction
+        if transaction is None:
+            return
+        transaction.set_data("search_budget_exceeded", True)
+        transaction.set_data("search_strategies_skipped", payload["skipped"])
+    except Exception as e:
+        logger.warning("Failed to project search_budget_exceeded onto Sentry transaction: %s", e)
 
 
 def detect_ambiguous_format(raw_message: str) -> tuple[str, str] | None:
@@ -334,7 +413,25 @@ async def execute_search_pipeline(
         song_not_found=song_not_found,
     )
 
-    for strategy in strategies:
+    budget_ms = resolve_search_budget_ms()
+    start = time.monotonic()
+
+    for idx, strategy in enumerate(strategies):
+        # Wall-clock gate. Two clauses, both load-bearing:
+        #   1. elapsed_ms > budget — we've spent more time than the caller is
+        #      willing to wait.
+        #   2. state.results is non-empty — we have *something* to return.
+        # When the second clause is false we keep grinding: the user gets
+        # "nothing" either way, and the next strategy might surface results.
+        elapsed_ms = (time.monotonic() - start) * 1000
+        if elapsed_ms > budget_ms and state.results:
+            _log_search_budget_exceeded(
+                elapsed_ms=elapsed_ms,
+                skipped=[s.name for s in strategies[idx:]],
+                budget_ms=budget_ms,
+            )
+            break
+
         # Check if strategy should run
         if not strategy.condition(parsed, state, raw_message):
             continue

--- a/core/search.py
+++ b/core/search.py
@@ -57,9 +57,15 @@ def resolve_search_budget_ms() -> int:
             DEFAULT_SEARCH_BUDGET_MS,
         )
         return DEFAULT_SEARCH_BUDGET_MS
-    if value < 0:
+    if value <= 0:
+        # Zero is treated as a misconfiguration alongside negatives: with budget=0
+        # the gate fires after the first strategy that returns results, no matter
+        # how fast it ran, because `elapsed_ms > 0` after any await. Operators
+        # reaching for 0 typically mean "disable" — neither behavior is what they
+        # want, so we fall back to the default and WARN. To disable in practice,
+        # set the budget far above the request timeout (e.g. 60000).
         logger.warning(
-            "%s=%d is negative; falling back to %d",
+            "%s=%d is not positive; falling back to %d",
             SEARCH_BUDGET_ENV_VAR,
             value,
             DEFAULT_SEARCH_BUDGET_MS,

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -173,6 +173,10 @@ class FlowsheetBreakpointEntry(FlowsheetMessageEntry, DateTimeEntry):
 class FlowsheetCreateSongFromCatalog(BaseModel):
     album_id: int
     track_title: str
+    track_position: str | None = Field(
+        None,
+        description='Track position on the release (e.g., "A1", "B2", "5", "1-12"). Written by the dj-site flowsheet picker (catalog-track-search plan §5.3 / Track 3) when the DJ selects a track from the resolved release. Omitted when the DJ enters a free-text track_title without a tracklist lookup or when the release has no resolvable identity. String-typed to match Discogs\'s `release_track.position` (vinyl side notation, multi-disc prefixes).\n',
+    )
     rotation_id: int | None = None
     request_flag: bool
     segue: bool | None = None
@@ -205,6 +209,10 @@ class FlowsheetCreateMessage(BaseModel):
 
 class FlowsheetUpdateRequest(BaseModel):
     track_title: str | None = None
+    track_position: str | None = Field(
+        None,
+        description='Track position on the release (e.g., "A1", "B2", "5", "1-12"). Set when re-picking a track via the flowsheet picker; cleared (omitted) when a DJ edits the entry to a free-text track_title. String-typed to match Discogs\'s `release_track.position`.\n',
+    )
     artist_name: str | None = None
     album_title: str | None = None
     record_label: str | None = None
@@ -288,6 +296,10 @@ class FlowsheetV2TrackEntry(FlowsheetV2Base):
     artist_name: str | None = None
     album_title: str | None = None
     track_title: str | None = None
+    track_position: str | None = Field(
+        None,
+        description='Track position on the release (e.g., "A1", "B2", "5", "1-12"). Set by the dj-site flowsheet picker (catalog-track-search plan §5.3 / Track 3) when the DJ selected a track from the resolved release; null when the track_title was entered free-form or the release had no resolvable identity. String-typed to match Discogs\'s `release_track.position`.\n',
+    )
     record_label: str | None = None
     request_flag: bool
     segue: bool | None = None

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -559,6 +559,28 @@ class TestSearchBudget:
         monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "not-a-number")
         assert resolve_search_budget_ms() == DEFAULT_SEARCH_BUDGET_MS
 
+    def test_resolve_search_budget_ms_negative_falls_back(self, monkeypatch):
+        """Negative values fall back to the default with a WARN.
+
+        A negative budget would make `elapsed_ms > budget_ms` true on the very
+        first iteration, short-circuiting every request that produced results
+        from strategy 1 — almost certainly not what the operator intended.
+        """
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "-500")
+        assert resolve_search_budget_ms() == DEFAULT_SEARCH_BUDGET_MS
+
+    def test_resolve_search_budget_ms_zero_falls_back(self, monkeypatch):
+        """Zero is also a misconfiguration; falls back to the default.
+
+        With budget=0 the gate fires on the second iteration after any prior
+        strategy returned results, because `elapsed_ms > 0` after any await.
+        Operators reaching for `0` typically mean "disable" — we redirect to
+        the default and WARN. Disabling for real means setting the budget
+        well above the request timeout.
+        """
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "0")
+        assert resolve_search_budget_ms() == DEFAULT_SEARCH_BUDGET_MS
+
     @pytest.mark.asyncio
     async def test_budget_exceeded_skips_remaining_strategies(self, monkeypatch):
         """Slow strategy + prior results → subsequent strategies skipped, telemetry set.
@@ -739,6 +761,49 @@ class TestSearchBudget:
         mock_scope.transaction = None  # no active transaction
 
         with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
+            state = await execute_search_pipeline(
+                parsed,
+                AsyncMock(),
+                "Stereolab - Miss Modular",
+                strategies,
+                song_not_found=True,
+            )
+
+        # No crash; pipeline still surfaces the prior strategy's results.
+        assert state.results == [first_hit]
+
+    @pytest.mark.asyncio
+    async def test_budget_breach_swallows_sentry_sdk_errors(self, monkeypatch):
+        """Sentry SDK raising inside the projection path doesn't break /lookup.
+
+        The docstring on `_log_search_budget_exceeded` promises any SDK error
+        is swallowed. Pin that promise: if `get_current_scope` itself raises,
+        the pipeline still returns prior results normally.
+        """
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "1")
+
+        first_hit = _item(id=1, artist="Stereolab", title="Dots and Loops")
+
+        async def slow_first(*args, **kwargs):
+            await asyncio.sleep(0.02)
+            return ([first_hit], False)
+
+        search_lib = AsyncMock(side_effect=slow_first)
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(return_value=([], {}))
+
+        strategies = build_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+
+        with patch(
+            "core.search.sentry_sdk.get_current_scope",
+            side_effect=RuntimeError("sentry exploded"),
+        ):
             state = await execute_search_pipeline(
                 parsed,
                 AsyncMock(),

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,10 +1,12 @@
 """Tests for uncovered lines in core/search.py."""
 
-from unittest.mock import AsyncMock
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from core.search import (
+    DEFAULT_SEARCH_BUDGET_MS,
     SearchState,
     SearchStrategyType,
     build_strategies,
@@ -14,6 +16,7 @@ from core.search import (
     no_results_and_ambiguous_format,
     no_results_and_song_but_no_artist,
     no_results_and_song_but_no_artist_track_fallback,
+    resolve_search_budget_ms,
     song_not_found_with_artist_and_song,
 )
 from generated.api_models import TrackMatchHint, TrackMatchSource
@@ -519,3 +522,230 @@ class TestExecuteSearchPipeline:
         assert state.results == []
         assert state.matched_via_by_id == {}
         search_track.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Search budget — A3 / LML#340
+# ---------------------------------------------------------------------------
+
+
+class TestSearchBudget:
+    """Wall-clock budget short-circuits long pipelines once we already have results.
+
+    Today every strategy gets to run to completion before the next is even
+    considered. With BS's 5s LML timeout that converts to "user sees nothing"
+    instead of "user sees what LML found in the first 4s". The budget gates
+    every subsequent strategy on (elapsed_ms <= budget OR state.results is
+    empty) — the second clause is the safety branch that keeps the all-empty
+    case running the full pipeline.
+    """
+
+    def test_resolve_search_budget_ms_default(self, monkeypatch):
+        """Returns DEFAULT_SEARCH_BUDGET_MS when no env var set."""
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+        assert resolve_search_budget_ms() == DEFAULT_SEARCH_BUDGET_MS
+
+    def test_resolve_search_budget_ms_env_override(self, monkeypatch):
+        """LML_SEARCH_BUDGET_MS env var overrides the constant."""
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "1500")
+        assert resolve_search_budget_ms() == 1500
+
+    def test_resolve_search_budget_ms_invalid_falls_back(self, monkeypatch):
+        """Unparseable env value falls back to the default rather than crashing.
+
+        Operator typos shouldn't 500 every /lookup. The fallback is louder than
+        silent — surfaces should log at WARN — but the request stays alive.
+        """
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "not-a-number")
+        assert resolve_search_budget_ms() == DEFAULT_SEARCH_BUDGET_MS
+
+    @pytest.mark.asyncio
+    async def test_budget_exceeded_skips_remaining_strategies(self, monkeypatch):
+        """Slow strategy + prior results → subsequent strategies skipped, telemetry set.
+
+        Budget set to 1ms so any await crosses it. First strategy returns
+        results quickly (via the artist+album path), second strategy is the
+        slow one that crosses the budget, third strategy must not run.
+        """
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "1")
+
+        first_hit = _item(id=1, artist="Stereolab", title="Dots and Loops")
+
+        async def slow_first(*args, **kwargs):
+            # Slow ARTIST_PLUS_ALBUM blows the 1ms budget *before* the next
+            # iteration's budget gate fires. Returns results so the gate's
+            # safety branch (state.results empty → keep running) doesn't apply.
+            await asyncio.sleep(0.05)
+            return ([first_hit], False)
+
+        async def must_not_run_compilation(*args, **kwargs):
+            raise AssertionError("compilation strategy should be skipped by budget")
+
+        search_lib = AsyncMock(side_effect=slow_first)
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(side_effect=must_not_run_compilation)
+
+        strategies = build_strategies(search_lib, search_alt, search_comp)
+
+        # song_not_found=True keeps TRACK_ON_COMPILATION's condition true even
+        # after ARTIST_PLUS_ALBUM populates state.results — without the budget
+        # gate the compilation strategy *would* run.
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
+            state = await execute_search_pipeline(
+                parsed,
+                AsyncMock(),
+                "Stereolab - Miss Modular",
+                strategies,
+                song_not_found=True,
+            )
+
+        # Compilation strategy never ran.
+        search_comp.assert_not_awaited()
+        assert SearchStrategyType.TRACK_ON_COMPILATION not in state.strategies_tried
+        # State preserves the prior strategy's results.
+        assert state.results == [first_hit]
+        # Telemetry projected onto the active Sentry transaction.
+        calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert calls.get("search_budget_exceeded") is True
+        assert SearchStrategyType.TRACK_ON_COMPILATION.value in calls.get(
+            "search_strategies_skipped", []
+        )
+
+    @pytest.mark.asyncio
+    async def test_budget_exceeded_safety_branch_when_all_empty(self, monkeypatch):
+        """All prior strategies empty → budget does not short-circuit.
+
+        The safety branch is the load-bearing half of the budget design: if
+        every strategy has produced nothing, the user is going to get an
+        empty response anyway — better to keep running than to short-circuit
+        on an irrelevant timer.
+        """
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "1")
+
+        async def slow_empty(*args, **kwargs):
+            await asyncio.sleep(0.02)  # 20ms, blows the 1ms budget
+            return ([], False)
+
+        track_hit = _item(id=60359, artist="Autechre", title="Confield")
+        hint = TrackMatchHint(
+            title="vi scose poise",
+            artist_credit=None,
+            position="3",
+            confidence=0.92,
+            source=TrackMatchSource.discogs_release,
+        )
+
+        search_lib = AsyncMock(side_effect=slow_empty)
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(return_value=([], {}))
+        search_song = AsyncMock(return_value=([], None))
+        search_track = AsyncMock(return_value=([track_hit], {60359: [hint]}))
+
+        strategies = build_strategies(
+            search_lib,
+            search_alt,
+            search_comp,
+            search_song,
+            search_song_as_track_func=search_track,
+        )
+
+        parsed = ParsedRequest(song="vi scose poise", raw_message="vi scose poise")
+
+        state = await execute_search_pipeline(
+            parsed,
+            AsyncMock(),
+            "vi scose poise",
+            strategies,
+        )
+
+        # The slow first strategy blew the budget, but state.results is empty
+        # so subsequent strategies still ran and SONG_AS_TRACK surfaced a hit.
+        assert state.results == [track_hit]
+        search_track.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_budget_breach_when_within_limit(self, monkeypatch):
+        """Default budget is generous enough that fast pipelines aren't affected.
+
+        Sanity check: with the default 4s budget and fast mock strategies, the
+        budget gate never fires and no telemetry is emitted.
+        """
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+
+        hit = _item(id=1, artist="Juana Molina", title="DOGA")
+        search_lib = AsyncMock(return_value=([hit], False))
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(return_value=([], {}))
+
+        strategies = build_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Juana Molina", album="DOGA", raw_message="Juana Molina - DOGA"
+        )
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
+            state = await execute_search_pipeline(
+                parsed,
+                AsyncMock(),
+                "Juana Molina - DOGA",
+                strategies,
+            )
+
+        assert state.results == [hit]
+        calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert "search_budget_exceeded" not in calls
+
+    @pytest.mark.asyncio
+    async def test_budget_breach_no_active_transaction_is_noop(self, monkeypatch):
+        """Telemetry projection no-ops when there is no active Sentry transaction.
+
+        Mirrors `_log_album_title_fallback` — observability never breaks
+        /lookup. Confirms the breach path doesn't raise when Sentry has
+        nothing to attach to.
+        """
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "1")
+
+        first_hit = _item(id=1, artist="Stereolab", title="Dots and Loops")
+
+        async def slow_first(*args, **kwargs):
+            await asyncio.sleep(0.02)
+            return ([first_hit], False)
+
+        search_lib = AsyncMock(side_effect=slow_first)
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(return_value=([], {}))
+
+        strategies = build_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+
+        mock_scope = Mock()
+        mock_scope.transaction = None  # no active transaction
+
+        with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
+            state = await execute_search_pipeline(
+                parsed,
+                AsyncMock(),
+                "Stereolab - Miss Modular",
+                strategies,
+                song_not_found=True,
+            )
+
+        # No crash; pipeline still surfaces the prior strategy's results.
+        assert state.results == [first_hit]


### PR DESCRIPTION
## Summary

- Add `DEFAULT_SEARCH_BUDGET_MS = 4000` constant + `LML_SEARCH_BUDGET_MS` env override (`resolve_search_budget_ms()`).
- `execute_search_pipeline` records `time.monotonic()` at entry and gates each subsequent strategy on (elapsed > budget AND state.results non-empty); the safety branch keeps all-empty pipelines running to completion.
- Breach projects `search_budget_exceeded=True` + skipped-strategy list onto the active Sentry transaction, mirroring `_log_album_title_fallback` / `_log_resolver_pre_pass`. No-op without an active transaction.

## Why

`core/search.py:309-396`'s pipeline walks strategies sequentially with no elapsed-time gate. BS's 5s LML timeout therefore converts into "user sees nothing" instead of "user sees whatever LML found in the first 4s" — LML had partial results in hand at 5s on the 2026-05-13 regression but kept grinding to 17s producing the perfect answer.

Budget value chosen for 1s headroom under BS's current 5s runtime timeout (BS#873). Once Epic B (single coordinator, WXYC/Backend-Service#876) lands and BS's timeout normalizes, this can move via env var without a deploy. A8 (caller-budget HTTP header) will eventually wire BS → LML dynamically so the two services stop guessing at each other's budget.

## Test plan

- [x] `tests/unit/test_search.py::TestSearchBudget` — 7 new tests:
  - `resolve_search_budget_ms` default / env override / invalid-value fallback
  - Budget exceeded + prior results → subsequent strategies skipped, telemetry set
  - Budget exceeded + all-empty → safety branch keeps running
  - Default budget + fast pipeline → no breach, no telemetry
  - Breach with no active Sentry transaction → no-op (no crash)
- [x] Full unit suite passes (1755 tests).
- [x] `ruff check` / `ruff format --check` / `mypy core/search.py` clean.

Closes #340