### PR TITLE
fix(enrichment): surface streaming URLs on Discogs-miss path (closes #401)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1723,9 +1723,6 @@ async def enrich_artwork_results(
         *,
         is_top1: bool,
     ) -> tuple[LibraryItem, DiscogsSearchResult | None]:
-        if not artwork:
-            return (item, artwork)
-
         artist = item.alternate_artist_name or item.artist or ""
         search_term = song or item.title or ""
 
@@ -1735,13 +1732,20 @@ async def enrich_artwork_results(
             else None
         )
 
-        # Top-1 scalars; non-top-1 leaves these as None and renders with
-        # streaming-URL fallbacks only.
-        year_result = top1_year if is_top1 else None
-        artist_bio = top1_bio if is_top1 else None
-        wikipedia_url = top1_wiki if is_top1 else None
+        # Album-derived fields are positionally gated: only on top-1, and
+        # only when top-1 actually has artwork. When ``artwork`` is None
+        # here (this branch is also taken for the synthesized no-Discogs-
+        # match streaming-only result), these stay None — preserves the
+        # docstring's positional-gating invariant.
+        is_album_derived_eligible = is_top1 and artwork is not None
+        year_result = top1_year if is_album_derived_eligible else None
+        artist_bio = top1_bio if is_album_derived_eligible else None
+        wikipedia_url = top1_wiki if is_album_derived_eligible else None
 
-        # Get streaming URLs: prefer direct links from DB, fall back to search URLs
+        # Get streaming URLs: prefer direct links from DB, fall back to search URLs.
+        # Runs unconditionally — releases that ARE on streaming but ISN'T
+        # in the WXYC catalog (a Discogs miss) still surface streaming
+        # buttons via the synthesized result below (LML#401 / BS#1184).
         spotify_url = None
         apple_music_override = None
         youtube_music_url = None
@@ -1790,11 +1794,12 @@ async def enrich_artwork_results(
             "soundcloud_url": soundcloud_url,
         }
 
