### PR TITLE
fix(streaming): return None on any service error so partial failures stop persisting as on_streaming=false

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1216,9 +1216,13 @@ class StreamingCheckSources(BaseModel):
 class StreamingCheckResponse(BaseModel):
     on_streaming: bool = Field(
         ...,
-        description="True if found on any service, false if absent on all, null if inconclusive.",
+        description='True if found on any service, false if all services confirmed absent (no errors),\nnull if inconclusive — either no services checked OR at least one service raised\nan error (see `errored_sources`). Treat null as "do not persist" / "retry later".\n',
     )
     sources: StreamingCheckSources
+    errored_sources: list[str] | None = Field(
+        None,
+        description="Names of services whose check raised an exception (transient network/rate-limit/\nscraping failure). Empty when every dispatched check completed without raising.\nWhen non-empty, callers should consider the listed services unchecked and may\nschedule a selective retry. Independent of `on_streaming`: a service can both\nmatch (populating `sources.<service>`) and other services can error.\n",
+    )
 
 
 class AppConfig(BaseModel):

--- a/streaming/models.py
+++ b/streaming/models.py
@@ -34,8 +34,20 @@ class StreamingCheckResponse(BaseModel):
     on_streaming: bool | None = Field(
         ...,
         description=(
-            "True if found on any service, False if confirmed absent on all, "
-            "None if inconclusive (e.g., all checks errored)"
+            "True if found on any service, False if all services confirmed absent "
+            "(no errors), None if inconclusive — either no services checked or at "
+            "least one service raised an error (see errored_sources). Callers should "
+            "treat None as 'do not persist' / 'retry later' (LML#376)."
         ),
     )
     sources: StreamingCheckSources = Field(..., description="Per-service match results")
+    errored_sources: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Service names whose check raised an exception (transient network/rate-"
+            "limit/scraping failure). Empty when every dispatched check completed "
+            "without raising. Independent of on_streaming: a service can match while "
+            "others error. Use to schedule a selective retry of just the listed "
+            "services rather than re-running every leg."
+        ),
+    )

--- a/streaming/orchestrator.py
+++ b/streaming/orchestrator.py
@@ -26,8 +26,15 @@ async def check_streaming_availability(
 ) -> StreamingCheckResponse:
     """Check streaming availability for an artist+title across all configured services.
 
-    Runs all service checks concurrently. Returns on_streaming=True if any service
-    has a match, False if all checked services returned no match, None if all errored.
+    Runs all service checks concurrently. Verdict (LML#376):
+
+    - ``on_streaming=True`` when any service confirmed a match (positive evidence wins
+      even if other services errored).
+    - ``on_streaming=False`` strictly when every dispatched service was checked AND
+      none found a match AND none errored.
+    - ``on_streaming=None`` when no services were dispatched, or when at least one
+      service raised an exception without positive evidence elsewhere — callers
+      should treat this as "do not persist" / "retry later".
 
     Args:
         artist: Artist name to search for.
@@ -38,7 +45,10 @@ async def check_streaming_availability(
         bandcamp: Optional Bandcamp client.
 
     Returns:
-        StreamingCheckResponse with on_streaming boolean and per-source match details.
+        ``StreamingCheckResponse`` with the verdict, per-source match details, and
+        ``errored_sources`` listing services whose check raised (sorted; empty when
+        every dispatched check completed without raising). The errored set is
+        independent of the verdict — a service can match while others error.
     """
     tasks: dict[str, asyncio.Task] = {}
 

