### PR TITLE
fix(entity_resolution): V/A guard on seed_identities (LML#385)

### DIFF
--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -28,6 +28,7 @@ import sys
 
 import aiosqlite
 from dotenv import load_dotenv
+from wxyc_etl.text import is_compilation_artist
 
 from scripts.entity_resolution.dedup import EntityDeduplicator
 from scripts.entity_resolution.discogs import DiscogsReconciler
@@ -196,12 +197,24 @@ async def prune_orphan_identities(
 
 
 async def seed_identities(store: EntityStore, artists: list[str]) -> int:
-    """Seed entity.identity with library artist names. Returns count of new rows."""
+    """Seed entity.identity with library artist names. Returns count of new rows.
+
+    Skips ``is_compilation_artist`` matches (V/A bucket entries like
+    ``"Various Artists - Rock - A"`` and ``"Soundtracks - C"``) — these are
+    filed by the catalog librarian for shelf navigation, not real artists,
+    and must not enter the identity store. See LML#385; sibling of the
+    live-writeback guard in LML#379.
+    """
     seeded = 0
+    skipped_compilation = 0
     for artist in artists:
+        if is_compilation_artist(artist):
+            skipped_compilation += 1
+            continue
         result = await store.upsert_identity(library_name=artist)
         if result is not None:
             seeded += 1
+    logger.info("seed.skipped_compilation count=%d", skipped_compilation)
     return seeded
 
 

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -663,6 +663,57 @@ class TestOrphanPass:
 
 
 @pytest.mark.pg
+class TestSeedIdentitiesCompilationGuard:
+    """Acceptance tests for LML#385: V/A filings never enter entity.identity.
+
+    The audit on LML#379 found 67 polluted rows in prod ``entity.identity``
+    seeded by prior runs of this function. The guard adds an
+    ``is_compilation_artist`` check inside the upsert loop; these PG-backed
+    tests pin the contract end-to-end.
+    """
+
+    @pytest.mark.asyncio
+    async def test_seed_skips_v_a_rows_in_pg(self, pg_source):
+        """V/A bucket entries from the librarian's shelf-navigation filings stay out."""
+        store = EntityStore(pg_source)
+        snapshot = [
+            "Various Artists - Soundtracks",
+            "Soundtracks - A",
+            "V/A - Rock - C",
+            "Juana Molina",
+        ]
+
+        await seed_identities(store, snapshot)
+
+        rows = await pg_source.fetchall(
+            "SELECT library_name FROM entity.identity ORDER BY library_name"
+        )
+        assert [r["library_name"] for r in rows] == ["Juana Molina"]
+
+    @pytest.mark.asyncio
+    async def test_seed_preserves_real_artists_with_v_a_lookalikes(self, pg_source):
+        """The wxyc-etl 0.5.0 keep-set: anchored matcher must not trip on real artists.
+
+        ``Epic Soundtracks`` (Swell Maps drummer) and ``The 27 Various``
+        (Minneapolis indie band) end in / contain the V/A token but are not
+        V/A filings. They must seed successfully.
+        """
+        store = EntityStore(pg_source)
+        snapshot = ["Epic Soundtracks", "The 27 Various", "Jessica Pratt"]
+
+        await seed_identities(store, snapshot)
+
+        rows = await pg_source.fetchall(
+            "SELECT library_name FROM entity.identity ORDER BY library_name"
+        )
+        assert [r["library_name"] for r in rows] == [
+            "Epic Soundtracks",
+            "Jessica Pratt",
+            "The 27 Various",
+        ]
+
+
+@pytest.mark.pg
 class TestDeduplicationIntegration:
     """Test deduplication against real PostgreSQL."""
 

--- a/tests/unit/test_entity_resolution_seed.py
+++ b/tests/unit/test_entity_resolution_seed.py
@@ -1,0 +1,96 @@
+"""Unit tests for ``seed_identities`` V/A guard (LML#385).
+
+Mock-store layer: verifies the ``is_compilation_artist`` filter inside
+``seed_identities`` skips V/A bucket entries and lets real artists through.
+The keep-set / false-positive control rows (``Epic Soundtracks``,
+``The 27 Various``) lock the wxyc-etl 0.5.0 anchored matcher's behavior at
+the call site that LML#379's audit found polluted.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.entity_resolution.__main__ import seed_identities
+from scripts.entity_resolution.store import Identity
+
+
+@pytest.fixture
+def mock_store():
+    """Mock EntityStore whose ``upsert_identity`` records every call."""
+    store = AsyncMock()
+    store.upsert_identity = AsyncMock(
+        side_effect=lambda library_name, **_: Identity(
+            id=hash(library_name) & 0xFFFF, library_name=library_name
+        )
+    )
+    return store
+
+
+class TestSeedIdentitiesCompilationGuard:
+    @pytest.mark.asyncio
+    async def test_skips_v_a_filings_and_seeds_real_artists(self, mock_store):
+        """The four-artist mix from LML#385's issue body.
+
+        ``Hermanos Gutiérrez`` is a canonical WXYC artist; ``Epic Soundtracks``
+        is the false-positive control row from the wxyc-etl 0.5.0 keep-set
+        (real Swell Maps drummer, name ends in "Soundtracks" but is not a V/A
+        filing).
+        """
+        artists = [
+            "Soundtracks - A",
+            "Various Artists - Rock - C",
+            "Hermanos Gutiérrez",
+            "Epic Soundtracks",
+        ]
+
+        seeded = await seed_identities(mock_store, artists)
+
+        assert seeded == 2
+        seeded_names = [
+            call.kwargs["library_name"] for call in mock_store.upsert_identity.await_args_list
+        ]
+        assert seeded_names == ["Hermanos Gutiérrez", "Epic Soundtracks"]
+
+    @pytest.mark.asyncio
+    async def test_logs_skipped_count(self, mock_store, caplog):
+        """``seed.skipped_compilation count=N`` lands at INFO each run."""
+        artists = ["Soundtracks - A", "Various Artists - Rock - C", "Hermanos Gutiérrez"]
+
+        with caplog.at_level(logging.INFO, logger="scripts.entity_resolution.__main__"):
+            await seed_identities(mock_store, artists)
+
+        assert any(
+            "seed.skipped_compilation count=2" in record.message for record in caplog.records
+        ), f"expected count=2 in logs, got: {[r.message for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_canonical_fixture_artists_all_seeded(self, mock_store):
+        """No-compilation snapshot: every artist seeds, count=0."""
+        artists = ["Juana Molina", "Jessica Pratt", "Chuquimamani-Condori"]
+
+        seeded = await seed_identities(mock_store, artists)
+
+        assert seeded == 3
+        assert mock_store.upsert_identity.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self, mock_store):
+        """Empty snapshot: returns 0, no upserts."""
+        seeded = await seed_identities(mock_store, [])
+
+        assert seeded == 0
+        mock_store.upsert_identity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upsert_returning_none_not_counted(self, mock_store):
+        """``upsert_identity`` returning None (row already existed) does not bump ``seeded``."""
+        mock_store.upsert_identity = AsyncMock(return_value=None)
+
+        seeded = await seed_identities(mock_store, ["Stereolab", "Cat Power"])
+
+        assert seeded == 0
+        assert mock_store.upsert_identity.await_count == 2

--- a/tests/unit/test_entity_resolution_seed.py
+++ b/tests/unit/test_entity_resolution_seed.py
@@ -23,9 +23,7 @@ def mock_store():
     """Mock EntityStore whose ``upsert_identity`` records every call."""
     store = AsyncMock()
     store.upsert_identity = AsyncMock(
-        side_effect=lambda library_name, **_: Identity(
-            id=hash(library_name) & 0xFFFF, library_name=library_name
-        )
+        side_effect=lambda library_name, **_: Identity(id=1, library_name=library_name)
     )
     return store
 


### PR DESCRIPTION
## Summary

Adds `is_compilation_artist` filter to `seed_identities` so V/A bucket filings (`Various Artists - Rock - C`, `Soundtracks - A`, etc.) never enter `entity.identity`. Bulk-load sibling of LML#379's live-writeback fix.

The 2026-05-26 audit on LML#379 found 67 polluted rows in prod `entity.identity` — every one of them filed by `seed_identities` over librarian-arranged Z-bucket entries in `library.artist`. The filing is invariant from the librarian's perspective (shelf navigation), so the cleanup needs to live on the LML side.

## Change

- `scripts/entity_resolution/__main__.py` — import `is_compilation_artist` at module scope; add the filter inside the upsert loop; log `seed.skipped_compilation count=N` at INFO so the next campaign's delta is legible.

## Scope

In-function filter only — `prune_orphan_identities` continues to receive the unfiltered snapshot. The 67 historical rows remain until a separate one-shot cleanup; this PR's acceptance is "no new pollution", per the issue body.

## Test plan

- [x] Unit: `tests/unit/test_entity_resolution_seed.py` — 5 cases including the four-artist mix from the issue body (`Soundtracks - A`, `Various Artists - Rock - C`, `Hermanos Gutiérrez`, `Epic Soundtracks`) and the canonical-fixture no-skip path.
- [x] Integration (`@pytest.mark.pg`): two PG-backed tests confirming V/A rows stay out and the wxyc-etl 0.5.0 keep-set (`Epic Soundtracks`, `The 27 Various`) seeds correctly.
- [x] Full unit suite: 1905 passed locally.
- [ ] Operational: one full reconciliation run on staging/prod with the new guard; V/A audit re-run post-campaign to confirm no new pollution.

## Related

- WXYC/library-metadata-lookup#379 — CLOSED. The live-writeback sibling fix; provided the audit data this PR responds to.
- WXYC/library-metadata-lookup#377 — CLOSED (PR #387). Orphan-pass on the same `seed_identities` function; landed first.
- WXYC/wxyc-etl#129 / #130 — CLOSED. The 0.5.0 matcher rewrite that makes this guard safe against false positives.

Closes #385