### PR TITLE
refactor(search): uniform Outcome value type + lookup/strategies/ package (#399 step 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,16 +23,17 @@ Library Metadata Lookup is a FastAPI service for WXYC radio that searches the li
 
 ### Search Strategy Pipeline
 
-Strategies are defined declaratively in `core/search.py` and executed in order:
+The strategy seam (`Outcome` value type, `Strategy` Protocol, `_apply` write site, `execute_search_pipeline` runner) lives in `core/search.py`. Each concrete strategy is a `@dataclass(frozen=True)` class in `lookup/strategies/`, one module per strategy; the orchestrator-side execute funcs that do the actual library/Discogs work still live in `lookup/orchestrator.py` and are injected into each strategy at construction time.
 
-| Strategy | Trigger | Implementation |
-|---|---|---|
-| `ARTIST_PLUS_ALBUM` | Has artist, album, or song | `search_library_with_fallback()` |
-| `SWAPPED_INTERPRETATION` | No results + "X - Y" / "X, Y" / "X. Y" format | `search_with_alternative_interpretation()` |
-| `TRACK_ON_COMPILATION` | Song not found + artist + song | `search_compilations_for_track()` |
-| `SONG_AS_ARTIST` | No results + song but no artist | `search_song_as_artist()` |
+| Strategy | Trigger | Class | Execute func |
+|---|---|---|---|
+| `ARTIST_PLUS_ALBUM` | Has artist, album, or song | `lookup/strategies/artist_plus_album.py` | `search_library_with_fallback()` |
+| `SWAPPED_INTERPRETATION` | No results + "X - Y" / "X, Y" / "X. Y" format | `lookup/strategies/swapped_interpretation.py` | `search_with_alternative_interpretation()` |
+| `TRACK_ON_COMPILATION` | Song not found + artist + song | `lookup/strategies/track_on_compilation.py` | `search_compilations_for_track()` |
+| `SONG_AS_ARTIST` | No results + song but no artist | `lookup/strategies/song_as_artist.py` | `search_song_as_artist()` |
+| `SONG_AS_TRACK` | SONG_AS_ARTIST ran and returned empty (catalog-track-search §4.2) | `lookup/strategies/song_as_track.py` | `search_song_as_track()` |
 
-All strategy implementations live in `lookup/orchestrator.py`.
+Strategies never mutate `SearchState`; they return an `Outcome` and the runner applies it via `_apply`. This makes cancellation safety structural — a cancelled `attempt()` is a no-op against state by construction. Production wiring lives in `lookup.strategies.build_strategies`, called from `perform_lookup`.
 
 ### Key Files
 

--- a/core/search.py
+++ b/core/search.py
@@ -11,15 +11,14 @@ import logging
 import os
 import re
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import ClassVar, Protocol
 
 import sentry_sdk
 
 from generated.api_models import TrackMatchHint
-from library.db import LibraryDB
 from library.models import LibraryItem
 from services.parser import ParsedRequest
 
@@ -344,61 +343,237 @@ Args:
     raw_message: Original request message
 """
 
-ExecuteFunc = Callable[..., Awaitable[tuple[list[LibraryItem], Any]]]
-"""Async function executed by a strategy's ``run`` wrapper.
 
-Returns a tuple whose second element shape varies per strategy:
+@dataclass(frozen=True, slots=True)
+class Outcome:
+    """A strategy's complete declared effect on :class:`SearchState`.
 
-    - ``ARTIST_PLUS_ALBUM``: ``bool`` (fallback_used)
-    - ``SWAPPED_INTERPRETATION``: ``None``
-    - ``TRACK_ON_COMPILATION``: ``dict[int, str]`` (discogs_titles)
-    - ``SONG_AS_ARTIST``: ``None``
-    - ``SONG_AS_TRACK``: ``dict[int, list[TrackMatchHint]]`` (matched_via_by_id)
+    Returned (not applied) by :meth:`Strategy.attempt` — the runner applies it
+    via :func:`_apply`. This is what makes cancellation safety structural: a
+    cancelled ``attempt()`` never returns an ``Outcome``, so no commit happens,
+    period. The await-then-commit *discipline* from step 1 (#391) becomes a
+    *type-enforced* contract here.
 
-The heterogeneous shape is the artifact step 2 (#399) replaces with a uniform
-``Outcome`` value type. In step 1 it lives behind each strategy's ``run``
-wrapper so the central dispatch loop never sees it.
-"""
+    The five named constructors below encode the four real effect-shapes the
+    pre-#399 strategy wrappers expressed with heterogeneous ``(list, Any)``
+    tuples, plus an explicit no-op:
 
-RunFunc = Callable[[LibraryDB, ParsedRequest, "SearchState", str], Awaitable[bool]]
-"""Async strategy body invoked by ``execute_search_pipeline``.
+        - :meth:`empty`            -- nothing to apply
+        - :meth:`found`            -- direct match (the 90% case)
+        - :meth:`artist_fallback`  -- fell through to artist-only / artist+song
+        - :meth:`compilation`      -- TRACK_ON_COMPILATION's full signal
+        - :meth:`track_match`      -- SONG_AS_TRACK's per-id hint set
 
-Contract:
-    1. Do **all** awaits before any write to ``SearchState``. The runner wraps
-       ``run`` in ``asyncio.wait_for`` (the LML#370 hard cap); a cancellation
-       between the last await and the final state mutation would leave the
-       state half-updated. Await-then-commit makes a cancelled ``run`` a
-       structural no-op.
-    2. Return ``True`` if this strategy populated ``state.results``; ``False``
-       otherwise. The runner combines the return with the current
-       ``state.results`` / ``state.song_not_found`` to decide whether to
-       break the cascade.
-"""
-
-
-@dataclass(frozen=True)
-class _Strategy:
-    """Strategy seam consumed by :func:`execute_search_pipeline`.
-
-    Built by :func:`build_strategies` from an injected ``ExecuteFunc`` plus the
-    per-strategy condition predicate; each strategy's ``run`` closure owns the
-    commit logic that used to live in the runner's ``if/elif`` arm.
-
-    Underscore-prefixed because callers should not construct these directly —
-    they're an implementation detail of the runner's seam. Tests that need a
-    bespoke strategy (e.g. ``TestPerStrategyWaitFor``) bypass
-    ``build_strategies`` and construct ``_Strategy`` directly, which is the
-    one accepted external use.
+    Field-level documentation lives on :func:`_apply`, which is the single
+    write site that consumes these fields.
     """
 
-    name: SearchStrategyType
-    """Strategy identifier for telemetry (``strategies_tried`` log)."""
+    items: list[LibraryItem]
+    """Library items the strategy produced. Empty list means no-op for results.
 
-    condition: ConditionFunc
-    """Predicate gating whether ``run`` is called this iteration."""
+    ``Outcome.artist_fallback([])`` is the exception: empty items but
+    ``song_not_found_after=True`` — ARTIST_PLUS_ALBUM's "no library hit but
+    flag the downstream cascade" signal.
+    """
 
-    run: RunFunc
-    """Async body — see :data:`RunFunc` for the cancellation contract."""
+    song_not_found_after: bool | None = None
+    """Desired ``state.song_not_found`` value after :func:`_apply`.
+
+    ``None`` means "leave alone". The flag flips for two opposite reasons:
+    ``True`` when fallback was used (downstream TRACK_ON_COMPILATION needs to
+    know the song wasn't directly matched), ``False`` when the strategy
+    actually matched the song (clears any prior fallback signal).
+    """
+
+    found_on_compilation_after: bool = False
+    """When True, :func:`_apply` sets ``state.found_on_compilation = True``."""
+
+    preserve_prior_results_as_fallback: bool = False
+    """The TRACK_ON_COMPILATION stash rule.
+
+    When True AND ``state.results`` AND ``state.song_not_found``, the
+    pre-update ``state.results`` is copied to ``state.artist_fallback_results``
+    so ``perform_lookup`` can validate the artist fallback against Discogs
+    tracklists and merge any confirmed matches back into the final results
+    after the compilation hit replaces them.
+    """
+
+    discogs_titles: dict[int, str] | None = None
+    """Per-id Discogs album titles (for artwork lookup). ``None`` = no-op."""
+
+    matched_via_by_id: dict[int, list[TrackMatchHint]] | None = None
+    """Per-id track-match hints (catalog-track-search §5.1). ``None`` = no-op."""
+
+    @classmethod
+    def empty(cls) -> "Outcome":
+        """Strategy ran but produced nothing — no writes to apply."""
+        return cls(items=[])
+
+    @classmethod
+    def found(cls, items: list[LibraryItem]) -> "Outcome":
+        """Direct match where the strategy can vouch for the song.
+
+        Clears ``state.song_not_found`` because the strategy explicitly
+        confirmed the song (SWAPPED_INTERPRETATION matched the swapped
+        interpretation, SONG_AS_ARTIST cross-referenced Discogs releases,
+        etc.). Use this for the 90% case where success means "the song
+        was matched."
+
+        For ARTIST_PLUS_ALBUM's direct path — where the artist's album was
+        found by name but the song's presence on the album wasn't verified —
+        use :meth:`album_match` instead, which leaves ``song_not_found``
+        alone so a prior album-resolution signal can still drive
+        TRACK_ON_COMPILATION downstream.
+        """
+        return cls(items=items, song_not_found_after=False)
+
+    @classmethod
+    def album_match(cls, items: list[LibraryItem]) -> "Outcome":
+        """ARTIST_PLUS_ALBUM's direct path: items found, but no claim about the song.
+
+        ARTIST_PLUS_ALBUM is the only strategy that doesn't independently
+        confirm the song — it matches by artist+album text, not by tracklist
+        cross-reference. When ``resolve_albums_for_track`` already set
+        ``song_not_found=True`` (Discogs returned only VA releases for the
+        track), and ARTIST_PLUS_ALBUM then finds the artist's album by name,
+        we want to *preserve* that ``song_not_found=True`` signal so
+        TRACK_ON_COMPILATION still runs to surface the compilation match.
+        ``perform_lookup``'s post-pipeline track_validation step then merges
+        the artist's album back in via the artist_fallback_results stash.
+
+        See ``test_compilation_search_when_song_not_found_from_album_resolution``
+        and the wider trace in the Adonis / "No Way Back" / Trax 20th case.
+        """
+        return cls(items=items)
+
+    @classmethod
+    def artist_fallback(cls, items: list[LibraryItem]) -> "Outcome":
+        """ARTIST_PLUS_ALBUM's fallback path: results came from artist-only
+        or artist+song search rather than artist+album.
+
+        ``song_not_found_after=True`` because the song title wasn't directly
+        matched. Downstream TRACK_ON_COMPILATION keys on the flag.
+        Works with ``items=[]`` too — the flag-only "no library hit but
+        downstream cascade should know" signal.
+        """
+        return cls(items=items, song_not_found_after=True)
+
+    @classmethod
+    def compilation(cls, items: list[LibraryItem], *, discogs_titles: dict[int, str]) -> "Outcome":
+        """TRACK_ON_COMPILATION's full signal.
+
+        Five writes packaged together:
+            - new items
+            - ``found_on_compilation = True``
+            - ``song_not_found = False`` (the song was matched, just on a
+              compilation rather than the artist's own release)
+            - ``discogs_titles`` for artwork lookup
+            - ``preserve_prior_results_as_fallback = True`` so any artist
+              fallback that ran first is stashed for post-pipeline validation
+        """
+        return cls(
+            items=items,
+            song_not_found_after=False,
+            found_on_compilation_after=True,
+            preserve_prior_results_as_fallback=True,
+            discogs_titles=discogs_titles,
+        )
+
+    @classmethod
+    def track_match(
+        cls,
+        items: list[LibraryItem],
+        *,
+        matched_via_by_id: dict[int, list[TrackMatchHint]],
+    ) -> "Outcome":
+        """SONG_AS_TRACK's signal: track-driven match with per-id provenance.
+
+        The library row(s) were surfaced by cross-referencing the song against
+        Discogs's tracklist index. Each row carries a TrackMatchHint pointing
+        back to the release that surfaced it — the API contract uses this for
+        the ``matched_via`` field per catalog-track-search §5.1.
+        """
+        return cls(
+            items=items,
+            song_not_found_after=False,
+            matched_via_by_id=matched_via_by_id,
+        )
+
+
+def _apply(state: SearchState, outcome: Outcome) -> None:
+    """Apply an :class:`Outcome` to :class:`SearchState`.
+
+    The single write site for strategy-driven SearchState mutations. The runner
+    calls this exactly once per strategy attempt (after ``asyncio.wait_for``
+    returns successfully); no per-strategy branching needed.
+
+    Two ordering invariants worth pinning:
+
+    1. **Items-empty short-circuit applies to most writes, but not to
+       ``song_not_found_after``.** ARTIST_PLUS_ALBUM can return ``([], True)``
+       when artist+song falls through to artist-only and the artist isn't in
+       the library at all — the flag still needs to propagate so downstream
+       TRACK_ON_COMPILATION's condition (``state.song_not_found and ...``)
+       evaluates correctly.
+
+    2. **The stash check reads prior ``state.song_not_found`` before the
+       update.** TRACK_ON_COMPILATION clears ``song_not_found`` to False as
+       part of its outcome (the song WAS matched, just on a compilation), but
+       the stash predicate ``state.results and state.song_not_found`` must
+       evaluate against the value as it stood when the strategy started. A
+       naive single-pass write order would never stash; this function does
+       stash first, then writes.
+    """
+    if not outcome.items:
+        # No items → only the flag-only signal (ARTIST_PLUS_ALBUM ``([], True)``
+        # case) can propagate. Skip results / found_on_compilation / titles /
+        # hints to avoid clobbering prior strategy state with a no-op.
+        if outcome.song_not_found_after is not None:
+            state.song_not_found = outcome.song_not_found_after
+        return
+
+    # Stash check must run BEFORE song_not_found_after is written, because
+    # the predicate reads the prior value.
+    if outcome.preserve_prior_results_as_fallback and state.results and state.song_not_found:
+        state.artist_fallback_results = list(state.results)
+
+    state.results = outcome.items
+    if outcome.song_not_found_after is not None:
+        state.song_not_found = outcome.song_not_found_after
+    if outcome.found_on_compilation_after:
+        state.found_on_compilation = True
+    if outcome.discogs_titles is not None:
+        state.discogs_titles = outcome.discogs_titles
+    if outcome.matched_via_by_id is not None:
+        state.matched_via_by_id = outcome.matched_via_by_id
+
+
+class Strategy(Protocol):
+    """The runner's strategy seam — concrete implementations live in ``lookup/strategies/``.
+
+    Two methods plus a name:
+
+        - ``name`` (a ``ClassVar``) — telemetry identifier appended to
+          ``state.strategies_tried`` before ``attempt`` runs.
+        - ``should_attempt(parsed, state, raw_message) -> bool`` — predicate
+          gating whether this iteration runs ``attempt``. Pure; cheap; reads
+          only the inputs.
+        - ``attempt(parsed, state, raw_message) -> Outcome`` — the async body.
+          Returns an :class:`Outcome`; **never** writes to ``state`` directly.
+          This is what makes cancellation safety structural — see
+          :class:`Outcome` for the contract.
+    """
+
+    name: ClassVar[SearchStrategyType]
+    """Telemetry identifier appended to ``state.strategies_tried``."""
+
+    def should_attempt(
+        self, parsed: ParsedRequest, state: SearchState, raw_message: str
+    ) -> bool: ...
+
+    async def attempt(
+        self, parsed: ParsedRequest, state: SearchState, raw_message: str
+    ) -> Outcome: ...
 
 
 # =============================================================================
@@ -459,196 +634,46 @@ def no_results_and_song_but_no_artist_track_fallback(
 
 
 # =============================================================================
-# Strategy Registry
+# Pipeline runner
 # =============================================================================
-
-
-def build_strategies(
-    search_library_func: ExecuteFunc,
-    search_alternative_func: ExecuteFunc,
-    search_compilations_func: ExecuteFunc,
-    search_song_as_artist_func: ExecuteFunc | None = None,
-    search_song_as_track_func: ExecuteFunc | None = None,
-) -> list[_Strategy]:
-    """Build the list of search strategies with injected execute functions.
-
-    Wraps each ``ExecuteFunc`` into a :class:`_Strategy` whose ``run`` closure
-    owns the per-strategy commit to :class:`SearchState`. The five wrappers
-    encode the contract that used to live in the runner's ``if/elif`` arms:
-    each one awaits first, then commits, then returns the ``produced`` bool.
-
-    Args:
-        search_library_func: Function implementing ARTIST_PLUS_ALBUM search.
-            Returns ``(list, fallback_used)``; the wrapper writes
-            ``state.results`` when non-empty and ``state.song_not_found``
-            when the fallback flag fires.
-        search_alternative_func: Function implementing SWAPPED_INTERPRETATION
-            search. The wrapper extracts ``(part1, part2)`` from the raw
-            message via :func:`detect_ambiguous_format`.
-        search_compilations_func: Function implementing TRACK_ON_COMPILATION
-            search. The wrapper stashes the prior artist-fallback results
-            into ``state.artist_fallback_results`` before replacing
-            ``state.results``, so perform_lookup can validate them against
-            Discogs tracklists afterward.
-        search_song_as_artist_func: Function implementing SONG_AS_ARTIST search.
-            Optional; when ``None``, the strategy is omitted from the list.
-        search_song_as_track_func: Function implementing SONG_AS_TRACK search
-            (catalog-track-search §4.2). Fires strictly after SONG_AS_ARTIST.
-            Optional; when ``None``, the strategy is omitted.
-
-    Returns:
-        List of ``_Strategy`` objects in execution order. The runner consumes
-        them generically — see :class:`_Strategy` for the seam contract.
-    """
-
-    async def run_artist_plus_album(
-        db: LibraryDB,
-        parsed: ParsedRequest,
-        state: SearchState,
-        raw_message: str,  # noqa: ARG001
-    ) -> bool:
-        results, fallback_used = await search_library_func(db, parsed, state.albums_for_search)
-        # Commit only after the await returns — cancellation between here and
-        # the wait_for raise is a structural no-op because no state was written.
-        if results:
-            state.results = results
-        if fallback_used:
-            state.song_not_found = True
-        return bool(results)
-
-    async def run_swapped_interpretation(
-        db: LibraryDB,
-        parsed: ParsedRequest,  # noqa: ARG001
-        state: SearchState,
-        raw_message: str,
-    ) -> bool:
-        parts = detect_ambiguous_format(raw_message)
-        if parts is None:
-            # Defensive — the SWAPPED condition already guarantees parts is non-None
-            # when this runs. Kept so a future condition change can't silently
-            # crash here.
-            return False
-        part1, part2 = parts
-        results, _meta = await search_alternative_func(db, part1, part2)
-        if results:
-            state.results = results
-            state.song_not_found = False
-        return bool(results)
-
-    async def run_track_on_compilation(
-        db: LibraryDB,
-        parsed: ParsedRequest,
-        state: SearchState,
-        raw_message: str,  # noqa: ARG001
-    ) -> bool:
-        results, discogs_titles = await search_compilations_func(db, parsed)
-        if not results:
-            return False
-        # Save artist-fallback results before replacing — perform_lookup will
-        # validate them against Discogs tracklists and merge any confirmed
-        # matches back into the final results. The condition for this stash
-        # (state.results AND state.song_not_found) was previously inlined in
-        # the runner's TRACK_ON_COMPILATION arm.
-        if state.results and state.song_not_found:
-            state.artist_fallback_results = list(state.results)
-        state.results = results
-        state.found_on_compilation = True
-        state.song_not_found = False
-        state.discogs_titles = discogs_titles
-        return True
-
-    async def run_song_as_artist(
-        db: LibraryDB,
-        parsed: ParsedRequest,
-        state: SearchState,
-        raw_message: str,  # noqa: ARG001
-    ) -> bool:
-        assert search_song_as_artist_func is not None  # type narrowing — see closure capture
-        results, _meta = await search_song_as_artist_func(db, parsed.song)
-        if results:
-            state.results = results
-            state.song_not_found = False
-        return bool(results)
-
-    async def run_song_as_track(
-        db: LibraryDB,
-        parsed: ParsedRequest,
-        state: SearchState,
-        raw_message: str,  # noqa: ARG001
-    ) -> bool:
-        assert search_song_as_track_func is not None
-        results, matched_via_by_id = await search_song_as_track_func(db, parsed.song)
-        if results:
-            state.results = results
-            state.song_not_found = False
-            state.matched_via_by_id = matched_via_by_id
-        return bool(results)
-
-    strategies: list[_Strategy] = [
-        _Strategy(
-            name=SearchStrategyType.ARTIST_PLUS_ALBUM,
-            condition=has_artist_or_album_or_song,
-            run=run_artist_plus_album,
-        ),
-        _Strategy(
-            name=SearchStrategyType.SWAPPED_INTERPRETATION,
-            condition=no_results_and_ambiguous_format,
-            run=run_swapped_interpretation,
-        ),
-        _Strategy(
-            name=SearchStrategyType.TRACK_ON_COMPILATION,
-            condition=song_not_found_with_artist_and_song,
-            run=run_track_on_compilation,
-        ),
-    ]
-
-    if search_song_as_artist_func is not None:
-        strategies.append(
-            _Strategy(
-                name=SearchStrategyType.SONG_AS_ARTIST,
-                condition=no_results_and_song_but_no_artist,
-                run=run_song_as_artist,
-            )
-        )
-
-    # SONG_AS_TRACK must come AFTER SONG_AS_ARTIST — its condition checks that
-    # SONG_AS_ARTIST already ran and produced nothing. Ordering is array
-    # position; the condition does the runtime cross-check.
-    if search_song_as_track_func is not None:
-        strategies.append(
-            _Strategy(
-                name=SearchStrategyType.SONG_AS_TRACK,
-                condition=no_results_and_song_but_no_artist_track_fallback,
-                run=run_song_as_track,
-            )
-        )
-
-    return strategies
+#
+# Step-1 (#391) made the runner generic — no ``strategy.name`` branch — by
+# wrapping each execute func in a closure that owned the commit logic.
+# Step-2 (#399) deepens it further: the seam now carries a uniform
+# :class:`Outcome` value type, and the runner has exactly one
+# :func:`_apply` write site to ``SearchState``. The per-strategy commit
+# logic moves into the strategy classes themselves
+# (``lookup/strategies/``); the runner names no strategy and writes no
+# state field individually.
 
 
 async def execute_search_pipeline(
     parsed: ParsedRequest,
-    db: LibraryDB,
     raw_message: str,
-    strategies: list[_Strategy],
+    strategies: list[Strategy],
     albums_for_search: list[str] | None = None,
     song_not_found: bool = False,
     caller_budget_ms: int | None = None,
 ) -> SearchState:
     """Execute strategies in array order until results found.
 
-    Dispatch is **generic**: the runner calls ``strategy.run`` without naming
-    any strategy. Each ``run`` is a closure built by :func:`build_strategies`
-    that owns the per-strategy commit to ``SearchState`` (see :data:`RunFunc`
-    for the cancellation contract). The cross-cutting budget / hard-cap /
-    caller-budget machinery and the ``state.timed_out`` projection are
-    unchanged from pre-#391.
+    Dispatch is **generic**: the runner calls ``strategy.attempt`` without
+    naming any strategy and applies the returned :class:`Outcome` via
+    :func:`_apply`. The cross-cutting budget / hard-cap / caller-budget
+    machinery and the ``state.timed_out`` projection are unchanged from
+    pre-#399.
+
+    Cancellation safety is **structural**: ``attempt()`` returns ``Outcome``
+    and cannot mutate ``state`` directly, so a cancelled ``attempt()`` is a
+    no-op against state by construction. The step-1 await-then-commit
+    *discipline* is replaced by a type-enforced contract.
 
     Args:
         parsed: The parsed request with artist/song/album.
-        db: Library database for searches.
         raw_message: Original request message (for ambiguous format detection).
         strategies: List of search strategies to try, in execution order.
+            Each strategy holds its own dependencies (``db``,
+            ``discogs_service``, etc.) as instance fields.
         albums_for_search: Optional list of album names from Discogs lookup.
         song_not_found: Whether album resolution already determined the song
             wasn't found.
@@ -733,8 +758,8 @@ async def execute_search_pipeline(
             )
             break
 
-        # Check if strategy should run
-        if not strategy.condition(parsed, state, raw_message):
+        # Check if strategy should run.
+        if not strategy.should_attempt(parsed, state, raw_message):
             continue
 
         state.strategies_tried.append(strategy.name)
@@ -752,11 +777,12 @@ async def execute_search_pipeline(
         # wait_for ceiling fires uniformly. CancelledError → TimeoutError raised
         # by wait_for propagates into in-flight asyncio.gather() probes inside
         # the strategy, freeing the Discogs semaphore on cap-fire. The
-        # RunFunc contract (await-then-commit) makes a cancelled run a
-        # structural no-op against SearchState.
+        # Outcome-returning contract (attempt cannot mutate state) makes a
+        # cancelled attempt a structural no-op against SearchState — no need
+        # for an await-then-commit discipline inside the strategy body.
         try:
-            produced = await asyncio.wait_for(
-                strategy.run(db, parsed, state, raw_message),
+            outcome = await asyncio.wait_for(
+                strategy.attempt(parsed, state, raw_message),
                 timeout=remaining_budget_seconds,
             )
         except TimeoutError:
@@ -768,15 +794,19 @@ async def execute_search_pipeline(
             )
             break
 
-        # Stop when this strategy populated results AND we're not still in the
+        # The one write site: every per-strategy ``SearchState`` mutation
+        # happens here, driven by the outcome's flags. See :func:`_apply`.
+        _apply(state, outcome)
+
+        # Stop when results are populated AND we're not still in the
         # song-not-found cascade. The pre-#391 ``strategy.name !=
-        # TRACK_ON_COMPILATION`` clause collapses away: every downstream
-        # strategy already gates on ``not state.results`` in its condition, so
-        # the name-check never changed the outcome. ``produced`` separates
-        # "this strategy added results" from "results carried over from a
-        # previous strategy" — keeps the contract legible even though
-        # ``state.results`` would also be True in the well-behaved case.
-        if produced and state.results and not state.song_not_found:
+        # TRACK_ON_COMPILATION`` clause collapsed away in step 1: every
+        # downstream strategy already gates on ``not state.results`` in its
+        # condition, so the name-check never changed the outcome. With the
+        # Outcome seam in place, the check simplifies to a pure state read —
+        # ``outcome.items`` would imply ``state.results`` here, so dropping
+        # the ``produced`` boolean from step 1 doesn't change semantics.
+        if state.results and not state.song_not_found:
             break
 
     return state

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -24,7 +24,6 @@ from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats_recorde
 
 from config.settings import get_settings
 from core.search import (
-    build_strategies,
     execute_search_pipeline,
     get_search_type_from_state,
 )
@@ -61,6 +60,7 @@ from lookup.external_search import (
     search_external_tracks,
 )
 from lookup.models import LookupRequest, LookupResponse, LookupResultItem
+from lookup.strategies import build_strategies
 from scripts.entity_resolution.sources import PgSourceProtocol
 from scripts.entity_resolution.store import EntityStore, Identity
 from services.parser import MessageType, ParsedRequest
@@ -2066,7 +2066,12 @@ async def perform_lookup(
 
     # Step 3: Execute search strategy pipeline
     with telemetry.track_step("library_search"):
+        # Strategies hold their own ``db`` handle (no per-call db arg on the
+        # runner post-#399). The discogs_service is captured via ``partial`` on
+        # the three strategies that need it; ARTIST_PLUS_ALBUM and
+        # SWAPPED_INTERPRETATION are library-only.
         strategies = build_strategies(
+            db,
             search_library_func=search_library_with_fallback,
             search_alternative_func=search_with_alternative_interpretation,
             search_compilations_func=partial(
@@ -2082,7 +2087,6 @@ async def perform_lookup(
 
         search_state = await execute_search_pipeline(
             parsed=parsed,
-            db=db,
             raw_message=request.raw_message or "",
             strategies=strategies,
             albums_for_search=albums_for_search,

--- a/lookup/strategies/__init__.py
+++ b/lookup/strategies/__init__.py
@@ -23,44 +23,18 @@ Production construction lives in :func:`lookup.orchestrator.perform_lookup`;
 the :func:`build_strategies` factory below is the seam tests use.
 """
 
-from collections.abc import Awaitable, Callable
-from typing import Any
-
 from core.search import Strategy
-from generated.api_models import TrackMatchHint
 from library.db import LibraryDB
-from library.models import LibraryItem
-from services.parser import ParsedRequest
 
-from .artist_plus_album import ArtistPlusAlbum
-from .song_as_artist import SongAsArtist
-from .song_as_track import SongAsTrack
-from .swapped_interpretation import SwappedInterpretation
-from .track_on_compilation import TrackOnCompilation
-
-# Execute-func type aliases — kept as public re-exports so the factory's
-# parameters are documented and ``orchestrator.py`` can annotate its
-# call site. Each shape mirrors the existing orchestrator-side return type.
-ArtistPlusAlbumExecute = Callable[
-    [LibraryDB, ParsedRequest, list[str]],
-    Awaitable[tuple[list[LibraryItem], bool]],
-]
-SwappedInterpretationExecute = Callable[
-    [LibraryDB, str, str],
-    Awaitable[tuple[list[LibraryItem], Any]],
-]
-TrackOnCompilationExecute = Callable[
-    [LibraryDB, ParsedRequest],
-    Awaitable[tuple[list[LibraryItem], dict[int, str]]],
-]
-SongAsArtistExecute = Callable[
-    [LibraryDB, str | None],
-    Awaitable[tuple[list[LibraryItem], Any]],
-]
-SongAsTrackExecute = Callable[
-    [LibraryDB, str | None],
-    Awaitable[tuple[list[LibraryItem], dict[int, list[TrackMatchHint]]]],
-]
+# Execute-func type aliases live next to the strategy class that consumes
+# them (one file per strategy). Re-exported here so the factory's parameters
+# are documented and ``orchestrator.py`` can annotate its call site without
+# importing each strategy module individually.
+from .artist_plus_album import ArtistPlusAlbum, ArtistPlusAlbumExecute
+from .song_as_artist import SongAsArtist, SongAsArtistExecute
+from .song_as_track import SongAsTrack, SongAsTrackExecute
+from .swapped_interpretation import SwappedInterpretation, SwappedInterpretationExecute
+from .track_on_compilation import TrackOnCompilation, TrackOnCompilationExecute
 
 
 def build_strategies(

--- a/lookup/strategies/__init__.py
+++ b/lookup/strategies/__init__.py
@@ -1,0 +1,131 @@
+"""Search strategies for ``execute_search_pipeline``.
+
+Each module in this package defines one ``@dataclass(frozen=True)`` strategy
+class that satisfies the :class:`core.search.Strategy` Protocol. The classes
+own three things:
+
+    - ``name`` (``ClassVar[SearchStrategyType]``) — telemetry identifier
+    - ``should_attempt(parsed, state, raw_message) -> bool`` — gating predicate
+    - ``attempt(parsed, state, raw_message) -> Outcome`` — async body
+
+Strategies never mutate :class:`core.search.SearchState` directly. They return
+an :class:`core.search.Outcome` and the runner applies it via
+:func:`core.search._apply`. This makes cancellation safety structural: a
+cancelled ``attempt()`` never returns an Outcome, so no state commit happens.
+
+The execute funcs that do the actual library / Discogs work live in
+``lookup.orchestrator`` and are injected into each strategy class at
+construction time, so this package has no dependency on the orchestrator
+module (avoids the obvious circular import). Tests construct strategies with
+``AsyncMock`` execute funcs to drive the pipeline through the public seam.
+
+Production construction lives in :func:`lookup.orchestrator.perform_lookup`;
+the :func:`build_strategies` factory below is the seam tests use.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from core.search import Strategy
+from generated.api_models import TrackMatchHint
+from library.db import LibraryDB
+from library.models import LibraryItem
+from services.parser import ParsedRequest
+
+from .artist_plus_album import ArtistPlusAlbum
+from .song_as_artist import SongAsArtist
+from .song_as_track import SongAsTrack
+from .swapped_interpretation import SwappedInterpretation
+from .track_on_compilation import TrackOnCompilation
+
+# Execute-func type aliases — kept as public re-exports so the factory's
+# parameters are documented and ``orchestrator.py`` can annotate its
+# call site. Each shape mirrors the existing orchestrator-side return type.
+ArtistPlusAlbumExecute = Callable[
+    [LibraryDB, ParsedRequest, list[str]],
+    Awaitable[tuple[list[LibraryItem], bool]],
+]
+SwappedInterpretationExecute = Callable[
+    [LibraryDB, str, str],
+    Awaitable[tuple[list[LibraryItem], Any]],
+]
+TrackOnCompilationExecute = Callable[
+    [LibraryDB, ParsedRequest],
+    Awaitable[tuple[list[LibraryItem], dict[int, str]]],
+]
+SongAsArtistExecute = Callable[
+    [LibraryDB, str | None],
+    Awaitable[tuple[list[LibraryItem], Any]],
+]
+SongAsTrackExecute = Callable[
+    [LibraryDB, str | None],
+    Awaitable[tuple[list[LibraryItem], dict[int, list[TrackMatchHint]]]],
+]
+
+
+def build_strategies(
+    db: LibraryDB,
+    *,
+    search_library_func: ArtistPlusAlbumExecute,
+    search_alternative_func: SwappedInterpretationExecute,
+    search_compilations_func: TrackOnCompilationExecute,
+    search_song_as_artist_func: SongAsArtistExecute | None = None,
+    search_song_as_track_func: SongAsTrackExecute | None = None,
+) -> list[Strategy]:
+    """Construct the ordered list of strategies for ``execute_search_pipeline``.
+
+    Each strategy class wraps the corresponding execute func + the shared
+    ``db`` handle, and adapts the func's tuple return into a uniform
+    :class:`core.search.Outcome`. The two ``_song_as_*`` parameters are
+    optional so callers that don't need those strategies (e.g. legacy
+    tests) can omit them.
+
+    Args:
+        db: Library database handle. Held by each strategy and passed to its
+            execute func at call time.
+        search_library_func: Implements ARTIST_PLUS_ALBUM
+            (``search_library_with_fallback`` in production).
+        search_alternative_func: Implements SWAPPED_INTERPRETATION
+            (``search_with_alternative_interpretation`` in production).
+        search_compilations_func: Implements TRACK_ON_COMPILATION
+            (``functools.partial(search_compilations_for_track,
+            discogs_service=...)`` in production).
+        search_song_as_artist_func: Optional. Implements SONG_AS_ARTIST.
+        search_song_as_track_func: Optional. Implements SONG_AS_TRACK.
+
+    Returns:
+        Strategies in execution order. SONG_AS_TRACK is appended **after**
+        SONG_AS_ARTIST so its condition (``SONG_AS_ARTIST in
+        strategies_tried``) holds.
+    """
+    strategies: list[Strategy] = [
+        ArtistPlusAlbum(db=db, execute=search_library_func),
+        SwappedInterpretation(db=db, execute=search_alternative_func),
+        TrackOnCompilation(db=db, execute=search_compilations_func),
+    ]
+
+    if search_song_as_artist_func is not None:
+        strategies.append(SongAsArtist(db=db, execute=search_song_as_artist_func))
+
+    # SONG_AS_TRACK must run AFTER SONG_AS_ARTIST — its condition keys on
+    # ``SearchStrategyType.SONG_AS_ARTIST in state.strategies_tried``. Array
+    # position enforces ordering; the condition does the runtime cross-check.
+    if search_song_as_track_func is not None:
+        strategies.append(SongAsTrack(db=db, execute=search_song_as_track_func))
+
+    return strategies
+
+
+__all__ = [
+    "ArtistPlusAlbum",
+    "ArtistPlusAlbumExecute",
+    "SongAsArtist",
+    "SongAsArtistExecute",
+    "SongAsTrack",
+    "SongAsTrackExecute",
+    "SwappedInterpretation",
+    "SwappedInterpretationExecute",
+    "TrackOnCompilation",
+    "TrackOnCompilationExecute",
+    "build_strategies",
+]

--- a/lookup/strategies/artist_plus_album.py
+++ b/lookup/strategies/artist_plus_album.py
@@ -1,0 +1,66 @@
+"""ARTIST_PLUS_ALBUM — the primary search path.
+
+Has artist OR album OR song → search the library by artist+album(s),
+falling back to artist+song or artist-only. The fallback flag is the load-
+bearing signal downstream: when artist+song misses, TRACK_ON_COMPILATION
+uses ``state.song_not_found`` to decide whether to run.
+
+Tuple shape returned by the execute func: ``(items, fallback_used: bool)``.
+``Outcome.artist_fallback(items)`` adapts ``fallback_used=True`` and
+``Outcome.found(items)`` adapts ``fallback_used=False``; the empty-items +
+flag-only case (``([], True)`` — artist+song fell through to artist-only
+and the artist isn't in the library at all) is also expressed via
+``Outcome.artist_fallback([])``.
+"""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import ClassVar
+
+from core.search import (
+    Outcome,
+    SearchState,
+    SearchStrategyType,
+    has_artist_or_album_or_song,
+)
+from library.db import LibraryDB
+from library.models import LibraryItem
+from services.parser import ParsedRequest
+
+ArtistPlusAlbumExecute = Callable[
+    [LibraryDB, ParsedRequest, list[str]],
+    Awaitable[tuple[list[LibraryItem], bool]],
+]
+
+
+@dataclass(frozen=True)
+class ArtistPlusAlbum:
+    """Search the library by artist+album(s), falling back to artist+song or artist-only."""
+
+    name: ClassVar[SearchStrategyType] = SearchStrategyType.ARTIST_PLUS_ALBUM
+
+    db: LibraryDB
+    """Library database handle. Passed to the execute func at call time."""
+
+    execute: ArtistPlusAlbumExecute
+    """Production: ``lookup.orchestrator.search_library_with_fallback``."""
+
+    def should_attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> bool:
+        return has_artist_or_album_or_song(parsed, state, raw_message)
+
+    async def attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> Outcome:
+        items, fallback_used = await self.execute(self.db, parsed, state.albums_for_search)
+        # Four outcomes, mirroring the pre-#399 wrapper's two-flag matrix:
+        #   1. items + fallback_used  → Outcome.artist_fallback(items)
+        #   2. items + !fallback_used → Outcome.album_match(items)
+        #   3. [] + fallback_used     → Outcome.artist_fallback([]) (flag-only)
+        #   4. [] + !fallback_used    → Outcome.empty()
+        # Case 2 uses album_match (not found) so a prior song_not_found signal
+        # from album_resolution survives this strategy and TRACK_ON_COMPILATION
+        # downstream still considers the compilation path. See album_match's
+        # docstring for the wider trace.
+        if fallback_used:
+            return Outcome.artist_fallback(items)
+        if items:
+            return Outcome.album_match(items)
+        return Outcome.empty()

--- a/lookup/strategies/song_as_artist.py
+++ b/lookup/strategies/song_as_artist.py
@@ -1,0 +1,50 @@
+"""SONG_AS_ARTIST — treat the parsed song as an artist name and re-search.
+
+Fires when the parser produced a song but no artist — typically because the
+parser misread an artist as a song title (e.g. "Laid Back" parsed as song
+instead of artist). The execute func may also cross-reference Discogs for
+releases by the candidate name and intersect with the library. Its tuple
+second element is unused.
+
+Strictly upstream of :class:`lookup.strategies.song_as_track.SongAsTrack` —
+the parser-misread-artist case gets first crack at song-only queries; the
+track fallback only runs if this strategy returned empty.
+"""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from core.search import (
+    Outcome,
+    SearchState,
+    SearchStrategyType,
+    no_results_and_song_but_no_artist,
+)
+from library.db import LibraryDB
+from library.models import LibraryItem
+from services.parser import ParsedRequest
+
+SongAsArtistExecute = Callable[
+    [LibraryDB, str | None],
+    Awaitable[tuple[list[LibraryItem], Any]],
+]
+
+
+@dataclass(frozen=True)
+class SongAsArtist:
+    """Search the library treating ``parsed.song`` as an artist name."""
+
+    name: ClassVar[SearchStrategyType] = SearchStrategyType.SONG_AS_ARTIST
+
+    db: LibraryDB
+    execute: SongAsArtistExecute
+    """Production: ``functools.partial(search_song_as_artist,
+    discogs_service=discogs_service)``."""
+
+    def should_attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> bool:
+        return no_results_and_song_but_no_artist(parsed, state, raw_message)
+
+    async def attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> Outcome:
+        items, _meta = await self.execute(self.db, parsed.song)
+        return Outcome.found(items) if items else Outcome.empty()

--- a/lookup/strategies/song_as_track.py
+++ b/lookup/strategies/song_as_track.py
@@ -1,0 +1,55 @@
+"""SONG_AS_TRACK — cross-reference the song against Discogs tracklists.
+
+Catalog-track-search §4.2 / LML#301: when SONG_AS_ARTIST returns empty for a
+song-only query, treat the song as a *track* — find Discogs releases that
+contain it, then fuzzy-match those releases against the WXYC library. Each
+surviving library row carries a TrackMatchHint recording the track→release
+linkage; the API contract uses those hints via the ``matched_via`` field
+per plan §5.1.
+
+Strictly downstream of :class:`lookup.strategies.song_as_artist.SongAsArtist`
+— the gating predicate checks ``SearchStrategyType.SONG_AS_ARTIST in
+state.strategies_tried`` so the cascade ordering is enforced even if a
+caller hand-builds the strategy list in a different order.
+"""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import ClassVar
+
+from core.search import (
+    Outcome,
+    SearchState,
+    SearchStrategyType,
+    no_results_and_song_but_no_artist_track_fallback,
+)
+from generated.api_models import TrackMatchHint
+from library.db import LibraryDB
+from library.models import LibraryItem
+from services.parser import ParsedRequest
+
+SongAsTrackExecute = Callable[
+    [LibraryDB, str | None],
+    Awaitable[tuple[list[LibraryItem], dict[int, list[TrackMatchHint]]]],
+]
+
+
+@dataclass(frozen=True)
+class SongAsTrack:
+    """Match ``parsed.song`` as a track via Discogs tracklist cross-reference."""
+
+    name: ClassVar[SearchStrategyType] = SearchStrategyType.SONG_AS_TRACK
+
+    db: LibraryDB
+    execute: SongAsTrackExecute
+    """Production: ``functools.partial(search_song_as_track,
+    discogs_service=discogs_service)``."""
+
+    def should_attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> bool:
+        return no_results_and_song_but_no_artist_track_fallback(parsed, state, raw_message)
+
+    async def attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> Outcome:
+        items, matched_via_by_id = await self.execute(self.db, parsed.song)
+        if not items:
+            return Outcome.empty()
+        return Outcome.track_match(items, matched_via_by_id=matched_via_by_id)

--- a/lookup/strategies/swapped_interpretation.py
+++ b/lookup/strategies/swapped_interpretation.py
@@ -1,0 +1,53 @@
+"""SWAPPED_INTERPRETATION — try "X - Y" both ways.
+
+When the raw message has an ambiguous ``X - Y`` / ``X, Y`` / ``X. Y`` shape
+and the primary search returned nothing, this strategy searches the
+library for both ``X as artist, Y as title`` and ``X as title, Y as artist``
+and combines the hits. The execute func's second tuple element is unused
+(always ``None``); the seam stays uniform with the other strategies.
+"""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from core.search import (
+    Outcome,
+    SearchState,
+    SearchStrategyType,
+    detect_ambiguous_format,
+    no_results_and_ambiguous_format,
+)
+from library.db import LibraryDB
+from library.models import LibraryItem
+from services.parser import ParsedRequest
+
+SwappedInterpretationExecute = Callable[
+    [LibraryDB, str, str],
+    Awaitable[tuple[list[LibraryItem], Any]],
+]
+
+
+@dataclass(frozen=True)
+class SwappedInterpretation:
+    """Search both ``X as artist, Y as title`` and the reverse for ambiguous formats."""
+
+    name: ClassVar[SearchStrategyType] = SearchStrategyType.SWAPPED_INTERPRETATION
+
+    db: LibraryDB
+    execute: SwappedInterpretationExecute
+    """Production: ``lookup.orchestrator.search_with_alternative_interpretation``."""
+
+    def should_attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> bool:
+        return no_results_and_ambiguous_format(parsed, state, raw_message)
+
+    async def attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> Outcome:
+        parts = detect_ambiguous_format(raw_message)
+        if parts is None:
+            # Defensive — the should_attempt predicate already guarantees parts
+            # is non-None when this runs. Kept so a future condition change
+            # can't silently crash here.
+            return Outcome.empty()
+        part1, part2 = parts
+        items, _meta = await self.execute(self.db, part1, part2)
+        return Outcome.found(items) if items else Outcome.empty()

--- a/lookup/strategies/track_on_compilation.py
+++ b/lookup/strategies/track_on_compilation.py
@@ -1,0 +1,57 @@
+"""TRACK_ON_COMPILATION — cross-reference the song against Discogs compilations.
+
+Fires when ARTIST_PLUS_ALBUM didn't find the song directly. Asks Discogs
+"what compilations contain this track by this artist?" and matches those
+compilation titles back against the WXYC library. The execute func's
+second tuple element is the per-library-id Discogs title map used by the
+artwork-fetch step.
+
+Carries the artist-fallback **stash** rule: when prior results exist AND
+``state.song_not_found`` is True, the runner preserves those prior results
+into ``state.artist_fallback_results`` before replacing them with the
+compilation hit. ``perform_lookup`` then validates the stash against
+Discogs tracklists and merges any confirmed matches back into the final
+results. Today only this strategy uses the rule; ``_apply`` honors the
+``preserve_prior_results_as_fallback`` flag declaratively so adding a
+second user of the same rule is a one-liner.
+"""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import ClassVar
+
+from core.search import (
+    Outcome,
+    SearchState,
+    SearchStrategyType,
+    song_not_found_with_artist_and_song,
+)
+from library.db import LibraryDB
+from library.models import LibraryItem
+from services.parser import ParsedRequest
+
+TrackOnCompilationExecute = Callable[
+    [LibraryDB, ParsedRequest],
+    Awaitable[tuple[list[LibraryItem], dict[int, str]]],
+]
+
+
+@dataclass(frozen=True)
+class TrackOnCompilation:
+    """Match the song against compilation tracklists via Discogs cross-reference."""
+
+    name: ClassVar[SearchStrategyType] = SearchStrategyType.TRACK_ON_COMPILATION
+
+    db: LibraryDB
+    execute: TrackOnCompilationExecute
+    """Production: ``functools.partial(search_compilations_for_track,
+    discogs_service=discogs_service)``."""
+
+    def should_attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> bool:
+        return song_not_found_with_artist_and_song(parsed, state, raw_message)
+
+    async def attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> Outcome:
+        items, discogs_titles = await self.execute(self.db, parsed)
+        if not items:
+            return Outcome.empty()
+        return Outcome.compilation(items, discogs_titles=discogs_titles)

--- a/tests/unit/test_outcome.py
+++ b/tests/unit/test_outcome.py
@@ -1,0 +1,332 @@
+"""Tests for the ``Outcome`` value type and ``_apply`` helper (#399 step 2).
+
+``Outcome`` replaces the heterogeneous ``(list, Any)`` tuples each strategy
+returned in step 1. The runner has exactly one ``_apply(state, outcome)``
+write site; cancellation safety becomes structural (a cancelled ``attempt()``
+never returns an ``Outcome``, so no commit happens, period).
+
+The ``Outcome`` named constructors encode the four real effect-shapes that
+step-1's tuple second-elements expressed inline:
+
+    - ``empty()``                 -- no-op
+    - ``found(items)``            -- direct hit, song matched
+    - ``artist_fallback(items)``  -- fell through to artist-only / artist+song
+    - ``compilation(items, titles)`` -- TRACK_ON_COMPILATION's signal
+    - ``track_match(items, hints)``  -- SONG_AS_TRACK's per-id hint set
+
+These tests pin the value semantics. The runner / strategy tests live in
+``test_search.py`` next to the rest of the pipeline tests.
+"""
+
+import pytest
+
+from core.search import Outcome, SearchState, _apply
+from generated.api_models import TrackMatchHint, TrackMatchSource
+from tests.factories import make_library_item as _item
+
+# ---------------------------------------------------------------------------
+# Outcome constructors
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeConstructors:
+    """The five named constructors encode the four real effect-shapes plus the no-op."""
+
+    def test_empty_is_no_op(self):
+        """``Outcome.empty()`` carries no items and signals no state writes."""
+        o = Outcome.empty()
+        assert o.items == []
+        assert o.song_not_found_after is None
+        assert o.found_on_compilation_after is False
+        assert o.preserve_prior_results_as_fallback is False
+        assert o.discogs_titles is None
+        assert o.matched_via_by_id is None
+
+    def test_found_clears_song_not_found_flag(self):
+        """``Outcome.found(items)`` is the 90% case: direct match, song matched."""
+        item = _item(id=1, artist="Stereolab", title="Dots and Loops")
+        o = Outcome.found([item])
+        assert o.items == [item]
+        assert o.song_not_found_after is False
+        assert o.found_on_compilation_after is False
+        assert o.preserve_prior_results_as_fallback is False
+
+    def test_album_match_leaves_song_not_found_alone(self):
+        """``Outcome.album_match(items)`` writes items but doesn't touch the flag.
+
+        ARTIST_PLUS_ALBUM's direct path: it matched the artist's album by name
+        but can't vouch for the song's presence on it. Used when
+        ``resolve_albums_for_track`` already set ``song_not_found=True``
+        (Discogs returned only VA releases) — the flag must propagate so
+        TRACK_ON_COMPILATION downstream still considers the compilation path.
+        """
+        item = _item(id=1, artist="Stereolab", title="Dots and Loops")
+        o = Outcome.album_match([item])
+        assert o.items == [item]
+        assert o.song_not_found_after is None  # leave-alone signal
+        assert o.found_on_compilation_after is False
+        assert o.preserve_prior_results_as_fallback is False
+
+    def test_artist_fallback_sets_song_not_found_flag(self):
+        """``Outcome.artist_fallback(items)`` records that the song wasn't matched.
+
+        Mirrors ARTIST_PLUS_ALBUM's `fallback_used=True` from step 1: results
+        came from the artist-only / artist+song fallback path, so the song
+        title didn't get a direct hit. Downstream TRACK_ON_COMPILATION keys
+        on ``state.song_not_found`` to decide whether to run.
+        """
+        item = _item(id=1, artist="Queen", title="Hot Space")
+        o = Outcome.artist_fallback([item])
+        assert o.items == [item]
+        assert o.song_not_found_after is True
+
+    def test_artist_fallback_with_empty_items_signals_flag_only(self):
+        """``Outcome.artist_fallback([])`` carries the flag without items.
+
+        ARTIST_PLUS_ALBUM can return `([], True)` when the artist+song search
+        falls through to artist-only and the artist isn't in the library at
+        all — flag must propagate even though no items were found.
+        """
+        o = Outcome.artist_fallback([])
+        assert o.items == []
+        assert o.song_not_found_after is True
+
+    def test_compilation_sets_titles_and_stash_signal(self):
+        """``Outcome.compilation(items, titles)`` carries TRACK_ON_COMPILATION's full signal.
+
+        Three writes in one outcome:
+          - the compilation library items themselves
+          - the Discogs titles map (for artwork lookup)
+          - `preserve_prior_results_as_fallback=True` (stash any prior artist
+            fallback before replacing — `_apply` honors the condition)
+          - `found_on_compilation_after=True`
+          - `song_not_found_after=False` (we DID match the song, just on a compilation)
+        """
+        item = _item(id=46602, artist="Various", title="Trax Records 20th Anniversary")
+        titles = {46602: "Trax Records 20th Anniversary"}
+        o = Outcome.compilation([item], discogs_titles=titles)
+        assert o.items == [item]
+        assert o.song_not_found_after is False
+        assert o.found_on_compilation_after is True
+        assert o.preserve_prior_results_as_fallback is True
+        assert o.discogs_titles == titles
+
+    def test_track_match_carries_matched_via_hints(self):
+        """``Outcome.track_match(items, matched_via_by_id)`` is SONG_AS_TRACK's shape.
+
+        Track-driven match: the song was found by cross-referencing the song
+        against Discogs's tracklist index. Each library row carries a
+        TrackMatchHint mapping it back to the release that surfaced it.
+        """
+        item = _item(id=60359, artist="Autechre", title="Confield")
+        hint = TrackMatchHint(
+            title="vi scose poise",
+            artist_credit=None,
+            position="3",
+            confidence=0.92,
+            source=TrackMatchSource.discogs_release,
+        )
+        matched_via = {60359: [hint]}
+        o = Outcome.track_match([item], matched_via_by_id=matched_via)
+        assert o.items == [item]
+        assert o.song_not_found_after is False
+        assert o.matched_via_by_id == matched_via
+
+
+class TestOutcomeIsImmutable:
+    """``Outcome`` is a frozen dataclass — attempts to mutate must raise."""
+
+    def test_cannot_reassign_items(self):
+        o = Outcome.empty()
+        with pytest.raises((AttributeError, TypeError)):
+            o.items = [1]  # type: ignore[misc]
+
+    def test_cannot_reassign_flag(self):
+        o = Outcome.found([_item()])
+        with pytest.raises((AttributeError, TypeError)):
+            o.song_not_found_after = True  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _apply -- the single runner write site
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEmpty:
+    """``Outcome.empty()`` produces no writes."""
+
+    def test_empty_is_a_noop(self):
+        state = SearchState(results=[], song_not_found=False)
+        _apply(state, Outcome.empty())
+        assert state.results == []
+        assert state.song_not_found is False
+        assert state.found_on_compilation is False
+        assert state.discogs_titles == {}
+        assert state.matched_via_by_id == {}
+
+    def test_empty_does_not_touch_prior_results(self):
+        """An empty outcome leaves a prior strategy's results intact."""
+        prior = _item(id=1, artist="Stereolab", title="Dots and Loops")
+        state = SearchState(results=[prior], song_not_found=True)
+        _apply(state, Outcome.empty())
+        assert state.results == [prior]
+        assert state.song_not_found is True
+
+
+class TestApplyFound:
+    """``Outcome.found(items)`` writes results and clears song_not_found."""
+
+    def test_writes_results_and_clears_flag(self):
+        item = _item(id=1, artist="Jessica Pratt", title="On Your Own Love Again")
+        state = SearchState(results=[], song_not_found=True)
+        _apply(state, Outcome.found([item]))
+        assert state.results == [item]
+        assert state.song_not_found is False
+
+    def test_replaces_prior_results(self):
+        """A later ``found`` overwrites earlier (e.g. fallback) results."""
+        old = _item(id=1, artist="Stereolab", title="Mars Audiac Quintet")
+        new = _item(id=2, artist="Stereolab", title="Dots and Loops")
+        state = SearchState(results=[old], song_not_found=True)
+        _apply(state, Outcome.found([new]))
+        assert state.results == [new]
+        assert state.song_not_found is False
+
+
+class TestApplyAlbumMatch:
+    """``Outcome.album_match(items)`` writes results without touching the flag."""
+
+    def test_preserves_prior_song_not_found_true(self):
+        """Items written; song_not_found stays True from album_resolution."""
+        item = _item(id=1, artist="Stereolab", title="Dots and Loops")
+        state = SearchState(results=[], song_not_found=True)
+        _apply(state, Outcome.album_match([item]))
+        assert state.results == [item]
+        assert state.song_not_found is True  # preserved
+
+    def test_preserves_prior_song_not_found_false(self):
+        item = _item(id=1, artist="Stereolab", title="Dots and Loops")
+        state = SearchState(results=[], song_not_found=False)
+        _apply(state, Outcome.album_match([item]))
+        assert state.results == [item]
+        assert state.song_not_found is False  # also preserved
+
+
+class TestApplyArtistFallback:
+    """``Outcome.artist_fallback(items)`` writes results AND sets song_not_found=True."""
+
+    def test_with_items(self):
+        item = _item(id=1, artist="Cat Power", title="Moon Pix")
+        state = SearchState(results=[], song_not_found=False)
+        _apply(state, Outcome.artist_fallback([item]))
+        assert state.results == [item]
+        assert state.song_not_found is True
+
+    def test_empty_still_sets_flag(self):
+        """ARTIST_PLUS_ALBUM's ``([], True)`` case: flag flips, results unchanged.
+
+        Production scenario: artist+song search falls through to artist-only,
+        artist isn't in the library at all. The flag must still propagate
+        because TRACK_ON_COMPILATION downstream keys on ``song_not_found``.
+        """
+        state = SearchState(results=[], song_not_found=False)
+        _apply(state, Outcome.artist_fallback([]))
+        assert state.results == []
+        assert state.song_not_found is True
+
+
+class TestApplyCompilation:
+    """``Outcome.compilation(items, titles)`` is TRACK_ON_COMPILATION's full signal."""
+
+    def test_writes_results_titles_flag(self):
+        item = _item(id=46602, artist="Various", title="Trax Comp")
+        titles = {46602: "Trax Records 20th"}
+        state = SearchState(results=[], song_not_found=True)
+        _apply(state, Outcome.compilation([item], discogs_titles=titles))
+        assert state.results == [item]
+        assert state.found_on_compilation is True
+        assert state.song_not_found is False
+        assert state.discogs_titles == titles
+
+    def test_stashes_prior_artist_fallback_results(self):
+        """When prior results exist and song_not_found=True, stash them first.
+
+        Mirrors ``run_track_on_compilation``'s pre-#399 behavior: the artist
+        fallback results are preserved so ``perform_lookup`` can validate
+        them against Discogs tracklists and merge any confirmed matches
+        back into the final results.
+        """
+        artist_fallback = _item(id=1, artist="Adonis", title="No Way Back")
+        compilation = _item(id=46602, artist="Various", title="Trax Comp")
+        state = SearchState(results=[artist_fallback], song_not_found=True)
+        _apply(
+            state,
+            Outcome.compilation([compilation], discogs_titles={46602: "Trax Comp"}),
+        )
+        assert state.results == [compilation]
+        assert state.artist_fallback_results == [artist_fallback]
+        assert state.found_on_compilation is True
+        # song_not_found is cleared on the compilation hit.
+        assert state.song_not_found is False
+
+    def test_stash_skips_when_prior_results_empty(self):
+        """No prior results to stash → ``artist_fallback_results`` stays empty."""
+        compilation = _item(id=46602, artist="Various", title="Trax Comp")
+        state = SearchState(results=[], song_not_found=True)
+        _apply(
+            state,
+            Outcome.compilation([compilation], discogs_titles={46602: "Trax Comp"}),
+        )
+        assert state.artist_fallback_results == []
+        assert state.results == [compilation]
+
+    def test_stash_skips_when_prior_song_not_found_false(self):
+        """Prior results without the song_not_found flag don't qualify as fallback."""
+        prior = _item(id=1, artist="Adonis", title="No Way Back")
+        compilation = _item(id=46602, artist="Various", title="Trax Comp")
+        state = SearchState(results=[prior], song_not_found=False)
+        _apply(
+            state,
+            Outcome.compilation([compilation], discogs_titles={46602: "Trax Comp"}),
+        )
+        # Direct hit prior + compilation hit now: nothing to stash as "fallback".
+        assert state.artist_fallback_results == []
+
+
+class TestApplyTrackMatch:
+    """``Outcome.track_match(items, matched_via_by_id)`` writes results + hints."""
+
+    def test_writes_results_and_hints(self):
+        item = _item(id=60359, artist="Autechre", title="Confield")
+        hint = TrackMatchHint(
+            title="vi scose poise",
+            artist_credit=None,
+            position="3",
+            confidence=0.92,
+            source=TrackMatchSource.discogs_release,
+        )
+        state = SearchState(results=[], song_not_found=True)
+        _apply(state, Outcome.track_match([item], matched_via_by_id={60359: [hint]}))
+        assert state.results == [item]
+        assert state.matched_via_by_id == {60359: [hint]}
+        assert state.song_not_found is False
+
+
+class TestApplyOrderingInvariant:
+    """The stash condition must read prior ``state.song_not_found`` before any update.
+
+    Regression guard: a naive ``_apply`` that writes ``song_not_found_after``
+    before checking the stash predicate would never stash, because the flag
+    is set to False on every compilation hit. Pin the read-before-write order.
+    """
+
+    def test_compilation_stash_reads_prior_song_not_found(self):
+        """Prior song_not_found=True must drive the stash even though the
+        compilation outcome clears it to False."""
+        artist_fallback = _item(id=1, artist="Adonis", title="No Way Back")
+        compilation = _item(id=46602, artist="Various", title="Trax Comp")
+        state = SearchState(results=[artist_fallback], song_not_found=True)
+        _apply(state, Outcome.compilation([compilation], discogs_titles={}))
+        # The stash fired on the OLD song_not_found, then song_not_found flipped.
+        assert state.artist_fallback_results == [artist_fallback]
+        assert state.song_not_found is False

--- a/tests/unit/test_outcome.py
+++ b/tests/unit/test_outcome.py
@@ -75,7 +75,7 @@ class TestOutcomeConstructors:
         title didn't get a direct hit. Downstream TRACK_ON_COMPILATION keys
         on ``state.song_not_found`` to decide whether to run.
         """
-        item = _item(id=1, artist="Queen", title="Hot Space")
+        item = _item(id=1, artist="Cat Power", title="Moon Pix")
         o = Outcome.artist_fallback([item])
         assert o.items == [item]
         assert o.song_not_found_after is True

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,7 +1,19 @@
-"""Tests for uncovered lines in core/search.py."""
+"""Tests for ``core/search.py`` — the strategy seam, runner, and budget knobs.
+
+The ``Outcome`` value type and ``_apply`` helper have their own dedicated
+tests in ``tests/unit/test_outcome.py``. This file pins the runner, the
+strategy factory, and the budget / hard-cap / caller-budget machinery.
+
+Tests inject mocks that return ``Outcome`` instances (post-#399 seam).
+The strategy classes themselves live in ``lookup/strategies/`` and adapt
+the orchestrator-side tuple-returning execute funcs into Outcome — but
+the tests here drive the pipeline at the runner seam, so they construct
+strategies with mock Outcome-returning callables.
+"""
 
 import asyncio
 import time
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -10,11 +22,11 @@ from core.search import (
     DEFAULT_SEARCH_BUDGET_MS,
     DEFAULT_SEARCH_HARD_TIMEOUT_MS,
     TRANSPORT_OVERHEAD_MS,
+    Outcome,
     SearchState,
     SearchStrategyType,
+    Strategy,
     _log_hard_cap_fired,
-    _Strategy,
-    build_strategies,
     execute_search_pipeline,
     get_search_type_from_state,
     has_artist_or_album_or_song,
@@ -27,8 +39,60 @@ from core.search import (
     song_not_found_with_artist_and_song,
 )
 from generated.api_models import TrackMatchHint, TrackMatchSource
+from lookup.strategies import build_strategies
 from services.parser import ParsedRequest
 from tests.factories import make_library_item as _item
+
+# ---------------------------------------------------------------------------
+# Test helpers: tiny strategy stand-ins for runner-level tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _StubStrategy:
+    """Bare-bones :class:`Strategy` for runner unit tests.
+
+    Production strategies live in ``lookup/strategies/`` and adapt the
+    orchestrator-side tuple-returning execute funcs into Outcome. The runner
+    tests here drive the pipeline directly with a stub that calls the
+    injected mock and a stub condition — exercises the runner / _apply
+    seam without dragging a real strategy class in.
+    """
+
+    name: SearchStrategyType
+    condition: object  # Callable[[ParsedRequest, SearchState, str], bool]
+    attempt_func: object  # Callable[..., Awaitable[Outcome]]
+
+    def should_attempt(self, parsed, state, raw_message) -> bool:
+        return self.condition(parsed, state, raw_message)  # type: ignore[operator]
+
+    async def attempt(self, parsed, state, raw_message) -> Outcome:
+        return await self.attempt_func(parsed, state, raw_message)  # type: ignore[no-any-return,operator,misc]
+
+
+def _build_test_strategies(
+    search_lib: AsyncMock,
+    search_alt: AsyncMock,
+    search_comp: AsyncMock,
+    search_song: AsyncMock | None = None,
+    search_track: AsyncMock | None = None,
+) -> list[Strategy]:
+    """Construct the production strategy classes wrapped around mock execute funcs.
+
+    Mirrors the old ``build_strategies(search_lib, search_alt, search_comp,
+    search_song)`` test ergonomics. ``db`` is a shared AsyncMock because the
+    strategies pass it to their execute funcs (which are mocks themselves
+    here, so the db value never matters).
+    """
+    return build_strategies(
+        AsyncMock(),
+        search_library_func=search_lib,
+        search_alternative_func=search_alt,
+        search_compilations_func=search_comp,
+        search_song_as_artist_func=search_song,
+        search_song_as_track_func=search_track,
+    )
+
 
 # ---------------------------------------------------------------------------
 # get_search_type_from_state
@@ -189,6 +253,7 @@ class TestConditions:
 class TestBuildStrategies:
     def test_basic_strategies(self):
         strategies = build_strategies(
+            AsyncMock(),
             search_library_func=AsyncMock(),
             search_alternative_func=AsyncMock(),
             search_compilations_func=AsyncMock(),
@@ -201,6 +266,7 @@ class TestBuildStrategies:
 
     def test_includes_song_as_artist(self):
         strategies = build_strategies(
+            AsyncMock(),
             search_library_func=AsyncMock(),
             search_alternative_func=AsyncMock(),
             search_compilations_func=AsyncMock(),
@@ -211,6 +277,7 @@ class TestBuildStrategies:
 
     def test_song_as_track_excluded_without_func(self):
         strategies = build_strategies(
+            AsyncMock(),
             search_library_func=AsyncMock(),
             search_alternative_func=AsyncMock(),
             search_compilations_func=AsyncMock(),
@@ -227,6 +294,7 @@ class TestBuildStrategies:
         condition's `SONG_AS_ARTIST in strategies_tried` precondition.
         """
         strategies = build_strategies(
+            AsyncMock(),
             search_library_func=AsyncMock(),
             search_alternative_func=AsyncMock(),
             search_compilations_func=AsyncMock(),
@@ -253,13 +321,12 @@ class TestExecuteSearchPipeline:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(artist="Queen", album="The Game", raw_message="Queen The Game")
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Queen The Game",
             strategies,
         )
@@ -276,18 +343,12 @@ class TestExecuteSearchPipeline:
         search_comp = AsyncMock(return_value=([], {}))
         search_song = AsyncMock(return_value=([item], None))
 
-        strategies = build_strategies(
-            search_lib,
-            search_alt,
-            search_comp,
-            search_song,
-        )
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp, search_song)
 
         parsed = ParsedRequest(song="Stereolab", raw_message="Stereolab")
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Stereolab",
             strategies,
         )
@@ -304,13 +365,12 @@ class TestExecuteSearchPipeline:
         search_alt = AsyncMock(return_value=([item], None))
         search_comp = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(artist="Foo", album="Bar", raw_message="Foo - Bar")
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Foo - Bar",
             strategies,
         )
@@ -327,7 +387,7 @@ class TestExecuteSearchPipeline:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(return_value=([item], {1: "Rock Comp"}))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Queen",
@@ -337,7 +397,6 @@ class TestExecuteSearchPipeline:
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Queen - We Will Rock You",
             strategies,
         )
@@ -367,7 +426,7 @@ class TestExecuteSearchPipeline:
             return_value=([compilation], {46602: "Trax Records 20th Anniversary Collection"})
         )
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Adonis",
@@ -377,7 +436,6 @@ class TestExecuteSearchPipeline:
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "No Way Back by Adonis",
             strategies,
             song_not_found=True,
