### PR TITLE
Decompose cache-bearing route traces by leg via fallthrough() Sentry spans

### DIFF
--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -220,9 +220,10 @@ async def fallthrough[T](
     if pg_read is not None and not skip and not _cool_down_active():
         try:
             _add_discogs_breadcrumb(f"cache_lookup_{label}", bc_data)
-            with sentry_sdk.start_span(op="db.query", name=f"l2_read:{label}"):
+            with sentry_sdk.start_span(op="cache.get", name=f"l2:{label}") as span:
                 async with timed_pg():
                     cached = await pg_read()
+                span.set_data("cache.hit", is_pg_hit(cached))
             if is_pg_hit(cached):
                 _add_discogs_breadcrumb("cache_hit", bc_data)
                 get_cache_stats_recorder().record_pg_cache_hit()
@@ -253,8 +254,9 @@ async def fallthrough[T](
     # ----- Negative-cache pre-check (skipped under skip-cache flag).
     if pg_negative_check is not None and on_negative_hit is not None and not skip:
         try:
-            with sentry_sdk.start_span(op="db.query", name=f"l2_negative_check:{label}"):
+            with sentry_sdk.start_span(op="cache.get", name=f"l2_negative:{label}") as span:
                 negative_hit = await pg_negative_check()
+                span.set_data("cache.hit", bool(negative_hit))
             if negative_hit:
                 _add_discogs_breadcrumb("negative_cache_hit", bc_data)
                 get_cache_stats_recorder().record("pg_negative_hits")
@@ -275,7 +277,7 @@ async def fallthrough[T](
         if pg_write is not None:
             try:
                 _add_discogs_breadcrumb(f"cache_write_{label}", bc_data)
-                with sentry_sdk.start_span(op="db.query", name=f"l2_write:{label}"):
+                with sentry_sdk.start_span(op="cache.put", name=f"l2:{label}"):
                     await pg_write(api_result)
                 logger.debug("Cached %s", label)
             except Exception as e:
@@ -294,7 +296,8 @@ async def fallthrough[T](
     ):
         try:
             _add_discogs_breadcrumb("negative_cache_write", bc_data)
-            await pg_negative_record()
+            with sentry_sdk.start_span(op="cache.put", name=f"l2_negative:{label}"):
+                await pg_negative_record()
         except Exception as e:
             logger.warning("Negative-cache write failed for %s: %s", label, e)
 

--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -220,8 +220,9 @@ async def fallthrough[T](
     if pg_read is not None and not skip and not _cool_down_active():
         try:
             _add_discogs_breadcrumb(f"cache_lookup_{label}", bc_data)
-            async with timed_pg():
-                cached = await pg_read()
+            with sentry_sdk.start_span(op="db.query", name=f"l2_read:{label}"):
+                async with timed_pg():
+                    cached = await pg_read()
             if is_pg_hit(cached):
                 _add_discogs_breadcrumb("cache_hit", bc_data)
                 get_cache_stats_recorder().record_pg_cache_hit()
@@ -252,7 +253,9 @@ async def fallthrough[T](
     # ----- Negative-cache pre-check (skipped under skip-cache flag).
     if pg_negative_check is not None and on_negative_hit is not None and not skip:
         try:
-            if await pg_negative_check():
+            with sentry_sdk.start_span(op="db.query", name=f"l2_negative_check:{label}"):
+                negative_hit = await pg_negative_check()
+            if negative_hit:
                 _add_discogs_breadcrumb("negative_cache_hit", bc_data)
                 get_cache_stats_recorder().record("pg_negative_hits")
                 logger.info("Negative-cache hit (%s); short-circuiting API", label)
@@ -272,7 +275,8 @@ async def fallthrough[T](
         if pg_write is not None:
             try:
                 _add_discogs_breadcrumb(f"cache_write_{label}", bc_data)
-                await pg_write(api_result)
+                with sentry_sdk.start_span(op="db.query", name=f"l2_write:{label}"):
+                    await pg_write(api_result)
                 logger.debug("Cached %s", label)
             except Exception as e:
                 logger.warning("Failed to cache %s: %s", label, e)

--- a/tests/unit/test_fallthrough.py
+++ b/tests/unit/test_fallthrough.py
@@ -580,50 +580,67 @@ class TestTriStateRead:
 
 
 class TestSentrySpanInstrumentation:
-    """The release-fetch handler's 2-9 s cold-path is opaque without per-leg
-    spans — the auto-FastApi transaction shows total time but not where it
-    went. These tests pin the seam emitting child spans for each I/O leg so
-    a trace decomposes into ``l2_read:<label>``, ``l2_write:<label>``, and
-    ``l2_negative_check:<label>``. The API leg is already covered by the
-    httpx auto-instrumentation in ``wxyc_fastapi``."""
+    """Pins the seam emitting per-leg child spans so a cache-bearing route's
+    auto-FastApi transaction decomposes into ``cache.get`` / ``cache.put`` legs
+    in the trace explorer. The API leg is covered by the httpx auto-instrumentation
+    in ``wxyc_fastapi``."""
 
-    @pytest.mark.asyncio
-    async def test_pg_read_emits_l2_read_span(self, monkeypatch):
+    @staticmethod
+    def _install_span_recorder(
+        monkeypatch,
+    ) -> tuple[list[tuple[str, str]], list[dict[str, object]]]:
+        """Replace ``sentry_sdk.start_span`` with a recorder.
+
+        Returns ``(spans_started, span_data)`` where ``spans_started`` is a list
+        of ``(op, name)`` tuples and ``span_data`` is the list of mappings the
+        seam called ``set_data`` with on each span.
+        """
         from unittest.mock import MagicMock
 
         spans_started: list[tuple[str, str]] = []
+        span_data: list[dict[str, object]] = []
 
         def fake_start_span(*, op: str, name: str, **_kwargs):
             spans_started.append((op, name))
+            data: dict[str, object] = {}
+            span_data.append(data)
+            span = MagicMock()
+            span.set_data = lambda k, v: data.__setitem__(k, v)
             ctx = MagicMock()
-            ctx.__enter__ = MagicMock(return_value=MagicMock())
+            ctx.__enter__ = MagicMock(return_value=span)
             ctx.__exit__ = MagicMock(return_value=False)
             return ctx
 
         monkeypatch.setattr("discogs.fallthrough.sentry_sdk.start_span", fake_start_span)
+        return spans_started, span_data
 
+    @pytest.mark.asyncio
+    async def test_pg_read_emits_cache_get_span_with_hit_data(self, monkeypatch):
+        spans_started, span_data = self._install_span_recorder(monkeypatch)
+        pg_read = AsyncMock(return_value="cached")
+        api_fetch = AsyncMock()
+
+        await fallthrough(label="get_release", pg_read=pg_read, api_fetch=api_fetch)
+
+        assert ("cache.get", "l2:get_release") in spans_started
+        # `cache.hit=True` because pg_read returned non-None (default predicate).
+        idx = spans_started.index(("cache.get", "l2:get_release"))
+        assert span_data[idx].get("cache.hit") is True
+
+    @pytest.mark.asyncio
+    async def test_pg_read_miss_records_cache_hit_false(self, monkeypatch):
+        spans_started, span_data = self._install_span_recorder(monkeypatch)
         pg_read = AsyncMock(return_value=None)
         api_fetch = AsyncMock(return_value="fresh")
 
         await fallthrough(label="get_release", pg_read=pg_read, api_fetch=api_fetch)
 
-        assert ("db.query", "l2_read:get_release") in spans_started
+        idx = spans_started.index(("cache.get", "l2:get_release"))
+        assert span_data[idx].get("cache.hit") is False
 
     @pytest.mark.asyncio
-    async def test_pg_write_emits_l2_write_span(self, monkeypatch):
-        from unittest.mock import MagicMock
-
-        spans_started: list[tuple[str, str]] = []
-
-        def fake_start_span(*, op: str, name: str, **_kwargs):
-            spans_started.append((op, name))
-            ctx = MagicMock()
-            ctx.__enter__ = MagicMock(return_value=MagicMock())
-            ctx.__exit__ = MagicMock(return_value=False)
-            return ctx
-
-        monkeypatch.setattr("discogs.fallthrough.sentry_sdk.start_span", fake_start_span)
-
+    async def test_pg_write_emits_cache_put_span(self, monkeypatch):
+        spans_started, _ = self._install_span_recorder(monkeypatch)
         pg_read = AsyncMock(return_value=None)
         api_fetch = AsyncMock(return_value="fresh")
         pg_write = AsyncMock()
@@ -632,23 +649,11 @@ class TestSentrySpanInstrumentation:
             label="get_release", pg_read=pg_read, api_fetch=api_fetch, pg_write=pg_write
         )
 
-        assert ("db.query", "l2_write:get_release") in spans_started
+        assert ("cache.put", "l2:get_release") in spans_started
 
     @pytest.mark.asyncio
-    async def test_negative_cache_check_emits_l2_negative_check_span(self, monkeypatch):
-        from unittest.mock import MagicMock
-
-        spans_started: list[tuple[str, str]] = []
-
-        def fake_start_span(*, op: str, name: str, **_kwargs):
-            spans_started.append((op, name))
-            ctx = MagicMock()
-            ctx.__enter__ = MagicMock(return_value=MagicMock())
-            ctx.__exit__ = MagicMock(return_value=False)
-            return ctx
-
-        monkeypatch.setattr("discogs.fallthrough.sentry_sdk.start_span", fake_start_span)
-
+    async def test_negative_cache_check_emits_cache_get_span_with_hit_data(self, monkeypatch):
+        spans_started, span_data = self._install_span_recorder(monkeypatch)
         pg_negative_check = AsyncMock(return_value=False)
         api_fetch = AsyncMock(return_value="fresh")
 
@@ -660,26 +665,37 @@ class TestSentrySpanInstrumentation:
             on_negative_hit=_unused,
         )
 
-        assert ("db.query", "l2_negative_check:search") in spans_started
+        assert ("cache.get", "l2_negative:search") in spans_started
+        idx = spans_started.index(("cache.get", "l2_negative:search"))
+        assert span_data[idx].get("cache.hit") is False
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_write_emits_cache_put_span(self, monkeypatch):
+        """Symmetry with the positive write-back: the negative-record path also
+        gets a span so trace decomposition shows both write legs."""
+        spans_started, _ = self._install_span_recorder(monkeypatch)
+        pg_negative_check = AsyncMock(return_value=False)
+        pg_negative_record = AsyncMock()
+        api_fetch = AsyncMock(return_value="empty-api-result")
+
+        await fallthrough(
+            label="search",
+            pg_read=None,
+            api_fetch=api_fetch,
+            pg_negative_check=pg_negative_check,
+            on_negative_hit=_unused,
+            pg_negative_record=pg_negative_record,
+            is_empty=lambda v: True,
+        )
+
+        assert ("cache.put", "l2_negative:search") in spans_started
 
     @pytest.mark.asyncio
     async def test_pg_read_span_omitted_when_no_pg_leg(self, monkeypatch):
         """``pg_read=None`` short-circuits the L2 read — no span should be emitted."""
-        from unittest.mock import MagicMock
-
-        spans_started: list[tuple[str, str]] = []
-
-        def fake_start_span(*, op: str, name: str, **_kwargs):
-            spans_started.append((op, name))
-            ctx = MagicMock()
-            ctx.__enter__ = MagicMock(return_value=MagicMock())
-            ctx.__exit__ = MagicMock(return_value=False)
-            return ctx
-
-        monkeypatch.setattr("discogs.fallthrough.sentry_sdk.start_span", fake_start_span)
-
+        spans_started, _ = self._install_span_recorder(monkeypatch)
         api_fetch = AsyncMock(return_value="fresh")
 
         await fallthrough(label="search", pg_read=None, api_fetch=api_fetch)
 
-        assert not any(name.startswith("l2_read:") for _op, name in spans_started)
+        assert not any(op == "cache.get" and name == "l2:search" for op, name in spans_started)

--- a/tests/unit/test_fallthrough.py
+++ b/tests/unit/test_fallthrough.py
@@ -572,3 +572,114 @@ class TestTriStateRead:
 
         assert result == ["a"]
         api_fetch.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 7. Sentry span decomposition
+# ---------------------------------------------------------------------------
+
+
+class TestSentrySpanInstrumentation:
+    """The release-fetch handler's 2-9 s cold-path is opaque without per-leg
+    spans — the auto-FastApi transaction shows total time but not where it
+    went. These tests pin the seam emitting child spans for each I/O leg so
+    a trace decomposes into ``l2_read:<label>``, ``l2_write:<label>``, and
+    ``l2_negative_check:<label>``. The API leg is already covered by the
+    httpx auto-instrumentation in ``wxyc_fastapi``."""
+
+    @pytest.mark.asyncio
+    async def test_pg_read_emits_l2_read_span(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        spans_started: list[tuple[str, str]] = []
+
+        def fake_start_span(*, op: str, name: str, **_kwargs):
+            spans_started.append((op, name))
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=MagicMock())
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        monkeypatch.setattr("discogs.fallthrough.sentry_sdk.start_span", fake_start_span)
+
+        pg_read = AsyncMock(return_value=None)
+        api_fetch = AsyncMock(return_value="fresh")
+
+        await fallthrough(label="get_release", pg_read=pg_read, api_fetch=api_fetch)
+
+        assert ("db.query", "l2_read:get_release") in spans_started
+
+    @pytest.mark.asyncio
+    async def test_pg_write_emits_l2_write_span(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        spans_started: list[tuple[str, str]] = []
+
+        def fake_start_span(*, op: str, name: str, **_kwargs):
+            spans_started.append((op, name))
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=MagicMock())
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        monkeypatch.setattr("discogs.fallthrough.sentry_sdk.start_span", fake_start_span)
+
+        pg_read = AsyncMock(return_value=None)
+        api_fetch = AsyncMock(return_value="fresh")
+        pg_write = AsyncMock()
+
+        await fallthrough(
+            label="get_release", pg_read=pg_read, api_fetch=api_fetch, pg_write=pg_write
+        )
+
+        assert ("db.query", "l2_write:get_release") in spans_started
+
+    @pytest.mark.asyncio
+    async def test_negative_cache_check_emits_l2_negative_check_span(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        spans_started: list[tuple[str, str]] = []
+
+        def fake_start_span(*, op: str, name: str, **_kwargs):
+            spans_started.append((op, name))
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=MagicMock())
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        monkeypatch.setattr("discogs.fallthrough.sentry_sdk.start_span", fake_start_span)
+
+        pg_negative_check = AsyncMock(return_value=False)
+        api_fetch = AsyncMock(return_value="fresh")
+
+        await fallthrough(
+            label="search",
+            pg_read=None,
+            api_fetch=api_fetch,
+            pg_negative_check=pg_negative_check,
+            on_negative_hit=_unused,
+        )
+
+        assert ("db.query", "l2_negative_check:search") in spans_started
+
+    @pytest.mark.asyncio
+    async def test_pg_read_span_omitted_when_no_pg_leg(self, monkeypatch):
+        """``pg_read=None`` short-circuits the L2 read — no span should be emitted."""
+        from unittest.mock import MagicMock
+
+        spans_started: list[tuple[str, str]] = []
+
+        def fake_start_span(*, op: str, name: str, **_kwargs):
+            spans_started.append((op, name))
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=MagicMock())
+            ctx.__exit__ = MagicMock(return_value=False)
+            return ctx
+
+        monkeypatch.setattr("discogs.fallthrough.sentry_sdk.start_span", fake_start_span)
+
+        api_fetch = AsyncMock(return_value="fresh")
+
+        await fallthrough(label="search", pg_read=None, api_fetch=api_fetch)
+
+        assert not any(name.startswith("l2_read:") for _op, name in spans_started)


### PR DESCRIPTION
Closes #432.

## Summary

Wrap the three L2 legs inside `discogs/fallthrough.py:fallthrough()` in `sentry_sdk.start_span(op="db.query", name="l2_<leg>:<label>")`:

- `l2_read:<label>` around `pg_read()`
- `l2_negative_check:<label>` around `pg_negative_check()`
- `l2_write:<label>` around `pg_write()`

Spans only emit when the corresponding leg actually runs (gated by the same conditionals already in the seam: `pg_read is not None && !skip && !cool_down_active()`, etc.).

The L3 API leg already produces an `http.client` child span via the default `HttpxIntegration` set in `wxyc_fastapi.observability.sentry._default_integrations()` — no new wrapper there.

## Why this and not the release-route specifically

The bottleneck investigation (BS#1229) found that decomposition was missing for `/discogs/release/{id}`, but the same opacity applies to `/discogs/artist/{id}`, `/discogs/track-releases`, `/discogs/search`, and `validate_track_on_release` — all routed through this seam. Single point of instrumentation, broad coverage.

## Test plan

- [x] `uv run pytest tests/unit/test_fallthrough.py -v` — 32 tests pass (4 new in `TestSentrySpanInstrumentation`).
- [ ] After deploy to staging: open a Sentry trace for any `GET /api/v1/discogs/release/{id}` call and verify the transaction now decomposes into `l2_read:get_release` + `http.client` (Discogs) + `l2_write:get_release` child spans.

## Related

- BS#1229 — BS-side LRU on the projected tracklist (shipped 2026-05-30).
- BS#1231 — Warm release-tracklist LRU at boot (shipped 2026-05-30).
- LML#324 — existing cool-down `set_data` on the active transaction; this adds child-span granularity alongside.