### PR TITLE
asyncpg discipline: cache writes + V/A writeback guard + dedup merge txn

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -654,7 +654,13 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
-            async with self.pool.acquire() as conn:
+            async with self.pool.acquire() as conn, conn.transaction():
+                # Wrap the entire DELETE+INSERT cascade in a single transaction.
+                # Without this, asyncpg autocommits each statement and a
+                # cancellation mid-cascade leaves an artworked release with
+                # empty release_artist / release_track / etc., while
+                # cache_metadata.cached_at advances to "fresh". See WXYC#375.
+
                 # Upsert release row (including released date)
                 await conn.execute(
                     """
@@ -722,52 +728,65 @@ class DiscogsCacheService:
                         label_data,
                     )
 
-                # Delete + re-insert genres (table may not exist yet)
+                # Delete + re-insert genres (table may not exist yet).
+                # Nested conn.transaction() creates a SAVEPOINT inside the outer
+                # transaction, so a missing-table error reverts only this block
+                # without aborting the outer transaction.
                 try:
-                    await conn.execute(
-                        "DELETE FROM release_genre WHERE release_id = $1",
-                        release.release_id,
-                    )
-                    if release.genres:
-                        await conn.executemany(
-                            "INSERT INTO release_genre (release_id, genre) VALUES ($1, $2)",
-                            [(release.release_id, g) for g in release.genres],
+                    async with conn.transaction():
+                        await conn.execute(
+                            "DELETE FROM release_genre WHERE release_id = $1",
+                            release.release_id,
                         )
+                        if release.genres:
+                            await conn.executemany(
+                                "INSERT INTO release_genre (release_id, genre) VALUES ($1, $2)",
+                                [(release.release_id, g) for g in release.genres],
+                            )
                 except Exception:
                     pass
 
                 # Delete + re-insert styles (table may not exist yet)
                 try:
-                    await conn.execute(
-                        "DELETE FROM release_style WHERE release_id = $1",
-                        release.release_id,
-                    )
-                    if release.styles:
-                        await conn.executemany(
-                            "INSERT INTO release_style (release_id, style) VALUES ($1, $2)",
-                            [(release.release_id, s) for s in release.styles],
+                    async with conn.transaction():
+                        await conn.execute(
+                            "DELETE FROM release_style WHERE release_id = $1",
+                            release.release_id,
                         )
+                        if release.styles:
+                            await conn.executemany(
+                                "INSERT INTO release_style (release_id, style) VALUES ($1, $2)",
+                                [(release.release_id, s) for s in release.styles],
+                            )
                 except Exception:
                     pass
 
                 # Delete + re-insert videos (table may not exist yet)
                 try:
-                    await conn.execute(
-                        "DELETE FROM release_video WHERE release_id = $1",
-                        release.release_id,
-                    )
-                    if release.videos:
-                        await conn.executemany(
-                            """
-                            INSERT INTO release_video
-                                (release_id, sequence, src, title, duration, embed)
-                            VALUES ($1, $2, $3, $4, $5, $6)
-                            """,
-                            [
-                                (release.release_id, i + 1, v.src, v.title, v.duration, v.embed)
-                                for i, v in enumerate(release.videos)
-                            ],
+                    async with conn.transaction():
+                        await conn.execute(
+                            "DELETE FROM release_video WHERE release_id = $1",
+                            release.release_id,
                         )
+                        if release.videos:
+                            await conn.executemany(
+                                """
+                                INSERT INTO release_video
+                                    (release_id, sequence, src, title, duration, embed)
+                                VALUES ($1, $2, $3, $4, $5, $6)
+                                """,
+                                [
+                                    (
+                                        release.release_id,
+                                        i + 1,
+                                        v.src,
+                                        v.title,
+                                        v.duration,
+                                        v.embed,
+                                    )
+                                    for i, v in enumerate(release.videos)
+                                ],
+                            )
                 except Exception:
                     pass
 
@@ -996,7 +1015,11 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
-            async with self.pool.acquire() as conn:
+            async with self.pool.acquire() as conn, conn.transaction():
+                # Wrap the UPSERT + 4×(DELETE+INSERT) cascade in a single
+                # transaction so a cancellation mid-write doesn't leave the
+                # artist row updated with empty child tables. See WXYC#375.
+
                 # Upsert artist row
                 await conn.execute(
                     """

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 import logging
 import re
 
+from wxyc_etl.text import is_compilation_artist
+
 from discogs.service import DiscogsService
 from release.bandcamp_resolver import resolve_bandcamp_album
 from release.discogs_resolver import (
@@ -126,8 +128,16 @@ async def resolve_release(
 
     # Identity write-back: any newly-discovered IDs land in entity.identity
     # for the artist. Idempotent + COALESCE-based — never clobbers existing data.
-    # Require a non-empty artist name so we never insert library_name="".
-    if canonical is not None and canonical.artist and deps.entity_store is not None:
+    # Require a non-empty, non-compilation artist name so we never insert
+    # library_name="" or pollute the matcher's lookup space with V/A rows
+    # (read-side handlers like identity/router.py already skip these, but the
+    # rows still exist if write-side never guarded). See WXYC#379.
+    if (
+        canonical is not None
+        and canonical.artist
+        and not is_compilation_artist(canonical.artist)
+        and deps.entity_store is not None
+    ):
         await _writeback_identity(deps.entity_store, canonical, identifiers, warnings)
 
     return ReleaseResolveResponse(

--- a/scripts/entity_resolution/dedup.py
+++ b/scripts/entity_resolution/dedup.py
@@ -85,6 +85,10 @@ class EntityDeduplicator:
         merges all external IDs from the others into it, then deletes the
         duplicates. Reconciliation log entries are reassigned to the primary.
 
+        Runs the UPDATE + N×(REASSIGN + DELETE) inside a single asyncpg
+        transaction so a mid-loop interruption leaves either fully-merged
+        or fully-untouched state — never partial. See WXYC#380.
+
         Args:
             qid: The shared Wikidata QID.
             identities: List of Identity instances to merge (must have len >= 2).
@@ -109,21 +113,22 @@ class EntityDeduplicator:
             merged_apple = merged_apple or dup.apple_music_artist_id
             merged_bandcamp = merged_bandcamp or dup.bandcamp_id
 
-        # Update the primary identity with all merged IDs
-        await self._pg.execute(
-            _UPDATE_MERGED_SQL,
-            primary.id,
-            merged_discogs,
-            merged_mb,
-            merged_spotify,
-            merged_apple,
-            merged_bandcamp,
-        )
+        async with self._pg.acquire() as conn, conn.transaction():
+            # Update the primary identity with all merged IDs
+            await conn.execute(
+                _UPDATE_MERGED_SQL,
+                primary.id,
+                merged_discogs,
+                merged_mb,
+                merged_spotify,
+                merged_apple,
+                merged_bandcamp,
+            )
 
-        # Reassign logs and delete duplicates
-        for dup in duplicates:
-            await self._pg.execute(_REASSIGN_LOGS_SQL, primary.id, dup.id)
-            await self._pg.execute(_DELETE_DUPLICATE_SQL, dup.id)
+            # Reassign logs and delete duplicates
+            for dup in duplicates:
+                await conn.execute(_REASSIGN_LOGS_SQL, primary.id, dup.id)
+                await conn.execute(_DELETE_DUPLICATE_SQL, dup.id)
 
         logger.info(
             "Merged %d identities for QID %s into identity %d (%s)",

--- a/scripts/entity_resolution/sources.py
+++ b/scripts/entity_resolution/sources.py
@@ -14,6 +14,8 @@ import asyncio
 import logging
 import re
 import time
+from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any, Protocol, runtime_checkable
 
 import asyncpg
@@ -32,7 +34,7 @@ class PgSourceProtocol(Protocol):
     async def fetchall(self, query: str, *args: Any) -> list[dict[str, Any]]: ...
     async def fetchone(self, query: str, *args: Any) -> dict[str, Any] | None: ...
     async def execute(self, query: str, *args: Any) -> str: ...
-    def acquire(self) -> Any: ...
+    def acquire(self) -> AbstractAsyncContextManager[asyncpg.Connection]: ...
     async def close(self) -> None: ...
 
 
@@ -91,36 +93,21 @@ class PgSource:
         pool = await self._get_pool()
         return await pool.execute(query, *args)
 
-    def acquire(self) -> Any:
-        """Return an async context manager yielding a pooled connection.
+    @asynccontextmanager
+    async def acquire(self) -> AsyncIterator[asyncpg.Connection]:
+        """Yield a pooled connection for multi-statement transactions.
 
-        Use this when a caller needs to run multiple statements inside a
-        ``conn.transaction()`` (e.g., ``EntityDeduplicator.merge_group``). The
-        pool-level ``fetchall`` / ``fetchone`` / ``execute`` methods autocommit
-        each call and can't be grouped into a single transaction.
-
-        Returns an awaitable wrapper because ``_get_pool`` is async. Callers
-        use it as::
+        The pool-level ``fetchall`` / ``fetchone`` / ``execute`` methods
+        autocommit each call and can't be grouped, so callers needing
+        ``conn.transaction()`` semantics use this instead::
 
             async with pg.acquire() as conn:
                 async with conn.transaction():
                     await conn.execute(...)
         """
-
-        class _AcquireContext:
-            def __init__(self, source: PgSource) -> None:
-                self._source = source
-                self._ctx: Any = None
-
-            async def __aenter__(self) -> asyncpg.Connection:
-                pool = await self._source._get_pool()
-                self._ctx = pool.acquire()
-                return await self._ctx.__aenter__()
-
-            async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
-                return await self._ctx.__aexit__(exc_type, exc, tb)
-
-        return _AcquireContext(self)
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            yield conn
 
     async def close(self) -> None:
         """Close the connection pool."""

--- a/scripts/entity_resolution/sources.py
+++ b/scripts/entity_resolution/sources.py
@@ -32,6 +32,7 @@ class PgSourceProtocol(Protocol):
     async def fetchall(self, query: str, *args: Any) -> list[dict[str, Any]]: ...
     async def fetchone(self, query: str, *args: Any) -> dict[str, Any] | None: ...
     async def execute(self, query: str, *args: Any) -> str: ...
+    def acquire(self) -> Any: ...
     async def close(self) -> None: ...
 
 
@@ -89,6 +90,37 @@ class PgSource:
         """Execute a query and return the status string."""
         pool = await self._get_pool()
         return await pool.execute(query, *args)
+
+    def acquire(self) -> Any:
+        """Return an async context manager yielding a pooled connection.
+
+        Use this when a caller needs to run multiple statements inside a
+        ``conn.transaction()`` (e.g., ``EntityDeduplicator.merge_group``). The
+        pool-level ``fetchall`` / ``fetchone`` / ``execute`` methods autocommit
+        each call and can't be grouped into a single transaction.
+
+        Returns an awaitable wrapper because ``_get_pool`` is async. Callers
+        use it as::
+
+            async with pg.acquire() as conn:
+                async with conn.transaction():
+                    await conn.execute(...)
+        """
+
+        class _AcquireContext:
+            def __init__(self, source: PgSource) -> None:
+                self._source = source
+                self._ctx: Any = None
+
+            async def __aenter__(self) -> asyncpg.Connection:
+                pool = await self._source._get_pool()
+                self._ctx = pool.acquire()
+                return await self._ctx.__aenter__()
+
+            async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
+                return await self._ctx.__aexit__(exc_type, exc, tb)
+
+        return _AcquireContext(self)
 
     async def close(self) -> None:
         """Close the connection pool."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -48,6 +48,27 @@ def mock_settings(monkeypatch):
     )
 
 
+def make_mock_conn():
+    """Build a mock asyncpg.Connection that supports ``conn.transaction()``.
+
+    Shared across fixtures so the transaction-mock plumbing stays in one place.
+    Exposes ``_mock_tx_ctx`` for assertions on transaction entry/exit.
+    asyncpg's ``Connection.transaction()`` returns a Transaction object
+    supporting ``async with``; ``__aexit__`` with a non-None exc triggers
+    ROLLBACK on a real connection.
+    """
+    conn = AsyncMock()
+    conn.execute = AsyncMock()
+    conn.executemany = AsyncMock()
+
+    tx_ctx = MagicMock()
+    tx_ctx.__aenter__ = AsyncMock(return_value=tx_ctx)
+    tx_ctx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx_ctx)
+    conn._mock_tx_ctx = tx_ctx
+    return conn
+
+
 @pytest.fixture
 def mock_asyncpg_pool():
     """AsyncMock mimicking asyncpg.Pool."""
@@ -56,19 +77,7 @@ def mock_asyncpg_pool():
     pool.fetchrow = AsyncMock(return_value=None)
     pool.fetchval = AsyncMock(return_value=1)
 
-    conn = AsyncMock()
-    conn.execute = AsyncMock()
-    conn.executemany = AsyncMock()
-
-    # conn.transaction() must be a callable returning an async context manager.
-    # asyncpg's Connection.transaction() returns a Transaction object that
-    # supports `async with conn.transaction():` and propagates exceptions on
-    # __aexit__ as ROLLBACK.
-    tx_ctx = MagicMock()
-    tx_ctx.__aenter__ = AsyncMock(return_value=tx_ctx)
-    tx_ctx.__aexit__ = AsyncMock(return_value=False)
-    conn.transaction = MagicMock(return_value=tx_ctx)
-    conn._mock_tx_ctx = tx_ctx  # expose for assertions
+    conn = make_mock_conn()
 
     # acquire() must return an async context manager (not a coroutine).
     # asyncpg's pool.acquire() returns a PoolAcquireContext that supports

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -60,6 +60,16 @@ def mock_asyncpg_pool():
     conn.execute = AsyncMock()
     conn.executemany = AsyncMock()
 
+    # conn.transaction() must be a callable returning an async context manager.
+    # asyncpg's Connection.transaction() returns a Transaction object that
+    # supports `async with conn.transaction():` and propagates exceptions on
+    # __aexit__ as ROLLBACK.
+    tx_ctx = MagicMock()
+    tx_ctx.__aenter__ = AsyncMock(return_value=tx_ctx)
+    tx_ctx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx_ctx)
+    conn._mock_tx_ctx = tx_ctx  # expose for assertions
+
     # acquire() must return an async context manager (not a coroutine).
     # asyncpg's pool.acquire() returns a PoolAcquireContext that supports
     # `async with pool.acquire() as conn:`.  Use MagicMock so the call

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -429,3 +429,35 @@ class TestIdentityWriteBack:
             )
 
         store.upsert_identity.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "va_artist",
+        [
+            "Various",
+            "Various Artists",
+            "V.A.",
+            "V/A",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_skips_when_canonical_artist_is_compilation(self, va_artist):
+        """V/A artists must not pollute entity.identity.
+
+        Read-side V/A detection (identity/router.py, discogs/service.py) skips
+        these rows from the matcher's lookup space — but the rows still exist
+        if write-side never guarded against them. See WXYC/library-metadata-lookup#379.
+        """
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release(artist=va_artist)
+        store = AsyncMock()
+        deps = _deps(discogs=discogs, entity_store=store)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        store.upsert_identity.assert_not_called()

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1,5 +1,6 @@
 """Unit tests for discogs/cache_service.py."""
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -607,8 +608,6 @@ class TestWriteRelease:
         """A cancellation mid-cascade propagates through the transaction's __aexit__
         (which translates to ROLLBACK on a real connection) and surfaces to the caller.
         """
-        import asyncio
-
         conn = mock_asyncpg_pool._mock_conn
 
         # cache_metadata UPSERT is the last write — fail before it to simulate

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -577,6 +577,63 @@ class TestWriteRelease:
         # Must not raise
         await cache_service.write_release(release)
 
+    @pytest.mark.asyncio
+    async def test_write_release_wraps_in_transaction(self, cache_service, mock_asyncpg_pool):
+        """write_release runs the full DELETE+INSERT cascade inside conn.transaction().
+
+        Without the wrapper, asyncpg autocommits each statement; a mid-cascade
+        cancellation leaves an artworked release with empty release_artist /
+        empty tracklist / etc. See WXYC/library-metadata-lookup#375.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="DOGA",
+            artist="Juana Molina",
+            release_url="https://discogs.com/release/1",
+            tracklist=[TrackItem(position="1", title="la paradoja")],
+        )
+
+        await cache_service.write_release(release)
+
+        conn = mock_asyncpg_pool._mock_conn
+        # Outer transaction + savepoints for optional tables (release_genre /
+        # _style / _video) means transaction() is called more than once; we
+        # only need to verify the wrap exists.
+        conn.transaction.assert_called()
+        conn._mock_tx_ctx.__aenter__.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_release_rolls_back_on_cancellation(self, cache_service, mock_asyncpg_pool):
+        """A cancellation mid-cascade propagates through the transaction's __aexit__
+        (which translates to ROLLBACK on a real connection) and surfaces to the caller.
+        """
+        import asyncio
+
+        conn = mock_asyncpg_pool._mock_conn
+
+        # cache_metadata UPSERT is the last write — fail before it to simulate
+        # disconnect mid-cascade. The transaction wrapper must propagate.
+        async def raise_on_cache_metadata(sql, *args):
+            if "cache_metadata" in sql:
+                raise asyncio.CancelledError()
+
+        conn.execute = AsyncMock(side_effect=raise_on_cache_metadata)
+
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="DOGA",
+            artist="Juana Molina",
+            release_url="https://discogs.com/release/1",
+        )
+
+        with pytest.raises((asyncio.CancelledError, CacheUnavailableError)):
+            await cache_service.write_release(release)
+
+        # The transaction context manager must have been entered and exited.
+        # On real asyncpg, __aexit__ with a non-None exc triggers ROLLBACK.
+        conn.transaction.assert_called()
+        conn._mock_tx_ctx.__aexit__.assert_awaited()
+
 
 # ---------------------------------------------------------------------------
 # get_release (enriched)
@@ -919,6 +976,28 @@ class TestWriteArtistDetails:
         assert any("artist_name_variation" in sql for sql in all_sql)
         assert any("artist_member" in sql for sql in all_sql)
         assert any("artist_url" in sql for sql in all_sql)
+
+    @pytest.mark.asyncio
+    async def test_write_artist_details_wraps_in_transaction(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """write_artist_details runs UPSERT + 4×DELETE+INSERT inside conn.transaction().
+
+        Without the wrapper, a mid-cascade cancellation leaves an artist row
+        with empty aliases / variations / members / urls. See WXYC/library-metadata-lookup#375.
+        """
+        details = ArtistDetails(
+            artist_id=77,
+            name="Autechre",
+            aliases=[ArtistRef(id=500, name="Gescom")],
+        )
+
+        await cache_service.write_artist_details(details)
+
+        conn = mock_asyncpg_pool._mock_conn
+        conn.transaction.assert_called()
+        conn._mock_tx_ctx.__aenter__.assert_awaited()
+        conn._mock_tx_ctx.__aexit__.assert_awaited()
 
 
 class TestSearchArtistsByName:

--- a/tests/unit/test_entity_dedup.py
+++ b/tests/unit/test_entity_dedup.py
@@ -6,29 +6,22 @@ import pytest
 
 from scripts.entity_resolution.dedup import EntityDeduplicator
 from scripts.entity_resolution.store import Identity
+from tests.unit.conftest import make_mock_conn
 
 
 @pytest.fixture
 def mock_pg():
-    """Mock PgSource for entity store queries.
+    """Mock PgSource exposing pool-level methods plus ``acquire()`` for transactions.
 
-    Exposes both the legacy pool-level ``fetchall``/``execute`` (used by
-    ``find_duplicate_groups``) and an ``acquire()`` returning a connection
-    that supports ``conn.transaction()`` (used by ``merge_group`` per
-    WXYC/library-metadata-lookup#380).
+    ``find_duplicate_groups`` uses the legacy pool-level ``fetchall``/``execute``;
+    ``merge_group`` (WXYC#380) uses ``acquire()`` + ``conn.transaction()``.
     """
     pg = AsyncMock()
     pg.fetchall = AsyncMock(return_value=[])
     pg.execute = AsyncMock(return_value="UPDATE 0")
 
-    conn = AsyncMock()
+    conn = make_mock_conn()
     conn.execute = AsyncMock(return_value="UPDATE 0")
-
-    tx_ctx = MagicMock()
-    tx_ctx.__aenter__ = AsyncMock(return_value=tx_ctx)
-    tx_ctx.__aexit__ = AsyncMock(return_value=False)
-    conn.transaction = MagicMock(return_value=tx_ctx)
-    conn._mock_tx_ctx = tx_ctx
 
     acq_ctx = MagicMock()
     acq_ctx.__aenter__ = AsyncMock(return_value=conn)

--- a/tests/unit/test_entity_dedup.py
+++ b/tests/unit/test_entity_dedup.py
@@ -1,6 +1,6 @@
 """Unit tests for entity deduplication by shared Wikidata QID."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -10,10 +10,31 @@ from scripts.entity_resolution.store import Identity
 
 @pytest.fixture
 def mock_pg():
-    """Mock PgSource for entity store queries."""
+    """Mock PgSource for entity store queries.
+
+    Exposes both the legacy pool-level ``fetchall``/``execute`` (used by
+    ``find_duplicate_groups``) and an ``acquire()`` returning a connection
+    that supports ``conn.transaction()`` (used by ``merge_group`` per
+    WXYC/library-metadata-lookup#380).
+    """
     pg = AsyncMock()
     pg.fetchall = AsyncMock(return_value=[])
     pg.execute = AsyncMock(return_value="UPDATE 0")
+
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="UPDATE 0")
+
+    tx_ctx = MagicMock()
+    tx_ctx.__aenter__ = AsyncMock(return_value=tx_ctx)
+    tx_ctx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx_ctx)
+    conn._mock_tx_ctx = tx_ctx
+
+    acq_ctx = MagicMock()
+    acq_ctx.__aenter__ = AsyncMock(return_value=conn)
+    acq_ctx.__aexit__ = AsyncMock(return_value=False)
+    pg.acquire = MagicMock(return_value=acq_ctx)
+    pg._mock_conn = conn
     return pg
 
 
@@ -90,9 +111,37 @@ class TestMergeIdentities:
         ]
         await dedup.merge_group("Q378288", identities)
 
-        # Should have executed UPDATE for the primary identity and DELETE for dupes
-        calls = [str(c) for c in mock_pg.execute.call_args_list]
-        update_call = [c for c in calls if "UPDATE" in c]
+        # Should have executed UPDATE for the primary identity and DELETE for dupes,
+        # all on the connection acquired from the pool (not the pool-level execute).
+        conn = mock_pg._mock_conn
+        calls = [str(c) for c in conn.execute.call_args_list]
+        update_call = [c for c in calls if "UPDATE entity.identity" in c]
         delete_call = [c for c in calls if "DELETE" in c]
         assert len(update_call) >= 1, "Expected UPDATE for merged identity"
         assert len(delete_call) >= 1, "Expected DELETE for duplicate identity"
+
+    @pytest.mark.asyncio
+    async def test_merge_group_runs_in_single_transaction(self, dedup, mock_pg):
+        """merge_group acquires one connection and wraps all statements in a transaction.
+
+        Without the wrapper, each pg.execute() autocommits and a mid-loop
+        interruption leaves some duplicates reassigned-but-not-deleted (eventually
+        consistent next pass, but harder to reason about). See WXYC/library-metadata-lookup#380.
+        """
+        identities = [
+            Identity(id=1, library_name="A", wikidata_qid="Q1", reconciliation_status="reconciled"),
+            Identity(id=2, library_name="a", wikidata_qid="Q1", reconciliation_status="reconciled"),
+            Identity(
+                id=3, library_name="A.", wikidata_qid="Q1", reconciliation_status="reconciled"
+            ),
+        ]
+        await dedup.merge_group("Q1", identities)
+
+        # One acquire, one transaction, all statements on the same conn.
+        mock_pg.acquire.assert_called_once()
+        conn = mock_pg._mock_conn
+        conn.transaction.assert_called_once()
+        conn._mock_tx_ctx.__aenter__.assert_awaited_once()
+        conn._mock_tx_ctx.__aexit__.assert_awaited_once()
+        # Statements should land on the connection, not the pool wrapper.
+        assert conn.execute.await_count >= 1 + 2 * 2  # UPDATE + 2×(REASSIGN+DELETE)


### PR DESCRIPTION
## Summary

Three thematically-related asyncpg write-path correctness fixes touching `discogs/`, `release/`, and `scripts/entity_resolution/`. Two are transaction wrappers; one is a guard.

- **#375** `DiscogsCacheService.write_release` and `write_artist_details` wrap their full DELETE+INSERT cascades in `conn.transaction()`. Optional-table blocks (`release_genre` / `_style` / `_video`) use nested `conn.transaction()` (savepoints) so a missing-table error in those blocks reverts only that block without aborting the outer txn — preserving the legacy defensive shim. Without the outer wrapper, a cancellation mid-cascade left an artworked release with empty `release_artist` / `release_track` while `cache_metadata.cached_at` advanced to "fresh". Same failure family as the 2026-05-14 iOS v2 playlist artwork outage on the integrity side.
- **#379** `release/orchestrator._writeback_identity` is now guarded by `wxyc_etl.text.is_compilation_artist`. Read-side detection (`identity/router.py`, `discogs/service.py`) already filters V/A from the matcher; the write-side guard stops new V/A rows from entering `entity.identity` in the first place. **The audit + cleanup of existing V/A rows is intentionally NOT in this PR** — that depends on WXYC/wxyc-etl#129 (substring matcher tightening) so the audit query identifies pollution rows reliably.
- **#380** `EntityDeduplicator.merge_group` acquires one connection and wraps `UPDATE` + N×(`REASSIGN` + `DELETE`) in a single transaction. Adds `PgSource.acquire()` returning an async context manager that yields an `asyncpg.Connection` from the underlying pool.

## Test plan

- [x] New unit tests (TDD: RED → GREEN)
  - `test_write_release_wraps_in_transaction`
  - `test_write_release_rolls_back_on_cancellation`
  - `test_write_artist_details_wraps_in_transaction`
  - `test_skips_when_canonical_artist_is_compilation` (parametrized: "Various", "Various Artists", "V.A.", "V/A")
  - `test_merge_group_runs_in_single_transaction`
- [x] All previously-passing unit tests still pass (1865 passing, +8 from new tests)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy` clean (Success: no issues found in 257 source files)
- [ ] Post-deploy: integration check against discogs-cache for artworked-but-empty release rows (audit query in #375)

## Closes

- Closes #375
- Closes #379
- Closes #380

## Related

- WXYC/wxyc-etl#129 — blocks the V/A audit / cleanup follow-up to #379 (not in this PR)
- Project [#32](https://github.com/orgs/WXYC/projects/32) Epic E (Cache hierarchy unification — #879) — sibling work to #375