### PR TITLE
fix(observability): wire entry/exit logs + http.server span on /lookup/bulk

### DIFF
--- a/lookup/router.py
+++ b/lookup/router.py
@@ -305,6 +305,15 @@ async def handle_bulk_lookup(
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors()) from None
 
+    # Observability entry signal (LML#371). The bulk endpoint was silent in
+    # production: when a handler hung past the caller's AbortController, neither
+    # uvicorn's access log nor Sentry's automatic `http.server` transaction fired
+    # because both signals only commit on response completion. This INFO log
+    # fires synchronously before any awaits, so operators always see that a
+    # bulk request reached LML — even if the rest of the handler hangs and the
+    # response is never delivered.
+    logger.info("bulk lookup start: size=%d", len(request.items))
+
     # Honor the same `skip_cache` query flag the per-item route accepts. Backed
     # by a ContextVar, so setting once at the batch top propagates into each
     # `_run_one` task via the inherited task context.
@@ -367,70 +376,102 @@ async def handle_bulk_lookup(
                 lookup=lookup_response,
             )
 
-    with sentry_sdk.start_span(op="lml.bulk.batch", name=f"{len(request.items)} items") as span:
-        span.set_data("lml.bulk.size", len(request.items))
-        span.set_data("lml.bulk.max_concurrent", max_concurrent)
+    # Explicit `http.server` span (LML#371). Defense-in-depth against the
+    # FastApiIntegration's automatic transaction not landing for this endpoint
+    # — that's the gap that left 22:21-22:34 on 2026-05-24 with 0 spans for 26
+    # in-flight bulk requests despite the handler running. With this wrap, any
+    # Sentry trace explorer query for `op:http.server span.description:*lookup/bulk*`
+    # will surface bulk-route traffic.
+    with sentry_sdk.start_span(op="http.server", name="POST /api/v1/lookup/bulk") as http_span:
+        http_span.set_data("http.method", "POST")
+        http_span.set_data("http.target", "/api/v1/lookup/bulk")
+        http_span.set_data("lml.bulk.size", len(request.items))
+        http_span.set_data("lml.bulk.max_concurrent", max_concurrent)
 
-        # Race the gather against a client-disconnect sentinel. If the client
-        # departs first, cancel the gather so Discogs semaphore permits free
-        # for the next caller; without this, queue depth grows monotonically
-        # across batches.
-        #
-        # Spawning the sentinel must happen *after* `await http_request.json()`
-        # above has fully consumed the request body — _watch_disconnect awaits
-        # `request.receive()`, which would otherwise swallow `http.request`
-        # body messages the body parser needs.
-        gather_future = asyncio.gather(*(_run_one(i, item) for i, item in enumerate(request.items)))
-        sentinel_task = asyncio.create_task(
-            _watch_disconnect(http_request),
-            name="lml.bulk.disconnect_sentinel",
-        )
-        waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
+        with sentry_sdk.start_span(op="lml.bulk.batch", name=f"{len(request.items)} items") as span:
+            span.set_data("lml.bulk.size", len(request.items))
+            span.set_data("lml.bulk.max_concurrent", max_concurrent)
 
