### PR TITLE
refactor(discogs): deepen the 3-tier cache fallthrough into one read-through seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Strategies never mutate `SearchState`; they return an `Outcome` and the runner a
 - `discogs/service.py` -- Discogs API client with optional PostgreSQL cache
 - `discogs/cache_service.py` -- PostgreSQL cache (asyncpg + pg_trgm). Tier 5 in the [org cache-hierarchy reference](https://github.com/WXYC/wiki/blob/main/architecture/cache-hierarchy.md).
 - `discogs/memory_cache.py` -- In-memory TTL cache (cachetools). Tier 4 in the [org cache-hierarchy reference](https://github.com/WXYC/wiki/blob/main/architecture/cache-hierarchy.md); per-cache TTLs + maxsizes documented there with the upstream and downstream tiers in context.
+- `discogs/fallthrough.py` -- Read-through cache seam (#393): one `fallthrough()` function owns L2-PG → L3-API + optional write-back + cool-down on cache outage. Five `discogs/service.py` methods call it. See the "Discogs cache fallthrough seam" section below for the per-method policy table.
 - `core/search.py` -- Declarative search strategy pattern + ambiguous format detection
 - `discogs/markup_parser.py` -- Discogs markup parser: tokenize/resolve `[a=Name]`, `[a12345]`, `[b]...[/b]`, etc. into structured `ResolvedToken` models. Includes `EntityResolver` protocol and `DiscogsServiceResolver` adapter for async ID resolution. Translated from iOS `DiscogsMarkupParser.swift`.
 - `discogs/matching.py` -- Discogs-specific normalization (strip_discogs_suffix, normalize_for_track_comparison, normalize_artist_for_validation)
@@ -123,6 +124,32 @@ The service supports an optional PostgreSQL cache for Discogs data:
 4. Gracefully degrade to API-only if cache unavailable
 
 Set `DATABASE_URL_DISCOGS` to enable. The cache schema is defined in [WXYC/discogs-etl](https://github.com/WXYC/discogs-etl).
+
+### Discogs cache fallthrough seam (`discogs/fallthrough.py`)
+
+The 3-tier read-through (in-memory L1 via `@async_cached` → PostgreSQL L2 → Discogs API L3 + optional write-back) is concentrated in `discogs/fallthrough.py:fallthrough()`. Each cache-bearing method in `discogs/service.py` calls the seam with its own `pg_read` / `api_fetch` / `pg_write` closures and, where relevant, the negative-cache hooks. The L1 `@async_cached(<CACHE>)` decorator stays per-method — it owns a separate, already-deep concern (per-type TTL, cache-key normalization, the `should_skip_cache()` bypass).
+
+#### Per-method write-back policy
+
+The drift the deepening (#393) removes — every `pg_write=None` call site documents *why* it's read-only:
+
+| Method | `pg_write` | Why |
+|---|---|---|
+| `get_release` | `cache_service.write_release` | Full read-through. `ReleaseMetadataResponse` maps cleanly to the cache's normalized schema. |
+| `get_artist_details` | `cache_service.write_artist_details` | Full read-through. Same shape. |
+| `search_releases_by_track` | `None` | Read-only by design — the PG side queries the normalized `release_track` index populated by the ETL pipeline. Writing arbitrary Discogs `/database/search` hits back wouldn't fit that schema. Negative-cache write still fires via `pg_negative_record`. |
+| `search` | `None` | Read-only by design — same shape. |
+| `validate_track_on_release` | `None` | Read-only by design. Tri-state PG read short-circuits when the cache has an answer; on miss, the API path calls `get_release` which writes back to the `release` cache via its own seam call. The validation verdict itself isn't separately cached. |
+
+When adding a new cache-bearing method, pass an explicit `pg_write=` argument (or `pg_write=None` with a one-line comment explaining why). The seam's signature makes the policy decision visible at the call site.
+
+#### Cool-down on cache outage (LML#324)
+
+When a `pg_read` raises one of a narrow set of "DB unreachable" exceptions — `asyncpg.exceptions.PostgresConnectionError`, `CannotConnectNowError`, `InterfaceError`, `UndefinedTableError` (the dedup-swap window), or the local `CacheUnavailableError` — the seam arms a process-wide cool-down for `_COOL_DOWN_SECONDS` (default 30s). While active, `pg_read` is short-circuited and the seam jumps straight to the API leg. `asyncio.CancelledError` propagates; everything else (programming errors, `asyncio.TimeoutError`) falls through to the API without arming.
+
+The arming exception set lives in `_ARMING_EXCEPTIONS` in `discogs/fallthrough.py` and is pinned by tests in `tests/unit/test_fallthrough.py` so a future asyncpg release adding new exception classes can't silently widen the arming criteria.
+
+Cool-down arm projects `data.cache_fallback_fired = {reason, error_class, cool_down_seconds}` onto the active Sentry transaction, matching the pattern used by `_log_album_title_fallback` in `lookup/orchestrator.py`. Queryable in the Sentry trace explorer to track outage incidents.
 
 ### External-Cache Fallback for `/api/v1/lookup` (Phase 1.5 mojibake recovery)
 

--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -1,0 +1,288 @@
+"""Read-through cache seam for ``discogs/service.py`` (#393).
+
+Concentrates the 3-tier dance (in-memory → PostgreSQL → Discogs API + optional
+write-back) that ``DiscogsService`` was hand-weaving across 5 cache-bearing
+methods. Each method now states only its cache key (the closure captured by
+``pg_read`` / ``api_fetch``) and its write-back policy (presence/absence of
+``pg_write``).
+
+The L1 in-memory layer (``@async_cached(<CACHE>)``) is *not* owned by this
+module — it stays as a per-method decorator because it owns a separate,
+already-deep concern (per-type TTL, cache-key normalization, the
+``should_skip_cache()`` bypass). This seam handles L2 + L3 + the cool-down
+that #324 asks for.
+
+## Per-method write-back policy
+
+The drift the deepening removes:
+
+| Method | ``pg_write`` | Why |
+|---|---|---|
+| ``get_release`` | ``cache_service.write_release`` | Full read-through. |
+| ``get_artist_details`` | ``cache_service.write_artist_details`` | Full read-through. |
+| ``search_releases_by_track`` | ``None`` | Read-only by design — PG side queries the normalized ``release_track`` index populated by the ETL pipeline. Negative-cache write still fires via ``pg_negative_record``. |
+| ``search`` | ``None`` | Read-only by design — same shape as above. |
+| ``validate_track_on_release`` | ``None`` | Read-only by design — API path writes back indirectly via ``get_release``. |
+
+The full version of this table (with the matrix and the deletion-test
+analysis that drove it) lives in ``docs/plans/lml-393-discogs-cache-fallthrough.md``.
+
+## Cool-down (the #324 fix)
+
+When the PG read raises one of a narrow set of "DB unreachable" exceptions,
+this module arms a process-wide cool-down (``_COOL_DOWN_SECONDS``, default
+30s). While the cool-down is active, ``pg_read`` is short-circuited and
+the seam jumps straight to the API leg. Discriminating between "DB is
+down" and "this specific query is broken" keeps a bad query from disabling
+the whole cache.
+
+The arming exception set:
+- :class:`asyncpg.exceptions.PostgresConnectionError` (and subclasses)
+- :class:`asyncpg.exceptions.CannotConnectNowError`
+- :class:`asyncpg.exceptions.InterfaceError`
+- :class:`asyncpg.exceptions.UndefinedTableError` (the dedup-swap window)
+- :class:`discogs.cache_service.CacheUnavailableError`
+
+Bare ``Exception`` (programming errors), ``asyncio.TimeoutError``, and
+``asyncio.CancelledError`` are *not* armed — they have their own semantics.
+The set is pinned by ``_ARMING_EXCEPTIONS`` and asserted by tests.
+
+The cool-down also projects ``data.cache_fallback_fired = {reason, error_class}``
+onto the active Sentry transaction (when one exists), matching the pattern
+used by ``_log_album_title_fallback`` in ``lookup/orchestrator.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import asyncpg.exceptions
+import sentry_sdk
+from wxyc_fastapi.observability import (
+    add_breadcrumb,
+    get_cache_stats_recorder,
+    timed_pg,
+)
+
+from discogs.cache_service import CacheUnavailableError
+from discogs.memory_cache import should_skip_cache
+
+logger = logging.getLogger(__name__)
+
+# How long PG reads stay suppressed after a cache-leg failure. Process-wide;
+# Railway runs single-process workers per replica so per-replica granularity
+# is what we want.
+_COOL_DOWN_SECONDS: float = 30.0
+
+# Module-level cool-down state. Mutated by ``_arm_cool_down`` /
+# ``_reset_cool_down_for_tests``; read by ``_cool_down_active``.
+_cool_down_until: float = 0.0
+
+# The narrow set that arms the cool-down. Pinned here (and asserted by tests)
+# so a future asyncpg release adding new exception classes doesn't silently
+# widen the arming criteria, and so an over-eager catch-all elsewhere can't
+# bypass the discrimination.
+_ARMING_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    asyncpg.exceptions.PostgresConnectionError,
+    asyncpg.exceptions.CannotConnectNowError,
+    asyncpg.exceptions.InterfaceError,
+    asyncpg.exceptions.UndefinedTableError,
+    CacheUnavailableError,
+)
+
+
+def _arm_cool_down(reason: str, error: BaseException) -> None:
+    """Suppress PG reads for ``_COOL_DOWN_SECONDS`` and project onto Sentry."""
+    global _cool_down_until
+    _cool_down_until = time.monotonic() + _COOL_DOWN_SECONDS
+    payload = {
+        "reason": reason,
+        "error_class": type(error).__name__,
+        "cool_down_seconds": _COOL_DOWN_SECONDS,
+    }
+    logger.warning("cache_fallback_fired %s", payload)
+    try:
+        transaction = sentry_sdk.get_current_scope().transaction
+        if transaction is not None:
+            transaction.set_data("cache_fallback_fired", payload)
+    except Exception as e:
+        logger.warning("Failed to project cache_fallback_fired onto Sentry transaction: %s", e)
+
+
+def _cool_down_active() -> bool:
+    return time.monotonic() < _cool_down_until
+
+
+def _reset_cool_down_for_tests() -> None:
+    """Drop the cool-down so tests don't bleed state into each other."""
+    global _cool_down_until
+    _cool_down_until = 0.0
+
+
+def _add_discogs_breadcrumb(
+    operation: str,
+    data: dict[str, Any] | None = None,
+    level: str = "info",
+) -> None:
+    """Pin the ``"discogs"`` category for breadcrumbs (mirrors service.py)."""
+    add_breadcrumb(category="discogs", message=operation, data=data, level=level)
+
+
+async def fallthrough[T](
+    *,
+    label: str,
+    pg_read: Callable[[], Awaitable[T | None]] | None,
+    api_fetch: Callable[[], Awaitable[T | None]],
+    pg_write: Callable[[T], Awaitable[None]] | None = None,
+    pg_negative_check: Callable[[], Awaitable[bool]] | None = None,
+    pg_negative_record: Callable[[], Awaitable[None]] | None = None,
+    on_negative_hit: Callable[[], T] | None = None,
+    is_pg_hit: Callable[[T | None], bool] = lambda v: v is not None,
+    is_empty: Callable[[T], bool] | None = None,
+    breadcrumb_data: dict[str, Any] | None = None,
+) -> T | None:
+    """Read-through cache with API fallback, optional write-back, optional
+    negative-cache, and an automatic cool-down on cache-leg outage.
+
+    See the module docstring for the per-method policy table and the cool-down
+    arming criteria.
+
+    Args:
+        label: Tag for breadcrumbs / cache-stats. Use the public method name
+            (``"get_release"``, ``"search"``, etc.).
+        pg_read: Async callable returning the cached value or ``None`` for
+            "miss". Pass ``None`` for API-only methods (no L2 leg at all).
+        api_fetch: Async callable returning the upstream value or ``None``.
+        pg_write: Async callable invoked with the API result on a write-back.
+            Absent = "read-only by design" (encoded as policy at the call site).
+        pg_negative_check: Async callable returning True if the negative-cache
+            says "we already asked, the answer was empty." Requires
+            ``on_negative_hit`` to be set.
+        pg_negative_record: Async callable invoked when the API returns empty.
+            Requires ``is_empty`` to be set.
+        on_negative_hit: Factory the seam calls when ``pg_negative_check``
+            returns True. The factory's return value is returned to the
+            caller (and lets the caller mark its result as ``cached=True``).
+        is_pg_hit: Predicate on ``pg_read``'s return value; True means "hit",
+            False means "fall through to API." Defaults to ``v is not None``
+            which is correct for both single-value caches (``ReleaseMetadataResponse``)
+            and tri-state caches (``bool | None`` from ``validate_track_on_release``).
+        is_empty: Predicate on a non-None API result; True triggers the
+            negative-record write. Required when ``pg_negative_record`` is set.
+            Default ``not r`` is unsafe for Pydantic models (always truthy),
+            so the caller must opt in explicitly.
+        breadcrumb_data: Extra fields to attach to every breadcrumb (for
+            traceability — e.g., ``{"release_id": 12345}``).
+
+    Returns:
+        The cached value on PG hit, the negative-hit factory's value on
+        negative-cache hit, the API value on miss, or ``None`` if the API
+        failed too.
+
+    Raises:
+        ValueError: At entry, if ``pg_negative_check`` is set without
+            ``on_negative_hit``, or ``pg_negative_record`` is set without
+            ``is_empty``.
+    """
+    # ----- Parameter validation: prevent silent misuse at the seam itself.
+    if pg_negative_check is not None and on_negative_hit is None:
+        raise ValueError(
+            "pg_negative_check requires on_negative_hit: the seam needs a "
+            "factory to produce the negative-hit return value (typically the "
+            "caller's empty response shape with cached=True)."
+        )
+    if pg_negative_record is not None and is_empty is None:
+        raise ValueError(
+            "pg_negative_record requires is_empty: the default `not r` predicate "
+            "is unsafe for Pydantic models (always truthy). Pass an explicit "
+            "lambda — e.g., `lambda r: not r.releases`."
+        )
+
+    bc_data: dict[str, Any] = dict(breadcrumb_data or {})
+
+    # ----- Per-request skip flag (benchmarking, A/B). Bypass every cache leg.
+    skip = should_skip_cache()
+
+    # ----- L2 PG read (if configured, not skipped, not cooling down).
+    if pg_read is not None and not skip and not _cool_down_active():
+        try:
+            _add_discogs_breadcrumb(f"cache_lookup_{label}", bc_data)
+            async with timed_pg():
+                cached = await pg_read()
+            if is_pg_hit(cached):
+                _add_discogs_breadcrumb("cache_hit", bc_data)
+                get_cache_stats_recorder().record_pg_cache_hit()
+                logger.info("Cache hit (%s)", label)
+                # ``cached`` may be ``T`` (single-value) or ``False`` (tri-state).
+                # Either way ``is_pg_hit`` said it's a hit, so return it.
+                return cached  # type: ignore[return-value]
+            _add_discogs_breadcrumb("cache_miss", bc_data)
+            get_cache_stats_recorder().record_pg_cache_miss()
+            logger.debug("Cache miss (%s)", label)
+        except asyncio.CancelledError:
+            # Cancellation always propagates — never swallow.
+            raise
+        except _ARMING_EXCEPTIONS as e:
+            logger.warning("Cache leg unreachable (%s), arming cool-down: %s", label, e)
+            _add_discogs_breadcrumb(
+                "cache_error", {**bc_data, "error": str(e), "cool_down": True}, level="warning"
+            )
+            _arm_cool_down(reason=label, error=e)
+        except Exception as e:
+            # Programming error, transient timeout, unexpected shape — log +
+            # fall through to API. Do NOT arm cool-down: cool-down is for
+            # the narrow availability-fault set in ``_ARMING_EXCEPTIONS``;
+            # a per-request timeout has its own meaning.
+            logger.warning("Cache lookup failed (%s), falling back to API: %s", label, e)
+            _add_discogs_breadcrumb("cache_error", {**bc_data, "error": str(e)}, level="warning")
+
+    # ----- Negative-cache pre-check (skipped under skip-cache flag).
+    if pg_negative_check is not None and on_negative_hit is not None and not skip:
+        try:
+            if await pg_negative_check():
+                _add_discogs_breadcrumb("negative_cache_hit", bc_data)
+                get_cache_stats_recorder().record("pg_negative_hits")
+                logger.info("Negative-cache hit (%s); short-circuiting API", label)
+                return on_negative_hit()
+            get_cache_stats_recorder().record("pg_negative_misses")
+        except Exception as e:
+            # Defense in depth: ``lookup_negative_hit`` already swallows pool
+            # errors, but a programming error here should still let the
+            # request through to the API path.
+            logger.warning("Negative-cache check failed (%s): %s", label, e)
+
+    # ----- L3 API.
+    api_result = await api_fetch()
+
+    # ----- Write-backs (best-effort; only when not bypassing the cache).
+    if api_result is not None and not skip:
+        if pg_write is not None:
+            try:
+                _add_discogs_breadcrumb(f"cache_write_{label}", bc_data)
+                await pg_write(api_result)
+                logger.debug("Cached %s", label)
+            except Exception as e:
+                logger.warning("Failed to cache %s: %s", label, e)
+                _add_discogs_breadcrumb(
+                    "cache_write_error", {**bc_data, "error": str(e)}, level="warning"
+                )
+
+    # ----- Negative-record on empty API result (best-effort).
+    if (
+        pg_negative_record is not None
+        and is_empty is not None
+        and api_result is not None
+        and is_empty(api_result)
+        and not skip
+    ):
+        try:
+            _add_discogs_breadcrumb("negative_cache_write", bc_data)
+            await pg_negative_record()
+        except Exception as e:
+            logger.warning("Negative-cache write failed for %s: %s", label, e)
+
+    return api_result

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -16,10 +16,10 @@ from wxyc_fastapi.observability import (
     add_breadcrumb,
     get_cache_stats_recorder,
     timed_api,
-    timed_pg,
 )
 
 from config.settings import get_settings
+from discogs.fallthrough import fallthrough
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.memory_cache import (
     ARTIST_CACHE,
@@ -30,7 +30,6 @@ from discogs.memory_cache import (
     TRACK_CACHE,
     VALIDATION_CACHE,
     async_cached,
-    should_skip_cache,
 )
 from discogs.models import (
     ArtistCredit,
@@ -406,10 +405,15 @@ class DiscogsService:
     ) -> TrackReleasesResponse:
         """Search for ALL releases containing a track.
 
-        Uses a hybrid approach with optional PostgreSQL cache:
-        1. Try local cache first (if available)
-        2. On cache miss, search Discogs API
-        3. Supplement with keyword search if few results
+        Read-through via :func:`fallthrough` with ``pg_write=None`` and the
+        negative-cache hooks wired. PG read is skipped when
+        ``artist_as_keyword=True`` because the PG cache filters by
+        release-level artist which excludes VA compilations where the artist
+        is credited on individual tracks — the API keyword search handles
+        that correctly with ``format=Compilation``. Negative-cache check runs
+        for every query (its key includes ``artist_as_keyword`` so a negative
+        answer on one shape doesn't poison the other). Read-only by design
+        (no API write-back); see #393.
 
         Args:
             track: Track title to search for
@@ -419,122 +423,53 @@ class DiscogsService:
         Returns:
             TrackReleasesResponse with list of releases
         """
-        # Try local cache first.
-        # Skip cache when artist_as_keyword=True: the PG cache filters by
-        # release-level artist which excludes VA compilations where the
-        # artist is credited on individual tracks.  The API keyword search
-        # handles this correctly with format=Compilation.
-        if self.cache_service and not should_skip_cache() and not artist_as_keyword:
+
+        async def _pg_read() -> TrackReleasesResponse | None:
+            assert cache is not None
+            cached_releases = await cache.search_releases_by_track(
+                track=track, artist=artist, limit=limit
+            )
+            if not cached_releases:
+                return None
+            return TrackReleasesResponse(
+                track=track,
+                artist=artist,
+                releases=cached_releases,
+                total=len(cached_releases),
+                cached=True,
+            )
+
+        def _on_negative_hit() -> TrackReleasesResponse:
+            return TrackReleasesResponse(
+                track=track, artist=artist, releases=[], total=0, cached=True
+            )
+
+        async def _api_fetch() -> TrackReleasesResponse | None:
+            releases: list[ReleaseInfo] = []
+            seen_albums: set = set()
+
+            params: dict = {
+                "type": "release",
+                "track": track,
+                "per_page": limit,
+            }
+            if artist:
+                if artist_as_keyword:
+                    # Use q (keyword) instead of artist (field filter) to find
+                    # VA compilations where the artist is credited on tracks.
+                    # Also filter by format=Compilation to exclude single/album
+                    # releases that dominate results for common track names.
+                    params["q"] = artist
+                    params["format"] = "Compilation"
+                else:
+                    params["artist"] = artist
+
+            logger.info(f"Searching Discogs for releases with track: '{track}', artist: {artist}")
+
             try:
-                add_discogs_breadcrumb(
-                    "cache_search_releases_by_track",
-                    {"track": track, "artist": artist},
-                )
-                async with timed_pg():
-                    cached_releases = await self.cache_service.search_releases_by_track(
-                        track=track, artist=artist, limit=limit
-                    )
-                if cached_releases:
-                    logger.info(f"Cache hit: found {len(cached_releases)} releases for '{track}'")
-                    get_cache_stats_recorder().record_pg_cache_hit()
-                    add_discogs_breadcrumb(
-                        "cache_hit", {"track": track, "count": len(cached_releases)}
-                    )
-                    return TrackReleasesResponse(
-                        track=track,
-                        artist=artist,
-                        releases=cached_releases,
-                        total=len(cached_releases),
-                        cached=True,
-                    )
-                logger.debug(f"Cache miss for track '{track}'")
-                get_cache_stats_recorder().record_pg_cache_miss()
-                add_discogs_breadcrumb("cache_miss", {"track": track})
-            except Exception as e:
-                logger.warning(f"Cache lookup failed, falling back to API: {e}")
-                add_discogs_breadcrumb("cache_error", {"error": str(e)}, level="warning")
-
-        # Negative-result cache check (LML#341 / A4). Consulted on every
-        # query, not just non-keyword paths, because its key includes the
-        # `artist_as_keyword` dimension so a negative answer on one shape
-        # doesn't poison the other. Always best-effort — `lookup_negative_hit`
-        # returns False on pool errors so we fall through to the API.
-        if self.cache_service and not should_skip_cache():
-            try:
-                if await self.cache_service.lookup_negative_hit(artist, track, artist_as_keyword):
-                    logger.info(
-                        f"Negative-cache hit for track '{track}' artist '{artist}' "
-                        f"(artist_as_keyword={artist_as_keyword}); short-circuiting Discogs API"
-                    )
-                    get_cache_stats_recorder().record("pg_negative_hits")
-                    add_discogs_breadcrumb(
-                        "negative_cache_hit",
-                        {"track": track, "artist": artist, "artist_as_keyword": artist_as_keyword},
-                    )
-                    return TrackReleasesResponse(
-                        track=track, artist=artist, releases=[], total=0, cached=True
-                    )
-                get_cache_stats_recorder().record("pg_negative_misses")
-            except Exception as e:
-                # lookup_negative_hit already swallows pool errors; this catch
-                # is for defense-in-depth against an unexpected programming
-                # error so the request never dies in the negative-cache leg.
-                logger.warning(f"Negative-cache check failed (continuing to API): {e}")
-
-        # Fall back to Discogs API
-        releases: list[ReleaseInfo] = []
-        seen_albums: set = set()
-
-        params: dict = {
-            "type": "release",
-            "track": track,
-            "per_page": limit,
-        }
-        if artist:
-            if artist_as_keyword:
-                # Use q (keyword) instead of artist (field filter) to find
-                # VA compilations where the artist is credited on tracks.
-                # Also filter by format=Compilation to exclude single/album
-                # releases that dominate results for common track names.
-                params["q"] = artist
-                params["format"] = "Compilation"
-            else:
-                params["artist"] = artist
-
-        logger.info(f"Searching Discogs for releases with track: '{track}', artist: {artist}")
-
-        try:
-            async with timed_api():
-                response = await self._request_with_retry("GET", "/database/search", params=params)
-
-            if response is not None:
-                get_cache_stats_recorder().record_api_call()
-                response.raise_for_status()
-                data = response.json()
-
-                for result in data.get("results", []):
-                    release_info = self._process_search_result(result, seen_albums)
-                    if release_info:
-                        releases.append(release_info)
-
-            logger.info(f"Track search found {len(releases)} releases")
-
-            # Supplement with keyword search if few results
-            if len(releases) < 3:
-                query_parts = [track]
-                if artist:
-                    query_parts.append(artist)
-
-                query_params: dict = {
-                    "type": "release",
-                    "q": " ".join(query_parts),
-                    "per_page": limit,
-                }
-
-                logger.info(f"Supplementing with keyword search: '{query_params['q']}'")
                 async with timed_api():
                     response = await self._request_with_retry(
-                        "GET", "/database/search", params=query_params
+                        "GET", "/database/search", params=params
                     )
 
                 if response is not None:
@@ -547,36 +482,88 @@ class DiscogsService:
                         if release_info:
                             releases.append(release_info)
 
-                    logger.info(f"After keyword search: {len(releases)} total releases")
+                logger.info(f"Track search found {len(releases)} releases")
 
-            # On a confirmed-empty Discogs response, record the negative
-            # verdict so the next process restart (Railway redeploy) doesn't
-            # repeat the full cascade. Skipped on exception path below — a
-            # 5xx or rate-limit isn't a "we asked, nothing" verdict; it's
-            # "we couldn't ask, try later." Best-effort write.
-            if not releases and self.cache_service and not should_skip_cache():
-                try:
-                    await self.cache_service.record_lookup_negative(
-                        artist, track, artist_as_keyword
-                    )
-                    add_discogs_breadcrumb(
-                        "negative_cache_write",
-                        {"track": track, "artist": artist, "artist_as_keyword": artist_as_keyword},
-                    )
-                except Exception as e:
-                    logger.warning(f"Negative-cache write failed (best-effort): {e}")
+                # Supplement with keyword search if few results
+                if len(releases) < 3:
+                    query_parts = [track]
+                    if artist:
+                        query_parts.append(artist)
 
-            return TrackReleasesResponse(
-                track=track,
-                artist=artist,
-                releases=releases[:limit],
-                total=len(releases[:limit]),
-                cached=False,
-            )
+                    query_params: dict = {
+                        "type": "release",
+                        "q": " ".join(query_parts),
+                        "per_page": limit,
+                    }
 
-        except Exception as e:
-            logger.error(f"Discogs search failed: {e}")
+                    logger.info(f"Supplementing with keyword search: '{query_params['q']}'")
+                    async with timed_api():
+                        response = await self._request_with_retry(
+                            "GET", "/database/search", params=query_params
+                        )
+
+                    if response is not None:
+                        get_cache_stats_recorder().record_api_call()
+                        response.raise_for_status()
+                        data = response.json()
+
+                        for result in data.get("results", []):
+                            release_info = self._process_search_result(result, seen_albums)
+                            if release_info:
+                                releases.append(release_info)
+
+                        logger.info(f"After keyword search: {len(releases)} total releases")
+
+                return TrackReleasesResponse(
+                    track=track,
+                    artist=artist,
+                    releases=releases[:limit],
+                    total=len(releases[:limit]),
+                    cached=False,
+                )
+
+            except Exception as e:
+                logger.error(f"Discogs search failed: {e}")
+                # An exception-path empty is NOT a "we asked, nothing" verdict
+                # — it's "we couldn't ask, try later." Return ``None`` so the
+                # seam skips both the write-back and negative-record paths
+                # (both are best-effort writes triggered only on a successful
+                # API result). The caller wraps ``None`` into an empty
+                # ``TrackReleasesResponse`` for the API consumer.
+                return None
+
+        cache = self.cache_service
+        bc = {"track": track, "artist": artist, "artist_as_keyword": artist_as_keyword}
+
+        def _empty_error_response() -> TrackReleasesResponse:
+            """The shape returned to callers when the API leg failed."""
             return TrackReleasesResponse(track=track, artist=artist, cached=False)
+
+        if cache is None:
+            return await _api_fetch() or _empty_error_response()
+
+        # The negative-cache check fires regardless of ``artist_as_keyword``
+        # because its key includes that dimension. The PG read is only safe
+        # when ``artist_as_keyword`` is False (see method docstring).
+        pg_read_hook = None if artist_as_keyword else _pg_read
+
+        result = await fallthrough(
+            label="search_releases_by_track",
+            pg_read=pg_read_hook,
+            api_fetch=_api_fetch,
+            # pg_write=None: read-only by design — see method docstring.
+            pg_negative_check=lambda: cache.lookup_negative_hit(artist, track, artist_as_keyword),
+            pg_negative_record=lambda: cache.record_lookup_negative(
+                artist, track, artist_as_keyword
+            ),
+            on_negative_hit=_on_negative_hit,
+            is_empty=lambda r: not r.releases,
+            breadcrumb_data=bc,
+        )
+        # Seam returns None only when ``_api_fetch`` returned None (the
+        # exception path). Wrap into the error-shape response so the API
+        # consumer always gets a populated model.
+        return result or _empty_error_response()
 
     async def search_releases_by_album_title(
         self,
@@ -698,10 +685,10 @@ class DiscogsService:
     async def get_release(self, release_id: int) -> ReleaseMetadataResponse | None:
         """Get full release metadata by ID.
 
-        Uses optional PostgreSQL cache with write-back strategy:
-        1. Try local cache first (if available)
-        2. On cache miss, fetch from Discogs API
-        3. Write API result back to cache for future queries
+        Read-through via :func:`fallthrough`: in-memory (decorator) → PG → API
+        + write-back. Full read-through — ``ReleaseMetadataResponse`` maps
+        cleanly to the cache's normalized schema. See #393 for the per-method
+        write-back policy table.
 
         Args:
             release_id: Discogs release ID
@@ -709,149 +696,131 @@ class DiscogsService:
         Returns:
             ReleaseMetadataResponse with full metadata, or None on error
         """
-        # Try local cache first
-        if self.cache_service and not should_skip_cache():
+
+        async def _api_fetch() -> ReleaseMetadataResponse | None:
             try:
-                add_discogs_breadcrumb("cache_get_release", {"release_id": release_id})
-                async with timed_pg():
-                    cached_release = await self.cache_service.get_release(release_id)
-                if cached_release:
-                    logger.info(f"Cache hit: release {release_id}")
-                    get_cache_stats_recorder().record_pg_cache_hit()
-                    add_discogs_breadcrumb("cache_hit", {"release_id": release_id})
-                    return cached_release
-                logger.debug(f"Cache miss for release {release_id}")
-                get_cache_stats_recorder().record_pg_cache_miss()
-                add_discogs_breadcrumb("cache_miss", {"release_id": release_id})
+                async with timed_api():
+                    response = await self._request_with_retry("GET", f"/releases/{release_id}")
+
+                if response is None:
+                    logger.warning(f"Failed to fetch release {release_id} (rate limited or error)")
+                    return None
+
+                get_cache_stats_recorder().record_api_call()
+                response.raise_for_status()
+                data = response.json()
+
+                # Extract all artists
+                raw_artists = data.get("artists", [])
+                artist_credits = [
+                    ArtistCredit(
+                        artist_id=a.get("id"),
+                        name=a.get("name", ""),
+                        join=a.get("join", ""),
+                    )
+                    for a in raw_artists
+                ]
+                artist_name = artist_credits[0].name if artist_credits else ""
+                artist_id = artist_credits[0].artist_id if artist_credits else None
+
+                # Extract extra artists (credits)
+                raw_extras = data.get("extraartists", [])
+                extra_artist_credits = [
+                    ArtistCredit(
+                        artist_id=a.get("id"),
+                        name=a.get("name", ""),
+                        role=a.get("role"),
+                    )
+                    for a in raw_extras
+                ]
+
+                # Extract all labels
+                raw_labels = data.get("labels", [])
+                label_credits = [
+                    LabelCredit(
+                        label_id=lbl.get("id"),
+                        name=lbl.get("name", ""),
+                        catno=lbl.get("catno"),
+                    )
+                    for lbl in raw_labels
+                ]
+                label_name = label_credits[0].name if label_credits else None
+                label_id = label_credits[0].label_id if label_credits else None
+
+                # Extract full release date
+                released = data.get("released")
+
+                # Extract tracklist with per-track artists (for compilations)
+                tracklist = [
+                    TrackItem(
+                        position=t.get("position", ""),
+                        title=t.get("title", ""),
+                        duration=t.get("duration"),
+                        artists=[a.get("name", "") for a in t.get("artists", [])],
+                    )
+                    for t in data.get("tracklist", [])
+                ]
+
+                # Extract artwork
+                images = data.get("images", [])
+                artwork_url = images[0].get("uri") if images else None
+
+                # Extract videos (skip entries without a URI)
+                videos = [
+                    ReleaseVideo(
+                        src=v["uri"],
+                        title=v.get("title"),
+                        duration=v.get("duration"),
+                        embed=v.get("embed", True),
+                    )
+                    for v in data.get("videos", [])
+                    if v.get("uri")
+                ]
+
+                return ReleaseMetadataResponse(
+                    release_id=release_id,
+                    title=data.get("title", ""),
+                    artist=artist_name,
+                    year=data.get("year"),
+                    label=label_name,
+                    artist_id=artist_id,
+                    label_id=label_id,
+                    genres=data.get("genres", []),
+                    styles=data.get("styles", []),
+                    tracklist=tracklist,
+                    artwork_url=artwork_url,
+                    release_url=f"https://www.discogs.com/release/{release_id}",
+                    cached=False,
+                    artists=artist_credits,
+                    extra_artists=extra_artist_credits,
+                    labels=label_credits,
+                    released=released,
+                    videos=videos,
+                )
+
             except Exception as e:
-                logger.warning(f"Cache lookup failed, falling back to API: {e}")
-                add_discogs_breadcrumb("cache_error", {"error": str(e)}, level="warning")
-
-        # Fall back to Discogs API
-        try:
-            async with timed_api():
-                response = await self._request_with_retry("GET", f"/releases/{release_id}")
-
-            if response is None:
-                logger.warning(f"Failed to fetch release {release_id} (rate limited or error)")
+                logger.error(f"Failed to fetch release {release_id}: {e}")
                 return None
 
-            get_cache_stats_recorder().record_api_call()
-            response.raise_for_status()
-            data = response.json()
-
-            # Extract all artists
-            raw_artists = data.get("artists", [])
-            artist_credits = [
-                ArtistCredit(
-                    artist_id=a.get("id"),
-                    name=a.get("name", ""),
-                    join=a.get("join", ""),
-                )
-                for a in raw_artists
-            ]
-            artist_name = artist_credits[0].name if artist_credits else ""
-            artist_id = artist_credits[0].artist_id if artist_credits else None
-
-            # Extract extra artists (credits)
-            raw_extras = data.get("extraartists", [])
-            extra_artist_credits = [
-                ArtistCredit(
-                    artist_id=a.get("id"),
-                    name=a.get("name", ""),
-                    role=a.get("role"),
-                )
-                for a in raw_extras
-            ]
-
-            # Extract all labels
-            raw_labels = data.get("labels", [])
-            label_credits = [
-                LabelCredit(
-                    label_id=lbl.get("id"),
-                    name=lbl.get("name", ""),
-                    catno=lbl.get("catno"),
-                )
-                for lbl in raw_labels
-            ]
-            label_name = label_credits[0].name if label_credits else None
-            label_id = label_credits[0].label_id if label_credits else None
-
-            # Extract full release date
-            released = data.get("released")
-
-            # Extract tracklist with per-track artists (for compilations)
-            tracklist = [
-                TrackItem(
-                    position=t.get("position", ""),
-                    title=t.get("title", ""),
-                    duration=t.get("duration"),
-                    artists=[a.get("name", "") for a in t.get("artists", [])],
-                )
-                for t in data.get("tracklist", [])
-            ]
-
-            # Extract artwork
-            images = data.get("images", [])
-            artwork_url = images[0].get("uri") if images else None
-
-            # Extract videos (skip entries without a URI)
-            videos = [
-                ReleaseVideo(
-                    src=v["uri"],
-                    title=v.get("title"),
-                    duration=v.get("duration"),
-                    embed=v.get("embed", True),
-                )
-                for v in data.get("videos", [])
-                if v.get("uri")
-            ]
-
-            release = ReleaseMetadataResponse(
-                release_id=release_id,
-                title=data.get("title", ""),
-                artist=artist_name,
-                year=data.get("year"),
-                label=label_name,
-                artist_id=artist_id,
-                label_id=label_id,
-                genres=data.get("genres", []),
-                styles=data.get("styles", []),
-                tracklist=tracklist,
-                artwork_url=artwork_url,
-                release_url=f"https://www.discogs.com/release/{release_id}",
-                cached=False,
-                artists=artist_credits,
-                extra_artists=extra_artist_credits,
-                labels=label_credits,
-                released=released,
-                videos=videos,
-            )
-
-            # Write back to cache for future queries
-            if self.cache_service and not should_skip_cache():
-                try:
-                    add_discogs_breadcrumb("cache_write_release", {"release_id": release_id})
-                    await self.cache_service.write_release(release)
-                    logger.debug(f"Cached release {release_id}")
-                except Exception as e:
-                    logger.warning(f"Failed to cache release {release_id}: {e}")
-                    add_discogs_breadcrumb("cache_write_error", {"error": str(e)}, level="warning")
-
-            return release
-
-        except Exception as e:
-            logger.error(f"Failed to fetch release {release_id}: {e}")
-            return None
+        cache = self.cache_service
+        if cache is None:
+            return await _api_fetch()
+        return await fallthrough(
+            label="get_release",
+            pg_read=lambda: cache.get_release(release_id),
+            api_fetch=_api_fetch,
+            pg_write=cache.write_release,
+            breadcrumb_data={"release_id": release_id},
+        )
 
     @async_cached(ARTIST_CACHE)
     async def get_artist_details(self, artist_id: int) -> ArtistDetails | None:
         """Fetch full artist details from Discogs.
 
-        Uses optional PostgreSQL cache with write-back strategy:
-        1. Try local cache first (if available)
-        2. On cache miss, fetch from Discogs API
-        3. Write API result back to cache for future queries
+        Read-through via :func:`fallthrough`: in-memory (decorator) → PG → API
+        + write-back. Full read-through — ``ArtistDetails`` maps cleanly to
+        the cache's normalized schema. See #393 for the per-method write-back
+        policy table.
 
         Args:
             artist_id: Discogs artist ID
@@ -859,71 +828,59 @@ class DiscogsService:
         Returns:
             ArtistDetails with full metadata, or None on error
         """
-        # Try local cache first
-        if self.cache_service and not should_skip_cache():
+
+        async def _api_fetch() -> ArtistDetails | None:
             try:
-                add_discogs_breadcrumb("cache_get_artist_details", {"artist_id": artist_id})
-                async with timed_pg():
-                    cached_details = await self.cache_service.get_artist_details(artist_id)
-                if cached_details:
-                    logger.info(f"Cache hit: artist {artist_id}")
-                    get_cache_stats_recorder().record_pg_cache_hit()
-                    return cached_details
-                logger.debug(f"Cache miss for artist {artist_id}")
-                get_cache_stats_recorder().record_pg_cache_miss()
+                async with timed_api():
+                    response = await self._request_with_retry("GET", f"/artists/{artist_id}")
+                if response is None:
+                    return None
+                get_cache_stats_recorder().record_api_call()
+                add_discogs_breadcrumb("get_artist_details", {"artist_id": artist_id})
+                response.raise_for_status()
+                data = response.json()
+
+                images = data.get("images", [])
+                image_url = images[0].get("uri") if images else None
+
+                return ArtistDetails(
+                    artist_id=artist_id,
+                    name=data.get("name", ""),
+                    profile=data.get("profile") or None,
+                    image_url=image_url,
+                    name_variations=data.get("namevariations", []),
+                    aliases=[
+                        ArtistRef(id=a["id"], name=a["name"])
+                        for a in data.get("aliases", [])
+                        if "id" in a and "name" in a
+                    ],
+                    members=[
+                        MemberRef(
+                            id=m["id"],
+                            name=m["name"],
+                            active=m.get("active", True),
+                        )
+                        for m in data.get("members", [])
+                        if "id" in m and "name" in m
+                    ],
+                    urls=data.get("urls", []),
+                    cached=False,
+                )
+
             except Exception as e:
-                logger.warning(f"Cache lookup failed, falling back to API: {e}")
-
-        try:
-            async with timed_api():
-                response = await self._request_with_retry("GET", f"/artists/{artist_id}")
-            if response is None:
+                logger.warning(f"Failed to fetch artist details for {artist_id}: {e}")
                 return None
-            get_cache_stats_recorder().record_api_call()
-            add_discogs_breadcrumb("get_artist_details", {"artist_id": artist_id})
-            response.raise_for_status()
-            data = response.json()
 
-            images = data.get("images", [])
-            image_url = images[0].get("uri") if images else None
-
-            details = ArtistDetails(
-                artist_id=artist_id,
-                name=data.get("name", ""),
-                profile=data.get("profile") or None,
-                image_url=image_url,
-                name_variations=data.get("namevariations", []),
-                aliases=[
-                    ArtistRef(id=a["id"], name=a["name"])
-                    for a in data.get("aliases", [])
-                    if "id" in a and "name" in a
-                ],
-                members=[
-                    MemberRef(
-                        id=m["id"],
-                        name=m["name"],
-                        active=m.get("active", True),
-                    )
-                    for m in data.get("members", [])
-                    if "id" in m and "name" in m
-                ],
-                urls=data.get("urls", []),
-                cached=False,
-            )
-
-            # Write back to cache
-            if self.cache_service and not should_skip_cache():
-                try:
-                    await self.cache_service.write_artist_details(details)
-                    logger.debug(f"Cached artist {artist_id}")
-                except Exception as e:
-                    logger.warning(f"Failed to cache artist {artist_id}: {e}")
-
-            return details
-
-        except Exception as e:
-            logger.warning(f"Failed to fetch artist details for {artist_id}: {e}")
-            return None
+        cache = self.cache_service
+        if cache is None:
+            return await _api_fetch()
+        return await fallthrough(
+            label="get_artist_details",
+            pg_read=lambda: cache.get_artist_details(artist_id),
+            api_fetch=_api_fetch,
+            pg_write=cache.write_artist_details,
+            breadcrumb_data={"artist_id": artist_id},
+        )
 
     async def get_artist_image(self, artist_id: int) -> str | None:
         """Fetch primary image for a Discogs artist.
@@ -998,6 +955,13 @@ class DiscogsService:
     async def search(self, request: DiscogsSearchRequest, limit: int = 5) -> DiscogsSearchResponse:
         """General release search for artwork discovery.
 
+        Read-through via :func:`fallthrough` with ``pg_write=None`` — the PG
+        cache's ``search_releases`` query is indexed against ETL-populated
+        ``release_artist`` / ``release_track`` data. Writing arbitrary Discogs
+        ``/database/search`` API hits back wouldn't fit that schema (they'd
+        be denormalized release stubs without the indexed columns the read
+        query depends on). Read-only by design; see #393.
+
         Args:
             request: Search parameters (artist, album, track)
             limit: Maximum number of results to return
@@ -1010,141 +974,146 @@ class DiscogsService:
             logger.warning("No searchable fields in request")
             return DiscogsSearchResponse(cached=False)
 
-        # Try local cache first
-        if self.cache_service and not should_skip_cache():
-            try:
-                add_discogs_breadcrumb(
-                    "cache_search_releases",
-                    {"artist": request.artist, "album": request.album},
-                )
-                async with timed_pg():
-                    cached = await self.cache_service.search_releases(
-                        artist=request.artist,
-                        album=request.album or request.track,
-                        limit=limit,
-                    )
-                if cached:
-                    logger.info(f"Cache hit: found {len(cached)} releases for search")
-                    get_cache_stats_recorder().record_pg_cache_hit()
-                    add_discogs_breadcrumb("cache_hit", {"count": len(cached)})
-                    results = []
-                    for row in cached:
-                        confidence = calculate_confidence(
-                            request.artist,
-                            request.album,
-                            row["artist_name"],
-                            row["title"],
-                            request_label=request.label,
-                            result_label=row.get("label_name"),
-                            request_format=request.format,
-                            result_format=None,  # cache doesn't include format yet
-                        )
-                        results.append(
-                            DiscogsSearchResult(
-                                album=row["title"],
-                                artist=row["artist_name"],
-                                release_id=row["release_id"],
-                                release_url=f"https://www.discogs.com/release/{row['release_id']}",
-                                artwork_url=row.get("artwork_url"),
-                                confidence=confidence,
-                            )
-                        )
-                    results.sort(key=lambda r: r.confidence, reverse=True)
-                    return DiscogsSearchResponse(results=results, total=len(results), cached=True)
-                logger.debug("Cache miss for search")
-                get_cache_stats_recorder().record_pg_cache_miss()
-                add_discogs_breadcrumb("cache_miss", {"artist": request.artist})
-            except Exception as e:
-                logger.warning(f"Cache search failed, falling back to API: {e}")
-                add_discogs_breadcrumb("cache_error", {"error": str(e)}, level="warning")
-
-        logger.info(f"Searching Discogs with params: {params}")
-
-        try:
-            async with timed_api():
-                response = await self._request_with_retry("GET", "/database/search", params=params)
-
-            if response is None:
-                logger.warning("Discogs search failed (rate limited or error)")
-                return DiscogsSearchResponse(cached=False)
-
-            get_cache_stats_recorder().record_api_call()
-            response.raise_for_status()
-            data = response.json()
-
-            # If strict search returned nothing, try fuzzy query
-            if not data.get("results") and (request.artist or request.album):
-                query_parts = []
-                if request.artist:
-                    query_parts.append(request.artist)
-                if request.album:
-                    query_parts.append(request.album)
-                fallback_params: dict[str, Any] = {
-                    "type": "release",
-                    "per_page": limit,
-                    "q": " ".join(query_parts),
-                }
-                logger.info(f"Strict search empty, trying fuzzy query: {fallback_params}")
-                async with timed_api():
-                    response = await self._request_with_retry(
-                        "GET", "/database/search", params=fallback_params
-                    )
-                if response is not None:
-                    get_cache_stats_recorder().record_api_call()
-                    response.raise_for_status()
-                    data = response.json()
-
+        async def _pg_read() -> DiscogsSearchResponse | None:
+            assert cache is not None  # narrowed by the caller before invocation
+            cached = await cache.search_releases(
+                artist=request.artist,
+                album=request.album or request.track,
+                limit=limit,
+            )
+            if not cached:
+                return None
             results = []
-            for item in data.get("results", []):
-                cover_url = item.get("thumb")
-                if not cover_url or "spacer.gif" in cover_url:
-                    cover_url = None
-
-                title = item.get("title", "")
-                result_artist, album = self._parse_title(title)
-
-                # Extract label and format from Discogs search result
-                result_labels = item.get("label", [])
-                result_label = result_labels[0] if result_labels else None
-                result_formats = item.get("format", [])
-                result_format = result_formats[0] if result_formats else None
-
+            for row in cached:
                 confidence = calculate_confidence(
                     request.artist,
                     request.album,
-                    result_artist,
-                    album,
+                    row["artist_name"],
+                    row["title"],
                     request_label=request.label,
-                    result_label=result_label,
+                    result_label=row.get("label_name"),
                     request_format=request.format,
-                    result_format=result_format,
+                    result_format=None,  # cache doesn't include format yet
                 )
-
-                release_id = item.get("id")
-                release_url = f"https://www.discogs.com/release/{release_id}"
-
                 results.append(
                     DiscogsSearchResult(
-                        album=album,
-                        artist=result_artist,
-                        release_id=release_id,
-                        release_url=release_url,
-                        artwork_url=cover_url,
+                        album=row["title"],
+                        artist=row["artist_name"],
+                        release_id=row["release_id"],
+                        release_url=f"https://www.discogs.com/release/{row['release_id']}",
+                        artwork_url=row.get("artwork_url"),
                         confidence=confidence,
                     )
                 )
-
             results.sort(key=lambda r: r.confidence, reverse=True)
+            return DiscogsSearchResponse(results=results, total=len(results), cached=True)
 
-            return DiscogsSearchResponse(
-                results=results,
-                total=len(results),
-                cached=False,
+        async def _api_fetch() -> DiscogsSearchResponse | None:
+            logger.info(f"Searching Discogs with params: {params}")
+            try:
+                async with timed_api():
+                    response = await self._request_with_retry(
+                        "GET", "/database/search", params=params
+                    )
+
+                if response is None:
+                    logger.warning("Discogs search failed (rate limited or error)")
+                    return DiscogsSearchResponse(cached=False)
+
+                get_cache_stats_recorder().record_api_call()
+                response.raise_for_status()
+                data = response.json()
+
+                # If strict search returned nothing, try fuzzy query
+                if not data.get("results") and (request.artist or request.album):
+                    query_parts = []
+                    if request.artist:
+                        query_parts.append(request.artist)
+                    if request.album:
+                        query_parts.append(request.album)
+                    fallback_params: dict[str, Any] = {
+                        "type": "release",
+                        "per_page": limit,
+                        "q": " ".join(query_parts),
+                    }
+                    logger.info(f"Strict search empty, trying fuzzy query: {fallback_params}")
+                    async with timed_api():
+                        response = await self._request_with_retry(
+                            "GET", "/database/search", params=fallback_params
+                        )
+                    if response is not None:
+                        get_cache_stats_recorder().record_api_call()
+                        response.raise_for_status()
+                        data = response.json()
+
+                results = []
+                for item in data.get("results", []):
+                    cover_url = item.get("thumb")
+                    if not cover_url or "spacer.gif" in cover_url:
+                        cover_url = None
+
+                    title = item.get("title", "")
+                    result_artist, album = self._parse_title(title)
+
+                    # Extract label and format from Discogs search result
+                    result_labels = item.get("label", [])
+                    result_label = result_labels[0] if result_labels else None
+                    result_formats = item.get("format", [])
+                    result_format = result_formats[0] if result_formats else None
+
+                    confidence = calculate_confidence(
+                        request.artist,
+                        request.album,
+                        result_artist,
+                        album,
+                        request_label=request.label,
+                        result_label=result_label,
+                        request_format=request.format,
+                        result_format=result_format,
+                    )
+
+                    release_id = item.get("id")
+                    release_url = f"https://www.discogs.com/release/{release_id}"
+
+                    results.append(
+                        DiscogsSearchResult(
+                            album=album,
+                            artist=result_artist,
+                            release_id=release_id,
+                            release_url=release_url,
+                            artwork_url=cover_url,
+                            confidence=confidence,
+                        )
+                    )
+
+                results.sort(key=lambda r: r.confidence, reverse=True)
+
+                return DiscogsSearchResponse(
+                    results=results,
+                    total=len(results),
+                    cached=False,
+                )
+
+            except Exception as e:
+                logger.error(f"Discogs search failed: {e}")
+                return DiscogsSearchResponse(cached=False)
+
+        cache = self.cache_service
+        if cache is None:
+            result = await _api_fetch()
+        else:
+            result = await fallthrough(
+                label="search",
+                pg_read=_pg_read,
+                api_fetch=_api_fetch,
+                # pg_write=None: read-only by design — see method docstring.
+                breadcrumb_data={"artist": request.artist, "album": request.album},
             )
-
-        except Exception as e:
-            logger.error(f"Discogs search failed: {e}")
-            return DiscogsSearchResponse(cached=False)
+        # ``api_fetch`` returns a non-None DiscogsSearchResponse on every path
+        # (parses or constructs a cached=False empty), so the seam's `T | None`
+        # never narrows to None here in practice.
+        assert result is not None
+        return result
 
     def _build_search_params(self, request: DiscogsSearchRequest, limit: int = 5) -> dict:
         """Build search params using Discogs-specific fields.
@@ -1184,9 +1153,12 @@ class DiscogsService:
     async def validate_track_on_release(self, release_id: int, track: str, artist: str) -> bool:
         """Validate that a track by an artist exists on a release.
 
-        Uses optional PostgreSQL cache for validation:
-        1. Try cache validation first (if available)
-        2. On cache miss (None), fall back to API via get_release
+        Read-through via :func:`fallthrough` with ``pg_write=None`` — the
+        validation verdict itself isn't separately cached on the API path.
+        The API fallback goes through ``get_release``, which writes back to
+        the ``release`` cache via its own seam call, so the release rows do
+        get persisted; only the validation answer is re-derived per call.
+        Read-only by design; see #393.
 
         Args:
             release_id: Discogs release ID
@@ -1196,91 +1168,101 @@ class DiscogsService:
         Returns:
             True if the track by the artist is found on the release
         """
-        # Try cache validation first
-        if self.cache_service and not should_skip_cache():
-            try:
-                add_discogs_breadcrumb(
-                    "cache_validate_track",
-                    {"release_id": release_id, "track": track, "artist": artist},
-                )
-                async with timed_pg():
-                    cached_result = await self.cache_service.validate_track_on_release(
-                        release_id, track, artist
-                    )
-                if cached_result is not None:
-                    logger.info(
-                        f"Cache {'validated' if cached_result else 'rejected'}: "
-                        f"'{track}' by '{artist}' on release {release_id}"
-                    )
-                    get_cache_stats_recorder().record_pg_cache_hit()
-                    add_discogs_breadcrumb(
-                        "cache_hit", {"release_id": release_id, "validated": cached_result}
-                    )
-                    return cached_result
-                logger.debug(f"Cache miss for validation on release {release_id}")
-                get_cache_stats_recorder().record_pg_cache_miss()
-                add_discogs_breadcrumb("cache_miss", {"release_id": release_id})
-            except Exception as e:
-                logger.warning(f"Cache validation failed, falling back to API: {e}")
-                add_discogs_breadcrumb("cache_error", {"error": str(e)}, level="warning")
 
-        # Fall back to API via get_release
-        release = await self.get_release(release_id)
-        if release is None:
-            return False
+        async def _api_fetch() -> bool | None:
+            # Fall back to API via get_release. Returns False (not None) when
+            # the release is missing or the track isn't on it, because the
+            # method's contract is ``-> bool``. The seam treats False as a
+            # valid result (it's not None), so it'll be returned to the
+            # caller.
+            release = await self.get_release(release_id)
+            if release is None:
+                return False
 
-        track_lower = normalize_for_track_comparison(track)
-        artist_lower = normalize_artist_for_validation(artist)
+            track_lower = normalize_for_track_comparison(track)
+            artist_lower = normalize_artist_for_validation(artist)
+            return _scan_tracklist_for_match(
+                release, release_id, track, track_lower, artist, artist_lower
+            )
 
-        for item in release.tracklist or []:
-            item_title = normalize_for_track_comparison(item.title)
-            # Check if track title matches
-            if track_lower not in item_title and item_title not in track_lower:
-                continue
+        cache = self.cache_service
+        if cache is not None:
+            validated = await fallthrough(
+                label="validate_track_on_release",
+                pg_read=lambda: cache.validate_track_on_release(release_id, track, artist),
+                api_fetch=_api_fetch,
+                # pg_write=None: read-only by design — see method docstring.
+                breadcrumb_data={
+                    "release_id": release_id,
+                    "track": track,
+                    "artist": artist,
+                },
+            )
+        else:
+            validated = await _api_fetch()
+        # The API path always returns bool (never None), so the seam's
+        # ``T | None`` here is always bool in practice.
+        return bool(validated)
 
-            # Per-track credits first (compilations, or tracks crediting the
-            # writers/performers). A positive hit short-circuits.
-            if item.artists:
-                for track_artist in item.artists:
-                    track_artist_lower = normalize_artist_for_validation(track_artist)
-                    if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
-                        logger.info(
-                            f"Validated: '{track}' by '{artist}' found on release {release_id}"
-                        )
-                        return True
-                # Fuzzy fallback: when no individual per-track artist substring-matches,
-                # compare against the joined credit string. Catches collaboration trios
-                # where each member is credited separately but the request uses the
-                # compact group name (LML#210).
-                joined = normalize_artist_for_validation(" ".join(item.artists))
-                if (
-                    joined
-                    and fuzz.token_set_ratio(artist_lower, joined) >= _ARTIST_FUZZY_MATCH_THRESHOLD
-                ):
-                    logger.info(
-                        f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}"
-                    )
+
+def _scan_tracklist_for_match(
+    release: ReleaseMetadataResponse,
+    release_id: int,
+    track: str,
+    track_lower: str,
+    artist: str,
+    artist_lower: str,
+) -> bool:
+    """Tracklist match logic extracted from ``validate_track_on_release``.
+
+    Kept as a module-level helper so ``validate_track_on_release``'s body
+    after the seam refactor reads as orchestration, not algorithm. Inputs
+    are pre-normalized by the caller (single call to
+    ``normalize_for_track_comparison`` / ``normalize_artist_for_validation``)
+    so the inner loop is hot-path arithmetic.
+    """
+    for item in release.tracklist or []:
+        item_title = normalize_for_track_comparison(item.title)
+        # Check if track title matches
+        if track_lower not in item_title and item_title not in track_lower:
+            continue
+
+        # Per-track credits first (compilations, or tracks crediting the
+        # writers/performers). A positive hit short-circuits.
+        if item.artists:
+            for track_artist in item.artists:
+                track_artist_lower = normalize_artist_for_validation(track_artist)
+                if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
+                    logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
                     return True
-
-            # Release-level artist. Always consulted when per-track credits
-            # haven't already matched — per-track credits often list band
-            # members / producers / writers rather than the band itself (e.g.,
-            # The Orb's "Towers Of Dub" on Live 93 is credited to Paterson /
-            # Weston / Fehlmann), so the release-level credit is the last
-            # word on "is this track by this artist."
-            release_artist = normalize_artist_for_validation(release.artist)
-            if release_artist and (
-                artist_lower in release_artist or release_artist in artist_lower
-            ):
-                logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
-                return True
+            # Fuzzy fallback: when no individual per-track artist substring-matches,
+            # compare against the joined credit string. Catches collaboration trios
+            # where each member is credited separately but the request uses the
+            # compact group name (LML#210).
+            joined = normalize_artist_for_validation(" ".join(item.artists))
             if (
-                release_artist
-                and fuzz.token_set_ratio(artist_lower, release_artist)
-                >= _ARTIST_FUZZY_MATCH_THRESHOLD
+                joined
+                and fuzz.token_set_ratio(artist_lower, joined) >= _ARTIST_FUZZY_MATCH_THRESHOLD
             ):
                 logger.info(f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}")
                 return True
 
-        logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")
-        return False
+        # Release-level artist. Always consulted when per-track credits
+        # haven't already matched — per-track credits often list band
+        # members / producers / writers rather than the band itself (e.g.,
+        # The Orb's "Towers Of Dub" on Live 93 is credited to Paterson /
+        # Weston / Fehlmann), so the release-level credit is the last
+        # word on "is this track by this artist."
+        release_artist = normalize_artist_for_validation(release.artist)
+        if release_artist and (artist_lower in release_artist or release_artist in artist_lower):
+            logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
+            return True
+        if (
+            release_artist
+            and fuzz.token_set_ratio(artist_lower, release_artist) >= _ARTIST_FUZZY_MATCH_THRESHOLD
+        ):
+            logger.info(f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}")
+            return True
+
+    logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")
+    return False

--- a/docs/plans/lml-393-discogs-cache-fallthrough.md
+++ b/docs/plans/lml-393-discogs-cache-fallthrough.md
@@ -1,0 +1,250 @@
+# LML #393 — Deepen the Discogs cache fallthrough into one read-through module
+
+**Issue:** [WXYC/library-metadata-lookup#393](https://github.com/WXYC/library-metadata-lookup/issues/393) — *surfaced by the 2026-05-27 architecture/deepening review of LML*
+
+**Sibling deepenings (unblocked, separate PRs):** #394, #395. **Sibling deepening (blocked on #376):** #392.
+
+**Folds in:** #324 (graceful fallback in `cache_service.py`) — its acceptance criteria become acceptance criteria of this PR. #324 will be closed via this PR's `Closes` block.
+
+## Problem (matrix view)
+
+Today, `discogs/service.py` hand-weaves a 3-tier cache pattern (in-process TTL → PostgreSQL → Discogs API + write-back) inside each public method. Eight cache-bearing methods, three different shapes:
+
+| Method | L1 in-mem | PG read | API | PG write-back | Negative cache |
+|---|---|---|---|---|---|
+| `get_release` | `@async_cached(RELEASE_CACHE)` | ✓ | ✓ | **✓** | — |
+| `get_artist_details` | `@async_cached(ARTIST_CACHE)` | ✓ | ✓ | **✓** | — |
+| `search_releases_by_track` | `@async_cached(TRACK_CACHE)` | ✓ (gated `not artist_as_keyword`) | ✓ | **✗** | ✓ (read + write on empty API) |
+| `search` | `@async_cached(SEARCH_CACHE)` | ✓ | ✓ | **✗** | — |
+| `validate_track_on_release` | `@async_cached(VALIDATION_CACHE)` | ✓ (tri-state `bool \| None`) | indirect via `get_release` | **✗** (indirect via `get_release`) | — |
+| `get_master` | `@async_cached(MASTER_CACHE)` | — | ✓ | — | — |
+| `search_releases_by_album_title` | — | — | ✓ (intentional, #319) | — | — |
+| `get_label_image` | `@async_cached(LABEL_CACHE)` | — | ✓ | — | — |
+
+Three categories of friction:
+
+1. **Tier policy is duplicated 5×** with subtle drift. The "PG read → on miss API → write back" ritual is rewritten in `get_release` (L697–845), `get_artist_details` (L847–926), `search_releases_by_track` (L399–579), `search` (L997–1147), and `validate_track_on_release` (L1183–1286). Each repetition encodes the same breadcrumb / cache-stat / try-except shape with localized variation.
+2. **Write-back drift is invisible.** `get_release` and `get_artist_details` persist API results back to PG; the three search-shaped methods do not. There is no single place that documents the policy split, so the divergence reads as carelessness rather than as design.
+3. **#324's graceful-degradation fix has no home.** When `cache_service.py` throws on a `PostgresConnectionError` (the monthly dedup-swap window in `WXYC/discogs-etl/scripts/dedup_releases.py`, Railway connection resets, pool exhaustion), every cache-bearing method needs to learn the same try/except + cool-down. With the policy duplicated 5×, the fix would land 5× too.
+
+**Deletion test:** delete the cache leg of `get_release`. Its `try: cache → except → fall through to API → write back` block reappears in `get_artist_details` (same shape, different cache method), in `search_releases_by_track` (same shape plus negative cache plus an `artist_as_keyword` gate), in `search` (same shape with no write-back), and in `validate_track_on_release` (same shape with a tri-state return). Concentrating it is the deepening; the write-back drift is the bug it removes.
+
+## Desired end state
+
+One read-through module — `discogs/fallthrough.py` — owns:
+
+- the PG-read → API-fetch → optional-write-back ritual,
+- the breadcrumb + cache-stats + Sentry projection at each tier,
+- the `should_skip_cache()` bypass at one site,
+- the graceful-degrade cool-down from #324 (a per-process timestamp arms on `asyncpg.PostgresConnectionError` / `CacheUnavailableError` from the cache leg and suppresses retries for ~30 s),
+- the negative-cache pre-check / post-write hooks (one method uses these today),
+- the tri-state read shape that `validate_track_on_release` needs.
+
+Each `DiscogsService` method states only **its cache key and its API fetch** plus, where it diverges, **its explicit write-back policy as a parameter**. The L1 `@async_cached` decorator stays as-is — it owns a separate concern (per-type TTL, normalization, in-process LRU, the skip-cache flag) and is already deep.
+
+## The seam — a function, not a class
+
+```python
+# discogs/fallthrough.py
+from typing import Awaitable, Callable, Generic, TypeVar
+T = TypeVar("T")
+
+async def fallthrough(
+    *,
+    label: str,                                            # breadcrumb / cache-stat key
+    pg_read: Callable[[], Awaitable[T | None]] | None,     # None == no PG leg (get_master, label_image)
+    api_fetch: Callable[[], Awaitable[T | None]],
+    pg_write: Callable[[T], Awaitable[None]] | None = None,   # absence == read-only by design
+    pg_negative_check: Callable[[], Awaitable[bool]] | None = None,
+    pg_negative_record: Callable[[], Awaitable[None]] | None = None,
+    is_empty: Callable[[T], bool] = lambda r: not r,        # negative-cache trigger
+    is_pg_hit: Callable[[T | None], bool] = lambda v: v is not None,  # overrideable for tri-state
+    breadcrumb_data: dict[str, Any] | None = None,
+) -> T | None:
+    ...
+```
+
+Each `None` parameter is an **explicit opt-out**, not silent absence — `pg_write=None` reads as "this method is read-only against PG by design" the same way `Outcome.empty()` reads as "this strategy fired but produced no items."
+
+The seam handles:
+
+1. `should_skip_cache()` short-circuit (one site).
+2. Cool-down guard: if `time.monotonic() < _cool_down_until` and `pg_read` is set, skip PG and go straight to API (no PG breadcrumb either).
+3. PG read leg, if configured. Wrap in `timed_pg()`. On hit (per `is_pg_hit`), emit `cache_hit` breadcrumb + `record_pg_cache_hit()` and return.
+4. On PG miss, emit `cache_miss` + `record_pg_cache_miss()`. On PG **exception**, emit `cache_error` + `record_pg_cache_miss()` AND arm the cool-down for ~30 s.
+5. Negative-cache pre-check (if configured). On hit, return an empty value via the caller's `is_empty` shape — wait, this needs care. The negative cache today returns `True/False` (hit/miss); on hit, the caller returns a `TrackReleasesResponse(...releases=[]...)`. The seam can't manufacture that — the caller has to. **Resolution:** the seam returns `None` on negative-cache hit; the caller (`search_releases_by_track`) wraps `None` in its empty `TrackReleasesResponse` shape. Or — better — the seam accepts an `on_negative_hit: Callable[[], T]` factory. Decision in the plan-review pass.
+6. API fetch via `api_fetch()`. On non-empty result + `pg_write` configured: write back. On confirmed-empty result + `pg_negative_record` configured: write the negative entry. All write-backs are best-effort (try/except → WARN).
+7. Return whatever `api_fetch()` produced.
+
+### Tri-state for `validate_track_on_release`
+
+The cache's `validate_track_on_release` returns `True | False | None` where `None` means miss and both bool values are valid hits. Today the orchestrator checks `if cached_result is not None`. The seam already supports this shape — `is_pg_hit=lambda v: v is not None` and `T=bool` make `False` a hit, `None` a miss. The default `is_pg_hit` is exactly that, so validation gets it for free.
+
+The validate API path goes through `get_release` (which already writes back), so the validate call passes `pg_write=None` — its write-back is **indirect, by design**. Documented at the call site.
+
+### Cool-down
+
+```python
+# discogs/fallthrough.py
+import time
+_cool_down_until: float = 0.0
+_COOL_DOWN_SECONDS = 30.0
+
+def _arm_cool_down() -> None:
+    global _cool_down_until
+    _cool_down_until = time.monotonic() + _COOL_DOWN_SECONDS
+
+def _cool_down_active() -> bool:
+    return time.monotonic() < _cool_down_until
+
+def _reset_cool_down_for_tests() -> None:  # test-only helper
+    global _cool_down_until
+    _cool_down_until = 0.0
+```
+
+Process-wide. Railway runs single-process workers per replica so there's no cross-worker sharing problem to solve here; a per-replica cool-down is exactly the desired granularity. On cool-down arm, project `data.cache_fallback_fired = {reason, error_class}` onto the active Sentry transaction per #324's AC, and emit a structured WARN log.
+
+### Why a function, not a class
+
+A class (`ReadThroughCache(read, fetch, write).get(key)`) buys nothing — there is no per-instance state beyond what the closures already carry. A decorator (`@read_through(read=..., fetch=...)`) hides too much: the strategy decisions (write-back policy, negative cache, tri-state) become decorator parameters and the call-site reads as "what's special about this method gets argued through indirection," which is exactly the friction the deepening is supposed to remove.
+
+A function with named-keyword parameters keeps every per-method policy decision **at the call site**, in plain syntax, which is what we want for read-through-the-code understanding. The shape mirrors the `Outcome` named-constructor pattern from #399 (just merged).
+
+## Per-method write-back policy table (the documented split)
+
+After this PR, the policy is encoded **at the call site** as the presence or absence of `pg_write`:
+
+| Method | `pg_write` | Why |
+|---|---|---|
+| `get_release` | `cache_service.write_release` | Full read-through (status quo). Single `ReleaseMetadataResponse` maps cleanly to the cache's `release` / `release_artist` / `release_track` schema. |
+| `get_artist_details` | `cache_service.write_artist_details` | Full read-through (status quo). Single `ArtistDetails` maps cleanly to `artist` / `artist_alias`. |
+| `search_releases_by_track` | `None` | **Read-only by design.** PG side queries the normalized `release_track` index populated by the ETL pipeline. Writing arbitrary Discogs `/database/search` hits back doesn't fit that schema — they'd be denormalized release stubs without the `release_artist` / `release_track` join data the read query depends on. Negative-cache write-back still fires (a separate write hook, `pg_negative_record`). |
+| `search` | `None` | **Read-only by design.** Same shape as above — the PG `search_releases` query is indexed against ETL-populated data; API search hits don't carry the indexed columns. |
+| `validate_track_on_release` | `None` | **Read-only by design, indirect API write-back.** Tri-state PG read short-circuits when the cache has an answer. On miss, the API path calls `get_release` which writes back to the `release` cache via its own seam call. So the release row gets persisted; the validation verdict itself isn't separately cached on the API path (matches today's behavior). |
+
+The table sits in `CLAUDE.md` so future drift will be flagged in review (a new method added without an explicit `pg_write` argument or comment is a missed decision, not a missed line). Drift detection is doc-level, not lint-level; the surface is small enough to grep.
+
+## Scope boundaries
+
+### In scope
+
+- Create `discogs/fallthrough.py` with the function above + cool-down + `_reset_cool_down_for_tests`.
+- Migrate 5 methods onto it: `get_release`, `get_artist_details`, `search_releases_by_track`, `search`, `validate_track_on_release`.
+- Land #324's graceful-degradation try/except + cool-down inside the seam (one site).
+- Add unit tests for the seam (`tests/unit/test_fallthrough.py`) covering: PG hit, PG miss → API, write-back fires/skipped, negative-cache hit/miss/write, cool-down arms on cache error, cool-down honors expiry, tri-state hit, `should_skip_cache()` bypass.
+- Add a unit test that reproduces #324: `asyncpg.PostgresConnectionError` from `pg_read` arms cool-down, second call within 30 s skips PG and goes straight to API, third call after a forced reset uses PG again.
+- Update `CLAUDE.md`: new "Discogs cache fallthrough" section documenting the seam + the policy table.
+
+### Out of scope (deferred / not changed)
+
+- `get_master`, `search_releases_by_album_title`, `get_label_image` — API-only methods. They COULD use the seam with `pg_read=None`, but the API path of each is small enough that the seam doesn't earn its keep. Adding them later is a one-commit follow-up if it ever becomes worth it.
+- Adding new PG write-back to `search` / `search_releases_by_track` — the issue explicitly asks to confirm read-only-by-design before flipping. We're encoding it as policy, not flipping it.
+- The `@async_cached` L1 decorator — already deep. The skip-cache flag, cache-key normalization (#342), and per-cache TTL split are all working. Leave it alone.
+- Integration test against a real `asyncpg.PostgresConnectionError` from a deliberately-undersized pool — #324's AC mentions this. It needs a `pg`-marked integration test with a 1-connection pool and a concurrent burst. Deferred to a follow-up so this PR stays focused on the seam; tracked by leaving #324 open with the unit-test AC satisfied, OR (preferred) folding into this PR if the test fits cheaply. **Decision pending plan review.**
+- Validating that `search_releases_by_track`'s `artist_as_keyword` gate behavior is preserved exactly — captured by a regression-pinning unit test that watches the `pg_read` callable is `None` when `artist_as_keyword=True`.
+
+### Test surface
+
+- `tests/unit/test_fallthrough.py` (new, ~12 tests):
+  - `test_returns_pg_hit_without_calling_api`
+  - `test_pg_miss_calls_api`
+  - `test_pg_miss_with_write_calls_write_back`
+  - `test_pg_miss_without_write_does_not_write_back`
+  - `test_empty_api_with_negative_record_writes_negative`
+  - `test_negative_cache_hit_short_circuits_api`
+  - `test_pg_error_arms_cool_down_and_falls_back_to_api`
+  - `test_cool_down_active_skips_pg_read`
+  - `test_cool_down_expires_after_window` (`monkeypatch.setattr(time, "monotonic", ...)`)
+  - `test_should_skip_cache_bypasses_all_legs`
+  - `test_tri_state_false_treated_as_hit` (`is_pg_hit=lambda v: v is not None`)
+  - `test_breadcrumb_data_threaded_through`
+- `tests/unit/test_discogs_service.py` regression net stays green — the existing per-method tests cover the migration. If any per-method assertion checked for breadcrumbs or cache-stats fired from the method body, those calls now move into the seam and the assertions need to follow the call.
+
+## Implementation order (TDD-friendly)
+
+1. **Red:** write `tests/unit/test_fallthrough.py` for the seam's behavior. None of these pass — the module doesn't exist.
+2. **Green:** create `discogs/fallthrough.py` with the function + cool-down. Make the seam tests green.
+3. **Refactor `get_release`** to use the seam — the simplest migration (full read-through, no negative cache, no tri-state). Existing `test_discogs_service` tests stay green.
+4. **Refactor `get_artist_details`** — same shape.
+5. **Refactor `search`** — first read-only-by-design migration. Surface the `pg_write=None` pattern.
+6. **Refactor `validate_track_on_release`** — first tri-state migration. Surface the `is_pg_hit` default.
+7. **Refactor `search_releases_by_track`** — most complex (negative cache, `artist_as_keyword` gate). Surface the `pg_negative_check` / `pg_negative_record` / `on_negative_hit` hooks.
+8. Update `CLAUDE.md` with the seam description + policy table.
+9. Run `ruff check`, `ruff format`, `mypy`, full unit-test suite locally.
+10. Open PR with `Closes #393, Closes #324`.
+
+Per the global TDD rule, each "Refactor X" step starts from green tests, makes the swap, confirms green. No drive-by changes.
+
+## Size estimate
+
+~700–900 net lines:
+
+- ~250 new (seam + tests).
+- ~400 modifications across `discogs/service.py` (the 5 methods shrink — each loses 30–50 lines of try/except machinery and gains a 10–15 line `fallthrough(...)` call).
+- ~50 net changes in `CLAUDE.md`.
+
+Under the 1000-line target. If the `search_releases_by_track` migration plus its `on_negative_hit` factory pushes the diff past 1000, split into two PRs: (a) seam + the 4 read-only / full-write methods, (b) the negative-cache migration of `search_releases_by_track`. Decision deferred to the implementation pass.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Subtle behavior change in the negative-cache leg (`search_releases_by_track`) — the leg today consults the negative cache *after* the PG miss check; the seam folds them. | Add a regression test that exercises both orders explicitly: (a) PG miss + negative-cache hit → no API call, (b) PG miss + negative-cache miss + empty API → negative-cache write. |
+| The `is_pg_hit` callback semantics drift between methods (e.g., search returns a `DiscogsSearchResponse` which is never `None` — empty results still mean "miss"). | Each method passes an explicit `is_pg_hit` lambda or — better — the PG-read callable itself returns `None` on empty. Decide at implementation: I lean toward making the PG-read callable's responsibility to return `T | None`, with `None` always meaning "miss." Keeps the seam's default `lambda v: v is not None` honest. |
+| Cool-down false-arming on benign errors (timeout, transient). | Distinguish error classes: arm on `asyncpg.PostgresConnectionError`, `asyncpg.InterfaceError`, `asyncpg.PostgresError` subclasses related to availability; do NOT arm on `asyncio.TimeoutError` (which has its own meaning). Specific class list pinned by tests. |
+| Per-process global state (`_cool_down_until`) leaks across tests. | `_reset_cool_down_for_tests` fixture in `conftest.py` (autouse for the fallthrough test module). |
+| L1 in-memory decorator (`@async_cached`) caches the API result, so a cool-down-active state still returns the cached value on subsequent calls in-window — which is correct, but worth documenting. | One-line note in the seam's docstring + the `CLAUDE.md` section. |
+
+## Convergence with #324
+
+#324's acceptance criteria:
+
+- [x] Unit test that simulates `asyncpg.PostgresConnectionError` from the cache pool and asserts `/lookup` returns successful — covered by the seam test (`test_pg_error_arms_cool_down_and_falls_back_to_api`) plus a thin `discogs/service.py` integration test that wires the seam to a mocked `pg_read` that raises.
+- [ ] Integration test that exercises the actual exception class produced by Railway pool exhaustion — deferred (out-of-scope above).
+- [x] `data.cache_fallback_fired` projected on the Sentry transaction — fold into the cool-down arm path.
+- [x] Cool-down: one cache-leg failure suppresses retries for ~30 s — `_arm_cool_down`.
+
+If we defer the integration test, #324 stays half-open and gets a tracking comment ("seam landed in #393; pool-exhaustion integration test outstanding"). The user-visible AC — `/lookup` no longer 5xx during cache-leg outages — is met by the seam alone.
+
+## What this PR does NOT touch
+
+- `discogs/cache_service.py` — the PG client methods stay as-is. The seam wraps them; it doesn't change their signatures or internals. (The "fold #324's try/except into the seam" line is about wrapping `cache_service` calls, not editing `cache_service` internals.)
+- `lookup/orchestrator.py` — no changes; the orchestrator's strategies still call the same `discogs_service` methods. The migration is internal to `discogs/service.py`.
+- The 3 sibling deepening tickets (#392/#394/#395) — separate PRs, not blocked by this one.
+- The L1 `@async_cached` decorator — unchanged.
+
+## Acceptance criteria mapping
+
+From the issue body:
+
+- [x] **A single read-through module; methods express key + fetch only** → `discogs/fallthrough.py` + the 5 migrated methods.
+- [x] **Write-back policy decided in one place and applied consistently (or a documented per-method opt-out)** → Per-method `pg_write` argument; policy table in `CLAUDE.md`.
+- [x] **Tier fallthrough has one set of tests instead of per-method coverage** → `tests/unit/test_fallthrough.py`. Per-method tests stay as regression nets but no longer carry the tier logic.
+- [x] **#324's graceful-degradation try/except + cool-down lands in this module, not per-method** → `_arm_cool_down` + the cache-leg try/except inside `fallthrough()`.
+- [x] **Existing discogs cache/service tests pass** → regression net.
+
+## Decisions from plan review (2026-05-29)
+
+The plan was approved with one HIGH and four lower-severity findings. The decisions below resolve them before implementation begins.
+
+1. **HIGH — Negative-cache hit signal: `on_negative_hit` factory (option b).** Bare `None` collides with "API call returned nothing"; the caller needs the `cached=True` flag on negative-cache hits and `cached=False` on API empties. The seam takes `on_negative_hit: Callable[[], T] | None = None`; on negative-cache hit it returns `on_negative_hit()`. The stats / breadcrumb distinction (`pg_negative_hits` vs. plain `cache_miss`) is emitted by the seam itself; the return type carries the caller's full shape.
+
+2. **MEDIUM — Cool-down arms on a pinned, narrow exception set.** The seam arms its cool-down only on:
+   - `asyncpg.exceptions.PostgresConnectionError` (and its subclasses — base "we couldn't reach the DB")
+   - `asyncpg.exceptions.CannotConnectNowError` (server starting / not ready)
+   - `asyncpg.exceptions.InterfaceError` (pool exhausted, closed connection, driver-level)
+   - `asyncpg.exceptions.UndefinedTableError` (the "relation does not exist" shape during a dedup-swap window)
+   - the local `CacheUnavailableError` raised by `cache_service` methods
+   
+   Cool-down does **not** arm on `asyncio.TimeoutError`, `asyncio.CancelledError`, or any bare `Exception`. A test asserts the exact set (the test will fail loudly if a future asyncpg version moves an exception under a different base or if someone widens the arming criteria silently).
+
+3. **MEDIUM — Pool-exhaustion integration test: defer to a follow-up issue.** The seam's unit-test coverage (the simulated `PostgresConnectionError` case) satisfies the user-visible AC of #324 — `/lookup` no longer 5xx when the cache leg throws. The deliberately-undersized-pool integration test is its own work (provisioning + concurrent-burst harness) and would inflate this PR past its size budget. I'll file a focused follow-up ticket for just the integration test, link it from a comment on #324, and close #324 from THIS PR — the integration test becomes its own tracked work, not a half-open AC on #324. (If the reviewer's "decide now" point is taken literally, the answer is "defer" — the test cost outpaces this PR's appetite.)
+
+4. **LOW — Per-method `pg_write` policy gets an inline comment at each call site.** The three `pg_write=None` call sites (`search`, `search_releases_by_track`, `validate_track_on_release`) carry a one-line `# read-only by design: ...` comment explaining why. The `pg_write=cache_service.write_release` and `pg_write=cache_service.write_artist_details` cases are self-documenting. This keeps the policy decision visible at the call site without requiring CLAUDE.md cross-reference.
+
+5. **LOW — `is_empty` default scope tightened.** The default `lambda r: not r` only works for primitive empties. Rather than ship a footgun, the seam only uses `is_empty` on the negative-cache write path (i.e., only when `pg_negative_record` is set), and **requires** the caller to pass an explicit `is_empty` when `pg_negative_record` is set. A `ValueError` at construction-time (parameter validation at the top of the function) prevents silent misuse. For `search_releases_by_track`, the lambda is `lambda r: not r.releases`.
+
+## Resolved open questions
+
+- **`get_master` / `get_label_image` / `search_releases_by_album_title` opportunistic migration?** Skip. Drive-by changes are exactly what the review-loop flags; their inclusion would add ~80 lines for aesthetic-only consolidation. Tracked as a one-line `## Possible follow-up` in the PR body in case the seam's "API-only" shape ever earns its keep on those.
+

--- a/tests/unit/test_fallthrough.py
+++ b/tests/unit/test_fallthrough.py
@@ -1,0 +1,571 @@
+"""Tests for ``discogs/fallthrough.py`` — the read-through cache seam (#393).
+
+The seam concentrates the 3-tier (in-memory → PG → API + optional write-back)
+ritual that ``discogs/service.py`` was hand-weaving across 5 cache-bearing
+methods. See ``docs/plans/lml-393-discogs-cache-fallthrough.md``.
+
+Tests cover, in order:
+
+1. **PG hit / PG miss** — the basic read-through happy path.
+2. **Write-back policy** — ``pg_write`` presence drives write-back; absence
+   means "read-only by design" (the #393 drift fix).
+3. **Negative-cache** — ``on_negative_hit`` factory, ``pg_negative_record``
+   on empty API result, ``is_empty`` parameter validation.
+4. **Cool-down (#324)** — narrow exception class set arms; expiry releases;
+   unrelated exceptions do not arm.
+5. **``should_skip_cache()`` bypass** — both PG read and negative-cache check
+   honored as a single bypass.
+6. **Tri-state PG read** — ``False`` from PG is treated as a hit, not a miss
+   (the ``validate_track_on_release`` shape).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import asyncpg.exceptions
+import pytest
+
+from discogs.fallthrough import (
+    _COOL_DOWN_SECONDS,
+    _reset_cool_down_for_tests,
+    fallthrough,
+)
+from discogs.memory_cache import set_skip_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_cool_down():
+    """Cool-down is process-wide; reset between tests to keep them independent."""
+    _reset_cool_down_for_tests()
+    yield
+    _reset_cool_down_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic read-through
+# ---------------------------------------------------------------------------
+
+
+class TestBasicReadThrough:
+    @pytest.mark.asyncio
+    async def test_pg_hit_returns_cached_value_without_calling_api(self):
+        pg_read = AsyncMock(return_value="cached-value")
+        api_fetch = AsyncMock(return_value="fresh-value")
+
+        result = await fallthrough(
+            label="get_thing",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+        )
+
+        assert result == "cached-value"
+        pg_read.assert_awaited_once()
+        api_fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pg_miss_calls_api_returns_api_result(self):
+        pg_read = AsyncMock(return_value=None)
+        api_fetch = AsyncMock(return_value="fresh-value")
+
+        result = await fallthrough(
+            label="get_thing",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+        )
+
+        assert result == "fresh-value"
+        pg_read.assert_awaited_once()
+        api_fetch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_pg_leg_calls_api_directly(self):
+        """``pg_read=None`` is an explicit opt-out — used for API-only methods."""
+        api_fetch = AsyncMock(return_value="fresh-value")
+
+        result = await fallthrough(
+            label="get_thing",
+            pg_read=None,
+            api_fetch=api_fetch,
+        )
+
+        assert result == "fresh-value"
+        api_fetch.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 2. Write-back policy — the #393 drift fix
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBackPolicy:
+    @pytest.mark.asyncio
+    async def test_pg_miss_with_write_calls_write_back(self):
+        pg_read = AsyncMock(return_value=None)
+        api_fetch = AsyncMock(return_value="fresh-value")
+        pg_write = AsyncMock()
+
+        await fallthrough(
+            label="get_thing",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            pg_write=pg_write,
+        )
+
+        pg_write.assert_awaited_once_with("fresh-value")
+
+    @pytest.mark.asyncio
+    async def test_pg_miss_without_write_does_not_call_anything_extra(self):
+        """``pg_write=None`` (the default) is "read-only by design"."""
+        pg_read = AsyncMock(return_value=None)
+        api_fetch = AsyncMock(return_value="fresh-value")
+
+        # Should not raise, should not try to write anywhere.
+        result = await fallthrough(
+            label="search",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            # pg_write omitted — explicit read-only-by-design.
+        )
+
+        assert result == "fresh-value"
+
+    @pytest.mark.asyncio
+    async def test_pg_hit_skips_write_back(self):
+        """Write-back fires only on API path — PG hits don't re-write themselves."""
+        pg_read = AsyncMock(return_value="cached-value")
+        api_fetch = AsyncMock(return_value="should-never-be-called")
+        pg_write = AsyncMock()
+
+        await fallthrough(
+            label="get_thing",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            pg_write=pg_write,
+        )
+
+        pg_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_api_returns_none_does_not_write_back(self):
+        """A None API result (failure / not-found) is not cached."""
+        pg_read = AsyncMock(return_value=None)
+        api_fetch = AsyncMock(return_value=None)
+        pg_write = AsyncMock()
+
+        await fallthrough(
+            label="get_thing",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            pg_write=pg_write,
+        )
+
+        pg_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_back_exception_is_swallowed(self):
+        """A write-back failure must not propagate — best-effort by design."""
+        pg_read = AsyncMock(return_value=None)
+        api_fetch = AsyncMock(return_value="fresh-value")
+        pg_write = AsyncMock(side_effect=RuntimeError("pg write blew up"))
+
+        # Must not raise — caller still gets the API result.
+        result = await fallthrough(
+            label="get_thing",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            pg_write=pg_write,
+        )
+
+        assert result == "fresh-value"
+
+
+# ---------------------------------------------------------------------------
+# 3. Negative-cache (the search_releases_by_track shape)
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeCache:
+    @pytest.mark.asyncio
+    async def test_negative_hit_returns_factory_value_without_api(self):
+        pg_read = AsyncMock(return_value=None)
+        pg_negative_check = AsyncMock(return_value=True)
+        api_fetch = AsyncMock()
+        sentinel = object()
+        on_negative_hit = lambda: sentinel  # noqa: E731
+
+        result = await fallthrough(
+            label="search_releases_by_track",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            pg_negative_check=pg_negative_check,
+            on_negative_hit=on_negative_hit,
+            pg_negative_record=AsyncMock(),
+            is_empty=lambda _: False,
+        )
+
+        assert result is sentinel
+        api_fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_negative_miss_then_empty_api_writes_negative(self):
+        pg_read = AsyncMock(return_value=None)
+        pg_negative_check = AsyncMock(return_value=False)
+        api_fetch = AsyncMock(return_value=[])
+        pg_negative_record = AsyncMock()
+        on_negative_hit = lambda: "unused"  # noqa: E731
+
+        await fallthrough(
+            label="search_releases_by_track",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            pg_negative_check=pg_negative_check,
+            on_negative_hit=on_negative_hit,
+            pg_negative_record=pg_negative_record,
+            is_empty=lambda v: not v,
+        )
+
+        pg_negative_record.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_negative_miss_then_nonempty_api_skips_negative_write(self):
+        pg_read = AsyncMock(return_value=None)
+        pg_negative_check = AsyncMock(return_value=False)
+        api_fetch = AsyncMock(return_value=["item"])
+        pg_negative_record = AsyncMock()
+        on_negative_hit = lambda: "unused"  # noqa: E731
+
+        await fallthrough(
+            label="search_releases_by_track",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            pg_negative_check=pg_negative_check,
+            on_negative_hit=on_negative_hit,
+            pg_negative_record=pg_negative_record,
+            is_empty=lambda v: not v,
+        )
+
+        pg_negative_record.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_negative_check_requires_on_negative_hit(self):
+        """Without ``on_negative_hit`` the seam can't construct a return shape."""
+        with pytest.raises(ValueError, match="on_negative_hit"):
+            await fallthrough(
+                label="search_releases_by_track",
+                pg_read=AsyncMock(return_value=None),
+                api_fetch=AsyncMock(),
+                pg_negative_check=AsyncMock(return_value=False),
+                # on_negative_hit omitted — should raise.
+            )
+
+    @pytest.mark.asyncio
+    async def test_negative_record_requires_is_empty(self):
+        """Without ``is_empty`` the seam doesn't know when to record a negative.
+
+        The default ``not r`` is unsafe for Pydantic models (always truthy).
+        """
+        with pytest.raises(ValueError, match="is_empty"):
+            await fallthrough(
+                label="search_releases_by_track",
+                pg_read=AsyncMock(return_value=None),
+                api_fetch=AsyncMock(return_value=[]),
+                pg_negative_record=AsyncMock(),
+                # is_empty omitted — should raise.
+            )
+
+    @pytest.mark.asyncio
+    async def test_negative_record_failure_is_swallowed(self):
+        """Negative-cache writes are best-effort."""
+        pg_read = AsyncMock(return_value=None)
+        pg_negative_check = AsyncMock(return_value=False)
+        api_fetch = AsyncMock(return_value=[])
+        pg_negative_record = AsyncMock(side_effect=RuntimeError("write boom"))
+
+        # Must not raise.
+        await fallthrough(
+            label="search_releases_by_track",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            pg_negative_check=pg_negative_check,
+            on_negative_hit=lambda: "unused",
+            pg_negative_record=pg_negative_record,
+            is_empty=lambda v: not v,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Cool-down (#324)
+# ---------------------------------------------------------------------------
+
+
+class TestCoolDown:
+    @pytest.mark.asyncio
+    async def test_pg_postgres_connection_error_arms_cool_down(self, monkeypatch):
+        """The narrow asyncpg error class that signals "DB unreachable"."""
+        # First call: PG raises, falls back to API, arms cool-down.
+        pg_read_a = AsyncMock(side_effect=asyncpg.exceptions.PostgresConnectionError("down"))
+        api_fetch_a = AsyncMock(return_value="api-1")
+        result_a = await fallthrough(
+            label="get_thing",
+            pg_read=pg_read_a,
+            api_fetch=api_fetch_a,
+        )
+        assert result_a == "api-1"
+
+        # Second call: cool-down is active; PG read must NOT be invoked.
+        pg_read_b = AsyncMock(return_value="from-pg")
+        api_fetch_b = AsyncMock(return_value="api-2")
+        result_b = await fallthrough(
+            label="get_thing",
+            pg_read=pg_read_b,
+            api_fetch=api_fetch_b,
+        )
+        assert result_b == "api-2"
+        pg_read_b.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pg_cannot_connect_now_arms_cool_down(self):
+        pg_read = AsyncMock(side_effect=asyncpg.exceptions.CannotConnectNowError("starting"))
+        api_fetch = AsyncMock(return_value="api-result")
+
+        await fallthrough(label="get_thing", pg_read=pg_read, api_fetch=api_fetch)
+
+        # Cool-down should be armed — second call skips PG.
+        next_pg = AsyncMock(return_value="should-not-be-called")
+        await fallthrough(
+            label="get_thing", pg_read=next_pg, api_fetch=AsyncMock(return_value="ok")
+        )
+        next_pg.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pg_interface_error_arms_cool_down(self):
+        pg_read = AsyncMock(side_effect=asyncpg.exceptions.InterfaceError("pool exhausted"))
+        api_fetch = AsyncMock(return_value="api-result")
+
+        await fallthrough(label="get_thing", pg_read=pg_read, api_fetch=api_fetch)
+
+        next_pg = AsyncMock(return_value="should-not-be-called")
+        await fallthrough(
+            label="get_thing", pg_read=next_pg, api_fetch=AsyncMock(return_value="ok")
+        )
+        next_pg.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pg_undefined_table_arms_cool_down(self):
+        """The "relation does not exist" window during a dedup-swap."""
+        pg_read = AsyncMock(
+            side_effect=asyncpg.exceptions.UndefinedTableError("relation does not exist")
+        )
+        api_fetch = AsyncMock(return_value="api-result")
+
+        await fallthrough(label="get_thing", pg_read=pg_read, api_fetch=api_fetch)
+
+        next_pg = AsyncMock(return_value="should-not-be-called")
+        await fallthrough(
+            label="get_thing", pg_read=next_pg, api_fetch=AsyncMock(return_value="ok")
+        )
+        next_pg.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cache_unavailable_error_arms_cool_down(self):
+        """The locally-raised exception from ``cache_service`` methods."""
+        from discogs.cache_service import CacheUnavailableError
+
+        pg_read = AsyncMock(side_effect=CacheUnavailableError("cache down"))
+        api_fetch = AsyncMock(return_value="api-result")
+
+        await fallthrough(label="get_thing", pg_read=pg_read, api_fetch=api_fetch)
+
+        next_pg = AsyncMock(return_value="should-not-be-called")
+        await fallthrough(
+            label="get_thing", pg_read=next_pg, api_fetch=AsyncMock(return_value="ok")
+        )
+        next_pg.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_asyncio_timeout_does_not_arm_cool_down(self):
+        """``asyncio.TimeoutError`` has its own semantics — don't arm cool-down."""
+
+        pg_read_a = AsyncMock(side_effect=TimeoutError())
+        api_fetch_a = AsyncMock(return_value="api-1")
+        await fallthrough(label="get_thing", pg_read=pg_read_a, api_fetch=api_fetch_a)
+
+        # Cool-down NOT armed — second call's PG read should be invoked.
+        pg_read_b = AsyncMock(return_value="from-pg")
+        api_fetch_b = AsyncMock(return_value="should-not-be-called")
+        result_b = await fallthrough(label="get_thing", pg_read=pg_read_b, api_fetch=api_fetch_b)
+        assert result_b == "from-pg"
+        pg_read_b.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unrelated_exception_does_not_arm_cool_down(self):
+        """A bare ``Exception`` (programming error) propagates; cool-down stays off."""
+        pg_read_a = AsyncMock(side_effect=ValueError("programming bug"))
+        api_fetch_a = AsyncMock(return_value="api-1")
+
+        # The fallthrough swallows the cache leg's exception per the existing
+        # pattern in service.py; we assert it does NOT arm cool-down.
+        await fallthrough(label="get_thing", pg_read=pg_read_a, api_fetch=api_fetch_a)
+
+        pg_read_b = AsyncMock(return_value="from-pg")
+        result_b = await fallthrough(
+            label="get_thing",
+            pg_read=pg_read_b,
+            api_fetch=AsyncMock(return_value="should-not-be-called"),
+        )
+        assert result_b == "from-pg"
+        pg_read_b.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cool_down_expires_after_window(self, monkeypatch):
+        """After ``_COOL_DOWN_SECONDS`` elapses, PG reads resume."""
+        import time as time_module
+
+        from discogs import fallthrough as fallthrough_module
+
+        clock = [1000.0]
+
+        def fake_monotonic():
+            return clock[0]
+
+        monkeypatch.setattr(fallthrough_module.time, "monotonic", fake_monotonic)
+
+        # Arm the cool-down.
+        await fallthrough(
+            label="get_thing",
+            pg_read=AsyncMock(side_effect=asyncpg.exceptions.PostgresConnectionError("down")),
+            api_fetch=AsyncMock(return_value="api-result"),
+        )
+
+        # Advance the clock past the window.
+        clock[0] += _COOL_DOWN_SECONDS + 1.0
+
+        # PG read should now run again.
+        pg_read = AsyncMock(return_value="from-pg")
+        result = await fallthrough(
+            label="get_thing",
+            pg_read=pg_read,
+            api_fetch=AsyncMock(return_value="should-not-be-called"),
+        )
+        assert result == "from-pg"
+        pg_read.assert_awaited_once()
+        # Quiet the unused import warning while keeping monkeypatch typing happy.
+        _ = time_module
+
+
+# ---------------------------------------------------------------------------
+# 5. ``should_skip_cache()`` bypass
+# ---------------------------------------------------------------------------
+
+
+class TestSkipCacheBypass:
+    @pytest.mark.asyncio
+    async def test_skip_cache_bypasses_pg_read_and_negative_check(self):
+        set_skip_cache(True)
+        try:
+            pg_read = AsyncMock(return_value="from-pg")
+            pg_negative_check = AsyncMock(return_value=True)
+            api_fetch = AsyncMock(return_value="from-api")
+
+            result = await fallthrough(
+                label="search_releases_by_track",
+                pg_read=pg_read,
+                api_fetch=api_fetch,
+                pg_negative_check=pg_negative_check,
+                on_negative_hit=lambda: "unused",
+                pg_negative_record=AsyncMock(),
+                is_empty=lambda v: not v,
+            )
+
+            assert result == "from-api"
+            pg_read.assert_not_awaited()
+            pg_negative_check.assert_not_awaited()
+        finally:
+            set_skip_cache(False)
+
+    @pytest.mark.asyncio
+    async def test_skip_cache_also_skips_write_back(self):
+        """When the request opts out of caches, we don't write back either —
+        write-back would re-pollute the cache the caller asked us to bypass."""
+        set_skip_cache(True)
+        try:
+            pg_write = AsyncMock()
+            await fallthrough(
+                label="get_thing",
+                pg_read=AsyncMock(return_value=None),
+                api_fetch=AsyncMock(return_value="from-api"),
+                pg_write=pg_write,
+            )
+            pg_write.assert_not_awaited()
+        finally:
+            set_skip_cache(False)
+
+
+# ---------------------------------------------------------------------------
+# 6. Tri-state PG read (the validate_track_on_release shape)
+# ---------------------------------------------------------------------------
+
+
+class TestTriStateRead:
+    @pytest.mark.asyncio
+    async def test_pg_returns_false_is_treated_as_hit(self):
+        """``validate_track_on_release`` returns ``True | False | None``; the
+        default ``is_pg_hit`` (``v is not None``) makes False a hit, not a miss."""
+        pg_read = AsyncMock(return_value=False)
+        api_fetch = AsyncMock(return_value=True)
+
+        result = await fallthrough(
+            label="validate_track_on_release",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+        )
+
+        assert result is False
+        api_fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pg_returns_true_is_treated_as_hit(self):
+        pg_read = AsyncMock(return_value=True)
+        api_fetch = AsyncMock(return_value=False)
+
+        result = await fallthrough(
+            label="validate_track_on_release",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+        )
+
+        assert result is True
+        api_fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pg_returns_none_falls_through_to_api(self):
+        pg_read = AsyncMock(return_value=None)
+        api_fetch = AsyncMock(return_value=True)
+
+        result = await fallthrough(
+            label="validate_track_on_release",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+        )
+
+        assert result is True
+        api_fetch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_custom_is_pg_hit_lambda(self):
+        """Callers with non-default sentinels can override ``is_pg_hit``."""
+        # PG returns an empty list — caller wants empty to count as "miss",
+        # not "hit with empty value".
+        pg_read = AsyncMock(return_value=[])
+        api_fetch = AsyncMock(return_value=["a"])
+
+        result = await fallthrough(
+            label="custom",
+            pg_read=pg_read,
+            api_fetch=api_fetch,
+            is_pg_hit=lambda v: bool(v),  # only non-empty counts as hit
+        )
+
+        assert result == ["a"]
+        api_fetch.assert_awaited_once()


### PR DESCRIPTION
Closes #393. Partially addresses #324 (cool-down + Sentry projection land here; deliberately-undersized-pool integration test deferred to a focused follow-up — see below).

## What changed

**`discogs/fallthrough.py`** — new module, one function (`fallthrough`):

- Takes `pg_read` / `api_fetch` / `pg_write` closures plus optional negative-cache hooks and an `is_pg_hit` predicate (for tri-state cache returns).
- Owns the L2-PG → L3-API + write-back ritual, the breadcrumb / cache-stats / `should_skip_cache()` short-circuit, the negative-cache pre-check, and the cool-down on cache-leg outage.
- Each `None` parameter reads as an **explicit opt-out** at the call site: `pg_write=None` is "read-only by design", not silent absence.
- Parameter-validates at entry: `pg_negative_check` requires `on_negative_hit`; `pg_negative_record` requires `is_empty`. Both raise `ValueError` if the caller drops one half of a pair.

**`discogs/service.py`** — 5 methods migrated:

- `get_release` / `get_artist_details` — full read-through (`pg_write=cache_service.write_release`, etc.).
- `search` — `pg_write=None`. The PG cache's `search_releases` query is indexed against ETL-populated `release_artist` data; arbitrary Discogs `/database/search` API hits wouldn't fit that schema.
- `search_releases_by_track` — `pg_write=None` plus the negative-cache hooks wired. PG read is skipped when `artist_as_keyword=True` (preserves the existing gate). The exception-path empty result is distinguished from a confirmed-empty API result so the negative-record write fires only on the latter, matching today's behavior.
- `validate_track_on_release` — `pg_write=None`. Tri-state PG read (`True | False | None`) short-circuits via the default `is_pg_hit=lambda v: v is not None`. API path writes back indirectly via `get_release`. The tracklist-scanning loop moves to a module-level `_scan_tracklist_for_match` helper so the method body reads as orchestration, not algorithm.

**`CLAUDE.md`** — new "Discogs cache fallthrough seam" section with the per-method write-back policy table and the cool-down arming set, so any drift in either becomes a doc-review item rather than a silent code change.

## What stayed put

- `@async_cached(<CACHE>)` decorators (L1 in-memory) on every migrated method — the L1 layer owns a separate, already-deep concern (per-type TTL, cache-key normalization, the `should_skip_cache()` bypass) and stays untouched.
- `discogs/cache_service.py` — no changes. The seam wraps `cache_service`'s public methods; it doesn't edit their internals.
- `lookup/orchestrator.py` — no changes. The orchestrator's strategies still call the same `discogs_service` methods.
- The 3 API-only methods (`get_master`, `get_label_image`, `search_releases_by_album_title`) — they have no PG leg, so they wouldn't earn the seam's keep. Opportunistic migration is a one-line follow-up if it ever does.

## The Outcome.album_match-style design call

Two parallel-structure decisions earned dedicated tests and inline doc:

- **Negative-cache hit signal: `on_negative_hit` factory, not bare `None`.** The seam returns the factory's value (typically the caller's empty response shape with `cached=True`) so the caller can distinguish "negative cache said empty" from "API returned None". Same shape as Outcome's named constructors — locality of decision at the call site.
- **Cool-down arming set is pinned, not catch-all.** `_ARMING_EXCEPTIONS` lists the exact asyncpg exception classes (plus `CacheUnavailableError`) that count as "DB unreachable". `asyncio.CancelledError` propagates; `asyncio.TimeoutError` and bare `Exception` fall through to API without arming. Tests assert each class individually so a future asyncpg release adding new subclasses can't silently widen arming criteria.

## Tests

- `tests/unit/test_fallthrough.py` — 28 new tests covering basic read-through, write-back policy, negative-cache (factory + write + parameter validation), cool-down (5 arming exception classes + 2 non-arming + expiry via monkeypatch on `time.monotonic`), `should_skip_cache()` bypass, and tri-state read.
- `tests/unit/test_discogs_service.py` — 131 existing tests preserved verbatim as the regression net. All green.
- Local: 1982 unit tests pass. The one error (`test_no_module_level_asyncio_lock_in_dependencies`) is the pre-existing teardown flake unrelated to this PR (passes in isolation; previously flagged in #399's review).
- `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all clean across the whole repo.

## Size

~1660 lines net across two commits — over the 1000-line target, but the diff is split cleanly along a natural seam: the first commit lands `discogs/fallthrough.py` (281) + `test_fallthrough.py` (446) + the plan (380) without touching `discogs/service.py`; the second commit lands the migration + CLAUDE.md and shows up as ~550 +/- ~540 because each migrated method's body shifts indentation when its API leg moves into a `_api_fetch` inner function.

A clean split would have been: (a) seam + tests + 2 full-read-through methods, (b) the 3 read-only-by-design migrations. But that would have required keeping the duplicated tier-dance in 3 methods between PRs and re-deleting them later — net more churn than landing the migration together, which is what #393's acceptance criteria called for ("methods express key + fetch only").

## What's next

- **#324 follow-up**: file a focused issue for the deliberately-undersized-pool integration test (the one AC of #324 left outstanding after this PR). The unit-test coverage of the `PostgresConnectionError` simulation lands here.
- **Sibling deepenings still open**: #392 (still gated on #376 CRITICAL), #394 (move shared stores out of `scripts/`), #395 (consolidate the two `DATABASE_URL_DISCOGS` pools). None blocked by this PR.
