### PR TITLE
refactor(identity): consolidate discogs-cache pool with entity store

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -101,7 +101,15 @@ async def _build_discogs_pool() -> asyncpg.Pool | None:
         return None
 
 
-_get_discogs_pool, _close_discogs_pool = async_singleton(_build_discogs_pool)
+# Public seam (WXYC/library-metadata-lookup#395): both the Discogs cache
+# service AND the entity store reach into this getter for their
+# discogs-cache pool. Concentrating both paths through one
+# ``async_singleton`` instance gives one timeout/sizing policy, one
+# degradation signal on ``/health``, and one connection budget against the
+# backend. Pre-#395 the entity store ran its own racy lazy-init via
+# ``PgSource(dsn=...)`` on the same DSN — a second-pool window that
+# uncoordinated FD exhaustion + #357's racy-init audit both flagged.
+get_discogs_pool, close_discogs_pool = async_singleton(_build_discogs_pool)
 
 
 async def _build_discogs_service() -> DiscogsService | None:
@@ -113,7 +121,7 @@ async def _build_discogs_service() -> DiscogsService | None:
         logger.debug("No Discogs credentials set - Discogs service disabled")
         return None
 
-    pool = await _get_discogs_pool()
+    pool = await get_discogs_pool()
     cache_service = DiscogsCacheService(pool) if pool is not None else None
     if cache_service is not None:
         logger.info("Discogs cache service enabled")
@@ -162,7 +170,7 @@ async def close_discogs_service() -> None:
     # work the service might have in progress sees the pool until aclose
     # returns.
     await _close_discogs_service()