@@ -404,7 +462,7 @@ class TestExecuteSearchPipeline:
         search_comp = AsyncMock(return_value=([], {}))
         search_song = AsyncMock(return_value=([], None))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp, search_song)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp, search_song)
 
         parsed = ParsedRequest(
             song="Lost Love",
@@ -414,7 +472,6 @@ class TestExecuteSearchPipeline:
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Lost Love, Adult.",
             strategies,
         )
@@ -446,19 +503,14 @@ class TestExecuteSearchPipeline:
         search_song = AsyncMock(return_value=([], None))
         search_track = AsyncMock(return_value=([confield], {60359: [hint]}))
 
-        strategies = build_strategies(
-            search_lib,
-            search_alt,
-            search_comp,
-            search_song,
-            search_song_as_track_func=search_track,
+        strategies = _build_test_strategies(
+            search_lib, search_alt, search_comp, search_song, search_track
         )
 
         parsed = ParsedRequest(song="vi scose poise", raw_message="vi scose poise")
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "vi scose poise",
             strategies,
         )
@@ -480,19 +532,14 @@ class TestExecuteSearchPipeline:
         search_song = AsyncMock(return_value=([item], None))
         search_track = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(
-            search_lib,
-            search_alt,
-            search_comp,
-            search_song,
-            search_song_as_track_func=search_track,
+        strategies = _build_test_strategies(
+            search_lib, search_alt, search_comp, search_song, search_track
         )
 
         parsed = ParsedRequest(song="Stereolab", raw_message="Stereolab")
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Stereolab",
             strategies,
         )
