### PR TITLE
Accept X-Caller-Budget-Ms header on /api/v1/lookup (A8)

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -35,6 +35,17 @@ BS timeout normalizes, this value should move; in the meantime,
 
 SEARCH_BUDGET_ENV_VAR = "LML_SEARCH_BUDGET_MS"
 
+TRANSPORT_OVERHEAD_MS = 200
+"""Approximate round-trip overhead between LML and a caller (Backend-Service).
+
+When a caller advertises its own remaining budget via ``X-Caller-Budget-Ms``
+(A8 / LML#345), LML uses ``caller_budget - TRANSPORT_OVERHEAD_MS`` as the
+effective pipeline budget so the response can hit the wire and reach the
+caller before the caller's own timeout fires. 200 ms covers a typical
+loopback-to-Railway-edge round-trip with margin; if measurements ever show
+a tighter bound, narrow this constant rather than the caller-side header.
+"""
+
 
 def resolve_search_budget_ms() -> int:
     """Return the active search budget in ms, honoring ``LML_SEARCH_BUDGET_MS``.
@@ -72,6 +83,44 @@ def resolve_search_budget_ms() -> int:
         )
         return DEFAULT_SEARCH_BUDGET_MS
     return value
+
+
+def resolve_effective_search_budget_ms(caller_budget_ms: int | None) -> int:
+    """Return the effective pipeline budget given an optional caller-supplied budget.
+
+    Combines the env-var/default budget (:func:`resolve_search_budget_ms`) with
+    the caller's ``X-Caller-Budget-Ms`` header (A8 / LML#345). The contract:
+
+    - Caller header absent or non-positive → return the env-var budget (the A3
+      contract is unchanged for callers that don't opt in).
+    - Caller header below ``TRANSPORT_OVERHEAD_MS`` → treat as misconfiguration
+      (effective budget would be ≤ 0 and the gate would short-circuit the first
+      iteration). Fall back to the env-var budget.
+    - Caller header otherwise → effective = min(caller − overhead, env). The
+      ``min`` clamps so callers cannot claim more time than the operator has
+      authorized via the env var.
+
+    The transport-overhead subtraction is a one-way courtesy: LML stops slightly
+    before the caller would, so the response can hit the wire in time. See
+    :data:`TRANSPORT_OVERHEAD_MS` for the rationale.
+    """
+    env_budget = resolve_search_budget_ms()
+    if caller_budget_ms is None or caller_budget_ms <= 0:
+        return env_budget
+    caller_effective = caller_budget_ms - TRANSPORT_OVERHEAD_MS
+    if caller_effective <= 0:
+        # A caller asking for a budget below the transport overhead is
+        # effectively asking for zero or negative. The pipeline can't run
+        # meaningfully with a non-positive budget; fall back to env so the
+        # request stays alive rather than short-circuiting at strategy 1.
+        logger.warning(
+            "caller_budget_ms=%d is below TRANSPORT_OVERHEAD_MS=%d; falling back to env budget %d",
+            caller_budget_ms,
+            TRANSPORT_OVERHEAD_MS,
+            env_budget,
+        )
+        return env_budget
+    return min(caller_effective, env_budget)
 
 
 def _log_search_budget_exceeded(
@@ -398,6 +447,7 @@ async def execute_search_pipeline(
     strategies: list[SearchStrategy],
     albums_for_search: list[str] | None = None,
     song_not_found: bool = False,
+    caller_budget_ms: int | None = None,
 ) -> SearchState:
     """Execute strategies in array order until results found.
 
@@ -419,7 +469,19 @@ async def execute_search_pipeline(
         song_not_found=song_not_found,
     )
 
-    budget_ms = resolve_search_budget_ms()
+    budget_ms = resolve_effective_search_budget_ms(caller_budget_ms)
+    # Project the caller-budget value when present so Sentry trace explorer can
+    # split header-driven vs env-driven cutoffs (A8 / LML#345). The
+    # effective-budget computation already clamps to env, so we record the raw
+    # header value the caller sent — that's the diagnostic that matters
+    # (mismatched expectations between caller and LML).
+    if caller_budget_ms is not None:
+        try:
+            transaction = sentry_sdk.get_current_scope().transaction
+            if transaction is not None:
+                transaction.set_data("lml.caller_budget_ms", caller_budget_ms)
+        except Exception as e:
+            logger.warning("Failed to project lml.caller_budget_ms onto Sentry transaction: %s", e)
     start = time.monotonic()
 
     for idx, strategy in enumerate(strategies):

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1763,6 +1763,7 @@ async def perform_lookup(
     discogs_cache: DiscogsCacheService | None = None,
     mb_pg: PgSourceProtocol | None = None,
     http_client: httpx.AsyncClient | None = None,
+    caller_budget_ms: int | None = None,
 ) -> LookupResponse:
     """Orchestrate the full lookup pipeline.
 
@@ -1834,6 +1835,7 @@ async def perform_lookup(
             strategies=strategies,
             albums_for_search=albums_for_search,
             song_not_found=song_not_found,
+            caller_budget_ms=caller_budget_ms,
         )
 
         library_results = limit_results(search_state.results)

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 import sentry_sdk
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
 
 from core.dependencies import (
@@ -99,6 +99,16 @@ async def handle_lookup(
     posthog_client: Posthog | None = Depends(get_posthog_client),
     http_client: httpx.AsyncClient = Depends(get_apple_music_http_client),
     skip_cache: bool = False,
+    x_caller_budget_ms: int | None = Header(
+        default=None,
+        alias="X-Caller-Budget-Ms",
+        description=(
+            "Optional per-request budget in ms (A8 / LML#345). When set, the search "
+            "pipeline uses min(header − transport overhead, LML_SEARCH_BUDGET_MS) "
+            "as its wall-clock cutoff so LML returns slightly before the caller "
+            "times out. Non-positive values fall back to the env default."
+        ),
+    ),
 ):
     """Process a lookup request."""
     init_cache_stats()
@@ -120,6 +130,7 @@ async def handle_lookup(
             discogs_cache=discogs_cache,
             mb_pg=mb_pg,
             http_client=http_client,
+            caller_budget_ms=x_caller_budget_ms,
         )
 
         # Attach cache stats. wxyc-shared#86 has shipped the typed CacheStats

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -138,6 +138,48 @@ class TestHandleLookup:
         assert resp.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_caller_budget_header_forwarded_to_perform_lookup(self, app_client):
+        """X-Caller-Budget-Ms (A8 / LML#345) flows from the HTTP header into
+        perform_lookup's caller_budget_ms kwarg. The router is a thin layer;
+        if the header is dropped here the search pipeline's effective-budget
+        computation can't see it and BS#345's caller-supplied budgets become
+        no-ops. Pins both the header→arg path and the kwarg name.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/lookup",
+                    json=LOOKUP_BODY,
+                    headers={"X-Caller-Budget-Ms": "3000"},
+                )
+
+        assert resp.status_code == 200
+        assert mock_lookup.await_args.kwargs.get("caller_budget_ms") == 3000
+
+    @pytest.mark.asyncio
+    async def test_caller_budget_header_absent_forwards_none(self, app_client):
+        """When the caller doesn't send the header, perform_lookup receives
+        caller_budget_ms=None so the orchestrator can distinguish "no opinion"
+        from a numeric value and fall through to the env-default contract.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        assert mock_lookup.await_args.kwargs.get("caller_budget_ms") is None
+
+    @pytest.mark.asyncio
     async def test_extended_flag_forwarded_to_perform_lookup(self, app_client):
         """When the request body sets extended=true, the LookupRequest carried
         into perform_lookup must reflect that. The router is a thin layer;

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -7,6 +7,7 @@ import pytest
 
 from core.search import (
     DEFAULT_SEARCH_BUDGET_MS,
+    TRANSPORT_OVERHEAD_MS,
     SearchState,
     SearchStrategyType,
     build_strategies,
@@ -16,6 +17,7 @@ from core.search import (
     no_results_and_ambiguous_format,
     no_results_and_song_but_no_artist,
     no_results_and_song_but_no_artist_track_fallback,
+    resolve_effective_search_budget_ms,
     resolve_search_budget_ms,
     song_not_found_with_artist_and_song,
 )
@@ -814,3 +816,165 @@ class TestSearchBudget:
 
         # No crash; pipeline still surfaces the prior strategy's results.
         assert state.results == [first_hit]
+
+
+# ---------------------------------------------------------------------------
+# Caller-budget header — A8 / LML#345
+# ---------------------------------------------------------------------------
+
+
+class TestCallerBudget:
+    """Per-request caller budget via the X-Caller-Budget-Ms header.
+
+    BS aborts at 5s; LML's env-default budget is 4s. A request that knows it
+    has only 3s left (BS retry, fast-path caller, etc.) should be able to
+    say "I'm going to give up at 3s — don't grind past 2.8s." The header
+    plus the TRANSPORT_OVERHEAD_MS slack lets LML return slightly before
+    the caller times out.
+
+    Contract (per LML#345):
+      - Header absent or zero/negative → env default (unchanged from A3).
+      - Header present and < env default → effective = header − transport overhead.
+      - Header present and >= env default → effective = env default (clamp).
+    """
+
+    def test_resolve_effective_budget_no_caller_header(self, monkeypatch):
+        """No caller header → env default; same as the A3 contract."""
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+        assert resolve_effective_search_budget_ms(None) == DEFAULT_SEARCH_BUDGET_MS
+
+    def test_resolve_effective_budget_caller_smaller_than_env(self, monkeypatch):
+        """Caller budget tighter than env → effective = caller − transport overhead."""
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+        # Caller says "3000ms"; LML must return ~200ms earlier so the caller
+        # sees the response before its own timeout fires.
+        assert resolve_effective_search_budget_ms(3000) == 3000 - TRANSPORT_OVERHEAD_MS
+
+    def test_resolve_effective_budget_caller_larger_than_env_clamps(self, monkeypatch):
+        """Caller budget looser than env → clamp to env (don't grant more than the operator gave)."""
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "2000")
+        # Caller says "10000ms" but operator capped at 2000ms; we keep the cap.
+        assert resolve_effective_search_budget_ms(10000) == 2000
+
+    def test_resolve_effective_budget_caller_equal_to_env_returns_env(self, monkeypatch):
+        """When caller − overhead equals env, the tighter one wins (still env-minus-zero)."""
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "4000")
+        # Caller header equals env; effective is min(4000-200, 4000) = 3800.
+        assert resolve_effective_search_budget_ms(4000) == 4000 - TRANSPORT_OVERHEAD_MS
+
+    def test_resolve_effective_budget_caller_zero_or_negative_falls_back(self, monkeypatch):
+        """Caller header <= 0 is treated as misconfiguration; fall back to env."""
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+        assert resolve_effective_search_budget_ms(0) == DEFAULT_SEARCH_BUDGET_MS
+        assert resolve_effective_search_budget_ms(-500) == DEFAULT_SEARCH_BUDGET_MS
+
+    def test_resolve_effective_budget_caller_below_transport_overhead(self, monkeypatch):
+        """If caller − overhead would be negative, fall back to env.
+
+        A caller advertising a 100ms budget when transport overhead is 200ms
+        is asking for a negative budget. That short-circuits the safety
+        branch of the budget gate (`elapsed_ms > budget AND state.results`
+        is always true after the first strategy completes). Treat as
+        misconfiguration; fall back so the request stays alive.
+        """
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+        assert resolve_effective_search_budget_ms(150) == DEFAULT_SEARCH_BUDGET_MS
+        assert resolve_effective_search_budget_ms(TRANSPORT_OVERHEAD_MS) == DEFAULT_SEARCH_BUDGET_MS
+
+    @pytest.mark.asyncio
+    async def test_pipeline_honors_caller_budget(self, monkeypatch):
+        """Caller-budget arg, when small enough to fire, projects telemetry + skips strategies.
+
+        Mirrors `test_budget_exceeded_skips_remaining_strategies` from the A3
+        test class but with the budget flowing through the caller arg rather
+        than env. Confirms the wiring: `execute_search_pipeline(..., caller_budget_ms=X)`
+        produces the same gate behavior as `LML_SEARCH_BUDGET_MS=X-200`.
+        """
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+
+        first_hit = _item(id=1, artist="Stereolab", title="Dots and Loops")
+
+        async def slow_first(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return ([first_hit], False)
+
+        must_not_run_compilation = AsyncMock(
+            side_effect=AssertionError("compilation strategy should be skipped by budget")
+        )
+
+        search_lib = AsyncMock(side_effect=slow_first)
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = must_not_run_compilation
+
+        strategies = build_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        # caller_budget_ms = 201 → effective budget = 1 (201 - TRANSPORT_OVERHEAD_MS).
+        # Tightest valid effective budget; any await trips the gate.
+        with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
+            state = await execute_search_pipeline(
+                parsed,
+                AsyncMock(),
+                "Stereolab - Miss Modular",
+                strategies,
+                song_not_found=True,
+                caller_budget_ms=TRANSPORT_OVERHEAD_MS + 1,
+            )
+
+        search_comp.assert_not_awaited()
+        assert state.results == [first_hit]
+        # Telemetry pins both the budget-exceeded flag AND the caller-budget value,
+        # so trace explorer queries can distinguish header-driven from env-driven cutoffs.
+        calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert calls.get("search_budget_exceeded") is True
+        assert calls.get("lml.caller_budget_ms") == TRANSPORT_OVERHEAD_MS + 1
+
+    @pytest.mark.asyncio
+    async def test_pipeline_no_caller_budget_does_not_set_caller_attr(self, monkeypatch):
+        """When the caller doesn't send the header, the lml.caller_budget_ms attr is not set.
+
+        Sentry attribute hygiene: only set the attribute on traces where the
+        caller actually opted into the contract. Saves trace-explorer noise.
+        """
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "10000")
+
+        first_hit = _item(id=1, artist="Stereolab", title="Dots and Loops")
+
+        async def fast_first(*args, **kwargs):
+            return ([first_hit], False)
+
+        search_lib = AsyncMock(side_effect=fast_first)
+        search_alt = AsyncMock(return_value=([], None))
+        search_comp = AsyncMock(return_value=([], {}))
+
+        strategies = build_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
+            await execute_search_pipeline(
+                parsed,
+                AsyncMock(),
+                "Stereolab - Miss Modular",
+                strategies,
+                song_not_found=True,
+                # caller_budget_ms not passed.
+            )
+
+        keys = {c.args[0] for c in mock_transaction.set_data.call_args_list}
+        assert "lml.caller_budget_ms" not in keys


