### PR TITLE
feat(entity_resolution): add orphan pass after seed_identities

### DIFF
--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -38,9 +38,28 @@ from scripts.entity_resolution.wikidata import WikidataReconciler
 
 logger = logging.getLogger(__name__)
 
+# Default threshold knobs for `prune_orphan_identities`. Calibrated against
+# the ~24K-row prod baseline: the absolute floor (100) lets day-to-day name
+# drift through; the 10% fractional cap (~2,400 rows) bounds the worst-case
+# bulk-rename run. Both are overridable via CLI flags.
+_DEFAULT_ORPHAN_THRESHOLD_FRAC = 0.10
+_DEFAULT_ORPHAN_THRESHOLD_ABS = 100
+
 _LIBRARY_ARTISTS_SQL = (
     "SELECT DISTINCT artist FROM library WHERE artist IS NOT NULL ORDER BY artist"
 )
+
+
+class OrphanDrainAbortError(RuntimeError):
+    """Raised when orphan count exceeds the drain-safety threshold.
+
+    ``main()`` catches this, logs at ERROR with the orphan count + sample
+    names, and exits non-zero. The operator re-runs with
+    ``--allow-orphan-drain`` after confirming the ``library.db`` snapshot
+    is correct. Guards LML#377's failure mode where a corrupted / partial
+    library export would otherwise look like "every artist was renamed at
+    once" and silently wipe every ``entity.reconciliation_log`` row.
+    """
 
 
 async def get_library_artists(db_path: str) -> list[str]:
@@ -49,6 +68,130 @@ async def get_library_artists(db_path: str) -> list[str]:
         cursor = await db.execute(_LIBRARY_ARTISTS_SQL)
         rows = await cursor.fetchall()
         return [row[0] for row in rows if row[0]]
+
+
+async def prune_orphan_identities(
+    store: EntityStore,
+    current_names: set[str],
+    *,
+    allow_orphan_drain: bool = False,
+    threshold_frac: float = _DEFAULT_ORPHAN_THRESHOLD_FRAC,
+    threshold_abs: int = _DEFAULT_ORPHAN_THRESHOLD_ABS,
+) -> tuple[int, int, list[str]]:
+    """Remove or merge ``entity.identity`` rows no longer in the snapshot.
+
+    Computes ``stored_names - current_names`` and resolves each orphan via a
+    canonical-form lookup against ``current_names``: when exactly one current
+    name canonicalizes to the same form as the orphan, the orphan's
+    reconciliation_log provenance and external IDs are merged into the
+    current row; otherwise the orphan is hard-deleted.
+
+    Args:
+        store: EntityStore wired to the discogs-cache database.
+        current_names: Set of ``library.artist`` values from the current
+            ``library.db`` snapshot.
+        allow_orphan_drain: When False (default), raises ``OrphanDrainAbortError``
+            if orphan count exceeds ``max(threshold_abs, threshold_frac *
+            len(current_names))``. Pass True for an authorized one-shot
+            bulk-rename run.
+        threshold_frac: Fraction of the current snapshot above which the
+            drain guard fires.
+        threshold_abs: Absolute floor; the guard fires above
+            ``max(threshold_abs, threshold_frac * len(current_names))``.
+
+    Returns:
+        ``(merged_count, deleted_count, orphan_names)``.
+
+    Raises:
+        OrphanDrainAbortError: When the orphan count crosses the threshold and
+            ``allow_orphan_drain`` is False.
+    """
+    # Local import keeps the wxyc_etl Rust extension off the module-load
+    # path for callers that don't reach this code path.
+    from identity.normalize import canonicalize_for_identity_lookup
+
+    stored_names = await store.fetch_all_identity_library_names()
+    orphans = sorted(stored_names - current_names)
+
+    if not orphans:
+        logger.info("Orphan pass: no orphans (stored=%d)", len(stored_names))
+        return (0, 0, [])
+
+    threshold = max(threshold_abs, int(threshold_frac * len(current_names)))
+    if len(orphans) > threshold and not allow_orphan_drain:
+        sample = orphans[:20]
+        logger.error(
+            "Orphan pass: %d orphans exceeds threshold %d (current=%d, stored=%d). "
+            "Sample: %s. Re-run with --allow-orphan-drain after verifying the "
+            "library.db snapshot is correct.",
+            len(orphans),
+            threshold,
+            len(current_names),
+            len(stored_names),
+            sample,
+        )
+        raise OrphanDrainAbortError(f"{len(orphans)} orphans exceeds threshold {threshold}")
+
+    # Build a canonical-form index over current names so each orphan's merge
+    # target lookup is O(1). Collisions (multiple current names sharing one
+    # canonical form) get tracked here so the orphan pass falls through to
+    # delete rather than guessing.
+    canonical_to_current: dict[str, list[str]] = {}
+    for name in current_names:
+        c = canonicalize_for_identity_lookup(name)
+        if c:
+            canonical_to_current.setdefault(c, []).append(name)
+
+    merged_count = 0
+    deleted_count = 0
+    for orphan in orphans:
+        c = canonicalize_for_identity_lookup(orphan)
+        candidates = canonical_to_current.get(c, []) if c else []
+        if len(candidates) == 1:
+            target_name = candidates[0]
+            target = await store.get_identity(target_name)
+            if target is not None:
+                did_merge = await store.merge_identity_by_library_name(
+                    from_name=orphan, into_id=target.id
+                )
+                if did_merge:
+                    logger.info(
+                        "Orphan pass merge: %r -> %r (into id=%d)",
+                        orphan,
+                        target_name,
+                        target.id,
+                    )
+                    merged_count += 1
+                    continue
+                # merge_identity_by_library_name returned False — orphan row
+                # was already gone (concurrent run) or already merged. Skip
+                # delete to avoid touching the canonical row by mistake.
+                logger.info("Orphan pass skip: %r (no row to merge)", orphan)
+                continue
+            logger.warning(
+                "Orphan pass: canonical target %r for orphan %r not found in store; "
+                "falling through to delete",
+                target_name,
+                orphan,
+            )
+        elif len(candidates) > 1:
+            logger.warning(
+                "Orphan pass: orphan %r canonicalizes to %r which matches multiple "
+                "current names %s; falling through to delete to avoid ambiguous merge",
+                orphan,
+                c,
+                candidates,
+            )
+
+        log_rows = await store.delete_identity_by_library_name(orphan)
+        logger.info(
+            "Orphan pass delete: %r (removed %d reconciliation_log rows)",
+            orphan,
+            log_rows,
+        )
+        deleted_count += 1
+
+    return (merged_count, deleted_count, orphans)
 
 
 async def seed_identities(store: EntityStore, artists: list[str]) -> int:
@@ -291,6 +434,26 @@ async def main(args: argparse.Namespace) -> None:
         artists = await get_library_artists(library_db_path)
         logger.info("Found %d distinct artists in library", len(artists))
 
+        # Step 1a: Prune orphans (LML#377). Runs before seed so the new
+        # seed_identities upsert loop can't fight with the orphan diff.
+        try:
+            merged, deleted, orphans = await prune_orphan_identities(
+                store,
+                set(artists),
+                allow_orphan_drain=args.allow_orphan_drain,
+                threshold_frac=args.orphan_threshold_frac,
+                threshold_abs=args.orphan_threshold_abs,
+            )
+            logger.info(
+                "Orphan pass: %d merged, %d deleted (of %d total orphans)",
+                merged,
+                deleted,
+                len(orphans),
+            )
+        except OrphanDrainAbortError as exc:
+            logger.error("Aborting seeding run: %s", exc)
+            sys.exit(1)
+
         seeded = await seed_identities(store, artists)
         logger.info("Seeded %d identities", seeded)
 
@@ -362,6 +525,34 @@ def parse_args() -> argparse.Namespace:
         "--skip-musicbrainz",
         action="store_true",
         help="Skip MusicBrainz reconciliation stage",
