### PR TITLE
fix(observability): wire entry/exit logs + http.server span on /identity/bulk-resolve-libraries

### DIFF
--- a/identity/router.py
+++ b/identity/router.py
@@ -14,7 +14,9 @@ Provides:
 """
 
 import logging
+from collections import Counter
 
+import sentry_sdk
 from asyncpg.exceptions import PostgresError
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import ValidationError
@@ -215,40 +217,88 @@ async def bulk_resolve_libraries(
 
     store = _require_entity_store(entity_store)
 
-    results = []
-    for input_row in request.inputs:
-        if is_compilation_artist(input_row.artist_name):
-            results.append(compilation_result(input_row.library_id))
-            continue
+    # Entry signal (LML#430, sibling-of-#371). Fires synchronously before any
+    # awaits, so a handler that later hangs past the caller's AbortController
+    # still leaves a trace — uvicorn's access log and Sentry's automatic
+    # `http.server` transaction only commit on response completion, and the
+    # LML#355 audit hit exactly that gap (zero spans for 60 batches over the
+    # 2026-05-20 prod dry-run despite the handler running).
+    inputs_count = len(request.inputs)
+    logger.info("bulk resolve start: inputs=%d", inputs_count)
 
-        try:
-            # Three-leg fall-through lookup (issues #274 / #276): exact match
-            # first (handles the 99.8% dominant case where Backend's
-            # `library.artist_name` shape equals storage), then case-
-            # insensitive `LOWER()` (catches pure case drift), then canonical
-            # form (catches diacritic / `&`-vs-`and` / smart-quote / etc.
-            # divergence when storage happens to be canonical). Strictly ≥
-            # legacy `get_identity()` hit rate.
-            identity: Identity | None = await store.resolve_library_name(input_row.artist_name)
-        except (PostgresError, OSError):
-            # Fail closed on partial PG failure — the caller cannot
-            # distinguish "row had no identity" from "PG died before this
-            # row was tried". Same posture as ``/identity/bulk``.
-            logger.exception(
-                "Entity store query failed mid-bulk-resolve for library_id=%d artist_name=%r",
-                input_row.library_id,
-                input_row.artist_name,
-            )
-            raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
+    # Explicit `http.server` span (LML#430). Defense-in-depth against the
+    # FastApiIntegration's automatic transaction not landing for this endpoint
+    # — `op:http.server span.description:*bulk-resolve-libraries*` queries in
+    # the trace explorer will surface bulk-resolve traffic even when the
+    # automatic instrumentation misses. Mirrors PR #417's pattern for
+    # `/api/v1/lookup/bulk`.
+    with sentry_sdk.start_span(
+        op="http.server",
+        name="POST /api/v1/identity/bulk-resolve-libraries",
+    ) as http_span:
+        http_span.set_data("http.method", "POST")
+        http_span.set_data("http.target", "/api/v1/identity/bulk-resolve-libraries")
+        http_span.set_data("lml.bulk_resolve.inputs", inputs_count)
 
-        try:
-            result = await compose_for_identity(input_row.library_id, identity, store)
-        except (PostgresError, OSError):
-            logger.exception(
-                "Provenance fetch failed mid-bulk-resolve for library_id=%d",
-                input_row.library_id,
-            )
-            raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
-        results.append(result)
+        results = []
+        for input_row in request.inputs:
+            if is_compilation_artist(input_row.artist_name):
+                results.append(compilation_result(input_row.library_id))
+                continue
+
+            try:
+                # Three-leg fall-through lookup (issues #274 / #276): exact
+                # match first (handles the 99.8% dominant case where Backend's
+                # `library.artist_name` shape equals storage), then case-
+                # insensitive `LOWER()` (catches pure case drift), then
+                # canonical form (catches diacritic / `&`-vs-`and` /
+                # smart-quote / etc. divergence when storage happens to be
+                # canonical). Strictly ≥ legacy `get_identity()` hit rate.
+                identity: Identity | None = await store.resolve_library_name(input_row.artist_name)
+            except (PostgresError, OSError):
+                # Fail closed on partial PG failure — the caller cannot
+                # distinguish "row had no identity" from "PG died before this
+                # row was tried". Same posture as ``/identity/bulk``.
+                logger.exception(
+                    "Entity store query failed mid-bulk-resolve for library_id=%d artist_name=%r",
+                    input_row.library_id,
+                    input_row.artist_name,
+                )
+                http_span.set_data("http.status_code", 503)
+                raise HTTPException(
+                    status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
+                ) from None
+
+            try:
+                result = await compose_for_identity(input_row.library_id, identity, store)
+            except (PostgresError, OSError):
+                logger.exception(
+                    "Provenance fetch failed mid-bulk-resolve for library_id=%d",
+                    input_row.library_id,
+                )
+                http_span.set_data("http.status_code", 503)
+                raise HTTPException(
+                    status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
+                ) from None
+            results.append(result)
+
+        # Exit signal pairs with the entry log so operators can confirm
+        # response delivery and read off the per-kind verdict breakdown
+        # without correlating to a Sentry trace. The kind enum values
+        # (`single_artist`, `compilation`, `unresolved`) come from
+        # `BulkResolveResultKind` and are what the LML#355 audit needed when
+        # it had to fall back to local-cache simulation.
+        kinds = Counter(r.kind.value for r in results)
+        logger.info(
+            "bulk resolve complete: inputs=%d single_artist=%d compilation=%d unresolved=%d",
+            inputs_count,
+            kinds.get("single_artist", 0),
+            kinds.get("compilation", 0),
+            kinds.get("unresolved", 0),
+        )
+        http_span.set_data("lml.bulk_resolve.single_artist", kinds.get("single_artist", 0))
+        http_span.set_data("lml.bulk_resolve.compilation", kinds.get("compilation", 0))
+        http_span.set_data("lml.bulk_resolve.unresolved", kinds.get("unresolved", 0))
+        http_span.set_data("http.status_code", 200)
 
     return BulkResolveLibrariesResponse(results=results)

--- a/identity/router.py
+++ b/identity/router.py
@@ -13,6 +13,7 @@ Provides:
   rules. Composition lives in ``identity/bulk_resolve.py``.
 """
 
