### PR TITLE
Bump wxyc-etl to 0.5.0 (anchored is_compilation_artist)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "wxyc-fastapi[posthog]>=1.0.0,<2.0.0",
     "aiolimiter>=1.1.0",
     "python-multipart>=0.0.6",
-    "wxyc-etl>=0.4.0",
+    "wxyc-etl>=0.5.0,<0.6.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -159,16 +159,21 @@ class TestIsCompilationArtist:
     @pytest.mark.parametrize(
         "artist",
         [
-            pytest.param("Various Artists", id="various-artists"),
-            pytest.param("VARIOUS", id="various-upper"),
-            pytest.param("various", id="various-lower"),
-            pytest.param("Soundtrack Collection", id="soundtrack-collection"),
-            pytest.param("soundtrack", id="soundtrack"),
-            pytest.param("A Compilation Album", id="compilation"),
+            # Leading-prefix tokens — must start the string and be followed by a
+            # non-alphanumeric boundary or end-of-string (wxyc-etl 0.5.0 contract).
+            pytest.param("Various Artists", id="various-artists-leading"),
             pytest.param("V/A", id="v-slash-a"),
             pytest.param("v/a", id="v-slash-a-lower"),
             pytest.param("V.A.", id="v-dot-a"),
             pytest.param("v.a.", id="v-dot-a-lower"),
+            pytest.param("Soundtracks", id="soundtracks-leading"),
+            # Exact-match tokens — case-insensitive equality only.
+            pytest.param("VARIOUS", id="various-upper-exact"),
+            pytest.param("various", id="various-lower-exact"),
+            pytest.param("soundtrack", id="soundtrack-exact"),
+            pytest.param("Soundtrack", id="soundtrack-exact-titlecase"),
+            pytest.param("Compilation", id="compilation-exact"),
+            pytest.param("compilation", id="compilation-exact-lower"),
         ],
     )
     def test_compilation_keywords_detected(self, artist):
@@ -181,6 +186,18 @@ class TestIsCompilationArtist:
             pytest.param("Queen", id="queen"),
             pytest.param("The National", id="the-national"),
             pytest.param("DJ Shadow", id="dj-shadow"),
+            # wxyc-etl 0.5.0 tightened is_compilation_artist from substring scan
+            # to anchored leading-prefix + exact match. "compilation" and
+            # "soundtrack" are exact-only, so embedding them in a longer string
+            # no longer flags as a compilation artist. Real bands like "The
+            # Soundtrack of Our Lives" and "Various Production" are now correctly
+            # excluded. See https://github.com/WXYC/wxyc-etl/pull/130.
+            pytest.param("A Compilation Album", id="compilation-embedded"),
+            pytest.param("Compilation Hits", id="compilation-leading-but-exact-only"),
+            pytest.param("Soundtrack Collection", id="soundtrack-embedded"),
+            pytest.param("Original Motion Picture Soundtrack", id="soundtrack-trailing-exact-only"),
+            pytest.param("The Soundtrack of Our Lives", id="soundtrack-real-band"),
+            pytest.param("Various Production", id="various-real-artist"),
         ],
     )
     def test_non_compilation_artists(self, artist):

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.6" },
     { name = "uvicorn", specifier = ">=0.24.0" },
-    { name = "wxyc-etl", specifier = ">=0.4.0" },
+    { name = "wxyc-etl", specifier = ">=0.5.0,<0.6.0" },
     { name = "wxyc-fastapi", extras = ["posthog"], specifier = ">=1.0.0,<2.0.0" },
 ]
 provides-extras = ["dev"]