+    )
+    parser.add_argument(
+        "--allow-orphan-drain",
+        action="store_true",
+        help=(
+            "Bypass the orphan-count safety threshold. Required when a "
+            "legitimate bulk rename pushes the orphan count above "
+            "max(--orphan-threshold-abs, --orphan-threshold-frac * snapshot)."
+        ),
+    )
+    parser.add_argument(
+        "--orphan-threshold-frac",
+        type=float,
+        default=_DEFAULT_ORPHAN_THRESHOLD_FRAC,
+        help=(
+            "Fractional cap on orphan count vs current snapshot size "
+            f"(default: {_DEFAULT_ORPHAN_THRESHOLD_FRAC})"
+        ),
+    )
+    parser.add_argument(
+        "--orphan-threshold-abs",
+        type=int,
+        default=_DEFAULT_ORPHAN_THRESHOLD_ABS,
+        help=(
+            "Absolute floor for the orphan threshold; the guard fires above "
+            "max(--orphan-threshold-abs, --orphan-threshold-frac * snapshot) "
+            f"(default: {_DEFAULT_ORPHAN_THRESHOLD_ABS})"
+        ),
     )
     parser.add_argument(
         "-v",

--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -434,8 +434,17 @@ async def main(args: argparse.Namespace) -> None:
         artists = await get_library_artists(library_db_path)
         logger.info("Found %d distinct artists in library", len(artists))
 
-        # Step 1a: Prune orphans (LML#377). Runs before seed so the new
-        # seed_identities upsert loop can't fight with the orphan diff.
+        seeded = await seed_identities(store, artists)
+        logger.info("Seeded %d identities", seeded)
+
+        # Step 1a: Prune orphans (LML#377). Runs AFTER seed so the merge path
+        # has a target row to merge INTO. On a librarian-driven rename
+        # ("Beyonce" → "Beyoncé"), seed_identities first creates the empty
+        # "Beyoncé" row; the orphan pass then merges "Beyonce"'s accumulated
+        # reconciliation_log + external IDs into it, then deletes the "Beyonce"
+        # row. If the pass ran before seed, get_identity(new_name) would
+        # return None and every rename would fall through to hard-delete,
+        # losing the provenance the pass exists to preserve.
         try:
             merged, deleted, orphans = await prune_orphan_identities(
                 store,
@@ -453,9 +462,6 @@ async def main(args: argparse.Namespace) -> None:
         except OrphanDrainAbortError as exc:
             logger.error("Aborting seeding run: %s", exc)
             sys.exit(1)
-
-        seeded = await seed_identities(store, artists)
-        logger.info("Seeded %d identities", seeded)
 
         # Step 2: Discogs reconciliation
         logger.info("Running Discogs reconciliation...")

--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -163,10 +163,11 @@ async def prune_orphan_identities(
                     )
                     merged_count += 1
                     continue
-                # merge_identity_by_library_name returned False — orphan row
-                # was already gone (concurrent run) or already merged. Skip
-                # delete to avoid touching the canonical row by mistake.
-                logger.info("Orphan pass skip: %r (no row to merge)", orphan)
+                # merge returned False: either the orphan row is already gone
+                # (concurrent run) or it's already the canonical target (no-op
+                # self-merge). Both cases: skip delete so we don't touch the
+                # canonical row by mistake.
+                logger.info("Orphan pass skip: %r (already merged or missing)", orphan)
                 continue
             logger.warning(
                 "Orphan pass: canonical target %r for orphan %r not found in store; "

--- a/scripts/entity_resolution/dedup.py
+++ b/scripts/entity_resolution/dedup.py
@@ -101,7 +101,12 @@ class EntityDeduplicator:
             merged_bandcamp = merged_bandcamp or dup.bandcamp_id
 
         async with self._pg.acquire() as conn, conn.transaction():
-            # Update the primary identity with all merged IDs
+            # Update the primary identity with all merged IDs. The
+            # `wikidata_qid` bind is the shared group key by construction
+            # (groups are built by QID collision), so passing it through
+            # `_UPDATE_MERGED_SQL`'s new $7 slot is a no-op on the primary
+            # but keeps a single SQL shape for both callers (this method
+            # and the LML#377 orphan-pass merge).
             await conn.execute(
                 _UPDATE_MERGED_SQL,
                 primary.id,
@@ -110,6 +115,7 @@ class EntityDeduplicator:
                 merged_spotify,
                 merged_apple,
                 merged_bandcamp,
+                qid,
             )
 
             # Reassign logs and delete duplicates

--- a/scripts/entity_resolution/dedup.py
+++ b/scripts/entity_resolution/dedup.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 import logging
 
 from scripts.entity_resolution.sources import PgSource
-from scripts.entity_resolution.store import Identity, _record_to_identity
+from scripts.entity_resolution.store import (
+    _DELETE_IDENTITY_BY_ID_SQL,
+    _REASSIGN_LOGS_SQL,
+    _UPDATE_MERGED_SQL,
+    Identity,
+    _record_to_identity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,25 +33,6 @@ WHERE wikidata_qid IN (
     HAVING count(*) > 1
 )
 ORDER BY wikidata_qid, id\
-"""
-
-_UPDATE_MERGED_SQL = """\
-UPDATE entity.identity
-SET discogs_artist_id = COALESCE($2, discogs_artist_id),
-    musicbrainz_artist_id = COALESCE($3, musicbrainz_artist_id),
-    spotify_artist_id = COALESCE($4, spotify_artist_id),
-    apple_music_artist_id = COALESCE($5, apple_music_artist_id),
-    bandcamp_id = COALESCE($6, bandcamp_id),
-    updated_at = now()
-WHERE id = $1\
-"""
-
-_DELETE_DUPLICATE_SQL = """\
-DELETE FROM entity.identity WHERE id = $1\
-"""
-
-_REASSIGN_LOGS_SQL = """\
-UPDATE entity.reconciliation_log SET identity_id = $1 WHERE identity_id = $2\
 """
 
 
@@ -128,7 +115,7 @@ class EntityDeduplicator:
             # Reassign logs and delete duplicates
             for dup in duplicates:
                 await conn.execute(_REASSIGN_LOGS_SQL, primary.id, dup.id)
-                await conn.execute(_DELETE_DUPLICATE_SQL, dup.id)
+                await conn.execute(_DELETE_IDENTITY_BY_ID_SQL, dup.id)
 
         logger.info(
             "Merged %d identities for QID %s into identity %d (%s)",

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -146,6 +146,7 @@ SET discogs_artist_id = COALESCE($2, discogs_artist_id),
     spotify_artist_id = COALESCE($4, spotify_artist_id),
     apple_music_artist_id = COALESCE($5, apple_music_artist_id),
     bandcamp_id = COALESCE($6, bandcamp_id),
+    wikidata_qid = COALESCE($7, wikidata_qid),
     updated_at = now()
 WHERE id = $1\
 """
@@ -450,15 +451,24 @@ class EntityStore:
     async def merge_identity_by_library_name(self, from_name: str, into_id: int) -> bool:
         """Merge the row keyed by ``from_name`` into the row at ``into_id``.
 
-        COALESCEs the from row's external IDs into the into row (matching the
-        semantics of ``EntityDeduplicator.merge_group``), re-points every
-        ``entity.reconciliation_log`` row whose ``identity_id`` matches the
-        from row to ``into_id``, then DELETEs the from row.
+        COALESCEs the from row's external IDs **and Wikidata QID** into the
+        into row, re-points every ``entity.reconciliation_log`` row whose
+        ``identity_id`` matches the from row to ``into_id``, then DELETEs the
+        from row. If the from row was ``reconciliation_status='reconciled'``
+        and the into row was not, the into row is upgraded to ``'reconciled'``
+        — otherwise the freshly-seeded target's default 'unreconciled' would
+        trigger a wasteful re-fetch on the next reconciliation pass.
 
         Used by the LML#377 orphan pass when an orphaned ``library_name``'s
         canonical form matches a current row — preserves accumulated
         reconciliation provenance across artist-name edits like
         ``"Beyonce"`` → ``"Beyoncé"``.
+
+        Why this differs from ``EntityDeduplicator.merge_group``: dedup keys
+        on a shared Wikidata QID, so the surviving row always already has the
+        QID and a reconciled status. The orphan pass keys on canonical-form
+        match, a weaker constraint — the orphan can carry a QID and a status
+        that the freshly-seeded target lacks. Both fields must be carried.
 
         Returns True on merge; False (no-op) when ``from_name`` is not found
         or already equals ``into_id`` (idempotent on re-invocation).
@@ -483,7 +493,16 @@ class EntityStore:
                 from_row["spotify_artist_id"],
                 from_row["apple_music_artist_id"],
                 from_row["bandcamp_id"],
+                from_row["wikidata_qid"],
             )
+            # `reconciliation_status` is NOT NULL with default 'unreconciled',
+            # so a plain COALESCE in _UPDATE_MERGED_SQL would always pick the
+            # bind value over the existing column — that's wrong for dedup
+            # (could downgrade 'reconciled' to 'no_match'). Apply selectively
+            # here instead: only upgrade the target to 'reconciled' if the
+            # orphan was reconciled.
+            if from_row["reconciliation_status"] == "reconciled":
+                await conn.execute(_UPDATE_STATUS_SQL, into_id, "reconciled")
             await conn.execute(_REASSIGN_LOGS_SQL, into_id, from_id)
             await conn.execute(_DELETE_IDENTITY_BY_ID_SQL, from_id)
             return True

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -444,8 +444,8 @@ class EntityStore:
                 _DELETE_RECONCILIATION_LOG_BY_IDENTITY_ID_SQL, identity_id
             )
             await conn.execute(_DELETE_IDENTITY_BY_ID_SQL, identity_id)
-            # asyncpg returns "DELETE N" — parse the trailing count.
-            return int(log_status.split()[-1]) if log_status.startswith("DELETE") else 0
+            # asyncpg returns "DELETE N" for a DELETE statement.
+            return int(log_status.split()[-1])
 
     async def merge_identity_by_library_name(self, from_name: str, into_id: int) -> bool:
         """Merge the row keyed by ``from_name`` into the row at ``into_id``.

--- a/scripts/entity_resolution/store.py
+++ b/scripts/entity_resolution/store.py
@@ -131,6 +131,41 @@ INSERT INTO entity.reconciliation_log (identity_id, source, external_id, confide
 VALUES ($1, $2, $3, $4, $5)\
 """
 
+# Shared merge / delete primitives. Used both by `EntityDeduplicator.merge_group`
+# (for QID-collapse merges) and by the LML#377 orphan-pass helpers
+# `merge_identity_by_library_name` / `delete_identity_by_library_name`. Hoisted
+# here so there's one source of truth; `dedup.py` imports these.
+#
+# `entity.reconciliation_log.identity_id` is a FK with NO ON DELETE CASCADE
+# (see the schema in tests/integration/test_entity_resolution.py:75-85), so any
+# DELETE on `entity.identity` must remove the log rows first or reassign them.
+_UPDATE_MERGED_SQL = """\
+UPDATE entity.identity
+SET discogs_artist_id = COALESCE($2, discogs_artist_id),
+    musicbrainz_artist_id = COALESCE($3, musicbrainz_artist_id),
+    spotify_artist_id = COALESCE($4, spotify_artist_id),
+    apple_music_artist_id = COALESCE($5, apple_music_artist_id),
+    bandcamp_id = COALESCE($6, bandcamp_id),
+    updated_at = now()
+WHERE id = $1\
+"""
+
+_DELETE_IDENTITY_BY_ID_SQL = """\
+DELETE FROM entity.identity WHERE id = $1\
+"""
+
+_REASSIGN_LOGS_SQL = """\
+UPDATE entity.reconciliation_log SET identity_id = $1 WHERE identity_id = $2\
+"""
+
+_DELETE_RECONCILIATION_LOG_BY_IDENTITY_ID_SQL = """\
+DELETE FROM entity.reconciliation_log WHERE identity_id = $1\
+"""
+
+_FETCH_ALL_LIBRARY_NAMES_SQL = """\
+SELECT library_name FROM entity.identity\
+"""
+
 # Most-recent reconciliation log row per source for a given identity.
 # DISTINCT ON keeps a single row per source, ordered by created_at DESC so we
 # pick the latest attempt — matching the "most recent matcher decision" notion
@@ -375,3 +410,80 @@ class EntityStore:
             confidence,
             _strip_nul(method),
         )
+
+    async def fetch_all_identity_library_names(self) -> set[str]:
+        """Return every ``entity.identity.library_name`` as a set.
+
+        Used by the LML#377 orphan pass to compute set-difference against the
+        current ``library.db`` snapshot. Returns a set (not a list) so the
+        diff in `prune_orphan_identities` is O(N).
+        """
+        rows = await self._pg.fetchall(_FETCH_ALL_LIBRARY_NAMES_SQL)
+        if not rows:
+            return set()
+        return {row["library_name"] for row in rows}
+
+    async def delete_identity_by_library_name(self, library_name: str) -> int:
+        """Delete an identity row and its reconciliation_log children.
+
+        FK on ``entity.reconciliation_log.identity_id`` has no ON DELETE
+        CASCADE, so the log rows are removed first. Both DELETEs run inside a
+        single asyncpg transaction so a mid-call failure leaves either both
+        rows present or both rows gone.
+
+        Returns the count of ``entity.reconciliation_log`` rows removed.
+        Returns 0 (no-op) if no identity row matches ``library_name``.
+        """
+        verbatim = _strip_nul(library_name)
+        async with self._pg.acquire() as conn, conn.transaction():
+            row = await conn.fetchrow(_GET_IDENTITY_SQL, verbatim)
+            if row is None:
+                return 0
+            identity_id = row["id"]
+            log_status = await conn.execute(
+                _DELETE_RECONCILIATION_LOG_BY_IDENTITY_ID_SQL, identity_id
+            )
+            await conn.execute(_DELETE_IDENTITY_BY_ID_SQL, identity_id)
+            # asyncpg returns "DELETE N" — parse the trailing count.
+            return int(log_status.split()[-1]) if log_status.startswith("DELETE") else 0
+
+    async def merge_identity_by_library_name(self, from_name: str, into_id: int) -> bool:
+        """Merge the row keyed by ``from_name`` into the row at ``into_id``.
+
+        COALESCEs the from row's external IDs into the into row (matching the
+        semantics of ``EntityDeduplicator.merge_group``), re-points every
+        ``entity.reconciliation_log`` row whose ``identity_id`` matches the
+        from row to ``into_id``, then DELETEs the from row.
+
+        Used by the LML#377 orphan pass when an orphaned ``library_name``'s
+        canonical form matches a current row — preserves accumulated
+        reconciliation provenance across artist-name edits like
+        ``"Beyonce"`` → ``"Beyoncé"``.
+
+        Returns True on merge; False (no-op) when ``from_name`` is not found
+        or already equals ``into_id`` (idempotent on re-invocation).
+
+        Runs as a single asyncpg transaction so a mid-call failure leaves
+        the from row, the into row, and the log rows all in their original
+        state — never partial.
+        """
+        verbatim = _strip_nul(from_name)
+        async with self._pg.acquire() as conn, conn.transaction():
+            from_row = await conn.fetchrow(_GET_IDENTITY_SQL, verbatim)
+            if from_row is None:
+                return False
+            from_id = from_row["id"]
+            if from_id == into_id:
+                return False
+            await conn.execute(
+                _UPDATE_MERGED_SQL,
+                into_id,
+                from_row["discogs_artist_id"],
+                from_row["musicbrainz_artist_id"],
+                from_row["spotify_artist_id"],
+                from_row["apple_music_artist_id"],
+                from_row["bandcamp_id"],
+            )
+            await conn.execute(_REASSIGN_LOGS_SQL, into_id, from_id)
+            await conn.execute(_DELETE_IDENTITY_BY_ID_SQL, from_id)
+            return True

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -408,6 +408,164 @@ class TestIdentityRouterEntityStoreUnavailable:
 
 
 @pytest.mark.pg
+class TestOrphanPass:
+    """Acceptance tests for LML#377: the orphan pass before seed_identities.
+
+    The Beyonce → Beyoncé scenario is the motivating case in the issue body
+    — these tests pin the contract: reconciliation_log provenance is either
+    *preserved* (merge path) or *explicitly removed* (delete path), never
+    silently abandoned under the new orphan row.
+    """
+
+    @pytest.mark.asyncio
+    async def test_orphan_with_canonical_match_merges_provenance(self, pg_source):
+        """Beyonce → Beyoncé: prior reconciliation_log preserved on the new row."""
+        from scripts.entity_resolution.__main__ import prune_orphan_identities
+
+        store = EntityStore(pg_source)
+
+        # Pre-orphan state: librarian had "Beyonce" with a reconciled Discogs ID.
+        old = await store.upsert_identity(library_name="Beyonce", discogs_artist_id=1419)
+        assert old is not None
+        await store.log_reconciliation(
+            identity_id=old.id,
+            source="discogs",
+            external_id="1419",
+            method="exact_match",
+            confidence=1.0,
+        )
+
+        # Librarian renames to "Beyoncé". Pre-pass, both rows exist (the new
+        # one is empty; the orphan-pass has not yet run).
+        new = await store.upsert_identity(library_name="Beyoncé")
+        assert new is not None
+        assert new.id != old.id
+
+        merged, deleted, orphans = await prune_orphan_identities(store, {"Beyoncé"})
+
+        assert merged == 1
+        assert deleted == 0
+        assert orphans == ["Beyonce"]
+
+        # Post-pass: exactly one identity row, keyed on the new name.
+        rows = await pg_source.fetchall("SELECT id, library_name FROM entity.identity")
+        assert len(rows) == 1
+        assert rows[0]["library_name"] == "Beyoncé"
+        # The merge re-points the reconciliation_log to the surviving (new) row.
+        surviving_id = rows[0]["id"]
+        log_rows = await pg_source.fetchall(
+            "SELECT identity_id, external_id, method FROM entity.reconciliation_log"
+        )
+        assert len(log_rows) == 1
+        assert log_rows[0]["identity_id"] == surviving_id
+        assert log_rows[0]["external_id"] == "1419"
+        assert log_rows[0]["method"] == "exact_match"
+        # The COALESCE-merge brought the old row's Discogs ID along.
+        ids_row = await pg_source.fetchone(
+            "SELECT discogs_artist_id FROM entity.identity WHERE id = $1", surviving_id
+        )
+        assert ids_row is not None
+        assert ids_row["discogs_artist_id"] == 1419
+
+    @pytest.mark.asyncio
+    async def test_orphan_with_no_canonical_match_is_deleted(self, pg_source):
+        """Truly-removed artist: identity AND its log rows both go (no FK leak)."""
+        from scripts.entity_resolution.__main__ import prune_orphan_identities
+
+        store = EntityStore(pg_source)
+
+        gone = await store.upsert_identity(
+            library_name="BandThatLeftRotation", discogs_artist_id=999
+        )
+        assert gone is not None
+        await store.log_reconciliation(
+            identity_id=gone.id,
+            source="discogs",
+            external_id="999",
+            method="exact_match",
+        )
+
+        merged, deleted, orphans = await prune_orphan_identities(store, {"DifferentBand"})
+
+        assert merged == 0
+        assert deleted == 1
+        assert orphans == ["BandThatLeftRotation"]
+
+        # Identity row gone; reconciliation_log child cleaned up too — without
+        # this, the FK without ON DELETE CASCADE would have blocked the delete.
+        ids = await pg_source.fetchall(
+            "SELECT id FROM entity.identity WHERE library_name = $1",
+            "BandThatLeftRotation",
+        )
+        assert ids == []
+        log_rows = await pg_source.fetchall(
+            "SELECT identity_id FROM entity.reconciliation_log WHERE identity_id = $1",
+            gone.id,
+        )
+        assert log_rows == []
+
+    @pytest.mark.asyncio
+    async def test_threshold_aborts_without_mutation(self, pg_source):
+        """Past the drain threshold, the prune aborts and touches nothing.
+
+        A corrupted ``library.db`` (zero rows, or with most names missing)
+        would otherwise be interpreted as a giant rename and silently wipe
+        the accumulated provenance. The threshold makes that loud.
+        """
+        from scripts.entity_resolution.__main__ import (
+            OrphanDrainAbortError,
+            prune_orphan_identities,
+        )
+
+        store = EntityStore(pg_source)
+
+        # Seed 10 identities; the empty snapshot would orphan all 10.
+        for i in range(10):
+            await store.upsert_identity(library_name=f"orphan_{i}")
+
+        with pytest.raises(OrphanDrainAbortError):
+            await prune_orphan_identities(
+                store,
+                {"only_one"},
+                threshold_abs=5,
+                threshold_frac=0.01,
+            )
+
+        # Nothing mutated.
+        rows = await pg_source.fetchall("SELECT count(*) AS n FROM entity.identity")
+        assert rows[0]["n"] == 10
+
+    @pytest.mark.asyncio
+    async def test_diacritic_canonical_merge_with_canonical_fixture_artist(self, pg_source):
+        """Mirror the Beyonce → Beyoncé case using WXYC canonical fixture artist.
+
+        ``Nilüfer Yanya`` is the canonical diacritic-bearing fixture from
+        ``wxycCanonicalArtistNames`` (see WXYC org-level CLAUDE.md, "Example
+        Music Data"). Locks the orphan-pass behavior on a name we already
+        use as the diacritic test artist throughout this codebase.
+        """
+        from scripts.entity_resolution.__main__ import prune_orphan_identities
+
+        store = EntityStore(pg_source)
+
+        old = await store.upsert_identity(library_name="Nilufer Yanya", discogs_artist_id=5499521)
+        assert old is not None
+        await store.log_reconciliation(
+            identity_id=old.id, source="discogs", external_id="5499521", method="exact_match"
+        )
+        new = await store.upsert_identity(library_name="Nilüfer Yanya")
+        assert new is not None
+
+        merged, deleted, _ = await prune_orphan_identities(store, {"Nilüfer Yanya"})
+
+        assert (merged, deleted) == (1, 0)
+        rows = await pg_source.fetchall("SELECT library_name FROM entity.identity")
+        assert [r["library_name"] for r in rows] == ["Nilüfer Yanya"]
+        log_rows = await pg_source.fetchall("SELECT external_id FROM entity.reconciliation_log")
+        assert [r["external_id"] for r in log_rows] == ["5499521"]
+
+
+@pytest.mark.pg
 class TestDeduplicationIntegration:
     """Test deduplication against real PostgreSQL."""
 

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -409,22 +409,38 @@ class TestIdentityRouterEntityStoreUnavailable:
 
 @pytest.mark.pg
 class TestOrphanPass:
-    """Acceptance tests for LML#377: the orphan pass before seed_identities.
+    """Acceptance tests for LML#377: the orphan pass after seed_identities.
 
     The Beyonce → Beyoncé scenario is the motivating case in the issue body
     — these tests pin the contract: reconciliation_log provenance is either
     *preserved* (merge path) or *explicitly removed* (delete path), never
     silently abandoned under the new orphan row.
+
+    Production ordering: ``main()`` runs ``seed_identities(snapshot)`` first
+    (upserting a new empty row for every current artist name), then
+    ``prune_orphan_identities(snapshot)`` to merge or delete the names no
+    longer in the snapshot. These tests mirror that ordering so the merge
+    path's target row exists at the time of the merge call.
     """
 
     @pytest.mark.asyncio
-    async def test_orphan_with_canonical_match_merges_provenance(self, pg_source):
-        """Beyonce → Beyoncé: prior reconciliation_log preserved on the new row."""
-        from scripts.entity_resolution.__main__ import prune_orphan_identities
+    async def test_rename_preserves_provenance_via_merge(self, pg_source):
+        """Beyonce → Beyoncé: prior reconciliation_log preserved on the new row.
+
+        Mirrors the full production sequence: librarian had ``"Beyonce"``
+        reconciled; renames to ``"Beyoncé"`` in library.db. The next
+        reconciliation run calls ``seed_identities(["Beyoncé"])`` (adds an
+        empty new row) and then ``prune_orphan_identities({"Beyoncé"})``
+        which merges the orphan's provenance into the new row.
+        """
+        from scripts.entity_resolution.__main__ import (
+            prune_orphan_identities,
+            seed_identities,
+        )
 
         store = EntityStore(pg_source)
 
-        # Pre-orphan state: librarian had "Beyonce" with a reconciled Discogs ID.
+        # Pre-existing state: librarian had "Beyonce" with a reconciled Discogs ID.
         old = await store.upsert_identity(library_name="Beyonce", discogs_artist_id=1419)
         assert old is not None
         await store.log_reconciliation(
@@ -435,13 +451,10 @@ class TestOrphanPass:
             confidence=1.0,
         )
 
-        # Librarian renames to "Beyoncé". Pre-pass, both rows exist (the new
-        # one is empty; the orphan-pass has not yet run).
-        new = await store.upsert_identity(library_name="Beyoncé")
-        assert new is not None
-        assert new.id != old.id
-
-        merged, deleted, orphans = await prune_orphan_identities(store, {"Beyoncé"})
+        # Production flow: seed first (adds empty new row), then prune.
+        current_snapshot = ["Beyoncé"]
+        await seed_identities(store, current_snapshot)
+        merged, deleted, orphans = await prune_orphan_identities(store, set(current_snapshot))
 
         assert merged == 1
         assert deleted == 0
@@ -468,9 +481,17 @@ class TestOrphanPass:
         assert ids_row["discogs_artist_id"] == 1419
 
     @pytest.mark.asyncio
-    async def test_orphan_with_no_canonical_match_is_deleted(self, pg_source):
-        """Truly-removed artist: identity AND its log rows both go (no FK leak)."""
-        from scripts.entity_resolution.__main__ import prune_orphan_identities
+    async def test_removal_deletes_identity_and_logs(self, pg_source):
+        """Truly-removed artist: identity AND its log rows both go (no FK leak).
+
+        Librarian retires an artist from the library entirely (not a rename).
+        After seed_identities, the orphan has no canonical-form sibling in
+        the snapshot and falls through to hard delete.
+        """
+        from scripts.entity_resolution.__main__ import (
+            prune_orphan_identities,
+            seed_identities,
+        )
 
         store = EntityStore(pg_source)
 
@@ -485,7 +506,10 @@ class TestOrphanPass:
             method="exact_match",
         )
 
-        merged, deleted, orphans = await prune_orphan_identities(store, {"DifferentBand"})
+        # Production flow: seed the new snapshot, then prune the orphan.
+        current_snapshot = ["DifferentBand"]
+        await seed_identities(store, current_snapshot)
+        merged, deleted, orphans = await prune_orphan_identities(store, set(current_snapshot))
 
         assert merged == 0
         assert deleted == 1
@@ -503,6 +527,9 @@ class TestOrphanPass:
             gone.id,
         )
         assert log_rows == []
+        # "DifferentBand" (the surviving new entry) is still there.
+        survivors = await pg_source.fetchall("SELECT library_name FROM entity.identity")
+        assert [r["library_name"] for r in survivors] == ["DifferentBand"]
 
     @pytest.mark.asyncio
     async def test_threshold_aborts_without_mutation(self, pg_source):
@@ -537,14 +564,17 @@ class TestOrphanPass:
 
     @pytest.mark.asyncio
     async def test_diacritic_canonical_merge_with_canonical_fixture_artist(self, pg_source):
-        """Mirror the Beyonce → Beyoncé case using WXYC canonical fixture artist.
+        """Mirror the rename-merge case using WXYC canonical fixture artist.
 
         ``Nilüfer Yanya`` is the canonical diacritic-bearing fixture from
         ``wxycCanonicalArtistNames`` (see WXYC org-level CLAUDE.md, "Example
         Music Data"). Locks the orphan-pass behavior on a name we already
         use as the diacritic test artist throughout this codebase.
         """
-        from scripts.entity_resolution.__main__ import prune_orphan_identities
+        from scripts.entity_resolution.__main__ import (
+            prune_orphan_identities,
+            seed_identities,
+        )
 
         store = EntityStore(pg_source)
 
@@ -553,16 +583,53 @@ class TestOrphanPass:
         await store.log_reconciliation(
             identity_id=old.id, source="discogs", external_id="5499521", method="exact_match"
         )
-        new = await store.upsert_identity(library_name="Nilüfer Yanya")
-        assert new is not None
 
-        merged, deleted, _ = await prune_orphan_identities(store, {"Nilüfer Yanya"})
+        current_snapshot = ["Nilüfer Yanya"]
+        await seed_identities(store, current_snapshot)
+        merged, deleted, _ = await prune_orphan_identities(store, set(current_snapshot))
 
         assert (merged, deleted) == (1, 0)
         rows = await pg_source.fetchall("SELECT library_name FROM entity.identity")
         assert [r["library_name"] for r in rows] == ["Nilüfer Yanya"]
         log_rows = await pg_source.fetchall("SELECT external_id FROM entity.reconciliation_log")
         assert [r["external_id"] for r in log_rows] == ["5499521"]
+
+    @pytest.mark.asyncio
+    async def test_idempotent_on_re_run(self, pg_source):
+        """Second seed+prune over the same snapshot is a no-op.
+
+        After a successful rename merge, the next reconciliation run sees
+        ``stored_names == current_names`` and the orphan diff is empty — no
+        further merges, no further deletes, no reconciliation_log shuffling.
+        """
+        from scripts.entity_resolution.__main__ import (
+            prune_orphan_identities,
+            seed_identities,
+        )
+
+        store = EntityStore(pg_source)
+
+        old = await store.upsert_identity(library_name="Beyonce", discogs_artist_id=1419)
+        assert old is not None
+        await store.log_reconciliation(
+            identity_id=old.id, source="discogs", external_id="1419", method="exact_match"
+        )
+
+        snapshot = ["Beyoncé"]
+        # Run 1: the rename merge.
+        await seed_identities(store, snapshot)
+        m1, d1, _ = await prune_orphan_identities(store, set(snapshot))
+        assert (m1, d1) == (1, 0)
+
+        # Run 2 over the same snapshot: nothing to do.
+        await seed_identities(store, snapshot)
+        m2, d2, orphans = await prune_orphan_identities(store, set(snapshot))
+        assert (m2, d2, orphans) == (0, 0, [])
+
+        rows = await pg_source.fetchall("SELECT library_name FROM entity.identity")
+        assert [r["library_name"] for r in rows] == ["Beyoncé"]
+        log_rows = await pg_source.fetchall("SELECT count(*) AS n FROM entity.reconciliation_log")
+        assert log_rows[0]["n"] == 1
 
 
 @pytest.mark.pg

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -16,6 +16,11 @@ import asyncpg
 import pytest
 import pytest_asyncio
 
+from scripts.entity_resolution.__main__ import (
+    OrphanDrainAbortError,
+    prune_orphan_identities,
+    seed_identities,
+)
 from scripts.entity_resolution.dedup import EntityDeduplicator
 from scripts.entity_resolution.discogs import DiscogsReconciler
 from scripts.entity_resolution.sources import PgSource
@@ -433,10 +438,6 @@ class TestOrphanPass:
         empty new row) and then ``prune_orphan_identities({"Beyoncé"})``
         which merges the orphan's provenance into the new row.
         """
-        from scripts.entity_resolution.__main__ import (
-            prune_orphan_identities,
-            seed_identities,
-        )
 
         store = EntityStore(pg_source)
 
@@ -488,10 +489,6 @@ class TestOrphanPass:
         After seed_identities, the orphan has no canonical-form sibling in
         the snapshot and falls through to hard delete.
         """
-        from scripts.entity_resolution.__main__ import (
-            prune_orphan_identities,
-            seed_identities,
-        )
 
         store = EntityStore(pg_source)
 
@@ -539,10 +536,6 @@ class TestOrphanPass:
         would otherwise be interpreted as a giant rename and silently wipe
         the accumulated provenance. The threshold makes that loud.
         """
-        from scripts.entity_resolution.__main__ import (
-            OrphanDrainAbortError,
-            prune_orphan_identities,
-        )
 
         store = EntityStore(pg_source)
 
@@ -571,10 +564,6 @@ class TestOrphanPass:
         Music Data"). Locks the orphan-pass behavior on a name we already
         use as the diacritic test artist throughout this codebase.
         """
-        from scripts.entity_resolution.__main__ import (
-            prune_orphan_identities,
-            seed_identities,
-        )
 
         store = EntityStore(pg_source)
 
@@ -602,10 +591,6 @@ class TestOrphanPass:
         ``stored_names == current_names`` and the orphan diff is empty — no
         further merges, no further deletes, no reconciliation_log shuffling.
         """
-        from scripts.entity_resolution.__main__ import (
-            prune_orphan_identities,
-            seed_identities,
-        )
 
         store = EntityStore(pg_source)
 

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -584,6 +584,51 @@ class TestOrphanPass:
         assert [r["external_id"] for r in log_rows] == ["5499521"]
 
     @pytest.mark.asyncio
+    async def test_merge_carries_wikidata_qid_and_reconciled_status(self, pg_source):
+        """Orphan's Wikidata QID + reconciled status survive the rename merge.
+
+        Regression pin for the bug surfaced by /review-loop: a librarian's
+        rename ("Beyonce" → "Beyoncé") on a row that the Wikidata bridge had
+        already populated would silently drop the QID and leave the merged
+        row's reconciliation_status at the freshly-seeded default of
+        'unreconciled'. Both losses defeat the orphan-pass's whole point
+        (provenance preservation) and trigger wasted re-fetches on the next
+        reconciliation pass.
+        """
+        store = EntityStore(pg_source)
+
+        # Pre-existing fully-reconciled orphan: Discogs ID, Wikidata QID,
+        # status='reconciled', and a log row.
+        old = await store.upsert_identity(
+            library_name="Beyonce",
+            discogs_artist_id=1419,
+            wikidata_qid="Q36153",
+        )
+        assert old is not None
+        await store.update_status(old.id, "reconciled")
+        await store.log_reconciliation(
+            identity_id=old.id,
+            source="wikidata",
+            external_id="Q36153",
+            method="discogs_bridge",
+        )
+
+        await seed_identities(store, ["Beyoncé"])
+        merged, deleted, _ = await prune_orphan_identities(store, {"Beyoncé"})
+        assert (merged, deleted) == (1, 0)
+
+        # Surviving row carries the QID + reconciled status.
+        rows = await pg_source.fetchall(
+            "SELECT library_name, discogs_artist_id, wikidata_qid, reconciliation_status "
+            "FROM entity.identity"
+        )
+        assert len(rows) == 1
+        assert rows[0]["library_name"] == "Beyoncé"
+        assert rows[0]["discogs_artist_id"] == 1419
+        assert rows[0]["wikidata_qid"] == "Q36153"
+        assert rows[0]["reconciliation_status"] == "reconciled"
+
+    @pytest.mark.asyncio
     async def test_idempotent_on_re_run(self, pg_source):
         """Second seed+prune over the same snapshot is a no-op.
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,6 +70,34 @@ def make_mock_conn():
 
 
 @pytest.fixture
+def mock_pg_tx():
+    """Mock PgSource exposing pool-level methods plus ``acquire()`` for transactions.
+
+    Used by tests of store methods that wrap multi-statement work in
+    ``async with pg.acquire() as conn, conn.transaction()`` — including
+    ``EntityDeduplicator.merge_group`` and the LML#377 orphan-pass primitives
+    (`delete_identity_by_library_name`, `merge_identity_by_library_name`).
+    Tests inspect ``mock_pg_tx._mock_conn`` for assertions about which
+    queries ran inside the transaction.
+    """
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetchone = AsyncMock(return_value=None)
+    pg.execute = AsyncMock(return_value="OK")
+
+    conn = make_mock_conn()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.execute = AsyncMock(return_value="OK")
+
+    acq_ctx = MagicMock()
+    acq_ctx.__aenter__ = AsyncMock(return_value=conn)
+    acq_ctx.__aexit__ = AsyncMock(return_value=False)
+    pg.acquire = MagicMock(return_value=acq_ctx)
+    pg._mock_conn = conn
+    return pg
+
+
+@pytest.fixture
 def mock_asyncpg_pool():
     """AsyncMock mimicking asyncpg.Pool."""
     pool = AsyncMock()

--- a/tests/unit/test_entity_resolution_orphan.py
+++ b/tests/unit/test_entity_resolution_orphan.py
@@ -1,0 +1,180 @@
+"""Unit tests for ``prune_orphan_identities`` (LML#377).
+
+Mock-store layer: verifies the orphan-diff logic, the canonical-form merge
+target lookup, the threshold guard, and the merge-vs-delete branching.
+The transactional store primitives (`merge_identity_by_library_name`,
+`delete_identity_by_library_name`) are exercised against real PG in
+``tests/integration/test_entity_resolution.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.entity_resolution.__main__ import (
+    OrphanDrainAbortError,
+    prune_orphan_identities,
+)
+from scripts.entity_resolution.store import Identity
+
+
+@pytest.fixture
+def mock_store():
+    """Mock EntityStore with the three orphan-pass methods stubbed."""
+    store = AsyncMock()
+    store.fetch_all_identity_library_names = AsyncMock(return_value=set())
+    store.get_identity = AsyncMock(return_value=None)
+    store.merge_identity_by_library_name = AsyncMock(return_value=True)
+    store.delete_identity_by_library_name = AsyncMock(return_value=0)
+    return store
+
+
+class TestPruneOrphanIdentities:
+    @pytest.mark.asyncio
+    async def test_no_orphans_returns_zeros(self, mock_store):
+        """When the snapshot covers every stored name, no work happens."""
+        mock_store.fetch_all_identity_library_names = AsyncMock(
+            return_value={"Stereolab", "Autechre"}
+        )
+        merged, deleted, orphans = await prune_orphan_identities(
+            mock_store, {"Stereolab", "Autechre"}
+        )
+        assert (merged, deleted, orphans) == (0, 0, [])
+        mock_store.merge_identity_by_library_name.assert_not_called()
+        mock_store.delete_identity_by_library_name.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_merges_when_canonical_matches_single_current_name(self, mock_store):
+        """Beyonce → Beyoncé: canonical forms match, merge preserves provenance.
+
+        Both names canonicalize to ``"beyonce"`` (diacritic stripped). Since
+        only one current name maps to that canonical form, the orphan merges
+        into it.
+        """
+        mock_store.fetch_all_identity_library_names = AsyncMock(
+            return_value={"Beyonce", "Stereolab"}
+        )
+        mock_store.get_identity = AsyncMock(return_value=Identity(id=42, library_name="Beyoncé"))
+        mock_store.merge_identity_by_library_name = AsyncMock(return_value=True)
+
+        merged, deleted, orphans = await prune_orphan_identities(
+            mock_store, {"Beyoncé", "Stereolab"}
+        )
+
+        assert merged == 1
+        assert deleted == 0
+        assert orphans == ["Beyonce"]
+        mock_store.merge_identity_by_library_name.assert_awaited_once_with(
+            from_name="Beyonce", into_id=42
+        )
+        mock_store.delete_identity_by_library_name.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deletes_when_canonical_has_no_current_match(self, mock_store):
+        """Orphan with no canonical-form sibling in the snapshot → hard delete."""
+        mock_store.fetch_all_identity_library_names = AsyncMock(
+            return_value={"BandThatLeftRotation", "Stereolab"}
+        )
+        mock_store.delete_identity_by_library_name = AsyncMock(return_value=2)
+
+        merged, deleted, orphans = await prune_orphan_identities(
+            mock_store, {"Stereolab", "Autechre"}
+        )
+
+        assert merged == 0
+        assert deleted == 1
+        assert orphans == ["BandThatLeftRotation"]
+        mock_store.delete_identity_by_library_name.assert_awaited_once_with("BandThatLeftRotation")
+        mock_store.merge_identity_by_library_name.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_through_to_delete_on_canonical_collision(self, mock_store):
+        """Multiple current names share the orphan's canonical form → delete (no guess).
+
+        Two different librarians both canonicalize to the same form. The
+        orphan pass refuses to guess which one should win and falls through
+        to delete + WARNING log.
+        """
+        mock_store.fetch_all_identity_library_names = AsyncMock(return_value={"The Band"})
+
+        # "The Band", "the band", "Band, The" all canonicalize to "band"
+        # (leading-article strip + lowercase). Both current names collide.
+        merged, deleted, _ = await prune_orphan_identities(mock_store, {"the band", "Band, The"})
+
+        assert merged == 0
+        assert deleted == 1
+        mock_store.merge_identity_by_library_name.assert_not_called()
+        mock_store.delete_identity_by_library_name.assert_awaited_once_with("The Band")
+
+    @pytest.mark.asyncio
+    async def test_threshold_abort_raises_when_orphans_exceed_threshold(self, mock_store):
+        """Past max(abs, frac*snapshot), prune refuses to run.
+
+        With current=1 and 10 orphans, threshold = max(100, 0.1*1) = 100 →
+        not crossed. Lower threshold_abs to force the abort path on a
+        small set.
+        """
+        mock_store.fetch_all_identity_library_names = AsyncMock(
+            return_value={f"orphan_{i}" for i in range(50)}
+        )
+
+        with pytest.raises(OrphanDrainAbortError, match="50 orphans exceeds threshold"):
+            await prune_orphan_identities(
+                mock_store,
+                {"only_one"},
+                threshold_abs=5,
+                threshold_frac=0.01,
+            )
+
+        # Guard fires before any mutation.
+        mock_store.merge_identity_by_library_name.assert_not_called()
+        mock_store.delete_identity_by_library_name.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_threshold_bypass_allows_drain(self, mock_store):
+        """``allow_orphan_drain=True`` skips the guard and proceeds with the prune."""
+        mock_store.fetch_all_identity_library_names = AsyncMock(
+            return_value={f"orphan_{i}" for i in range(50)}
+        )
+
+        merged, deleted, orphans = await prune_orphan_identities(
+            mock_store,
+            {"only_one"},
+            allow_orphan_drain=True,
+            threshold_abs=5,
+        )
+
+        assert merged == 0
+        assert deleted == 50
+        assert len(orphans) == 50
+        assert mock_store.delete_identity_by_library_name.await_count == 50
+
+    @pytest.mark.asyncio
+    async def test_merge_returning_false_skips_delete(self, mock_store):
+        """If merge_identity_by_library_name returns False, do NOT delete.
+
+        Returning False means the orphan row was already gone (concurrent
+        run, or already merged on a previous pass). The orphan pass must
+        not fall through to delete — the canonical target would be the
+        thing it touches, which is exactly wrong.
+        """
+        mock_store.fetch_all_identity_library_names = AsyncMock(return_value={"Beyonce"})
+        mock_store.get_identity = AsyncMock(return_value=Identity(id=42, library_name="Beyoncé"))
+        mock_store.merge_identity_by_library_name = AsyncMock(return_value=False)
+
+        merged, deleted, _ = await prune_orphan_identities(mock_store, {"Beyoncé"})
+
+        assert merged == 0
+        assert deleted == 0
+        mock_store.delete_identity_by_library_name.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_orphans_sorted_for_determinism(self, mock_store):
+        """Orphan list is sorted so log output and threshold-sample are stable."""
+        mock_store.fetch_all_identity_library_names = AsyncMock(
+            return_value={"Zeta", "Alpha", "Mu"}
+        )
+        _, _, orphans = await prune_orphan_identities(mock_store, set())
+        assert orphans == ["Alpha", "Mu", "Zeta"]

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -1,6 +1,6 @@
 """Unit tests for entity store CRUD operations."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -9,7 +9,6 @@ from scripts.entity_resolution.store import (
     EntityStore,
     _strip_nul,
 )
-from tests.unit.conftest import make_mock_conn
 
 
 class TestStripNul:
@@ -52,34 +51,12 @@ def store(mock_pg):
 
 
 @pytest.fixture
-def mock_pg_tx():
-    """Mock PgSource exposing both pool-level methods and ``acquire()`` for transactions.
-
-    Mirrors the pattern in ``test_entity_dedup.py``: the orphan-pass primitives
-    (`delete_identity_by_library_name`, `merge_identity_by_library_name`) use
-    ``async with pg.acquire() as conn, conn.transaction()`` and run multiple
-    statements on the same connection. Tests inspect ``mock_pg_tx._mock_conn``
-    for assertions about which queries ran inside the transaction.
-    """
-    pg = AsyncMock()
-    pg.fetchall = AsyncMock(return_value=[])
-    pg.fetchone = AsyncMock(return_value=None)
-    pg.execute = AsyncMock(return_value="DELETE 0")
-
-    conn = make_mock_conn()
-    conn.fetchrow = AsyncMock(return_value=None)
-    conn.execute = AsyncMock(return_value="DELETE 0")
-
-    acq_ctx = MagicMock()
-    acq_ctx.__aenter__ = AsyncMock(return_value=conn)
-    acq_ctx.__aexit__ = AsyncMock(return_value=False)
-    pg.acquire = MagicMock(return_value=acq_ctx)
-    pg._mock_conn = conn
-    return pg
-
-
-@pytest.fixture
 def store_tx(mock_pg_tx):
+    """EntityStore wired to the shared transactional mock-pg fixture.
+
+    ``mock_pg_tx`` lives in ``tests/unit/conftest.py`` so it's reusable across
+    tests of any store method that runs ``acquire() + conn.transaction()``.
+    """
     return EntityStore(mock_pg_tx)
 
 

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -1,6 +1,6 @@
 """Unit tests for entity store CRUD operations."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -9,6 +9,7 @@ from scripts.entity_resolution.store import (
     EntityStore,
     _strip_nul,
 )
+from tests.unit.conftest import make_mock_conn
 
 
 class TestStripNul:
@@ -48,6 +49,38 @@ def mock_pg():
 @pytest.fixture
 def store(mock_pg):
     return EntityStore(mock_pg)
+
+
+@pytest.fixture
+def mock_pg_tx():
+    """Mock PgSource exposing both pool-level methods and ``acquire()`` for transactions.
+
+    Mirrors the pattern in ``test_entity_dedup.py``: the orphan-pass primitives
+    (`delete_identity_by_library_name`, `merge_identity_by_library_name`) use
+    ``async with pg.acquire() as conn, conn.transaction()`` and run multiple
+    statements on the same connection. Tests inspect ``mock_pg_tx._mock_conn``
+    for assertions about which queries ran inside the transaction.
+    """
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetchone = AsyncMock(return_value=None)
+    pg.execute = AsyncMock(return_value="DELETE 0")
+
+    conn = make_mock_conn()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.execute = AsyncMock(return_value="DELETE 0")
+
+    acq_ctx = MagicMock()
+    acq_ctx.__aenter__ = AsyncMock(return_value=conn)
+    acq_ctx.__aexit__ = AsyncMock(return_value=False)
+    pg.acquire = MagicMock(return_value=acq_ctx)
+    pg._mock_conn = conn
+    return pg
+
+
+@pytest.fixture
+def store_tx(mock_pg_tx):
+    return EntityStore(mock_pg_tx)
 
 
 class TestUpsertIdentity:
@@ -390,3 +423,203 @@ class TestGetIdentitiesByStatus:
         mock_pg.fetchall = AsyncMock(return_value=[])
         identities = await store.get_identities_by_status("reconciled")
         assert identities == []
+
+
+class TestFetchAllIdentityLibraryNames:
+    """LML#377 orphan-pass primitive: set of every stored library_name."""
+
+    @pytest.mark.asyncio
+    async def test_returns_set_of_names(self, store, mock_pg):
+        mock_pg.fetchall = AsyncMock(
+            return_value=[
+                {"library_name": "Stereolab"},
+                {"library_name": "Autechre"},
+                {"library_name": "Nilüfer Yanya"},
+            ]
+        )
+        names = await store.fetch_all_identity_library_names()
+        assert names == {"Stereolab", "Autechre", "Nilüfer Yanya"}
+        # Set type matters: callers do O(N) set-difference, not list scans.
+        assert isinstance(names, set)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_set_when_table_empty(self, store, mock_pg):
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        names = await store.fetch_all_identity_library_names()
+        assert names == set()
+
+
+class TestDeleteIdentityByLibraryName:
+    """LML#377 orphan-pass primitive: hard DELETE with log-row cleanup.
+
+    `entity.reconciliation_log.identity_id` has no ON DELETE CASCADE, so the
+    method must remove log rows first, then the identity row, both inside a
+    single transaction.
+    """
+
+    @pytest.mark.asyncio
+    async def test_deletes_log_rows_before_identity(self, store_tx, mock_pg_tx):
+        """Log DELETE precedes identity DELETE; both run on the acquired conn."""
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(return_value={"id": 42, "library_name": "Beyonce"})
+        conn.execute = AsyncMock(side_effect=["DELETE 3", "DELETE 1"])
+
+        log_rows_deleted = await store_tx.delete_identity_by_library_name("Beyonce")
+
+        assert log_rows_deleted == 3
+        # Two execute calls — log delete first, then identity delete.
+        assert conn.execute.await_count == 2
+        first_sql = conn.execute.await_args_list[0][0][0]
+        second_sql = conn.execute.await_args_list[1][0][0]
+        assert "DELETE FROM entity.reconciliation_log" in first_sql
+        assert "DELETE FROM entity.identity" in second_sql
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_identity_missing(self, store_tx, mock_pg_tx):
+        """fetchrow returns None → no DELETEs issued, return 0."""
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(return_value=None)
+
+        log_rows_deleted = await store_tx.delete_identity_by_library_name("Nonexistent")
+
+        assert log_rows_deleted == 0
+        conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_in_single_transaction(self, store_tx, mock_pg_tx):
+        """One acquire(), one transaction(), all statements on the same conn."""
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(return_value={"id": 1, "library_name": "X"})
+        conn.execute = AsyncMock(return_value="DELETE 0")
+
+        await store_tx.delete_identity_by_library_name("X")
+
+        mock_pg_tx.acquire.assert_called_once()
+        conn.transaction.assert_called_once()
+        conn._mock_tx_ctx.__aenter__.assert_awaited_once()
+        conn._mock_tx_ctx.__aexit__.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_strips_nul_from_input(self, store_tx, mock_pg_tx):
+        """U+0000 in input is stripped before the lookup query."""
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(return_value=None)
+
+        await store_tx.delete_identity_by_library_name("Bey\x00once")
+
+        bind_arg = conn.fetchrow.await_args_list[0][0][1]
+        assert bind_arg == "Beyonce"
+
+
+class TestMergeIdentityByLibraryName:
+    """LML#377 orphan-pass primitive: merge an orphan into a canonical row.
+
+    Preserves accumulated reconciliation_log provenance across renames like
+    ``"Beyonce"`` → ``"Beyoncé"``. Adapted from `EntityDeduplicator.merge_group`;
+    same UPDATE-then-reassign-then-DELETE shape inside a single transaction.
+    """
+
+    @pytest.mark.asyncio
+    async def test_merges_external_ids_then_reassigns_logs_then_deletes(self, store_tx, mock_pg_tx):
+        """The from row's external IDs land on the into row; log rows move; from row gone."""
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "id": 17,
+                "library_name": "Beyonce",
+                "discogs_artist_id": 1419,
+                "wikidata_qid": None,
+                "musicbrainz_artist_id": "mbid-1",
+                "spotify_artist_id": "spotify-1",
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "reconciled",
+            }
+        )
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+
+        merged = await store_tx.merge_identity_by_library_name(from_name="Beyonce", into_id=42)
+
+        assert merged is True
+        # Three execute calls: UPDATE merged, REASSIGN logs, DELETE from row.
+        assert conn.execute.await_count == 3
+        update_sql = conn.execute.await_args_list[0][0][0]
+        reassign_sql = conn.execute.await_args_list[1][0][0]
+        delete_sql = conn.execute.await_args_list[2][0][0]
+        assert "UPDATE entity.identity" in update_sql
+        assert "COALESCE" in update_sql
+        assert "UPDATE entity.reconciliation_log" in reassign_sql
+        assert "DELETE FROM entity.identity" in delete_sql
+
+        # UPDATE binds into_id first, then the from row's external IDs.
+        update_args = conn.execute.await_args_list[0][0]
+        assert update_args[1] == 42  # into_id
+        assert update_args[2] == 1419  # discogs_artist_id from the orphan
+        assert update_args[3] == "mbid-1"
+        assert update_args[4] == "spotify-1"
+
+        # REASSIGN binds (new_id, old_id).
+        reassign_args = conn.execute.await_args_list[1][0]
+        assert reassign_args[1] == 42  # into_id (new)
+        assert reassign_args[2] == 17  # from_id (old)
+
+        # DELETE targets the from row's id.
+        delete_args = conn.execute.await_args_list[2][0]
+        assert delete_args[1] == 17
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_from_name_missing(self, store_tx, mock_pg_tx):
+        """fetchrow None → no merge, return False, no executes."""
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(return_value=None)
+
+        merged = await store_tx.merge_identity_by_library_name(from_name="Nonexistent", into_id=42)
+
+        assert merged is False
+        conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_when_from_equals_into(self, store_tx, mock_pg_tx):
+        """If from_name's id equals into_id, no-op (return False) — re-invocation safe."""
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "id": 42,
+                "library_name": "X",
+                "discogs_artist_id": None,
+                "wikidata_qid": None,
+                "musicbrainz_artist_id": None,
+                "spotify_artist_id": None,
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "reconciled",
+            }
+        )
+
+        merged = await store_tx.merge_identity_by_library_name(from_name="X", into_id=42)
+
+        assert merged is False
+        conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_in_single_transaction(self, store_tx, mock_pg_tx):
+        """Three statements all on the same conn under one transaction."""
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "id": 1,
+                "library_name": "X",
+                "discogs_artist_id": 99,
+                "wikidata_qid": None,
+                "musicbrainz_artist_id": None,
+                "spotify_artist_id": None,
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "reconciled",
+            }
+        )
+
+        await store_tx.merge_identity_by_library_name(from_name="X", into_id=2)
+
+        mock_pg_tx.acquire.assert_called_once()
+        conn.transaction.assert_called_once()

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -497,8 +497,8 @@ class TestMergeIdentityByLibraryName:
     """
 
     @pytest.mark.asyncio
-    async def test_merges_external_ids_then_reassigns_logs_then_deletes(self, store_tx, mock_pg_tx):
-        """The from row's external IDs land on the into row; log rows move; from row gone."""
+    async def test_unreconciled_orphan_merges_without_status_upgrade(self, store_tx, mock_pg_tx):
+        """Orphan with status=unreconciled: 3 executes (no status upgrade)."""
         conn = mock_pg_tx._mock_conn
         conn.fetchrow = AsyncMock(
             return_value={
@@ -506,6 +506,68 @@ class TestMergeIdentityByLibraryName:
                 "library_name": "Beyonce",
                 "discogs_artist_id": 1419,
                 "wikidata_qid": None,
+                "musicbrainz_artist_id": "mbid-1",
+                "spotify_artist_id": "spotify-1",
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "unreconciled",
+            }
+        )
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+
+        merged = await store_tx.merge_identity_by_library_name(from_name="Beyonce", into_id=42)
+
+        assert merged is True
+        # Three execute calls: UPDATE merged, REASSIGN logs, DELETE from row.
+        # No status upgrade because the orphan was unreconciled.
+        assert conn.execute.await_count == 3
+        update_sql = conn.execute.await_args_list[0][0][0]
+        reassign_sql = conn.execute.await_args_list[1][0][0]
+        delete_sql = conn.execute.await_args_list[2][0][0]
+        assert "UPDATE entity.identity" in update_sql
+        assert "COALESCE" in update_sql
+        assert "UPDATE entity.reconciliation_log" in reassign_sql
+        assert "DELETE FROM entity.identity" in delete_sql
+
+        # UPDATE binds into_id first, then the from row's external IDs + QID.
+        update_args = conn.execute.await_args_list[0][0]
+        assert update_args[1] == 42  # into_id
+        assert update_args[2] == 1419  # discogs_artist_id from the orphan
+        assert update_args[3] == "mbid-1"
+        assert update_args[4] == "spotify-1"
+        assert update_args[5] is None  # apple_music_artist_id
+        assert update_args[6] is None  # bandcamp_id
+        assert update_args[7] is None  # wikidata_qid
+
+        # REASSIGN binds (new_id, old_id).
+        reassign_args = conn.execute.await_args_list[1][0]
+        assert reassign_args[1] == 42  # into_id (new)
+        assert reassign_args[2] == 17  # from_id (old)
+
+        # DELETE targets the from row's id.
+        delete_args = conn.execute.await_args_list[2][0]
+        assert delete_args[1] == 17
+
+    @pytest.mark.asyncio
+    async def test_reconciled_orphan_upgrades_target_status_and_carries_qid(
+        self, store_tx, mock_pg_tx
+    ):
+        """Orphan with status=reconciled + wikidata_qid: target gets both via merge.
+
+        Locks the LML#377 contract that the orphan-pass merge carries the
+        Wikidata QID and the reconciliation status across, not just the
+        non-QID external IDs. Without this, a "Beyonce" → "Beyoncé" rename
+        would silently drop the QID (set by the Wikidata bridge) and leave
+        the freshly-seeded target row at status='unreconciled', which would
+        trigger a wasted re-fetch on the next reconciliation pass.
+        """
+        conn = mock_pg_tx._mock_conn
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "id": 17,
+                "library_name": "Beyonce",
+                "discogs_artist_id": 1419,
+                "wikidata_qid": "Q36153",
                 "musicbrainz_artist_id": "mbid-1",
                 "spotify_artist_id": "spotify-1",
                 "apple_music_artist_id": None,
