### PR TITLE
Add POST /api/v1/lookup/bulk endpoint (LML#368)

### DIFF
--- a/lookup/models.py
+++ b/lookup/models.py
@@ -17,7 +17,7 @@ existing callers see no behavior change.
 
 from typing import Literal
 
-from pydantic import Field, SerializeAsAny
+from pydantic import BaseModel, Field, SerializeAsAny
 
 from generated.api_models import (
     DiscogsMatchResult,
@@ -76,7 +76,43 @@ class LookupResponse(_GeneratedLookupResponse):
     )
 
 
+BulkLookupResultStatus = Literal["match", "no_match", "error"]
+
+
+class BulkLookupResultItem(BaseModel):
+    """Per-item verdict for the bulk lookup endpoint.
+
+    ``lookup`` carries the full per-item ``LookupResponse`` so callers see the
+    same shape as the single-item endpoint when the lookup completed, regardless
+    of whether it produced results. ``status`` is a fast signal:
+
+    - ``match``    — ``lookup.results`` is non-empty
+    - ``no_match`` — ``lookup.results`` is empty (search ran, found nothing)
+    - ``error``    — ``perform_lookup`` raised; ``lookup`` is None, ``message`` set
+    """
+
+    index: int = Field(..., description="Zero-based index into the request `items` array.")
+    status: BulkLookupResultStatus
+    lookup: LookupResponse | None = None
+    message: str | None = None
+
+
+class BulkLookupRequest(BaseModel):
+    """Bulk variant of ``LookupRequest``. Items run concurrently under a
+    bounded semaphore; results return in input order."""
+
+    items: list[LookupRequest] = Field(..., min_length=1)
+
+
+class BulkLookupResponse(BaseModel):
+    results: list[BulkLookupResultItem]
+
+
 __all__ = [
+    "BulkLookupRequest",
+    "BulkLookupResponse",
+    "BulkLookupResultItem",
+    "BulkLookupResultStatus",
     "DiscogsMatchResult",
     "LibraryCatalogItem",
     "LookupRequest",

--- a/lookup/models.py
+++ b/lookup/models.py
@@ -82,10 +82,6 @@ BulkLookupResultStatus = Literal["match", "no_match", "error"]
 class BulkLookupResultItem(BaseModel):
     """Per-item verdict for the bulk lookup endpoint.
 
-    ``lookup`` carries the full per-item ``LookupResponse`` so callers see the
-    same shape as the single-item endpoint when the lookup completed, regardless
-    of whether it produced results. ``status`` is a fast signal:
-
     - ``match``    — ``lookup.results`` is non-empty
     - ``no_match`` — ``lookup.results`` is empty (search ran, found nothing)
     - ``error``    — ``perform_lookup`` raised; ``lookup`` is None, ``message`` set
@@ -98,9 +94,6 @@ class BulkLookupResultItem(BaseModel):
 
 
 class BulkLookupRequest(BaseModel):
-    """Bulk variant of ``LookupRequest``. Items run concurrently under a
-    bounded semaphore; results return in input order."""
-
     items: list[LookupRequest] = Field(..., min_length=1)
 
 

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -237,13 +237,15 @@ async def handle_bulk_lookup(
     entity_store: EntityStore | None = Depends(get_entity_store),
     posthog_client: Posthog | None = Depends(get_posthog_client),
     http_client: httpx.AsyncClient = Depends(get_apple_music_http_client),
+    skip_cache: bool = False,
     x_caller_budget_ms: int | None = Header(
         default=None,
         alias="X-Caller-Budget-Ms",
         description=(
             "Optional per-request budget in ms. Forwarded to each item's "
             "perform_lookup call; the per-item budget is independent of the "
-            "batch (each item sees the same caller-supplied ceiling)."
+            "batch (each item sees the same caller-supplied ceiling). The "
+            "`LML#345 follow-up will redefine this as a batch-level budget."
         ),
     ),
 ) -> BulkLookupResponse:
@@ -270,6 +272,12 @@ async def handle_bulk_lookup(
         request = BulkLookupRequest.model_validate(body)
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors()) from None
+
+    # Honor the same `skip_cache` query flag the per-item route accepts. Backed
+    # by a ContextVar, so setting once at the batch top propagates into each
+    # `_run_one` task via the inherited task context.
+    if skip_cache:
+        set_skip_cache(True)
 
     # One cache_stats context for the whole batch: the in-process caches are
     # shared, so aggregate counters reflect the batch's behavior — the property
@@ -309,12 +317,17 @@ async def handle_bulk_lookup(
                     )
             except Exception as e:
                 # Per-item isolation: one failure must not poison siblings.
+                # The error class is surfaced for caller-side classification,
+                # but the exception's str() may include SQL fragments, file
+                # paths, or upstream error bodies — strip to the class name to
+                # keep internals out of the response. Full traceback lands in
+                # Sentry via `logger.exception`.
                 logger.exception("bulk lookup item %d failed", index)
                 return BulkLookupResultItem(
                     index=index,
                     status="error",
                     lookup=None,
-                    message=f"{type(e).__name__}: {e}",
+                    message=type(e).__name__,
                 )
             return BulkLookupResultItem(
                 index=index,

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from collections import Counter
 from typing import TYPE_CHECKING
 
 import httpx
@@ -45,15 +46,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["lookup"])
 
-# LML#368: bulk endpoint accepts 1-100 items per request. Above the cap we
-# return 400 (per the ticket's acceptance criteria — not 413, which the
-# `/identity/bulk-resolve-libraries` precedent uses for its 1000-cap). The
-# cap is constant; if it needs to grow we change it here.
+# 400 (not 413) for oversize is the endpoint's contract; sibling
+# `/identity/bulk-resolve-libraries` chose 413 — keep them separate.
 _BULK_LOOKUP_INPUT_CAP = 100
 
-# Default in-flight concurrency cap for bulk items. Tunable via env so we can
-# react to per-deploy hardware without a code change. Bounded at the floor so
-# accidental `0` or negative values can't hang the request.
 _BULK_LOOKUP_DEFAULT_CONCURRENCY = 10
 
 
@@ -193,9 +189,13 @@ async def handle_lookup(
 
 
 def _max_concurrency_from_env() -> int:
-    """Resolve the bulk-item concurrency cap from env, floored at 1."""
+    """Resolve LML_BULK_MAX_CONCURRENT, floored at 1 to keep a misconfigured 0 from hanging.
+
+    Read at request time (not via `Settings`) to mirror `LML_SEARCH_BUDGET_MS`
+    in `core/search.py:resolve_search_budget_ms` — both are runtime knobs.
+    """
     raw = os.getenv("LML_BULK_MAX_CONCURRENT")
-    if raw is None or raw == "":
+    if not raw:
         return _BULK_LOOKUP_DEFAULT_CONCURRENCY
     try:
         return max(1, int(raw))
@@ -248,8 +248,7 @@ async def handle_bulk_lookup(
     ),
 ) -> BulkLookupResponse:
     """Bulk lookup. See route docstring for protocol."""
-    # Manual parse + cap-check so oversize gets 400 (per LML#368 acceptance
-    # criteria) rather than the 422 Pydantic would emit via max_length.
+    # Manual cap-check: 400 (not Pydantic's 422) for oversize batches.
     try:
         body = await http_request.json()
     except (ValueError, TypeError) as e:
@@ -272,16 +271,24 @@ async def handle_bulk_lookup(
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors()) from None
 
-    # One cache_stats context for the whole batch — the in-process caches are
-    # shared, so cumulative hit/miss counters reflect the batch's aggregate
-    # behavior (the property that motivates this endpoint).
+    # One cache_stats context for the whole batch: the in-process caches are
+    # shared, so aggregate counters reflect the batch's behavior — the property
+    # that motivates this endpoint.
     init_cache_stats()
 
     max_concurrent = _max_concurrency_from_env()
     semaphore = asyncio.Semaphore(max_concurrent)
+    batch_telemetry = RequestTelemetry(
+        api_call_keys=["discogs"],
+        distinct_id="library-metadata-lookup-service",
+        event_prefix="lookup.bulk",
+    )
 
     async def _run_one(index: int, item: LookupRequest) -> BulkLookupResultItem:
         async with semaphore:
+            # Per-item telemetry instance: required by perform_lookup's signature
+            # and avoids the `_current_step` race that would happen with a shared
+            # instance across concurrent items.
             telemetry = RequestTelemetry(
                 api_call_keys=["discogs"],
                 distinct_id="library-metadata-lookup-service",
@@ -302,8 +309,6 @@ async def handle_bulk_lookup(
                     )
             except Exception as e:
                 # Per-item isolation: one failure must not poison siblings.
-                # Log the traceback for observability but surface only the
-                # exception class + message to the caller — no internals.
                 logger.exception("bulk lookup item %d failed", index)
                 return BulkLookupResultItem(
                     index=index,
@@ -311,43 +316,30 @@ async def handle_bulk_lookup(
                     lookup=None,
                     message=f"{type(e).__name__}: {e}",
                 )
-            has_results = bool(lookup_response.results)
             return BulkLookupResultItem(
                 index=index,
-                status="match" if has_results else "no_match",
+                status="match" if lookup_response.results else "no_match",
                 lookup=lookup_response,
             )
 
     with sentry_sdk.start_span(op="lml.bulk.batch", name=f"{len(request.items)} items") as span:
-        if span is not None:
-            span.set_data("lml.bulk.size", len(request.items))
-            span.set_data("lml.bulk.max_concurrent", max_concurrent)
+        span.set_data("lml.bulk.size", len(request.items))
+        span.set_data("lml.bulk.max_concurrent", max_concurrent)
         results = await asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items)))
 
-    # Project the batch's aggregate cache_stats onto the active Sentry
-    # transaction so the join against the trace works the same as per-item
-    # /lookup. Sentry SDK errors must not break the request path.
-    stats = get_cache_stats()
-    _project_cache_stats_to_transaction(stats)
+    _project_cache_stats_to_transaction(get_cache_stats())
 
-    # Telemetry: one PostHog event for the batch summarizing per-item outcomes.
     if posthog_client:
-        match_count = sum(1 for r in results if r.status == "match")
-        no_match_count = sum(1 for r in results if r.status == "no_match")
-        error_count = sum(1 for r in results if r.status == "error")
-        try:
-            posthog_client.capture(
-                "lookup.bulk",
-                distinct_id="library-metadata-lookup-service",
-                properties={
-                    "batch_size": len(request.items),
-                    "match_count": match_count,
-                    "no_match_count": no_match_count,
-                    "error_count": error_count,
-                    "max_concurrent": max_concurrent,
-                },
-            )
-        except Exception:
-            logger.warning("PostHog capture failed for lookup.bulk", exc_info=True)
+        counts = Counter(r.status for r in results)
+        batch_telemetry.send_to_posthog(
+            posthog_client,
+            {
+                "batch_size": len(request.items),
+                "match_count": counts["match"],
+                "no_match_count": counts["no_match"],
+                "error_count": counts["error"],
+                "max_concurrent": max_concurrent,
+            },
+        )
 
     return BulkLookupResponse(results=results)

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 from typing import TYPE_CHECKING
 
 import httpx
 import sentry_sdk
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from pydantic import ValidationError
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
 
 from core.dependencies import (
@@ -24,7 +27,13 @@ from discogs.service import DiscogsService
 from generated.api_models import CacheStats
 from identity.dependencies import get_entity_store
 from library.db import LibraryDB
-from lookup.models import LookupRequest, LookupResponse
+from lookup.models import (
+    BulkLookupRequest,
+    BulkLookupResponse,
+    BulkLookupResultItem,
+    LookupRequest,
+    LookupResponse,
+)
 from lookup.orchestrator import perform_lookup
 from scripts.entity_resolution.sources import PgSource
 from scripts.entity_resolution.store import EntityStore
@@ -35,6 +44,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["lookup"])
+
+# LML#368: bulk endpoint accepts 1-100 items per request. Above the cap we
+# return 400 (per the ticket's acceptance criteria — not 413, which the
+# `/identity/bulk-resolve-libraries` precedent uses for its 1000-cap). The
+# cap is constant; if it needs to grow we change it here.
+_BULK_LOOKUP_INPUT_CAP = 100
+
+# Default in-flight concurrency cap for bulk items. Tunable via env so we can
+# react to per-deploy hardware without a code change. Bounded at the floor so
+# accidental `0` or negative values can't hang the request.
+_BULK_LOOKUP_DEFAULT_CONCURRENCY = 10
 
 
 def _project_cache_stats_to_transaction(stats: dict | None) -> None:
@@ -170,3 +190,164 @@ async def handle_lookup(
     except Exception as e:
         logger.error(f"Lookup failed: {e}")
         raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+def _max_concurrency_from_env() -> int:
+    """Resolve the bulk-item concurrency cap from env, floored at 1."""
+    raw = os.getenv("LML_BULK_MAX_CONCURRENT")
+    if raw is None or raw == "":
+        return _BULK_LOOKUP_DEFAULT_CONCURRENCY
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logger.warning(
+            "Invalid LML_BULK_MAX_CONCURRENT=%r, falling back to %d",
+            raw,
+            _BULK_LOOKUP_DEFAULT_CONCURRENCY,
+        )
+        return _BULK_LOOKUP_DEFAULT_CONCURRENCY
+
+
+@router.post(
+    "/lookup/bulk",
+    response_model=BulkLookupResponse,
+    summary="Bulk variant of /lookup — amortizes cold-cache cost across items",
+    description="""
+    Runs ``perform_lookup`` for each item in the request body under a bounded
+    semaphore (env: ``LML_BULK_MAX_CONCURRENT``, default 10). Results are
+    returned in input order. Per-item failures are isolated and surfaced as
+    ``status: error`` so one item cannot poison the batch.
+
+    Amortizes per-row cold-cache cost two ways: one HTTP roundtrip per N
+    items instead of N roundtrips, and the in-process TTL/LRU caches stay
+    warm across all N items in a batch.
+    """,
+    responses={
+        200: {"description": "Per-item verdicts in input order."},
+        400: {"description": f"Malformed body or batch above {_BULK_LOOKUP_INPUT_CAP}-item cap."},
+        422: {"description": "Request body failed Pydantic validation (e.g. empty items array)."},
+    },
+)
+async def handle_bulk_lookup(
+    http_request: Request,
+    db: LibraryDB = Depends(get_library_db),
+    discogs_service: DiscogsService | None = Depends(get_discogs_service),
+    discogs_cache: DiscogsCacheService | None = Depends(get_discogs_cache_service),
+    mb_pg: PgSource | None = Depends(get_musicbrainz_pg),
+    entity_store: EntityStore | None = Depends(get_entity_store),
+    posthog_client: Posthog | None = Depends(get_posthog_client),
+    http_client: httpx.AsyncClient = Depends(get_apple_music_http_client),
+    x_caller_budget_ms: int | None = Header(
+        default=None,
+        alias="X-Caller-Budget-Ms",
+        description=(
+            "Optional per-request budget in ms. Forwarded to each item's "
+            "perform_lookup call; the per-item budget is independent of the "
+            "batch (each item sees the same caller-supplied ceiling)."
+        ),
+    ),
+) -> BulkLookupResponse:
+    """Bulk lookup. See route docstring for protocol."""
+    # Manual parse + cap-check so oversize gets 400 (per LML#368 acceptance
+    # criteria) rather than the 422 Pydantic would emit via max_length.
+    try:
+        body = await http_request.json()
+    except (ValueError, TypeError) as e:
+        raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
+    items_raw = body.get("items")
+    if not isinstance(items_raw, list):
+        raise HTTPException(status_code=422, detail="`items` must be a JSON array.")
+    if len(items_raw) > _BULK_LOOKUP_INPUT_CAP:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Batch exceeded the {_BULK_LOOKUP_INPUT_CAP}-item cap (received {len(items_raw)})."
+            ),
+        )
+
+    try:
+        request = BulkLookupRequest.model_validate(body)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from None
+
+    # One cache_stats context for the whole batch — the in-process caches are
+    # shared, so cumulative hit/miss counters reflect the batch's aggregate
+    # behavior (the property that motivates this endpoint).
+    init_cache_stats()
+
+    max_concurrent = _max_concurrency_from_env()
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def _run_one(index: int, item: LookupRequest) -> BulkLookupResultItem:
+        async with semaphore:
+            telemetry = RequestTelemetry(
+                api_call_keys=["discogs"],
+                distinct_id="library-metadata-lookup-service",
+                event_prefix="lookup.bulk",
+            )
+            try:
+                with sentry_sdk.start_span(op="lml.bulk.item", name=f"item {index}"):
+                    lookup_response = await perform_lookup(
+                        request=item,
+                        db=db,
+                        discogs_service=discogs_service,
+                        telemetry=telemetry,
+                        entity_store=entity_store,
+                        discogs_cache=discogs_cache,
+                        mb_pg=mb_pg,
+                        http_client=http_client,
+                        caller_budget_ms=x_caller_budget_ms,
+                    )
+            except Exception as e:
+                # Per-item isolation: one failure must not poison siblings.
+                # Log the traceback for observability but surface only the
+                # exception class + message to the caller — no internals.
+                logger.exception("bulk lookup item %d failed", index)
+                return BulkLookupResultItem(
+                    index=index,
+                    status="error",
+                    lookup=None,
+                    message=f"{type(e).__name__}: {e}",
+                )
+            has_results = bool(lookup_response.results)
+            return BulkLookupResultItem(
+                index=index,
+                status="match" if has_results else "no_match",
+                lookup=lookup_response,
+            )
+
+    with sentry_sdk.start_span(op="lml.bulk.batch", name=f"{len(request.items)} items") as span:
+        if span is not None:
+            span.set_data("lml.bulk.size", len(request.items))
+            span.set_data("lml.bulk.max_concurrent", max_concurrent)
+        results = await asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items)))
+
+    # Project the batch's aggregate cache_stats onto the active Sentry
+    # transaction so the join against the trace works the same as per-item
+    # /lookup. Sentry SDK errors must not break the request path.
+    stats = get_cache_stats()
+    _project_cache_stats_to_transaction(stats)
+
+    # Telemetry: one PostHog event for the batch summarizing per-item outcomes.
+    if posthog_client:
+        match_count = sum(1 for r in results if r.status == "match")
+        no_match_count = sum(1 for r in results if r.status == "no_match")
+        error_count = sum(1 for r in results if r.status == "error")
+        try:
+            posthog_client.capture(
+                "lookup.bulk",
+                distinct_id="library-metadata-lookup-service",
+                properties={
+                    "batch_size": len(request.items),
+                    "match_count": match_count,
+                    "no_match_count": no_match_count,
+                    "error_count": error_count,
+                    "max_concurrent": max_concurrent,
+                },
+            )
+        except Exception:
+            logger.warning("PostHog capture failed for lookup.bulk", exc_info=True)
+
+    return BulkLookupResponse(results=results)

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -1,0 +1,256 @@
+"""Unit tests for `POST /api/v1/lookup/bulk` (LML#368).
+
+Bulk variant of `/api/v1/lookup` that amortizes per-row cold-cache cost across
+N items in a single request. The handler runs `perform_lookup` per item under
+a bounded semaphore; results are returned in input order and per-item failures
+are isolated so one item cannot poison the batch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from discogs.service import DiscogsService
+from library.db import LibraryDB
+from lookup.models import LookupResponse, LookupResultItem
+from tests.factories import make_catalog_item, make_match_result
+from tests.unit.conftest import override_deps
+
+
+@pytest.fixture
+def mock_db():
+    return AsyncMock(spec=LibraryDB)
+
+
+@pytest.fixture
+def mock_discogs():
+    return AsyncMock(spec=DiscogsService)
+
+
+@pytest.fixture
+def app_client(mock_db, mock_discogs, mock_settings):
+    from config.settings import get_settings
+    from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_library_db: mock_db,
+            get_discogs_service: mock_discogs,
+            get_posthog_client: None,
+            get_settings: mock_settings,
+        },
+    ):
+        yield app
+
+
+def _match_response(artist: str, album: str) -> LookupResponse:
+    """LookupResponse carrying one match — what Backend sees on a happy lookup."""
+    return LookupResponse(
+        results=[
+            LookupResultItem(
+                library_item=make_catalog_item(artist=artist, title=album),
+                artwork=make_match_result(album=album, artist=artist),
+            )
+        ],
+        search_type="direct",
+    )
+
+
+def _no_match_response() -> LookupResponse:
+    return LookupResponse(results=[], search_type="none")
+
+
+class TestBulkLookupEndpoint:
+    @pytest.mark.asyncio
+    async def test_happy_path_two_items(self, app_client):
+        """Two matching items → 200 with `match` status on each, in order."""
+        side_effect = [
+            _match_response("Jessica Pratt", "On Your Own Love Again"),
+            _match_response("Juana Molina", "DOGA"),
+        ]
+
+        with patch(
+            "lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=side_effect
+        ) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={
+                        "items": [
+                            {"artist": "Jessica Pratt", "album": "On Your Own Love Again"},
+                            {"artist": "Juana Molina", "album": "DOGA"},
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["results"]) == 2
+        assert [r["index"] for r in data["results"]] == [0, 1]
+        assert [r["status"] for r in data["results"]] == ["match", "match"]
+        assert (
+            data["results"][0]["lookup"]["results"][0]["library_item"]["artist"] == "Jessica Pratt"
+        )
+        assert (
+            data["results"][1]["lookup"]["results"][0]["library_item"]["artist"] == "Juana Molina"
+        )
+        assert mock_lookup.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_results_preserve_input_order(self, app_client):
+        """Even with mixed match/no_match/error, response[i] corresponds to request[i]."""
+
+        async def fake_lookup(request, **kwargs):
+            if request.artist == "boom":
+                raise RuntimeError("upstream failure")
+            if request.artist == "miss":
+                return _no_match_response()
+            return _match_response(request.artist, request.album or "")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=fake_lookup):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={
+                        "items": [
+                            {"artist": "Stereolab", "album": "Aluminum Tunes"},
+                            {"artist": "miss", "album": "X"},
+                            {"artist": "boom", "album": "Y"},
+                            {"artist": "Cat Power", "album": "Moon Pix"},
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [r["index"] for r in data["results"]] == [0, 1, 2, 3]
+        assert [r["status"] for r in data["results"]] == ["match", "no_match", "error", "match"]
+
+    @pytest.mark.asyncio
+    async def test_per_item_error_isolated(self, app_client):
+        """A raising item must not abort siblings; its result carries a message."""
+        side_effect = [
+            _match_response("Stereolab", "Aluminum Tunes"),
+            RuntimeError("upstream timeout"),
+        ]
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=side_effect):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={
+                        "items": [
+                            {"artist": "Stereolab", "album": "Aluminum Tunes"},
+                            {"artist": "Whoever", "album": "Whatever"},
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert results[0]["status"] == "match"
+        assert results[1]["status"] == "error"
+        assert results[1]["lookup"] is None
+        # Message surfaced but no internals leaked — body content is opaque to
+        # the test, just verify a non-empty string.
+        assert isinstance(results[1]["message"], str) and results[1]["message"]
+
+    @pytest.mark.asyncio
+    async def test_empty_items_rejected_with_422(self, app_client):
+        """`items: []` fails Pydantic min_length validation (no DB hit)."""
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post("/api/v1/lookup/bulk", json={"items": []})
+
+        assert resp.status_code == 422
+        mock_lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_oversize_input_rejected_with_400(self, app_client):
+        """101 items → 400 per LML#368 acceptance criteria (not 422)."""
+        oversized = [{"artist": f"Artist_{i}", "album": "x"} for i in range(101)]
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post("/api/v1/lookup/bulk", json={"items": oversized})
+
+        assert resp.status_code == 400
+        # Cap-check fires before any item work begins.
+        mock_lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_concurrency_bounded_by_semaphore(self, app_client, monkeypatch):
+        """Concurrent items in flight never exceed `lml_bulk_max_concurrent`.
+
+        Sets the cap to 2 and verifies the peak observed concurrency across a
+        7-item batch stays at 2. Without a bounded semaphore the gather would
+        admit all 7 immediately and the peak would be 7.
+        """
+        monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "2")
+
+        import asyncio
+
+        in_flight = 0
+        peak = 0
+        lock = asyncio.Lock()
+
+        async def fake_lookup(request, **kwargs):
+            nonlocal in_flight, peak
+            async with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)
+            async with lock:
+                in_flight -= 1
+            return _match_response(request.artist or "?", request.album or "?")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=fake_lookup):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={"items": [{"artist": f"a{i}", "album": "x"} for i in range(7)]},
+                )
+
+        assert resp.status_code == 200
+        assert peak <= 2, f"Peak concurrency was {peak}; semaphore did not bound it"
+
+    @pytest.mark.asyncio
+    async def test_no_match_status_when_results_empty(self, app_client):
+        """`results: []` in the per-item LookupResponse → top-level status no_match."""
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_no_match_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={"items": [{"artist": "Nobody Knows", "album": "Anywhere"}]},
+                )
+
+        assert resp.status_code == 200
+        result = resp.json()["results"][0]
+        assert result["status"] == "no_match"
+        # The LookupResponse is still surfaced so callers can inspect search_type
+        # / external_source / cache_stats even on a no-match.
+        assert result["lookup"]["search_type"] == "none"
+        assert result["lookup"]["results"] == []

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -8,7 +8,7 @@ are isolated so one item cannot poison the batch.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -137,10 +137,17 @@ class TestBulkLookupEndpoint:
 
     @pytest.mark.asyncio
     async def test_per_item_error_isolated(self, app_client):
