### PR TITLE
fix(enrichment): verify Apple Music album collection before returning URL

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1524,17 +1524,23 @@ def _build_streaming_search_url(base: str, artist: str, term: str) -> str:
 
 
 # Minimum fuzzy score (0-100) for accepting an iTunes Search result as a genuine
-# match for the requested artist + track. Mirrors the 80/80 artist+title floor
-# the streaming-availability batch matcher enforces
-# (scripts/streaming_availability/matching.py:is_acceptable_match). iTunes Search
-# ranking is non-deterministic for obscure artists, so a bare results[0]
-# intermittently surfaces a popular but wrong artist (e.g. "Pleasure"/"Joyous" ->
-# Sheryl Crow), and the wrong link then freezes onto the flowsheet row. See #389.
+# match for the requested artist + track (+ album, when provided). Mirrors the
+# 80/80 artist+title floor the streaming-availability batch matcher enforces
+# (scripts/streaming_availability/matching.py:is_acceptable_match). iTunes
+# Search ranking is non-deterministic for obscure artists, so a bare results[0]
+# intermittently surfaces a popular but wrong artist (e.g. "Pleasure"/"Joyous"
+# -> Sheryl Crow, see #389), and same-named tracks on multiple of an artist's
+# releases can land on the wrong album (e.g. Yenbett's "Hebebeb (Zrag)" -> the
+# track of the same name on Tzenni, see #396). Verification stops the wrong
+# link from freezing onto the flowsheet row.
 _APPLE_MUSIC_MATCH_FLOOR = 80.0
 
 
 async def _fetch_apple_music_url(
-    artist: str, song: str, http_client: httpx.AsyncClient | None = None
+    artist: str,
+    song: str,
+    album: str | None = None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> str | None:
     """Search the iTunes API for an Apple Music link. Free, no auth required.
 
@@ -1544,11 +1550,14 @@ async def _fetch_apple_music_url(
     LML outage (issue #241), so the per-call fallback was removed.
 
     Returns the ``trackViewUrl`` of the first result whose ``artistName`` and
-    ``trackName`` both clear ``_APPLE_MUSIC_MATCH_FLOOR`` against the requested
-    ``artist`` / ``song`` (diacritics-folded fuzzy token-set match), else
+    ``trackName`` (and, when ``album`` is provided, ``collectionName``) all
+    clear ``_APPLE_MUSIC_MATCH_FLOOR`` against the requested ``artist`` /
+    ``song`` / ``album`` (diacritics-folded fuzzy token-set match), else
     ``None``. iTunes Search ranking is unstable for obscure artists, so a bare
-    ``results[0]`` can confidently return the wrong artist; verifying avoids
-    persisting a wrong link onto the flowsheet row (#389).
+    ``results[0]`` can confidently return the wrong artist (#389) or — when
+    the same track title appears on multiple of the artist's releases — the
+    wrong album (#396); verifying avoids persisting a wrong link onto the
+    flowsheet row.
     """
     if http_client is None:
         return None
@@ -1564,6 +1573,7 @@ async def _fetch_apple_music_url(
 
         norm_artist = normalize_for_comparison(artist)
         norm_song = normalize_for_comparison(song)
+        norm_album = normalize_for_comparison(album) if album else None
         # token_set_ratio (not the batch matcher's token_sort_ratio) so extra
         # tokens on either side — "The", "feat. X", "(Remastered)" — don't sink
         # an otherwise-correct match.
@@ -1577,8 +1587,15 @@ async def _fetch_apple_music_url(
             track_score = fuzz.token_set_ratio(
                 norm_song, normalize_for_comparison(result.get("trackName", ""))
             )
-            if artist_score >= _APPLE_MUSIC_MATCH_FLOOR and track_score >= _APPLE_MUSIC_MATCH_FLOOR:
-                return track_url
+            if artist_score < _APPLE_MUSIC_MATCH_FLOOR or track_score < _APPLE_MUSIC_MATCH_FLOOR:
+                continue
+            if norm_album is not None:
+                album_score = fuzz.token_set_ratio(
+                    norm_album, normalize_for_comparison(result.get("collectionName", ""))
+                )
+                if album_score < _APPLE_MUSIC_MATCH_FLOOR:
+                    continue
+            return track_url
         return None
     except Exception:
         return None
@@ -1588,6 +1605,7 @@ async def enrich_artwork_results(
     items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]],
     discogs_service: DiscogsService | None,
     song: str | None = None,
+    album: str | None = None,
     library_db: LibraryDB | None = None,
     http_client: httpx.AsyncClient | None = None,
     *,
@@ -1712,7 +1730,7 @@ async def enrich_artwork_results(
         search_term = song or item.title or ""
 
         apple_music_result = (
-            await _fetch_apple_music_url(artist, search_term, http_client=http_client)
+            await _fetch_apple_music_url(artist, search_term, album=album, http_client=http_client)
             if (artist and search_term)
             else None
         )
@@ -2067,6 +2085,7 @@ async def perform_lookup(
                 items_with_artwork,
                 discogs_service,
                 song=parsed.song,
+                album=parsed.album,
                 library_db=db,
                 http_client=http_client,
                 extended=extended_mode,

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -145,6 +145,88 @@ class TestFetchAppleMusicUrl:
         assert result == "https://music.apple.com/us/album/joyous/1568229263"
 
     @pytest.mark.asyncio
+    async def test_rejects_right_track_on_wrong_album(self):
+        """Regression for the Yenbett -> Tzenni mismatch (#396).
+
+        Same-named track on multiple of the artist's releases: iTunes returns
+        the older more-indexed album's track; without album verification,
+        artist 100 + track 100 slip past #390's floor and persist the
+        wrong-album URL.
+        """
+        mock_client = self._mock_client(
+            [
+                {
+                    "artistName": "Noura Mint Seymali",
+                    "trackName": "Hebebeb (Zrag)",
+                    "collectionName": "Tzenni",
+                    "trackViewUrl": "https://music.apple.com/us/album/hebebeb-zrag/882843574?i=882843707",
+                }
+            ]
+        )
+
+        result = await _fetch_apple_music_url(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett", http_client=mock_client
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_accepts_when_album_matches(self):
+        """Album verification passes when the requested album matches the result's collection."""
+        mock_client = self._mock_client(
+            [
+                {
+                    "artistName": "Noura Mint Seymali",
+                    "trackName": "Hebebeb (Zrag)",
+                    "collectionName": "Tzenni",
+                    "trackViewUrl": "https://music.apple.com/us/album/tzenni/882843574?i=882843692",
+                }
+            ]
+        )
+
+        result = await _fetch_apple_music_url(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Tzenni", http_client=mock_client
+        )
+        assert result == "https://music.apple.com/us/album/tzenni/882843574?i=882843692"
+
+    @pytest.mark.asyncio
+    async def test_accepts_album_reissue_variant(self):
+        """token_set_ratio handles reissue/edition variants ('Tzenni' vs 'Tzenni (Deluxe Edition)')."""
+        mock_client = self._mock_client(
+            [
+                {
+                    "artistName": "Noura Mint Seymali",
+                    "trackName": "Hebebeb (Zrag)",
+                    "collectionName": "Tzenni (Deluxe Edition)",
+                    "trackViewUrl": "https://music.apple.com/us/album/tzenni-deluxe/9999",
+                }
+            ]
+        )
+
+        result = await _fetch_apple_music_url(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Tzenni", http_client=mock_client
+        )
+        assert result == "https://music.apple.com/us/album/tzenni-deluxe/9999"
+
+    @pytest.mark.asyncio
+    async def test_omitted_album_skips_album_check(self):
+        """Backward compat: when no album context is passed, verification mirrors pre-#396 behavior."""
+        mock_client = self._mock_client(
+            [
+                {
+                    "artistName": "Noura Mint Seymali",
+                    "trackName": "Hebebeb (Zrag)",
+                    "collectionName": "Tzenni",
+                    "trackViewUrl": "https://music.apple.com/us/album/tzenni/882843574?i=882843692",
+                }
+            ]
+        )
+
+        result = await _fetch_apple_music_url(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", http_client=mock_client
+        )
+        assert result == "https://music.apple.com/us/album/tzenni/882843574?i=882843692"
+
+    @pytest.mark.asyncio
     async def test_returns_none_on_no_results(self):
         mock_client = self._mock_client([])
 


### PR DESCRIPTION
**Stacked on #390**. Will retarget `main` once #390 merges (GitHub auto-rebases the base).

## Summary

Extension of #389/#390. The artist+track guard from #390 still accepts a result that lives on the **wrong album** when the same track title exists on multiple of an artist's releases. Concrete prod case: Noura Mint Seymali's "Hebebeb (Zrag)" exists on both **Tzenni** (2014) and **Yenbett** (2025); iTunes ranks the older more-indexed Tzenni track first, so a Yenbett flowsheet entry was being persisted with a Tzenni link (and Tzenni's 2014 `release_year` via the same path).

## Fix

`_fetch_apple_music_url` now accepts an optional `album: str | None` kwarg. When provided, the function additionally requires the iTunes result's `collectionName` to clear the same 80 floor used for artist + track. `album` is plumbed through `enrich_artwork_results` (as a sibling of `song`) from `perform_lookup` (`parsed.album`).

- Backward compatible: `album=None` → verification matches the post-#390 shape exactly.
- `token_set_ratio` (the choice documented in #390) cleanly accepts reissue/edition variants ("Tzenni" vs "Tzenni (Deluxe Edition)" → 100) and rejects different albums ("Yenbett" vs "Tzenni" → ~0).
- The 3-way guard re-shapes the loop to early-continue per check; an incidental win is that we no longer compute `track_score` when `artist_score` already failed.

## Tests (TDD: red → green)

`tests/unit/test_enrichment.py::TestFetchAppleMusicUrl` adds four:
- `test_rejects_right_track_on_wrong_album` — the Yenbett→Tzenni regression
- `test_accepts_when_album_matches` — same iTunes result, requested album matches → returns URL
- `test_accepts_album_reissue_variant` — "Tzenni" requested, "Tzenni (Deluxe Edition)" in iTunes → accepts
- `test_omitted_album_skips_album_check` — backward compat (no album kwarg)

Existing tests still green. Local gate: full unit suite 1913 passed (one unrelated pre-existing teardown flake in `test_dependencies` that passes in isolation, same as on #390); `ruff check` + `ruff format --check` + `mypy lookup/orchestrator.py` all clean.

## Notes / out of scope

- The natural follow-up (when verification rejects but the album genuinely IS on Apple Music — e.g. Yenbett, collection `1834383659`) is to do an album-first `entity=album` search + `https://itunes.apple.com/lookup?id=<collection>&entity=song` to locate the correct album's track. That's a second round-trip and a different shape; explicitly deferred in #396 to keep this PR scoped.
- The broader cluster (Pleasure / Yenbett / Tragic Magic) is tracked in **#397**. Tragic Magic (Spotify+Apple structurally unreachable on Discogs miss) is WXYC/Backend-Service#1184 and is independent.

Closes #396