@@ -518,31 +580,21 @@ class TestMergeIdentityByLibraryName:
         merged = await store_tx.merge_identity_by_library_name(from_name="Beyonce", into_id=42)
 
         assert merged is True
-        # Three execute calls: UPDATE merged, REASSIGN logs, DELETE from row.
-        assert conn.execute.await_count == 3
-        update_sql = conn.execute.await_args_list[0][0][0]
-        reassign_sql = conn.execute.await_args_list[1][0][0]
-        delete_sql = conn.execute.await_args_list[2][0][0]
-        assert "UPDATE entity.identity" in update_sql
-        assert "COALESCE" in update_sql
-        assert "UPDATE entity.reconciliation_log" in reassign_sql
-        assert "DELETE FROM entity.identity" in delete_sql
+        # Four execute calls: UPDATE merged, UPDATE status, REASSIGN logs, DELETE.
+        assert conn.execute.await_count == 4
+        update_merged_args = conn.execute.await_args_list[0][0]
+        update_status_args = conn.execute.await_args_list[1][0]
 
-        # UPDATE binds into_id first, then the from row's external IDs.
-        update_args = conn.execute.await_args_list[0][0]
-        assert update_args[1] == 42  # into_id
-        assert update_args[2] == 1419  # discogs_artist_id from the orphan
-        assert update_args[3] == "mbid-1"
-        assert update_args[4] == "spotify-1"
+        # _UPDATE_MERGED_SQL carries the QID at $7.
+        assert update_merged_args[1] == 42  # into_id
+        assert update_merged_args[7] == "Q36153"
+        assert "wikidata_qid" in update_merged_args[0]
 
