### PR TITLE
Tighten leading-article regex and cover An- / split-article cases

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -403,7 +403,7 @@ def limit_results(results: list) -> list:
     return results[:MAX_SEARCH_RESULTS]
 
 
-_LEADING_ARTICLE_RE = re.compile(r"^(the|a|an)\s+")
+_LEADING_ARTICLE_RE = re.compile(r"^(the|a|an)(\s+|$)")
 
 
 def _strip_leading_article(normalized: str) -> str:
@@ -425,8 +425,8 @@ def artist_matches_item(item: LibraryItem, artist: str) -> bool:
     Productions" while user input and Discogs credits keep the article,
     and the reverse ("Beatles" vs "The Beatles") also occurs. Both sides
     are compared as-is first; on miss, both are also compared with the
-    leading article stripped. The stripped path is skipped when the query
-    reduces to an empty string so a bare "The" doesn't match arbitrary rows.
+    leading article stripped. The stripped path is skipped when stripping
+    leaves the query empty so a bare "The" doesn't match arbitrary rows.
     """
     artist_normalized = normalize_for_comparison(artist)
     artist_no_article = _strip_leading_article(artist_normalized)

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -238,6 +238,16 @@ class TestArtistMatchesItem:
         item = make_library_item(id=1, artist="Tribe Called Quest", title="Midnight Marauders")
         assert artist_matches_item(item, "A Tribe Called Quest") is True
 
+    def test_leading_an_in_query_matches_article_less_artist(self):
+        """Query 'An Albatross' matches library row stored as 'Albatross'."""
+        item = make_library_item(id=1, artist="Albatross", title="Eat Lightning Shit Thunder")
+        assert artist_matches_item(item, "An Albatross") is True
+
+    def test_different_articles_on_each_side_match(self):
+        """Both sides carrying *different* articles still match after symmetric strip."""
+        item = make_library_item(id=1, artist="The Microphones", title="The Glow Pt. 2")
+        assert artist_matches_item(item, "A Microphones") is True
+
     def test_no_match_when_only_article_remains(self):
         """Degenerate input of just 'The' must not match arbitrary rows after stripping."""
         item = make_library_item(id=1, artist="Stereolab", title="Aluminum Tunes")


### PR DESCRIPTION
## Summary

Polish on the heels of #365. Two small follow-ups from review-loop cosmetics:

- **Anchor the leading-article regex.** \`^(the|a|an)\s+\` → \`^(the|a|an)(\s+|$)\` so a bare \"the\" / \"a\" / \"an\" query actually strips to \`\"\"\` and the existing truthiness guard in \`artist_matches_item\` becomes load-bearing. The previous regex was safe via dumb luck (stripped form == query for bare-article inputs), but the docstring's \"skipped when the query reduces to an empty string\" was forward-looking. Now describes current behavior.
- **Two new test cases**: leading \`\"An \"\` prefix using \"An Albatross\" (real WXYC library row), and both sides carrying *different* articles (\"A Microphones\" vs \"The Microphones\") to exercise the symmetric-strip path.

## Test plan

- [x] \`uv run pytest tests/\` — 2068 passed (+2), 114 deselected, 2 xfailed
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` clean
- [x] \`uv run mypy lookup/orchestrator.py\` clean
- [x] Bare-\"the\" degenerate-case test (\`test_no_match_when_only_article_remains\`) still green — the guard now takes the empty path explicitly