### PR TITLE
feat(cache): TTL cache search_artists_by_name (LML#359)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -17,6 +17,7 @@ from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
+from discogs.memory_cache import async_cached, create_ttl_cache
 from discogs.models import (
     ArtistCredit,
     ArtistDetails,
@@ -51,6 +52,18 @@ _ARTIST_FUZZY_MATCH_THRESHOLD = 70
 # cross-deploy savings outweigh the catch-up lag. Per WXYC/library-
 # metadata-lookup#341.
 _NEGATIVE_CACHE_DEFAULT_TTL_SECONDS = 604_800
+
+# In-process TTL cache for ``search_artists_by_name``. The trigram scan over
+# UNION(artist, artist_name_variation) was the dominant DB chokepoint in prod
+# (p50 = 303 ms × ~1k calls/day, ~317 s aggregate DB time per 24 h). The
+# resolver pre-pass in ``lookup.orchestrator.resolve_canonical_artist`` runs on
+# every inbound lookup regardless of ``LML_RESOLVE_ARTIST_CANONICAL``, so the
+# query is paid even when the canonical-swap behaviour is disabled. The WXYC
+# catalog input space is bounded (~30k library artists), so a 2k-entry LRU +
+# 1h TTL covers the working set after warmup. Registered with
+# ``create_ttl_cache`` so ``clear_all_caches()`` resets it alongside the
+# Discogs API memory caches. Per WXYC/library-metadata-lookup#359.
+_ARTIST_SEARCH_CACHE = create_ttl_cache(maxsize=2000, ttl=3600)
 
 
 def _negative_cache_key_hash(artist: str | None, track: str, artist_as_keyword: bool) -> bytes:
@@ -260,6 +273,7 @@ class DiscogsCacheService:
             logger.error(f"Cache search failed: {e}")
             raise CacheUnavailableError(f"Cache search failed: {e}") from e
 
+    @async_cached(_ARTIST_SEARCH_CACHE)
     async def search_artists_by_name(self, name: str, *, limit: int = 5) -> list[dict]:
         """Fuzzy-match an artist name against ``artist`` and ``artist_name_variation``.
 
@@ -267,6 +281,13 @@ class DiscogsCacheService:
         endpoint. Trigram similarity over diacritic-stripped lowercased
         names; the canonical ``artist.name`` is returned even when the
         match comes via ``artist_name_variation``.
+
+        Wrapped in ``_ARTIST_SEARCH_CACHE`` (TTLCache, maxsize=2000, ttl=1h)
+        because this query is the dominant DB chokepoint — see WXYC/library-
+        metadata-lookup#359. The cache key collapses to ``(name, limit)``
+        via the existing ``make_normalized_cache_key`` (case + diacritics
+        folded). The 1h TTL is conservative against the monthly discogs-cache
+        rebuild; intra-day staleness from incremental updates is acceptable.
 
         Args:
             name: Artist name (or skeleton) to search for.

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -921,6 +921,97 @@ class TestWriteArtistDetails:
         assert any("artist_url" in sql for sql in all_sql)
 
 
+class TestSearchArtistsByName:
+    @pytest.mark.asyncio
+    async def test_returns_canonical_artist(self, cache_service, mock_asyncpg_pool):
+        """Trigram hit returns the canonical artist row."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {"id": 9001, "name": "Stereolab", "score": 0.93},
+            ]
+        )
+        results = await cache_service.search_artists_by_name("Stereolab")
+        assert results == [{"id": 9001, "name": "Stereolab", "score": 0.93}]
+
+    @pytest.mark.asyncio
+    async def test_query_unions_artist_and_variation_tables(self, cache_service, mock_asyncpg_pool):
+        """The SQL must use the trigram operator and union the variation table."""
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.search_artists_by_name("Juana Molina", limit=3)
+        call = mock_asyncpg_pool.fetch.call_args
+        sql = call.args[0]
+        assert "artist" in sql
+        assert "artist_name_variation" in sql
+        assert "f_unaccent" in sql
+        assert "%" in sql  # trigram operator
+        assert call.args[1] == "Juana Molina"
+        assert call.args[2] == 3
+
+    @pytest.mark.asyncio
+    async def test_raises_cache_unavailable_on_pool_error(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=RuntimeError("conn lost"))
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.search_artists_by_name("anything")
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_db(self, cache_service, mock_asyncpg_pool):
+        """Repeated call with same args must not re-issue the underlying PG query.
+
+        WXYC/library-metadata-lookup#359: ``search_artists_by_name`` is the
+        dominant DB chokepoint (p50 = 303ms × ~1k calls/day). A per-process
+        TTL cache keyed by (name, limit) collapses repeat lookups to a hash.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[{"id": 1, "name": "Stereolab", "score": 0.91}]
+        )
+
+        first = await cache_service.search_artists_by_name("Stereolab")
+        second = await cache_service.search_artists_by_name("Stereolab")
+
+        assert first == second == [{"id": 1, "name": "Stereolab", "score": 0.91}]
+        assert mock_asyncpg_pool.fetch.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_different_name_hits_db(self, cache_service, mock_asyncpg_pool):
+        """Different names produce different cache entries — each hits PG once."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=[
+                [{"id": 1, "name": "Stereolab", "score": 0.91}],
+                [{"id": 2, "name": "Cat Power", "score": 0.88}],
+            ]
+        )
+
+        await cache_service.search_artists_by_name("Stereolab")
+        await cache_service.search_artists_by_name("Cat Power")
+
+        assert mock_asyncpg_pool.fetch.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_different_limit_hits_db(self, cache_service, mock_asyncpg_pool):
+        """The cache key includes ``limit``: same name + different limit is a miss."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[{"id": 1, "name": "Stereolab", "score": 0.91}]
+        )
+
+        await cache_service.search_artists_by_name("Stereolab", limit=5)
+        await cache_service.search_artists_by_name("Stereolab", limit=10)
+
+        assert mock_asyncpg_pool.fetch.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_result_not_cached(self, cache_service, mock_asyncpg_pool):
+        """An empty list is falsy but distinct from None — keep the behaviour with
+        ``async_cached``: only ``None`` is uncacheable, ``[]`` is a real answer that
+        should be cached to avoid re-running the trigram scan."""
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+
+        await cache_service.search_artists_by_name("Nonexistent")
+        await cache_service.search_artists_by_name("Nonexistent")
+
+        # Empty list is a legitimate result — cache it so the next call is free.
+        assert mock_asyncpg_pool.fetch.await_count == 1
+
+
 class TestSearchReleasesByTitle:
     @pytest.mark.asyncio
     async def test_returns_release_with_canonical_artist(self, cache_service, mock_asyncpg_pool):


### PR DESCRIPTION
Closes #359.

## Summary

`DiscogsCacheService.search_artists_by_name` is wrapped in the existing `@async_cached` decorator from `discogs.memory_cache`, backed by a 2,000-entry / 1-hour `TTLCache`. The trigram scan over `UNION(artist, artist_name_variation)` is the dominant DB chokepoint in prod (p50 = 303 ms × ~1,045 calls / 24 h = ~317 s aggregate DB time per day) and is paid on every inbound lookup because the resolver pre-pass in `lookup.orchestrator.resolve_canonical_artist` runs in shadow mode regardless of `LML_RESOLVE_ARTIST_CANONICAL`.

The cache key collapses to `(name, limit)` via the existing `make_normalized_cache_key` (case + diacritics folded). The WXYC catalog input space is bounded (~30k library artists), so a 2k-entry LRU covers the working set with high hit rate after warmup. The 1-hour TTL is conservative against the monthly discogs-cache rebuild; intra-day staleness from incremental updates is acceptable.

The cache is registered via `create_ttl_cache` so `clear_all_caches()` resets it alongside the Discogs API memory caches — no separate invalidation hook needed (the autouse `reset_caches` fixture in `tests/unit/conftest.py` already covers it).

## Tests

`tests/unit/test_cache_service.py::TestSearchArtistsByName` adds 7 cases:

- Returns the canonical artist row on a trigram hit.
- SQL targets the `artist` + `artist_name_variation` UNION with the trigram operator.
- Pool error surfaces as `CacheUnavailableError`.
- Repeated call with same args hits PG once (cache hit path).
- Different names produce separate cache entries.
- Different `limit` produces separate cache entries (key includes `limit`).
- Empty list is cached (only `None` is uncacheable in `async_cached`).

The first three pin existing behaviour that was previously untested in this file (the function had no dedicated test class). The last four are the new cache behaviour.

## Out of scope

- Index tuning on the underlying `artist` / `artist_name_variation` tables — that's a discogs-cache concern.
- Hard-invalidation hooks — the monthly rebuild + 1h TTL is sufficient.
- Resolver pre-pass tuning — see #318.

## Related

- WXYC/library-metadata-lookup#358 — sibling RCA finding (Discogs semaphore queueing spans).
- WXYC/library-metadata-lookup#360 — sibling RCA finding (unauthenticated `/api/v1/lookup` callers).
- WXYC/library-metadata-lookup#318 — resolver pre-pass shadow mode (the always-running caller).
- WXYC/Backend-Service#992 — downstream picker timeout that depends on this for tail-latency drop.