-        # Extended fields land on the top-1 result only. The non-top-1
-        # items keep their lean shape so non-iOS lookup callers (request
-        # line, dj-site proxy, BS catalog) don't pay payload bloat for
-        # results they ignore.
-        if extended and is_top1:
+        # Extended fields land on the top-1 result only and require artwork
+        # (same positional + artwork gating as the album-derived scalars).
+        # The non-top-1 items keep their lean shape so non-iOS lookup
+        # callers (request line, dj-site proxy, BS catalog) don't pay
+        # payload bloat for results they ignore.
+        if extended and is_album_derived_eligible:
             if top1_release is not None:
                 update["discogs_artist_id"] = top1_release.artist_id
                 update["tracklist"] = (
@@ -1808,6 +1813,16 @@ async def enrich_artwork_results(
                 top1_details.image_url if top1_details is not None else None
             )
             update["profile_tokens"] = top1_profile_tokens
+
+        if artwork is None:
+            # No Discogs match: return a synthesized streaming-only result.
+            # ``release_id=0`` / ``release_url=""`` are the sentinels
+            # Backend-Service (BS#1185) keys off of to skip
+            # ``extractAlbumMetadata`` while still consuming streaming URLs.
+            # Album-derived fields stay None (set above when
+            # ``is_album_derived_eligible`` is False), preserving the
+            # positional-gating invariant from this function's docstring.
+            return (item, DiscogsSearchResult(release_id=0, release_url="", **update))
 
         return (item, artwork.model_copy(update=update))
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1633,6 +1633,19 @@ async def enrich_artwork_results(
     this is fine in practice; the lookup pipeline guarantees the strongest
     match is in position 0.
 
+    **Behavior change vs. v0.6.0 (LML#401):** an item entering with
+    ``artwork=None`` no longer round-trips as ``(item, None)``. It returns
+    a synthesized ``DiscogsSearchResult(release_id=0, release_url="")``
+    carrying only the streaming-URL fields (Apple via iTunes Search +
+    Spotify/YT/BC/SC search-URL fallbacks). Album-derived scalars
+    (release_year, artist_bio, wikipedia_url) and the ``extended=True``
+    payload stay None on the synthesized result, preserving the positional-
+    gating invariant above. The ``(release_id=0, release_url="")`` pair is
+    a cross-service contract: Backend-Service (BS#1185) keys off of it to
+    skip ``extractAlbumMetadata`` while still consuming streaming URLs.
+    Required for the WXYC/BS#1184 fix — releases on Apple Music that aren't
+    in the WXYC/Discogs catalog now surface streaming buttons on iOS.
+
     ``extended=True`` additionally populates the new DiscogsMatchResult
     fields LML already loaded during the release+artist fetches:
     ``discogs_artist_id``, ``tracklist``, ``genres``, ``styles``, ``label``,
@@ -1815,13 +1828,9 @@ async def enrich_artwork_results(
             update["profile_tokens"] = top1_profile_tokens
 
         if artwork is None:
-            # No Discogs match: return a synthesized streaming-only result.
-            # ``release_id=0`` / ``release_url=""`` are the sentinels
-            # Backend-Service (BS#1185) keys off of to skip
-            # ``extractAlbumMetadata`` while still consuming streaming URLs.
-            # Album-derived fields stay None (set above when
-            # ``is_album_derived_eligible`` is False), preserving the
-            # positional-gating invariant from this function's docstring.
+            # No Discogs match: synthesize a streaming-only result. See
+            # docstring's "Behavior change vs. v0.6.0 (LML#401)" section
+            # for the BS#1185 sentinel contract.
             return (item, DiscogsSearchResult(release_id=0, release_url="", **update))
 
         return (item, artwork.model_copy(update=update))

--- a/tests/integration/test_streaming_on_discogs_miss.py
+++ b/tests/integration/test_streaming_on_discogs_miss.py
@@ -1,0 +1,148 @@
+"""Integration test for LML#401 — streaming URLs survive a Discogs miss.
+
+When a flowsheet entry's release isn't in the WXYC/Discogs catalog
+(``DiscogsService.search`` returns an empty result), the artwork block
+used to short-circuit at ``None`` inside ``enrich_artwork_results``.
+Backend-Service (WXYC/Backend-Service#1184) then had no Apple/Spotify
+URLs to project onto ``result.album``, so iOS rendered all-greyed
+streaming buttons for releases that demonstrably ARE on Apple Music
+(e.g. the "Tragic Magic" by Julianna Barwick & Mary Lattimore case
+that motivated this fix).
+
+The fix synthesizes a streaming-only ``DiscogsSearchResult`` with
+``release_id=0`` and ``release_url=""`` as sentinels — these tell
+Backend-Service (BS#1185) "no Discogs match, but streaming URLs are
+valid; do NOT call ``extractAlbumMetadata``".
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from discogs.models import DiscogsSearchResponse
+from lookup.models import LookupRequest
+from lookup.orchestrator import perform_lookup
+from tests.conftest import make_lml_telemetry
+
+
+class TestStreamingOnDiscogsMiss:
+    @pytest.mark.asyncio
+    async def test_apple_music_url_populated_when_discogs_returns_no_artwork(self, library_db):
+        """End-to-end: artist+album+song hit the library, Discogs returns
+        empty (no artwork), iTunes Search matches → top-1 result carries
+        the Apple Music URL via the synthesized streaming-only artwork.
+
+        Uses the seeded Stereolab entries (per CLAUDE.md fixture preference)
+        — the test forces the no-artwork branch by mocking
+        ``DiscogsService.search`` to return empty results regardless of
+        input. This mirrors the production failure mode where a release
+        exists in the WXYC library catalog (or matches an artist by FTS)
+        but the per-album Discogs search yields nothing.
+        """
+        from wxyc_fastapi.observability import init_cache_stats
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(
+            spec_set=[
+                "search",
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "get_release",
+                "cache_service",
+            ]
+        )
+        mock_service.cache_service = None
+        # Empty Discogs search → every library hit gets ``artwork=None``,
+        # exercising the LML#401 no-Discogs-match enrichment branch.
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        mock_service.get_release = AsyncMock(return_value=None)
+        mock_service.validate_track_on_release = AsyncMock(return_value=False)
+
+        apple_url = "https://music.apple.com/us/album/aluminum-tunes/1234567890"
+        with patch(
+            "lookup.orchestrator._fetch_apple_music_url",
+            return_value=apple_url,
+        ):
+            request = LookupRequest(
+                artist="Stereolab",
+                album="Aluminum Tunes",
+                song="Cybele's Reverie",
+                raw_message="Stereolab - Aluminum Tunes - Cybele's Reverie",
+            )
+            response = await perform_lookup(
+                request,
+                library_db,
+                mock_service,
+                make_lml_telemetry(),
+            )
+
+        assert len(response.results) >= 1, "Expected at least one library result"
+
+        top = response.results[0]
+        assert top.artwork is not None, (
+            "Synthetic streaming-only artwork should be present on Discogs miss"
+        )
+        # Sentinel pair that BS#1185 keys off of to skip extractAlbumMetadata.
+        assert top.artwork.release_id == 0
+        assert top.artwork.release_url == ""
+        # The whole point of LML#401: Apple URL surfaces on the no-Discogs-match path.
+        assert top.artwork.apple_music_url == apple_url
+        # Album-derived fields stay None — positional-gating invariant.
+        assert top.artwork.release_year is None
+        assert top.artwork.artist_bio is None
+        assert top.artwork.wikipedia_url is None
+        # Search-URL fallbacks fill (artist + song are non-empty).
+        assert top.artwork.spotify_url is not None
+        assert top.artwork.youtube_music_url is not None
+        assert top.artwork.bandcamp_url is not None
+        assert top.artwork.soundcloud_url is not None
+
+    @pytest.mark.asyncio
+    async def test_search_urls_fill_when_apple_match_fails(self, library_db):
+        """When iTunes Search has no clearable match either, the synthesized
+        artwork still carries the Spotify/YT/BC/SC search URLs so iOS isn't
+        stuck with all-greyed streaming buttons.
+        """
+        from wxyc_fastapi.observability import init_cache_stats
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(
+            spec_set=[
+                "search",
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "get_release",
+                "cache_service",
+            ]
+        )
+        mock_service.cache_service = None
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        mock_service.get_release = AsyncMock(return_value=None)
+        mock_service.validate_track_on_release = AsyncMock(return_value=False)
+
+        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
+            request = LookupRequest(
+                artist="Stereolab",
+                album="Aluminum Tunes",
+                song="Cybele's Reverie",
+                raw_message="Stereolab - Aluminum Tunes - Cybele's Reverie",
+            )
+            response = await perform_lookup(
+                request,
+                library_db,
+                mock_service,
+                make_lml_telemetry(),
+            )
+
+        assert len(response.results) >= 1
+        top = response.results[0]
+        assert top.artwork is not None
+        assert top.artwork.release_id == 0
+        assert top.artwork.apple_music_url is None  # iTunes had no match
+        # But search-URL fallbacks still fill — iOS gets at least four buttons.
+        assert top.artwork.spotify_url is not None
+        assert top.artwork.youtube_music_url is not None
+        assert top.artwork.bandcamp_url is not None
+        assert top.artwork.soundcloud_url is not None

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -308,12 +308,123 @@ class TestEnrichArtworkResults:
 
     @pytest.mark.asyncio
     async def test_handles_none_artwork(self):
-        item = make_library_item()
+        """An item with no Discogs match still gets a synthesized streaming-URL
+        artwork block (``release_id=0`` sentinel marks the synthetic shape).
 
-        results = await enrich_artwork_results([(item, None)], AsyncMock())
+        Per LML#401 / BS#1184: the no-Discogs-match path used to short-circuit
+        with ``artwork=None``, leaving releases that ARE on streaming but
+        ISN'T in the WXYC catalog (e.g. Tragic Magic) with no iOS streaming
+        buttons at all. The synthetic result surfaces the existing
+        search-URL fallbacks (Spotify/YT/BC/SC) without inviting BS's
+        ``extractAlbumMetadata`` projection — the ``release_id=0`` sentinel
+        is what Backend-Service (BS#1185) keys off of to skip album-derived
+        projections while still consuming streaming URLs.
+        """
+        item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
+
+        # No ``_fetch_apple_music_url`` patch — exercises the real
+        # ``http_client=None`` graceful-degrade path (function returns None).
+        results = await enrich_artwork_results([(item, None)], AsyncMock(), song="French Disko")
 
         _, enriched = results[0]
-        assert enriched is None
+        assert enriched is not None
+        # Sentinel: BS uses these to identify a streaming-only synthetic
+        # result and skip extractAlbumMetadata.
+        assert enriched.release_id == 0
+        assert enriched.release_url == ""
+        # Positional gating preserved: no album-derived fields anywhere.
+        assert enriched.release_year is None
+        assert enriched.artist_bio is None
+        assert enriched.wikipedia_url is None
+        # apple_music_url stays None because http_client is None.
+        assert enriched.apple_music_url is None
+        # Search-URL fallbacks fill (artist + song are non-empty).
+        assert enriched.spotify_url is not None
+        assert enriched.youtube_music_url is not None
+        assert enriched.bandcamp_url is not None
+        assert enriched.soundcloud_url is not None
+
+    @pytest.mark.asyncio
+    async def test_no_discogs_match_surfaces_apple_url_via_itunes(self):
+        """When ``_fetch_apple_music_url`` clears the 80/80/80 floor on a
+        no-Discogs-match item, the synthesized artwork carries the URL.
+
+        This is the Tragic Magic case from BS#1184 in miniature: an album
+        absent from the WXYC catalog but present on Apple Music.
+        """
+        item = make_library_item(
+            artist="Julianna Barwick & Mary Lattimore",
+            title="The Four Sleeping Princesses",
+        )
+
+        apple_url = "https://music.apple.com/us/album/tragic-magic/1843854211"
+        with patch(
+            "lookup.orchestrator._fetch_apple_music_url",
+            return_value=apple_url,
+        ):
+            results = await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                song="The Four Sleeping Princesses",
+                album="Tragic Magic",
+            )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.release_id == 0
+        assert enriched.apple_music_url == apple_url
+        # Album-derived fields stay None even though Apple matched — those
+        # are positionally gated and require a real Discogs artwork.
+        assert enriched.release_year is None
+        assert enriched.artist_bio is None
+        assert enriched.wikipedia_url is None
+
+    @pytest.mark.asyncio
+    async def test_no_discogs_match_preserves_positional_gating_for_lower_items(self):
+        """When ``items_with_artwork[0]`` has no artwork, no item in the
+        response carries album-derived fields — even items further down
+        that DO have artwork. The positional invariant from
+        ``enrich_artwork_results``' docstring stays intact post-#401.
+        """
+        items_with_artwork: list[tuple[object, DiscogsSearchResult | None]] = [
+            (
+                make_library_item(id=1, artist="Artist 1", title="Album 1"),
+                None,  # top-1 has no artwork
+            ),
+            (
+                make_library_item(id=2, artist="Artist 2", title="Album 2"),
+                make_discogs_result(release_id=42, artist="Artist 2", album="Album 2"),
+            ),
+        ]
+
+        discogs_service = AsyncMock()
+        # Even if Discogs would return data for the lower item, top-1 gating
+        # means the orchestrator never calls it.
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=42,
+            title="Album 2",
+            artist="Artist 2",
+            year=2020,
+            artist_id=99,
+            release_url="https://discogs.com/release/42",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=99,
+            name="Artist 2",
+            profile="bio",
+            urls=["https://en.wikipedia.org/wiki/Artist_2"],
+        )
+
+        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
+            results = await enrich_artwork_results(items_with_artwork, discogs_service, song="Song")
+
+        # Both items return non-None artwork (synthetic for top-1, real for
+        # lower); but neither carries album-derived fields.
+        for _, enriched in results:
+            assert enriched is not None
+            assert enriched.release_year is None
+            assert enriched.artist_bio is None
+            assert enriched.wikipedia_url is None
 
     @pytest.mark.asyncio
     async def test_handles_no_discogs_service(self):
@@ -781,6 +892,12 @@ class TestEnrichArtworkResultsExtended:
         None, no item gets release-year enrichment — even items further
         down that have artwork. BS/iOS only consume results[0] so this is
         fine in practice; documented in the function's docstring.
+
+        Post-LML#401: position 0 is now a synthesized streaming-only
+        ``DiscogsSearchResult`` (release_id=0 sentinel) rather than None,
+        so a release that's on Apple Music can still surface a streaming
+        button on the no-Discogs-match path. The positional-gating
+        invariant still holds — both positions have ``release_year=None``.
         """
         items_with_artwork = [
             (make_library_item(id=1), None),
@@ -800,10 +917,15 @@ class TestEnrichArtworkResultsExtended:
         with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
             results = await enrich_artwork_results(items_with_artwork, discogs_service)
 
-        # Position 0 stays None-artwork; position 1 gets streaming URLs
-        # but NOT release_year — the gate skipped it.
-        assert results[0][1] is None
+        # Position 0 is now a synthetic streaming-only result (release_id=0
+        # sentinel marks it for BS#1185 to skip extractAlbumMetadata);
+        # position 1 keeps its real artwork. Neither carries release_year.
+        assert results[0][1] is not None
+        assert results[0][1].release_id == 0
+        assert results[0][1].release_url == ""
+        assert results[0][1].release_year is None
         assert results[1][1] is not None
+        assert results[1][1].release_id == 2
         assert results[1][1].release_year is None
         # No release fetch fired — fetch_top1_release_details short-circuits
         # when top-1's artwork is None.

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -308,17 +308,10 @@ class TestEnrichArtworkResults:
 
     @pytest.mark.asyncio
     async def test_handles_none_artwork(self):
-        """An item with no Discogs match still gets a synthesized streaming-URL
-        artwork block (``release_id=0`` sentinel marks the synthetic shape).
-
-        Per LML#401 / BS#1184: the no-Discogs-match path used to short-circuit
-        with ``artwork=None``, leaving releases that ARE on streaming but
-        ISN'T in the WXYC catalog (e.g. Tragic Magic) with no iOS streaming
-        buttons at all. The synthetic result surfaces the existing
-        search-URL fallbacks (Spotify/YT/BC/SC) without inviting BS's
-        ``extractAlbumMetadata`` projection — the ``release_id=0`` sentinel
-        is what Backend-Service (BS#1185) keys off of to skip album-derived
-        projections while still consuming streaming URLs.
+        """No-Discogs-match items return a synthesized streaming-only
+        ``DiscogsSearchResult`` (``release_id=0`` sentinel; see LML#401).
+        With ``http_client=None`` the Apple lookup degrades gracefully and
+        only the search-URL fallbacks fill.
         """
         item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
 


### PR DESCRIPTION
## Summary

Splits the streaming-URL block out of `enrich_artwork_results`' `if not artwork: return` guard so free-text flowsheet entries surface Apple/Spotify links even when their release isn't in the WXYC/Discogs catalog.

## Problem

`_fetch_apple_music_url` (post-#390 / #398, verified) used to run inside the `if not artwork: return` early return in `enrich_artwork_results`' `enrich_one` closure. On a Discogs miss, the function was never invoked at all — so even when iTunes Search would return an exact match for the `(artist, track[, album])` tuple, the lookup response carried no Apple URL. Combined with Backend-Service composing `result.album` solely from LML's verified Discogs `artwork` block (WXYC/Backend-Service#1184 Layer A), the net effect: a release on Apple Music or Spotify that lacks a Discogs match in the WXYC catalog never gets a streaming link surfaced to the iOS now-playing card. The "Tragic Magic" / Julianna Barwick & Mary Lattimore case is the most legible symptom.

## Solution

`enrich_one` now runs `_fetch_apple_music_url` and the streaming-URL fallback build unconditionally. On a no-Discogs-match path it returns a synthesized `DiscogsSearchResult(release_id=0, release_url="")` carrying only the streaming-URL fields. `release_id=0` / `release_url=""` are the sentinels Backend-Service (WXYC/Backend-Service#1185) keys off of to skip `extractAlbumMetadata` while still consuming the streaming URLs.

The positional gating invariant from `enrich_artwork_results`' docstring is preserved verbatim: album-derived fields (`release_year`, `artist_bio`, `wikipedia_url`) and the `extended=True` payload are now gated on `is_top1 AND artwork is not None`. Top-1-with-no-artwork still leaves those scalars None across every item in the response.

## Tests

- **3 new unit tests** in `tests/unit/test_enrichment.py::TestEnrichArtworkResults`:
  - `test_handles_none_artwork` (updated from the old "returns None" assertion) — confirms search-URL fallbacks fill on the synthetic shape with `http_client=None`.
  - `test_no_discogs_match_surfaces_apple_url_via_itunes` — the Tragic Magic case in miniature: synthetic artwork carries the iTunes Apple URL.
  - `test_no_discogs_match_preserves_positional_gating_for_lower_items` — top-1 with no artwork still strips album-derived fields from lower items that DO have artwork.
- **1 updated existing test** in `TestEnrichArtworkResultsExtended::test_top1_with_no_artwork_leaves_all_release_year_none` — now asserts the synthetic shape at position 0 while preserving the original "no `release_year` anywhere" intent.
- **1 new integration test file** `tests/integration/test_streaming_on_discogs_miss.py` — exercises both Apple-match and no-Apple-match paths through `perform_lookup` + the seeded `library_db` fixture with a mocked DiscogsService.

## Constraints honored

- The 80/80/80 `token_set_ratio` floor inside `_fetch_apple_music_url` is unchanged (#390 + #398).
- No coupling of runtime `lookup/` code to the `scripts/` package — shared-matcher extraction stays deferred per #389.
- `http_client is None` graceful-degrade preserved (returns `apple_music_url=None`).
- Artwork-present output path is byte-identical to today (33/33 enrichment unit tests + 2159 default-suite tests pass).

## Local pre-flight

```
uv run ruff check lookup/orchestrator.py tests/unit/test_enrichment.py tests/integration/test_streaming_on_discogs_miss.py  # All checks passed!
uv run ruff format --check ...                                                                                              # 3 files already formatted
uv run mypy lookup/orchestrator.py tests/unit/test_enrichment.py tests/integration/test_streaming_on_discogs_miss.py        # Success: no issues found in 3 source files
uv run pytest -q                                                                                                            # 2159 passed, 122 deselected, 2 xfailed, 1 error (pre-existing flaky teardown)
```

The 1 error is the pre-existing `test_no_module_level_asyncio_lock_in_dependencies` ("Event loop is closed") teardown — passes in isolation, unrelated to this change.

## Related

- Parent: WXYC/Backend-Service#1184 (Tragic Magic structural reachability cluster).
- Sibling that consumes this output: WXYC/Backend-Service#1185 (BS write/read path projection; blocked by this PR).
- Independent cross-repo sibling: WXYC/wxyc-ios-64#303 (inline V2 → proxy fallback when streaming URLs are absent inline).
- Builds on: WXYC/library-metadata-lookup#389 + #390 (artist+track verification at 80 floor) and #396 + #398 (album verification at 80 floor) — the verified `_fetch_apple_music_url` is what this PR extends the reach of.
- Adjacent: WXYC/library-metadata-lookup#400 — the systemic upstream wrong-album-fallback bug. If #400 lands "approach 2" (surface `album_match_confidence`), BS#1185's projection collapses into "low confidence → take the streaming-only path produced by this PR" — they slot together naturally.
- Cluster tracker: WXYC/library-metadata-lookup#397.

Closes #401.
