### PR TITLE
Cancel-aware bulk-lookup gather (LML#372)

### DIFF
--- a/docs/plans/lml-372-cancel-aware-bulk-gather.md
+++ b/docs/plans/lml-372-cancel-aware-bulk-gather.md
@@ -1,0 +1,191 @@
+# LML#372 — Cancel-aware bulk-lookup gather
+
+## Problem (one-paragraph recap)
+
+`POST /api/v1/lookup/bulk` fans items into the 5-permit Discogs semaphore under an `asyncio.gather`. When a client's `AbortController` fires (BS runtime: 30 s; per-row cron: 8 s), uvicorn closes the socket but does **not** propagate cancellation into the handler. The gather keeps draining; queued items keep holding the semaphore; the next batch piles on. Result: 10 consecutive 30 s-flat-line batches with 20/20 errors observed in the 2026-05-24 22:21–22:34 UTC autopsy ([BS#1064 comment](https://github.com/WXYC/Backend-Service/issues/1064#issuecomment-4531269302)).
+
+Issue: [LML#372](https://github.com/WXYC/library-metadata-lookup/issues/372). This plan ships **mitigation (1) only** — cancel-aware gather. Mitigations (2) admission control, (3) raise the semaphore, and (4) fair queueing are explicitly out of scope; (2) is the natural next ship if (1) leaves a residual cliff.
+
+## Goal & non-goals
+
+**Goal.** When the calling client closes its socket, the LML handler observes the disconnect, cancels the in-flight `gather`, and releases the Discogs semaphore permits held by abandoned items — before the next batch arrives.
+
+**Non-goals.**
+- Changing the public contract of `POST /api/v1/lookup/bulk`. Behavior for callers that stay connected is identical.
+- Changing the 5-permit semaphore. Discogs's 60/min ceiling is the real cap; growing the semaphore moves the cliff, doesn't remove it.
+- Admission control / 503 on queue depth. Sibling ticket; layered if needed.
+- Fair queueing across callers. Out of scope.
+- Per-item budgeting changes. The existing `X-Caller-Budget-Ms` passthrough stays as-is; the `LML#345` follow-up redefines it as a batch-level budget separately.
+- Sibling `LML#370` (cascade-exhaustion ceiling) and `LML#371` (uvicorn span observability gap) — separate tickets, separate PRs.
+
+## Design
+
+### Cancel-aware execution
+
+Replace the single line at `lookup/router.py:341`:
+
+```python
+results = await asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items)))
+```
+
+with a structured pattern that races the gather against a disconnect sentinel and cancels the gather if the client departs first. Python 3.12 (per `pyproject.toml:requires-python = ">=3.12"`) — `asyncio.TaskGroup` is available, but TaskGroup propagation semantics on external cancellation are awkward for our "abandon and return partial telemetry" intent; a plain `asyncio.wait([gather_task, sentinel_task], return_when=FIRST_COMPLETED)` over named tasks is cleaner and matches Starlette's own background-cancellation pattern.
+
+Sketch (final form lives in `lookup/router.py`):
+
+```python
+async def _watch_disconnect(request: Request, *, poll_interval_s: float = 0.25) -> None:
+    while True:
+        if await request.is_disconnected():
+            return
+        await asyncio.sleep(poll_interval_s)
+
+# ...inside handle_bulk_lookup, replacing the bare gather:
+gather_task = asyncio.create_task(
+    asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items))),
+    name="lml.bulk.gather",
+)
+sentinel_task = asyncio.create_task(_watch_disconnect(http_request), name="lml.bulk.disconnect")
+
+with sentry_sdk.start_span(op="lml.bulk.batch", name=f"{len(request.items)} items") as span:
+    span.set_data("lml.bulk.size", len(request.items))
+    span.set_data("lml.bulk.max_concurrent", max_concurrent)
+    done, pending = await asyncio.wait(
+        {gather_task, sentinel_task}, return_when=asyncio.FIRST_COMPLETED
+    )
+
+    client_aborted = sentinel_task in done and not gather_task.done()
+    span.set_data("lml.bulk.client_aborted", client_aborted)
+    if client_aborted:
+        # Tag is global-scope (filterable across all routes); span data carries
+        # the bulk-specific context. The key-name asymmetry is intentional.
+        sentry_sdk.set_tag("lml.client_aborted", "true")
+        gather_task.cancel()
+        # Drain the cancellation; per-item _run_one already isolates Exception,
+        # so CancelledError propagates cleanly through gather().
+        with contextlib.suppress(asyncio.CancelledError):
+            await gather_task
+        # Free the sentinel; gather_task is already done.
+        # No partial-results path: returning an HTTPException matches the
+        # transport reality (the client is gone) and keeps the telemetry
+        # branch dead-simple.
+        raise HTTPException(status_code=499, detail="client disconnected")
+
+    # Happy path: cancel the sentinel, harvest results.
+    sentinel_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await sentinel_task
+    results = gather_task.result()
+```
+
+**Status code 499** — Nginx-style "client closed request". Not a standard HTTP code but widely understood; uvicorn won't actually deliver the body (the socket is closed) so the code is for our logs/Sentry only. The alternative is letting the exception propagate as a 500, which would pollute Sentry with self-inflicted errors. We can also return without raising — but FastAPI will still serialize a body the client won't read; `raise HTTPException` short-circuits cleanly and keeps the `lml.bulk.batch` span as `internal_error` for filtering.
+
+### Why this propagates cancellation correctly
+
+1. `_run_one` (router.py:295–336) catches `Exception`, **not** `BaseException`. `asyncio.CancelledError` inherits from `BaseException` in Python 3.8+. Cancellation flows through.
+2. `discogs/service.py:343-388` uses explicit `acquire()` + `try/finally release()`. The `finally` runs on `CancelledError`. Semaphore permit returns immediately.
+3. `asyncio.Semaphore.acquire()` on Python 3.12 is cancellation-safe — no permit leak if cancelled mid-wait (Python 3.10+ fixed the historical leak).
+4. `gather()` on a task that's cancelled raises `CancelledError`; cancelling the wrapping `gather_task` propagates `cancel()` to each child coroutine-task that `gather` spawned internally. (`asyncio.gather` wraps coroutine args in tasks at call time.)
+
+### Telemetry
+
+Per the acceptance criteria:
+- **Sentry tag**: `lml.client_aborted=true` on the active scope (so the `lml.bulk.batch` transaction is filterable in trace explorer).
+- **Span data**: `lml.bulk.client_aborted` (bool) on the `lml.bulk.batch` span.
+- **Log line**: `logger.warning("bulk lookup aborted by client after %d/%d items started", started, total)` — `started` is "tasks that began executing"; cheap to compute by tracking a counter inside `_run_one` (increment before the semaphore await; this is best-effort, not load-bearing).
+- **PostHog**: skip on abort. The `batch_telemetry.send_to_posthog` block at router.py:345 is for completed-batch analytics; partial-batch abort events would skew the existing `match_count` / `no_match_count` / `error_count` aggregates. If we later need per-abort counting, that's a separate event (`lookup.bulk.aborted`), not a mutilated `lookup.bulk` event.
+
+### What we deliberately do **not** change
+
+- `_run_one` exception isolation — unchanged. `CancelledError` is NOT caught; it propagates through `gather` and up to the `gather_task` wrapper, where we suppress it explicitly.
+- `_project_cache_stats_to_transaction` — on abort, the in-process cache stats reflect partial work. That's acceptable; the existing `_project_cache_stats_to_transaction(get_cache_stats())` call won't run because we raise before reaching it. (No-op on abort is correct: the trace's `lml.cache.*` data attributes would be a partial-batch lie.)
+- `discogs/service.py` semaphore code — already correct under cancellation. Adding instrumentation here belongs to LML#371.
+- `perform_lookup` itself — read-path, idempotent cache writes, no transaction integrity hazard if cancelled mid-Discogs-fetch.
+
+## Files touched
+
+| File | Change | LoC |
+|---|---|---:|
+| `lookup/router.py` | Disconnect sentinel + cancel-aware gather wrapping; `lml.client_aborted` tag/span data; warning log on abort. | ~50 |
+| `tests/unit/test_bulk_lookup_endpoint.py` | New `TestBulkLookupClientAbort` class — 4 tests (see plan). | ~150 |
+| `tests/factories.py` | If needed: helper for a `Request` whose `is_disconnected()` flips after N polls. (Likely just inline in the new test class.) | 0–20 |
+
+No changes to:
+- `discogs/service.py` (semaphore release already correct under `CancelledError`)
+- `lookup/orchestrator.py` (read-path; cancellation-safe)
+- `config/settings.py` (no new knobs)
+- `main.py` (no router-wiring changes)
+- `pyproject.toml` (no new deps)
+
+## TDD steps
+
+Following the repo's TDD-required convention (LML CLAUDE.md "TDD (Required)"):
+
+1. **Red 1 — disconnect cancels gather.**
+   Test: `test_client_disconnect_cancels_in_flight_items`. Use a `perform_lookup` mock that sleeps long enough to outlast the disconnect; patch `Request.is_disconnected` with `AsyncMock` (it's awaited; a plain `Mock` returns a coroutine-less truthy that breaks `await`) so it returns `False` once then `True`; assert the handler raises `HTTPException(499)`, that the mock's `await_count` is strictly less than the input length (later items never executed), AND that `posthog_client.capture` was never called — the abort path must not emit a mutilated `lookup.bulk` event.
+
+2. **Green 1.** Implement sentinel + `asyncio.wait` + cancel + suppress as above. Confirm Red 1 passes.
+
+3. **Red 2 — semaphore permits released after abort.**
+   Test: `test_client_disconnect_releases_semaphore_permits`. Construct an `asyncio.Semaphore(5)`; patch `get_semaphore` to return it; mock `perform_lookup` to acquire it via the real Discogs path (or, simpler: a synthetic `_run_one` that acquires the same semaphore and sleeps). After abort, assert `semaphore._value == 5`. Mark `# noqa` for `_value` access if ruff complains; the alternative is `await asyncio.wait_for(semaphore.acquire(), timeout=0.1)` × 5 which is functionally equivalent.
+
+4. **Green 2.** Should pass without further changes — relies on `discogs/service.py:387-388`'s existing `finally semaphore.release()`. If it doesn't, that's the bug to fix.
+
+5. **Red 3 — Sentry tag set on abort.**
+   Test: `test_client_disconnect_sets_sentry_tag`. Use `sentry_sdk.start_transaction(...)` in the test harness (or `with sentry_sdk.push_scope():` and inspect after); after abort, assert the scope carries `lml.client_aborted=true`. The pattern is in the existing wxyc-fastapi test suite if we need a reference.
+
+6. **Green 3.** `sentry_sdk.set_tag` call inside the abort branch.
+
+7. **Red 4 — happy path unchanged.**
+   Already covered by `test_happy_path_two_items` and `test_results_preserve_input_order`. Re-run; if either breaks, the wrapping introduced a regression (likely from gather-task-creation timing or the sentinel polling interfering). No new test needed unless those two pass and we want belt-and-suspenders coverage of "client stays connected, sentinel cancels cleanly on return".
+
+8. **Refactor.** Extract `_watch_disconnect` and the abort branch into module-private helpers if the handler grows past ~40 added lines. Probably not necessary at this scope.
+
+## Test plan summary
+
+| Test | What it pins |
+|---|---|
+| `test_client_disconnect_cancels_in_flight_items` | Mid-batch disconnect aborts gather; not all items execute; PostHog not called on the abort path. |
+| `test_client_disconnect_releases_semaphore_permits` | Semaphore returns to full capacity after abort. |
+| `test_client_disconnect_sets_sentry_tag` | `lml.client_aborted=true` lands on the scope. |
+| `test_happy_path_two_items` (existing) | No regression on connected-client path. |
+| `test_results_preserve_input_order` (existing) | No regression on connected-client path with mixed match/no_match/error. |
+
+**Out of unit-test scope** — verified via the acceptance-criteria repro instead:
+
+Re-run BS album-level-backfill at `BACKFILL_BULK_RATE_PER_MIN=4` against staging LML; observe (via Sentry trace explorer) that per-batch wall time stays bounded across batches 17–30+ and no 30 s flat-line cliff appears. Pre-merge if possible; post-merge if staging lacks the load. The cliff is reproducible from BS so this is a real check, not theater.
+
+## Rollout
+
+1. PR opens against `main`. CI runs lint + typecheck + unit + pg + external_api + marker-sync.
+2. Merge to `main` → auto-deploy to staging.
+3. **Staging soak**: trigger BS album-level-backfill at `BACKFILL_BULK_RATE_PER_MIN=4` against staging LML for 10 minutes. Confirm in Sentry trace explorer:
+   - `lml.bulk.batch` spans with `lml.client_aborted=true` appear when batches exceed BS's 30 s budget.
+   - `lml.discogs.semaphore` wait spans do not exhibit the monotonic-deepening pattern from the 22:21–22:34 UTC autopsy.
+4. PR to `prod` (cherry-pick or fast-forward from `main` per repo's two-branch convention).
+5. **Prod observation** — 30 min after deploy: query Sentry `lml.client_aborted:true` to confirm tag is firing under live BS+rom+cron traffic; sanity-check that aborts correlate with caller-side timeouts (not new errors).
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `is_disconnected()` poll interferes with handler perf | Low | Low | 0.25 s poll is cheap; only one per request; release-resources behavior wins. |
+| Cancellation propagation skips a child task (gather wraps args at creation) | Low | Medium | Test 1 directly pins this; reproduce in CI not theory. |
+| Cancellation triggers a partial-state write somewhere downstream | Very low | Low | LML bulk path is read-only; cache writes are idempotent upserts. |
+| Sentinel task leaks if happy path exits early | Low | Low | Happy path explicitly `sentinel_task.cancel()`; covered by existing happy-path test. |
+| Staging soak doesn't reproduce because staging lacks load | Medium | Low | Fall back to prod soak with a feature flag — but we don't need a flag if unit tests + staging smoke pass; the patch surface is small and reversible. |
+| Status 499 breaks a caller's response parsing | Very low | Low | BS / rom both treat any non-2xx as an error and fall back; the socket is already closed so the caller will never see the code anyway. |
+
+## Definition of done
+
+- All 5 tests (3 new + 2 existing) pass locally and in CI.
+- `ruff check`, `ruff format --check`, `mypy` clean.
+- Sentry trace explorer query `lml.client_aborted:true` returns results during staging BS-backfill soak.
+- No regression in `lml.discogs.semaphore` wait p95 from pre-merge baseline (verified post-deploy).
+- PR cross-references LML#372 with `Closes #372`; PR body links the autopsy comment.
+
+## Out-of-scope follow-ups (not this PR)
+
+- **Mitigation (2)** — admission control on semaphore queue depth (separate ticket if needed).
+- **LML#370** — per-item cascade-exhaustion ceiling.
+- **LML#371** — uvicorn span observability gap.
+- **`lookup.bulk.aborted` PostHog event** — if we later want to count aborts per caller; separate decision.

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1527,6 +1527,10 @@ class LookupResponse(BaseModel):
     )
     cache_stats: CacheStats | None = None
     identity: LookupIdentityBlock | None = None
+    timeout: bool | None = Field(
+        False,
+        description='True when LML\'s server-side hard cap fired and the search pipeline was abandoned mid-execution (LML#370). `results` may be partial or empty in that case. Callers can use this to distinguish "no match" (empty `results`, `timeout: false`) from "ran out of time" (`results` may be empty, `timeout: true`). The hard cap is an internal LML safety floor independent of the caller\'s `X-Caller-Budget-Ms` header; see LML#338 / LML#340 / LML#370 for the cascade-budget design.\n',
+    )
 
 
 class BulkResolveLibrariesRequest(BaseModel):

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import sentry_sdk
@@ -188,6 +189,29 @@ async def handle_lookup(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
+async def _watch_disconnect(request: Request) -> None:
+    """Sentinel task: returns when the client closes its socket.
+
+    uvicorn does not propagate client-side socket close into the handler — the
+    handler keeps running and the in-flight `gather` keeps draining queued
+    Discogs work, holding 5-permit semaphore permits past the point any caller
+    cares about the result. We race this sentinel against the gather and cancel
+    the gather when the sentinel wins (LML#372).
+
+    Awaits ``request.receive()`` directly rather than polling
+    ``request.is_disconnected()`` — the polling helper hangs under httpx's
+    ASGITransport in tests (anyio CancelScope/asyncio interaction), and the
+    direct ``receive()`` loop is the canonical Starlette pattern anyway. By the
+    time this coroutine runs, the handler has already consumed the request
+    body via ``http_request.json()``, so the only message the receive channel
+    will emit is ``http.disconnect``.
+    """
+    while True:
+        message = await request.receive()
+        if message.get("type") == "http.disconnect":
+            return
+
+
 def _max_concurrency_from_env() -> int:
     """Resolve LML_BULK_MAX_CONCURRENT, floored at 1 to keep a misconfigured 0 from hanging.
 
@@ -338,7 +362,59 @@ async def handle_bulk_lookup(
     with sentry_sdk.start_span(op="lml.bulk.batch", name=f"{len(request.items)} items") as span:
         span.set_data("lml.bulk.size", len(request.items))
         span.set_data("lml.bulk.max_concurrent", max_concurrent)
-        results = await asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items)))
+
+        # Race the gather against a client-disconnect sentinel (LML#372). If the
+        # client departs first (their AbortController fired, the socket closed),
+        # cancel the gather so the 5-permit Discogs semaphore frees its permits
+        # for the next caller. Without this, queue depth grows monotonically
+        # across batches and the next caller eats the wait.
+        #
+        # `asyncio.gather` returns a `_GatheringFuture` that is already scheduled
+        # — no `create_task` wrapping needed (and that wrapping would TypeError).
+        gather_future = asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items)))
+        sentinel_task = asyncio.create_task(
+            _watch_disconnect(http_request),
+            name="lml.bulk.disconnect_sentinel",
+        )
+
+        # mypy needs help inferring the heterogeneous set as a uniform Future
+        # type — gather_future is `_GatheringFuture[Any]`, sentinel_task is
+        # `Task[None]`; both satisfy `Future`.
+        waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
+        try:
+            done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
+        except BaseException:
+            gather_future.cancel()
+            sentinel_task.cancel()
+            raise
+
+        client_aborted = sentinel_task in done and not gather_future.done()
+        span.set_data("lml.bulk.client_aborted", client_aborted)
+
+        if client_aborted:
+            # Tag is global-scope (filterable across all routes in Sentry trace
+            # explorer); span data carries the bulk-specific context. The
+            # key-name asymmetry is intentional.
+            sentry_sdk.set_tag("lml.client_aborted", "true")
+            gather_future.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await gather_future
+            logger.warning(
+                "bulk lookup aborted by client (batch size %d, max_concurrent %d)",
+                len(request.items),
+                max_concurrent,
+            )
+            # 499: Nginx-style "client closed request". The socket is already
+            # closed so the caller will never see the body — the code is for
+            # our logs/Sentry. Skip the PostHog batch event: partial counts
+            # would skew the existing batch-completion analytics.
+            raise HTTPException(status_code=499, detail="client disconnected")
+
+        # Happy path: cancel the sentinel and harvest results.
+        sentinel_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await sentinel_task
+        results = gather_future.result()
 
     _project_cache_stats_to_transaction(get_cache_stats())
 

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -196,20 +196,28 @@ async def _watch_disconnect(request: Request) -> None:
     handler keeps running and the in-flight `gather` keeps draining queued
     Discogs work, holding 5-permit semaphore permits past the point any caller
     cares about the result. We race this sentinel against the gather and cancel
-    the gather when the sentinel wins (LML#372).
+    the gather when the sentinel wins.
 
     Awaits ``request.receive()`` directly rather than polling
     ``request.is_disconnected()`` — the polling helper hangs under httpx's
     ASGITransport in tests (anyio CancelScope/asyncio interaction), and the
-    direct ``receive()`` loop is the canonical Starlette pattern anyway. By the
-    time this coroutine runs, the handler has already consumed the request
-    body via ``http_request.json()``, so the only message the receive channel
-    will emit is ``http.disconnect``.
+    direct ``receive()`` loop is the canonical Starlette pattern anyway.
     """
     while True:
         message = await request.receive()
         if message.get("type") == "http.disconnect":
             return
+
+
+async def _cancel_and_drain(future: asyncio.Future[Any]) -> None:
+    """Cancel a future and swallow the resulting ``CancelledError``.
+
+    Used twice in the bulk handler (gather cleanup on abort + sentinel cleanup
+    on happy path) — extracted so the two branches stay symmetric.
+    """
+    future.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await future
 
 
 def _max_concurrency_from_env() -> int:
@@ -363,27 +371,21 @@ async def handle_bulk_lookup(
         span.set_data("lml.bulk.size", len(request.items))
         span.set_data("lml.bulk.max_concurrent", max_concurrent)
 
-        # Race the gather against a client-disconnect sentinel (LML#372). If the
-        # client departs first (their AbortController fired, the socket closed),
-        # cancel the gather so the 5-permit Discogs semaphore frees its permits
-        # for the next caller. Without this, queue depth grows monotonically
-        # across batches and the next caller eats the wait.
-        #
-        # `asyncio.gather` returns a `_GatheringFuture` that is already scheduled
-        # — no `create_task` wrapping needed (and that wrapping would TypeError).
+        # Race the gather against a client-disconnect sentinel. If the client
+        # departs first, cancel the gather so Discogs semaphore permits free
+        # for the next caller; without this, queue depth grows monotonically
+        # across batches.
         gather_future = asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items)))
         sentinel_task = asyncio.create_task(
             _watch_disconnect(http_request),
             name="lml.bulk.disconnect_sentinel",
         )
-
-        # mypy needs help inferring the heterogeneous set as a uniform Future
-        # type — gather_future is `_GatheringFuture[Any]`, sentinel_task is
-        # `Task[None]`; both satisfy `Future`.
         waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
+
         try:
             done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
         except BaseException:
+            # Parent task cancellation must propagate to both children.
             gather_future.cancel()
             sentinel_task.cancel()
             raise
@@ -392,28 +394,20 @@ async def handle_bulk_lookup(
         span.set_data("lml.bulk.client_aborted", client_aborted)
 
         if client_aborted:
-            # Tag is global-scope (filterable across all routes in Sentry trace
-            # explorer); span data carries the bulk-specific context. The
-            # key-name asymmetry is intentional.
+            # Tag is global-scope (filterable across all routes); span data
+            # carries the bulk-specific context. Key-name asymmetry intentional.
             sentry_sdk.set_tag("lml.client_aborted", "true")
-            gather_future.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await gather_future
+            await _cancel_and_drain(gather_future)
             logger.warning(
                 "bulk lookup aborted by client (batch size %d, max_concurrent %d)",
                 len(request.items),
                 max_concurrent,
             )
-            # 499: Nginx-style "client closed request". The socket is already
-            # closed so the caller will never see the body — the code is for
-            # our logs/Sentry. Skip the PostHog batch event: partial counts
-            # would skew the existing batch-completion analytics.
+            # 499 = Nginx "client closed request". Skip PostHog: partial counts
+            # would skew batch-completion analytics.
             raise HTTPException(status_code=499, detail="client disconnected")
 
-        # Happy path: cancel the sentinel and harvest results.
-        sentinel_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await sentinel_task
+        await _cancel_and_drain(sentinel_task)
         results = gather_future.result()
 
     _project_cache_stats_to_transaction(get_cache_stats())

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -375,6 +375,11 @@ async def handle_bulk_lookup(
         # departs first, cancel the gather so Discogs semaphore permits free
         # for the next caller; without this, queue depth grows monotonically
         # across batches.
+        #
+        # Spawning the sentinel must happen *after* `await http_request.json()`
+        # above has fully consumed the request body — _watch_disconnect awaits
+        # `request.receive()`, which would otherwise swallow `http.request`
+        # body messages the body parser needs.
         gather_future = asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items)))
         sentinel_task = asyncio.create_task(
             _watch_disconnect(http_request),
@@ -385,9 +390,12 @@ async def handle_bulk_lookup(
         try:
             done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
         except BaseException:
-            # Parent task cancellation must propagate to both children.
-            gather_future.cancel()
-            sentinel_task.cancel()
+            # Parent task cancellation must propagate to both children AND
+            # the children must be drained, not just signalled — otherwise the
+            # semaphore permits this PR exists to release are still held while
+            # the cancellation propagates asynchronously.
+            await _cancel_and_drain(gather_future)
+            await _cancel_and_drain(sentinel_task)
             raise
 
         client_aborted = sentinel_task in done and not gather_future.done()

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -448,3 +448,219 @@ class TestBulkLookupEndpoint:
                 )
 
         assert resp.status_code == 200
+
+
+class TestBulkLookupClientAbort:
+    """Cancel-aware gather under client disconnect (LML#372).
+
+    Under load, callers' AbortControllers fire at their per-call budget while
+    LML's gather kept draining queued items — semaphore permits stayed held,
+    queue depth grew monotonically across batches. These tests pin the fix:
+    on disconnect, the handler cancels in-flight items, releases permits, and
+    short-circuits with HTTP 499.
+
+    The disconnect-detection mechanism (``await request.receive()`` → look for
+    ``http.disconnect``) is standard Starlette; under httpx's ASGITransport the
+    receive channel doesn't emit disconnect cleanly (anyio CancelScope ↔
+    asyncio interaction), so tests patch ``_watch_disconnect`` directly to
+    simulate disconnect. The mechanism itself is exercised in production by
+    uvicorn.
+    """
+
+    @staticmethod
+    def _disconnect_after(delay_s: float = 0.05):
+        """Replacement sentinel that 'detects' disconnect after `delay_s`.
+
+        Lets the gather schedule and start items, then returns (signaling
+        disconnect) so the abort branch runs.
+        """
+        import asyncio
+
+        async def fake_sentinel(_request):
+            await asyncio.sleep(delay_s)
+            return
+
+        return fake_sentinel
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_cancels_in_flight_items(
+        self, mock_db, mock_discogs, mock_settings
+    ):
+        """Mid-batch disconnect aborts gather; not all items execute; no PostHog event.
+
+        Pins three behaviors at once:
+        1. Handler returns 499 (Nginx-style "client closed request") so the
+           abort branch is filterable in logs/Sentry.
+        2. `perform_lookup`'s await_count is strictly less than the batch size:
+           items queued behind the bulk-route semaphore never started.
+        3. The PostHog batch event is NOT emitted on abort — partial counts
+           would skew the existing batch-completion analytics.
+        """
+        import asyncio
+
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from main import app
+
+        mock_posthog = Mock()
+        mock_posthog.capture = Mock()
+
+        async def slow_lookup(request, **kwargs):
+            # Outlast the sentinel's disconnect signal (fires ~50ms after the
+            # gather starts).
+            await asyncio.sleep(5)
+            return _match_response(request.artist or "?", request.album or "?")
+
+        with override_deps(
+            app,
+            {
+                get_library_db: mock_db,
+                get_discogs_service: mock_discogs,
+                get_posthog_client: mock_posthog,
+                get_settings: mock_settings,
+            },
+        ):
+            with (
+                patch(
+                    "lookup.router.perform_lookup",
+                    new_callable=AsyncMock,
+                    side_effect=slow_lookup,
+                ) as mock_lookup,
+                patch("lookup.router._watch_disconnect", self._disconnect_after()),
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    resp = await asyncio.wait_for(
+                        ac.post(
+                            "/api/v1/lookup/bulk",
+                            json={"items": [{"artist": f"a{i}", "album": "x"} for i in range(20)]},
+                        ),
+                        timeout=3.0,
+                    )
+
+        assert resp.status_code == 499, f"Expected 499 on client disconnect, got {resp.status_code}"
+        assert mock_lookup.await_count < 20, (
+            f"All {mock_lookup.await_count}/20 items completed — abort did not cancel "
+            "in-flight items"
+        )
+        mock_posthog.capture.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_releases_semaphore_permits(self, app_client, monkeypatch):
+        """Cancellation propagates into per-item tasks → semaphore permits returned.
+
+        The 5-permit Discogs semaphore in production lives in `discogs/service.py`
+        and is released in a `try/finally`. The bulk route's own bounded semaphore
+        (set via LML_BULK_MAX_CONCURRENT) gets `__aexit__`'d via `async with` for
+        each item. We pin the propagation directly: count how many items reach a
+        `finally` cleanup block. On clean cancellation, the count equals the
+        max-concurrency cap (whichever started == whichever cleaned up). If the
+        cancel doesn't propagate, started > cleaned_up — and that's the bug
+        LML#372 fixes.
+        """
+        import asyncio
+
+        monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "2")
+
+        started = 0
+        cleaned_up = 0
+
+        async def slow_lookup(request, **kwargs):
+            nonlocal started, cleaned_up
+            started += 1
+            try:
+                await asyncio.sleep(5)
+                return _match_response(request.artist or "?", request.album or "?")
+            finally:
+                cleaned_up += 1
+
+        with (
+            patch(
+                "lookup.router.perform_lookup",
+                new_callable=AsyncMock,
+                side_effect=slow_lookup,
+            ),
+            patch("lookup.router._watch_disconnect", self._disconnect_after()),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await asyncio.wait_for(
+                    ac.post(
+                        "/api/v1/lookup/bulk",
+                        json={"items": [{"artist": f"a{i}", "album": "x"} for i in range(6)]},
+                    ),
+                    timeout=3.0,
+                )
+
+        assert resp.status_code == 499
+        # Concurrency=2 ⇒ at most 2 items started before abort. They must ALL
+        # have hit `finally` (cancellation propagated into the sleep, which is
+        # CancelledError-aware). If `started > cleaned_up`, the cancel didn't
+        # reach the per-item tasks and semaphore permits leaked.
+        assert started > 0, "no items started — test mis-configured"
+        assert started == cleaned_up, (
+            f"{started - cleaned_up} item(s) started but never cleaned up — "
+            "cancellation did not propagate into per-item tasks"
+        )
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_sets_sentry_tag(self, mock_db, mock_discogs, mock_settings):
+        """`lml.client_aborted=true` lands on the active Sentry scope on abort.
+
+        Filterable in trace explorer: `lml.client_aborted:true` should return
+        the aborted-batch transactions for triage.
+        """
+        import asyncio
+
+        import sentry_sdk
+
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from main import app
+
+        captured_tags: dict[str, str] = {}
+        original_set_tag = sentry_sdk.set_tag
+
+        def capture_tag(key, value):
+            captured_tags[key] = value
+            return original_set_tag(key, value)
+
+        async def slow_lookup(request, **kwargs):
+            await asyncio.sleep(5)
+            return _match_response(request.artist or "?", request.album or "?")
+
+        with override_deps(
+            app,
+            {
+                get_library_db: mock_db,
+                get_discogs_service: mock_discogs,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+            },
+        ):
+            with (
+                patch(
+                    "lookup.router.perform_lookup",
+                    new_callable=AsyncMock,
+                    side_effect=slow_lookup,
+                ),
+                patch("lookup.router._watch_disconnect", self._disconnect_after()),
+                patch("lookup.router.sentry_sdk.set_tag", side_effect=capture_tag),
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as ac:
+                    resp = await asyncio.wait_for(
+                        ac.post(
+                            "/api/v1/lookup/bulk",
+                            json={"items": [{"artist": f"a{i}", "album": "x"} for i in range(4)]},
+                        ),
+                        timeout=3.0,
+                    )
+
+        assert resp.status_code == 499
+        assert captured_tags.get("lml.client_aborted") == "true", (
+            f"Expected lml.client_aborted=true tag; got {captured_tags!r}"
+        )

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -8,14 +8,19 @@ are isolated so one item cannot poison the batch.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import sentry_sdk
 from httpx import ASGITransport, AsyncClient
 
+from config.settings import get_settings
+from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
 from discogs.service import DiscogsService
 from library.db import LibraryDB
 from lookup.models import LookupResponse, LookupResultItem
+from main import app
 from tests.factories import make_catalog_item, make_match_result
 from tests.unit.conftest import override_deps
 
@@ -32,10 +37,6 @@ def mock_discogs():
 
 @pytest.fixture
 def app_client(mock_db, mock_discogs, mock_settings):
-    from config.settings import get_settings
-    from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
-    from main import app
-
     with override_deps(
         app,
         {
@@ -344,10 +345,6 @@ class TestBulkLookupEndpoint:
     @pytest.mark.asyncio
     async def test_posthog_batch_event_emitted(self, mock_db, mock_discogs, mock_settings):
         """When PostHog is configured, the batch route emits exactly one event."""
-        from config.settings import get_settings
-        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
-        from main import app
-
         mock_posthog = Mock()
         mock_posthog.capture = Mock()
         mock_posthog.flush = Mock()
@@ -459,22 +456,13 @@ class TestBulkLookupClientAbort:
     on disconnect, the handler cancels in-flight items, releases permits, and
     short-circuits with HTTP 499.
 
-    The disconnect-detection mechanism (``await request.receive()`` → look for
-    ``http.disconnect``) is standard Starlette; under httpx's ASGITransport the
-    receive channel doesn't emit disconnect cleanly (anyio CancelScope ↔
-    asyncio interaction), so tests patch ``_watch_disconnect`` directly to
-    simulate disconnect. The mechanism itself is exercised in production by
-    uvicorn.
+    Tests patch ``_watch_disconnect`` directly; the receive-channel mechanism
+    is exercised in production by uvicorn.
     """
 
     @staticmethod
     def _disconnect_after(delay_s: float = 0.05):
-        """Replacement sentinel that 'detects' disconnect after `delay_s`.
-
-        Lets the gather schedule and start items, then returns (signaling
-        disconnect) so the abort branch runs.
-        """
-        import asyncio
+        """Replacement sentinel that 'detects' disconnect after `delay_s`."""
 
         async def fake_sentinel(_request):
             await asyncio.sleep(delay_s)
@@ -496,18 +484,11 @@ class TestBulkLookupClientAbort:
         3. The PostHog batch event is NOT emitted on abort — partial counts
            would skew the existing batch-completion analytics.
         """
-        import asyncio
-
-        from config.settings import get_settings
-        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
-        from main import app
-
         mock_posthog = Mock()
         mock_posthog.capture = Mock()
 
         async def slow_lookup(request, **kwargs):
-            # Outlast the sentinel's disconnect signal (fires ~50ms after the
-            # gather starts).
+            # Outlast the sentinel's disconnect signal.
             await asyncio.sleep(5)
             return _match_response(request.artist or "?", request.album or "?")
 
@@ -559,8 +540,6 @@ class TestBulkLookupClientAbort:
         cancel doesn't propagate, started > cleaned_up — and that's the bug
         LML#372 fixes.
         """
-        import asyncio
-
         monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "2")
 
         started = 0
@@ -595,10 +574,6 @@ class TestBulkLookupClientAbort:
                 )
 
         assert resp.status_code == 499
-        # Concurrency=2 ⇒ at most 2 items started before abort. They must ALL
-        # have hit `finally` (cancellation propagated into the sleep, which is
-        # CancelledError-aware). If `started > cleaned_up`, the cancel didn't
-        # reach the per-item tasks and semaphore permits leaked.
         assert started > 0, "no items started — test mis-configured"
         assert started == cleaned_up, (
             f"{started - cleaned_up} item(s) started but never cleaned up — "
@@ -606,20 +581,12 @@ class TestBulkLookupClientAbort:
         )
 
     @pytest.mark.asyncio
-    async def test_client_disconnect_sets_sentry_tag(self, mock_db, mock_discogs, mock_settings):
+    async def test_client_disconnect_sets_sentry_tag(self, app_client):
         """`lml.client_aborted=true` lands on the active Sentry scope on abort.
 
         Filterable in trace explorer: `lml.client_aborted:true` should return
         the aborted-batch transactions for triage.
         """
-        import asyncio
-
-        import sentry_sdk
-
-        from config.settings import get_settings
-        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
-        from main import app
-
         captured_tags: dict[str, str] = {}
         original_set_tag = sentry_sdk.set_tag
 
@@ -631,34 +598,25 @@ class TestBulkLookupClientAbort:
             await asyncio.sleep(5)
             return _match_response(request.artist or "?", request.album or "?")
 
-        with override_deps(
-            app,
-            {
-                get_library_db: mock_db,
-                get_discogs_service: mock_discogs,
-                get_posthog_client: None,
-                get_settings: mock_settings,
-            },
+        with (
+            patch(
+                "lookup.router.perform_lookup",
+                new_callable=AsyncMock,
+                side_effect=slow_lookup,
+            ),
+            patch("lookup.router._watch_disconnect", self._disconnect_after()),
+            patch("lookup.router.sentry_sdk.set_tag", side_effect=capture_tag),
         ):
-            with (
-                patch(
-                    "lookup.router.perform_lookup",
-                    new_callable=AsyncMock,
-                    side_effect=slow_lookup,
-                ),
-                patch("lookup.router._watch_disconnect", self._disconnect_after()),
-                patch("lookup.router.sentry_sdk.set_tag", side_effect=capture_tag),
-            ):
-                async with AsyncClient(
-                    transport=ASGITransport(app=app), base_url="http://test"
-                ) as ac:
-                    resp = await asyncio.wait_for(
-                        ac.post(
-                            "/api/v1/lookup/bulk",
-                            json={"items": [{"artist": f"a{i}", "album": "x"} for i in range(4)]},
-                        ),
-                        timeout=3.0,
-                    )
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await asyncio.wait_for(
+                    ac.post(
+                        "/api/v1/lookup/bulk",
+                        json={"items": [{"artist": f"a{i}", "album": "x"} for i in range(4)]},
+                    ),
+                    timeout=3.0,
+                )
 
         assert resp.status_code == 499
         assert captured_tags.get("lml.client_aborted") == "true", (

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -528,17 +528,19 @@ class TestBulkLookupClientAbort:
         mock_posthog.capture.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_client_disconnect_releases_semaphore_permits(self, app_client, monkeypatch):
-        """Cancellation propagates into per-item tasks → semaphore permits returned.
+    async def test_client_disconnect_cancels_per_item_tasks_cleanly(self, app_client, monkeypatch):
+        """Cancellation reaches per-item tasks AND each unwinds via its `finally`.
 
-        The 5-permit Discogs semaphore in production lives in `discogs/service.py`
-        and is released in a `try/finally`. The bulk route's own bounded semaphore
-        (set via LML_BULK_MAX_CONCURRENT) gets `__aexit__`'d via `async with` for
-        each item. We pin the propagation directly: count how many items reach a
-        `finally` cleanup block. On clean cancellation, the count equals the
-        max-concurrency cap (whichever started == whichever cleaned up). If the
-        cancel doesn't propagate, started > cleaned_up — and that's the bug
-        LML#372 fixes.
+        Semaphore release is a downstream consequence: the 5-permit Discogs
+        semaphore in `discogs/service.py` releases via `try/finally`, and the
+        bulk route's own bounded semaphore (set via LML_BULK_MAX_CONCURRENT)
+        releases via `async with semaphore:` __aexit__. Both unwinds run iff
+        cancellation reaches the per-item coroutine.
+
+        Proxy assertion: count `started` (each item that entered slow_lookup)
+        and `cleaned_up` (each that exited via `finally`). On clean cancellation
+        propagation, started == cleaned_up. If the cancel doesn't reach the
+        per-item tasks, started > cleaned_up — and that's the bug LML#372 fixes.
         """
         monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "2")
 


### PR DESCRIPTION
## Summary

- Race the bulk-lookup gather against a client-disconnect sentinel; on abort, cancel the gather, free Discogs-semaphore permits, tag Sentry `lml.client_aborted=true`, and short-circuit with HTTP 499.
- Sentinel awaits `request.receive()` (canonical Starlette pattern) — wakes on `http.disconnect` under uvicorn; blocks forever under httpx ASGITransport in tests (which is fine — it naturally loses to gather in happy paths).
- Skip PostHog on abort; partial counts would skew batch-completion analytics.

## Why

Under load, callers' AbortControllers fired at their per-call budget (BS runtime 30s, per-row cron 8s) while uvicorn did not propagate the socket close into the handler. The in-flight `asyncio.gather` kept draining queued items behind the 5-permit Discogs semaphore, queue depth grew monotonically across batches, and the next batch piled on. See the [BS#1064 autopsy comment](https://github.com/WXYC/Backend-Service/issues/1064#issuecomment-4531269302) for the cliff math (10 consecutive batches at 30,000ms flat).

Same root cause as BS#1064 (cron 21% timeout) and BS#1078 (album-level-backfill batch-17 cliff).

## Plan

Full plan at `docs/plans/lml-372-cancel-aware-bulk-gather.md` (committed alongside the implementation).

## Test plan

- [x] `tests/unit/test_bulk_lookup_endpoint.py::TestBulkLookupClientAbort` — three new tests pin (1) abort cancels in-flight items + no PostHog event + 499 status, (2) cancellation propagates into per-item tasks (`started == cleaned_up`), (3) `lml.client_aborted=true` lands on the Sentry scope.
- [x] 17/17 tests in `test_bulk_lookup_endpoint.py` pass (3 new + 14 pre-existing — no regression).
- [x] 1845/1845 in `tests/unit/` pass.
- [x] `ruff check`, `ruff format --check`, `mypy lookup/router.py` all clean.
- [ ] **Staging soak** (post-merge): trigger BS album-level-backfill at `BACKFILL_BULK_RATE_PER_MIN=4` against staging LML; confirm in Sentry trace explorer that `lml.bulk.batch` spans with `lml.client_aborted=true` appear when batches exceed BS's 30s budget AND `lml.discogs.semaphore` wait spans do not exhibit the monotonic-deepening pattern.

## Out of scope (separate tickets)

- Admission control on semaphore queue depth (mitigation 2 from the issue).
- Fair queueing across callers (mitigation 4).
- LML#370 per-item cascade-exhaustion ceiling.
- LML#371 uvicorn span observability gap.

Closes #372