### PR TITLE
feat(discogs): honor artwork_checked_at in cache-hit predicate

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -483,7 +483,8 @@ class DiscogsCacheService:
         """
         try:
             release_row = await self.pool.fetchrow(
-                "SELECT id, title, release_year, artwork_url, released FROM release WHERE id = $1",
+                "SELECT id, title, release_year, artwork_url, released, artwork_checked_at "
+                "FROM release WHERE id = $1",
                 release_id,
             )
 
@@ -631,6 +632,7 @@ class DiscogsCacheService:
                 genres=[row["genre"] for row in genre_rows],
                 styles=[row["style"] for row in style_rows],
                 artwork_url=release_row["artwork_url"],
+                artwork_checked_at=release_row["artwork_checked_at"],
                 tracklist=tracklist,
                 release_url=f"https://www.discogs.com/release/{release_id}",
                 cached=True,
@@ -662,16 +664,28 @@ class DiscogsCacheService:
                 # empty release_artist / release_track / etc., while
                 # cache_metadata.cached_at advances to "fresh". See WXYC#375.
 
-                # Upsert release row (including released date)
+                # Upsert release row. `artwork_checked_at` is stamped to
+                # `now()` on every write — `write_release` is only called
+                # from the live-Discogs-API path (via the fallthrough seam),
+                # so by definition we just asked Discogs about this row's
+                # artwork. The downstream `is_pg_hit` predicate in
+                # `discogs/service.py:get_release` reads this column to
+                # avoid re-fetching genuinely-imageless releases
+                # (WXYC/library-metadata-lookup#423, backed by the schema
+                # column from WXYC/discogs-etl#239).
                 await conn.execute(
                     """
-                    INSERT INTO release (id, title, release_year, artwork_url, released)
-                    VALUES ($1, $2, $3, $4, $5)
+                    INSERT INTO release (
+                        id, title, release_year, artwork_url, released,
+                        artwork_checked_at
+                    )
+                    VALUES ($1, $2, $3, $4, $5, now())
                     ON CONFLICT (id) DO UPDATE SET
                         title = EXCLUDED.title,
                         release_year = EXCLUDED.release_year,
                         artwork_url = EXCLUDED.artwork_url,
