### PR TITLE
feat(lookup): MusicBrainz tracklist rescue on Discogs-miss + extended

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -253,19 +253,14 @@ def _log_album_title_fallback(
         logger.warning("Failed to project album_title_fallback onto Sentry transaction: %s", e)
 
 
-def _project_mb_rescue_attrs(attempted: bool, tracklist_found: bool) -> None:
+def _project_mb_rescue_attrs(*, attempted: bool, tracklist_found: bool) -> None:
     """Project MusicBrainz tracklist-rescue outcome onto the active Sentry trace.
 
-    Two boolean attrs on the synth path's enrichment span:
-    - ``lookup.mb_rescue.attempted``: gating condition met (top-1 + extended
-      + ``mb_pg`` set + non-empty artist + non-empty album).
-    - ``lookup.mb_rescue.tracklist_found``: resolver returned a non-empty
-      tracklist (similarity floor cleared and PG returned rows).
-
-    Always reports both — ``attempted=False`` with ``tracklist_found=False``
-    means the gate skipped (no MB cache configured, non-extended call, or
-    missing inputs). This lets the trace query "how often does the rescue
-    fire, and how often does it hit?" without inferring from absence.
+    Called from the synth path only when the rescue was eligible (top-1 +
+    extended + ``mb_pg`` set + non-empty artist + non-empty album), so the
+    trace gets an attr per eligible call — non-eligible lookups never emit
+    the boolean, keeping the trace explorer's filter on ``attempted=true``
+    informative.
 
     Silent on Sentry SDK errors; observability never breaks /lookup.
     """
@@ -1917,17 +1912,13 @@ async def enrich_artwork_results(
             # synthesizing the streaming-only result. Same positional gate
             # as the rest of the extended payload — only the top-1 item is
             # eligible, and only when extended mode is on.
-            mb_rescue_attempted = False
-            mb_rescue_hit = False
             if is_top1 and extended and mb_pg is not None and item.artist and album:
-                mb_rescue_attempted = True
                 mb_tracklist = await resolve_tracklist_via_musicbrainz(
                     item.artist, album, mb_pg=mb_pg
                 )
                 if mb_tracklist:
-                    mb_rescue_hit = True
                     update["tracklist"] = mb_tracklist
-            _project_mb_rescue_attrs(mb_rescue_attempted, mb_rescue_hit)
+                _project_mb_rescue_attrs(attempted=True, tracklist_found=bool(mb_tracklist))
 
             # See docstring's "Behavior change vs. v0.6.0 (LML#401)"
             # section for the BS#1185 sentinel contract.

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -63,6 +63,7 @@ from lookup.external_search import (
 )
 from lookup.models import LookupRequest, LookupResponse, LookupResultItem
 from lookup.strategies import build_strategies
+from release.musicbrainz_resolver import resolve_tracklist_via_musicbrainz
 from services.parser import MessageType, ParsedRequest
 
 logger = logging.getLogger(__name__)
@@ -250,6 +251,31 @@ def _log_album_title_fallback(
             transaction.set_data("album_title_fallback", payload)
     except Exception as e:
         logger.warning("Failed to project album_title_fallback onto Sentry transaction: %s", e)
+
+
+def _project_mb_rescue_attrs(attempted: bool, tracklist_found: bool) -> None:
+    """Project MusicBrainz tracklist-rescue outcome onto the active Sentry trace.
+
+    Two boolean attrs on the synth path's enrichment span:
+    - ``lookup.mb_rescue.attempted``: gating condition met (top-1 + extended
+      + ``mb_pg`` set + non-empty artist + non-empty album).
+    - ``lookup.mb_rescue.tracklist_found``: resolver returned a non-empty
+      tracklist (similarity floor cleared and PG returned rows).
+
+    Always reports both — ``attempted=False`` with ``tracklist_found=False``
+    means the gate skipped (no MB cache configured, non-extended call, or
+    missing inputs). This lets the trace query "how often does the rescue
+    fire, and how often does it hit?" without inferring from absence.
+
+    Silent on Sentry SDK errors; observability never breaks /lookup.
+    """
+    try:
+        transaction = sentry_sdk.get_current_scope().transaction
+        if transaction is not None:
+            transaction.set_data("lookup.mb_rescue.attempted", attempted)
+            transaction.set_data("lookup.mb_rescue.tracklist_found", tracklist_found)
+    except Exception as e:
+        logger.warning("Failed to project mb_rescue attrs onto Sentry transaction: %s", e)
 
 
 def _log_track_validation(
@@ -1670,6 +1696,7 @@ async def enrich_artwork_results(
     extended: bool = False,
     warm_cache: bool = False,
     discogs_cache: DiscogsCacheService | None = None,
+    mb_pg: PgSourceProtocol | None = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Enrich artwork results with release year, artist details, and streaming links.
 
@@ -1886,9 +1913,24 @@ async def enrich_artwork_results(
             update["profile_tokens"] = top1_profile_tokens
 
         if artwork is None:
-            # No Discogs match: synthesize a streaming-only result. See
-            # docstring's "Behavior change vs. v0.6.0 (LML#401)" section
-            # for the BS#1185 sentinel contract.
+            # No Discogs match: try MusicBrainz for a tracklist before
+            # synthesizing the streaming-only result. Same positional gate
+            # as the rest of the extended payload — only the top-1 item is
+            # eligible, and only when extended mode is on.
+            mb_rescue_attempted = False
+            mb_rescue_hit = False
+            if is_top1 and extended and mb_pg is not None and item.artist and album:
+                mb_rescue_attempted = True
+                mb_tracklist = await resolve_tracklist_via_musicbrainz(
+                    item.artist, album, mb_pg=mb_pg
+                )
+                if mb_tracklist:
+                    mb_rescue_hit = True
+                    update["tracklist"] = mb_tracklist
+            _project_mb_rescue_attrs(mb_rescue_attempted, mb_rescue_hit)
+
+            # See docstring's "Behavior change vs. v0.6.0 (LML#401)"
+            # section for the BS#1185 sentinel contract.
             return (item, DiscogsSearchResult(release_id=0, release_url="", **update))
 
         return (item, artwork.model_copy(update=update))
@@ -2177,6 +2219,7 @@ async def perform_lookup(
                 extended=extended_mode,
                 warm_cache=warm_cache_mode,
                 discogs_cache=discogs_cache,
+                mb_pg=mb_pg,
             )
 
     # Project the request-side flags onto the active Sentry transaction so

--- a/release/musicbrainz_resolver.py
+++ b/release/musicbrainz_resolver.py
@@ -1,0 +1,151 @@
+"""MusicBrainz-cache tracklist resolver.
+
+Tier-3.5 fallback for `/api/v1/lookup`: when the Discogs cascade misses
+(``artwork is None``) and the caller has opted into ``extended=true``,
+``resolve_tracklist_via_musicbrainz`` looks up an ``(artist, album)`` pair
+against the musicbrainz-cache PostgreSQL database and projects the matched
+release's tracklist onto the Discogs track-item shape. The result lands on
+the synth ``DiscogsSearchResult(release_id=0, ...)`` inline, so
+Backend-Service consumes it without learning MB exists (cross-cache-identity
+pivot, BS#800).
+
+Returns ``None`` on no match, low similarity, missing ``mb_pg``, blank
+input, or any DB error. ``None`` is a valid synth-side value (the BS#1185
+sentinel contract treats ``tracklist`` as nullable) so partial degradation
+is silent — the picker falls back to its empty-dropdown UX, which is what
+it would have shown anyway.
+
+Live MusicBrainz API is intentionally out of scope. The PG cache covers
+the residual rotation rows the picker cares about; standing up a new HTTP
+client + rate limiter for an estimated handful of rows isn't worth the
+ops surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from entity.sources import PgSourceProtocol
+from generated.api_models import DiscogsTrackItem
+
+logger = logging.getLogger(__name__)
+
+# Matches `CANONICAL_ARTIST_SIMILARITY_FLOOR` in ``lookup/orchestrator.py``.
+# False-positive tracklists are worse than no tracklist — the DJ types the
+# correct tracks in 10s either way, but a wrong tracklist gets unknowingly
+# committed to the flowsheet.
+_SIMILARITY_FLOOR: float = 0.70
+
+# Top-1 (artist, album) candidate plus its tracklist in one round trip.
+# The artist-credit and release-name % predicates both gate with pg_trgm,
+# so the floor is enforced twice: first in PG (any score below the
+# similarity-cutoff yields zero rows), then in Python (defensive, in case
+# a future PG tunable lowers the % cutoff below our floor). Ordering by
+# medium position, then track position, keeps multi-disc releases in
+# play order.
+_MB_TRACKLIST_FOR_ALBUM_SQL = """\
+WITH candidate AS (
+    SELECT r.id AS release_id,
+           ac.name AS release_artist,
+           r.name AS release_title,
+           similarity(lower(r.name), lower($2)) AS album_score,
+           similarity(lower(ac.name), lower($1)) AS artist_score
+    FROM mb_release r
+    JOIN mb_artist_credit ac ON ac.id = r.artist_credit
+    WHERE lower(r.name) % lower($2)
+      AND lower(ac.name) % lower($1)
+    ORDER BY album_score DESC, artist_score DESC
+    LIMIT 1
+)
+SELECT c.release_id,
+       c.album_score,
+       c.artist_score,
+       m.position AS medium_position,
+       t.position AS position,
+       t.name AS title,
+       t.length AS length_ms
+FROM candidate c
+JOIN mb_medium m ON m.release = c.release_id
+JOIN mb_track t ON t.medium = m.id
+ORDER BY m.position, t.position
+"""
+
+
+def _is_blank(value: str | None) -> bool:
+    return value is None or not value.strip()
+
+
+def _format_duration_ms(length_ms: int | None) -> str | None:
+    """Format MB's integer ms length as ``M:SS``.
+
+    Matches the free-text duration Discogs returns on its tracklist items
+    (e.g. ``"4:05"``). MB stores ``NULL`` length when a release medium
+    didn't include duration metadata — pass through as ``None``.
+    """
+    if length_ms is None:
+        return None
+    total_seconds = max(0, int(length_ms)) // 1000
+    minutes, seconds = divmod(total_seconds, 60)
+    return f"{minutes}:{seconds:02d}"
+
+
+async def resolve_tracklist_via_musicbrainz(
+    artist: str | None,
+    album: str | None,
+    *,
+    mb_pg: PgSourceProtocol | None,
+) -> list[DiscogsTrackItem] | None:
+    """Look up ``(artist, album)`` in musicbrainz-cache; return its tracklist.
+
+    Returns ``None`` when any of the following hold:
+    - ``mb_pg`` is ``None`` (cache not configured)
+    - ``artist`` or ``album`` is blank
+    - PG returns zero rows (no candidate cleared the trigram cutoff)
+    - the winning candidate's artist or album similarity is below
+      ``_SIMILARITY_FLOOR``
+    - the PG query raises (logged at WARN; never re-raised)
+    """
+    if mb_pg is None:
+        return None
+    if _is_blank(artist) or _is_blank(album):
+        return None
+
+    try:
+        rows: list[dict[str, Any]] = await mb_pg.fetchall(
+            _MB_TRACKLIST_FOR_ALBUM_SQL, artist, album
+        )
+    except Exception as e:
+        logger.warning(
+            "MusicBrainz tracklist resolver query failed for (%r, %r): %s",
+            artist,
+            album,
+            e,
+        )
+        return None
+
+    if not rows:
+        return None
+
+    first = rows[0]
+    album_score = float(first.get("album_score") or 0.0)
+    artist_score = float(first.get("artist_score") or 0.0)
+    if album_score < _SIMILARITY_FLOOR or artist_score < _SIMILARITY_FLOOR:
+        logger.info(
+            "MB tracklist candidate for (%r, %r) below floor: artist=%.2f album=%.2f",
+            artist,
+            album,
+            artist_score,
+            album_score,
+        )
+        return None
+
+    return [
+        DiscogsTrackItem(
+            position=str(row.get("position", "")),
+            title=row.get("title") or "",
+            duration=_format_duration_ms(row.get("length_ms")),
+            artists=[],
+        )
+        for row in rows
+    ]

--- a/release/musicbrainz_resolver.py
+++ b/release/musicbrainz_resolver.py
@@ -23,6 +23,7 @@ ops surface.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -32,29 +33,38 @@ from generated.api_models import DiscogsTrackItem
 logger = logging.getLogger(__name__)
 
 # Matches `CANONICAL_ARTIST_SIMILARITY_FLOOR` in ``lookup/orchestrator.py``.
+# Kept duplicated rather than imported to avoid a circular import with the
+# orchestrator (which imports this module). Bump both together on calibration.
 # False-positive tracklists are worse than no tracklist — the DJ types the
 # correct tracks in 10s either way, but a wrong tracklist gets unknowingly
 # committed to the flowsheet.
 _SIMILARITY_FLOOR: float = 0.70
 
-# Top-1 (artist, album) candidate plus its tracklist in one round trip.
-# The artist-credit and release-name % predicates both gate with pg_trgm,
-# so the floor is enforced twice: first in PG (any score below the
-# similarity-cutoff yields zero rows), then in Python (defensive, in case
-# a future PG tunable lowers the % cutoff below our floor). Ordering by
-# medium position, then track position, keeps multi-disc releases in
-# play order.
+# Hard ceiling on the PG round trip. The rescue fires inside
+# ``enrich_artwork_results``, AFTER the cascade's ``LML_SEARCH_HARD_TIMEOUT_MS``
+# already closed; without this, a slow MB query could push the response past
+# Backend-Service's 30s ``AbortController`` ceiling and surface as a CORS-less
+# 502 to the dj-site picker.
+_PG_TIMEOUT_S: float = 2.0
+
+# Top-1 (artist, album) candidate plus its tracklist in one round trip. The
+# ``lower(f_unaccent(...))`` wrapping matches the Phase 1.5 mojibake-recovery
+# pattern in ``lookup/external_search.py``: diacritic-stripped inputs (e.g.
+# "Sigur Ros" against MB's "Sigur Rós") must hit when both sides are normalized.
+# Index dependency: expression-trigram indexes on ``lower(f_unaccent(name))``
+# on ``mb_release.name`` and ``mb_artist_credit.name`` (mirrors the index
+# requirement called out in ``external_search.py``).
 _MB_TRACKLIST_FOR_ALBUM_SQL = """\
 WITH candidate AS (
     SELECT r.id AS release_id,
            ac.name AS release_artist,
            r.name AS release_title,
-           similarity(lower(r.name), lower($2)) AS album_score,
-           similarity(lower(ac.name), lower($1)) AS artist_score
+           similarity(lower(f_unaccent(r.name)), lower(f_unaccent($2))) AS album_score,
+           similarity(lower(f_unaccent(ac.name)), lower(f_unaccent($1))) AS artist_score
     FROM mb_release r
     JOIN mb_artist_credit ac ON ac.id = r.artist_credit
-    WHERE lower(r.name) % lower($2)
-      AND lower(ac.name) % lower($1)
+    WHERE lower(f_unaccent(r.name)) % lower(f_unaccent($2))
+      AND lower(f_unaccent(ac.name)) % lower(f_unaccent($1))
     ORDER BY album_score DESC, artist_score DESC
     LIMIT 1
 )
@@ -112,9 +122,18 @@ async def resolve_tracklist_via_musicbrainz(
         return None
 
     try:
-        rows: list[dict[str, Any]] = await mb_pg.fetchall(
-            _MB_TRACKLIST_FOR_ALBUM_SQL, artist, album
+        rows: list[dict[str, Any]] = await asyncio.wait_for(
+            mb_pg.fetchall(_MB_TRACKLIST_FOR_ALBUM_SQL, artist, album),
+            timeout=_PG_TIMEOUT_S,
         )
+    except TimeoutError:
+        logger.warning(
+            "MusicBrainz tracklist resolver timed out after %.1fs for (%r, %r)",
+            _PG_TIMEOUT_S,
+            artist,
+            album,
+        )
+        return None
     except Exception as e:
         logger.warning(
             "MusicBrainz tracklist resolver query failed for (%r, %r): %s",

--- a/tests/unit/release/test_musicbrainz_resolver.py
+++ b/tests/unit/release/test_musicbrainz_resolver.py
@@ -1,0 +1,178 @@
+"""Unit tests for release/musicbrainz_resolver.py.
+
+`mb_pg.fetchall` is mocked — no real PostgreSQL traffic. Tests cover:
+- happy path: candidate hits, similarity floors pass, tracklist projection
+- no mb_pg / blank input → None (caller skips silently)
+- empty rows from PG → None (no candidate match)
+- candidate below artist or album similarity floor → None
+- DB error from mb_pg → None (caller handles missing tracklist)
+- length-ms → "M:SS" formatting; NULL length → None duration
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from release.musicbrainz_resolver import (
+    _format_duration_ms,
+    resolve_tracklist_via_musicbrainz,
+)
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_mb_pg_is_none():
+    result = await resolve_tracklist_via_musicbrainz("Stereolab", "Aluminum Tunes", mb_pg=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("artist", "album"),
+    [("", "X"), ("   ", "X"), ("X", ""), ("X", "   "), (None, "X"), ("X", None)],
+)
+async def test_returns_none_on_blank_input(artist, album):
+    mb_pg = AsyncMock()
+    mb_pg.fetchall = AsyncMock(return_value=[])
+
+    result = await resolve_tracklist_via_musicbrainz(artist, album, mb_pg=mb_pg)
+
+    assert result is None
+    mb_pg.fetchall.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_pg_returns_empty():
+    mb_pg = AsyncMock()
+    mb_pg.fetchall = AsyncMock(return_value=[])
+
+    result = await resolve_tracklist_via_musicbrainz("Stereolab", "Aluminum Tunes", mb_pg=mb_pg)
+
+    assert result is None
+    mb_pg.fetchall.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_projects_track_rows_to_track_items():
+    # The release matched cleanly (both similarity scores above floor) and PG
+    # returned three tracks in medium/position order.
+    mb_pg = AsyncMock()
+    mb_pg.fetchall = AsyncMock(
+        return_value=[
+            {
+                "release_id": 42,
+                "album_score": 0.95,
+                "artist_score": 0.99,
+                "medium_position": 1,
+                "position": 1,
+                "title": "Brakhage",
+                "length_ms": 252000,
+            },
+            {
+                "release_id": 42,
+                "album_score": 0.95,
+                "artist_score": 0.99,
+                "medium_position": 1,
+                "position": 2,
+                "title": "Cybele's Reverie",
+                "length_ms": 245000,
+            },
+            {
+                "release_id": 42,
+                "album_score": 0.95,
+                "artist_score": 0.99,
+                "medium_position": 1,
+                "position": 3,
+                "title": "Olv 26",
+                "length_ms": None,
+            },
+        ]
+    )
+
+    result = await resolve_tracklist_via_musicbrainz(
+        "Stereolab", "Emperor Tomato Ketchup", mb_pg=mb_pg
+    )
+
+    assert result is not None
+    assert len(result) == 3
+    assert result[0].position == "1"
+    assert result[0].title == "Brakhage"
+    assert result[0].duration == "4:12"
+    assert result[1].position == "2"
+    assert result[1].duration == "4:05"
+    assert result[2].duration is None
+    # Per-track artists left empty; controllers fall back to release-level
+    # artist on the picker side.
+    assert result[0].artists == []
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_artist_score_below_floor():
+    mb_pg = AsyncMock()
+    mb_pg.fetchall = AsyncMock(
+        return_value=[
+            {
+                "release_id": 1,
+                "album_score": 0.95,
+                "artist_score": 0.55,  # below 0.70 floor
+                "medium_position": 1,
+                "position": 1,
+                "title": "Track",
+                "length_ms": 180000,
+            }
+        ]
+    )
+
+    result = await resolve_tracklist_via_musicbrainz("Stereolab", "Aluminum Tunes", mb_pg=mb_pg)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_album_score_below_floor():
+    mb_pg = AsyncMock()
+    mb_pg.fetchall = AsyncMock(
+        return_value=[
+            {
+                "release_id": 1,
+                "album_score": 0.40,  # below 0.70 floor
+                "artist_score": 0.95,
+                "medium_position": 1,
+                "position": 1,
+                "title": "Track",
+                "length_ms": 180000,
+            }
+        ]
+    )
+
+    result = await resolve_tracklist_via_musicbrainz("Stereolab", "Aluminum Tunes", mb_pg=mb_pg)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_on_pg_exception():
+    # DB unavailability must never propagate; the synth path stays valid
+    # with tracklist=None.
+    mb_pg = AsyncMock()
+    mb_pg.fetchall = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+    result = await resolve_tracklist_via_musicbrainz("Stereolab", "Aluminum Tunes", mb_pg=mb_pg)
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    ("length_ms", "expected"),
+    [
+        (None, None),
+        (0, "0:00"),
+        (59000, "0:59"),
+        (60000, "1:00"),
+        (245000, "4:05"),
+        (3600000, "60:00"),  # MB length spans rare hour-long tracks; format degrades
+    ],
+)
+def test_format_duration_ms(length_ms, expected):
+    assert _format_duration_ms(length_ms) == expected

--- a/tests/unit/release/test_musicbrainz_resolver.py
+++ b/tests/unit/release/test_musicbrainz_resolver.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -159,6 +159,25 @@ async def test_returns_none_on_pg_exception():
     mb_pg.fetchall = AsyncMock(side_effect=RuntimeError("connection refused"))
 
     result = await resolve_tracklist_via_musicbrainz("Stereolab", "Aluminum Tunes", mb_pg=mb_pg)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_on_pg_timeout():
+    # A slow MB query must not push the response past Backend-Service's
+    # 30s AbortController; the timeout coerces it to a quiet None.
+    import asyncio
+
+    async def hang(*_args, **_kwargs):
+        await asyncio.sleep(60)
+        return []
+
+    mb_pg = AsyncMock()
+    mb_pg.fetchall = hang
+
+    with patch("release.musicbrainz_resolver._PG_TIMEOUT_S", 0.05):
+        result = await resolve_tracklist_via_musicbrainz("Stereolab", "Aluminum Tunes", mb_pg=mb_pg)
 
     assert result is None
 

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -940,3 +940,175 @@ class TestEnrichArtworkResultsExtended:
         assert match.artist_bio == "A great artist."
         assert match.wikipedia_url == "https://en.wikipedia.org/wiki/Artist"
         assert match.spotify_url == "https://open.spotify.com/search/Artist%20Song"
+
+
+class TestMbTracklistRescue:
+    """``mb_pg`` rescue: when the top-1 result has no Discogs artwork AND
+    ``extended=true``, ``enrich_artwork_results`` calls
+    ``resolve_tracklist_via_musicbrainz`` and stitches the tracklist onto
+    the synth ``DiscogsSearchResult(release_id=0, ...)``. The picker's
+    rotation-tracks controller then consumes it inline.
+
+    Tests mock the resolver — no PG traffic.
+    """
+
+    @staticmethod
+    def _track_items():
+        from generated.api_models import DiscogsTrackItem
+
+        return [
+            DiscogsTrackItem(position="1", title="Brakhage", duration="4:12", artists=[]),
+            DiscogsTrackItem(position="2", title="Cybele's Reverie", duration="4:05", artists=[]),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_synth_carries_mb_tracklist_when_resolver_hits(self):
+        item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
+        mb_pg = AsyncMock()
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch(
+                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+                new=AsyncMock(return_value=self._track_items()),
+            ) as resolver,
+        ):
+            results = await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                album="Emperor Tomato Ketchup",
+                extended=True,
+                mb_pg=mb_pg,
+            )
+
+        _, enriched = results[0]
+        assert enriched.release_id == 0  # synth sentinel preserved
+        assert enriched.tracklist is not None
+        assert [t.title for t in enriched.tracklist] == ["Brakhage", "Cybele's Reverie"]
+        resolver.assert_awaited_once_with("Stereolab", "Emperor Tomato Ketchup", mb_pg=mb_pg)
+
+    @pytest.mark.asyncio
+    async def test_no_resolver_call_when_extended_is_false(self):
+        item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
+        mb_pg = AsyncMock()
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch(
+                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+                new=AsyncMock(),
+            ) as resolver,
+        ):
+            await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                album="Emperor Tomato Ketchup",
+                extended=False,
+                mb_pg=mb_pg,
+            )
+
+        resolver.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_resolver_call_when_mb_pg_is_none(self):
+        item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch(
+                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+                new=AsyncMock(),
+            ) as resolver,
+        ):
+            await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                album="Emperor Tomato Ketchup",
+                extended=True,
+                mb_pg=None,
+            )
+
+        resolver.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_resolver_call_when_top1_has_artwork(self):
+        item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
+        artwork = make_discogs_result(release_id=42)
+        mb_pg = AsyncMock()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=42,
+            title="Emperor Tomato Ketchup",
+            artist="Stereolab",
+            year=1996,
+            artist_id=None,
+            release_url="https://discogs.com/release/42",
+        )
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch(
+                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+                new=AsyncMock(),
+            ) as resolver,
+        ):
+            await enrich_artwork_results(
+                [(item, artwork)],
+                discogs_service,
+                album="Emperor Tomato Ketchup",
+                extended=True,
+                mb_pg=mb_pg,
+            )
+
+        resolver.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_resolver_call_when_album_empty(self):
+        item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
+        mb_pg = AsyncMock()
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch(
+                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+                new=AsyncMock(),
+            ) as resolver,
+        ):
+            await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                album=None,
+                extended=True,
+                mb_pg=mb_pg,
+            )
+
+        resolver.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_synth_tracklist_none_when_resolver_misses(self):
+        # Resolver returned ``None`` (low similarity / no row / DB error).
+        # The synth still composes; ``tracklist`` stays absent / falsy.
+        item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
+        mb_pg = AsyncMock()
+
+        with (
+            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
+            patch(
+                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+                new=AsyncMock(return_value=None),
+            ) as resolver,
+        ):
+            results = await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                album="Aluminum Tunes",
+                extended=True,
+                mb_pg=mb_pg,
+            )
+
+        resolver.assert_awaited_once()
+        _, enriched = results[0]
+        assert enriched.release_id == 0
+        # Either absent or an empty/None-equivalent tracklist — both fine.
+        assert not enriched.tracklist


### PR DESCRIPTION
Closes #426.

## Summary

- New `release/musicbrainz_resolver.py` — `resolve_tracklist_via_musicbrainz(artist, album, *, mb_pg)` queries musicbrainz-cache and projects `mb_release → mb_medium → mb_track` rows onto `DiscogsTrackItem`. Trigram-gated in PG, similarity-floor-gated (0.70 on both artist and album) in Python, with `None`-on-miss/error semantics so the synth path degrades silently when MB can't rescue.
- Hook in `lookup/orchestrator.py:enrich_artwork_results` at the BS#1185 sentinel composition site (`if artwork is None: return synthesized DiscogsSearchResult(release_id=0, ...)`). Gated on `is_top1 AND extended AND mb_pg AND item.artist AND album`. Result lands in `update[\"tracklist\"]` before the synth is composed.
- New `mb_pg: PgSourceProtocol | None = None` parameter on `enrich_artwork_results`; passed through from `perform_lookup` (already received `mb_pg` from the Phase 1.5 mojibake-recovery work).
- Sentry telemetry: `lookup.mb_rescue.{attempted,tracklist_found}` projected onto the active trace via `_project_mb_rescue_attrs`, mirroring the wrap-at-chokepoint + project-onto-span pattern used by `_log_album_title_fallback` and the `cache_fallback_fired` attribute.

## Test plan

- [x] `uv run pytest tests/unit/release/test_musicbrainz_resolver.py` — 18 new tests pass (blank input, no `mb_pg`, empty PG rows, low artist score, low album score, PG exception, `_format_duration_ms` parametrized for None / 0 / 59000 / 60000 / 245000 / 3600000)
- [x] `uv run pytest tests/unit/test_enrichment.py::TestMbTracklistRescue` — 6 orchestrator-level cases pass: resolver-hit composes tracklist on synth, `extended=False` skips, `mb_pg=None` skips, top-1 having artwork skips, empty album skips, resolver-miss leaves `tracklist=None`
- [x] `uv run pytest tests/unit/` — 2013/2013 pass (1 unrelated event-loop teardown error in `test_dependencies.py::test_no_module_level_asyncio_lock_in_dependencies` that passes in isolation)
- [x] `uv run ruff check` + `uv run ruff format --check` clean
- [x] `uv run mypy release/musicbrainz_resolver.py lookup/orchestrator.py` — no issues
- [ ] Integration test (PG-marked, hits real `mb_release / mb_medium / mb_track`) — follow-up issue; local MB cache schema doesn't currently include `mb_release` at the joinable level
- [ ] Post-deploy: spot-check `POST /api/v1/lookup` against a known-Tragic-Magic-class `(artist, album)` with `extended=true` and confirm `results[0].artwork.tracklist` is non-null

## Follow-up (Backend-Service)

A separate BS PR will rename `getDiscogsReleaseIdByRotationId` → `resolveRotationPickerSource()`, widen its return to `{ releaseId, inlineTracklist }`, pass `extended: true` on the tier-3 LML call, and short-circuit the controller on `inlineTracklist != null`. That's blocked on this PR shipping to staging and prod.