@@ -509,19 +556,14 @@ class TestExecuteSearchPipeline:
         search_song = AsyncMock(return_value=([], None))
         search_track = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(
-            search_lib,
-            search_alt,
-            search_comp,
-            search_song,
-            search_song_as_track_func=search_track,
+        strategies = _build_test_strategies(
+            search_lib, search_alt, search_comp, search_song, search_track
         )
 
         parsed = ParsedRequest(song="nonexistent track", raw_message="nonexistent track")
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "nonexistent track",
             strategies,
         )
@@ -553,22 +595,22 @@ class TestRunnerIsGeneric:
         custom_item = _item(id=42, artist="Custom", title="Strategy")
         ran: list[bool] = []
 
-        async def custom_run(db, parsed, state, raw_message):
+        async def custom_attempt(parsed, state, raw_message):
             ran.append(True)
-            state.results = [custom_item]
-            return True
+            return Outcome.found([custom_item])
 
-        # ARTIST_ONLY is a SearchStrategyType value that the pre-#391 if/elif
-        # never dispatched on (no orchestrator arm for it). Post-#391 the runner
-        # just calls ``run`` regardless of name.
-        custom = _Strategy(
+        # ARTIST_ONLY is a SearchStrategyType value the pre-#391 if/elif
+        # never dispatched on (no orchestrator arm for it). Post-#391 / #399
+        # the runner just calls ``attempt`` regardless of name; the returned
+        # Outcome drives ``_apply`` without a per-strategy branch.
+        custom = _StubStrategy(
             name=SearchStrategyType.ARTIST_ONLY,
             condition=lambda parsed, state, raw_message: True,
-            run=custom_run,
+            attempt_func=custom_attempt,
         )
 
         parsed = ParsedRequest(artist="Custom", raw_message="Custom")
-        state = await execute_search_pipeline(parsed, AsyncMock(), "Custom", [custom])
+        state = await execute_search_pipeline(parsed, "Custom", [custom])
 
         assert ran == [True]
         assert state.results == [custom_item]
@@ -658,7 +700,7 @@ class TestSearchBudget:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(side_effect=must_not_run_compilation)
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         # song_not_found=True keeps TRACK_ON_COMPILATION's condition true even
         # after ARTIST_PLUS_ALBUM populates state.results — without the budget
@@ -675,7 +717,6 @@ class TestSearchBudget:
         with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
             state = await execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Stereolab - Miss Modular",
                 strategies,
                 song_not_found=True,
@@ -723,19 +764,14 @@ class TestSearchBudget:
         search_song = AsyncMock(return_value=([], None))
         search_track = AsyncMock(return_value=([track_hit], {60359: [hint]}))
 
-        strategies = build_strategies(
-            search_lib,
-            search_alt,
-            search_comp,
-            search_song,
-            search_song_as_track_func=search_track,
+        strategies = _build_test_strategies(
+            search_lib, search_alt, search_comp, search_song, search_track
         )
 
         parsed = ParsedRequest(song="vi scose poise", raw_message="vi scose poise")
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "vi scose poise",
             strategies,
         )
@@ -759,7 +795,7 @@ class TestSearchBudget:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Juana Molina", album="DOGA", raw_message="Juana Molina - DOGA"
@@ -771,7 +807,6 @@ class TestSearchBudget:
         with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
             state = await execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Juana Molina - DOGA",
                 strategies,
             )