### PR DESCRIPTION
## Summary

Implements [A8 / #345](https://github.com/WXYC/library-metadata-lookup/issues/345). Lets callers (Backend-Service, future request-o-matic clients, etc.) advertise their own remaining budget via an opt-in HTTP header, and uses it as the wall-clock budget for the search pipeline so LML returns *before* the caller's own timeout fires.

## Contract

- **Caller header absent or non-positive** → unchanged from the A3 contract: budget is the env-var/default value (`LML_SEARCH_BUDGET_MS`, default 4000ms).
- **Caller header set** → effective budget = `min(caller − TRANSPORT_OVERHEAD_MS, env_budget)`. The 200ms overhead subtraction is a one-way courtesy so LML returns slightly before the caller; the `min` clamps so callers cannot extend past the operator-configured ceiling.
- **Caller header below `TRANSPORT_OVERHEAD_MS`** (i.e. negative effective budget) → treat as misconfiguration; fall back to env budget so the request stays alive rather than short-circuiting at strategy 1.

## Telemetry

When the caller header is present, the orchestrator projects `lml.caller_budget_ms` onto the active Sentry transaction (raw value, not the clamped effective). This is what lets the trace explorer distinguish header-driven cutoffs from env-driven ones — and surface mismatched-expectation cases where a caller advertised X but the operator only granted Y.

## Test coverage

- `tests/unit/test_search.py::TestCallerBudget` — 8 cases: the 6-way effective-budget math (no caller, caller smaller than env, caller larger than env clamps, caller equal to env, caller ≤ 0, caller below transport overhead) plus end-to-end pipeline behavior (caller budget fires the gate, telemetry projects) plus the absent-header negative case (`lml.caller_budget_ms` not set when header missing — Sentry attribute hygiene).
- `tests/unit/test_lookup_router.py` — header → `caller_budget_ms` kwarg flow, both present and absent.

## Test plan

- [x] `uv run pytest tests/unit/test_search.py::TestCallerBudget tests/unit/test_lookup_router.py` — 35 passed
- [x] `uv run pytest -m \"not pg and not external_api\"` — 2020 passed
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean

Closes #345