-                        released = EXCLUDED.released
+                        released = EXCLUDED.released,
+                        artwork_checked_at = EXCLUDED.artwork_checked_at
                     """,
                     release.release_id,
                     release.title,

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -810,10 +810,17 @@ class DiscogsService:
             pg_read=lambda: cache.get_release(release_id),
             api_fetch=_api_fetch,
             pg_write=cache.write_release,
-            # A row with `artwork_url IS NULL` is a partial miss: the bulk
-            # loader leaves ~48% of `release` rows that way (LML#414). Fall
-            # through to the API so the write-back back-patches the cover.
-            is_pg_hit=lambda v: v is not None and v.artwork_url is not None,
+            # `artwork_url IS NULL AND artwork_checked_at IS NULL` is the
+            # "never asked" state — the bulk loader populated the row but
+            # LML has not yet asked Discogs (~48% of release rows are like
+            # this; see WXYC/library-metadata-lookup#414 and
+            # WXYC/discogs-etl#239). Falling through to the API is the
+            # back-fill path. Once `artwork_checked_at` is set, both
+            # "asked, got a cover" and "asked, no cover" are full hits —
+            # we don't re-ask Discogs about the no-cover tail.
+            is_pg_hit=lambda v: (
+                v is not None and (v.artwork_url is not None or v.artwork_checked_at is not None)
+            ),
             breadcrumb_data={"release_id": release_id},
         )
 

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1063,6 +1063,10 @@ class DiscogsReleaseMetadata(BaseModel):
     styles: list[str] | None = []
     tracklist: list[DiscogsTrackItem] | None = Field([], validate_default=True)
     artwork_url: str | None = None
+    artwork_checked_at: AwareDatetime | None = Field(
+        None,
+        description="Timestamp of the most recent live Discogs API call that resolved\nthis release's artwork. `null` means LML's bulk loader populated\nthe row but the live API has not been queried yet (the \"never\nasked\" state); a value means LML hit the live API and either\npopulated `artwork_url` or confirmed Discogs has no cover. LML\nuses this to distinguish bulk-loader gaps (which it back-fills)\nfrom genuinely-imageless releases (which it does not refetch).\nSee WXYC/discogs-etl#239 + WXYC/library-metadata-lookup#423.\n",
+    )
     release_url: str
     cached: bool | None = False
     artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -210,6 +210,7 @@ class TestGetRelease:
                 "release_year": 1980,
                 "artwork_url": "https://img.com/a.jpg",
                 "released": None,
+                "artwork_checked_at": None,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -245,6 +246,7 @@ class TestGetRelease:
                 "release_year": 2000,
                 "artwork_url": None,
                 "released": None,
+                "artwork_checked_at": None,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -275,6 +277,7 @@ class TestGetRelease:
                 "release_year": 1996,
                 "artwork_url": None,
                 "released": None,
+                "artwork_checked_at": None,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -325,6 +328,7 @@ class TestGetRelease:
                 "release_year": 1998,
                 "artwork_url": None,
                 "released": None,
+                "artwork_checked_at": None,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -355,6 +359,7 @@ class TestGetRelease:
                 "release_year": 1996,
                 "artwork_url": None,
                 "released": None,
+                "artwork_checked_at": None,
             }
         )
 
@@ -398,6 +403,50 @@ class TestWriteRelease:
         conn = mock_asyncpg_pool._mock_conn
         assert conn.execute.call_count >= 3  # insert release, artist, delete tracks, cache_metadata
         assert conn.executemany.call_count >= 1  # insert tracks
+
+    @pytest.mark.asyncio
+    async def test_release_upsert_stamps_artwork_checked_at_now(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """The release-row UPSERT must stamp ``artwork_checked_at = now()`` in
+        the SQL itself. ``write_release`` is only invoked from the live
+        Discogs-API path (via the fallthrough seam), so every call by
+        definition means "we just asked Discogs about this row". The
+        downstream ``is_pg_hit`` predicate reads this column to skip
+        re-fetching genuinely-imageless releases; if the stamp regresses,
+        LML burns Discogs rate limit on every lookup of an imageless tail
+        row. Regression pin for WXYC/library-metadata-lookup#423 / backed by
+        WXYC/discogs-etl#239.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=33696616,
+            title="White Label Promo",
+            artist="Stereolab",
+            artwork_url=None,
+            artwork_checked_at=None,  # API-derived; the stamp is SQL-side.
+            release_url="https://discogs.com/release/33696616",
+        )
+
+        await cache_service.write_release(release)
+
+        conn = mock_asyncpg_pool._mock_conn
+        # The first execute is the release upsert.
+        release_sql = conn.execute.call_args_list[0][0][0]
+        assert "artwork_checked_at" in release_sql, (
+            "release upsert must reference artwork_checked_at "
+            "(predicate consumer in service.py:get_release)"
+        )
+        assert "now()" in release_sql, (
+            "release upsert must stamp now() on artwork_checked_at — see WXYC#423"
+        )
+        # Pinned together: the EXCLUDED.artwork_checked_at line must also
+        # appear so the ON CONFLICT path stamps the same now() value, not
+        # leave the column at its prior value on re-upsert.
+        assert "artwork_checked_at = EXCLUDED.artwork_checked_at" in release_sql, (
+            "ON CONFLICT must update artwork_checked_at from EXCLUDED so the "
+            "re-upsert path refreshes the stamp; without this, re-asking "
+            "Discogs leaves artwork_checked_at at its prior value."
+        )
 
     @pytest.mark.asyncio
     async def test_error_raises(self, cache_service, mock_asyncpg_pool):
@@ -650,6 +699,7 @@ class TestGetReleaseEnriched:
                 "release_year": 2001,
                 "artwork_url": "https://img.com/a.jpg",
                 "released": "2001-04-30",
+                "artwork_checked_at": None,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -935,7 +935,7 @@ class TestGetRelease:
         completes: API result returned with artwork_url=None, write-back records
         the row. The next lookup must see artwork_checked_at set (from this
         write-back via cache_service.write_release) and treat it as a hit —