@@ -1252,17 +1252,17 @@ wheels = [
 
 [[package]]
 name = "wxyc-etl"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-json-logger" },
     { name = "sentry-sdk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/21/11d20c97a21153c64fbc26e4b5a8be66b269c0dbce48c6e1648346797323/wxyc_etl-0.4.0.tar.gz", hash = "sha256:962c95adaa11932866422756651ea1debcee085243db53d87b740be9ba210919", size = 151119, upload-time = "2026-05-11T16:26:15.264Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/90/81f5b041a006f23bb3dcfaf0fa3645e6a4b28c00bec481296e57976e68a2/wxyc_etl-0.5.0.tar.gz", hash = "sha256:5f9f0f3fb05f55c5316823114a067bb2a596460c87f3b9259de1f28261cb5965", size = 151770, upload-time = "2026-05-25T17:20:51.497Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/da/a8a1abee60641b50bf1842ff01972492912cf32d819b1a8c3dd6fd1a31ca/wxyc_etl-0.4.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4adcab8c8860cc407972bf10b238536cf870816051b8d6d743311d1ad2e17b33", size = 843142, upload-time = "2026-05-11T16:26:10.849Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/45/76d4411e443de7030b68ce28ad3e875e474fa329265444cf11da723b3fd6/wxyc_etl-0.4.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1edfbb1e9db4b82eb7a731a9f5295edc8050b1a857867b7f6e55b47c6bd6e899", size = 877222, upload-time = "2026-05-11T16:26:12.397Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d9/f173ae9633a45b56a7c176ecc878217708c93a34a8ed9217c6478243e406/wxyc_etl-0.4.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b75f7847b3decdb4f127f33540f2ee0f40cc12fd61d1ef97f82396b6f4965e1", size = 1102479, upload-time = "2026-05-11T16:26:13.97Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/21/3d045adab8c5e736dcb050a9363f9eebc5e45f4adc8b1a8d4662c69457a3/wxyc_etl-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6a3345989795997e8e1a62dcedde7ad802da129cdbf6726887d42bfe7d3a43f6", size = 845218, upload-time = "2026-05-25T17:20:46.56Z" },
+    { url = "https://files.pythonhosted.org/packages/af/af/e42e57c5ffb8ba92d1fe68f8b65ebc75c3aa680b9d8c328e655f0dd5f6e9/wxyc_etl-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0bcf67e15fd3f5a57bb11bc978adca990630290808bee08176d8d605246fb32", size = 879005, upload-time = "2026-05-25T17:20:48.1Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/127b7e35ee41c93d3b564637e03723e91a383fd7ffbd3bd135504b3c1b5d/wxyc_etl-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536c5a117d14f0aec684fcaf0f106cc32c7cca8c7a1b32304b1611fcf94f36ca", size = 1105909, upload-time = "2026-05-25T17:20:49.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `wxyc-etl` dependency from `>=0.4.0` to `>=0.5.0,<0.6.0` in `pyproject.toml` (matching the existing major-pin style for `wxyc-fastapi[posthog]>=1.0.0,<2.0.0`). `uv.lock` refreshed.
- Update `tests/unit/test_matching.py::TestIsCompilationArtist` to reflect the new anchored-prefix + exact-match contract: drop two cases that pinned the old substring behavior (`Soundtrack Collection`, `A Compilation Album`), reorganize the positives by token class (leading-prefix vs exact-only), and pin the new semantics on both true and false sides — including real-band negatives like `The Soundtrack of Our Lives` and `Various Production`.

No production code changes. All consumers of `is_compilation_artist` (`identity/bulk_resolve.py`, `lookup/orchestrator.py`, `discogs/service.py`, `discogs/cache_service.py`, etc.) want the tighter rule — they're checking "is this row an upstream catalog comp-artist marker", and the new behavior strictly reduces false positives.

Upstream PR with full rationale: https://github.com/WXYC/wxyc-etl/pull/130

Closes #383

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy . --ignore-missing-imports` — `Success: no issues found in 257 source files`
- [x] `pytest` — 2120 passed (+10 vs baseline 0.4.0 due to expanded parametrize), 2 xfailed (pre-existing), 1 ERROR in `tests/unit/test_dependencies.py::test_no_module_level_asyncio_lock_in_dependencies` that reproduces on baseline `0.4.0` and is unrelated to this change (it's an ordering-dependent asyncio teardown artifact).
- [x] Hand-verified `is_compilation_artist` outputs against the new contract for the full positive/negative matrix.