### PR TITLE
Tolerate leading-article asymmetry in artist_matches_item

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -403,16 +403,43 @@ def limit_results(results: list) -> list:
     return results[:MAX_SEARCH_RESULTS]
 
 
+_LEADING_ARTICLE_RE = re.compile(r"^(the|a|an)\s+")
+
+
+def _strip_leading_article(normalized: str) -> str:
+    """Strip a leading English article from a lowercase-normalized name.
+
+    Operates on the output of ``normalize_for_comparison`` (already
+    lowercased and trimmed), so the article check can be anchored and
+    case-blind.
+    """
+    return _LEADING_ARTICLE_RE.sub("", normalized, count=1)
+
+
 def artist_matches_item(item: LibraryItem, artist: str) -> bool:
     """Check if a library item matches the given artist name.
 
-    Checks both the primary artist and alternate_artist_name fields.
+    Compares against both ``item.artist`` and ``item.alternate_artist_name``.
+    Tolerates a leading-article asymmetry between query and catalog —
+    library catalogers commonly file "The Black Dog" as "Black Dog
+    Productions" while user input and Discogs credits keep the article,
+    and the reverse ("Beatles" vs "The Beatles") also occurs. Both sides
+    are compared as-is first; on miss, both are also compared with the
+    leading article stripped. The stripped path is skipped when the query
+    reduces to an empty string so a bare "The" doesn't match arbitrary rows.
     """
     artist_normalized = normalize_for_comparison(artist)
-    if normalize_for_comparison(item.artist).startswith(artist_normalized):
-        return True
-    if item.alternate_artist_name:
-        if normalize_for_comparison(item.alternate_artist_name).startswith(artist_normalized):
+    artist_no_article = _strip_leading_article(artist_normalized)
+
+    for candidate in (item.artist, item.alternate_artist_name):
+        if not candidate:
+            continue
+        cand_normalized = normalize_for_comparison(candidate)
+        if cand_normalized.startswith(artist_normalized):
+            return True
+        if artist_no_article and _strip_leading_article(cand_normalized).startswith(
+            artist_no_article
+        ):
             return True
     return False
 

--- a/tests/integration/test_alternate_artist.py
+++ b/tests/integration/test_alternate_artist.py
@@ -88,3 +88,83 @@ class TestAlternateArtistIntegration:
         results = await db.search(query="Luke Vibert")
         filtered = filter_results_by_artist(results, "Luke Vibert")
         assert len(filtered) == 2
