### PR TITLE
Consume lookup_negative cache in search_releases_by_track

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -10,9 +10,11 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 """
 
 import asyncio
+import hashlib
 import logging
 
 from rapidfuzz import fuzz
+from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.models import (
@@ -42,6 +44,33 @@ class CacheUnavailableError(Exception):
 # on a release. Tied to that constant by intent, not duplicated by accident.
 _ARTIST_FUZZY_MATCH_THRESHOLD = 70
 
+# Default TTL for a negative-cache entry (7 days, matching the
+# migration's column default). 7 days is conservative: tracks that
+# eventually land on Discogs (new releases) shouldn't be pinned negative
+# forever, but most rare-artist lookups span >24 h between repeats, so the
+# cross-deploy savings outweigh the catch-up lag. Per WXYC/library-
+# metadata-lookup#341.
+_NEGATIVE_CACHE_DEFAULT_TTL_SECONDS = 604_800
+
+
+def _negative_cache_key_hash(artist: str | None, track: str, artist_as_keyword: bool) -> bytes:
+    """Hash the (artist, track, artist_as_keyword) tuple into a stable 32-byte key.
+
+    Strings flow through `to_match_form` — the same normalizer used by
+    `make_normalized_cache_key` in `discogs/memory_cache.py` (per A5 / LML#272)
+    — so diacritic and case variations of the same user-typed query
+    collapse to one key. The `artist_as_keyword` boolean is part of the
+    key because it picks a different Discogs API call shape
+    (`params["q"]` + `format=Compilation` vs. `params["artist"]`), and a
+    negative answer on one shape doesn't transfer to the other.
+
+    Returned as bytes for direct binding to the bytea PK column.
+    """
+    norm_artist = normalize_for_comparison(artist or "")
+    norm_track = normalize_for_comparison(track)
+    payload = f"{norm_artist}\x1f{norm_track}\x1f{int(bool(artist_as_keyword))}"
+    return hashlib.sha256(payload.encode("utf-8")).digest()
+
 
 class DiscogsCacheService:
     """Service for querying and updating the local Discogs cache.
@@ -66,6 +95,92 @@ class DiscogsCacheService:
         except Exception as e:
             logger.warning(f"Cache health check failed: {e}")
             return False
+
+    async def lookup_negative_hit(
+        self, artist: str | None, track: str, artist_as_keyword: bool
+    ) -> bool:
+        """Return True if a non-expired negative-cache entry exists for this query.
+
+        Used by `discogs/service.py:search_releases_by_track` to short-circuit
+        the Discogs API on queries we've already asked and got nothing for.
+        TTL is enforced inline by the query (`now() < attempted_at +
+        ttl_seconds * interval '1 second'`) so callers don't need to
+        re-check expiration.
+
+        Best-effort: any pool error returns False so the caller falls
+        through to the API path exactly as if the negative cache said
+        "no entry." Errors are logged at warning level.
+
+        Args:
+            artist: Artist name (None when LML's `q=` keyword search ran).
+            track: Track title.
+            artist_as_keyword: True when this corresponds to the API
+                `params["q"]` + `format=Compilation` path; False for
+                `params["artist"]` field filter.
+
+        Returns:
+            True on hit (the API would return empty), False otherwise.
+        """
+        key_hash = _negative_cache_key_hash(artist, track, artist_as_keyword)
+        try:
+            row = await self.pool.fetchval(
+                """
+                SELECT 1
+                FROM lookup_negative
+                WHERE key_hash = $1
+                  AND now() < attempted_at + (ttl_seconds * interval '1 second')
+                LIMIT 1
+                """,
+                key_hash,
+            )
+            return row is not None
+        except Exception as e:
+            logger.warning(f"lookup_negative_hit failed (treating as miss): {e}")
+            return False
+
+    async def record_lookup_negative(
+        self,
+        artist: str | None,
+        track: str,
+        artist_as_keyword: bool,
+        ttl_seconds: int = _NEGATIVE_CACHE_DEFAULT_TTL_SECONDS,
+    ) -> None:
+        """Record a negative verdict so the next process can short-circuit.
+
+        Upserts on conflict so a re-write resets `attempted_at` (the TTL
+        clock starts fresh on every confirmation that the answer is still
+        "nothing"). Best-effort: pool errors are swallowed at warning
+        level — at worst we miss the write and the next request pays the
+        API cost again, identical to today's behavior pre-A4.
+
+        Args:
+            artist: Artist name (None when LML's `q=` keyword search ran).
+            track: Track title.
+            artist_as_keyword: Distinguishes the API call shape (see
+                `lookup_negative_hit`).
+            ttl_seconds: Per-row TTL override. Defaults to 7 days; the
+                table column also defaults to 604800 so the override is
+                only useful for shorter (e.g. test-driven) windows.
+        """
+        key_hash = _negative_cache_key_hash(artist, track, artist_as_keyword)
+        try:
+            await self.pool.execute(
+                """
+                INSERT INTO lookup_negative
+                  (key_hash, artist, track, artist_as_keyword, ttl_seconds)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (key_hash) DO UPDATE SET
+                  attempted_at = now(),
+                  ttl_seconds = EXCLUDED.ttl_seconds
+                """,
+                key_hash,
+                artist,
+                track,
+                artist_as_keyword,
+                ttl_seconds,
+            )
+        except Exception as e:
+            logger.warning(f"record_lookup_negative failed (best-effort write): {e}")
 
     async def search_releases_by_track(
         self, track: str, artist: str | None = None, limit: int = 20

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -424,6 +424,33 @@ class DiscogsService:
                 logger.warning(f"Cache lookup failed, falling back to API: {e}")
                 add_discogs_breadcrumb("cache_error", {"error": str(e)}, level="warning")
 
+        # Negative-result cache check (LML#341 / A4). Consulted on every
+        # query, not just non-keyword paths, because its key includes the
+        # `artist_as_keyword` dimension so a negative answer on one shape
+        # doesn't poison the other. Always best-effort — `lookup_negative_hit`
+        # returns False on pool errors so we fall through to the API.
+        if self.cache_service and not should_skip_cache():
+            try:
+                if await self.cache_service.lookup_negative_hit(artist, track, artist_as_keyword):
+                    logger.info(
+                        f"Negative-cache hit for track '{track}' artist '{artist}' "
+                        f"(artist_as_keyword={artist_as_keyword}); short-circuiting Discogs API"
+                    )
+                    get_cache_stats_recorder().record("pg_negative_hits")
+                    add_discogs_breadcrumb(
+                        "negative_cache_hit",
+                        {"track": track, "artist": artist, "artist_as_keyword": artist_as_keyword},
+                    )
+                    return TrackReleasesResponse(
+                        track=track, artist=artist, releases=[], total=0, cached=True
+                    )
+                get_cache_stats_recorder().record("pg_negative_misses")
+            except Exception as e:
+                # lookup_negative_hit already swallows pool errors; this catch
+                # is for defense-in-depth against an unexpected programming
+                # error so the request never dies in the negative-cache leg.
+                logger.warning(f"Negative-cache check failed (continuing to API): {e}")
+
         # Fall back to Discogs API
         releases: list[ReleaseInfo] = []
         seen_albums: set = set()
@@ -491,6 +518,23 @@ class DiscogsService:
                             releases.append(release_info)
 
                     logger.info(f"After keyword search: {len(releases)} total releases")
+
+            # On a confirmed-empty Discogs response, record the negative
+            # verdict so the next process restart (Railway redeploy) doesn't
+            # repeat the full cascade. Skipped on exception path below — a
+            # 5xx or rate-limit isn't a "we asked, nothing" verdict; it's
+            # "we couldn't ask, try later." Best-effort write.
+            if not releases and self.cache_service and not should_skip_cache():
+                try:
+                    await self.cache_service.record_lookup_negative(
+                        artist, track, artist_as_keyword
+                    )
+                    add_discogs_breadcrumb(
+                        "negative_cache_write",
+                        {"track": track, "artist": artist, "artist_as_keyword": artist_as_keyword},
+                    )
+                except Exception as e:
+                    logger.warning(f"Negative-cache write failed (best-effort): {e}")
 
             return TrackReleasesResponse(
                 track=track,

--- a/tests/integration/test_lookup_negative_cache.py
+++ b/tests/integration/test_lookup_negative_cache.py
@@ -1,0 +1,171 @@
+"""Integration tests for `DiscogsCacheService.lookup_negative_hit` /
+`record_lookup_negative` against a real PostgreSQL.
+
+The unit tests in `tests/unit/test_cache_service.py` mock the asyncpg pool;
+this tier exercises the round-trip across an actual `lookup_negative` table
+so a divergence between the migration (in `WXYC/discogs-etl`) and the LML
+read/write path can be caught before it ships.
+
+The table is created inline rather than via alembic because the alembic
+migration ships separately in `WXYC/discogs-etl`. Schema mirrors
+`alembic/versions/0006_lookup_negative.py` verbatim — if the discogs-etl
+migration ever diverges, fix it here and there in the same PR. Per the
+A4 ticket (`WXYC/library-metadata-lookup#341`).
+
+Run with: pytest -m pg -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from discogs.cache_service import DiscogsCacheService
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def pg_pool():
+    try:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+    yield pool
+    await pool.close()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_lookup_negative_table(pg_pool):
+    """Create a fresh `lookup_negative` table for each test."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS lookup_negative CASCADE")
+        await conn.execute(
+            """
+            CREATE TABLE lookup_negative (
+                key_hash          bytea PRIMARY KEY,
+                artist            text,
+                track             text,
+                artist_as_keyword boolean,
+                attempted_at      timestamptz NOT NULL DEFAULT now(),
+                ttl_seconds       integer NOT NULL DEFAULT 604800
+            )
+            """
+        )
+        await conn.execute(
+            "CREATE INDEX idx_lookup_negative_attempted_at ON lookup_negative(attempted_at)"
+        )
+    yield
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS lookup_negative CASCADE")
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_record_then_hit_round_trip(pg_pool):
+    """The classic happy path: write a negative verdict, then read it back."""
+    cache = DiscogsCacheService(pg_pool)
+
+    # Initial state: no entry, no hit.
+    assert await cache.lookup_negative_hit("Stereolab", "Made-up Track", False) is False
+
+    # Write the negative verdict.
+    await cache.record_lookup_negative("Stereolab", "Made-up Track", False)
+
+    # Second look: hit.
+    assert await cache.lookup_negative_hit("Stereolab", "Made-up Track", False) is True
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_expired_entry_returns_miss(pg_pool):
+    """A row whose `attempted_at + ttl_seconds * interval '1 second'` has
+    elapsed must NOT count as a hit. Verifies the TTL gate in the WHERE clause."""
+    cache = DiscogsCacheService(pg_pool)
+
+    # Write with a 1-second TTL...
+    await cache.record_lookup_negative("Cat Power", "Imaginary Song", False, ttl_seconds=1)
+    # ...then push attempted_at back two seconds so the row is past TTL.
+    async with pg_pool.acquire() as conn:
+        await conn.execute("UPDATE lookup_negative SET attempted_at = now() - interval '2 seconds'")
+
+    assert await cache.lookup_negative_hit("Cat Power", "Imaginary Song", False) is False
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_artist_as_keyword_dimension_is_independent(pg_pool):
+    """A negative entry written with `artist_as_keyword=False` does NOT hit
+    a lookup with `artist_as_keyword=True`. The two API call shapes have
+    independent negative caches."""
+    cache = DiscogsCacheService(pg_pool)
+    await cache.record_lookup_negative("Stereolab", "Fuses", False)
+
+    assert await cache.lookup_negative_hit("Stereolab", "Fuses", False) is True
+    assert await cache.lookup_negative_hit("Stereolab", "Fuses", True) is False
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_diacritic_and_case_normalization_collapses_to_one_key(pg_pool):
+    """Two queries that differ only by diacritics/case must share one entry —
+    the cache key normalizes through `to_match_form` (A5/LML#272 semantics)."""
+    cache = DiscogsCacheService(pg_pool)
+
+    # Write with canonical casing + diacritics.
+    await cache.record_lookup_negative("Nilüfer Yanya", "Heavyweight Champion", False)
+
+    # ASCII / lowercase variant must hit the same row.
+    assert await cache.lookup_negative_hit("nilufer yanya", "HEAVYWEIGHT CHAMPION", False) is True
+
+    # And the row count is 1, not 2.
+    async with pg_pool.acquire() as conn:
+        count = await conn.fetchval("SELECT COUNT(*) FROM lookup_negative")
+        assert count == 1
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_repeated_record_refreshes_attempted_at(pg_pool):
+    """A second `record_lookup_negative` for the same key MUST refresh
+    `attempted_at` (ON CONFLICT DO UPDATE). Without that, a steady stream
+    of `record_*` calls would keep stamping rows that are already there
+    but never extend their TTL — defeating the cross-deploy refresh."""
+    cache = DiscogsCacheService(pg_pool)
+
+    await cache.record_lookup_negative("Juana Molina", "Made-up Track", False)
+    async with pg_pool.acquire() as conn:
+        first_stamp = await conn.fetchval("SELECT attempted_at FROM lookup_negative LIMIT 1")
+
+    # Re-write the same key.
+    await cache.record_lookup_negative("Juana Molina", "Made-up Track", False)
+    async with pg_pool.acquire() as conn:
+        second_stamp = await conn.fetchval("SELECT attempted_at FROM lookup_negative LIMIT 1")
+        # Still exactly one row, not two.
+        count = await conn.fetchval("SELECT COUNT(*) FROM lookup_negative")
+
+    assert count == 1
+    assert second_stamp >= first_stamp
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_null_artist_supported(pg_pool):
+    """LML's `q=` keyword path may pass artist=None. The key hash must
+    still be deterministic, and the row writes / reads cleanly."""
+    cache = DiscogsCacheService(pg_pool)
+
+    await cache.record_lookup_negative(None, "Anonymous Track", False)
+
+    assert await cache.lookup_negative_hit(None, "Anonymous Track", False) is True
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT artist, track FROM lookup_negative LIMIT 1")
+        assert row["artist"] is None
+        assert row["track"] == "Anonymous Track"

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -992,3 +992,97 @@ class TestSearchTracksByTitle:
         mock_asyncpg_pool.fetch = AsyncMock(side_effect=RuntimeError("conn lost"))
         with pytest.raises(CacheUnavailableError):
             await cache_service.search_tracks_by_title("anything")
+
+
+# ---------------------------------------------------------------------------
+# Negative-result cache (LML#341 / A4)
+# ---------------------------------------------------------------------------
+
+
+class TestLookupNegativeHit:
+    @pytest.mark.asyncio
+    async def test_hit_returns_true_for_non_expired_row(self, cache_service, mock_asyncpg_pool):
+        # Non-NULL fetchval means "found a non-expired row".
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=1)
+        result = await cache_service.lookup_negative_hit("Stereolab", "Fuses", False)
+        assert result is True
+        # The lookup query must select the table and gate on TTL inline.
+        sql = mock_asyncpg_pool.fetchval.call_args.args[0]
+        assert "lookup_negative" in sql
+        assert "attempted_at" in sql
+        assert "ttl_seconds" in sql
+
+    @pytest.mark.asyncio
+    async def test_miss_returns_false_when_no_row(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=None)
+        result = await cache_service.lookup_negative_hit("Stereolab", "Fuses", False)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_distinguishes_artist_as_keyword_dimension(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        # The cache key must include `artist_as_keyword` so that
+        # `q=Stereolab` (compilation search) does NOT hit a negative entry
+        # written for the `artist=Stereolab` (field-filter) path. Verify
+        # the two key_hashes differ.
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=None)
+        await cache_service.lookup_negative_hit("Stereolab", "Fuses", False)
+        await cache_service.lookup_negative_hit("Stereolab", "Fuses", True)
+        # Both calls used key_hash as the WHERE-bound parameter (args[1]).
+        keys = [call.args[1] for call in mock_asyncpg_pool.fetchval.call_args_list]
+        assert keys[0] != keys[1], "artist_as_keyword must change the key_hash"
+
+    @pytest.mark.asyncio
+    async def test_normalized_for_case_and_diacritics(self, cache_service, mock_asyncpg_pool):
+        # Two queries that differ only by case/diacritics on artist or track
+        # should hash to the same key. Mirrors the existing
+        # `make_normalized_cache_key` semantics used by the @async_cached
+        # decorators (A5 / LML#272) so the negative cache lines up with
+        # what the in-memory cache treats as "the same query."
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=None)
+        await cache_service.lookup_negative_hit("Nilüfer Yanya", "Heavyweight Champion", False)
+        await cache_service.lookup_negative_hit("nilufer yanya", "heavyweight champion", False)
+        keys = [call.args[1] for call in mock_asyncpg_pool.fetchval.call_args_list]
+        assert keys[0] == keys[1], "diacritic + case-only variations must collapse to one key"
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_pool_error_does_not_raise(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        # The negative cache is best-effort. A connection blip must NOT
+        # block the request — fall through to the API as if the cache
+        # said "no entry" rather than propagate the error.
+        mock_asyncpg_pool.fetchval = AsyncMock(side_effect=RuntimeError("conn lost"))
+        result = await cache_service.lookup_negative_hit("anything", "anywhere", False)
+        assert result is False
+
+
+class TestRecordLookupNegative:
+    @pytest.mark.asyncio
+    async def test_inserts_row_with_default_ttl(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.execute = AsyncMock(return_value="INSERT 0 1")
+        await cache_service.record_lookup_negative("Stereolab", "Fuses", False)
+        call = mock_asyncpg_pool.execute.call_args
+        sql = call.args[0]
+        assert "INSERT INTO lookup_negative" in sql
+        # ON CONFLICT to refresh attempted_at on re-write so the TTL is reset.
+        assert "ON CONFLICT" in sql.upper()
+        # Default ttl_seconds=604800 (7 days).
+        assert 604800 in call.args[1:], f"expected ttl_seconds=604800 among bound args: {call.args}"
+
+    @pytest.mark.asyncio
+    async def test_accepts_custom_ttl(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.execute = AsyncMock(return_value="INSERT 0 1")
+        await cache_service.record_lookup_negative("X", "Y", False, ttl_seconds=3600)
+        call = mock_asyncpg_pool.execute.call_args
+        assert 3600 in call.args[1:]
+
+    @pytest.mark.asyncio
+    async def test_swallows_pool_error_does_not_raise(self, cache_service, mock_asyncpg_pool):
+        # Write is best-effort. A pool blip must NOT surface to the caller
+        # — at worst we miss the negative-cache write and the next request
+        # for the same query pays the API cost again, exactly like today.
+        mock_asyncpg_pool.execute = AsyncMock(side_effect=RuntimeError("conn lost"))
+        # Should not raise.
+        await cache_service.record_lookup_negative("anything", "anywhere", False)

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -522,6 +522,10 @@ class TestSearchReleasesByTrack:
                 )
             ]
         )
