### PR TITLE
fix(enrichment): verify iTunes artist/track before returning Apple Music URL

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1523,6 +1523,16 @@ def _build_streaming_search_url(base: str, artist: str, term: str) -> str:
     return f"{base}{quote(query)}"
 
 
+# Minimum fuzzy score (0-100) for accepting an iTunes Search result as a genuine
+# match for the requested artist + track. Mirrors the 80/80 artist+title floor
+# the streaming-availability batch matcher enforces
+# (scripts/streaming_availability/matching.py:is_acceptable_match). iTunes Search
+# ranking is non-deterministic for obscure artists, so a bare results[0]
+# intermittently surfaces a popular but wrong artist (e.g. "Pleasure"/"Joyous" ->
+# Sheryl Crow), and the wrong link then freezes onto the flowsheet row. See #389.
+_APPLE_MUSIC_MATCH_FLOOR = 80.0
+
+
 async def _fetch_apple_music_url(
     artist: str, song: str, http_client: httpx.AsyncClient | None = None
 ) -> str | None:
@@ -1532,18 +1542,41 @@ async def _fetch_apple_music_url(
     provided so callers can degrade gracefully. Constructing a fresh
     ``httpx.AsyncClient`` per probe is what leaked FDs in the 2026-05-01
     LML outage (issue #241), so the per-call fallback was removed.
+
+    Returns the ``trackViewUrl`` of the first result whose ``artistName`` and
+    ``trackName`` both clear ``_APPLE_MUSIC_MATCH_FLOOR`` against the requested
+    ``artist`` / ``song`` (diacritics-folded fuzzy token-set match), else
+    ``None``. iTunes Search ranking is unstable for obscure artists, so a bare
+    ``results[0]`` can confidently return the wrong artist; verifying avoids
+    persisting a wrong link onto the flowsheet row (#389).
     """
     if http_client is None:
         return None
+    from rapidfuzz import fuzz
+
     try:
         query = quote(f"{artist} {song}")
-        url = f"https://itunes.apple.com/search?term={query}&entity=song&media=music&limit=1"
+        url = f"https://itunes.apple.com/search?term={query}&entity=song&media=music&limit=5"
         resp = await http_client.get(url)
         if resp.status_code != 200:
             return None
-        data = resp.json()
-        results = data.get("results", [])
-        return results[0].get("trackViewUrl") if results else None
+        results = resp.json().get("results", [])
+
+        norm_artist = normalize_for_comparison(artist)
+        norm_song = normalize_for_comparison(song)
+        for result in results:
+            track_url = result.get("trackViewUrl")
+            if not track_url:
+                continue
+            artist_score = fuzz.token_set_ratio(
+                norm_artist, normalize_for_comparison(result.get("artistName", ""))
+            )
+            track_score = fuzz.token_set_ratio(
+                norm_song, normalize_for_comparison(result.get("trackName", ""))
+            )
+            if artist_score >= _APPLE_MUSIC_MATCH_FLOOR and track_score >= _APPLE_MUSIC_MATCH_FLOOR:
+                return track_url
+        return None
     except Exception:
         return None
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1564,6 +1564,9 @@ async def _fetch_apple_music_url(
 
         norm_artist = normalize_for_comparison(artist)
         norm_song = normalize_for_comparison(song)
+        # token_set_ratio (not the batch matcher's token_sort_ratio) so extra
+        # tokens on either side — "The", "feat. X", "(Remastered)" — don't sink
+        # an otherwise-correct match.
         for result in results:
             track_url = result.get("trackViewUrl")
             if not track_url:

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -39,22 +39,110 @@ class TestBuildStreamingSearchUrl:
 
 
 class TestFetchAppleMusicUrl:
-    @pytest.mark.asyncio
-    async def test_returns_url_on_success(self):
+    @staticmethod
+    def _mock_client(results: list[dict]):
         import httpx
 
         mock_response = httpx.Response(
             200,
-            json={"results": [{"trackViewUrl": "https://music.apple.com/us/album/test/123"}]},
+            json={"results": results},
             request=httpx.Request("GET", "https://itunes.apple.com/search"),
         )
         mock_client = AsyncMock(spec=httpx.AsyncClient)
         mock_client.get = AsyncMock(return_value=mock_response)
+        return mock_client
+
+    @pytest.mark.asyncio
+    async def test_returns_url_on_success(self):
+        mock_client = self._mock_client(
+            [
+                {
+                    "artistName": "Kate Bush",
+                    "trackName": "The Saxophone Song",
+                    "trackViewUrl": "https://music.apple.com/us/album/test/123",
+                }
+            ]
+        )
 
         result = await _fetch_apple_music_url(
             "Kate Bush", "The Saxophone Song", http_client=mock_client
         )
         assert result == "https://music.apple.com/us/album/test/123"
+
+    @pytest.mark.asyncio
+    async def test_skips_wrong_artist_and_picks_correct_lower_result(self):
+        """Regression for the Pleasure/'Joyous' -> Sheryl Crow mismatch (#389).
+
+        iTunes Search relevance is unstable for obscure artists and can rank a
+        popular but wrong artist first. The correct match must be chosen over a
+        higher-ranked wrong-artist result, not blindly taken from results[0].
+        """
+        mock_client = self._mock_client(
+            [
+                {
+                    "artistName": "Sheryl Crow",
+                    "trackName": "All I Wanna Do",
+                    "trackViewUrl": "https://music.apple.com/us/album/all-i-wanna-do/1440651031",
+                },
+                {
+                    "artistName": "Pleasure",
+                    "trackName": "Joyous",
+                    "trackViewUrl": "https://music.apple.com/us/album/joyous/1568229263",
+                },
+            ]
+        )
+
+        result = await _fetch_apple_music_url("Pleasure", "Joyous", http_client=mock_client)
+        assert result == "https://music.apple.com/us/album/joyous/1568229263"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_only_wrong_artist(self):
+        """A confident-but-wrong link is worse than no link: reject, don't return it."""
+        mock_client = self._mock_client(
+            [
+                {
+                    "artistName": "Sheryl Crow",
+                    "trackName": "All I Wanna Do",
+                    "trackViewUrl": "https://music.apple.com/us/album/all-i-wanna-do/1440651031",
+                }
+            ]
+        )
+
+        result = await _fetch_apple_music_url("Pleasure", "Joyous", http_client=mock_client)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_matches_despite_diacritics(self):
+        """Diacritic-folded comparison: 'Nilüfer Yanya' must match iTunes' 'Nilufer Yanya'."""
+        mock_client = self._mock_client(
+            [
+                {
+                    "artistName": "Nilufer Yanya",
+                    "trackName": "Stabilise",
+                    "trackViewUrl": "https://music.apple.com/us/album/stabilise/1480000000",
+                }
+            ]
+        )
+
+        result = await _fetch_apple_music_url("Nilüfer Yanya", "Stabilise", http_client=mock_client)
+        assert result == "https://music.apple.com/us/album/stabilise/1480000000"
+
+    @pytest.mark.asyncio
+    async def test_skips_result_missing_track_url(self):
+        """A matching result with no trackViewUrl is skipped in favor of a usable one."""
+        mock_client = self._mock_client(
+            [
+                {"artistName": "Pleasure", "trackName": "Joyous"},
+                {
+                    "artistName": "Pleasure",
+                    "trackName": "Joyous",
+                    "trackViewUrl": "https://music.apple.com/us/album/joyous/1568229263",
+                },
+            ]
+        )
+
+        result = await _fetch_apple_music_url("Pleasure", "Joyous", http_client=mock_client)
+        assert result == "https://music.apple.com/us/album/joyous/1568229263"
 
     @pytest.mark.asyncio
     async def test_returns_none_on_no_results(self):

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -146,15 +146,7 @@ class TestFetchAppleMusicUrl:
 
     @pytest.mark.asyncio
     async def test_returns_none_on_no_results(self):
-        import httpx
-
-        mock_response = httpx.Response(
-            200,
-            json={"results": []},
-            request=httpx.Request("GET", "https://itunes.apple.com/search"),
-        )
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client = self._mock_client([])
 
         result = await _fetch_apple_music_url(
             "Obscure Artist", "Obscure Song", http_client=mock_client


### PR DESCRIPTION
## Summary

`_fetch_apple_music_url` returned `results[0].get("trackViewUrl")` from the iTunes Search API with **no verification** that the result's artist/track matched the request. iTunes ranking is non-deterministic for obscure artists, so it intermittently returned a popular but wrong artist — the now-playing **"Joyous" by Pleasure** resolved to **Sheryl Crow's "All I Wanna Do"** (and, on other plays of the same song, to a third unrelated artist or to nothing). The wrong URL was persisted inline on `flowsheet.apple_music_url` at enrichment time and served to the iOS now-playing view.

## Fix

Query `limit=5` and return the first result whose `artistName` **and** `trackName` both clear an **80/80** diacritics-folded fuzzy token-set floor, else `None`. This mirrors the guard the streaming-availability batch matcher already enforces (`scripts/streaming_availability/matching.py:is_acceptable_match`). A missing Apple Music button is strictly better than a confidently-wrong link.

- Reuses `wxyc_etl.text.to_match_form` (already imported as `normalize_for_comparison`) + `rapidfuzz.fuzz`, both already used in the module — no coupling to the `scripts/` package.
- Preserves the `http_client is None` graceful-degrade and the broad `except` (the per-call client fallback was removed in the #241 FD-leak fix).

## Tests (TDD: red → green)

`tests/unit/test_enrichment.py::TestFetchAppleMusicUrl`:
- wrong-artist `results[0]` + correct lower-ranked result → picks the correct one (the Pleasure/Joyous regression)
- only a wrong-artist result → `None`
- diacritic-folded match ("Nilüfer Yanya" vs iTunes "Nilufer Yanya")
- existing happy-path / no-result / error paths still pass (happy-path fixtures updated to carry the real `artistName`/`trackName` shape)

Local gate: full unit suite green (1909 passed; one unrelated `test_dependencies` teardown flake that passes in isolation), `ruff check` + `ruff format --check` + `mypy` clean.

## Follow-up

The already-poisoned inline `flowsheet.apple_music_url` rows in Backend-Service prod still need a surgical scrub (`SET apple_music_url = NULL` on artist-mismatched rows); handled separately.

Closes #389