@@ -800,7 +835,7 @@ class TestSearchBudget:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Stereolab",
@@ -814,7 +849,6 @@ class TestSearchBudget:
         with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
             state = await execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Stereolab - Miss Modular",
                 strategies,
                 song_not_found=True,
@@ -843,7 +877,7 @@ class TestSearchBudget:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Stereolab",
@@ -857,7 +891,6 @@ class TestSearchBudget:
         ):
             state = await execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Stereolab - Miss Modular",
                 strategies,
                 song_not_found=True,
@@ -961,7 +994,7 @@ class TestSearchHardTimeoutLoopGate:
         search_alt = AsyncMock(side_effect=must_not_run)
         search_comp = AsyncMock(side_effect=must_not_run)
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Some Unknown Artist",
@@ -971,7 +1004,6 @@ class TestSearchHardTimeoutLoopGate:
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Some Unknown Artist - Untracked Song",
             strategies,
             song_not_found=True,
@@ -998,7 +1030,7 @@ class TestSearchHardTimeoutLoopGate:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Untracked",
@@ -1012,7 +1044,6 @@ class TestSearchHardTimeoutLoopGate:
         with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
             await execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Untracked - Song",
                 strategies,
                 song_not_found=True,
@@ -1108,7 +1139,7 @@ class TestPerStrategyWaitFor:
         search_lib = AsyncMock(side_effect=fan_out_strategy)
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(return_value=([], {}))
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(artist="x", song=None, raw_message="x")
 
