### PR TITLE
fix(racy-lazy-init): migrate get_musicbrainz_pg + DiscogsService._get_client to async_singleton

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 # health endpoint reports `unhealthy` instead of repeatedly retrying connect).
 # See WXYC/library-metadata-lookup#283.
 _library_db: LibraryDB | None = None
-_musicbrainz_pg: PgSource | None = None
 
 
 async def get_library_db(settings: Settings = Depends(get_settings)) -> LibraryDB:
@@ -193,6 +192,36 @@ async def get_discogs_cache_service(
     return service.cache_service
 
 
+async def _build_musicbrainz_pg() -> PgSource | None:
+    """Build the PgSource backing the musicbrainz-cache external-cache fallback.
+
+    Returns ``None`` when ``DATABASE_URL_MUSICBRAINZ`` is unset — the lookup
+    endpoint then gracefully degrades to discogs-only fallback (or
+    library-only when neither cache is configured). The race-free wiring
+    lives in ``async_singleton`` (LML#435 / LML#357 audit follow-up); this
+    factory just owns the config-load + log-on-failure shape, matching the
+    pattern of ``_build_discogs_pool`` and ``_build_apple_music_http_client``
+    in this same file.
+    """
+    settings = get_settings()
+    dsn = settings.database_url_musicbrainz
+    if not dsn:
+        logger.debug("DATABASE_URL_MUSICBRAINZ not set -- MB cache fallback disabled")
+        return None
+    try:
+        pg = PgSource(dsn)
+        logger.info("MusicBrainz cache source initialized")
+        return pg
+    except Exception as e:
+        logger.warning("Failed to initialize MusicBrainz cache source: %s: %s", type(e).__name__, e)
+        return None
+
+
+_get_musicbrainz_pg_singleton, _close_musicbrainz_pg_singleton = async_singleton(
+    _build_musicbrainz_pg
+)
+
+
 async def get_musicbrainz_pg(
     settings: Settings = Depends(get_settings),
 ) -> PgSource | None:
@@ -200,34 +229,18 @@ async def get_musicbrainz_pg(
 
     Used by the Phase 1.5 mojibake-recovery external-cache fallback in
     ``/api/v1/lookup``. Returns ``None`` when ``DATABASE_URL_MUSICBRAINZ`` is
-    unset so the lookup endpoint gracefully degrades to discogs-only fallback
-    (or library-only when neither cache is configured).
+    unset so the lookup endpoint gracefully degrades.
+
+    The ``settings`` argument is preserved for FastAPI DI compatibility; the
+    underlying ``async_singleton`` factory reads from ``get_settings()`` so
+    concurrent cold-start callers see a single, race-free init (LML#435).
     """
-    global _musicbrainz_pg
-
-    if _musicbrainz_pg is not None:
-        return _musicbrainz_pg
-
-    dsn = settings.database_url_musicbrainz
-    if not dsn:
-        logger.debug("DATABASE_URL_MUSICBRAINZ not set -- MB cache fallback disabled")
-        return None
-
-    try:
-        _musicbrainz_pg = PgSource(dsn)
-        logger.info("MusicBrainz cache source initialized")
-        return _musicbrainz_pg
-    except Exception as e:
-        logger.warning("Failed to initialize MusicBrainz cache source: %s: %s", type(e).__name__, e)
-        return None
+    return await _get_musicbrainz_pg_singleton()
 
 
 async def close_musicbrainz_pg() -> None:
-    """Close the musicbrainz-cache PgSource."""
-    global _musicbrainz_pg
-    if _musicbrainz_pg is not None:
-        await _musicbrainz_pg.close()
-        _musicbrainz_pg = None
+    """Close the musicbrainz-cache PgSource on app shutdown."""
+    await _close_musicbrainz_pg_singleton()
 
 
 async def _build_apple_music_http_client() -> httpx.AsyncClient:

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -197,11 +197,7 @@ async def _build_musicbrainz_pg() -> PgSource | None:
 
     Returns ``None`` when ``DATABASE_URL_MUSICBRAINZ`` is unset — the lookup
     endpoint then gracefully degrades to discogs-only fallback (or
-    library-only when neither cache is configured). The race-free wiring
-    lives in ``async_singleton`` (LML#435 / LML#357 audit follow-up); this
-    factory just owns the config-load + log-on-failure shape, matching the
-    pattern of ``_build_discogs_pool`` and ``_build_apple_music_http_client``
-    in this same file.
+    library-only when neither cache is configured).
     """
     settings = get_settings()
     dsn = settings.database_url_musicbrainz
@@ -228,12 +224,9 @@ async def get_musicbrainz_pg(
     """Get a PgSource for the musicbrainz-cache PostgreSQL DB, if configured.
 
     Used by the Phase 1.5 mojibake-recovery external-cache fallback in
-    ``/api/v1/lookup``. Returns ``None`` when ``DATABASE_URL_MUSICBRAINZ`` is
-    unset so the lookup endpoint gracefully degrades.
-
-    The ``settings`` argument is preserved for FastAPI DI compatibility; the
-    underlying ``async_singleton`` factory reads from ``get_settings()`` so
-    concurrent cold-start callers see a single, race-free init (LML#435).
+    ``/api/v1/lookup``. The ``settings`` argument looks dead but is
+    preserved for FastAPI DI compatibility — the underlying singleton
+    factory reads from ``get_settings()`` directly.
     """
     return await _get_musicbrainz_pg_singleton()
 

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -12,6 +12,7 @@ import httpx
 import sentry_sdk
 from rapidfuzz import fuzz
 from wxyc_etl.text import is_compilation_artist
+from wxyc_fastapi.http import async_singleton
 from wxyc_fastapi.observability import (
     add_breadcrumb,
     get_cache_stats_recorder,
@@ -258,26 +259,55 @@ class DiscogsService:
             raise ValueError("Provide either token or api_key+api_secret")
         self.token = token or api_key  # backward-compat for callers reading .token
         self.cache_service = cache_service
+        # Test seam: tests assign ``service._client = mock`` before any call;
+        # the singleton getter respects that pre-set value (see _get_client).
         self._client: httpx.AsyncClient | None = None
+        # Per-instance ``async_singleton`` for the HTTP client (LML#435 /
+        # LML#357 audit follow-up). One (build, close) pair per
+        # DiscogsService instance so each instance keeps its own lock-guarded
+        # client; the prior `if self._client is None: self._client = …`
+        # pattern was a lock-free lazy-init that orphaned one
+        # ``httpx.AsyncClient`` per cold-start concurrent burst. Mirrors
+        # ``clients/streaming/base.py:BaseStreamingClient`` and
+        # ``core/dependencies.py`` for the same pattern; see LML#241 / #242
+        # / #243 for the original FD-leak class.
+        self._build_client, self._close_client = async_singleton(self._make_client)
+
+    async def _make_client(self) -> httpx.AsyncClient:
+        """Construct the underlying HTTP client.
+
+        Called at most once per instance lifetime by the ``async_singleton``
+        wrapper in ``_build_client``. Carries the per-instance auth header
+        so token-vs-key/secret callers each get the right ``Authorization``.
+        """
+        return httpx.AsyncClient(
+            base_url=DISCOGS_API_BASE,
+            headers={
+                "Authorization": self._auth_header,
+                "User-Agent": "LibraryMetadataLookupService/1.0",
+            },
+            timeout=10.0,
+        )
 
     async def _get_client(self) -> httpx.AsyncClient:
-        """Get or create the HTTP client."""
-        if self._client is None:
-            self._client = httpx.AsyncClient(
-                base_url=DISCOGS_API_BASE,
-                headers={
-                    "Authorization": self._auth_header,
-                    "User-Agent": "LibraryMetadataLookupService/1.0",
-                },
-                timeout=10.0,
-            )
-        return self._client
+        """Get or create the HTTP client.
+
+        Honors a test-set ``self._client`` (tests sometimes pre-assign a
+        mock client); otherwise delegates to the singleton getter so
+        concurrent first-callers race-safely converge on one instance.
+        """
+        if self._client is not None:
+            return self._client
+        client = await self._build_client()
+        # Cache on the instance so future calls (and ``service._client``
+        # introspection in tests) see the same value the singleton holds.
+        self._client = client
+        return client
 
     async def close(self):
         """Close the HTTP client."""
-        if self._client:
-            await self._client.aclose()
-            self._client = None
+        await self._close_client()
+        self._client = None
 
     async def check_api(self) -> DiscogsApiCheckResult:
         """Probe Discogs API connectivity, classifying the failure mode.

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -262,23 +262,16 @@ class DiscogsService:
         # Test seam: tests assign ``service._client = mock`` before any call;
         # the singleton getter respects that pre-set value (see _get_client).
         self._client: httpx.AsyncClient | None = None
-        # Per-instance ``async_singleton`` for the HTTP client (LML#435 /
-        # LML#357 audit follow-up). One (build, close) pair per
-        # DiscogsService instance so each instance keeps its own lock-guarded
-        # client; the prior `if self._client is None: self._client = …`
-        # pattern was a lock-free lazy-init that orphaned one
-        # ``httpx.AsyncClient`` per cold-start concurrent burst. Mirrors
-        # ``clients/streaming/base.py:BaseStreamingClient`` and
-        # ``core/dependencies.py`` for the same pattern; see LML#241 / #242
-        # / #243 for the original FD-leak class.
+        # Per-instance singleton — see clients/streaming/base.py for the
+        # same pattern (LML#241 FD-leak class).
         self._build_client, self._close_client = async_singleton(self._make_client)
 
     async def _make_client(self) -> httpx.AsyncClient:
         """Construct the underlying HTTP client.
 
-        Called at most once per instance lifetime by the ``async_singleton``
-        wrapper in ``_build_client``. Carries the per-instance auth header
-        so token-vs-key/secret callers each get the right ``Authorization``.
+        Method (not free function) so ``self._auth_header`` closes over the
+        per-instance token-vs-key/secret distinction without threading the
+        header through ``async_singleton``'s factory signature.
         """
         return httpx.AsyncClient(
             base_url=DISCOGS_API_BASE,
@@ -305,7 +298,14 @@ class DiscogsService:
         return client
 
     async def close(self):
-        """Close the HTTP client."""
+        """Close the HTTP client.
+
+        For a test-injected ``self._client`` (a mock), the singleton's
+        internal instance is still ``None``, so ``_close_client()`` is a
+        no-op for it. Acceptable because tests use ``AsyncMock``, which
+        needs no teardown; a real pre-assigned client (only seen in tests
+        today) would be a leak.
+        """
         await self._close_client()
         self._client = None
 

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -50,6 +50,27 @@ def test_no_module_level_asyncio_lock_in_dependencies():
     )
 
 
+def test_no_global_musicbrainz_pg_in_dependencies():
+    """LML#435 (LML#357 audit follow-up): `get_musicbrainz_pg` must not use
+    the `global _musicbrainz_pg` + None-check + assign lazy-init pattern.
+
+    The pre-fix shape has a zero-width TOCTOU race today (sync `PgSource()`
+    constructor — no await between the None-check and the assignment), but
+    that race reactivates the moment anyone adds an await between them —
+    exactly the failure mode `get_entity_store` had pre-#395, where a probe
+    await opened a real race window and orphaned a PgSource per cold-start
+    burst. Pin the migration to `async_singleton` so re-introducing the
+    racy shape fails this test.
+    """
+    src = Path(deps_module.__file__).read_text()
+    assert "global _musicbrainz_pg" not in src, (
+        "core/dependencies.py uses `global _musicbrainz_pg` — the lock-free "
+        "lazy-init pattern that LML#357's audit flagged as racy. Migrate to "
+        "`async_singleton(_build_musicbrainz_pg)` (mirroring the Discogs "
+        "pool + Apple Music client pattern in the same file). See LML#435."
+    )
+
+
 # ---------------------------------------------------------------------------
 # get_library_db
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -10,6 +10,7 @@ import core.dependencies as deps_module
 from core.dependencies import (
     close_discogs_service,
     close_library_db,
+    close_musicbrainz_pg,
     get_discogs_service,
     get_library_db,
     get_posthog_client,
@@ -20,17 +21,19 @@ from core.dependencies import (
 def reset_globals():
     """Reset module-level singleton state between tests.
 
-    The Discogs service + pool singletons live inside `async_singleton`
-    closures (WXYC/library-metadata-lookup#283), so the only safe way to
+    The Discogs service + pool + musicbrainz_pg singletons live inside
+    `async_singleton` closures (#283, #435), so the only safe way to
     rebuild them between tests is via their public closers. We drive the
     coroutine with `asyncio.run` so this fixture stays sync (autouse async
     fixtures don't work for sync tests under pytest-asyncio strict mode).
     """
     deps_module._library_db = None
     asyncio.run(close_discogs_service())
+    asyncio.run(close_musicbrainz_pg())
     yield
     deps_module._library_db = None
     asyncio.run(close_discogs_service())
+    asyncio.run(close_musicbrainz_pg())
 
 
 def test_no_module_level_asyncio_lock_in_dependencies():

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -1,11 +1,13 @@
 """Unit tests for discogs/service.py."""
 
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
+import discogs.service as discogs_service_module
 from discogs.models import (
     DiscogsSearchRequest,
     DiscogsSearchResponse,
@@ -14,6 +16,27 @@ from discogs.models import (
     TrackReleasesResponse,
 )
 from discogs.service import DiscogsApiCheckResult, DiscogsService
+
+
+def test_no_lockfree_lazy_init_in_get_client():
+    """LML#435 (LML#357 audit follow-up): `DiscogsService._get_client` must
+    not use the unguarded `self._client = httpx.AsyncClient(...)` lazy-init
+    pattern.
+
+    On cold start, two concurrent first-callers both see `self._client is
+    None`, both construct a fresh `httpx.AsyncClient`, and only one is
+    retained — the orphan is never closed (1 FD leaked per process lifetime
+    per cold-start burst). Smaller magnitude than the #241 / #242 incident
+    but the same class. Migrate to per-instance `async_singleton` (mirroring
+    `clients/streaming/base.py:BaseStreamingClient`) so the race closes.
+    """
+    src = Path(discogs_service_module.__file__).read_text()
+    assert "self._client = httpx.AsyncClient(" not in src, (
+        "discogs/service.py constructs `self._client = httpx.AsyncClient(...)` "
+        "inside a lock-free lazy-init — the racy pattern LML#357's audit "
+        "flagged. Migrate to per-instance `async_singleton` (template: "
+        "clients/streaming/base.py:BaseStreamingClient). See LML#435."
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Migrates two racy lazy-inits (the remaining gaps the [#357](https://github.com/WXYC/library-metadata-lookup/issues/357) audit surfaced) to `async_singleton`:

- `core/dependencies.py:get_musicbrainz_pg` — drops the `global _musicbrainz_pg` + lock-free check/assign pattern in favor of `async_singleton(_build_musicbrainz_pg)`, mirroring `_build_discogs_pool` and `_build_apple_music_http_client` in the same file. Zero-width TOCTOU race today (sync `PgSource()` constructor); reactivates the moment anyone adds an await between check and assign — exactly the failure mode `get_entity_store` had pre-#395.
- `discogs/service.py:DiscogsService._get_client` — drops the unguarded `if self._client is None: self._client = httpx.AsyncClient(...)` lazy-init in favor of per-instance `async_singleton`, mirroring `clients/streaming/base.py:BaseStreamingClient`. Cold-start concurrent first-callers previously orphaned one `httpx.AsyncClient` per burst.

## Test plan

- [x] Two new structural pins (`test_no_global_musicbrainz_pg_in_dependencies`, `test_no_lockfree_lazy_init_in_get_client`). TDD-confirmed red against unmodified handler, green after change.
- [x] Existing behavior tests preserved: `test_get_client_creates_once`, `test_close`, `test_get_client_uses_auth_header` all still green (call-twice-returns-same-instance contract).
- [x] Full unit suite: 2031/2031 pass.
- [x] `ruff check` + `ruff format --check` + `mypy core/dependencies.py discogs/service.py` all green locally.

Closes #435