-        covered by `test_cache_hit_with_checked_at_does_not_call_api`.
+        covered by `test_cache_hit_with_checked_at_set_and_null_artwork_does_not_call_api`.
         """
         stale = ReleaseMetadataResponse(
             release_id=33696616,

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -1,5 +1,6 @@
 """Unit tests for discogs/service.py."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -875,10 +876,15 @@ class TestGetRelease:
         assert result.cached is True
 
     @pytest.mark.asyncio
-    async def test_cache_hit_with_null_artwork_falls_through_to_api(self, service_with_cache):
-        """A cache row with artwork_url=None is a partial miss: hit the API to fill it in,
-        then write back. Without this, bulk-loaded rows whose XML lacked images stay
-        permanently artworkless and downstream consumers (BS V2, iOS) render placeholders.
+    async def test_cache_hit_with_null_artwork_and_null_checked_at_falls_through_to_api(
+        self, service_with_cache
+    ):
+        """A cache row with `artwork_url IS NULL AND artwork_checked_at IS NULL`
+        is the "never asked" state: the bulk loader populated the row but LML
+        has not yet asked Discogs about the artwork. Predicate must fall through
+        to the API to back-fill. Without this, bulk-loaded rows whose XML lacked
+        images stay permanently artworkless and downstream consumers (BS V2, iOS)
+        render placeholders.
         """
         stale = ReleaseMetadataResponse(
             release_id=33696615,
@@ -886,6 +892,7 @@ class TestGetRelease:
             artist="Lucy Liyou",
             release_url="https://discogs.com/release/33696615",
             artwork_url=None,
+            artwork_checked_at=None,
             cached=True,
         )
         service_with_cache.cache_service.get_release = AsyncMock(return_value=stale)
@@ -923,11 +930,12 @@ class TestGetRelease:
     async def test_cache_null_artwork_with_imageless_api_still_writes_back(
         self, service_with_cache
     ):
-        """Cache row has artwork_url=None AND the live API genuinely returns no
-        images. Fall-through still completes: API result returned with
-        artwork_url=None, write-back records the row. Until discogs-etl#239
-        ships (artwork_checked_at), every lookup re-runs this path; a future
-        regression swallowing the write-back here would only surface in prod.
+        """Cache row is "never asked" (artwork_url=None, artwork_checked_at=None)
+        and the live API genuinely returns no images. Fall-through still
+        completes: API result returned with artwork_url=None, write-back records
+        the row. The next lookup must see artwork_checked_at set (from this
+        write-back via cache_service.write_release) and treat it as a hit —
+        covered by `test_cache_hit_with_checked_at_does_not_call_api`.
         """
         stale = ReleaseMetadataResponse(
             release_id=33696616,
@@ -935,6 +943,7 @@ class TestGetRelease:
             artist="Stereolab",
             release_url="https://discogs.com/release/33696616",
             artwork_url=None,
+            artwork_checked_at=None,
             cached=True,
         )
         service_with_cache.cache_service.get_release = AsyncMock(return_value=stale)
@@ -967,6 +976,39 @@ class TestGetRelease:
         service_with_cache.cache_service.write_release.assert_called_once()
         written = service_with_cache.cache_service.write_release.call_args.args[0]
         assert written.artwork_url is None
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_with_checked_at_set_and_null_artwork_does_not_call_api(
+        self, service_with_cache
+    ):
+        """Cache row has ``artwork_url=None`` but ``artwork_checked_at`` set —
+        the "asked Discogs, genuinely no image" state. Predicate must treat
+        this as a full hit and skip the API call. Without honoring
+        ``artwork_checked_at``, LML re-fetches every imageless release on
+        every lookup, burning Discogs rate limit (WXYC#423).
+        """
+        cached = ReleaseMetadataResponse(
+            release_id=33696616,
+            title="White Label Promo",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/33696616",
+            artwork_url=None,
+            artwork_checked_at=datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC),
+            cached=True,
+        )
+        service_with_cache.cache_service.get_release = AsyncMock(return_value=cached)
+        service_with_cache.cache_service.write_release = AsyncMock()
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_request:
+            result = await service_with_cache.get_release(33696616)
+
+        mock_request.assert_not_called()
+        service_with_cache.cache_service.write_release.assert_not_called()
+        assert result is cached
 
     @pytest.mark.asyncio
     async def test_404_returns_none(self, service):