-    await _close_discogs_pool()
+    await close_discogs_pool()
 
 
 async def get_discogs_cache_service(

--- a/entity/sources.py
+++ b/entity/sources.py
@@ -53,22 +53,49 @@ class SparqlSourceProtocol(Protocol):
 class PgSource:
     """PostgreSQL source transport wrapping asyncpg.
 
-    Args:
-        dsn: PostgreSQL connection string.
+    Two construction shapes:
+
+    * ``PgSource(dsn=...)`` — owns its pool. Used by per-DSN paths whose
+      pool lifecycle does not coincide with another (e.g. the musicbrainz
+      cache: ``core/dependencies.get_musicbrainz_pg``).
+    * ``PgSource(pool=...)`` — borrows an externally-managed pool. Used by
+      paths that share a process-wide pool via a single provider seam
+      (e.g. the discogs-cache entity store, which reuses the pool built
+      by ``core/dependencies.get_discogs_pool`` — see
+      WXYC/library-metadata-lookup#395). The external owner closes the
+      pool; this source's ``close()`` is a no-op so concurrent teardown
+      from this side never closes the pool out from under a still-live
+      Discogs cache service.
+
+    Exactly one of ``dsn`` / ``pool`` must be supplied.
     """
 
-    def __init__(self, dsn: str) -> None:
+    def __init__(
+        self,
+        dsn: str | None = None,
+        *,
+        pool: asyncpg.Pool | None = None,
+    ) -> None:
+        if (dsn is None) == (pool is None):
+            raise ValueError("PgSource requires exactly one of `dsn` or `pool`")
         self._dsn = dsn
-        self._pool: asyncpg.Pool | None = None
+        self._pool: asyncpg.Pool | None = pool
+        self._owns_pool: bool = pool is None
         # Serializes concurrent first-callers to ``_get_pool``. Without it,
         # both callers pass the ``self._pool is None`` check and each await
         # ``asyncpg.create_pool``, orphaning all but one pool with up to 5
-        # open connections (FDs). See issue #241.
+        # open connections (FDs). See issue #241. Only meaningful for the
+        # owned-pool path; the borrowed-pool path never enters the
+        # create-pool branch.
         self._pool_lock: asyncio.Lock = asyncio.Lock()
 
     async def _get_pool(self) -> asyncpg.Pool:
         if self._pool is not None:
             return self._pool
+        # Borrowed-pool sources set ``self._pool`` at construction and never
+        # reach this path. Owned-pool sources fall through to a lock-guarded
+        # ``asyncpg.create_pool`` per the issue #241 fix.
+        assert self._dsn is not None  # narrowed by __init__ XOR check
         async with self._pool_lock:
             if self._pool is None:
                 self._pool = await asyncpg.create_pool(self._dsn, min_size=1, max_size=5)
@@ -110,8 +137,13 @@ class PgSource:
             yield conn
 
     async def close(self) -> None:
-        """Close the connection pool."""
-        if self._pool is not None:
+        """Close the connection pool.
+
+        No-op for borrowed-pool sources — the external owner controls the
+        pool's lifecycle and closing it here would tear it out from under
+        every other consumer (WXYC/library-metadata-lookup#395).
+        """
+        if self._pool is not None and self._owns_pool:
             await self._pool.close()
             self._pool = None
 

--- a/identity/dependencies.py
+++ b/identity/dependencies.py
@@ -1,19 +1,29 @@
 """FastAPI dependency providers for identity resolution."""
 
+import asyncio
 import logging
 
 from asyncpg.exceptions import PostgresError
 from fastapi import Depends
 
 from config.settings import Settings, get_settings
+from core.dependencies import get_discogs_pool
 from entity.sources import PgSource
 from entity.store import EntityStore
 
 logger = logging.getLogger(__name__)
 
 _entity_store: EntityStore | None = None
-_entity_pg: PgSource | None = None
 _entity_probe_failed: bool = False
+# Serializes concurrent first-callers to ``get_entity_store``. Pre-WXYC#395
+# this lazy-init was unlocked — concurrent first-callers each constructed a
+# ``PgSource(dsn=...)`` and each ran the probe, orphaning every PgSource
+# but the last writer (one of #357's documented racy-init findings). We
+# can't use ``async_singleton`` here because its instance-cache short-
+# circuits on ``not None``, and the probe-failed verdict needs to be
+# cached as ``None`` for the process lifetime so a missing-schema deploy
+# doesn't probe on every request.
+_entity_store_lock: asyncio.Lock = asyncio.Lock()
 
 # Lightweight probe: confirms the schema is applied without scanning rows.
 _PROBE_SQL = "SELECT 1 FROM entity.identity LIMIT 0"
@@ -24,62 +34,79 @@ async def get_entity_store(
 ) -> EntityStore | None:
     """Get EntityStore instance backed by the discogs-cache database.
 
-    The entity store reuses the ``DATABASE_URL_DISCOGS`` connection since
-    the ``entity`` schema lives in the discogs-cache PostgreSQL database.
+    The entity store reuses the discogs-cache ``asyncpg.Pool`` built by
+    ``core.dependencies.get_discogs_pool`` — one pool, one timeout/sizing
+    policy, one degradation signal on ``/health`` (WXYC#395).
 
     Returns ``None`` — which the router renders as 503 — when
-    ``DATABASE_URL_DISCOGS`` is unset, the DSN is unreachable, or the
-    ``entity.identity`` table is missing. A failed probe is cached for
+    ``DATABASE_URL_DISCOGS`` is unset, the shared pool is unavailable, or
+    the ``entity.identity`` table is missing. A failed probe is cached for
     the process lifetime; Railway redeploys are the recovery path.
     """
-    global _entity_store, _entity_pg, _entity_probe_failed
+    global _entity_store, _entity_probe_failed
 
     if _entity_store is not None:
         return _entity_store
     if _entity_probe_failed:
         return None
 
-    dsn = settings.database_url_discogs
-    if not dsn:
-        logger.debug("DATABASE_URL_DISCOGS not set -- entity store disabled")
-        return None
+    async with _entity_store_lock:
+        # Re-check under the lock so the second concurrent caller does not
+        # re-run the probe after the first one settled it.
+        if _entity_store is not None:
+            return _entity_store
+        if _entity_probe_failed:
+            return None
 
-    pg = PgSource(dsn)
-    try:
-        await pg.fetchone(_PROBE_SQL)
-    except (PostgresError, OSError) as e:
-        logger.warning(
-            "Entity store probe failed; disabling identity routes: %s: %s",
-            type(e).__name__,
-            e,
-        )
-        _entity_probe_failed = True
-        await _safe_close(pg)
-        return None
-    except Exception as e:
-        logger.warning("Unexpected error initializing entity store: %s: %s", type(e).__name__, e)
-        _entity_probe_failed = True
-        await _safe_close(pg)
-        return None
+        if not settings.database_url_discogs:
+            logger.debug("DATABASE_URL_DISCOGS not set -- entity store disabled")
+            return None
 
-    _entity_pg = pg
-    _entity_store = EntityStore(pg)
-    logger.info("Entity store initialized")
-    return _entity_store
+        pool = await get_discogs_pool()
+        if pool is None:
+            # Pool factory failed — the cache-service path will also see
+            # ``None`` and degrade to API-only. Don't cache the failure: a
+            # future ``close_discogs_pool()`` + getter cycle (e.g. test
+            # tear-down, or a singleton reset after a transient outage)
+            # should let a subsequent caller rebuild without restart.
+            logger.warning(
+                "Shared discogs-cache pool is unavailable; entity store disabled "
+                "(WXYC/library-metadata-lookup#395)."
+            )
+            return None
 
+        pg = PgSource(pool=pool)
+        try:
+            await pg.fetchone(_PROBE_SQL)
+        except (PostgresError, OSError) as e:
+            logger.warning(
+                "Entity store probe failed; disabling identity routes: %s: %s",
+                type(e).__name__,
+                e,
+            )
+            _entity_probe_failed = True
+            return None
+        except Exception as e:
+            logger.warning(
+                "Unexpected error initializing entity store: %s: %s", type(e).__name__, e
+            )
+            _entity_probe_failed = True
+            return None
 
-async def _safe_close(pg: PgSource) -> None:
-    try:
-        await pg.close()
-    except Exception:
-        pass
+        _entity_store = EntityStore(pg)
+        logger.info("Entity store initialized")
+        return _entity_store
 
 
 async def close_entity_store() -> None:
-    """Close the entity store PgSource connection."""
-    global _entity_store, _entity_pg, _entity_probe_failed
-    if _entity_pg is not None:
-        await _entity_pg.close()
-        _entity_pg = None
+    """Reset the entity store singleton.
+
+    The underlying pool is owned by ``core.dependencies.get_discogs_pool``
+    (its ``close_discogs_pool`` is the canonical teardown); this closer
+    only clears the entity-store cache so the next ``get_entity_store()``
+    re-runs the probe. The ``PgSource`` here is the borrowed-pool variant
+    whose ``close()`` is a no-op by design (WXYC#395).
+    """
+    global _entity_store, _entity_probe_failed
     _entity_store = None
     _entity_probe_failed = False

--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -88,14 +88,19 @@ async def app_client(monkeypatch):
     """ASGI client with the LML app pointed at the test PG."""
     from httpx import ASGITransport, AsyncClient
 
+    import core.dependencies as core_deps
     import identity.dependencies as deps
     from config.settings import get_settings
 
     monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
     get_settings.cache_clear()
     deps._entity_store = None
-    deps._entity_pg = None
     deps._entity_probe_failed = False
+    # Post-WXYC#395 the entity store reuses ``core.dependencies.get_discogs_pool``.
+    # Clearing the entity-store singleton alone leaves the shared pool cached;
+    # the next ``get_entity_store`` would reuse it (which is fine within one
+    # test) but a parallel suite that toggles the DSN env var would race.
+    await core_deps.close_discogs_pool()
 
     from main import app
 
@@ -103,8 +108,8 @@ async def app_client(monkeypatch):
         yield ac
 
     deps._entity_store = None
-    deps._entity_pg = None
     deps._entity_probe_failed = False
+    await core_deps.close_discogs_pool()
     get_settings.cache_clear()
 
 

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -370,22 +370,25 @@ class TestIdentityRouterEntityStoreUnavailable:
     @pytest_asyncio.fixture
     async def app_with_pg_dsn(self, monkeypatch):
         """Reset the dep cache and point Settings at the test DSN."""
+        import core.dependencies as core_deps
         import identity.dependencies as deps
         from config.settings import get_settings
 
         monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
         get_settings.cache_clear()
         deps._entity_store = None
-        deps._entity_pg = None
         deps._entity_probe_failed = False
+        # Post-WXYC#395 the entity store reuses ``core.dependencies.get_discogs_pool``.
+        # Reset the shared pool so each test sees a fresh init cycle.
+        await core_deps.close_discogs_pool()
 
         from main import app
 
         yield app
 
         deps._entity_store = None
-        deps._entity_pg = None
         deps._entity_probe_failed = False
+        await core_deps.close_discogs_pool()
         get_settings.cache_clear()
 
     @pytest.mark.asyncio

--- a/tests/unit/test_identity_dependencies.py
+++ b/tests/unit/test_identity_dependencies.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import AsyncMock, patch
+
 import asyncpg
 import pytest
 
+import core.dependencies as core_deps
 import identity.dependencies as deps
 from config.settings import Settings
 
@@ -13,12 +17,41 @@ from config.settings import Settings
 def _reset_dep_state():
     """Ensure each test sees a fresh dependency cache."""
     deps._entity_store = None
-    deps._entity_pg = None
     deps._entity_probe_failed = False
     yield
     deps._entity_store = None
-    deps._entity_pg = None
     deps._entity_probe_failed = False
+
+
+@pytest.fixture
+def _reset_discogs_pool():
+    """Tear down the core-dependencies discogs pool around tests that exercise it."""
+
+    async def _run():
+        await core_deps.close_discogs_pool()
+
+    asyncio.run(_run())
+    yield
+    asyncio.run(_run())
+
+
+@pytest.fixture
+def _fake_discogs_pool(monkeypatch, _reset_discogs_pool):
+    """Stub ``asyncpg.create_pool`` so ``get_discogs_pool`` returns a fake.
+
+    Post-WXYC#395 the entity store reaches into ``core.dependencies.get_discogs_pool``
+    instead of constructing its own pool. Tests that exercise the probe
+    therefore need the shared pool factory to succeed; otherwise the entity
+    store short-circuits to ``None`` before the probe ever runs.
+    """
+    fake_pool = AsyncMock(name="shared-discogs-pool")
+    fake_pool.fetchval = AsyncMock(return_value=1)
+
+    async def fake_create_pool(*args, **kwargs):
+        return fake_pool
+
+    monkeypatch.setattr("core.dependencies.asyncpg.create_pool", fake_create_pool)
+    return fake_pool
 
 
 def _settings(dsn: str | None) -> Settings:
@@ -38,38 +71,37 @@ async def test_returns_none_when_dsn_unset():
 
 
 @pytest.mark.asyncio
-async def test_returns_none_when_probe_raises_undefined_table(monkeypatch):
+async def test_returns_none_when_probe_raises_undefined_table(monkeypatch, _fake_discogs_pool):
     """Probe failure (entity schema not applied) → store disabled."""
 
     async def boom(self, query, *args):
         raise asyncpg.UndefinedTableError('relation "entity.identity" does not exist')
 
     monkeypatch.setattr("entity.sources.PgSource.fetchone", boom)
-    monkeypatch.setattr(
-        "entity.sources.PgSource.close",
-        _noop_close,
-    )
+    settings = _settings("postgresql://x:y@127.0.0.1:1/z")
+    monkeypatch.setattr("core.dependencies.get_settings", lambda: settings)
 
-    result = await deps.get_entity_store(_settings("postgresql://x:y@127.0.0.1:1/z"))
+    result = await deps.get_entity_store(settings)
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_returns_none_when_probe_raises_oserror(monkeypatch):
+async def test_returns_none_when_probe_raises_oserror(monkeypatch, _fake_discogs_pool):
     """Probe failure (PG host unreachable) → store disabled."""
 
     async def boom(self, query, *args):
         raise OSError("connection refused")
 
     monkeypatch.setattr("entity.sources.PgSource.fetchone", boom)
-    monkeypatch.setattr("entity.sources.PgSource.close", _noop_close)
+    settings = _settings("postgresql://x:y@127.0.0.1:1/z")
+    monkeypatch.setattr("core.dependencies.get_settings", lambda: settings)
 
-    result = await deps.get_entity_store(_settings("postgresql://x:y@127.0.0.1:1/z"))
+    result = await deps.get_entity_store(settings)
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_probe_failure_is_cached(monkeypatch):
+async def test_probe_failure_is_cached(monkeypatch, _fake_discogs_pool):
     """A failed probe is not retried on subsequent calls (process-lifetime cache)."""
     call_count = 0
 
@@ -79,9 +111,9 @@ async def test_probe_failure_is_cached(monkeypatch):
         raise asyncpg.UndefinedTableError("nope")
 
     monkeypatch.setattr("entity.sources.PgSource.fetchone", boom)
-    monkeypatch.setattr("entity.sources.PgSource.close", _noop_close)
-
     settings = _settings("postgresql://x:y@127.0.0.1:1/z")
+    monkeypatch.setattr("core.dependencies.get_settings", lambda: settings)
+
     assert await deps.get_entity_store(settings) is None
     assert await deps.get_entity_store(settings) is None
     assert await deps.get_entity_store(settings) is None
@@ -89,15 +121,146 @@ async def test_probe_failure_is_cached(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_returns_store_when_probe_succeeds(monkeypatch):
+async def test_returns_store_when_probe_succeeds(monkeypatch, _fake_discogs_pool):
     async def ok(self, query, *args):
         return None  # SELECT ... LIMIT 0 returns no rows
 
     monkeypatch.setattr("entity.sources.PgSource.fetchone", ok)
+    settings = _settings("postgresql://x:y@127.0.0.1:1/z")
+    monkeypatch.setattr("core.dependencies.get_settings", lambda: settings)
 
-    result = await deps.get_entity_store(_settings("postgresql://x:y@127.0.0.1:1/z"))
+    result = await deps.get_entity_store(settings)
     assert result is not None
 
 
-async def _noop_close(self):
-    return None
+# ---------------------------------------------------------------------------
+# Consolidation contract (WXYC/library-metadata-lookup#395): the entity store
+# must draw its discogs-cache connection from the same pool-provider seam as
+# the Discogs cache service. Two pools on one DSN contend for the same
+# backend connection budget and surface different degradation signals — see
+# the issue body for the audit detail.
+# ---------------------------------------------------------------------------
+
+
+class TestSinglePoolContract:
+    """The entity store and the Discogs cache service must share one
+    ``asyncpg.Pool`` for ``DATABASE_URL_DISCOGS``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_entity_store_and_discogs_cache_share_one_pool(
+        self, monkeypatch, _reset_discogs_pool
+    ):
+        """``get_entity_store`` and ``get_discogs_service`` must resolve to the
+        same underlying asyncpg pool object so there is one connection-budget
+        and one degradation signal for the discogs-cache DB.
+        """
+        settings = Settings(
+            discogs_token="test-token",
+            database_url_discogs="postgresql://x:y@127.0.0.1:1/z",
+            sentry_dsn=None,
+            posthog_api_key=None,
+            enable_telemetry=False,
+            library_db_path="test_library.db",
+        )
+
+        # One pool fake covers both call sites. `fetchval("SELECT 1")` is the
+        # cache-service health probe; the entity-store probe runs via the
+        # `PgSource.fetchone` monkeypatch below — both end up grabbing the
+        # same pool from `get_discogs_pool`.
+        fake_pool = AsyncMock(name="shared-discogs-pool")
+        fake_pool.fetchval = AsyncMock(return_value=1)
+
+        async def fake_create_pool(*args, **kwargs):
+            return fake_pool
+
+        async def probe_ok(self, query, *args):
+            return None  # SELECT ... LIMIT 0
+
+        monkeypatch.setattr("entity.sources.PgSource.fetchone", probe_ok)
+
+        with (
+            patch("core.dependencies.get_settings", return_value=settings),
+            patch("core.dependencies.asyncpg.create_pool", side_effect=fake_create_pool),
+        ):
+            store = await deps.get_entity_store(settings)
+            service = await core_deps.get_discogs_service(settings)
+
+        assert store is not None
+        assert service is not None
+        assert service.cache_service is not None
+        # `store._pg` wraps a PgSource that should reference the same pool the
+        # cache service got. The PgSource keeps the pool on `_pool` so it can
+        # be acquired for queries; cache_service stores it on `pool`.
+        assert store._pg._pool is service.cache_service.pool is fake_pool
+
+    @pytest.mark.asyncio
+    async def test_get_discogs_pool_is_public(self):
+        """`core.dependencies.get_discogs_pool` must be a public, awaitable
+        getter. The entity-store seam imports it by this name (WXYC#395);
+        renaming or unpublishing it would silently break the consolidation.
+        """
+        from core import dependencies
+
+        assert hasattr(dependencies, "get_discogs_pool"), (
+            "core.dependencies.get_discogs_pool must be public — it is the "
+            "single seam the entity-store reaches into for its discogs-cache "
+            "pool (WXYC/library-metadata-lookup#395)."
+        )
+        assert callable(dependencies.get_discogs_pool)
+
+
+class TestEntityStoreLazyInitRace:
+    """Concurrent first-callers to ``get_entity_store`` must produce exactly
+    one probe call. The pre-consolidation code constructed a fresh
+    ``PgSource`` per racing caller, each of which ran the probe — orphaning
+    everything but the last writer. Lock-guarded init closes that window.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_entity_store_probes_once(self, monkeypatch, _reset_discogs_pool):
+        settings = Settings(
+            discogs_token="test-token",
+            database_url_discogs="postgresql://x:y@127.0.0.1:1/z",
+            sentry_dsn=None,
+            posthog_api_key=None,
+            enable_telemetry=False,
+            library_db_path="test_library.db",
+        )
+
+        fake_pool = AsyncMock(name="shared-discogs-pool")
+        fake_pool.fetchval = AsyncMock(return_value=1)
+
+        async def fake_create_pool(*args, **kwargs):
+            return fake_pool
+
+        probe_calls = 0
+        release_event = asyncio.Event()
+
+        async def probe_ok(self, query, *args):
+            nonlocal probe_calls
+            probe_calls += 1
+            # Yield long enough for every concurrent caller to reach the
+            # probe await before any of them assigns the cached store.
+            await release_event.wait()
+            return None
+
+        monkeypatch.setattr("entity.sources.PgSource.fetchone", probe_ok)
+
+        with (
+            patch("core.dependencies.get_settings", return_value=settings),
+            patch("core.dependencies.asyncpg.create_pool", side_effect=fake_create_pool),
+        ):
+            tasks = [asyncio.create_task(deps.get_entity_store(settings)) for _ in range(8)]
+            for _ in range(4):
+                await asyncio.sleep(0)
+            release_event.set()
+            results = await asyncio.gather(*tasks)
+
+        assert probe_calls == 1, (
+            f"PgSource.fetchone probe ran {probe_calls} times for 8 "
+            "concurrent first-callers — the lazy init must be lock-guarded "
+            "so only one caller drives the probe (WXYC/library-metadata-lookup#395 / #357)."
+        )
+        # All callers must see the same EntityStore instance.
+        assert len({id(r) for r in results}) == 1


### PR DESCRIPTION
## Summary

`DATABASE_URL_DISCOGS` was reached by two independent connection mechanisms: the canonical `core/dependencies._build_discogs_pool` (race-free via `async_singleton`) feeding `DiscogsService` + `DiscogsCacheService`, and a separate racy lazy-init in `identity/dependencies.get_entity_store` that constructed `PgSource(dsn=...)` behind an unlocked module-global. Concurrent first-callers to the entity-store path each constructed a `PgSource`, each ran the probe, and orphaned every PgSource but the last writer — the same FD-leak class #357 audited the codebase for. The two pools also contended for the same backend connection budget under separate timeout/sizing policies (10 s vs. asyncpg's 30 s default), so exhaustion under load surfaced non-deterministically.

This PR collapses both paths through one provider seam.

## Changes

- `core/dependencies.py` — promote `_get_discogs_pool` / `_close_discogs_pool` to public `get_discogs_pool` / `close_discogs_pool`. `_build_discogs_pool` stays the private factory; the singleton wiring already routes through `async_singleton`, so the lock-guarded init was already in place for the cache-service path.
- `entity/sources.py` — `PgSource` accepts an externally-managed pool via `pool=` (keyword-only). The DSN-string constructor is preserved so the musicbrainz path keeps working unchanged. The borrowed-pool variant's `close()` is a no-op so concurrent teardown from the entity-store side never closes the pool out from under a still-live Discogs cache service.
- `identity/dependencies.py` — `get_entity_store` now takes the shared pool from `get_discogs_pool`, wraps it in `PgSource(pool=...)`, runs the existing `SELECT 1 FROM entity.identity LIMIT 0` probe, and caches the verdict for the process lifetime. Lazy-init is lock-guarded with double-check so concurrent first-callers see one probe call. `async_singleton` is the wrong shape here — its instance-cache short-circuits on `not None`, so it can't cache the probe-failed-→-None verdict; the hand-rolled lock plus inline double-check stays surgical.

## Behavior preserved

- Identity routes still return 503 when the schema or DSN is absent (`_ENTITY_STORE_UNAVAILABLE_DETAIL` unchanged).
- The entity-store probe still runs on first call.
- Failed probe is still cached for the process lifetime.
- musicbrainz `PgSource` instances are untouched — they still use the DSN constructor and own their own pool.
- `/health` already used `discogs_service.cache_service` for the `discogs_cache` probe (which goes through the shared pool); no health-endpoint change was needed.

A new "shared pool unavailable" log branch covers the case where the DSN is set but the pool factory failed (e.g. transient outage). That branch is intentionally **not** cached so a later `close_discogs_pool` + getter cycle (test tear-down, transient recovery) lets a subsequent caller rebuild without restart.

## Tests

TDD: three failing tests were added before the implementation, then went green:

- `TestSinglePoolContract.test_entity_store_and_discogs_cache_share_one_pool` — asserts `store._pg._pool is service.cache_service.pool is fake_pool`. Structural pin of the consolidation.
- `TestSinglePoolContract.test_get_discogs_pool_is_public` — guards against a future rename that would silently break the entity-store import.
- `TestEntityStoreLazyInitRace.test_concurrent_get_entity_store_probes_once` — 8 concurrent first-callers must produce exactly one probe call. Mirrors the existing `TestPgSourcePoolRace` / `TestGetDiscogsServicePoolRace` pattern in `tests/unit/test_fd_leak_regression_241.py`.

Pre-existing identity-dependency tests were updated to wire through the shared-pool fixture. Integration tests in `test_bulk_resolve_libraries.py` and `test_entity_resolution.py` reset the shared discogs pool around each test.

Local checks: `uv run ruff check`, `uv run ruff format --check`, `uv run mypy . --ignore-missing-imports`, and `uv run pytest tests/unit/` all clean. The pre-existing teardown flake `test_no_module_level_asyncio_lock_in_dependencies` ("Event loop is closed", passes in isolation, fails via shared event-loop state in full-suite runs) still surfaces — orthogonal to this change.

## Related

- Closes #395
- #357 — racy-lazy-init audit. This resolves one of its sub-findings; #357 stays open as the tracking ticket for the rest of the audit.
- #394 / #421 — sibling that moved entity store + sources out of `scripts/` into `entity/`; unblocked this work.
- #393 / #416 — prior cache-fallthrough deepening in the same area.

## Diff

6 files changed, 315 insertions(+), 77 deletions(-)