+import asyncio
 import logging
 from collections import Counter
 
@@ -217,12 +218,16 @@ async def bulk_resolve_libraries(
 
     store = _require_entity_store(entity_store)
 
-    # Entry signal (LML#430, sibling-of-#371). Fires synchronously before any
-    # awaits, so a handler that later hangs past the caller's AbortController
-    # still leaves a trace — uvicorn's access log and Sentry's automatic
-    # `http.server` transaction only commit on response completion, and the
-    # LML#355 audit hit exactly that gap (zero spans for 60 batches over the
-    # 2026-05-20 prod dry-run despite the handler running).
+    # Entry signal (LML#430, sibling-of-#371). Fires before the per-input PG
+    # loop, so a handler that hangs inside the loop still leaves a trace —
+    # uvicorn's access log and Sentry's automatic `http.server` transaction
+    # only commit on response completion, and the LML#355 audit hit exactly
+    # that gap (zero spans for 60 batches over the 2026-05-20 prod dry-run
+    # despite the handler running). Note: `await http_request.json()` above
+    # ran before this point, so the "before any awaits" guarantee is for the
+    # downstream loop only; a hang during JSON parse is not covered here, but
+    # body parse is bounded by request size and was not the LML#355 failure
+    # mode.
     inputs_count = len(request.inputs)
     logger.info("bulk resolve start: inputs=%d", inputs_count)
 
@@ -241,46 +246,69 @@ async def bulk_resolve_libraries(
         http_span.set_data("lml.bulk_resolve.inputs", inputs_count)
 
         results = []
-        for input_row in request.inputs:
-            if is_compilation_artist(input_row.artist_name):
-                results.append(compilation_result(input_row.library_id))
-                continue
+        try:
+            for input_row in request.inputs:
+                if is_compilation_artist(input_row.artist_name):
+                    results.append(compilation_result(input_row.library_id))
+                    continue
 
-            try:
-                # Three-leg fall-through lookup (issues #274 / #276): exact
-                # match first (handles the 99.8% dominant case where Backend's
-                # `library.artist_name` shape equals storage), then case-
-                # insensitive `LOWER()` (catches pure case drift), then
-                # canonical form (catches diacritic / `&`-vs-`and` /
-                # smart-quote / etc. divergence when storage happens to be
-                # canonical). Strictly ≥ legacy `get_identity()` hit rate.
-                identity: Identity | None = await store.resolve_library_name(input_row.artist_name)
-            except (PostgresError, OSError):
-                # Fail closed on partial PG failure — the caller cannot
-                # distinguish "row had no identity" from "PG died before this
-                # row was tried". Same posture as ``/identity/bulk``.
-                logger.exception(
-                    "Entity store query failed mid-bulk-resolve for library_id=%d artist_name=%r",
-                    input_row.library_id,
-                    input_row.artist_name,
-                )
-                http_span.set_data("http.status_code", 503)
-                raise HTTPException(
-                    status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
-                ) from None
+                try:
+                    # Three-leg fall-through lookup (issues #274 / #276): exact
+                    # match first (handles the 99.8% dominant case where
+                    # Backend's `library.artist_name` shape equals storage),
+                    # then case-insensitive `LOWER()` (catches pure case
+                    # drift), then canonical form (catches diacritic /
+                    # `&`-vs-`and` / smart-quote / etc. divergence when
+                    # storage happens to be canonical). Strictly ≥ legacy
+                    # `get_identity()` hit rate.
+                    identity: Identity | None = await store.resolve_library_name(
+                        input_row.artist_name
+                    )
+                except (PostgresError, OSError):
+                    # Fail closed on partial PG failure — the caller cannot
+                    # distinguish "row had no identity" from "PG died before
+                    # this row was tried". Same posture as ``/identity/bulk``.
+                    logger.exception(
+                        "Entity store query failed mid-bulk-resolve for "
+                        "library_id=%d artist_name=%r",
+                        input_row.library_id,
+                        input_row.artist_name,
+                    )
+                    http_span.set_data("http.status_code", 503)
+                    raise HTTPException(
+                        status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
+                    ) from None
 
-            try:
-                result = await compose_for_identity(input_row.library_id, identity, store)
-            except (PostgresError, OSError):
-                logger.exception(
-                    "Provenance fetch failed mid-bulk-resolve for library_id=%d",
-                    input_row.library_id,
-                )
-                http_span.set_data("http.status_code", 503)
-                raise HTTPException(
-                    status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
-                ) from None
-            results.append(result)
+                try:
+                    result = await compose_for_identity(input_row.library_id, identity, store)
+                except (PostgresError, OSError):
+                    logger.exception(
+                        "Provenance fetch failed mid-bulk-resolve for library_id=%d",
+                        input_row.library_id,
+                    )
+                    http_span.set_data("http.status_code", 503)
+                    raise HTTPException(
+                        status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
+                    ) from None
+                results.append(result)
+        except asyncio.CancelledError:
+            # Client aborted mid-loop. The sequential per-input loop has no
+            # gather/sentinel structure (unlike PR #417's `/lookup/bulk`
+            # shape), so CancelledError raised at the next `await` point is
+            # the only abort signal we get. Pin 499 on the span before
+            # re-raising so the audit-style query
+            # `op:http.server http.status_code:499` surfaces these in Sentry,
+            # and emit a warn log so Railway also carries the record.
+            # CancelledError is re-raised (not converted to HTTPException) —
+            # the asyncio cancellation contract requires this, and the client
+            # is gone anyway so there is nobody to read a 499 response.
+            http_span.set_data("http.status_code", 499)
+            logger.warning(
+                "bulk resolve aborted by client: inputs=%d processed=%d",
+                inputs_count,
+                len(results),
+            )
+            raise
 
         # Exit signal pairs with the entry log so operators can confirm
         # response delivery and read off the per-kind verdict breakdown

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -309,10 +309,13 @@ class TestBulkResolveObservability:
 
     These tests pin the defensive instrumentation that closes the gap on this
     sibling endpoint, mirroring the shape PR #417 landed for `/lookup/bulk`:
-    1. An ``INFO`` log at handler entry carrying `inputs=<N>` — fires BEFORE
-       any awaits, so a totally-hung handler still produces this signal.
+    1. An ``INFO`` log at handler entry carrying `inputs=<N>` — fires before
+       the per-input PG loop, so a handler that hangs in the loop still
+       produces this signal.
     2. An ``INFO`` log at handler exit carrying the per-kind verdict counts.
     3. An explicit Sentry ``http.server`` span tied to the bulk-resolve route.
+    4. A ``http.status_code=499`` pin on the span when the client aborts
+       mid-loop (CancelledError caught and re-raised).
 
     The matching production change is in
     ``identity/router.py:bulk_resolve_libraries``.
@@ -409,6 +412,90 @@ class TestBulkResolveObservability:
         assert "single_artist" in exit_msg, exit_msg
         assert "compilation" in exit_msg, exit_msg
         assert "unresolved" in exit_msg, exit_msg
+
+    @pytest.mark.asyncio
+    async def test_499_set_on_span_when_client_aborts_mid_loop(
+        self, app_client, mock_entity_store, caplog
+    ):
+        """Mid-loop CancelledError → http.status_code=499 on span + warn log.
+
+        The sequential per-input loop has no gather/sentinel structure (unlike
+        PR #417's `/lookup/bulk` shape), so the only signal of a client abort
+        is the `asyncio.CancelledError` raised at the next `await` point.
+        Without an explicit catch the span closes with no ``http.status_code``
+        set, and the audit-style query
+        ``op:http.server http.status_code:499`` returns nothing.
+
+        The handler must catch ``CancelledError``, pin 499 on the span, emit
+        a warn log so Railway carries a record, and re-raise so the asyncio
+        cancellation contract is honored.
+        """
+        import asyncio
+        import logging
+        from unittest.mock import MagicMock
+
+        async def cancel_mid_lookup(name: str):
+            raise asyncio.CancelledError()
+
+        mock_entity_store.resolve_library_name.side_effect = cancel_mid_lookup
+
+        # Capture the span so we can assert set_data calls after the request
+        # raises out of the test client.
+        span_mock = MagicMock()
+        span_cm = MagicMock()
+        span_cm.__enter__ = MagicMock(return_value=span_mock)
+        span_cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("identity.router.sentry_sdk.start_span", return_value=span_cm):
+            with caplog.at_level(logging.WARNING, logger="identity.router"):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app_client), base_url="http://test"
+                ) as ac:
+                    # CancelledError propagating out of the handler surfaces to
+                    # the test client as a connection-level exception. We don't
+                    # care which exact class — only that the span was tagged
+                    # 499 and the warn log fired before the re-raise. Use a
+                    # bare try/except (rather than pytest.raises(BaseException),
+                    # which trips B017) so any exception class — including
+                    # CancelledError, which subclasses BaseException not
+                    # Exception — is captured.
+                    raised: BaseException | None = None
+                    try:
+                        await ac.post(
+                            "/api/v1/identity/bulk-resolve-libraries",
+                            json={
+                                "inputs": [
+                                    {
+                                        "library_id": 1,
+                                        "artist_name": "Juana Molina",
+                                        "album_title": "DOGA",
+                                    }
+                                ]
+                            },
+                        )
+                    except BaseException as e:
+                        raised = e
+                    assert raised is not None, (
+                        "Expected CancelledError (or wrapped client-abort exception) "
+                        "to propagate out of the test client; nothing raised."
+                    )
+
+        status_data_calls = [
+            c for c in span_mock.set_data.call_args_list if c.args[0] == "http.status_code"
+        ]
+        assert any(c.args[1] == 499 for c in status_data_calls), (
+            f"Expected http.status_code=499 on span; saw: {status_data_calls}"
+        )
+
+        abort_logs = [
+            r
+            for r in caplog.records
+            if "abort" in r.message.lower() or "client" in r.message.lower()
+        ]
+        assert abort_logs, (
+            f"Expected a warn log mentioning the client abort; got: "
+            f"{[r.message for r in caplog.records]}"
+        )
 
     @pytest.mark.asyncio
     async def test_http_server_span_emitted(self, app_client, mock_entity_store):

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -6,9 +6,10 @@ internals are covered separately in `test_bulk_resolve_composer.py`.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
+import sentry_sdk
 from httpx import ASGITransport, AsyncClient
 
 from entity.store import Identity