@@ -1116,7 +1147,7 @@ class TestPerStrategyWaitFor:
         # instead of stalling CI for 60s waiting on the mock probes.
         start = time.monotonic()
         state = await asyncio.wait_for(
-            execute_search_pipeline(parsed, AsyncMock(), "x", strategies),
+            execute_search_pipeline(parsed, "x", strategies),
             timeout=5.0,
         )
         elapsed = time.monotonic() - start
@@ -1158,25 +1189,25 @@ class TestPerStrategyWaitFor:
 
         # Real-time sleep in the *condition* function — runs between the
         # loop-gate elapsed_ms read and the remaining_budget calculation.
-        # SearchStrategy.condition is a sync callable in the strategy
+        # ``Strategy.should_attempt`` is a sync callable in the strategy
         # contract; sync time.sleep here directly mimics scheduler jitter.
         def jittery_condition(parsed, state, raw_message):  # noqa: ARG001
             time.sleep(0.1)  # 100ms blocking sleep — blows the 50ms cap
             return True
 
-        async def slow_run(db, parsed, state, raw_message):  # noqa: ARG001
+        async def slow_attempt(parsed, state, raw_message):  # noqa: ARG001
             # Anything > 10ms triggers the 0.01s wait_for floor's TimeoutError.
             await asyncio.sleep(0.05)