+        # The negative cache is consulted in every path now (A4); pin its
+        # return so this test still exercises the API leg.
+        service_with_cache.cache_service.lookup_negative_hit = AsyncMock(return_value=False)
+        service_with_cache.cache_service.record_lookup_negative = AsyncMock()
 
         # Set up API to return the VA compilation we actually want
         mock_resp = MagicMock()
@@ -552,6 +556,127 @@ class TestSearchReleasesByTrack:
         assert len(result.releases) >= 1
         assert result.releases[0].is_compilation is True
         assert result.cached is False
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_hit_short_circuits_api(self, service_with_cache):
+        """A pre-existing negative-cache entry must skip the Discogs API entirely (LML#341 / A4)."""
+        service_with_cache.cache_service.search_releases_by_track = AsyncMock(return_value=[])
+        service_with_cache.cache_service.lookup_negative_hit = AsyncMock(return_value=True)
+        service_with_cache.cache_service.record_lookup_negative = AsyncMock()
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_request:
+            result = await service_with_cache.search_releases_by_track(
+                "Imaginary Track", "Imaginary Artist"
+            )
+
+        assert result.releases == []
+        assert result.cached is True
+        # The whole point: zero API calls fired.
+        mock_request.assert_not_called()
+        # Write-on-empty must NOT fire when the empty came from the cache.
+        service_with_cache.cache_service.record_lookup_negative.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_miss_falls_through_to_api(self, service_with_cache):
+        """When the negative cache says no, the API is hit normally."""
+        service_with_cache.cache_service.search_releases_by_track = AsyncMock(return_value=[])
+        service_with_cache.cache_service.lookup_negative_hit = AsyncMock(return_value=False)
+        service_with_cache.cache_service.record_lookup_negative = AsyncMock()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "results": [{"title": "Stereolab - Aluminum Tunes", "id": 1}]
+        }
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ):
+            result = await service_with_cache.search_releases_by_track("Fuses", "Stereolab")
+
+        service_with_cache.cache_service.lookup_negative_hit.assert_called_once()
+        assert len(result.releases) >= 1
+        # Non-empty API response — negative-cache write must NOT fire.
+        service_with_cache.cache_service.record_lookup_negative.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_api_response_writes_negative_cache(self, service_with_cache):
+        """An API response with zero results must persist the negative verdict (LML#341 / A4)."""
+        service_with_cache.cache_service.search_releases_by_track = AsyncMock(return_value=[])
+        service_with_cache.cache_service.lookup_negative_hit = AsyncMock(return_value=False)
+        service_with_cache.cache_service.record_lookup_negative = AsyncMock()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"results": []}
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ):
+            result = await service_with_cache.search_releases_by_track(
+                "Definitely Not A Real Track", "Definitely Not A Real Artist"
+            )
+
+        assert result.releases == []
+        service_with_cache.cache_service.record_lookup_negative.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_api_exception_does_not_write_negative_cache(self, service_with_cache):
+        """A 5xx or network failure is not a 'we asked, nothing' verdict — don't persist it."""
+        service_with_cache.cache_service.search_releases_by_track = AsyncMock(return_value=[])
+        service_with_cache.cache_service.lookup_negative_hit = AsyncMock(return_value=False)
+        service_with_cache.cache_service.record_lookup_negative = AsyncMock()
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+            side_effect=Exception("Discogs 502"),
+        ):
+            result = await service_with_cache.search_releases_by_track("X", "Y")
+
+        assert result.releases == []
+        service_with_cache.cache_service.record_lookup_negative.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_consulted_for_artist_as_keyword(self, service_with_cache):
+        """The negative cache also covers the keyword path — its key dimension distinguishes shapes."""
+        service_with_cache.cache_service.search_releases_by_track = AsyncMock(return_value=[])
+        service_with_cache.cache_service.lookup_negative_hit = AsyncMock(return_value=True)
+        service_with_cache.cache_service.record_lookup_negative = AsyncMock()
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_request:
+            result = await service_with_cache.search_releases_by_track(
+                "track", "artist", artist_as_keyword=True
+            )
+
+        # Positive-cache path was bypassed (artist_as_keyword=True), but the
+        # negative-cache path was still consulted with artist_as_keyword=True
+        # passed through.
+        service_with_cache.cache_service.search_releases_by_track.assert_not_called()
+        service_with_cache.cache_service.lookup_negative_hit.assert_called_once()
+        call_args = service_with_cache.cache_service.lookup_negative_hit.call_args
+        assert call_args.args[2] is True or call_args.kwargs.get("artist_as_keyword") is True
+        # And the negative hit prevented any API call.
+        assert result.releases == []
+        assert result.cached is True
+        mock_request.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Consumer side of WXYC/discogs-etl#225's `0006_lookup_negative` migration. LML's positive PG cache holds empty `TrackReleasesResponse` hits in process memory, but the verdict never persists — every Railway redeploy wipes the in-memory cache and the next request for a not-on-Discogs artist pays a full ~16-s Discogs cascade. With 3-5 deploys/day, the cache stays semi-warm at best.

