### PR TITLE
refactor(discogs): address review-loop nits on fallthrough seam

### DIFF
--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -75,7 +75,9 @@ logger = logging.getLogger(__name__)
 
 # How long PG reads stay suppressed after a cache-leg failure. Process-wide;
 # Railway runs single-process workers per replica so per-replica granularity
-# is what we want.
+# is what we want. Heads-up for future-Jake: switching to a multi-process
+# worker model (e.g. gunicorn with N workers per replica) would mean each
+# worker arms its own cool-down independently — no cross-worker propagation.
 _COOL_DOWN_SECONDS: float = 30.0
 
 # Module-level cool-down state. Mutated by ``_arm_cool_down`` /
@@ -93,6 +95,13 @@ _ARMING_EXCEPTIONS: tuple[type[BaseException], ...] = (
     asyncpg.exceptions.UndefinedTableError,
     CacheUnavailableError,
 )
+
+
+# Default predicate for ``fallthrough(is_pg_hit=...)``. Hoisted to module scope
+# (rather than inlined as a default lambda) so ``repr(fallthrough)`` and the
+# signature read "default sentinel" instead of "anonymous lambda".
+def _default_is_pg_hit(v: object | None) -> bool:
+    return v is not None
 
 
 def _arm_cool_down(reason: str, error: BaseException) -> None:
@@ -141,7 +150,7 @@ async def fallthrough[T](
     pg_negative_check: Callable[[], Awaitable[bool]] | None = None,
     pg_negative_record: Callable[[], Awaitable[None]] | None = None,
     on_negative_hit: Callable[[], T] | None = None,
-    is_pg_hit: Callable[[T | None], bool] = lambda v: v is not None,
+    is_pg_hit: Callable[[T | None], bool] = _default_is_pg_hit,
     is_empty: Callable[[T], bool] | None = None,
     breadcrumb_data: dict[str, Any] | None = None,
 ) -> T | None:

--- a/tests/unit/test_fallthrough.py
+++ b/tests/unit/test_fallthrough.py
@@ -34,6 +34,13 @@ from discogs.fallthrough import (
 from discogs.memory_cache import set_skip_cache
 
 
+def _unused() -> str:
+    """Placeholder factory for ``on_negative_hit`` when the test path doesn't
+    exercise the negative-hit branch — keeps the seam's type contract happy
+    without sprinkling ``lambda: "unused"  # noqa: E731`` at every call site."""
+    return "unused"
+
+
 @pytest.fixture(autouse=True)
 def _reset_cool_down():
     """Cool-down is process-wide; reset between tests to keep them independent."""
@@ -213,7 +220,7 @@ class TestNegativeCache:
         pg_negative_check = AsyncMock(return_value=False)
         api_fetch = AsyncMock(return_value=[])
         pg_negative_record = AsyncMock()
-        on_negative_hit = lambda: "unused"  # noqa: E731
+        on_negative_hit = _unused
 
         await fallthrough(
             label="search_releases_by_track",
@@ -233,7 +240,7 @@ class TestNegativeCache:
         pg_negative_check = AsyncMock(return_value=False)
         api_fetch = AsyncMock(return_value=["item"])
         pg_negative_record = AsyncMock()
-        on_negative_hit = lambda: "unused"  # noqa: E731
+        on_negative_hit = _unused
 
         await fallthrough(
             label="search_releases_by_track",
@@ -288,7 +295,7 @@ class TestNegativeCache:
             pg_read=pg_read,
             api_fetch=api_fetch,
             pg_negative_check=pg_negative_check,
-            on_negative_hit=lambda: "unused",
+            on_negative_hit=_unused,
             pg_negative_record=pg_negative_record,
             is_empty=lambda v: not v,
         )
@@ -420,8 +427,6 @@ class TestCoolDown:
     @pytest.mark.asyncio
     async def test_cool_down_expires_after_window(self, monkeypatch):
         """After ``_COOL_DOWN_SECONDS`` elapses, PG reads resume."""
-        import time as time_module
-
         from discogs import fallthrough as fallthrough_module
 
         clock = [1000.0]
@@ -450,8 +455,6 @@ class TestCoolDown:
         )
         assert result == "from-pg"
         pg_read.assert_awaited_once()
-        # Quiet the unused import warning while keeping monkeypatch typing happy.
-        _ = time_module
 
 
 # ---------------------------------------------------------------------------
@@ -473,7 +476,7 @@ class TestSkipCacheBypass:
                 pg_read=pg_read,
                 api_fetch=api_fetch,
                 pg_negative_check=pg_negative_check,
-                on_negative_hit=lambda: "unused",
+                on_negative_hit=_unused,
                 pg_negative_record=AsyncMock(),
                 is_empty=lambda v: not v,
             )


### PR DESCRIPTION
Post-merge cleanup of the cosmetic items surfaced by the review-loop on #416. Five nits were called out; this PR addresses four and skips one per the reviewer's recommendation. Behavior-preserving; the existing tests for `discogs/fallthrough.py` and `discogs/service.py` are the regression net (161 tests, all green locally).

## Nits and disposition

| Nit | File | Action |
|---|---|---|
| 1. Heads-up that the cool-down's process-wide scope assumes a single-process worker model | `discogs/fallthrough.py:78` | Extended the comment to note that switching to gunicorn-style multi-process workers would mean each worker arms its own cool-down independently. |
| 2. Hoist `is_pg_hit=lambda v: v is not None` to a module-level constant so `repr(fallthrough)` reads "default sentinel" rather than "anonymous lambda" | `discogs/fallthrough.py:144` | Added `_default_is_pg_hit(v) -> bool` at module scope; swapped the signature default to reference it. |
| 3. Encapsulate `_cool_down_until` + `_arm_cool_down` in a `_CoolDown` class | `discogs/fallthrough.py:99-100` | **SKIPPED** per the reviewer's note ("doesn't pay for itself here — the global + reset helper is fine for the one piece of state we need to test"). |
| 4. Drop `_ = time_module` and the unused `import time as time_module` | `tests/unit/test_fallthrough.py:453-454` | Deleted both. The seam's own `import time` is what the test monkeypatches via `fallthrough_module.time`; the local import was never needed. |
| 5. Replace the four repeated `lambda: "unused"  # noqa: E731` with a named helper | `tests/unit/test_fallthrough.py:216,236,291,476` | Added `_unused() -> str` at module scope; four call sites now reference it directly. The single `lambda: sentinel` at line 195 stays — localized, one occurrence, the noqa is fine there. |

## CI gates run locally

- `uv run ruff check .` — all checks passed
- `uv run ruff format --check .` — 274 files already formatted
- `uv run --with mypy mypy --ignore-missing-imports discogs/fallthrough.py tests/unit/test_fallthrough.py` — no issues found
- `uv run python -m pytest tests/unit/test_fallthrough.py tests/unit/test_discogs_service.py` — 161 passed in 0.23s

(The two pre-existing mypy errors in `tests/integration/test_api_discogs.py` are unrelated to this PR; they exist on `main`.)