-        """A raising item must not abort siblings; its result carries a message."""
+        """A raising item must not abort siblings; its result carries a sanitized message.
+
+        The sibling row completes; the failing row reports the exception class name
+        only. We deliberately do not surface `str(e)` — exception payloads can
+        carry SQL fragments, file paths, or upstream error bodies. Sentry retains
+        the full traceback for diagnosis via `logger.exception`.
+        """
+        leaky_payload = "secret_table_name in SELECT * FROM internal_table"
         side_effect = [
             _match_response("Stereolab", "Aluminum Tunes"),
-            RuntimeError("upstream timeout"),
+            RuntimeError(leaky_payload),
         ]
 
         with patch("lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=side_effect):
@@ -162,9 +169,9 @@ class TestBulkLookupEndpoint:
         assert results[0]["status"] == "match"
         assert results[1]["status"] == "error"
         assert results[1]["lookup"] is None
-        # Message surfaced but no internals leaked — body content is opaque to
-        # the test, just verify a non-empty string.
-        assert isinstance(results[1]["message"], str) and results[1]["message"]
+        # Surface the class only — payload contents must NOT appear in the response.
+        assert results[1]["message"] == "RuntimeError"
+        assert leaky_payload not in results[1]["message"]
 
     @pytest.mark.asyncio
     async def test_empty_items_rejected_with_422(self, app_client):
@@ -254,3 +261,190 @@ class TestBulkLookupEndpoint:
         # / external_source / cache_stats even on a no-match.
         assert result["lookup"]["search_type"] == "none"
         assert result["lookup"]["results"] == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_body_returns_400(self, app_client):
+        """A non-JSON body must hit the manual-parse 400 branch before any item work."""
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    content=b"not json",
+                    headers={"content-type": "application/json"},
+                )
+
+        assert resp.status_code == 400
+        assert "malformed json" in resp.json()["detail"].lower()
+        mock_lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_body_must_be_object_returns_400(self, app_client):
+        """A JSON array (not object) at the top level is a 400, not a 422."""
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                # Send a JSON array at top level — valid JSON, wrong shape.
+                resp = await ac.post("/api/v1/lookup/bulk", json=[])
+
+        assert resp.status_code == 400
+        mock_lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_items_must_be_array_returns_422(self, app_client):
+        """`items` present but not a list → 422 (structural-validation tier)."""
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post("/api/v1/lookup/bulk", json={"items": "nope"})
+
+        assert resp.status_code == 422
+        mock_lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skip_cache_query_param_sets_contextvar(self, app_client):
+        """`?skip_cache=true` must flip the in-process ContextVar at batch entry.
+
+        Mirrors `/api/v1/lookup`'s `skip_cache` flag (router.py:131-132). The
+        ContextVar is task-context-inherited, so a single set at the batch top
+        propagates to every concurrent per-item task without per-item resets.
+        """
+        from discogs.memory_cache import should_skip_cache
+
+        observed: list[bool] = []
+
+        async def fake_lookup(request, **kwargs):
+            # Reads the ContextVar from the per-item task — must inherit the
+            # batch-level set.
+            observed.append(should_skip_cache())
+            return _match_response(request.artist or "?", request.album or "?")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=fake_lookup):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk?skip_cache=true",
+                    json={
+                        "items": [
+                            {"artist": "Juana Molina", "album": "DOGA"},
+                            {"artist": "Jessica Pratt", "album": "On Your Own Love Again"},
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 200
+        assert observed == [True, True], (
+            "skip_cache ContextVar did not propagate to per-item perform_lookup tasks"
+        )
+
+    @pytest.mark.asyncio
+    async def test_posthog_batch_event_emitted(self, mock_db, mock_discogs, mock_settings):
+        """When PostHog is configured, the batch route emits exactly one event."""
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from main import app
+
+        mock_posthog = Mock()
+        mock_posthog.capture = Mock()
+        mock_posthog.flush = Mock()
+
+        async def fake_lookup(request, **kwargs):
+            if request.artist == "miss":
+                return _no_match_response()
+            if request.artist == "boom":
+                raise RuntimeError("boom")
+            return _match_response(request.artist or "?", request.album or "?")
+
+        with override_deps(
+            app,
+            {
+                get_library_db: mock_db,
+                get_discogs_service: mock_discogs,
+                get_posthog_client: mock_posthog,
+                get_settings: mock_settings,
+            },
+        ):
+            with patch(
+                "lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=fake_lookup
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    resp = await ac.post(
+                        "/api/v1/lookup/bulk",
+                        json={
+                            "items": [
+                                {"artist": "Stereolab", "album": "Aluminum Tunes"},
+                                {"artist": "miss", "album": "X"},
+                                {"artist": "boom", "album": "Y"},
+                            ]
+                        },
+                    )
+
+        assert resp.status_code == 200
+        # Exactly one batch-level event, not one per item.
+        assert mock_posthog.capture.call_count == 1
+        # Inspect the payload — keys differ by Posthog client version, so just
+        # verify the count breakdown landed somewhere in the captured payload.
+        captured_payload = repr(mock_posthog.capture.call_args)
+        assert "batch_size" in captured_payload
+        assert "match_count" in captured_payload
+        assert "no_match_count" in captured_payload
+        assert "error_count" in captured_payload
+
+    @pytest.mark.asyncio
+    async def test_invalid_concurrency_env_falls_back_to_default(
+        self, app_client, monkeypatch, caplog
+    ):
+        """Garbage in `LML_BULK_MAX_CONCURRENT` must fall back to the default + warn.
+
+        Pins the contract documented at `_max_concurrency_from_env`: a misconfigured
+        env var doesn't blow up the route, it warns and uses the default.
+        """
+        import logging
+
+        monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "not-an-int")
+
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_no_match_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                with caplog.at_level(logging.WARNING, logger="lookup.router"):
+                    resp = await ac.post(
+                        "/api/v1/lookup/bulk",
+                        json={"items": [{"artist": "Cat Power", "album": "Moon Pix"}]},
+                    )
+
+        assert resp.status_code == 200
+        assert any(
+            "LML_BULK_MAX_CONCURRENT" in rec.message and "falling back" in rec.message
+            for rec in caplog.records
+        ), "Expected a fallback warning for malformed LML_BULK_MAX_CONCURRENT"
+
+    @pytest.mark.asyncio
+    async def test_zero_concurrency_env_floored_to_one(self, app_client, monkeypatch):
+        """`LML_BULK_MAX_CONCURRENT=0` must floor to 1, not hang the batch."""
+        monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "0")
+
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_no_match_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={"items": [{"artist": "Juana Molina", "album": "DOGA"}]},
+                )
+
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/lookup/bulk` — a batched variant of `/api/v1/lookup` that amortizes per-row cold-cache cost across N items in a single request. Motivated by the 2026-05-23 drain analysis ([LML#337](https://github.com/WXYC/library-metadata-lookup/issues/337) cold-cache regression + [BS#995](https://github.com/WXYC/Backend-Service/issues/995) static gate): single-row throughput is ~14 rows/min, which leaves the 1.6M residual months out at single-row rates. Bulk collapses the in-process TTL/LRU cache reuse window from a single item to the whole batch.

Per-item logic still flows through `perform_lookup` — this is a thin gather wrapper, not a divergent code path.

## Shape

```
POST /api/v1/lookup/bulk
Authorization: Bearer <LML_API_KEY>
Content-Type: application/json

