### PR TITLE
fix(orchestrator): album-match floor on artist-fallback path (closes #400)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -739,6 +739,49 @@ def _release_matches_library_row(release: ReleaseInfo, item: LibraryItem) -> boo
     return False
 
 
+# Minimum fuzzy score (0-100) for accepting a library-row title as a genuine
+# album match for the DJ-typed album. Mirrors `_APPLE_MUSIC_MATCH_FLOOR` and
+# the streaming-availability batch matcher. When the artist-fallback branches
+# of `search_library_with_fallback` surface a row whose title doesn't clear
+# this floor against the typed album, the row would otherwise carry the
+# matched Discogs release's `release_year` / `apple_music_url` / `spotify_url`
+# / `discogs_url` / `artwork_url` onto a flowsheet row tagged with a
+# completely different album — the contamination shape documented in #400
+# (~184k rows; 16,532 distinct Discogs URLs each attached to many distinct
+# DJ-typed `(artist, album)` pairs). #390 / #398 tightened the iTunes-result
+# verification; this tightens the LML lookup result itself.
+_ALBUM_MATCH_FLOOR = 80.0
+
+
+def _filter_results_by_album_match(
+    results: list[LibraryItem],
+    album: str | None,
+) -> list[LibraryItem]:
+    """Drop library rows whose title doesn't clear `_ALBUM_MATCH_FLOOR` against
+    the typed album. No-ops when `album` is empty or whitespace-only.
+
+    Pure CPU (`rapidfuzz.fuzz.token_set_ratio` + `to_match_form`); no I/O —
+    safe to call in the lookup hot path without compounding the LML cascade
+    semaphore-queue accumulation (the BS#1064 / BS#1078 failure mode).
+    """
+    if not album or not album.strip():
+        return results
+    from rapidfuzz import fuzz
+
+    norm_album = normalize_for_comparison(album)
+    kept: list[LibraryItem] = []
+    for item in results:
+        title_norm = normalize_for_comparison(item.title or "")
+        if fuzz.token_set_ratio(norm_album, title_norm) >= _ALBUM_MATCH_FLOOR:
+            kept.append(item)
+    if len(kept) < len(results):
+        logger.info(
+            f"Album-match floor dropped {len(results) - len(kept)} of {len(results)} "
+            f"artist-fallback candidates against typed album '{album}' (#400)"
+        )
+    return kept
+
+
 async def search_library_with_fallback(
     db: LibraryDB,
     parsed: ParsedRequest,
@@ -839,6 +882,7 @@ async def search_library_with_fallback(
         query = f"{parsed.artist} {parsed.song}"
         results = await db.search(query=query, limit=_FETCH_LIMIT)
         results = filter_results_by_artist(results, parsed.artist)
+        results = _filter_results_by_album_match(results, parsed.album)
 
         if results:
             song_lower = parsed.song.lower()
@@ -852,6 +896,7 @@ async def search_library_with_fallback(
         logger.info(f"No results for albums {albums}, trying artist only: '{parsed.artist}'")
         results = await db.search(query=parsed.artist, limit=_FETCH_LIMIT)
         results = filter_results_by_artist(results, parsed.artist)
+        results = _filter_results_by_album_match(results, parsed.album)
         if results:
             return results, True
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -759,10 +759,6 @@ def _filter_results_by_album_match(
 ) -> list[LibraryItem]:
     """Drop library rows whose title doesn't clear `_ALBUM_MATCH_FLOOR` against
     the typed album. No-ops when `album` is empty or whitespace-only.
-
-    Pure CPU (`rapidfuzz.fuzz.token_set_ratio` + `to_match_form`); no I/O —
-    safe to call in the lookup hot path without compounding the LML cascade
-    semaphore-queue accumulation (the BS#1064 / BS#1078 failure mode).
     """
     if not album or not album.strip():
         return results
@@ -777,7 +773,7 @@ def _filter_results_by_album_match(
     if len(kept) < len(results):
         logger.info(
             f"Album-match floor dropped {len(results) - len(kept)} of {len(results)} "
-            f"artist-fallback candidates against typed album '{album}' (#400)"
+            f"artist-fallback candidates against typed album '{album}'"
         )
     return kept
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,6 +87,12 @@ SEED_ITEMS = [
     (39, "Confield", "Autechre", "EL", 16, 1, "Electronic", "CD"),
     (40, "1st Class", "Large Professor", "HH", 1, 1, "Hiphop", "CD"),
     (41, "...Destroys The Space Invaders", "Prince Jammy", "RE", 1, 1, "Reggae", "Vinyl"),
+    # Nina Simone: top-2 prod offender in the #400 evidence table
+    # (/release/1402136 → 150 distinct DJ-typed albums across 419 rows). The
+    # library carries Pastel Blues but NOT every Nina Simone album a DJ might
+    # type — the artist-fallback contamination floor (#400) must drop
+    # candidates whose titles don't clear 80 against the typed album.
+    (42, "Pastel Blues", "Nina Simone", "SI", 1, 1, "Jazz", "Vinyl"),
     # Junior Kimbrough: title-album and same-artist comp that both contain the
     # song "Meet Me in the City". Exercises song-title-vs-primary-album
     # ranking when several library candidates by the same artist all pass

--- a/tests/integration/test_album_match_floor.py
+++ b/tests/integration/test_album_match_floor.py
@@ -33,20 +33,14 @@ class TestAlbumMatchFloorIntegration:
     @pytest.mark.asyncio
     async def test_nina_simone_wild_is_the_wind_does_not_surface_pastel_blues(self, library_db):
         """The exact prod-evidence failure mode: artist matches the library but
-        the typed album doesn't, and the artist-fallback cascade would
-        otherwise contaminate the flowsheet row with a wrong-album Discogs
-        release.
+        the typed album doesn't, and the artist-fallback cascade would otherwise
+        contaminate the flowsheet row with a wrong-album Discogs release.
 
         Library seed has Nina Simone / Pastel Blues only. Request types album
-        "Wild Is the Wind" + song "Sinnerman". Without the floor:
-        artist-fallback surfaces Pastel Blues, enrichment attaches its
-        release metadata, BS persists `release_year` / `apple_music_url` /
-        `spotify_url` / `discogs_url` onto a row tagged "Wild Is the Wind".
-
-        With the floor: token_set_ratio("Wild Is the Wind", "Pastel Blues")
-        is well below 80 (no shared significant tokens), the candidate is
-        dropped, and no album-derived enrichment leaks. The response mirrors
-        the unknown-artist shape.
+        "Wild Is the Wind" + song "Sinnerman" —
+        token_set_ratio("Wild Is the Wind", "Pastel Blues") sits well below 80
+        (no shared significant tokens), so the candidate is dropped and the
+        response mirrors the unknown-artist shape.
         """
         from wxyc_fastapi.observability import init_cache_stats
 

--- a/tests/integration/test_album_match_floor.py
+++ b/tests/integration/test_album_match_floor.py
@@ -1,0 +1,134 @@
+"""Integration test for the artist-fallback album-match floor (LML#400).
+
+End-to-end exercise of ``perform_lookup`` against a real (in-memory)
+``LibraryDB`` with the seeded Nina Simone fixture (top-2 prod offender from
+the #400 evidence table — `/release/1402136`, 150 distinct DJ-typed albums
+across 419 contaminated rows).
+
+When a DJ types a Nina Simone album that the WXYC library doesn't physically
+carry (e.g. "Wild Is the Wind") plus a song that Nina Simone DOES have on a
+DIFFERENT album in the library ("Sinnerman" → "Pastel Blues"), the
+artist-fallback cascade historically surfaced the wrong-album library row,
+and ``enrich_artwork_results`` then attached Pastel Blues' Discogs release
+year / Apple Music URL / Spotify URL / Discogs URL / artwork URL onto a
+flowsheet row tagged with album "Wild Is the Wind". The floor rejects the
+candidate before enrichment runs.
+
+Companion to the unit tests in ``tests/unit/test_album_match_floor.py``.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.models import DiscogsSearchResponse
+from lookup.models import LookupRequest
+from lookup.orchestrator import perform_lookup
+from tests.conftest import make_lml_telemetry
+
+
+class TestAlbumMatchFloorIntegration:
+    """Pin the #400 prod contamination shape against a real LibraryDB."""
+
+    @pytest.mark.asyncio
+    async def test_nina_simone_wild_is_the_wind_does_not_surface_pastel_blues(self, library_db):
+        """The exact prod-evidence failure mode: artist matches the library but
+        the typed album doesn't, and the artist-fallback cascade would
+        otherwise contaminate the flowsheet row with a wrong-album Discogs
+        release.
+
+        Library seed has Nina Simone / Pastel Blues only. Request types album
+        "Wild Is the Wind" + song "Sinnerman". Without the floor:
+        artist-fallback surfaces Pastel Blues, enrichment attaches its
+        release metadata, BS persists `release_year` / `apple_music_url` /
+        `spotify_url` / `discogs_url` onto a row tagged "Wild Is the Wind".
+
+        With the floor: token_set_ratio("Wild Is the Wind", "Pastel Blues")
+        is well below 80 (no shared significant tokens), the candidate is
+        dropped, and no album-derived enrichment leaks. The response mirrors
+        the unknown-artist shape.
+        """
+        from wxyc_fastapi.observability import init_cache_stats
+
+        init_cache_stats()
+
+        # Discogs returns nothing — exercise pure library-side cascade. The
+        # floor must fire on the LML side regardless of whether Discogs
+        # would have rescued the lookup with the right album.
+        mock_service = AsyncMock(
+            spec_set=[
+                "search",
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "get_release",
+                "cache_service",
+            ]
+        )
+        mock_service.cache_service = None
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        mock_service.get_release = AsyncMock(return_value=None)
+        mock_service.validate_track_on_release = AsyncMock(return_value=False)
+
+        request = LookupRequest(
+            artist="Nina Simone",
+            album="Wild Is the Wind",
+            song="Sinnerman",
+            raw_message="Sinnerman by Nina Simone — Wild Is the Wind",
+        )
+        response = await perform_lookup(
+            request,
+            library_db,
+            mock_service,
+            make_lml_telemetry(),
+        )
+
+        # Floor dropped Pastel Blues → no library row surfaces. The response
+        # mirrors the unknown-artist shape and BS won't write any
+        # album-derived metadata onto the flowsheet row.
+        result_albums = [r.library_item.title for r in response.results]
+        assert "Pastel Blues" not in result_albums, (
+            "Wrong-album fallback leaked: Pastel Blues surfaced for typed album "
+            "'Wild Is the Wind'. This is the exact #400 prod contamination shape."
+        )
+
+    @pytest.mark.asyncio
+    async def test_nina_simone_pastel_blues_typed_correctly_still_surfaces(self, library_db):
+        """Companion green case: when the DJ types Pastel Blues, the library
+        row surfaces normally. The floor doesn't gate correctly-typed
+        requests.
+        """
+        from wxyc_fastapi.observability import init_cache_stats
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(
+            spec_set=[
+                "search",
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "get_release",
+                "cache_service",
+            ]
+        )
+        mock_service.cache_service = None
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        mock_service.get_release = AsyncMock(return_value=None)
+        mock_service.validate_track_on_release = AsyncMock(return_value=False)
+
+        request = LookupRequest(
+            artist="Nina Simone",
+            album="Pastel Blues",
+            song="Sinnerman",
+            raw_message="Sinnerman by Nina Simone — Pastel Blues",
+        )
+        response = await perform_lookup(
+            request,
+            library_db,
+            mock_service,
+            make_lml_telemetry(),
+        )
+
+        result_albums = [r.library_item.title for r in response.results]
+        assert "Pastel Blues" in result_albums, (
+            f"Expected Pastel Blues in results when typed correctly, got {result_albums}"
+        )

--- a/tests/unit/test_album_match_floor.py
+++ b/tests/unit/test_album_match_floor.py
@@ -42,8 +42,7 @@ class TestArtistFallbackAlbumMatchFloor:
     80-floor token_set_ratio against the requested album, otherwise drop.
     """
 
-    @pytest.mark.asyncio
-    async def test_floor_constant_is_80(self):
+    def test_floor_constant_is_80(self):
         """Pinned at the same value as #390/#398's ``_APPLE_MUSIC_MATCH_FLOOR``."""
         assert _ALBUM_MATCH_FLOOR == 80.0
 
@@ -57,10 +56,6 @@ class TestArtistFallbackAlbumMatchFloor:
         typed album, and downstream enrichment inherits the matched release's
         Discogs URL / release year / Spotify URL / Apple URL onto a row tagged
         ``album_title="Kind of Blue"``.
-
-        With the floor in place: artist-fallback candidates whose titles don't
-        clear ``token_set_ratio >= 80`` against ``parsed.album`` are dropped.
-        Nothing survives → empty result, mirroring the unknown-artist shape.
         """
         # Library has Miles Davis but only "Bitches Brew" and "On the Corner".
         # Neither title overlaps with "Kind of Blue" at token_set_ratio >= 80.
@@ -323,11 +318,6 @@ class TestArtistFallbackAlbumMatchFloor:
         pastel = make_library_item(
             id=70, artist="Nina Simone", title="Pastel Blues", call_letters="SI"
         )
-        # artist+song hit returns Pastel Blues (which the floor will drop
-        # because "Pastel Blues" doesn't clear 80 against "Wild Is the Wind").
-        # The cascade then falls through to artist-only — same Pastel Blues
-        # surfaces there and gets dropped again. Both branches enforce the
-        # floor, so nothing leaks downstream.
         mock_library_db.search.side_effect = [
             [pastel],  # artist+song hit
             [pastel],  # artist-only hit

--- a/tests/unit/test_album_match_floor.py
+++ b/tests/unit/test_album_match_floor.py
@@ -1,0 +1,352 @@
+"""Unit tests for the artist-fallback album-match floor (LML#400).
+
+When ``search_library_with_fallback`` falls through to the artist-only branch
+(``song_not_found=True``), it historically returned an arbitrary library row
+for the requested artist regardless of how that row's title related to the
+DJ-typed album. Downstream ``enrich_artwork_results`` then attached the
+matched Discogs release's ``release_year`` / ``apple_music_url`` /
+``spotify_url`` / ``discogs_url`` / ``artwork_url`` and Backend-Service wrote
+those onto the flowsheet row — contaminating ~184k free-text rows in prod
+(see #400 evidence). #390 and #398 tightened the iTunes-result verification;
+this guard tightens the LML lookup result itself.
+
+Behavior under test: when ``parsed.album`` is non-empty AND the candidate
+library row's title doesn't clear ``token_set_ratio >= _ALBUM_MATCH_FLOOR``
+against ``parsed.album`` (diacritic-folded), the row is rejected. If every
+artist-fallback candidate is rejected, the function returns the
+unknown-artist shape (``[], song_not_found_flag``) — no album-derived
+metadata leaks downstream.
+
+Mirrors the 80-floor + ``rapidfuzz.fuzz.token_set_ratio`` +
+``wxyc_etl.text.to_match_form`` primitives used by ``_fetch_apple_music_url``
+(#390 / #398).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lookup.orchestrator import (
+    _ALBUM_MATCH_FLOOR,
+    search_library_with_fallback,
+)
+from services.parser import MessageType, ParsedRequest
+from tests.factories import make_library_item
+
+
+class TestArtistFallbackAlbumMatchFloor:
+    """Artist-fallback contamination guard (LML#400).
+
+    Locked Approach 1: when the DJ-typed album is non-empty and the cascade
+    falls through to artist-only matching, surviving rows must clear the
+    80-floor token_set_ratio against the requested album, otherwise drop.
+    """
+
+    @pytest.mark.asyncio
+    async def test_floor_constant_is_80(self):
+        """Pinned at the same value as #390/#398's ``_APPLE_MUSIC_MATCH_FLOOR``."""
+        assert _ALBUM_MATCH_FLOOR == 80.0
+
+    @pytest.mark.asyncio
+    async def test_artist_fallback_rejected_when_typed_album_misses_library_titles(
+        self, mock_library_db
+    ):
+        """The #400 failure mode: Miles Davis / Kind of Blue against a library that
+        has Miles Davis but no Kind of Blue. Without the floor the cascade returns
+        an arbitrary Miles Davis library row whose title bears no relation to the
+        typed album, and downstream enrichment inherits the matched release's
+        Discogs URL / release year / Spotify URL / Apple URL onto a row tagged
+        ``album_title="Kind of Blue"``.
+
+        With the floor in place: artist-fallback candidates whose titles don't
+        clear ``token_set_ratio >= 80`` against ``parsed.album`` are dropped.
+        Nothing survives → empty result, mirroring the unknown-artist shape.
+        """
+        # Library has Miles Davis but only "Bitches Brew" and "On the Corner".
+        # Neither title overlaps with "Kind of Blue" at token_set_ratio >= 80.
+        bitches_brew = make_library_item(
+            id=10, artist="Miles Davis", title="Bitches Brew", call_letters="DA"
+        )
+        on_the_corner = make_library_item(
+            id=11,
+            artist="Miles Davis",
+            title="On the Corner",
+            call_letters="DA",
+            release_call_number=2,
+        )
+        # search.side_effect drives the cascade:
+        #   1) artist+song (FTS) → no match
+        #   2) artist-only → returns the contaminating candidates
+        mock_library_db.search.side_effect = [
+            [],
+            [bitches_brew, on_the_corner],
+        ]
+
+        parsed = ParsedRequest(
+            song="So What",
+            artist="Miles Davis",
+            album="Kind of Blue",
+            raw_message="So What by Miles Davis - Kind of Blue",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        # Both candidates fail the 80-floor against "Kind of Blue" → empty.
+        assert results == []
+        # song_not_found stays True so downstream cascades know nothing surfaced
+        # and the response mirrors the unknown-artist shape.
+        assert fallback is True
+
+    @pytest.mark.asyncio
+    async def test_artist_fallback_keeps_candidate_when_title_clears_floor(self, mock_library_db):
+        """When the artist-fallback candidate's title actually matches the typed
+        album (token_set_ratio >= 80), it survives the floor.
+
+        Token-set-ratio handles "Kind of Blue" vs "Kind of Blue (50th
+        Anniversary Edition)" — the extra parenthetical doesn't sink the
+        match because token_set is set-based, not order-or-length-based.
+        """
+        # Same artist, with a title that overlaps the typed album.
+        anniversary = make_library_item(
+            id=20,
+            artist="Miles Davis",
+            title="Kind of Blue (50th Anniversary Edition)",
+            call_letters="DA",
+        )
+        # Artist-only path: artist+song misses, artist-only returns the rich title.
+        mock_library_db.search.side_effect = [
+            [],
+            [anniversary],
+        ]
+
+        parsed = ParsedRequest(
+            song="So What",
+            artist="Miles Davis",
+            album="Kind of Blue",
+            raw_message="So What by Miles Davis - Kind of Blue",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        assert len(results) == 1
+        assert results[0].id == 20
+        assert fallback is True
+
+    @pytest.mark.asyncio
+    async def test_floor_skipped_when_typed_album_empty(self, mock_library_db):
+        """No typed album = no contamination signal. The cascade behaves exactly
+        as before — every artist-fallback candidate is returned for the
+        downstream ``filter_results_by_track_validation`` sweep to verify.
+
+        This is the regression pin against the 808 State / Flow Coma case
+        (``test_artist_fallback_when_discogs_albums_not_in_library`` in
+        test_orchestrator_helpers.py): no ``parsed.album`` means the floor
+        doesn't fire, and downstream Discogs track validation does its job.
+        """
+        false_positive = make_library_item(
+            id=958,
+            artist="808 State",
+            title="808 State",
+            call_letters="Ei",
+        )
+        mock_library_db.search.side_effect = [
+            [false_positive],  # artist+song fuzzy match
+        ]
+
+        parsed = ParsedRequest(
+            song="Flow Coma",
+            artist="808 State",
+            # No album provided.
+            raw_message="flow coma by 808 state",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        # Floor doesn't fire (parsed.album is None) → existing behavior preserved.
+        assert len(results) == 1
+        assert results[0].id == 958
+        assert fallback is True
+
+    @pytest.mark.asyncio
+    async def test_floor_skipped_when_typed_album_whitespace_only(self, mock_library_db):
+        """A whitespace-only ``parsed.album`` doesn't carry any contamination
+        signal — treat it as no-album so the floor doesn't fire."""
+        candidate = make_library_item(
+            id=30,
+            artist="Outkast",
+            title="Stankonia",
+            call_letters="OU",
+        )
+        mock_library_db.search.side_effect = [
+            [candidate],  # artist+song
+        ]
+
+        parsed = ParsedRequest(
+            song="Ms. Jackson",
+            artist="Outkast",
+            album="   ",  # whitespace only
+            raw_message="Ms. Jackson - Outkast",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        assert len(results) == 1
+        assert results[0].id == 30
+        assert fallback is True
+
+    @pytest.mark.asyncio
+    async def test_floor_rejects_outkast_top_offender(self, mock_library_db):
+        """Concrete prod offender from the #400 evidence table: Outkast's
+        single Discogs release (``/release/1171368``) was inherited as
+        metadata for 110 distinct DJ-typed album variants across 246 rows.
+
+        With the floor, a DJ typing "Outkast / Aquemini" against a library
+        that surfaces "Stankonia" via artist-fallback returns empty —
+        Stankonia's title doesn't clear 80-floor against "Aquemini".
+        """
+        stankonia = make_library_item(id=40, artist="Outkast", title="Stankonia", call_letters="OU")
+        mock_library_db.search.side_effect = [
+            [],  # artist+song
+            [stankonia],  # artist-only
+        ]
+
+        parsed = ParsedRequest(
+            song="Rosa Parks",
+            artist="Outkast",
+            album="Aquemini",
+            raw_message="Rosa Parks - Outkast - Aquemini",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        assert results == []
+        assert fallback is True
+
+    @pytest.mark.asyncio
+    async def test_floor_rejects_hank_williams_top_offender(self, mock_library_db):
+        """Concrete prod offender: Hank Williams ``/release/14773378`` was
+        inherited across 130 distinct (artist, album) variants. DJ types
+        "Hank Williams / Lovesick Blues", library only surfaces "Moanin'
+        the Blues" — token_set_ratio is below 80, candidate is rejected.
+
+        ``token_set_ratio`` shares "Blues" between the two titles, but the
+        rest of the tokens differ enough to keep the ratio below 80. Pin
+        the live value with a sanity assert against rapidfuzz to guard
+        against drift if the upstream tokenizer ever changes.
+        """
+        from rapidfuzz import fuzz
+        from wxyc_etl.text import to_match_form
+
+        # Sanity-check the live ratio so the test isn't relying on opaque
+        # internals. If rapidfuzz ever drifts above 80 here we want to know.
+        assert (
+            fuzz.token_set_ratio(
+                to_match_form("Lovesick Blues"),
+                to_match_form("Moanin' the Blues"),
+            )
+            < _ALBUM_MATCH_FLOOR
+        )
+
+        moanin = make_library_item(
+            id=50, artist="Hank Williams", title="Moanin' the Blues", call_letters="WI"
+        )
+        mock_library_db.search.side_effect = [
+            [],  # artist+song
+            [moanin],  # artist-only
+        ]
+
+        parsed = ParsedRequest(
+            song="Lovesick Blues",
+            artist="Hank Williams",
+            album="Lovesick Blues",
+            raw_message="Lovesick Blues - Hank Williams",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        assert results == []
+        assert fallback is True
+
+    @pytest.mark.asyncio
+    async def test_floor_handles_diacritics_via_normalization(self, mock_library_db):
+        """``to_match_form`` strips diacritics before scoring, so accented
+        album titles match the unaccented form (and vice versa)."""
+        canonical = make_library_item(
+            id=60,
+            artist="Hermanos Gutiérrez",
+            title="El Bueno Y El Malo",
+            call_letters="GU",
+        )
+        mock_library_db.search.side_effect = [
+            [],  # artist+song
+            [canonical],  # artist-only
+        ]
+
+        # DJ typed ASCII-only album, library row carries accented variant.
+        parsed = ParsedRequest(
+            song="Tres Hermanos",
+            artist="Hermanos Gutierrez",
+            album="El Bueno y el Malo",  # diacritic-free + casing variant
+            raw_message="Tres Hermanos - Hermanos Gutierrez",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        assert len(results) == 1
+        assert results[0].id == 60
+        assert fallback is True
+
+    @pytest.mark.asyncio
+    async def test_artist_plus_song_branch_also_filtered(self, mock_library_db):
+        """The artist+song branch (not just artist-only) is also a contamination
+        source: ``search_library_with_fallback`` may return a row from
+        ``f"{artist} {song}"`` keyword matching that has nothing to do with
+        the typed album. The floor must apply to that branch too.
+        """
+        # FTS for "Nina Simone Sinnerman" surfaces "Pastel Blues" (which has
+        # Sinnerman on it). But the DJ typed album="Wild Is the Wind".
+        # token_set_ratio("Wild Is the Wind", "Pastel Blues") is below 80.
+        pastel = make_library_item(
+            id=70, artist="Nina Simone", title="Pastel Blues", call_letters="SI"
+        )
+        # artist+song hit returns Pastel Blues (which the floor will drop
+        # because "Pastel Blues" doesn't clear 80 against "Wild Is the Wind").
+        # The cascade then falls through to artist-only — same Pastel Blues
+        # surfaces there and gets dropped again. Both branches enforce the
+        # floor, so nothing leaks downstream.
+        mock_library_db.search.side_effect = [
+            [pastel],  # artist+song hit
+            [pastel],  # artist-only hit
+        ]
+
+        parsed = ParsedRequest(
+            song="Sinnerman",
+            artist="Nina Simone",
+            album="Wild Is the Wind",
+            raw_message="Sinnerman by Nina Simone — Wild Is the Wind",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        # Pastel Blues is a real Nina Simone album that contains Sinnerman, but
+        # the DJ typed "Wild Is the Wind" — surfacing Pastel Blues would attach
+        # Pastel Blues metadata onto a flowsheet row tagged Wild Is the Wind.
+        # The floor drops it.
+        assert results == []
+        assert fallback is True

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -474,7 +474,13 @@ class TestSearchLibraryWithFallback:
 
     @pytest.mark.asyncio
     async def test_falls_back_to_artist_only_when_no_discogs_albums(self, mock_library_db):
-        """Falls back to artist-only when Discogs found no albums (empty list)."""
+        """Falls back to artist-only when Discogs found no albums (empty list).
+
+        With no typed album, the #400 album-match floor does not fire and the
+        cascade returns the artist-only candidate as before. The with-typed-
+        album-but-no-library-match shape is pinned in
+        ``tests/unit/test_album_match_floor.py``.
+        """
         item = make_library_item(
             id=2,
             artist="Queen",
@@ -490,7 +496,6 @@ class TestSearchLibraryWithFallback:
         parsed = ParsedRequest(
             song="Test Song",
             artist="Queen",
-            album="Unknown Album",
             raw_message="Test",
             is_request=True,
             message_type=MessageType.REQUEST,


### PR DESCRIPTION
## Problem

When `search_library_with_fallback` in `lookup/orchestrator.py` falls through to its artist-only branch (or its artist+song keyword branch returns a row whose title doesn't relate to the typed album), the cascade historically returned an arbitrary library row for the typed artist. Downstream `enrich_artwork_results` then attached the matched Discogs release's `release_year` / `apple_music_url` / `spotify_url` / `discogs_url` / `artwork_url` and Backend-Service wrote those onto the flowsheet row — tagged with a completely different album.

Prod evidence in WXYC/library-metadata-lookup#400: ~184k free-text flowsheet rows carry this shape, attached to 16,532 distinct Discogs release URLs each bound to multiple `(artist, album)` pairs. Top offenders include Nina Simone (`/release/1402136` — 150 distinct DJ-typed albums across 419 rows), Outkast (110 distinct), Hank Williams (130 distinct), Miles Davis (65 distinct).

WXYC/library-metadata-lookup#390 and WXYC/library-metadata-lookup#398 tightened the iTunes-result verification (artist match floor; track-on-album-collection check). This PR tightens the LML lookup result itself — the upstream Discogs release that BS pulls year / artwork / spotify / discogs from.

## Approach (locked: approach 1)

Reject artist-fallback candidates whose library titles don't clear `rapidfuzz.fuzz.token_set_ratio >= 80` against `parsed.album` when `parsed.album` is non-empty. On sub-floor, every candidate drops and the function returns the unknown-artist shape (`[], song_not_found_flag`) — same shape LML already returns for an unknown artist. No `LookupResponse` contract change. No `wxyc-shared/api.yaml` ripple. No BS consumer update needed.

Why approach 1 over approach 2 (surface `album_match_confidence`):
- Hermetic to LML — single-repo PR.
- Matches the existing "no-result for unknown shape" behavior at every consumer that already handles it.
- Reversible: if the floor turns out to be too strict, bumping `_ALBUM_MATCH_FLOOR` is a one-line knob.
- Floor mirrors the values in WXYC/library-metadata-lookup#390 / WXYC/library-metadata-lookup#398 — keeps the verification surface coherent.

## Implementation

New helper at `lookup/orchestrator.py:742`:

```python
_ALBUM_MATCH_FLOOR = 80.0

def _filter_results_by_album_match(
    results: list[LibraryItem],
    album: str | None,
) -> list[LibraryItem]:
    if not album or not album.strip():
        return results
    from rapidfuzz import fuzz
    norm_album = normalize_for_comparison(album)
    kept = [
        item for item in results
        if fuzz.token_set_ratio(norm_album, normalize_for_comparison(item.title or "")) >= _ALBUM_MATCH_FLOOR
    ]
    if len(kept) < len(results):
        logger.info(
            f"Album-match floor dropped {len(results) - len(kept)} of {len(results)} "
            f"artist-fallback candidates against typed album '{album}' (#400)"
        )
    return kept
```

Called at both cascade legs (`f"{parsed.artist} {parsed.song}"` keyword path and the artist-only path) in `search_library_with_fallback`.

Pure CPU, no I/O. Lazy `from rapidfuzz import fuzz` matches the 5 other lazy-import sites in this file. Reuses `normalize_for_comparison` already imported at module scope. Safe to call in the lookup hot path without compounding the LML cascade semaphore-queue accumulation (the BS#1064 / BS#1078 failure mode documented in the memory and in `project_lml_cascade_mechanism.md`).

One existing test modified: `test_falls_back_to_artist_only_when_no_discogs_albums` had `album="Unknown Album"` which would now be rejected by the floor (Queen titles don't match "Unknown Album"). Dropped the album field (still exercises the artist-only fallback shape) and added a docstring note pointing readers to the new test file.

Nina Simone fixture added to `tests/integration/conftest.py` (call letters `SI`, "Pastel Blues" — top-2 prod offender from the #400 evidence table).

## Tests

| Suite | Result |
|---|---|
| `tests/unit/test_album_match_floor.py` (9 new) | **9 / 9 passing** |
| `tests/integration/test_album_match_floor.py` (2 new) | **2 / 2 passing** |
| `tests/unit/test_orchestrator_helpers.py` (1 modified) | passing |
| **`tests/unit/` (full suite)** | **1931 / 1931 passing** in 82.13s |

Unit cases:
- `test_floor_constant_is_80` — pinned at the same value as WXYC/library-metadata-lookup#390 / WXYC/library-metadata-lookup#398's `_APPLE_MUSIC_MATCH_FLOOR`.
- `test_artist_fallback_rejected_when_typed_album_misses_library_titles` — Miles Davis / Kind of Blue against a library with Bitches Brew + On the Corner only. Both candidates fail the floor → empty result.
- `test_artist_fallback_keeps_candidate_when_title_clears_floor` — Kind of Blue (50th Anniversary Edition) clears via `token_set_ratio`.
- `test_floor_skipped_when_typed_album_empty` — regression pin against the 808 State / Flow Coma case in `test_orchestrator_helpers.py`.
- `test_floor_skipped_when_typed_album_whitespace_only` — Outkast with `album="   "` still surfaces.
- `test_floor_rejects_outkast_top_offender` — concrete prod offender (`/release/1171368`, 110 distinct albums across 246 rows).
- `test_floor_rejects_hank_williams_top_offender` — concrete prod offender; includes a live `rapidfuzz.fuzz.token_set_ratio` assertion so the test isn't relying on opaque ratio internals.
- `test_floor_handles_diacritics_via_normalization` — Hermanos Gutiérrez / ASCII variant via `wxyc_etl.text.to_match_form`.
- `test_artist_plus_song_branch_also_filtered` — Nina Simone Sinnerman: the FTS hit "Pastel Blues" gets dropped when the DJ typed "Wild Is the Wind".

Integration cases (real `LibraryDB`, Discogs mocked to empty so the library-side floor is the unit-under-test):
- `test_nina_simone_wild_is_the_wind_does_not_surface_pastel_blues` — wrong-album case; Pastel Blues is in the library but DJ typed "Wild Is the Wind" → floor drops it.
- `test_nina_simone_pastel_blues_typed_correctly_still_surfaces` — green companion; typed-correctly request returns Pastel Blues.

## Local pre-flight

```
pytest tests/unit/                # 1931 passed in 82.13s
ruff check                        # All checks passed!
ruff format --check               # 265 files already formatted
mypy . --ignore-missing-imports   # Success: no issues found in 265 source files
```

## Out of scope (followups)

- **One-shot backfill of the 184k contaminated rows** — separate ticket to be filed after this PR deploys to prod and soaks. Needs pacing + circuit-breaker per WXYC/Backend-Service#994 / WXYC/Backend-Service#995. Will leverage the bulk endpoint (WXYC/library-metadata-lookup#368) for compression.
- **Discogs-side contamination shapes** — this PR drops the library row that would have surfaced the wrong Discogs release. `enrich_artwork_results` is keyed on the matched library row, so suppressing the wrong library row cascades to suppress the wrong Discogs enrichment. A follow-up could add an end-to-end integration test where Discogs DOES return a candidate release to confirm the suppression works through both layers.
- **Approach-2 confidence-band variant** — explicitly declined for this PR. If LML ever needs to surface "we found a candidate but album confidence is below floor" as a positive signal (vs the current "no result"), that's a `wxyc-shared/api.yaml` change with codegen + BS consumer updates. Today there's no consumer that distinguishes "no result" from "low confidence" — both fall back to the same `SearchUrlProvider` path on BS. Re-evaluate if a consumer needs the distinction.

Closes #400.

Refs: WXYC/library-metadata-lookup#397 (Tragic Magic cluster tracker), WXYC/library-metadata-lookup#390, WXYC/library-metadata-lookup#398 (sibling iTunes-result verification floors). Also relates to WXYC/Backend-Service#1184 (Tragic Magic structural reachability — this PR is the "stop producing wrong-album metadata upstream" complement to BS#1184's "make the client adapt to missing metadata" iOS-side fix in WXYC/wxyc-ios-64#303).
