### PR TITLE
feat(auth): structured logging on 401/403 paths

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -12,16 +12,67 @@ attached to routes before consumers are updated. Roll out: deploy with the
 flag off, update each consumer to send the bearer header, then flip the flag
 on. See ``docs/lml-release-resolve-plan.md`` (in tubafrenzy) for the full
 phasing.
+
+Structured logging on the 401 / 403 branches (WXYC/library-metadata-lookup#360):
+prod sees ~946 unauthenticated ``/api/v1/lookup`` calls per day and we can't
+identify the caller from Sentry span attributes (no work happens on the
+unauth path, no useful tags get set). Each rejection emits a single
+``logger.warning`` with the request context (client IP, user-agent, path,
+method, reason) so we can grep Railway logs to find the dominant caller.
+The token itself is never logged — the reason code distinguishes the three
+failure modes.
 """
 
 from __future__ import annotations
 
-from fastapi import Depends, Header, HTTPException
+import logging
+
+from fastapi import Depends, Header, HTTPException, Request
 
 from config.settings import Settings, get_settings
 
+logger = logging.getLogger(__name__)
+
+
+def _client_ip(request: Request) -> str | None:
+    """Return the originating client IP, honoring ``X-Forwarded-For`` first hop.
+
+    Railway terminates TLS at its edge and forwards via a proxy, so
+    ``request.client.host`` is the proxy's address. ``X-Forwarded-For`` carries
+    the original client as its leftmost entry (rest of the chain is proxies).
+    Fall back to ``request.client.host`` when the header is absent.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        first_hop = forwarded.split(",", 1)[0].strip()
+        if first_hop:
+            return first_hop
+    if request.client is not None:
+        return request.client.host
+    return None
+
+
+def _log_auth_rejection(request: Request, *, reason: str) -> None:
+    """Emit a structured WARNING for an unauthenticated/unauthorized call.
+
+    Keep the field set minimal and stable so a single Railway-log query can
+    answer "who is the dominant caller". Fields land on the log record both
+    as ``extra`` kwargs (so a JSON formatter can lift them) and as
+    ``%(...)s`` substitutions in the message (so the default text formatter
+    still surfaces them).
+    """
+    fields = {
+        "client_ip": _client_ip(request),
+        "user_agent": request.headers.get("user-agent"),
+        "path": request.url.path,
+        "method": request.method,
+        "reason": reason,
+    }
+    logger.warning("lml.auth.rejected %s", fields, extra=fields)
+
 
 async def require_lml_key(
+    request: Request,
     settings: Settings = Depends(get_settings),
     authorization: str | None = Header(None),
 ) -> None:
@@ -32,8 +83,12 @@ async def require_lml_key(
     - ``LML_REQUIRE_AUTH=false`` -> no-op (the deploy-then-flip rollout window).
     - ``LML_REQUIRE_AUTH=true`` and ``LML_API_KEY`` unset -> 500 (misconfig; fail loudly
       so we don't accept all requests by accident).
-    - ``LML_REQUIRE_AUTH=true`` and header missing -> 401.
-    - ``LML_REQUIRE_AUTH=true`` and header present but malformed or wrong token -> 403.
+    - ``LML_REQUIRE_AUTH=true`` and header missing -> 401 + WARNING log
+      (``reason=missing_authorization``).
+    - ``LML_REQUIRE_AUTH=true`` and header present but malformed scheme -> 403
+      + WARNING log (``reason=invalid_token_scheme``).
+    - ``LML_REQUIRE_AUTH=true`` and scheme correct but token wrong -> 403
+      + WARNING log (``reason=invalid_token_value``).
     - ``LML_REQUIRE_AUTH=true`` and header is ``Bearer <correct>`` (case-insensitive
       scheme per RFC 7235) -> pass.
     """
@@ -47,8 +102,13 @@ async def require_lml_key(
         )
 
     if not authorization:
+        _log_auth_rejection(request, reason="missing_authorization")
         raise HTTPException(status_code=401, detail="Missing authorization")
 
     parts = authorization.split(" ", 1)
-    if len(parts) != 2 or parts[0].lower() != "bearer" or parts[1] != settings.lml_api_key:
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        _log_auth_rejection(request, reason="invalid_token_scheme")
+        raise HTTPException(status_code=403, detail="Invalid token")
+    if parts[1] != settings.lml_api_key:
+        _log_auth_rejection(request, reason="invalid_token_value")
         raise HTTPException(status_code=403, detail="Invalid token")

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from fastapi import HTTPException
+from starlette.requests import Request
 
 from config.settings import Settings
 
@@ -22,6 +25,36 @@ def _settings(*, require_auth: bool = False, key: str | None = None) -> Settings
     )
 
 
+def _request(
+    *,
+    method: str = "POST",
+    path: str = "/api/v1/lookup",
+    client: tuple[str, int] | None = ("10.0.0.7", 51234),
+    headers: dict[str, str] | None = None,
+) -> Request:
+    """Build a minimal Starlette ``Request`` for direct dep tests.
+
+    The dep only reads ``request.client``, ``request.headers``, ``request.url.path``,
+    and ``request.method``, so we construct a scope with just those fields populated.
+    """
+    encoded_headers = [
+        (k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in (headers or {}).items()
+    ]
+    scope: dict = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("latin-1"),
+        "query_string": b"",
+        "headers": encoded_headers,
+        "client": client,
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
 class TestRequireLmlKey:
     """Direct unit tests for the FastAPI dep."""
 
@@ -29,7 +62,11 @@ class TestRequireLmlKey:
     async def test_flag_off_no_header_passes(self):
         from core.auth import require_lml_key
 
-        await require_lml_key(settings=_settings(require_auth=False), authorization=None)
+        await require_lml_key(
+            request=_request(),
+            settings=_settings(require_auth=False),
+            authorization=None,
+        )
 
     @pytest.mark.asyncio
     async def test_flag_off_with_garbage_header_passes(self):
@@ -37,6 +74,7 @@ class TestRequireLmlKey:
         from core.auth import require_lml_key
 
         await require_lml_key(
+            request=_request(),
             settings=_settings(require_auth=False),
             authorization="not even bearer-shaped",
         )
@@ -47,6 +85,7 @@ class TestRequireLmlKey:
 
         with pytest.raises(HTTPException) as exc:
             await require_lml_key(
+                request=_request(),
                 settings=_settings(require_auth=True, key="secret"),
                 authorization=None,
             )
@@ -58,6 +97,7 @@ class TestRequireLmlKey:
 
         with pytest.raises(HTTPException) as exc:
             await require_lml_key(
+                request=_request(),
                 settings=_settings(require_auth=True, key="secret"),
                 authorization="Bearer wrong",
             )
@@ -70,6 +110,7 @@ class TestRequireLmlKey:
 
         with pytest.raises(HTTPException) as exc:
             await require_lml_key(
+                request=_request(),
                 settings=_settings(require_auth=True, key="secret"),
                 authorization="secret",
             )
@@ -81,6 +122,7 @@ class TestRequireLmlKey:
 
         with pytest.raises(HTTPException) as exc:
             await require_lml_key(
+                request=_request(),
                 settings=_settings(require_auth=True, key="secret"),
                 authorization="Basic c2VjcmV0",
             )
@@ -91,6 +133,7 @@ class TestRequireLmlKey:
         from core.auth import require_lml_key
 
         await require_lml_key(
+            request=_request(),
             settings=_settings(require_auth=True, key="secret"),
             authorization="Bearer secret",
         )
@@ -101,6 +144,7 @@ class TestRequireLmlKey:
         from core.auth import require_lml_key
 
         await require_lml_key(
+            request=_request(),
             settings=_settings(require_auth=True, key="secret"),
             authorization="bearer secret",
         )
@@ -112,10 +156,177 @@ class TestRequireLmlKey:
 
         with pytest.raises(HTTPException) as exc:
             await require_lml_key(
+                request=_request(),
                 settings=_settings(require_auth=True, key=None),
                 authorization="Bearer anything",
             )
         assert exc.value.status_code == 500
+
+
+class TestRequireLmlKeyLogging:
+    """Pin the structured-logging surface added for WXYC/library-metadata-lookup#360.
+
+    Each 401/403 branch must emit a WARNING with ``client_ip``, ``user_agent``, ``path``,
+    ``method``, and ``reason`` so we can identify the dominant caller of
+    ``/api/v1/lookup``'s 946 daily 401s without re-pulling Sentry traces. The token
+    itself is never logged — neither raw nor hashed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_header_logs_warning_with_request_context(self, caplog):
+        from core.auth import require_lml_key
+
+        with caplog.at_level(logging.WARNING, logger="core.auth"):
+            with pytest.raises(HTTPException):
+                await require_lml_key(
+                    request=_request(
+                        method="POST",
+                        path="/api/v1/lookup",
+                        client=("10.0.0.7", 51234),
+                        headers={"user-agent": "tubafrenzy/1.0"},
+                    ),
+                    settings=_settings(require_auth=True, key="secret"),
+                    authorization=None,
+                )
+
+        records = [r for r in caplog.records if r.name == "core.auth"]
+        assert len(records) == 1, f"expected 1 auth log, got {len(records)}: {records}"
+        rec = records[0]
+        assert rec.levelno == logging.WARNING
+        assert rec.client_ip == "10.0.0.7"
+        assert rec.user_agent == "tubafrenzy/1.0"
+        assert rec.path == "/api/v1/lookup"
+        assert rec.method == "POST"
+        assert rec.reason == "missing_authorization"
+
+    @pytest.mark.asyncio
+    async def test_missing_header_uses_x_forwarded_for_first_hop(self, caplog):
+        # Railway puts a proxy in front of the service; the true client IP comes via
+        # X-Forwarded-For. The first hop is the original client.
+        from core.auth import require_lml_key
+
+        with caplog.at_level(logging.WARNING, logger="core.auth"):
+            with pytest.raises(HTTPException):
+                await require_lml_key(
+                    request=_request(
+                        client=("172.16.0.1", 1234),  # proxy
+                        headers={
+                            "user-agent": "curl/8.0",
+                            "x-forwarded-for": "198.51.100.42, 172.16.0.1",
+                        },
+                    ),
+                    settings=_settings(require_auth=True, key="secret"),
+                    authorization=None,
+                )
+
+        rec = next(r for r in caplog.records if r.name == "core.auth")
+        assert rec.client_ip == "198.51.100.42"
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_logs_warning_with_invalid_token_value_reason(self, caplog):
+        from core.auth import require_lml_key
+
+        with caplog.at_level(logging.WARNING, logger="core.auth"):
+            with pytest.raises(HTTPException):
+                await require_lml_key(
+                    request=_request(
+                        client=("10.0.0.8", 9000),
+                        headers={"user-agent": "BackendService/1.2"},
+                    ),
+                    settings=_settings(require_auth=True, key="secret"),
+                    authorization="Bearer wrong",
+                )
+
+        rec = next(r for r in caplog.records if r.name == "core.auth")
+        assert rec.levelno == logging.WARNING
+        assert rec.client_ip == "10.0.0.8"
+        assert rec.user_agent == "BackendService/1.2"
+        assert rec.path == "/api/v1/lookup"
+        assert rec.method == "POST"
+        assert rec.reason == "invalid_token_value"
+
+    @pytest.mark.asyncio
+    async def test_wrong_scheme_logs_invalid_token_scheme_reason(self, caplog):
+        from core.auth import require_lml_key
+
+        with caplog.at_level(logging.WARNING, logger="core.auth"):
+            with pytest.raises(HTTPException):
+                await require_lml_key(
+                    request=_request(headers={"user-agent": "probe/1.0"}),
+                    settings=_settings(require_auth=True, key="secret"),
+                    authorization="Basic c2VjcmV0",
+                )
+
+        rec = next(r for r in caplog.records if r.name == "core.auth")
+        assert rec.reason == "invalid_token_scheme"
+
+    @pytest.mark.asyncio
+    async def test_malformed_header_logs_invalid_token_scheme_reason(self, caplog):
+        # No space between scheme and token — splits to one part, treated as bad scheme.
+        from core.auth import require_lml_key
+
+        with caplog.at_level(logging.WARNING, logger="core.auth"):
+            with pytest.raises(HTTPException):
+                await require_lml_key(
+                    request=_request(),
+                    settings=_settings(require_auth=True, key="secret"),
+                    authorization="secret",
+                )
+
+        rec = next(r for r in caplog.records if r.name == "core.auth")
+        assert rec.reason == "invalid_token_scheme"
+
+    @pytest.mark.asyncio
+    async def test_success_emits_no_warning(self, caplog):
+        # Healthy requests must not pollute the log stream.
+        from core.auth import require_lml_key
+
+        with caplog.at_level(logging.WARNING, logger="core.auth"):
+            await require_lml_key(
+                request=_request(),
+                settings=_settings(require_auth=True, key="secret"),
+                authorization="Bearer secret",
+            )
+
+        assert [r for r in caplog.records if r.name == "core.auth"] == []
+
+    @pytest.mark.asyncio
+    async def test_log_does_not_contain_token_value(self, caplog):
+        # Defensive: even though we log a "reason" rather than the token, make sure
+        # nothing in the record (message or any attribute) carries the raw token.
+        from core.auth import require_lml_key
+
+        with caplog.at_level(logging.WARNING, logger="core.auth"):
+            with pytest.raises(HTTPException):
+                await require_lml_key(
+                    request=_request(),
+                    settings=_settings(require_auth=True, key="secret"),
+                    authorization="Bearer hunter2-secret-token",
+                )
+
+        rec = next(r for r in caplog.records if r.name == "core.auth")
+        # Check both the formatted message and every attribute on the record.
+        formatted = rec.getMessage()
+        assert "hunter2-secret-token" not in formatted
+        for value in vars(rec).values():
+            assert "hunter2-secret-token" not in str(value)
+
+    @pytest.mark.asyncio
+    async def test_missing_client_does_not_crash(self, caplog):
+        # request.client can be None when the ASGI scope omits it (test harness, etc.).
+        from core.auth import require_lml_key
+
+        with caplog.at_level(logging.WARNING, logger="core.auth"):
+            with pytest.raises(HTTPException):
+                await require_lml_key(
+                    request=_request(client=None, headers={"user-agent": "x"}),
+                    settings=_settings(require_auth=True, key="secret"),
+                    authorization=None,
+                )
+
+        rec = next(r for r in caplog.records if r.name == "core.auth")
+        assert rec.client_ip is None
+        assert rec.user_agent == "x"
 
 
 class TestProtectedRouteRegistration:


### PR DESCRIPTION
## Summary

Prod sees ~946 unauthenticated `POST /api/v1/lookup` calls per day (28% of total lookup traffic). Sentry span attributes don't expose request headers on the rejected-auth path because no work happens and no useful tags get set, so we can't identify the dominant caller. This PR adds structured logging on the 401 / 403 branches of `core/auth.py:require_lml_key`.

Each rejection now emits a single WARNING with:

- `client_ip` (honoring `X-Forwarded-For` first hop — Railway terminates TLS at its edge so `request.client.host` is the proxy)
- `user_agent`
- `path`
- `method`
- `reason` — one of `missing_authorization`, `invalid_token_scheme`, `invalid_token_value`

After 24h of prod data the project has an actionable identifier (IP or UA) for the dominant caller — we can then decide whether to (a) update the misconfigured client, (b) whitelist source IPs, or (c) accept the noise.

## Design notes

- **Logger:** stdlib `logging` (`logger = logging.getLogger(__name__)`), matching the rest of the codebase. No new dependency. Fields land on the record both as `extra=` kwargs (so a JSON formatter can lift them) and as a `%s`-substituted dict in the message (so the default text formatter still surfaces them in Railway).
- **Level:** WARNING. INFO would compete with traffic logs; ERROR overstates a routine rejection.
- **Request injection:** `request: Request` is the first positional parameter (no `Depends()` wrapper needed — FastAPI resolves the `Request` type annotation directly).
- **`X-Forwarded-For` parsing:** first hop only, comma-split, stripped. Falls back to `request.client.host` when the header is absent; returns `None` when both are missing.
- **Token never logged:** neither raw nor hashed — the three reason codes carry all the information we need.
- **Behavior unchanged:** 401 / 403 status codes, response bodies, and the `LML_REQUIRE_AUTH=false` short-circuit are all untouched. Pure additive logging.

## Test plan

- [x] Failing tests added first (TDD): 8 new tests in `TestRequireLmlKeyLogging`, parameterized over the three reason codes plus edge cases.
- [x] `caplog`-based assertions on log level, fields, and (defensively) that the raw token never appears in any record attribute or message.
- [x] Existing `TestRequireLmlKey` and `TestProtectedRouteRegistration` tests updated to pass the new `request` arg; still pass.
- [x] `uv run pytest tests/unit/` — 1808 passed.
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.

## Related

- WXYC/library-metadata-lookup#358 — sibling RCA finding (semaphore instrumentation)
- WXYC/library-metadata-lookup#359 — sibling RCA finding (trigram cache)
- WXYC/Backend-Service#992 — picker RCA context where the 946/day finding was surfaced

Closes #360