{ "items": [{"artist": "...", "album": "...", "song": "..."}, ...] }
```

Response (results in input order):

```json
{ "results": [
  {"index": 0, "status": "match",    "lookup": { ...LookupResponse... }},
  {"index": 1, "status": "no_match", "lookup": { ...empty results... }},
  {"index": 2, "status": "error",    "lookup": null, "message": "..."}
] }
```

`status` is a fast signal:

- `match` — `lookup.results` is non-empty
- `no_match` — search ran, no rows matched
- `error` — `perform_lookup` raised; sibling items unaffected

## Internals

- `asyncio.gather` + bounded `asyncio.Semaphore` (mirrors `bulk-resolve-libraries` precedent, [LML#278](https://github.com/WXYC/library-metadata-lookup/pull/278))
- Concurrency cap: `LML_BULK_MAX_CONCURRENT` env (default 10), floored at 1
- Input cap: 100 items per request, returns **400** above (per ticket acceptance criteria; `bulk-resolve-libraries` uses 413 but the ticket spec is 400)
- Empty `items: []` → 422 via Pydantic `min_length=1`
- Per-item exception → `status: error` + `message: "ErrorClass: ..."` — internals not leaked
- Sentry: batch span (`lml.bulk.batch`) wraps per-item spans (`lml.bulk.item`); `perform_lookup`'s internal `telemetry.track_step` spans hang off the per-item span naturally
- One `init_cache_stats()` at the batch top so the in-process cache counters aggregate across items; projected onto the batch transaction the same way the per-item route does
- PostHog: one `lookup.bulk` event per batch with `batch_size`, `{match,no_match,error}_count`, `max_concurrent`

## Hot-path posture

Per-item `/api/v1/lookup` is untouched — same signature, same code path. The bulk route lives in `lookup/router.py` alongside it and reuses every dependency (`get_library_db`, `get_discogs_service`, `get_discogs_cache_service`, `get_musicbrainz_pg`, `get_entity_store`, `get_posthog_client`, `get_apple_music_http_client`). LML bearer auth applies via `main.py`'s router-level `Depends(require_lml_key)`.

## What's NOT in this PR

- **api.yaml + generated Pydantic models**: this PR defines the request/response shapes in `lookup/models.py` directly (same pattern as the Phase 1.5 `include_external_caches` override). A wxyc-shared PR will add `LookupBulkRequest` / `LookupBulkResponse` and the generated models can supersede the local definitions in a follow-up.
- **Backend-Service caller**: [BS#1041](https://github.com/WXYC/Backend-Service/issues/1041) (album-level backfill job) is the first consumer; it's blocked-by this PR.

## Test plan

- [x] 1835/1835 unit tests pass (`uv run pytest tests/unit/ -q`)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `mypy lookup/` clean
- [x] New unit-test file `tests/unit/test_bulk_lookup_endpoint.py` covers:
  - [x] happy path: 2 items return `match` in order
  - [x] mixed match/no_match/error preserves input order
  - [x] per-item error isolated; siblings complete; error result carries `message`
  - [x] `items: []` → 422
  - [x] 101 items → 400 (cap-check fires before any item work)
  - [x] semaphore bounds peak in-flight concurrency
  - [x] `no_match` status when `lookup.results` is empty

## Related

- Closes #368
- Unblocks [WXYC/Backend-Service#1041](https://github.com/WXYC/Backend-Service/issues/1041) (album-level backfill, the first consumer)
- [#337](https://github.com/WXYC/library-metadata-lookup/issues/337) / [#338](https://github.com/WXYC/library-metadata-lookup/issues/338) — per-item cold-cache regression; this PR addresses cumulative per-batch cost, complementary to Epic A's per-item work
- [#272](https://github.com/WXYC/library-metadata-lookup/pull/272) / [#278](https://github.com/WXYC/library-metadata-lookup/pull/278) — `bulk-resolve-libraries` precedent (shape + semaphore pattern)
- [#345](https://github.com/WXYC/library-metadata-lookup/issues/345) — `X-Caller-Budget-Ms` header is forwarded to each per-item `perform_lookup` once it ships