### PR TITLE
Instrument validate_track_on_release calls for A7 audit

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -7,7 +7,9 @@ track validation -> artwork fetch -> metadata enrichment -> context message.
 
 import asyncio
 import logging
+import random
 import re
+import time
 from collections.abc import Coroutine
 from dataclasses import dataclass
 from functools import partial
@@ -248,6 +250,64 @@ def _log_album_title_fallback(
             transaction.set_data("album_title_fallback", payload)
     except Exception as e:
         logger.warning("Failed to project album_title_fallback onto Sentry transaction: %s", e)
+
+
+def _log_track_validation(
+    *,
+    source: str,
+    release_id: int,
+    song: str,
+    artist: str | None,
+    verdict: bool,
+    latency_ms: float,
+    sample_rate: float = 0.01,
+) -> None:
+    """Audit instrumentation for ``DiscogsService.validate_track_on_release`` (A7 / LML#344).
+
+    The cascade has two validation call sites: the inline check inside
+    ``TRACK_ON_COMPILATION``'s ``process_release`` and the post-cascade
+    sweep in ``filter_results_by_track_validation``. The audit ticket wants
+    to know how often the second call runs after the first already vetted
+    the same release, and how often the two verdicts disagree.
+
+    This helper records each call with a ``source`` label so downstream
+    Sentry analysis can split (release_id, verdict) pairs by source.
+    Two surfaces:
+
+    - **Sentry breadcrumb on every call** — trace explorer queries against
+      ``category:track_validation`` to count divergences without log-pipeline
+      tooling. Always-on; cost is microseconds per call.
+    - **Structured INFO log on a 1% sample** — cheap Railway-log grep target
+      for spot-checking. The full population is too large to log at INFO,
+      so the sample is randomized per call.
+
+    Both surfaces are non-essential; any SDK exception is swallowed and the
+    request proceeds. Same swallow pattern as :func:`_log_album_title_fallback`
+    / :func:`_log_resolver_pre_pass`.
+
+    The acceptance criterion from #344 is "7 days of data" — this helper
+    ships the instrumentation; the decision about whether to delete one of
+    the call sites is a follow-up after the data is in.
+    """
+    payload: dict[str, Any] = {
+        "source": source,
+        "release_id": release_id,
+        "song": song,
+        "artist": artist,
+        "verdict": verdict,
+        "latency_ms": round(latency_ms, 2),
+    }
+    try:
+        sentry_sdk.add_breadcrumb(
+            category="track_validation",
+            level="info",
+            data=payload,
+        )
+    except Exception as e:
+        logger.warning("Failed to add track_validation breadcrumb: %s", e)
+
+    if random.random() < sample_rate:
+        logger.info("track_validation %s", payload)
 
 
 def _log_resolver_pre_pass(outcome: ResolverOutcome, *, actual_swap: bool) -> None:
@@ -588,13 +648,24 @@ async def search_song_as_track(
         # that don't always contain the track on the tracklist. Deferred until
         # after library matching so we only pay the API cost for releases we'd
         # actually return, mirroring search_compilations_for_track.
-        if release.release_id and not await discogs_service.validate_track_on_release(
-            release.release_id, song, release.artist
-        ):
-            logger.debug(
-                f"SONG_AS_TRACK: skipping '{release.album}' — track not validated on release"
+        if release.release_id:
+            _validation_start = time.monotonic()
+            is_valid = await discogs_service.validate_track_on_release(
+                release.release_id, song, release.artist
             )
-            continue
+            _log_track_validation(
+                source="song_as_track",
+                release_id=release.release_id,
+                song=song,
+                artist=release.artist,
+                verdict=is_valid,
+                latency_ms=(time.monotonic() - _validation_start) * 1000,
+            )
+            if not is_valid:
+                logger.debug(
+                    f"SONG_AS_TRACK: skipping '{release.album}' — track not validated on release"
+                )
+                continue
 
         for item in eligible:
             hint = TrackMatchHint(
@@ -987,8 +1058,17 @@ async def search_compilations_for_track(
             # Deferred until after library matching so we only validate
             # releases we might actually return — saving API calls.
             if discogs_service and release_info.release_id and parsed.artist:
+                _validation_start = time.monotonic()
                 is_valid = await discogs_service.validate_track_on_release(
                     release_info.release_id, song_search, parsed.artist
+                )
+                _log_track_validation(
+                    source="compilation_inline",
+                    release_id=release_info.release_id,
+                    song=song_search,
+                    artist=parsed.artist,
+                    verdict=is_valid,
+                    latency_ms=(time.monotonic() - _validation_start) * 1000,
                 )
                 if not is_valid:
                     logger.info(
@@ -1252,8 +1332,17 @@ async def filter_results_by_track_validation(
                     )
                     return None
 
+                _validation_start = time.monotonic()
                 is_valid = await discogs_service.validate_track_on_release(
                     best_result.release_id, song, artist
+                )
+                _log_track_validation(
+                    source="step_3b",
+                    release_id=best_result.release_id,
+                    song=song,
+                    artist=artist,
+                    verdict=is_valid,
+                    latency_ms=(time.monotonic() - _validation_start) * 1000,
                 )
                 if is_valid:
                     logger.info(

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -26,6 +26,7 @@ from generated.api_models import (
     TrackMatchSource,
 )
 from lookup.orchestrator import (
+    _log_track_validation,
     artist_matches_item,
     build_context_message,
     fetch_artwork_for_items,
@@ -1533,3 +1534,130 @@ class TestSearchSongAsTrack:
         assert matched_via[11111][0].artist_credit == "Adonis"
         queries = [call.kwargs["query"] for call in db.search.await_args_list]
         assert any(q.startswith("Various ") for q in queries)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _log_track_validation (A7 / LML#344 audit instrumentation)
+# ---------------------------------------------------------------------------
+
+
+class TestLogTrackValidation:
+    """Audit instrumentation for the two validate_track_on_release call sites.
+
+    LML#344 wants to know how often the step-3b validation runs after
+    TRACK_ON_COMPILATION's inline validation already vetted the same release,
+    and how often the two verdicts diverge. The helper records each
+    validation call with a source label so downstream Sentry analysis can
+    split (release_id, verdict) pairs by source.
+
+    Two surfaces:
+      - Sentry breadcrumb every call (always-on; trace explorer queries against it).
+      - Structured INFO log on a 1% sample (cheap Railway-log grep target).
+
+    Sample rate is parameterizable so tests can force the deterministic branch.
+    """
+
+    def test_records_breadcrumb_on_every_call(self):
+        """Every call must produce a Sentry breadcrumb (always-on for trace explorer)."""
+        with patch("lookup.orchestrator.sentry_sdk.add_breadcrumb") as mock_breadcrumb:
+            _log_track_validation(
+                source="compilation_inline",
+                release_id=12345,
+                song="VI Scose Poise",
+                artist="Autechre",
+                verdict=True,
+                latency_ms=42.5,
+                sample_rate=0.0,  # disable log sampling; only breadcrumb path
+            )
+        mock_breadcrumb.assert_called_once()
+        call = mock_breadcrumb.call_args
+        assert call.kwargs["category"] == "track_validation"
+        data = call.kwargs["data"]
+        assert data["source"] == "compilation_inline"
+        assert data["release_id"] == 12345
+        assert data["song"] == "VI Scose Poise"
+        assert data["artist"] == "Autechre"
+        assert data["verdict"] is True
+        assert data["latency_ms"] == 42.5
+
+    def test_samples_info_log_at_configured_rate(self):
+        """When the random sample fires, an INFO log is emitted alongside the breadcrumb."""
+        with (
+            patch("lookup.orchestrator.random.random", return_value=0.005),  # 0.5% < 1% → fires
+            patch("lookup.orchestrator.logger") as mock_logger,
+            patch("lookup.orchestrator.sentry_sdk.add_breadcrumb"),
+        ):
+            _log_track_validation(
+                source="step_3b",
+                release_id=1,
+                song="x",
+                artist="y",
+                verdict=False,
+                latency_ms=1.0,
+                sample_rate=0.01,
+            )
+        # logger.info called with the structured payload
+        info_calls = [c for c in mock_logger.info.call_args_list if "track_validation" in str(c)]
+        assert len(info_calls) == 1
+
+    def test_does_not_sample_info_log_when_rate_misses(self):
+        """When the random draw exceeds the sample rate, no INFO log fires.
+
+        Even at 1% sampling we still need the *deterministic* off-path so
+        Railway logs aren't flooded by every /lookup. The breadcrumb path
+        runs unconditionally; only the structured log is gated.
+        """
+        with (
+            patch("lookup.orchestrator.random.random", return_value=0.99),  # 99% > 1% → no fire
+            patch("lookup.orchestrator.logger") as mock_logger,
+            patch("lookup.orchestrator.sentry_sdk.add_breadcrumb"),
+        ):
+            _log_track_validation(
+                source="step_3b",
+                release_id=1,
+                song="x",
+                artist="y",
+                verdict=False,
+                latency_ms=1.0,
+                sample_rate=0.01,
+            )
+        info_calls = [c for c in mock_logger.info.call_args_list if "track_validation" in str(c)]
+        assert len(info_calls) == 0
+
+    def test_handles_sentry_sdk_failure(self):
+        """A Sentry SDK exception must not break /lookup.
+
+        Mirrors the swallow-and-log pattern in _log_album_title_fallback /
+        _log_resolver_pre_pass / _log_search_budget_exceeded. The audit
+        layer is non-essential — it cannot be allowed to take down the
+        request path.
+        """
+        with patch(
+            "lookup.orchestrator.sentry_sdk.add_breadcrumb",
+            side_effect=RuntimeError("sentry exploded"),
+        ):
+            # Must not raise.
+            _log_track_validation(
+                source="compilation_inline",
+                release_id=1,
+                song="x",
+                artist="y",
+                verdict=True,
+                latency_ms=1.0,
+                sample_rate=0.0,
+            )
+
+    def test_handles_null_artist(self):
+        """Some call paths pass artist=None; the helper must accept it."""
+        with patch("lookup.orchestrator.sentry_sdk.add_breadcrumb") as mock_breadcrumb:
+            _log_track_validation(
+                source="step_3b",
+                release_id=1,
+                song="x",
+                artist=None,
+                verdict=False,
+                latency_ms=1.0,
+                sample_rate=0.0,
+            )
+        data = mock_breadcrumb.call_args.kwargs["data"]
+        assert data["artist"] is None


### PR DESCRIPTION
## Summary

Implements [A7 / #344](https://github.com/WXYC/library-metadata-lookup/issues/344). Adds telemetry instrumentation on each call to `DiscogsService.validate_track_on_release` so the audit can answer: how often does step 3b's validation duplicate `TRACK_ON_COMPILATION`'s inline check, and how often do the two verdicts disagree?

## What changed

New helper `_log_track_validation(source, release_id, song, artist, verdict, latency_ms, sample_rate=0.01)` in `lookup/orchestrator.py`. Wraps the three call sites with source labels:

- **`compilation_inline`** — inside `search_compilations_for_track`'s `process_release`, validates BEFORE adding a release to results.
- **`step_3b`** — inside `filter_results_by_track_validation`, the post-cascade sweep called from `perform_lookup` step 3b.
- **`song_as_track`** — inside `search_song_as_track`. Out of the ticket's narrow scope but instrumenting it is free, and complete data lets the analyst see all the places validation runs.

The ticket's primary audit question is the compilation_inline vs step_3b divergence; trace explorer queries can filter to just those two.

## Two telemetry surfaces

| Surface | When | Cost | Audit use |
|---|---|---|---|
| `sentry_sdk.add_breadcrumb(category="track_validation", data={...})` | Every call | µs | Trace-explorer queries against `category:track_validation`; can group by `data.source` and `data.release_id` to count divergence |
| `logger.info("track_validation ...")` | 1% sample (`random.random() < sample_rate`) | µs | Cheap Railway-log grep target for spot-check |

Both surfaces are non-essential; any Sentry SDK exception is swallowed (same pattern as `_log_album_title_fallback` / `_log_resolver_pre_pass` / `_log_search_budget_exceeded`).

## Test coverage

`TestLogTrackValidation` — 5 cases:
1. Breadcrumb fires on every call (always-on path)
2. INFO log fires when random draw < sample_rate
3. INFO log does NOT fire when random draw >= sample_rate
4. Sentry SDK exception is swallowed; request proceeds
5. `artist=None` is accepted (some call paths pass null)

## Acceptance criteria status

- [x] **Telemetry instrumentation** on all three call sites with source labels.
- [ ] **7 days of data collected** — operational. Wait for prod traffic + Sentry trace explorer.
- [ ] **Decision recorded** — follow-up ticket after the data window. Either delete step_3b's validation for releases already vetted by `compilation_inline`, or document the divergence in `orchestrator.py`.

The PR ships criterion 1. Criteria 2 and 3 are not in-PR work.

## Test plan

- [x] `uv run pytest tests/unit/test_orchestrator_helpers.py::TestLogTrackValidation` — 5 passed
- [x] `uv run pytest -m \"not pg and not external_api\"` — 2025 passed
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean

Partially addresses #344 (instrumentation half). The analysis half is a deliberate operational follow-up.