@@ -294,3 +295,159 @@ class TestBulkResolveLibrariesEndpoint:
 
         assert resp.status_code == 422
         mock_entity_store.resolve_library_name.assert_not_awaited()
+
+
+class TestBulkResolveObservability:
+    """Entry/exit instrumentation pins (LML#430, sibling of #371 / PR #417).
+
+    The bulk-resolve-libraries route emits no `http.server` Sentry spans and no
+    log lines visible to Sentry — the [#355](https://github.com/WXYC/library-metadata-lookup/issues/355)
+    audit's prescribed Sentry pivot couldn't run because of this gap. The same
+    root cause as #371 applies: FastAPI integration's automatic transaction
+    commits on response completion, so a handler that hangs past the caller's
+    AbortController leaves zero server-side signal.
+
+    These tests pin the defensive instrumentation that closes the gap on this
+    sibling endpoint, mirroring the shape PR #417 landed for `/lookup/bulk`:
+    1. An ``INFO`` log at handler entry carrying `inputs=<N>` — fires BEFORE
+       any awaits, so a totally-hung handler still produces this signal.
+    2. An ``INFO`` log at handler exit carrying the per-kind verdict counts.
+    3. An explicit Sentry ``http.server`` span tied to the bulk-resolve route.
+
+    The matching production change is in
+    ``identity/router.py:bulk_resolve_libraries``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_entry_log_includes_inputs_count(self, app_client, mock_entity_store, caplog):
+        """An INFO log fires at handler entry with inputs=N.
+
+        Load-bearing observability signal — synchronous fire before any awaits
+        means a hung handler still produces this line. Pins the entry-log
+        shape so refactors don't accidentally drop it.
+        """
+        import logging
+
+        mock_entity_store.resolve_library_name.return_value = None
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            with caplog.at_level(logging.INFO, logger="identity.router"):
+                resp = await ac.post(
+                    "/api/v1/identity/bulk-resolve-libraries",
+                    json={
+                        "inputs": [
+                            {"library_id": 1, "artist_name": "Juana Molina", "album_title": "DOGA"},
+                            {"library_id": 2, "artist_name": "Stereolab", "album_title": "AT"},
+                            {"library_id": 3, "artist_name": "Cat Power", "album_title": "Moon"},
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 200
+        entry_records = [
+            r for r in caplog.records if "bulk resolve" in r.message and "start" in r.message
+        ]
+        assert entry_records, (
+            "Expected an INFO log at bulk-resolve handler entry; got logs: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        entry_msg = entry_records[0].message
+        assert "3" in entry_msg, f"Entry log missing inputs count: {entry_msg!r}"
+
+    @pytest.mark.asyncio
+    async def test_exit_log_includes_verdict_counts(self, app_client, mock_entity_store, caplog):
+        """An INFO log fires at handler exit carrying per-kind verdict counts.
+
+        Pairs with the entry log — operators can read off the
+        single_artist / compilation / unresolved breakdown directly from
+        Railway without correlating to a Sentry trace.
+        """
+        import logging
+
+        async def resolve(name: str):
+            if name == "Stereolab":
+                return _identity("Stereolab", id=1, discogs_artist_id=2154)
+            return None
+
+        mock_entity_store.resolve_library_name.side_effect = resolve
+        mock_entity_store.get_latest_provenance_by_source.return_value = {}
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            with caplog.at_level(logging.INFO, logger="identity.router"):
+                resp = await ac.post(
+                    "/api/v1/identity/bulk-resolve-libraries",
+                    json={
+                        "inputs": [
+                            {
+                                "library_id": 1,
+                                "artist_name": "Various Artists",
+                                "album_title": "VA",
+                            },
+                            {"library_id": 2, "artist_name": "Stereolab", "album_title": "AT"},
+                            {"library_id": 3, "artist_name": "Unknown", "album_title": "X"},
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 200
+        exit_records = [
+            r for r in caplog.records if "bulk resolve" in r.message and "complete" in r.message
+        ]
+        assert exit_records, (
+            "Expected an INFO log at bulk-resolve handler exit; got logs: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        exit_msg = exit_records[0].message
+        # Pin the shape: inputs + the three kinds present. The format string
+        # may use `=` or `:` — assert on keyword presence + count values, not
+        # the exact format token.
+        assert "inputs" in exit_msg, exit_msg
+        assert "single_artist" in exit_msg, exit_msg
+        assert "compilation" in exit_msg, exit_msg
+        assert "unresolved" in exit_msg, exit_msg
+
+    @pytest.mark.asyncio
+    async def test_http_server_span_emitted(self, app_client, mock_entity_store):
+        """An explicit Sentry `http.server` span wraps the handler.
+
+        Defensive against the FastApiIntegration's automatic transaction not
+        landing for this endpoint (the gap LML#355's audit hit). With the
+        wrap, a query for `op:http.server span.description:*bulk-resolve-libraries*`
+        in the trace explorer always surfaces traffic.
+        """
+        captured_spans: list[dict] = []
+        original_start_span = sentry_sdk.start_span
+
+        def capture_start_span(*args, **kwargs):
+            captured_spans.append({"args": args, "kwargs": kwargs})
+            return original_start_span(*args, **kwargs)
+
+        mock_entity_store.resolve_library_name.return_value = None
+
+        with patch("identity.router.sentry_sdk.start_span", side_effect=capture_start_span):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/identity/bulk-resolve-libraries",
+                    json={
+                        "inputs": [
+                            {"library_id": 1, "artist_name": "Juana Molina", "album_title": "DOGA"}
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 200
+        http_server_spans = [s for s in captured_spans if s["kwargs"].get("op") == "http.server"]
+        assert http_server_spans, (
+            "Expected at least one Sentry span with op='http.server'; got ops: "
+            f"{[s['kwargs'].get('op') for s in captured_spans]}"
+        )
+        span_name = http_server_spans[0]["kwargs"].get("name", "")
+        assert "bulk-resolve-libraries" in span_name, (
+            f"Expected http.server span name to include 'bulk-resolve-libraries'; got {span_name!r}"
+        )


### PR DESCRIPTION
## Summary

- Add an INFO log at handler entry (`bulk resolve start: inputs=N`) that fires before the per-input PG loop, so a handler that hangs inside the loop still leaves a trace.
- Add an INFO log at handler exit (`bulk resolve complete: inputs=N single_artist=A compilation=B unresolved=C`) so the verdict breakdown is visible in Railway without correlating to a Sentry trace.
- Wrap the handler body in an explicit `sentry_sdk.start_span(op="http.server", name="POST /api/v1/identity/bulk-resolve-libraries")` so the route appears in the Sentry trace explorer under `op:http.server span.description:*bulk-resolve-libraries*` even when the FastApiIntegration's automatic transaction does not land.
- Project `lml.bulk_resolve.{inputs,single_artist,compilation,unresolved}` plus `http.status_code` (200, 499, or 503) onto the same span for query-time filtering.
- Catch `asyncio.CancelledError` raised mid-loop (client abort), pin `http.status_code=499` on the span, warn-log the abort with `inputs=N processed=M`, then re-raise so the asyncio cancellation contract is honored.

Mirrors the shape PR #417 landed for `/api/v1/lookup/bulk` (closing #371). Same root-cause class — both uvicorn's access log and Sentry's automatic `http.server` transaction commit on response completion, so a handler that hangs past the caller's AbortController produces zero server-side signal. The #355 audit hit exactly this: the run_id `481b448d-7424-4a86-b3cc-db9aca533882` (60 batches across 2026-05-20) generated zero `http.server` spans even though the handler was visibly running. The entry log + explicit Sentry span close that gap on this sibling endpoint.

## Note on issue #430 acceptance criterion 5

The original ticket asked for `lml.cache.*` projection onto the span (reusing `_project_cache_stats_to_transaction` from `lookup/router.py`). That criterion is **N/A for this route**: bulk-resolve-libraries does only PG lookups against `entity.identity` via `EntityStore.resolve_library_name` and `compose_for_identity` — no Discogs L1/L2 cache calls, so `lml.cache.*` counters would all be zero. The per-input verdict counts (the actual data the #355 audit was looking for) are projected as `lml.bulk_resolve.*` instead.

## Test plan

- [x] Four new pinned tests in `tests/unit/test_bulk_resolve_libraries_endpoint.py::TestBulkResolveObservability` (entry log, exit log, http.server span, 499-on-CancelledError). TDD-confirmed red against unmodified handler, green after change.
- [x] Full bulk-resolve-libraries unit file: 12/12 pass.
- [x] Full unit suite: 2023/2023 pass.
- [x] `ruff check` + `ruff format --check` + `mypy identity/router.py` all green locally.
- [ ] Sentry: confirm a new `op:http.server name:"POST /api/v1/identity/bulk-resolve-libraries"` span appears in the trace explorer after the next staging deploy.

Closes #430
