### PR TITLE
feat(observability): instrument semaphore + rate-limiter acquire as Sentry spans

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -82,6 +82,25 @@ _MAX_RETRY_DELAY_SECONDS = 60.0
 _ARTIST_FUZZY_MATCH_THRESHOLD = 70
 
 
+def _approx_semaphore_queue_depth(semaphore: asyncio.Semaphore) -> int:
+    """Return an approximate count of waiters queued behind ``semaphore``.
+
+    Used only for Sentry-span observability (see WXYC/library-metadata-lookup#358).
+    The value is read *before* the awaiting caller takes a permit, so it reflects
+    pre-acquire backlog rather than steady-state utilisation.
+
+    Inspects ``asyncio.Semaphore._waiters`` — a private CPython attribute, but the
+    only way to see queued tasks without acquiring a permit ourselves. If the
+    attribute is missing on a future CPython release, the helper returns ``-1``
+    so the metric is identifiable as "unknown" rather than silently misleading.
+    """
+    try:
+        waiters = semaphore._waiters  # type: ignore[attr-defined]
+        return len(waiters) if waiters else 0
+    except AttributeError:
+        return -1
+
+
 def _compute_retry_delay(attempt: int, retry_after_header: str | None) -> float:
     """Compute how long to sleep before the next retry of a 429-rate-limited request.
 
@@ -324,9 +343,18 @@ class DiscogsService:
         semaphore = get_semaphore()
         rate_limiter = get_rate_limiter()
 
-        async with semaphore:
+        # Explicit acquire/release (not `async with semaphore:`) so the wait
+        # is wrapped in a Sentry span. The 5-permit semaphore is the dominant
+        # source of pre-request dark time on backfill cascades — sampling the
+        # queue depth right before the await gives the trace explorer a
+        # relative-load signal per call. See WXYC/library-metadata-lookup#358.
+        with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.semaphore") as span:
+            span.set_data("lml.semaphore.queue_depth", _approx_semaphore_queue_depth(semaphore))
+            await semaphore.acquire()
+        try:
             for attempt in range(max_retries + 1):
-                await rate_limiter.acquire()
+                with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.rate_limiter"):
+                    await rate_limiter.acquire()
 
                 try:
                     response = await client.request(method, path, params=params)
@@ -356,6 +384,8 @@ class DiscogsService:
                 except httpx.RequestError as e:
                     logger.error(f"Discogs request failed: {e}")
                     return None
+        finally:
+            semaphore.release()
 
         return None
 

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -356,6 +356,149 @@ class TestRequestWithRetry:
 
 
 # ---------------------------------------------------------------------------
+# _request_with_retry: Sentry span instrumentation for acquire waits
+# ---------------------------------------------------------------------------
+
+
+class TestRequestWithRetrySpans:
+    """Sentry-span coverage for the chokepoints that produce RCA dark time.
+
+    The 85% un-instrumented dark time on `/api/v1/lookup` slow-path requests
+    (24h prod data, Sentry trace explorer) is the queue wait *before* the 5-permit
+    semaphore is acquired and the token-bucket wait inside the retry loop. These
+    tests pin both `sentry_sdk.start_span` invocations so a future refactor can't
+    silently drop the observability. See WXYC/library-metadata-lookup#358.
+    """
+
+    @pytest.mark.asyncio
+    async def test_emits_semaphore_acquire_span(self, service):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_client.request = AsyncMock(return_value=mock_resp)
+        service._client = mock_client
+
+        with patch("discogs.service.sentry_sdk") as mock_sdk:
+            mock_sdk.start_span.return_value.__enter__.return_value = MagicMock()
+            mock_sdk.start_span.return_value.__exit__.return_value = False
+            await service._request_with_retry("GET", "/test", max_retries=0)
+
+        span_names = [call.kwargs.get("name") for call in mock_sdk.start_span.call_args_list]
+        assert "lml.discogs.semaphore" in span_names, (
+            f"expected lml.discogs.semaphore span, got: {span_names}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_rate_limiter_acquire_span(self, service):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_client.request = AsyncMock(return_value=mock_resp)
+        service._client = mock_client
+
+        with patch("discogs.service.sentry_sdk") as mock_sdk:
+            mock_sdk.start_span.return_value.__enter__.return_value = MagicMock()
+            mock_sdk.start_span.return_value.__exit__.return_value = False
+            await service._request_with_retry("GET", "/test", max_retries=0)
+
+        span_names = [call.kwargs.get("name") for call in mock_sdk.start_span.call_args_list]
+        assert "lml.discogs.rate_limiter" in span_names, (
+            f"expected lml.discogs.rate_limiter span, got: {span_names}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_semaphore_span_carries_queue_depth(self, service):
+        """The semaphore span must carry an `lml.semaphore.queue_depth` attribute.
+
+        Sentry trace explorer uses this to surface backlog magnitude per call
+        — distinguishing "first-in-line, paid full Discogs round-trip" from
+        "queued behind N peers." Read approximate queue depth *before* the
+        await so the value reflects pre-acquire load.
+        """
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_client.request = AsyncMock(return_value=mock_resp)
+        service._client = mock_client
+
+        captured_spans: dict[str, MagicMock] = {}
+
+        def _start_span(*, op: str, name: str, **kwargs):
+            ctx = MagicMock()
+            span = MagicMock()
+            ctx.__enter__.return_value = span
+            ctx.__exit__.return_value = False
+            captured_spans[name] = span
+            return ctx
+
+        with patch("discogs.service.sentry_sdk") as mock_sdk:
+            mock_sdk.start_span.side_effect = _start_span
+            await service._request_with_retry("GET", "/test", max_retries=0)
+
+        sem_span = captured_spans.get("lml.discogs.semaphore")
+        assert sem_span is not None, (
+            f"expected a captured semaphore span, got names: {list(captured_spans)}"
+        )
+        data_keys = {call.args[0] for call in sem_span.set_data.call_args_list}
+        assert "lml.semaphore.queue_depth" in data_keys, (
+            f"expected lml.semaphore.queue_depth set_data, got: {data_keys}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_semaphore_released_after_exception(self, service):
+        """The acquire/release pair must survive an exception inside the request.
+
+        Rewriting `async with semaphore:` to explicit acquire/release is the
+        instrumentation hook point, but it also takes ownership of the cleanup
+        contract — a permit must not leak when the request body raises.
+        """
+        from discogs.ratelimit import get_semaphore, reset_rate_limiting
+
+        reset_rate_limiting()
+
+        mock_client = AsyncMock()
+        # httpx.RequestError is caught inside _request_with_retry, so use a
+        # non-handled exception class to force the try/finally to do the work.
+        mock_client.request = AsyncMock(side_effect=RuntimeError("kaboom"))
+        service._client = mock_client
+
+        sem = get_semaphore()
+        baseline = sem._value
+
+        with pytest.raises(RuntimeError):
+            await service._request_with_retry("GET", "/test", max_retries=0)
+
+        assert sem._value == baseline, (
+            f"semaphore leaked permits: baseline={baseline}, after={sem._value}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_semaphore_span_op_is_lock_acquire(self, service):
+        """Both spans are tagged op='lock.acquire' so they roll up cleanly."""
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_client.request = AsyncMock(return_value=mock_resp)
+        service._client = mock_client
+
+        with patch("discogs.service.sentry_sdk") as mock_sdk:
+            mock_sdk.start_span.return_value.__enter__.return_value = MagicMock()
+            mock_sdk.start_span.return_value.__exit__.return_value = False
+            await service._request_with_retry("GET", "/test", max_retries=0)
+
+        ops_by_name = {
+            call.kwargs.get("name"): call.kwargs.get("op")
+            for call in mock_sdk.start_span.call_args_list
+        }
+        assert ops_by_name.get("lml.discogs.semaphore") == "lock.acquire"
+        assert ops_by_name.get("lml.discogs.rate_limiter") == "lock.acquire"
+
+
+# ---------------------------------------------------------------------------
 # _parse_title
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Wraps the two pre-request waits in `discogs/service.py:_request_with_retry` with `sentry_sdk.start_span` so the queue wait before the 5-permit semaphore and the token-bucket wait inside the retry loop attribute to named spans instead of un-instrumented dark time. 24h prod data on `/api/v1/lookup` shows ~85% of slow-path total is currently un-measured; this ticket buys the observability needed to decide whether the fix is bumping `discogs_max_concurrent`, caching the slow trigram query, or shedding load on cold-cache cascade.

- `lml.discogs.semaphore` (op `lock.acquire`) with attribute `lml.semaphore.queue_depth` — waiter count read *before* the await, so the value reflects pre-acquire backlog rather than steady-state utilisation.
- `lml.discogs.rate_limiter` (op `lock.acquire`) inside the per-attempt retry loop.

The semaphore is now acquired/released explicitly (was `async with semaphore:`) so the wait is wrappable — `async with` gives no hook point. Cleanup moves into a `try/finally` so a permit can't leak when the request body raises.

## Implementation notes

- `_approx_semaphore_queue_depth` inspects `asyncio.Semaphore._waiters` — a private CPython attribute, but the only way to see queued tasks without acquiring a permit ourselves. If the attribute disappears on a future CPython release the helper returns `-1` so the metric is identifiable as "unknown" rather than silently misleading.
- No behavior change: same permit count, same rate, same retry count, same exception flow.

## Tests

Five new unit tests in `tests/unit/test_discogs_service.py::TestRequestWithRetrySpans` pin:

- Both span names (`lml.discogs.semaphore`, `lml.discogs.rate_limiter`) emit.
- Both spans tag `op="lock.acquire"` so they roll up cleanly in the trace explorer.
- `lml.semaphore.queue_depth` is set on the semaphore span.
- The semaphore permit is released on exception (no-leak contract for the new `try/finally`).

Suite-wide: 1805 unit tests pass; `ruff check` + `ruff format --check` + `mypy . --ignore-missing-imports` all clean.

## Test plan

- [x] `lml.discogs.semaphore` span asserted in unit test
- [x] `lml.discogs.rate_limiter` span asserted in unit test
- [x] `lml.semaphore.queue_depth` attribute asserted in unit test
- [x] No-leak `try/finally` regression covered by exception-path test
- [ ] After merge + 24h of prod data, query `lml.discogs.semaphore` span durations under `/api/v1/lookup` in the [Sentry trace explorer](https://wxyc.sentry.io/explore/traces/?project=4511363514302464) to confirm the long-tail attribution lands where the issue body predicted.

## Related

- WXYC/library-metadata-lookup#359 — sibling observability ticket
- WXYC/library-metadata-lookup#360 — sibling observability ticket
- WXYC/Backend-Service#992 — picker fast-fail (5s); depends on this data for the upstream fix
- WXYC/Backend-Service#873 — known cold-cache cascade pattern; same root cause class

Closes #358.