+
+
+class TestLeadingArticleIntegration:
+    """End-to-end test that mirrors the real WXYC Black Dog catalog rows.
+
+    Library row 274 (Spanners) is stored as artist="Black Dog Productions"
+    with no alternate, while newer rows for the same artist carry
+    alternate_artist_name="Black Dog". A user request "by The Black Dog"
+    must surface both.
+    """
+
+    @pytest_asyncio.fixture
+    async def db_with_black_dog(self, tmp_path):
+        db_file = tmp_path / "test_library.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("""
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                artist TEXT,
+                call_letters TEXT,
+                artist_call_number INTEGER,
+                release_call_number INTEGER,
+                genre TEXT,
+                format TEXT,
+                alternate_artist_name TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE VIRTUAL TABLE library_fts USING fts5(
+                title, artist, alternate_artist_name,
+                content='library', content_rowid='id'
+            )
+        """)
+        # Mirrors prod rows 273/274: older Warp-era filings with no alternate.
+        conn.execute(
+            "INSERT INTO library VALUES "
+            "(274, 'Spanners', 'Black Dog Productions', 'Bl', 11, 2, 'Electronic', 'CD', NULL)"
+        )
+        conn.execute(
+            "INSERT INTO library_fts(rowid, title, artist, alternate_artist_name) "
+            "VALUES (274, 'Spanners', 'Black Dog Productions', NULL)"
+        )
+        # Mirrors prod rows 68523-68526: newer filings that carry the alternate.
+        conn.execute(
+            "INSERT INTO library VALUES "
+            "(68523, 'Further Vexations', 'Black Dog Productions', 'Bl', 11, 3, "
+            "'Electronic', 'CD', 'Black Dog')"
+        )
+        conn.execute(
+            "INSERT INTO library_fts(rowid, title, artist, alternate_artist_name) "
+            "VALUES (68523, 'Further Vexations', 'Black Dog Productions', 'Black Dog')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = LibraryDB(db_path=db_file)
+        await db.connect()
+        yield db
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_query_with_leading_the_finds_article_less_row(self, db_with_black_dog):
+        """'The Black Dog' must surface row 274 even though the catalog drops 'The'."""
+        results = await db_with_black_dog.search(query="Spanners")
+        filtered = filter_results_by_artist(results, "The Black Dog")
+
+        assert any(r.id == 274 for r in filtered), (
+            f"Expected row 274 (Spanners) in {[r.id for r in filtered]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_with_leading_the_finds_alternate_match(self, db_with_black_dog):
+        """'The Black Dog' must also match rows whose alternate is 'Black Dog'."""
+        results = await db_with_black_dog.search(query="Further Vexations")
+        filtered = filter_results_by_artist(results, "The Black Dog")
+
+        assert any(r.id == 68523 for r in filtered), (
+            f"Expected row 68523 in {[r.id for r in filtered]}"
+        )

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -229,9 +229,9 @@ class TestArtistMatchesItem:
         assert artist_matches_item(item, "The Black Dog") is True
 
     def test_article_less_query_matches_leading_the_artist(self):
-        """Reverse direction: query 'Beatles' matches library row stored as 'The Beatles'."""
-        item = make_library_item(id=1, artist="The Beatles", title="Revolver")
-        assert artist_matches_item(item, "Beatles") is True
+        """Reverse direction: query 'Microphones' matches library row stored as 'The Microphones'."""
+        item = make_library_item(id=1, artist="The Microphones", title="The Glow Pt. 2")
+        assert artist_matches_item(item, "Microphones") is True
 
     def test_leading_a_in_query_matches_article_less_artist(self):
         """Query 'A Tribe Called Quest' matches library row stored as 'Tribe Called Quest'."""
@@ -245,7 +245,7 @@ class TestArtistMatchesItem:
 
     def test_article_tolerance_does_not_create_false_positive(self):
         """Article-stripping must not collapse different artists into a match."""
-        item = make_library_item(id=1, artist="The Beatles", title="Revolver")
+        item = make_library_item(id=1, artist="The Microphones", title="The Glow Pt. 2")
         assert artist_matches_item(item, "The Black Dog") is False
 
 

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -203,6 +203,51 @@ class TestArtistMatchesItem:
         )
         assert artist_matches_item(item, "plug") is True
 
+    # ------------------------------------------------------------------
+    # Leading-article tolerance — bidirectional.
+    #
+    # Library catalogers commonly file bands without the leading "The"
+    # ("Black Dog Productions" rather than "The Black Dog"). User input
+    # and Discogs credits often include it. The matcher must accept the
+    # asymmetry in either direction so requests like "Psil-cosyin by The
+    # Black Dog" surface the catalog row.
+    # ------------------------------------------------------------------
+
+    def test_leading_the_in_query_matches_article_less_artist(self):
+        """Query 'The Black Dog' matches library row stored as 'Black Dog Productions'."""
+        item = make_library_item(id=274, artist="Black Dog Productions", title="Spanners")
+        assert artist_matches_item(item, "The Black Dog") is True
+
+    def test_leading_the_in_query_matches_article_less_alternate(self):
+        """Query 'The Black Dog' matches library row whose alternate is 'Black Dog'."""
+        item = make_library_item(
+            id=68523,
+            artist="Black Dog Productions",
+            title="Further Vexations",
+            alternate_artist_name="Black Dog",
+        )
+        assert artist_matches_item(item, "The Black Dog") is True
+
+    def test_article_less_query_matches_leading_the_artist(self):
+        """Reverse direction: query 'Beatles' matches library row stored as 'The Beatles'."""
+        item = make_library_item(id=1, artist="The Beatles", title="Revolver")
+        assert artist_matches_item(item, "Beatles") is True
+
+    def test_leading_a_in_query_matches_article_less_artist(self):
+        """Query 'A Tribe Called Quest' matches library row stored as 'Tribe Called Quest'."""
+        item = make_library_item(id=1, artist="Tribe Called Quest", title="Midnight Marauders")
+        assert artist_matches_item(item, "A Tribe Called Quest") is True
+
+    def test_no_match_when_only_article_remains(self):
+        """Degenerate input of just 'The' must not match arbitrary rows after stripping."""
+        item = make_library_item(id=1, artist="Stereolab", title="Aluminum Tunes")
+        assert artist_matches_item(item, "The") is False
+
+    def test_article_tolerance_does_not_create_false_positive(self):
+        """Article-stripping must not collapse different artists into a match."""
+        item = make_library_item(id=1, artist="The Beatles", title="Revolver")
+        assert artist_matches_item(item, "The Black Dog") is False
+
 
 # ---------------------------------------------------------------------------
 # Tests: build_context_message


### PR DESCRIPTION
## Summary

Fix \`artist_matches_item\` so requests like \"Psil-cosyin by The Black Dog\" surface the matching library row even when the catalog files the artist without the leading article (\"Black Dog Productions\"). Strips a leading \`the\`/\`a\`/\`an\` from both sides as a fallback after the existing prefix check, with a guard so a bare \"The\" doesn't match arbitrary rows. Reverse asymmetry (user types \"Beatles\", library has \"The Beatles\") works the same way.

## Test plan

- [x] Unit tests cover both directions, \"A \" prefix, degenerate \"The\" input, and a cross-artist negative control
- [x] Integration test fixture mirrors the actual prod Black Dog rows (\`274\` Spanners with empty alternate, \`68523\` Further Vexations with alternate \"Black Dog\")
- [x] \`uv run pytest tests/\` — 2066 passed, 114 deselected (pg + external_api), 2 xfailed
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` clean
- [x] \`uv run mypy lookup/orchestrator.py\` clean
- [ ] Sanity-check against prod after staging deploy by re-running \`lookup \"Psil-cosyin by The Black Dog\"\`

Closes #364