-        try:
-            done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
-        except BaseException:
-            # Parent task cancellation must propagate to both children AND
-            # the children must be drained, not just signalled — otherwise the
-            # semaphore permits this PR exists to release are still held while
-            # the cancellation propagates asynchronously.
-            await _cancel_and_drain(gather_future)
-            await _cancel_and_drain(sentinel_task)
-            raise
-
-        client_aborted = sentinel_task in done and not gather_future.done()
-        span.set_data("lml.bulk.client_aborted", client_aborted)
-
-        if client_aborted:
-            # Tag is global-scope (filterable across all routes); span data
-            # carries the bulk-specific context. Key-name asymmetry intentional.
-            sentry_sdk.set_tag("lml.client_aborted", "true")
-            await _cancel_and_drain(gather_future)
-            logger.warning(
-                "bulk lookup aborted by client (batch size %d, max_concurrent %d)",
-                len(request.items),
-                max_concurrent,
+            # Race the gather against a client-disconnect sentinel. If the
+            # client departs first, cancel the gather so Discogs semaphore
+            # permits free for the next caller; without this, queue depth grows
+            # monotonically across batches.
+            #
+            # Spawning the sentinel must happen *after* `await
+            # http_request.json()` above has fully consumed the request body —
+            # _watch_disconnect awaits `request.receive()`, which would
+            # otherwise swallow `http.request` body messages the body parser
+            # needs.
+            gather_future = asyncio.gather(
+                *(_run_one(i, item) for i, item in enumerate(request.items))
             )
-            # 499 = Nginx "client closed request". Skip PostHog: partial counts
-            # would skew batch-completion analytics.
-            raise HTTPException(status_code=499, detail="client disconnected")
+            sentinel_task = asyncio.create_task(
+                _watch_disconnect(http_request),
+                name="lml.bulk.disconnect_sentinel",
+            )
+            waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
 
-        await _cancel_and_drain(sentinel_task)
-        results = gather_future.result()
+            try:
+                done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
+            except BaseException:
+                # Parent task cancellation must propagate to both children AND
+                # the children must be drained, not just signalled — otherwise
+                # the semaphore permits this PR exists to release are still
+                # held while the cancellation propagates asynchronously.
+                await _cancel_and_drain(gather_future)
+                await _cancel_and_drain(sentinel_task)
+                raise
 
-    _project_cache_stats_to_transaction(get_cache_stats())
+            client_aborted = sentinel_task in done and not gather_future.done()
+            span.set_data("lml.bulk.client_aborted", client_aborted)
 
-    if posthog_client:
-        counts = Counter(r.status for r in results)
-        batch_telemetry.send_to_posthog(
-            posthog_client,
-            {
-                "batch_size": len(request.items),
-                "match_count": counts["match"],
-                "no_match_count": counts["no_match"],
-                "error_count": counts["error"],
-                "max_concurrent": max_concurrent,
-            },
+            if client_aborted:
+                # Tag is global-scope (filterable across all routes); span data
+                # carries the bulk-specific context. Key-name asymmetry
+                # intentional.
+                sentry_sdk.set_tag("lml.client_aborted", "true")
+                await _cancel_and_drain(gather_future)
+                # Exit log fires for the abort branch too — operators see the
+                # batch size + abort reason without digging into Sentry.
+                logger.warning(
+                    "bulk lookup aborted by client: size=%d max_concurrent=%d",
+                    len(request.items),
+                    max_concurrent,
+                )
+                http_span.set_data("http.status_code", 499)
+                # 499 = Nginx "client closed request". Skip PostHog: partial
+                # counts would skew batch-completion analytics.
+                raise HTTPException(status_code=499, detail="client disconnected")
+
+            await _cancel_and_drain(sentinel_task)
+            results = gather_future.result()
+
+        _project_cache_stats_to_transaction(get_cache_stats())
+
+        if posthog_client:
+            counts = Counter(r.status for r in results)
+            batch_telemetry.send_to_posthog(
+                posthog_client,
+                {
+                    "batch_size": len(request.items),
+                    "match_count": counts["match"],
+                    "no_match_count": counts["no_match"],
+                    "error_count": counts["error"],
+                    "max_concurrent": max_concurrent,
+                },
+            )
+
+        # Observability exit signal (LML#371). Pairs with the entry log so
+        # operators can confirm response delivery and read off the status
+        # breakdown without correlating to a Sentry trace.
+        exit_counts = Counter(r.status for r in results)
+        logger.info(
+            "bulk lookup complete: size=%d match=%d no_match=%d error=%d",
+            len(request.items),
+            exit_counts["match"],
+            exit_counts["no_match"],
+            exit_counts["error"],
         )
+        http_span.set_data("http.status_code", 200)
 
     return BulkLookupResponse(results=results)

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -305,13 +305,10 @@ async def handle_bulk_lookup(
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors()) from None
 
-    # Observability entry signal (LML#371). The bulk endpoint was silent in
-    # production: when a handler hung past the caller's AbortController, neither
-    # uvicorn's access log nor Sentry's automatic `http.server` transaction fired
-    # because both signals only commit on response completion. This INFO log
-    # fires synchronously before any awaits, so operators always see that a
-    # bulk request reached LML — even if the rest of the handler hangs and the
-    # response is never delivered.
+    # Entry signal (LML#371). Fires synchronously before any awaits, so a
+    # handler that later hangs past the caller's AbortController still leaves
+    # a trace — uvicorn's access log and Sentry's automatic `http.server`
+    # transaction only commit on response completion.
     logger.info("bulk lookup start: size=%d", len(request.items))
 
     # Honor the same `skip_cache` query flag the per-item route accepts. Backed
@@ -448,8 +445,9 @@ async def handle_bulk_lookup(
 
         _project_cache_stats_to_transaction(get_cache_stats())
 
+        counts = Counter(r.status for r in results)
+
         if posthog_client:
-            counts = Counter(r.status for r in results)
             batch_telemetry.send_to_posthog(
                 posthog_client,
                 {
@@ -461,16 +459,15 @@ async def handle_bulk_lookup(
                 },
             )
 
-        # Observability exit signal (LML#371). Pairs with the entry log so
-        # operators can confirm response delivery and read off the status
-        # breakdown without correlating to a Sentry trace.
-        exit_counts = Counter(r.status for r in results)
+        # Exit signal pairs with the entry log so operators can confirm
+        # response delivery and read off the status breakdown without
+        # correlating to a Sentry trace.
         logger.info(
             "bulk lookup complete: size=%d match=%d no_match=%d error=%d",
             len(request.items),
-            exit_counts["match"],
-            exit_counts["no_match"],
-            exit_counts["error"],
+            counts["match"],
+            counts["no_match"],
+            counts["error"],
         )
         http_span.set_data("http.status_code", 200)
 

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -447,6 +447,161 @@ class TestBulkLookupEndpoint:
         assert resp.status_code == 200
 
 
+class TestBulkLookupObservability:
+    """Entry/exit instrumentation pins (LML#371).
+
+    The bulk endpoint was silent in production — successful requests emitted no
+    uvicorn access lines AND no Sentry ``http.server`` spans (issue #371). The
+    underlying cause was that both signals fire on response completion, so a
+    handler that hung past the client's AbortController timeout left zero trace
+    on the server side even though Discogs work was visibly running downstream.
+
+    These tests pin the defensive instrumentation that closes the gap:
+    1. An ``INFO`` log at handler entry carrying the request shape — fires
+       BEFORE any awaits, so even a totally-hung handler produces this signal.
+    2. An ``INFO`` log at handler exit carrying status counts — confirms
+       response completion and gives operators a count breakdown without
+       digging into Sentry.
+    3. A Sentry ``http.server`` span tied to the bulk route — emitted via an
+       explicit ``start_span(op="http.server", ...)`` wrap so the signal does
+       not depend on the FastApiIntegration patch landing for this specific
+       endpoint.
+
+    The matching production change is in ``lookup/router.py:handle_bulk_lookup``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_entry_log_includes_request_shape(self, app_client, caplog):
+        """An INFO log fires at handler entry with size + max_concurrent.
+
+        This is the load-bearing observability signal — it fires synchronously
+        before any awaits, so even if the handler later hangs and the response
+        never completes, operators see the request shape in Railway logs.
+        """
+        import logging
+
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_no_match_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                with caplog.at_level(logging.INFO, logger="lookup.router"):
+                    resp = await ac.post(
+                        "/api/v1/lookup/bulk",
+                        json={
+                            "items": [
+                                {"artist": "Juana Molina", "album": "DOGA"},
+                                {"artist": "Cat Power", "album": "Moon Pix"},
+                                {"artist": "Stereolab", "album": "Aluminum Tunes"},
+                            ]
+                        },
+                    )
+
+        assert resp.status_code == 200
+        entry_records = [
+            r for r in caplog.records if "bulk lookup" in r.message and "start" in r.message
+        ]
+        assert entry_records, (
+            "Expected an INFO log at bulk handler entry; got logs: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        entry_msg = entry_records[0].message
+        # Pin the shape: size of the batch must be in the log line so operators
+        # can correlate Railway log entries with caller-side batch sizes.
+        assert "3" in entry_msg, f"Entry log missing batch size: {entry_msg!r}"
+
+    @pytest.mark.asyncio
+    async def test_exit_log_includes_status_counts(self, app_client, caplog):
+        """An INFO log fires at handler exit carrying per-status counts.
+
+        Pairs with the entry log: the exit log confirms the response completed
+        and gives operators a count breakdown (match/no_match/error) without
+        having to query Sentry or correlate by trace id.
+        """
+        import logging
+
+        async def fake_lookup(request, **kwargs):
+            if request.artist == "miss":
+                return _no_match_response()
+            if request.artist == "boom":
+                raise RuntimeError("boom")
+            return _match_response(request.artist or "?", request.album or "?")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=fake_lookup):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                with caplog.at_level(logging.INFO, logger="lookup.router"):
+                    resp = await ac.post(
+                        "/api/v1/lookup/bulk",
+                        json={
+                            "items": [
+                                {"artist": "Juana Molina", "album": "DOGA"},
+                                {"artist": "miss", "album": "X"},
+                                {"artist": "boom", "album": "Y"},
+                            ]
+                        },
+                    )
+
+        assert resp.status_code == 200
+        exit_records = [
+            r for r in caplog.records if "bulk lookup" in r.message and "complete" in r.message
+        ]
+        assert exit_records, (
+            "Expected an INFO log at bulk handler exit; got logs: "
+            f"{[r.message for r in caplog.records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_server_span_emitted_for_bulk(self, app_client):
+        """An ``http.server`` Sentry span is started with the bulk route name.
+
+        Pins the explicit ``sentry_sdk.start_span(op="http.server", ...)`` in
+        the handler. Without this, observability of the bulk endpoint depended
+        entirely on the FastApiIntegration's automatic instrumentation — which
+        the production logs at 22:21-22:34 on 2026-05-24 showed was not firing
+        for hung handlers (the album-level-backfill case in #371).
+        """
+        captured_spans: list[dict] = []
+        original_start_span = sentry_sdk.start_span
+
+        def capture_start_span(*args, **kwargs):
+            captured_spans.append({"args": args, "kwargs": kwargs})
+            return original_start_span(*args, **kwargs)
+
+        with (
+            patch(
+                "lookup.router.perform_lookup",
+                new_callable=AsyncMock,
+                return_value=_no_match_response(),
+            ),
+            patch("lookup.router.sentry_sdk.start_span", side_effect=capture_start_span),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={"items": [{"artist": "Juana Molina", "album": "DOGA"}]},
+                )
+
+        assert resp.status_code == 200
+        http_server_spans = [s for s in captured_spans if s["kwargs"].get("op") == "http.server"]
+        assert http_server_spans, (
+            "Expected at least one Sentry span with op='http.server'; got: "
+            f"{[s['kwargs'].get('op') for s in captured_spans]}"
+        )
+        # The span's name must identify the bulk route so operators can filter
+        # for `span.description: POST /api/v1/lookup/bulk` in the trace explorer.
+        span_name = http_server_spans[0]["kwargs"].get("name", "")
+        assert "lookup/bulk" in span_name, (
+            f"Expected http.server span name to include 'lookup/bulk'; got {span_name!r}"
+        )
+
+
 class TestBulkLookupClientAbort:
     """Cancel-aware gather under client disconnect (LML#372).
 


### PR DESCRIPTION
## Summary

- Add an INFO log at bulk handler entry (`bulk lookup start: size=N`) that fires synchronously before any awaits, so operators always see that a bulk request reached LML even if the rest of the handler hangs and the response is never delivered.
- Add an INFO log at handler exit (`bulk lookup complete: size=N match=A no_match=B error=C`) so the status breakdown is visible in Railway without correlating to a Sentry trace.
- Wrap the handler body in an explicit `sentry_sdk.start_span(op="http.server", name="POST /api/v1/lookup/bulk")` so the bulk route appears in the Sentry trace explorer under `op:http.server span.description:*lookup/bulk*` even when the FastApiIntegration's automatic transaction does not land.
- Promote the existing client-abort warning to the same `size=... max_concurrent=...` shape and pin `http.status_code` on the http.server span for both 200 and 499 paths.

The root-cause hypothesis from the ticket: both uvicorn's access log and Sentry's automatic `http.server` transaction commit on response completion, so a handler that hangs past the caller's AbortController (the album-level-backfill case at 22:21-22:34 UTC on 2026-05-24) produced zero server-side signal even though downstream Discogs work was visibly running. The entry log + explicit Sentry span close that gap.

## Test plan

- [ ] CI: unit tests pass (`pytest -m "not pg and not external_api"`).
- [ ] Local: hit `/api/v1/lookup/bulk` with a 2-item body, observe `bulk lookup start: size=2` and `bulk lookup complete: size=2 ...` lines on stdout.
- [ ] Sentry: confirm a new `op:http.server name:"POST /api/v1/lookup/bulk"` span appears in the trace explorer after the next staging deploy.

Closes #371