### PR TITLE
fix(orchestrator): prefer release.images[0].uri over artist/label fallback

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1458,10 +1458,18 @@ async def find_library_albums_with_cached_track(
 
 
 async def _resolve_fallback_artwork(discogs_service: DiscogsService, release_id: int) -> str | None:
-    """Try artist image, then label image, for a release with no cover art."""
+    """Try the release's own cover (images[0]), then artist image, then label image."""
     release = await discogs_service.get_release(release_id)
     if not release:
         return None
+
+    # The search endpoint's `cover_image` is sometimes empty for releases whose
+    # release-detail `images[0].uri` is populated. Prefer that over the
+    # artist/label image fallback so enrichment-worker callers (single LML
+    # round-trip) recover the same cover the /proxy/metadata/album legacy
+    # two-call path produces via populateReleaseMetadata.
+    if release.artwork_url:
+        return release.artwork_url
 
     if release.artist_id:
         image = await discogs_service.get_artist_image(release.artist_id)

--- a/tests/integration/test_fallback_artwork.py
+++ b/tests/integration/test_fallback_artwork.py
@@ -1,0 +1,58 @@
+"""Integration test for `_resolve_fallback_artwork` against the real Discogs API.
+
+Companion to the unit test
+``tests/unit/test_orchestrator_helpers.py::TestFetchArtworkFallback::test_uses_release_artwork_when_search_misses``.
+
+The unit test mocks ``DiscogsService.get_release`` to assert the function
+prefers ``release.artwork_url`` over the artist/label image fallback. This
+integration test confirms the same fix end-to-end against a real Discogs
+release that has ``images[0].uri`` populated.
+
+Marked ``external_api`` — hits the real Discogs API; self-skips if
+``DISCOGS_TOKEN`` is unset.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from discogs.models import DiscogsSearchRequest
+from discogs.service import DiscogsService
+from lookup.orchestrator import _resolve_fallback_artwork
+
+DISCOGS_TOKEN = os.environ.get("DISCOGS_TOKEN")
+
+pytestmark = [
+    pytest.mark.external_api,
+    pytest.mark.skipif(not DISCOGS_TOKEN, reason="DISCOGS_TOKEN not set"),
+]
+
+
+@pytest.mark.asyncio
+async def test_resolves_to_release_images_uri_when_present():
+    """Given a real Discogs release whose ``images[0].uri`` is populated,
+    ``_resolve_fallback_artwork`` must return that URL. Picks the top search
+    hit for Stereolab / Aluminum Tunes (the project-wide example fixture) so
+    the test stays anchored to a real catalog entry rather than a hard-coded
+    release_id that could be deleted upstream."""
+    service = DiscogsService(token=DISCOGS_TOKEN)
+
+    search = await service.search(DiscogsSearchRequest(artist="Stereolab", album="Aluminum Tunes"))
+    assert search.results, "Stereolab / Aluminum Tunes search returned no hits"
+    release_id = search.results[0].release_id
+
+    release = await service.get_release(release_id)
+    assert release is not None, f"get_release({release_id}) returned None"
+    assert release.artwork_url, (
+        f"release {release_id} has no images[0].uri — pick a different fixture; "
+        "test premise is that the release object carries an artwork URL"
+    )
+
+    resolved = await _resolve_fallback_artwork(service, release_id)
+    assert resolved == release.artwork_url, (
+        f"expected fallback to return release.artwork_url={release.artwork_url!r}; "
+        f"got {resolved!r}. The function must prefer release.images[0].uri over "
+        "the artist/label image fallback."
+    )

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1331,6 +1331,36 @@ class TestFetchArtworkFallback:
         assert results[0][1] is not None
         assert results[0][1].artwork_url is None
 
+    @pytest.mark.asyncio
+    async def test_uses_release_artwork_when_search_misses(self, mock_discogs_service):
+        """When search returned no cover_image but get_release surfaces an
+        artwork_url (from images[0].uri), prefer the release-level cover over
+        the artist/label image fallback. The /proxy/metadata/album legacy
+        two-call path already does this via populateReleaseMetadata; the
+        enrichment-worker takes the single-call path, so the fallback resolver
+        is the only place that can surface the cover for it."""
+        items = [make_library_item(id=1, artist="Autechre", title="Confield")]
+
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[make_discogs_result(release_id=28138, artwork_url=None)]
+        )
+        mock_discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=28138,
+            title="Confield",
+            artist="Autechre",
+            artist_id=77,
+            label_id=233,
+            artwork_url="https://i.discogs.com/release-cover.jpg",
+            release_url="https://www.discogs.com/release/28138",
+        )
+
+        results = await fetch_artwork_for_items(items, mock_discogs_service)
+
+        assert len(results) == 1
+        assert results[0][1].artwork_url == "https://i.discogs.com/release-cover.jpg"
+        mock_discogs_service.get_artist_image.assert_not_called()
+        mock_discogs_service.get_label_image.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Tests: search_song_as_track (catalog-track-search §4.2, LML#301)


### PR DESCRIPTION
## Summary

- `_resolve_fallback_artwork` was loading the release detail (which already extracts `artwork_url` from `data["images"][0]["uri"]`) but then skipping it and only trying artist/label images. Added a 3-line `if release.artwork_url: return release.artwork_url` right after the `get_release` guard so the lookup pipeline's single-call path surfaces the same cover the legacy two-call `/proxy/metadata/album` path produces via `populateReleaseMetadata`.
- This was the root cause of dj-site showing cassette placeholders while iOS V2 showed real covers for the same flowsheet rows — see the diagnosis chain in #408.

Closes #408.

## Test plan

- [x] Unit: `tests/unit/test_orchestrator_helpers.py::TestFetchArtworkFallback::test_uses_release_artwork_when_search_misses` — given a release with `artwork_url` set, fallback returns it and does not call `get_artist_image` / `get_label_image`. Confirmed RED against current `main`, GREEN after the fix.
- [x] Unit: 5 pre-existing `TestFetchArtworkFallback` cases still pass (artist image fallback, label image fallback, no-fallback-when-cover-exists, all-null path, `get_release` returns None).
- [x] Unit suite: 1922 passed.
- [x] Integration: `tests/integration/test_fallback_artwork.py::test_resolves_to_release_images_uri_when_present` — marked `external_api`, hits real Discogs via Stereolab / Aluminum Tunes, asserts `_resolve_fallback_artwork` returns `release.artwork_url`. Passes locally.
- [x] `ruff format` clean, `ruff check` clean, `mypy lookup/orchestrator.py tests/unit/test_orchestrator_helpers.py tests/integration/test_fallback_artwork.py --ignore-missing-imports` clean.