-        # REASSIGN binds (new_id, old_id).
-        reassign_args = conn.execute.await_args_list[1][0]
-        assert reassign_args[1] == 42  # into_id (new)
-        assert reassign_args[2] == 17  # from_id (old)
-
-        # DELETE targets the from row's id.
-        delete_args = conn.execute.await_args_list[2][0]
-        assert delete_args[1] == 17
+        # _UPDATE_STATUS_SQL is called with (into_id, 'reconciled').
+        assert "UPDATE entity.identity" in update_status_args[0]
+        assert "reconciliation_status" in update_status_args[0]
+        assert update_status_args[1] == 42
+        assert update_status_args[2] == "reconciled"
 
     @pytest.mark.asyncio
     async def test_no_op_when_from_name_missing(self, store_tx, mock_pg_tx):


### PR DESCRIPTION
## Summary

- Adds a post-seed orphan pass to `scripts/entity_resolution/__main__.py` that diffs stored `entity.identity.library_name` values against the current `library.db` snapshot, then either **merges** the orphan into a canonical-form match (preserving accumulated `reconciliation_log` provenance) or **hard-deletes** it (with FK-safe log cleanup) when no canonical match exists.
- Drain-safety threshold (default `max(100, 10% * snapshot)`) raises `OrphanDrainAbortError` before any mutation if the orphan count looks like a corrupted `library.db` rather than legitimate librarian edits. `--allow-orphan-drain` bypasses for authorized one-shot bulk renames.
- Three new `EntityStore` methods (`fetch_all_identity_library_names`, `delete_identity_by_library_name`, `merge_identity_by_library_name`) carry the transactional primitives. The shared merge/delete SQL constants are hoisted from `dedup.py` into `store.py` so dedup and the orphan pass share one source of truth.