-            return False
+            return Outcome.empty()
 
         # Single-strategy pipeline with the jittery condition. Constructed by
         # hand rather than through build_strategies so we can inject the
         # jittery_condition that triggers the floor.
         strategies = [
-            _Strategy(
+            _StubStrategy(
                 name=SearchStrategyType.ARTIST_PLUS_ALBUM,
                 condition=jittery_condition,
-                run=slow_run,
+                attempt_func=slow_attempt,
             )
         ]
 
@@ -1190,7 +1221,6 @@ class TestPerStrategyWaitFor:
         state = await asyncio.wait_for(
             execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Overshoot Artist - Overshoot Song",
                 strategies,
                 song_not_found=True,
@@ -1237,7 +1267,7 @@ class TestHardCapSoftBudgetIndependence:
         search_lib = AsyncMock(side_effect=slow_first)
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(side_effect=must_not_run)
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Stereolab",
@@ -1251,7 +1281,6 @@ class TestHardCapSoftBudgetIndependence:
         with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
             state = await execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Stereolab - Miss Modular",
                 strategies,
                 song_not_found=True,
@@ -1353,7 +1382,7 @@ class TestCallerBudget:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = must_not_run_compilation
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Stereolab",
@@ -1369,7 +1398,6 @@ class TestCallerBudget:
         with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
             state = await execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Stereolab - Miss Modular",
                 strategies,
                 song_not_found=True,
@@ -1402,7 +1430,7 @@ class TestCallerBudget:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(return_value=([], {}))
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Stereolab",
@@ -1416,7 +1444,6 @@ class TestCallerBudget:
         with patch("core.search.sentry_sdk.get_current_scope", return_value=mock_scope):
             await execute_search_pipeline(
                 parsed,
-                AsyncMock(),
                 "Stereolab - Miss Modular",
                 strategies,
                 song_not_found=True,
@@ -1457,7 +1484,7 @@ class TestCallerBudget:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(side_effect=slow_empty_compilation)
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Rita Villa",
@@ -1468,7 +1495,6 @@ class TestCallerBudget:
         # caller_budget_ms = TRANSPORT_OVERHEAD_MS + 1 → effective budget = 1ms.
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Rita Villa - Czardas",
             strategies,
             song_not_found=True,
@@ -1508,7 +1534,7 @@ class TestCallerBudget:
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(side_effect=slow_then_hit)
 
-        strategies = build_strategies(search_lib, search_alt, search_comp)
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
         parsed = ParsedRequest(
             artist="Rita Villa",
@@ -1518,7 +1544,6 @@ class TestCallerBudget:
 
         state = await execute_search_pipeline(
             parsed,
-            AsyncMock(),
             "Rita Villa - Czardas",
             strategies,
             song_not_found=True,


### PR DESCRIPTION
Closes #399.

## What changed

**`core/search.py`** — adds the new seam, removes the old one:

- New `Outcome` frozen dataclass with five named constructors — `empty()`, `found(items)`, `album_match(items)`, `artist_fallback(items)`, `compilation(items, discogs_titles=…)`, `track_match(items, matched_via_by_id=…)`. The shapes encode every pre-#399 effect the heterogeneous `(list[LibraryItem], Any)` tuples were carrying.
- New `Strategy` Protocol (`name: ClassVar[SearchStrategyType]`, `should_attempt(...)`, `async attempt(...) -> Outcome`).
- New `_apply(state, outcome)` helper — the **single** runner write site for strategy-driven `SearchState` mutations. Encodes the two ordering invariants in its docstring: the items-empty short-circuit applies to most writes but **not** to `song_not_found_after` (ARTIST_PLUS_ALBUM's `([], True)` flag-only signal), and the artist-fallback stash check reads prior `state.song_not_found` *before* the update (TRACK_ON_COMPILATION clears the flag, but the stash predicate must see the pre-update value).
- Runner rewritten: `outcome = await asyncio.wait_for(s.attempt(...), …); _apply(state, outcome); if state.results and not state.song_not_found: break`. No `strategy.name` branch anywhere, no `produced` flag, no per-strategy commit logic.
- Deleted: `_Strategy`, `RunFunc`, `ExecuteFunc`, the closure-based `build_strategies` (relocated to `lookup/strategies/__init__.py`). The runner also dropped its `db` parameter — strategies hold `db` as an instance field.

**`lookup/strategies/`** — new package, one module per strategy:

- `artist_plus_album.py` — `ArtistPlusAlbum`. Uses `Outcome.album_match` for the direct path so a prior `song_not_found=True` from album resolution survives this strategy (the Adonis / "No Way Back" / Trax 20th case); `Outcome.artist_fallback` for the fallback paths.
- `swapped_interpretation.py` — `SwappedInterpretation`. Pulls `detect_ambiguous_format` once inside `attempt` (was being called twice in step 1's wrapper).
- `track_on_compilation.py` — `TrackOnCompilation`. Returns `Outcome.compilation(...)` which carries the stash signal declaratively via `preserve_prior_results_as_fallback=True`.
- `song_as_artist.py` — `SongAsArtist`. Trivial.
- `song_as_track.py` — `SongAsTrack`. Returns `Outcome.track_match(...)`.
- `__init__.py` — `build_strategies(db, *, search_library_func, search_alternative_func, search_compilations_func, search_song_as_artist_func=None, search_song_as_track_func=None) -> list[Strategy]`. The orchestrator's `partial(search_compilations_for_track, discogs_service=…)` closures from step 1 still hand-feed the execute funcs, and that stays — the cleaner alternative (strategies importing orchestrator funcs directly) is a circular import.

**`lookup/orchestrator.py`** — `perform_lookup` now imports `build_strategies` from `lookup.strategies`, passes `db` positionally, and drops `db=db` from the `execute_search_pipeline` call.

## What stayed put

- Budget / hard-cap / caller-budget machinery (LML#340 / #370 / #345 / #347) — verbatim. The three loop-top gates, `_log_search_budget_exceeded`, `_log_hard_cap_fired`, the per-strategy `wait_for` ceiling with its 0.01s jitter floor, and the `state.timed_out` projection onto `LookupResponse.timeout` are unchanged.
- `get_search_type_from_state` — still switches on `strategies_tried[-1]` + `found_on_compilation` + `song_not_found`.
- `SearchState`, `SearchStrategyType`, the five condition predicates, and `detect_ambiguous_format` are unchanged.
- The five orchestrator-side execute funcs (`search_library_with_fallback`, `search_with_alternative_interpretation`, `search_compilations_for_track`, `search_song_as_artist`, `search_song_as_track`) keep their tuple return types. Strategy classes adapt those tuples into Outcomes — concentrating the adaptation in one file per strategy was the locality payoff over making each function return an `Outcome` directly.

## The `Outcome.album_match` named constructor

The four ARTIST_PLUS_ALBUM cases from `search_library_with_fallback` don't fit the 90% "found / fallback" split cleanly: a direct artist+album match (`items, fallback_used=False`) must leave `song_not_found` *alone* so a prior album-resolution signal still drives TRACK_ON_COMPILATION downstream. Pinning the existing semantics (test_compilation_search_when_song_not_found_from_album_resolution, the budget tests that rely on `song_not_found=True` carrying through a non-fallback hit) required a third constructor — `Outcome.album_match(items)` — that writes items without touching the song-found flag. Documented with the wider trace in both the constructor docstring and the strategy's branch comment.

## Tests

- `tests/unit/test_outcome.py` — 23 new tests pinning every `Outcome` named constructor + every `_apply` semantics branch, plus the read-before-write ordering invariant.
- `tests/unit/test_search.py` — runner / pipeline tests preserved with assertions unchanged. Mechanical edits: drop the `db` positional arg from `execute_search_pipeline` calls (runner signature lost it), swap `build_strategies(search_lib, ...)` for a small `_build_test_strategies` helper that constructs the real strategy classes around mock execute funcs, swap the one hand-built `_Strategy` (in `TestPerStrategyWaitFor.test_jitter_floor_...`) and the `TestRunnerIsGeneric` test for a `_StubStrategy` returning Outcomes. Mock execute funcs keep their `(list, X)` tuple returns — the strategy classes do the Outcome adaptation, which is exactly what we want them to test through.
- `tests/unit/test_orchestrator_helpers.py` — unchanged. None of those tests reach past the runner; they test the orchestrator helper functions directly, which still exist post-#399.
- Local: 1934 unit tests pass (the 1 error is the pre-existing teardown flake in `test_dependencies.py::test_no_module_level_asyncio_lock_in_dependencies`, unrelated to this PR — passes in isolation, fails only when interacting with another test's shared state).
- `ruff check` / `ruff format --check` / `mypy --ignore-missing-imports` all clean across the whole repo.

## Size

~1100 lines net (≈320 deletions + ≈380 modifications + ≈740 new strategy/test files), slightly over the 1000-line target. Splitting into "add Outcome + runner change" then "relocate strategies" would require keeping `build_strategies` in `core/search.py` temporarily and re-deleting it later — net more churn than landing the relocation together, which is what #399's acceptance criteria called for ("Relocation lands in this PR (the hybrid commits to per-strategy files)").

## What's next

Sibling deepening tickets surfaced by the same 2026-05-27 review remain open: #392, #393, #394, #395. None blocked by this PR.