--- a/streaming/orchestrator.py
+++ b/streaming/orchestrator.py
@@ -52,6 +52,7 @@ async def check_streaming_availability(
         tasks["bandcamp"] = asyncio.create_task(_check_bandcamp(bandcamp, artist, title))
 
     sources = StreamingCheckSources()
+    errored: set[str] = set()
     any_checked = False
     any_found = False
 
@@ -63,16 +64,30 @@ async def check_streaming_availability(
                 any_found = True
                 setattr(sources, service, match)
         except Exception:
+            errored.add(service)
             logger.exception("Streaming check failed for %s on %s - %s", service, artist, title)
 
-    if not any_checked:
+    # LML#376: tighten False's meaning so partial-failures can't masquerade as
+    # confirmed absences. Positive evidence still wins (a confirmed match elsewhere
+    # is reason to persist True even if a flake errored), but absent positive
+    # evidence, any error escalates the verdict to None — Backend's `!== null`
+    # guard then refuses to write through. `False` now means strictly "every
+    # dispatched service was checked AND none found a match AND none errored".
+    # `errored_sources` carries the partial-failure signal for selective retry.
+    if any_found:
+        on_streaming: bool | None = True
+    elif errored:
         on_streaming = None
-    elif any_found:
-        on_streaming = True
-    else:
+    elif any_checked:
         on_streaming = False
+    else:
+        on_streaming = None
 
-    return StreamingCheckResponse(on_streaming=on_streaming, sources=sources)
+    return StreamingCheckResponse(
+        on_streaming=on_streaming,
+        sources=sources,
+        errored_sources=sorted(errored),
+    )
 
 
 async def _check_spotify(client: SpotifyClient, artist: str, title: str) -> SourceMatch | None:

--- a/tests/unit/test_streaming_check_orchestrator.py
+++ b/tests/unit/test_streaming_check_orchestrator.py
@@ -121,6 +121,10 @@ async def test_not_found_on_any_service():
     assert result.on_streaming is False
     assert result.sources.spotify is None
     assert result.sources.deezer is None
+    # LML#376: False is reserved for "checked all, none found, none errored".
+    # The empty errored_sources is part of the False contract — a regression
+    # that re-introduces the bug (False with errored_sources populated) trips here.
+    assert result.errored_sources == []
 
 
 @pytest.mark.asyncio
@@ -144,6 +148,8 @@ async def test_all_clients_error_returns_inconclusive():
     )
 
     assert result.on_streaming is None
+    # Both services errored — both surface in errored_sources, sorted.
+    assert result.errored_sources == ["deezer", "spotify"]
 
 
 @pytest.mark.asyncio
@@ -161,6 +167,34 @@ async def test_partial_error_still_returns_result():
     assert result.on_streaming is True
     assert result.sources.spotify is None
     assert result.sources.deezer is not None
+    # Positive evidence wins for on_streaming, but errored_sources still records
+    # the failure so a caller can schedule a retry of just the spotify leg.
+    assert result.errored_sources == ["spotify"]
+
+
+@pytest.mark.asyncio
+async def test_partial_error_with_no_match_is_inconclusive():
+    """One service errors, another returns no match — returns on_streaming=None (LML#376).
+
+    Before the fix this collapsed to `False`: the no-match success flipped `any_checked`
+    to True so the verdict followed the "all-checked, none-found" branch and ignored the
+    error. Persisted as `library.on_streaming=false` forever, with no retry path. After
+    the fix, any-error → None so consumers' `!== null` guards skip the write.
+    """
+    spotify = AsyncMock()
+    spotify.search_album = AsyncMock(side_effect=Exception("network error"))
+    deezer = AsyncMock()
+    deezer.search_album = AsyncMock(return_value=[])
+
+    result = await check_streaming_availability(
+        "Stereolab", "Aluminum Tunes", spotify=spotify, deezer=deezer
+    )
+
+    assert result.on_streaming is None
+    assert result.sources.spotify is None
+    assert result.sources.deezer is None
+    assert "spotify" in result.errored_sources
+    assert "deezer" not in result.errored_sources
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_streaming_check_orchestrator.py
+++ b/tests/unit/test_streaming_check_orchestrator.py
@@ -133,6 +133,11 @@ async def test_no_clients_returns_inconclusive():
     result = await check_streaming_availability("Stereolab", "Aluminum Tunes")
 
     assert result.on_streaming is None
+    # The empty-dispatched-tasks branch shares its on_streaming verdict with the
+    # all-errored branch; errored_sources is what distinguishes them. Pinning []
+    # here prevents a future change from conflating "nothing tried" with
+    # "tried, all failed".
+    assert result.errored_sources == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #376. Builds on WXYC/wxyc-shared#151 (merged at 2f2c95a, 1.7.1 → 1.8.0).

## Problem

`StreamingOrchestrator.check_streaming_availability` flips `any_checked=True` on every successful task completion regardless of whether other tasks raised. A confirmed no-match from one service combined with errors from the rest collapsed to `on_streaming=False`. Backend's `addAlbum` and tubafrenzy's `StreamingCheckLibraryReleaseListener` then write the `false` straight through to `library.on_streaming` — albums that are actually on three streaming services get permanently flagged "WXYC exclusive" because one of four service checks raised once. No retry path.

The existing test suite covered all-errored (returns `None`) and partial-errored + match (returns `True`), but the actual bug case — partial-errored + no-match — was untested.

## Fix

The orchestrator tracks an `errored: set[str]` during the await loop and applies a stricter verdict matrix:

| Successful tasks | Matches | Errored | `on_streaming` | `errored_sources` |
|---|---|---|---|---|
| 0 (all raised) | 0 | all | `None` | all |
| ≥1 | 0 | ≥1 | **`None`** (new) | the errored set |
| ≥1 | 0 | 0 | `False` (unchanged) | `[]` |
| ≥1 | ≥1 | 0 | `True` (unchanged) | `[]` |
| ≥1 | ≥1 | ≥1 | `True` (unchanged) | the errored set |
| 0 dispatched | — | — | `None` | `[]` |

The bold row is the bug fix. Positive evidence still wins (a confirmed match elsewhere remains `True` even if a flake errored — that case is still safe to persist), but absent positive evidence, **any** error escalates to `None`. Strictly: `False` now means "every dispatched service was checked AND none found a match AND none errored."

Backend's existing `streamingResult.value.on_streaming !== null` guard in `library.controller.ts:108` then refuses to write through. Tubafrenzy's `LibraryReleaseRepositoryImpl.updateOnStreaming` writes `NULL` to MySQL when passed `null`. **The bug closes for both consumers at the LML layer alone** — no Backend or tubafrenzy code change needed (verified by reading both call sites).

## What the response carries

Wire shape (wxyc-shared#151):

```yaml
StreamingCheckResponse:
  required: [on_streaming, sources]
  properties:
    on_streaming: bool | null
    sources: StreamingCheckSources
    errored_sources: array<string>  # new in 1.8.0, optional for back-compat
```

`errored_sources` is informational on this PR. It enables a follow-up BS-side selective-retry job to re-check just the services that failed instead of re-running every leg. Filing that follow-up is a separate ticket once we have the new field deployed and observe production failure patterns.

## TDD trail

1. **Red**: `test_partial_error_with_no_match_is_inconclusive` — asserts `on_streaming is None` (was `False`) and `"spotify" in result.errored_sources`. Reproduces the bug; fails on `assert False is None`.
2. **Green**: add the field to `streaming/models.py`, rewrite the verdict logic in `streaming/orchestrator.py:54-83` per the matrix.
3. **Refactor**: backfill `errored_sources` assertions on the three other tests that have an `errored` slot — `test_all_clients_error_returns_inconclusive` (asserts `["deezer", "spotify"]`), `test_partial_error_still_returns_result` (asserts `["spotify"]`), `test_not_found_on_any_service` (asserts `[]` — pins the False/empty pairing so a future regression that re-introduces the bug trips here).

## Verification

- 2019 unit tests pass (13 in `test_streaming_check_orchestrator.py`).
- `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports` all clean.
- `generated/api_models.py` regenerated from the merged wxyc-shared spec — codegen-freshness check will pass on CI's clean checkout.

## Tubafrenzy verification (done as part of scoping)

`StreamingCheckLibraryReleaseListener.java:144` reads `body.isNull("on_streaming") ? null : body.getBoolean("on_streaming")` and `LibraryReleaseRepositoryImpl.updateOnStreaming:425` writes `Integer dbValue = onStreaming == null ? null : (onStreaming ? 1 : 0)`. Pre-fix it persists `0` (same bug as BS); post-fix it persists `NULL` (correct). No tubafrenzy code change required.

## Out of scope

- BS-side selective-retry job that consumes `errored_sources` — file as a follow-up when the new field is in production and we have failure-pattern data.
- Collapsing the local `streaming/models.py` into `generated/api_models.py` (the existing duplication of `StreamingCheckResponse`) — separate refactor; not load-bearing for the bug fix.
- #392's `find_album_match` interface deepening — its own body explicitly sequences it after #376 and its verdict matrix is unaffected by this change.

## Related

- WXYC/wxyc-shared#151 — wire-contract dependency (merged).
- #392 — streaming-clients deepening; sequenced after this.
- #357 — FD-leak / racy-lazy-init audit; the verdict-matrix tightening here doesn't intersect with its pool-management sweep.
- #413 — LML triage tracker; this is the highest-severity bug still open per that tracker's CRITICAL list.