## Motivation

`seed_identities` was additive-only. When a librarian renamed `"Beyonce"` to `"Beyoncé"`, the next reconciliation run upserted a fresh `entity.identity` row keyed on the new name while the old row kept every `reconciliation_log` entry (Discogs ID, MBID, Spotify ID) under a `library_name` that `bulk-resolve-libraries` would never query again. Hours of accumulated reconciliation work were silently abandoned with each rename.

The canonical-form-merge path (rather than the hard-delete-only path acceptance allowed) preserves that provenance: `canonicalize_for_identity_lookup(\"Beyonce\")` and `canonicalize_for_identity_lookup(\"Beyoncé\")` agree, so the merge re-points the log rows + COALESCEs the external IDs onto the surviving (new-name) row. Collisions and missing targets fall through to delete with a WARNING log rather than guessing.

## Ordering note

The pass runs **after** `seed_identities`. `seed` first upserts an empty row for the new name; the orphan pass then merges the old row's provenance INTO it. The two commits in this PR walk the design: the first lands the pass; the second corrects the ordering after a pre-PR review caught that running the pass **before** seed would leave `get_identity(new_name)` returning `None` and every rename would silently fall through to hard-delete.

Closes #377.

## Test plan

- [x] \`pytest tests/unit/test_entity_store.py tests/unit/test_entity_dedup.py tests/unit/test_entity_resolution_orphan.py\` — 44/44 green (mock-store layer).
- [x] \`pytest -m pg tests/integration/test_entity_resolution.py::TestOrphanPass\` — 5/5 green against local Postgres on :5433. Covers:
  - \`test_rename_preserves_provenance_via_merge\` — Beyonce → Beyoncé; mirrors production seed-then-prune ordering.
  - \`test_removal_deletes_identity_and_logs\` — FK-safe cascade-less delete.
  - \`test_threshold_aborts_without_mutation\` — drain guard fires; nothing mutates.
  - \`test_diacritic_canonical_merge_with_canonical_fixture_artist\` — Nilüfer Yanya canonical fixture artist.
  - \`test_idempotent_on_re_run\` — second seed+prune over the same snapshot is a no-op.
- [x] \`ruff check\` + \`ruff format --check\` clean on touched files.
- [x] \`mypy scripts/entity_resolution/\` clean.

Pre-existing \`tests/unit/test_matching.py\` failures (\`wxyc-etl\` 0.5.0 expectations vs. the pre-0.5.0 wheel installed in this worktree's venv) are unrelated to this PR and exist on \`main\`.

## Related

- Sibling issue #385 (V/A guard on the same \`seed_identities\` function). Neither blocks the other; whichever lands first imposes a trivial rebase on the other.