### PR DESCRIPTION
## Summary

Lands the LML side of the artwork-NULL ambiguity. The schema column shipped in [WXYC/discogs-etl#239](https://github.com/WXYC/discogs-etl/issues/239) (merged) and the OpenAPI field is on [WXYC/wxyc-shared#149](https://github.com/WXYC/wxyc-shared/pull/149) (open). This PR is the runtime consumer.

- **`cache_service.get_release`** SELECTs `artwork_checked_at` and round-trips it through `ReleaseMetadataResponse`.
- **`cache_service.write_release`** stamps `artwork_checked_at = now()` in the SQL UPSERT (both INSERT and ON CONFLICT branches). `write_release` is only called from the live Discogs-API path via the fallthrough seam, so every write is by definition "we just asked Discogs about this row".
- **`service.get_release`** `is_pg_hit` predicate now honors both columns:
  ```python
  v is not None and (v.artwork_url is not None or v.artwork_checked_at is not None)
  ```
  `artwork_url IS NULL AND artwork_checked_at IS NULL` is the "never asked" state — falls through to the API to back-fill. Either column set is a full hit; we stop re-fetching genuinely-imageless releases.
- **Generated model**: `generated/api_models.py` regen against the v1.7.1 OpenAPI surface.

## Why

[PR #415](https://github.com/WXYC/library-metadata-lookup/pull/415) shipped runtime tolerance for the 48.31% NULL-artwork bulk-loader gap by always treating `artwork_url IS NULL` as a partial miss. That cleared the immediate iOS / dj-site placeholder issue but burns Discogs rate limit forever on the long tail of genuinely-imageless releases (the live API returns `images=[]` and we re-ask on every subsequent lookup).

This PR closes the loop. `artwork_checked_at` distinguishes:

| State | `artwork_url` | `artwork_checked_at` | Predicate verdict |
|---|---|---|---|
| Got a cover | not null | (any) | hit |
| Asked, no cover | null | not null | hit |
| Never asked | null | null | fall through to API |

## Test plan

- [x] `test_cache_hit_with_checked_at_set_and_null_artwork_does_not_call_api` — predicate honors `artwork_checked_at` (NEW)
- [x] `test_cache_hit_with_null_artwork_and_null_checked_at_falls_through_to_api` — both-null is the only fall-through state (updated)
- [x] `test_cache_null_artwork_with_imageless_api_still_writes_back` — write-back fires on imageless API result (updated)
- [x] `test_release_upsert_stamps_artwork_checked_at_now` — SQL UPSERT references `artwork_checked_at` + `now()` + `EXCLUDED.artwork_checked_at` (NEW regression pin)
- [x] `tests/unit/test_cache_service.py` + `tests/unit/test_discogs_service.py` — 200 tests passing
- [x] Full unit suite — 1989 passed (one pre-existing flake in `test_dependencies.py` unrelated to this PR)
- [x] `ruff check` + `ruff format --check` both clean

## Companion + dependency chain

- **Hard dependency**: [WXYC/wxyc-shared#149](https://github.com/WXYC/wxyc-shared/pull/149) — must merge first so v1.7.1 publishes; the regenerated `generated/api_models.py` in this PR is forward-compatible with the published surface.
- **Hard dependency**: [WXYC/discogs-etl#239](https://github.com/WXYC/discogs-etl/issues/239) — merged. The column exists on the cache schema.
- **Closes**: WXYC/library-metadata-lookup#414, #423.
- **Unblocks**: [WXYC/library-metadata-lookup#221](https://github.com/WXYC/library-metadata-lookup/issues/221) top-up drain — the partial index from #239 + `write_release`'s NOW() stamp give #221 a write-once-and-move-on signal.

Closes #423
