### PR TITLE
fix(discogs): fall through to API when cache row has null artwork_url

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -810,6 +810,10 @@ class DiscogsService:
             pg_read=lambda: cache.get_release(release_id),
             api_fetch=_api_fetch,
             pg_write=cache.write_release,
+            # A row with `artwork_url IS NULL` is a partial miss: the bulk
+            # loader leaves ~48% of `release` rows that way (LML#414). Fall
+            # through to the API so the write-back back-patches the cover.
+            is_pg_hit=lambda v: v is not None and v.artwork_url is not None,
             breadcrumb_data={"release_id": release_id},
         )
 

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -865,6 +865,7 @@ class TestGetRelease:
             title="Cached Album",
             artist="Artist",
             release_url="https://discogs.com/release/123",
+            artwork_url="https://img.com/cached.jpg",
             cached=True,
         )
         service_with_cache.cache_service.get_release = AsyncMock(return_value=cached)
@@ -872,6 +873,51 @@ class TestGetRelease:
         result = await service_with_cache.get_release(123)
         assert result.title == "Cached Album"
         assert result.cached is True
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_with_null_artwork_falls_through_to_api(self, service_with_cache):
+        """A cache row with artwork_url=None is a partial miss: hit the API to fill it in,
+        then write back. Without this, bulk-loaded rows whose XML lacked images stay
+        permanently artworkless and downstream consumers (BS V2, iOS) render placeholders.
+        """
+        stale = ReleaseMetadataResponse(
+            release_id=33696615,
+            title="Loved By Sound, Lost in Forms",
+            artist="Lucy Liyou",
+            release_url="https://discogs.com/release/33696615",
+            artwork_url=None,
+            cached=True,
+        )
+        service_with_cache.cache_service.get_release = AsyncMock(return_value=stale)
+        service_with_cache.cache_service.write_release = AsyncMock()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "Loved By Sound, Lost in Forms",
+            "artists": [{"name": "Lucy Liyou"}],
+            "tracklist": [],
+            "images": [{"uri": "https://img.discogs.com/cover.jpg"}],
+            "labels": [],
+            "genres": [],
+            "styles": [],
+        }
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ) as mock_request:
+            result = await service_with_cache.get_release(33696615)
+
+        mock_request.assert_called_once()
+        assert result is not None
+        assert result.artwork_url == "https://img.discogs.com/cover.jpg"
+        service_with_cache.cache_service.write_release.assert_called_once()
+        written = service_with_cache.cache_service.write_release.call_args.args[0]
+        assert written.artwork_url == "https://img.discogs.com/cover.jpg"
 
     @pytest.mark.asyncio
     async def test_404_returns_none(self, service):

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -920,6 +920,55 @@ class TestGetRelease:
         assert written.artwork_url == "https://img.discogs.com/cover.jpg"
 
     @pytest.mark.asyncio
+    async def test_cache_null_artwork_with_imageless_api_still_writes_back(
+        self, service_with_cache
+    ):
+        """Cache row has artwork_url=None AND the live API genuinely returns no
+        images. Fall-through still completes: API result returned with
+        artwork_url=None, write-back records the row. Until discogs-etl#239
+        ships (artwork_checked_at), every lookup re-runs this path; a future
+        regression swallowing the write-back here would only surface in prod.
+        """
+        stale = ReleaseMetadataResponse(
+            release_id=33696616,
+            title="White Label Promo",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/33696616",
+            artwork_url=None,
+            cached=True,
+        )
+        service_with_cache.cache_service.get_release = AsyncMock(return_value=stale)
+        service_with_cache.cache_service.write_release = AsyncMock()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "White Label Promo",
+            "artists": [{"name": "Stereolab"}],
+            "tracklist": [],
+            "images": [],
+            "labels": [],
+            "genres": [],
+            "styles": [],
+        }
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ) as mock_request:
+            result = await service_with_cache.get_release(33696616)
+
+        mock_request.assert_called_once()
+        assert result is not None
+        assert result.artwork_url is None
+        service_with_cache.cache_service.write_release.assert_called_once()
+        written = service_with_cache.cache_service.write_release.call_args.args[0]
+        assert written.artwork_url is None
+
+    @pytest.mark.asyncio
     async def test_404_returns_none(self, service):
         with patch.object(
             service, "_request_with_retry", new_callable=AsyncMock, return_value=None


### PR DESCRIPTION
## Summary

- Treat \`cache_hit && release.artwork_url IS NULL\` as a partial miss in \`DiscogsService.get_release\` so the existing API path + write-back can repair rows the bulk loader landed without artwork.
- Add a unit test that mocks the cache returning a release with \`artwork_url=None\`, asserts the API is called, the populated cover comes back, and the row is written through to the cache.

## Why

iOS + dj-site flowsheet rows added via Backend-Service V2 keep rendering placeholder images even after the Backend drain shipped (WXYC/Backend-Service#1209 / PR #1214). Direct LML lookup against prod for release \`33696615\` (Lucy Liyou, \"Loved By Sound, Lost in Forms\") returned \`artwork_url: null\` with \`cache_stats.api_calls: 0\` — a cache-only path. The prod cache row exists but has \`artwork_url IS NULL\`; the live Discogs API has \`images[0].uri\` populated. The cache hit on the NULL row preempted the API call.

48.31% of \`release\` rows in the prod cache currently have \`artwork_url IS NULL\` (39,585 / 81,948), so this isn't a one-off. The bulk loader is the upstream cause; a separate ticket against discogs-etl will track that. The LML side should be tolerant either way.

## Limitation

For releases that genuinely have no Discogs cover, every cache hit now triggers an API call (which writes the same NULL back). In-process \`RELEASE_CACHE\` memoization absorbs the repeat within one process; across restarts it re-fires. Acceptable while the 48% backfill drains down to genuinely-imageless releases. The durable fix is an \`artwork_checked_at\` column in \`release\` so NULL-with-timestamp is distinguishable from NULL-never-asked — separate ticket against discogs-etl.

## Test plan

- [x] \`uv run pytest tests/unit/test_discogs_service.py::TestGetRelease\` — 9 tests pass, including the new \`test_cache_hit_with_null_artwork_falls_through_to_api\`.
- [x] \`uv run pytest tests/unit/\` — 1955 passed (1 pre-existing test-ordering error on \`test_dependencies.py\`, present on main).
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` clean on changed files.
- [ ] Staging smoke: after merge, run the prod-repro lookup against staging and confirm \`api_calls > 0\` and \`artwork_url\` populated.
- [ ] Re-query a 33696615 lookup against prod after \`prod\` deploy and confirm placeholders clear in the BS V2 endpoint.

Closes #414