This PR adds two methods on `DiscogsCacheService` (`lookup_negative_hit` + `record_lookup_negative`) and wires them into `search_releases_by_track` so a confirmed-empty Discogs response is persisted as a negative verdict and short-circuits the next process's API call.

- Cache key: SHA-256 of `(to_match_form(artist), to_match_form(track), artist_as_keyword)`. Mirrors the `make_normalized_cache_key` semantics from A5/LML#272 so diacritic + case variations collapse to one entry. The `artist_as_keyword` boolean is part of the key — `q=` and `artist=` API call shapes have independent negative caches.
- TTL enforced inline via `WHERE now() < attempted_at + ttl_seconds * interval '1 second'` (the migration's index supports this gate).
- Pool errors on the read leg are swallowed (treated as a miss); write errors are swallowed at warning level. The negative cache is best-effort — at worst we miss the write and pay the API cost again.
- `pg_negative_hits` / `pg_negative_misses` recorded via the generic `cache_stats_recorder.record(key)` so the Sentry trace projection in BS picks them up as `lml.cache.pg_negative_*` automatically. No `wxyc-fastapi` change required.
- Exception path on the API call does NOT write a negative entry — a 5xx or network failure isn't a "we asked, nothing" verdict, it's "couldn't ask."

## Deploy

This PR depends on WXYC/discogs-etl#225 being applied to staging + prod discogs-cache (alembic upgrade head). The code is defensive: if the table doesn't exist, `lookup_negative_hit` swallows the error and falls through to the API path. No harm, but no benefit either until the migration lands.

## Test plan

- [x] `pytest tests/unit/test_cache_service.py` — 55/55 pass (8 new + 47 prior).
- [x] `pytest tests/unit/test_discogs_service.py` — 123/123 pass (5 new + 118 prior, with one prior test updated to pin `lookup_negative_hit=False`).
- [x] `pytest -m pg tests/integration/test_lookup_negative_cache.py` — 6/6 pass against local discogs-cache PG.
- [x] `pytest tests/unit/` — 1799/1799 pass.
- [x] `ruff check` — clean.
- [x] `ruff format --check` — clean.

Closes #341