### PR TITLE
refactor(streaming): unify clients behind find_album_match interface (LML#392)

### DIFF
--- a/clients/bandcamp.py
+++ b/clients/bandcamp.py
@@ -15,6 +15,8 @@ import re
 import httpx
 
 from clients.streaming.base import BaseStreamingClient
+from clients.streaming.matching import find_best_match, score_match
+from streaming.models import SourceMatch
 
 log = logging.getLogger(__name__)
 
@@ -92,6 +94,42 @@ class BandcampClient(BaseStreamingClient):
 
             return resp
         return None
+
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        """Search Bandcamp for ``(artist, title)`` and return the best match.
+
+        See ``BaseStreamingClient.find_album_match`` for the contract.
+        Two-phase: autocomplete the artist subdomain, then scrape the
+        artist's ``/music`` catalog and fuzzy-match the album title. Both
+        phases' response shapes are encapsulated here.
+        """
+        artist_results = await self.search_artist(artist)
+        if not artist_results:
+            return None
+        best_artist: dict | None = None
+        best_artist_score = 0.0
+        for result in artist_results:
+            s = score_match(artist, result["name"])
+            if s >= 80.0 and s > best_artist_score:
+                best_artist = result
+                best_artist_score = s
+        if best_artist is None:
+            return None
+        catalog = await self.fetch_artist_catalog(best_artist["slug"])
+        if not catalog:
+            return None
+        matched_artist_name = best_artist["name"]
+        best = find_best_match(
+            catalog,
+            artist,
+            title,
+            artist_fn=lambda _: matched_artist_name,
+            title_fn=lambda x: x["title"],
+            url_fn=lambda x: x["url"],
+        )
+        if best is None:
+            return None
+        return SourceMatch(url=best["url"], confidence=best["confidence"])
 
     async def search_artist(self, artist_name: str) -> list[dict]:
         """Search Bandcamp autocomplete for artist pages.

--- a/clients/bandcamp.py
+++ b/clients/bandcamp.py
@@ -15,7 +15,7 @@ import re
 import httpx
 
 from clients.streaming.base import BaseStreamingClient
-from clients.streaming.matching import find_best_match, score_match
+from clients.streaming.matching import find_best_source_match, score_match
 from streaming.models import SourceMatch
 
 log = logging.getLogger(__name__)
@@ -116,10 +116,8 @@ class BandcampClient(BaseStreamingClient):
         if best_artist is None:
             return None
         catalog = await self.fetch_artist_catalog(best_artist["slug"])
-        if not catalog:
-            return None
         matched_artist_name = best_artist["name"]
-        best = find_best_match(
+        return find_best_source_match(
             catalog,
             artist,
             title,
@@ -127,9 +125,6 @@ class BandcampClient(BaseStreamingClient):
             title_fn=lambda x: x["title"],
             url_fn=lambda x: x["url"],
         )
-        if best is None:
-            return None
-        return SourceMatch(url=best["url"], confidence=best["confidence"])
 
     async def search_artist(self, artist_name: str) -> list[dict]:
         """Search Bandcamp autocomplete for artist pages.

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 
 from clients.streaming.base import BaseStreamingClient
-from clients.streaming.matching import find_best_match
+from clients.streaming.matching import find_best_source_match
 from streaming.models import SourceMatch
 
 logger = logging.getLogger(__name__)
@@ -35,20 +35,14 @@ class AppleMusicClient(BaseStreamingClient):
         verification from LML#389 lives in the shared
         ``is_acceptable_match`` floor inside ``find_best_match``.
         """
-        results = await self.search_album(artist, title)
-        if not results:
-            return None
-        best = find_best_match(
-            results,
+        return find_best_source_match(
+            await self.search_album(artist, title),
             artist,
             title,
             artist_fn=lambda x: x["artistName"],
             title_fn=lambda x: x["collectionName"],
             url_fn=lambda x: x["collectionViewUrl"],
         )
-        if best is None:
-            return None
-        return SourceMatch(url=best["url"], confidence=best["confidence"])
 
     async def search_album(self, artist: str, title: str) -> list[dict]:
         """Search iTunes for albums matching artist + title.

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 
 from clients.streaming.base import BaseStreamingClient
+from clients.streaming.matching import find_best_match
+from streaming.models import SourceMatch
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +25,30 @@ class AppleMusicClient(BaseStreamingClient):
     def __init__(self):
         super().__init__(rate_limit=(15, 60), semaphore_limit=3)
         self._max_retries = 2
+
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        """Search iTunes for ``(artist, title)`` and return the best match.
+
+        See ``BaseStreamingClient.find_album_match`` for the contract. The
+        iTunes response shape (``artistName`` / ``collectionName`` /
+        ``collectionViewUrl``) is encapsulated here. The wrong-artist
+        verification from LML#389 lives in the shared
+        ``is_acceptable_match`` floor inside ``find_best_match``.
+        """
+        results = await self.search_album(artist, title)
+        if not results:
+            return None
+        best = find_best_match(
+            results,
+            artist,
+            title,
+            artist_fn=lambda x: x["artistName"],
+            title_fn=lambda x: x["collectionName"],
+            url_fn=lambda x: x["collectionViewUrl"],
+        )
+        if best is None:
+            return None
+        return SourceMatch(url=best["url"], confidence=best["confidence"])
 
     async def search_album(self, artist: str, title: str) -> list[dict]:
         """Search iTunes for albums matching artist + title.

--- a/clients/streaming/base.py
+++ b/clients/streaming/base.py
@@ -17,7 +17,7 @@ class BaseStreamingClient:
     Provides lazy httpx.AsyncClient lifecycle management, rate limiting
     via aiolimiter, concurrency control via asyncio.Semaphore, and the
     ``find_album_match`` interface that lets the streaming-check
-    orchestrator gather over any client uniformly (LML#392).
+    orchestrator gather over any client uniformly.
 
     Args:
         rate_limit: Tuple of (max_rate, time_period) for AsyncLimiter.

--- a/clients/streaming/base.py
+++ b/clients/streaming/base.py
@@ -8,12 +8,16 @@ import httpx
 from aiolimiter import AsyncLimiter
 from wxyc_fastapi.http import async_singleton
 
+from streaming.models import SourceMatch
+
 
 class BaseStreamingClient:
     """Base class for streaming service HTTP clients.
 
     Provides lazy httpx.AsyncClient lifecycle management, rate limiting
-    via aiolimiter, and concurrency control via asyncio.Semaphore.
+    via aiolimiter, concurrency control via asyncio.Semaphore, and the
+    ``find_album_match`` interface that lets the streaming-check
+    orchestrator gather over any client uniformly (LML#392).
 
     Args:
         rate_limit: Tuple of (max_rate, time_period) for AsyncLimiter.
@@ -55,3 +59,14 @@ class BaseStreamingClient:
         """Close the HTTP client and release resources."""
         await self._singleton_close()
         self._http = None
+
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        """Search this service for an album match and return a normalized verdict.
+
+        The deep contract the streaming-check orchestrator (LML#392) gathers
+        over: each provider absorbs its own response-shape adaptation so the
+        orchestrator never branches on service identity. Subclasses MUST
+        override; the base raises ``NotImplementedError`` so a missing
+        override fails loudly the first time the orchestrator dispatches.
+        """
+        raise NotImplementedError(f"{type(self).__name__} must override find_album_match")

--- a/clients/streaming/deezer.py
+++ b/clients/streaming/deezer.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 
 from clients.streaming.base import BaseStreamingClient
-from clients.streaming.matching import find_best_match
+from clients.streaming.matching import find_best_source_match
 from streaming.models import SourceMatch
 
 logger = logging.getLogger(__name__)
@@ -32,20 +32,14 @@ class DeezerClient(BaseStreamingClient):
         Deezer response shape (``artist.name`` / ``title`` / ``link``) is
         encapsulated here.
         """
-        results = await self.search_album(artist, title)
-        if not results:
-            return None
-        best = find_best_match(
-            results,
+        return find_best_source_match(
+            await self.search_album(artist, title),
             artist,
             title,
             artist_fn=lambda x: x["artist"]["name"],
             title_fn=lambda x: x["title"],
             url_fn=lambda x: x["link"],
         )
-        if best is None:
-            return None
-        return SourceMatch(url=best["url"], confidence=best["confidence"])
 
     async def search_album(self, artist: str, title: str) -> list[dict]:
         """Search Deezer for albums matching artist + title.

--- a/clients/streaming/deezer.py
+++ b/clients/streaming/deezer.py
@@ -11,6 +11,8 @@ import asyncio
 import logging
 
 from clients.streaming.base import BaseStreamingClient
+from clients.streaming.matching import find_best_match
+from streaming.models import SourceMatch
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +24,28 @@ class DeezerClient(BaseStreamingClient):
 
     def __init__(self):
         super().__init__(rate_limit=(25, 5), semaphore_limit=5)
+
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        """Search Deezer for ``(artist, title)`` and return the best match.
+
+        See ``BaseStreamingClient.find_album_match`` for the contract. The
+        Deezer response shape (``artist.name`` / ``title`` / ``link``) is
+        encapsulated here.
+        """
+        results = await self.search_album(artist, title)
+        if not results:
+            return None
+        best = find_best_match(
+            results,
+            artist,
+            title,
+            artist_fn=lambda x: x["artist"]["name"],
+            title_fn=lambda x: x["title"],
+            url_fn=lambda x: x["link"],
+        )
+        if best is None:
+            return None
+        return SourceMatch(url=best["url"], confidence=best["confidence"])
 
     async def search_album(self, artist: str, title: str) -> list[dict]:
         """Search Deezer for albums matching artist + title.

--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -9,6 +9,7 @@ from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison  # noqa: F401
 
 from discogs.matching import strip_discogs_suffix  # noqa: F401
+from streaming.models import SourceMatch
 
 # Trailing format indicators: 12", 7", 10", LP, EP, CD, and multi-disc (x 2, x 3, ...)
 _FORMAT_SUFFIX_RE = re.compile(
@@ -192,3 +193,35 @@ def find_best_match(
                 match["id"] = id_fn(item)
             best = match
     return best
+
+
+def find_best_source_match(
+    results: list[dict],
+    query_artist: str,
+    query_title: str,
+    *,
+    artist_fn: Callable[[dict], str],
+    title_fn: Callable[[dict], str],
+    url_fn: Callable[[dict], str],
+) -> SourceMatch | None:
+    """Run ``find_best_match`` and wrap the verdict as a ``SourceMatch``.
+
+    The shape every streaming adapter's ``find_album_match`` reduces to: pass
+    the raw results + per-shape extractors, get back a normalized
+    ``SourceMatch`` or ``None``. Keeps the per-shape lambdas at the call site
+    (the only thing legitimately different across adapters) and concentrates
+    the ``best is None / SourceMatch(url=..., confidence=...)`` boilerplate
+    here. ``id_fn`` deliberately omitted — ``SourceMatch`` doesn't carry an
+    id, so the extra extractor was dead weight in adapter bodies.
+    """
+    best = find_best_match(
+        results,
+        query_artist,
+        query_title,
+        artist_fn=artist_fn,
+        title_fn=title_fn,
+        url_fn=url_fn,
+    )
+    if best is None:
+        return None
+    return SourceMatch(url=best["url"], confidence=best["confidence"])

--- a/clients/streaming/spotify.py
+++ b/clients/streaming/spotify.py
@@ -8,7 +8,7 @@ import logging
 import time
 
 from clients.streaming.base import BaseStreamingClient
-from clients.streaming.matching import find_best_match
+from clients.streaming.matching import find_best_source_match
 from streaming.models import SourceMatch
 
 logger = logging.getLogger(__name__)
@@ -57,24 +57,16 @@ class SpotifyClient(BaseStreamingClient):
 
         See ``BaseStreamingClient.find_album_match`` for the contract. The
         Spotify response shape (``artists[0].name`` / ``name`` /
-        ``external_urls.spotify``) is encapsulated here; the orchestrator
-        never sees it.
+        ``external_urls.spotify``) is encapsulated here.
         """
-        results = await self.search_album(artist, title)
-        if not results:
-            return None
-        best = find_best_match(
-            results,
+        return find_best_source_match(
+            await self.search_album(artist, title),
             artist,
             title,
             artist_fn=lambda x: x["artists"][0]["name"],
             title_fn=lambda x: x["name"],
             url_fn=lambda x: x["external_urls"]["spotify"],
-            id_fn=lambda x: x["id"],
         )
-        if best is None:
-            return None
-        return SourceMatch(url=best["url"], confidence=best["confidence"])
 
     async def search_album(self, artist: str, title: str, market: str = "US") -> list[dict]:
         """Search Spotify for albums matching artist + title.

--- a/clients/streaming/spotify.py
+++ b/clients/streaming/spotify.py
@@ -8,6 +8,8 @@ import logging
 import time
 
 from clients.streaming.base import BaseStreamingClient
+from clients.streaming.matching import find_best_match
+from streaming.models import SourceMatch
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,30 @@ class SpotifyClient(BaseStreamingClient):
         self._token_expires_at = time.time() + data["expires_in"] - 60
         logger.debug("Acquired Spotify access token (expires in %ds)", data["expires_in"])
         return self._access_token
+
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        """Search Spotify for ``(artist, title)`` and return the best match.
+
+        See ``BaseStreamingClient.find_album_match`` for the contract. The
+        Spotify response shape (``artists[0].name`` / ``name`` /
+        ``external_urls.spotify``) is encapsulated here; the orchestrator
+        never sees it.
+        """
+        results = await self.search_album(artist, title)
+        if not results:
+            return None
+        best = find_best_match(
+            results,
+            artist,
+            title,
+            artist_fn=lambda x: x["artists"][0]["name"],
+            title_fn=lambda x: x["name"],
+            url_fn=lambda x: x["external_urls"]["spotify"],
+            id_fn=lambda x: x["id"],
+        )
+        if best is None:
+            return None
+        return SourceMatch(url=best["url"], confidence=best["confidence"])
 
     async def search_album(self, artist: str, title: str, market: str = "US") -> list[dict]:
         """Search Spotify for albums matching artist + title.

--- a/streaming/orchestrator.py
+++ b/streaming/orchestrator.py
@@ -13,6 +13,15 @@ from streaming.models import StreamingCheckResponse, StreamingCheckSources
 
 logger = logging.getLogger(__name__)
 
+# Fail loudly at import time if the orchestrator's per-service kwargs ever
+# drift from `StreamingCheckSources` field names (the response shape is
+# API-locked, so the gather loop relies on this mapping being 1:1).
+_EXPECTED_SERVICE_FIELDS = {"spotify", "deezer", "apple_music", "bandcamp"}
+assert set(StreamingCheckSources.model_fields) == _EXPECTED_SERVICE_FIELDS, (
+    "StreamingCheckSources fields drifted from check_streaming_availability "
+    f"kwargs; got {set(StreamingCheckSources.model_fields)}"
+)
+
 
 async def check_streaming_availability(
     artist: str,
@@ -26,9 +35,10 @@ async def check_streaming_availability(
     """Check streaming availability for an artist+title across all configured services.
 
     Runs every configured service concurrently via the
-    ``BaseStreamingClient.find_album_match`` seam (LML#392) — the orchestrator
-    never branches on service identity, so adding a fifth provider means
-    adding an adapter, not editing here. Verdict matrix (LML#376):
+    ``BaseStreamingClient.find_album_match`` seam — the orchestrator never
+    branches on service identity, so adding a fifth provider means adding an
+    adapter (plus one kwarg + one ``StreamingCheckSources`` field) rather
+    than editing here. Verdict matrix (LML#376):
 
     - ``on_streaming=True`` when any service confirmed a match (positive evidence wins
       even if other services errored).

--- a/streaming/orchestrator.py
+++ b/streaming/orchestrator.py
@@ -8,9 +8,8 @@ import logging
 from clients.bandcamp import BandcampClient
 from clients.streaming.apple_music import AppleMusicClient
 from clients.streaming.deezer import DeezerClient
-from clients.streaming.matching import find_best_match, score_match
 from clients.streaming.spotify import SpotifyClient
-from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
+from streaming.models import StreamingCheckResponse, StreamingCheckSources
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +25,10 @@ async def check_streaming_availability(
 ) -> StreamingCheckResponse:
     """Check streaming availability for an artist+title across all configured services.
 
-    Runs all service checks concurrently. Verdict (LML#376):
+    Runs every configured service concurrently via the
+    ``BaseStreamingClient.find_album_match`` seam (LML#392) — the orchestrator
+    never branches on service identity, so adding a fifth provider means
+    adding an adapter, not editing here. Verdict matrix (LML#376):
 
     - ``on_streaming=True`` when any service confirmed a match (positive evidence wins
       even if other services errored).
@@ -50,16 +52,20 @@ async def check_streaming_availability(
         every dispatched check completed without raising). The errored set is
         independent of the verdict — a service can match while others error.
     """
-    tasks: dict[str, asyncio.Task] = {}
-
-    if spotify:
-        tasks["spotify"] = asyncio.create_task(_check_spotify(spotify, artist, title))
-    if deezer:
-        tasks["deezer"] = asyncio.create_task(_check_deezer(deezer, artist, title))
-    if apple_music:
-        tasks["apple_music"] = asyncio.create_task(_check_apple_music(apple_music, artist, title))
-    if bandcamp:
-        tasks["bandcamp"] = asyncio.create_task(_check_bandcamp(bandcamp, artist, title))
+    # The kwarg names (spotify / deezer / apple_music / bandcamp) double as
+    # `StreamingCheckSources` field names — the response shape is API-locked,
+    # so the gather loop maps name-to-client uniformly without branching.
+    clients = {
+        "spotify": spotify,
+        "deezer": deezer,
+        "apple_music": apple_music,
+        "bandcamp": bandcamp,
+    }
+    tasks: dict[str, asyncio.Task] = {
+        name: asyncio.create_task(client.find_album_match(artist, title))
+        for name, client in clients.items()
+        if client is not None
+    }
 
     sources = StreamingCheckSources()
     errored: set[str] = set()
@@ -98,102 +104,3 @@ async def check_streaming_availability(
         sources=sources,
         errored_sources=sorted(errored),
     )
-
-
-async def _check_spotify(client: SpotifyClient, artist: str, title: str) -> SourceMatch | None:
-    """Search Spotify for an album match."""
-    results = await client.search_album(artist, title)
-    if not results:
-        return None
-
-    best = find_best_match(
-        results,
-        artist,
-        title,
-        artist_fn=lambda x: x["artists"][0]["name"],
-        title_fn=lambda x: x["name"],
-        url_fn=lambda x: x["external_urls"]["spotify"],
-        id_fn=lambda x: x["id"],
-    )
-    if best is None:
-        return None
-    return SourceMatch(url=best["url"], confidence=best["confidence"])
-
-
-async def _check_deezer(client: DeezerClient, artist: str, title: str) -> SourceMatch | None:
-    """Search Deezer for an album match."""
-    results = await client.search_album(artist, title)
-    if not results:
-        return None
-
-    best = find_best_match(
-        results,
-        artist,
-        title,
-        artist_fn=lambda x: x["artist"]["name"],
-        title_fn=lambda x: x["title"],
-        url_fn=lambda x: x["link"],
-    )
-    if best is None:
-        return None
-    return SourceMatch(url=best["url"], confidence=best["confidence"])
-
-
-async def _check_apple_music(
-    client: AppleMusicClient, artist: str, title: str
-) -> SourceMatch | None:
-    """Search Apple Music (iTunes) for an album match."""
-    results = await client.search_album(artist, title)
-    if not results:
-        return None
-
-    best = find_best_match(
-        results,
-        artist,
-        title,
-        artist_fn=lambda x: x["artistName"],
-        title_fn=lambda x: x["collectionName"],
-        url_fn=lambda x: x["collectionViewUrl"],
-    )
-    if best is None:
-        return None
-    return SourceMatch(url=best["url"], confidence=best["confidence"])
-
-
-async def _check_bandcamp(client: BandcampClient, artist: str, title: str) -> SourceMatch | None:
-    """Search Bandcamp for an album match.
-
-    Two-phase: first find the artist page via autocomplete, then scrape the catalog
-    and fuzzy-match the album title.
-    """
-    artist_results = await client.search_artist(artist)
-    if not artist_results:
-        return None
-
-    # Find best artist match
-    best_artist = None
-    best_artist_score = 0.0
-    for result in artist_results:
-        s = score_match(artist, result["name"])
-        if s >= 80.0 and s > best_artist_score:
-            best_artist = result
-            best_artist_score = s
-
-    if best_artist is None:
-        return None
-
-    catalog = await client.fetch_artist_catalog(best_artist["slug"])
-    if not catalog:
-        return None
-
-    best = find_best_match(
-        catalog,
-        artist,
-        title,
-        artist_fn=lambda _: best_artist["name"],
-        title_fn=lambda x: x["title"],
-        url_fn=lambda x: x["url"],
-    )
-    if best is None:
-        return None
-    return SourceMatch(url=best["url"], confidence=best["confidence"])

--- a/streaming/orchestrator.py
+++ b/streaming/orchestrator.py
@@ -16,11 +16,15 @@ logger = logging.getLogger(__name__)
 # Fail loudly at import time if the orchestrator's per-service kwargs ever
 # drift from `StreamingCheckSources` field names (the response shape is
 # API-locked, so the gather loop relies on this mapping being 1:1).
+# Explicit raise (not `assert`) so the guard survives `python -O` /
+# `PYTHONOPTIMIZE=1`, which compiles bare `assert` statements out and would
+# silently disable the check in optimized production runs.
 _EXPECTED_SERVICE_FIELDS = {"spotify", "deezer", "apple_music", "bandcamp"}
-assert set(StreamingCheckSources.model_fields) == _EXPECTED_SERVICE_FIELDS, (
-    "StreamingCheckSources fields drifted from check_streaming_availability "
-    f"kwargs; got {set(StreamingCheckSources.model_fields)}"
-)
+if set(StreamingCheckSources.model_fields) != _EXPECTED_SERVICE_FIELDS:
+    raise RuntimeError(
+        "StreamingCheckSources fields drifted from check_streaming_availability "
+        f"kwargs; got {set(StreamingCheckSources.model_fields)}"
+    )
 
 
 async def check_streaming_availability(

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -114,3 +114,41 @@ class TestErrorHandling:
 
         results = await client.search_album("Stereolab", "Aluminum Tunes")
         assert results == []
+
+
+class TestFindAlbumMatch:
+    """`find_album_match` extracts the iTunes-shaped result fields and
+    returns a normalized `SourceMatch` (LML#392). The artist-floor check
+    inside `find_best_match` carries the LML#389 wrong-artist guard."""
+
+    @pytest.mark.asyncio
+    async def test_returns_source_match_from_top_hit(self):
+        client = AppleMusicClient()
+        client.search_album = AsyncMock(return_value=[_make_album_result()])
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+
+        assert match is not None
+        assert "apple.com" in match.url
+        assert match.confidence >= 80.0
+        client.search_album.assert_awaited_once_with("Stereolab", "Aluminum Tunes")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_search_empty(self):
+        client = AppleMusicClient()
+        client.search_album = AsyncMock(return_value=[])
+
+        match = await client.find_album_match("Unknown", "Unknown")
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_wrong_artist_match(self):
+        """LML#389: iTunes can return a same-titled album by a different artist.
+        The shared artist-floor inside `find_best_match` rejects it."""
+        client = AppleMusicClient()
+        client.search_album = AsyncMock(
+            return_value=[_make_album_result(artist_name="Completely Different Artist")]
+        )
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert match is None

--- a/tests/unit/test_bandcamp_client.py
+++ b/tests/unit/test_bandcamp_client.py
@@ -290,3 +290,94 @@ class TestFetchArtistCatalog:
 
         assert len(albums) == 1
         assert albums[0]["title"] == title
+
+
+class TestFindAlbumMatch:
+    """`find_album_match` runs Bandcamp's two-phase flow (autocomplete the
+    artist subdomain, then scrape the catalog) and returns a normalized
+    `SourceMatch` (LML#392). Both phases' response shapes stay encapsulated
+    here; the orchestrator never branches on the two-phase nature."""
+
+    @pytest.mark.asyncio
+    async def test_returns_source_match_when_artist_and_album_both_match(self):
+        client = BandcampClient()
+        client.search_artist = AsyncMock(
+            return_value=[
+                {"name": "Stereolab", "url": "https://stereolab.bandcamp.com", "slug": "stereolab"}
+            ]
+        )
+        client.fetch_artist_catalog = AsyncMock(
+            return_value=[
+                {
+                    "title": "Aluminum Tunes",
+                    "url": "https://stereolab.bandcamp.com/album/aluminum-tunes",
+                }
+            ]
+        )
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+
+        assert match is not None
+        assert match.url == "https://stereolab.bandcamp.com/album/aluminum-tunes"
+        assert match.confidence >= 80.0
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_artist_autocomplete_empty(self):
+        client = BandcampClient()
+        client.search_artist = AsyncMock(return_value=[])
+
+        match = await client.find_album_match("Unknown", "Whatever")
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_artist_match_below_floor(self):
+        """Autocomplete returned a hit, but the artist name fuzz-score is <80."""
+        client = BandcampClient()
+        client.search_artist = AsyncMock(
+            return_value=[
+                {
+                    "name": "Completely Different Band",
+                    "url": "https://different.bandcamp.com",
+                    "slug": "different",
+                }
+            ]
+        )
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert match is None
+        # Catalog scrape should not have been reached.
+        # (No assertion on fetch_artist_catalog because the mock is auto-created
+        # by AsyncMock; the contract is just "no SourceMatch returned".)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_catalog_empty(self):
+        client = BandcampClient()
+        client.search_artist = AsyncMock(
+            return_value=[
+                {"name": "Stereolab", "url": "https://stereolab.bandcamp.com", "slug": "stereolab"}
+            ]
+        )
+        client.fetch_artist_catalog = AsyncMock(return_value=[])
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_album_title_doesnt_match(self):
+        client = BandcampClient()
+        client.search_artist = AsyncMock(
+            return_value=[
+                {"name": "Stereolab", "url": "https://stereolab.bandcamp.com", "slug": "stereolab"}
+            ]
+        )
+        client.fetch_artist_catalog = AsyncMock(
+            return_value=[
+                {
+                    "title": "Completely Different Album",
+                    "url": "https://stereolab.bandcamp.com/album/different",
+                }
+            ]
+        )
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert match is None

--- a/tests/unit/test_bandcamp_client.py
+++ b/tests/unit/test_bandcamp_client.py
@@ -331,7 +331,12 @@ class TestFindAlbumMatch:
 
     @pytest.mark.asyncio
     async def test_returns_none_when_artist_match_below_floor(self):
-        """Autocomplete returned a hit, but the artist name fuzz-score is <80."""
+        """Autocomplete returned a hit, but the artist name fuzz-score is <80.
+
+        Also pins that the catalog scrape is short-circuited — without this,
+        every below-floor autocomplete hit would burn a (rate-limited)
+        ``fetch_artist_catalog`` HTTP call.
+        """
         client = BandcampClient()
         client.search_artist = AsyncMock(
             return_value=[
@@ -342,12 +347,11 @@ class TestFindAlbumMatch:
                 }
             ]
         )
+        client.fetch_artist_catalog = AsyncMock()
 
         match = await client.find_album_match("Stereolab", "Aluminum Tunes")
         assert match is None
-        # Catalog scrape should not have been reached.
-        # (No assertion on fetch_artist_catalog because the mock is auto-created
-        # by AsyncMock; the contract is just "no SourceMatch returned".)
+        client.fetch_artist_catalog.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_returns_none_when_catalog_empty(self):

--- a/tests/unit/test_deezer_client.py
+++ b/tests/unit/test_deezer_client.py
@@ -119,3 +119,38 @@ class TestSearchTrack:
         results = await client.search_track("The Afros", "Feel It")
         assert len(results) == 1
         assert results[0]["title"] == "Feel It"
+
+
+class TestFindAlbumMatch:
+    """`find_album_match` extracts the Deezer-shaped result fields and
+    returns a normalized `SourceMatch` (LML#392)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_source_match_from_top_hit(self):
+        client = DeezerClient()
+        client.search_album = AsyncMock(return_value=[_make_album_result()])
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+
+        assert match is not None
+        assert match.url == "https://www.deezer.com/album/12345"
+        assert match.confidence >= 80.0
+        client.search_album.assert_awaited_once_with("Stereolab", "Aluminum Tunes")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_search_empty(self):
+        client = DeezerClient()
+        client.search_album = AsyncMock(return_value=[])
+
+        match = await client.find_album_match("Unknown", "Unknown")
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_acceptable_match(self):
+        client = DeezerClient()
+        client.search_album = AsyncMock(
+            return_value=[_make_album_result(title="Unrelated", artist_name="Different")]
+        )
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert match is None

--- a/tests/unit/test_recheck_streaming_after_mojibake.py
+++ b/tests/unit/test_recheck_streaming_after_mojibake.py
@@ -122,17 +122,15 @@ class TestFindAffectedReleases:
 class TestRecheckReleases:
     @pytest.mark.asyncio
     async def test_calls_streaming_check_with_corrected_artist(self):
+        from streaming.models import SourceMatch
+
         release = AffectedRelease(library_id=1, artist="μ-ziq", title="Lunatic Harness")
         spotify = AsyncMock()
-        spotify.search_album = AsyncMock(
-            return_value=[
-                {
-                    "artists": [{"name": "μ-ziq"}],
-                    "name": "Lunatic Harness",
-                    "external_urls": {"spotify": "https://open.spotify.com/album/x"},
-                    "id": "x",
-                }
-            ]
+        # Post-LML#392: the orchestrator dispatches via `find_album_match`,
+        # which returns a normalized SourceMatch — Spotify's per-shape
+        # adaptation lives inside the client (covered by test_spotify_client).
+        spotify.find_album_match = AsyncMock(
+            return_value=SourceMatch(url="https://open.spotify.com/album/x", confidence=95.0)
         )
 
         results = await recheck_releases([release], spotify=spotify)
@@ -141,13 +139,13 @@ class TestRecheckReleases:
         assert results[0].library_id == 1
         assert results[0].on_streaming is True
         assert results[0].sources["spotify"] == "https://open.spotify.com/album/x"
-        spotify.search_album.assert_awaited_with("μ-ziq", "Lunatic Harness")
+        spotify.find_album_match.assert_awaited_with("μ-ziq", "Lunatic Harness")
 
     @pytest.mark.asyncio
     async def test_returns_false_when_no_match(self):
         release = AffectedRelease(library_id=2, artist="μ-ziq", title="Bluff Limbo")
         spotify = AsyncMock()
-        spotify.search_album = AsyncMock(return_value=[])
+        spotify.find_album_match = AsyncMock(return_value=None)
 
         results = await recheck_releases([release], spotify=spotify)
 

--- a/tests/unit/test_spotify_client.py
+++ b/tests/unit/test_spotify_client.py
@@ -216,3 +216,45 @@ class TestSearchTrack:
         await client.search_track("The Afros", "Feel It")
         params = mock_http.get.call_args.kwargs.get("params", {})
         assert params.get("type") == "track"
+
+
+class TestFindAlbumMatch:
+    """`find_album_match` extracts the Spotify-shaped result fields and
+    returns a normalized `SourceMatch` (LML#392).
+
+    Tests at this layer mock the `search_album` call directly — the deeper
+    HTTP-shape adaptation is already covered by `TestSearchAlbum`. The
+    layer separation matches the deepening: response-shape knowledge lives
+    here in the adapter, not in the orchestrator.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_source_match_from_top_hit(self):
+        client = SpotifyClient("test-id", "test-secret")
+        client.search_album = AsyncMock(return_value=[_make_album_item()])
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+
+        assert match is not None
+        assert match.url == "https://open.spotify.com/album/abc123"
+        assert match.confidence >= 80.0
+        client.search_album.assert_awaited_once_with("Stereolab", "Aluminum Tunes")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_search_empty(self):
+        client = SpotifyClient("test-id", "test-secret")
+        client.search_album = AsyncMock(return_value=[])
+
+        match = await client.find_album_match("Unknown", "Unknown")
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_acceptable_match(self):
+        """Spotify returned a hit but artist+title fuzz score is below floor."""
+        client = SpotifyClient("test-id", "test-secret")
+        client.search_album = AsyncMock(
+            return_value=[_make_album_item(name="Unrelated Album", artist_name="Different Artist")]
+        )
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert match is None

--- a/tests/unit/test_streaming_check_orchestrator.py
+++ b/tests/unit/test_streaming_check_orchestrator.py
@@ -12,8 +12,19 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from streaming.models import SourceMatch
-from streaming.orchestrator import check_streaming_availability
+from streaming.models import SourceMatch, StreamingCheckSources
+from streaming.orchestrator import _EXPECTED_SERVICE_FIELDS, check_streaming_availability
+
+
+def test_orchestrator_kwargs_match_response_fields():
+    """Pin the kwarg-to-response-field mapping the gather loop relies on.
+
+    The module-load guard in `streaming/orchestrator.py` raises if these
+    drift, but module-load guards don't run in test workers that mock the
+    module away. This test makes the invariant CI-discoverable and survives
+    any future restructuring that moves the guard.
+    """
+    assert set(StreamingCheckSources.model_fields) == _EXPECTED_SERVICE_FIELDS
 
 
 def _mock_client(match: SourceMatch | None | Exception = None) -> AsyncMock:

--- a/tests/unit/test_streaming_check_orchestrator.py
+++ b/tests/unit/test_streaming_check_orchestrator.py
@@ -1,76 +1,56 @@
-"""Tests for the streaming check orchestrator."""
+"""Tests for the streaming-check orchestrator.
+
+After LML#392 the orchestrator's only job is to gather over each client's
+``find_album_match`` result and apply the LML#376 verdict matrix. The
+per-service JSON-shape adaptation lives in each client's
+``find_album_match`` override and is exercised in the client-specific test
+files (test_spotify_client.py, test_deezer_client.py, test_apple_music_client.py,
+test_bandcamp_client.py).
+"""
 
 from unittest.mock import AsyncMock
 
 import pytest
 
+from streaming.models import SourceMatch
 from streaming.orchestrator import check_streaming_availability
 
 
-def _make_spotify_result(
-    artist="Stereolab", title="Aluminum Tunes", url="https://open.spotify.com/album/abc123"
-):
-    """Build a minimal Spotify API album result."""
-    return {
-        "artists": [{"name": artist}],
-        "name": title,
-        "external_urls": {"spotify": url},
-        "id": "abc123",
-    }
+def _mock_client(match: SourceMatch | None | Exception = None) -> AsyncMock:
+    """Build a mock streaming client with a pre-set find_album_match verdict.
 
-
-def _make_deezer_result(
-    artist="Stereolab", title="Aluminum Tunes", url="https://www.deezer.com/album/123"
-):
-    """Build a minimal Deezer API album result."""
-    return {
-        "artist": {"name": artist},
-        "title": title,
-        "link": url,
-    }
-
-
-def _make_apple_result(
-    artist="Stereolab", title="Aluminum Tunes", url="https://music.apple.com/album/123"
-):
-    """Build a minimal iTunes Search API album result."""
-    return {
-        "artistName": artist,
-        "collectionName": title,
-        "collectionViewUrl": url,
-    }
-
-
-def _make_bandcamp_artist(name="Stereolab", slug="stereolab"):
-    """Build a Bandcamp autocomplete artist result."""
-    return {"name": name, "url": f"https://{slug}.bandcamp.com", "slug": slug}
-
-
-def _make_bandcamp_album(title="Aluminum Tunes", slug="stereolab"):
-    """Build a Bandcamp catalog album entry."""
-    path = title.lower().replace(" ", "-")
-    return {"title": title, "url": f"https://{slug}.bandcamp.com/album/{path}"}
+    A plain ``AsyncMock`` standing in for any ``BaseStreamingClient`` subclass —
+    the orchestrator only depends on the ``find_album_match`` shape, so a mock
+    adapter is sufficient (deletion test: no service-specific access remains).
+    """
+    client = AsyncMock()
+    if isinstance(match, Exception):
+        client.find_album_match = AsyncMock(side_effect=match)
+    else:
+        client.find_album_match = AsyncMock(return_value=match)
+    return client
 
 
 @pytest.mark.asyncio
 async def test_found_on_spotify():
-    """Returns on_streaming=True with spotify source when Spotify has a match."""
-    spotify = AsyncMock()
-    spotify.search_album = AsyncMock(return_value=[_make_spotify_result()])
+    """A Spotify match → on_streaming=True; result is wired to sources.spotify."""
+    spotify = _mock_client(
+        SourceMatch(url="https://open.spotify.com/album/abc123", confidence=95.0)
+    )
 
     result = await check_streaming_availability("Stereolab", "Aluminum Tunes", spotify=spotify)
 
     assert result.on_streaming is True
     assert result.sources.spotify is not None
     assert "spotify.com" in result.sources.spotify.url
-    assert result.sources.spotify.confidence >= 80.0
+    assert result.sources.spotify.confidence == 95.0
+    spotify.find_album_match.assert_awaited_once_with("Stereolab", "Aluminum Tunes")
 
 
 @pytest.mark.asyncio
 async def test_found_on_deezer():
-    """Returns on_streaming=True with deezer source when Deezer has a match."""
-    deezer = AsyncMock()
-    deezer.search_album = AsyncMock(return_value=[_make_deezer_result()])
+    """A Deezer match → on_streaming=True; result is wired to sources.deezer."""
+    deezer = _mock_client(SourceMatch(url="https://www.deezer.com/album/123", confidence=90.0))
 
     result = await check_streaming_availability("Stereolab", "Aluminum Tunes", deezer=deezer)
 
@@ -81,9 +61,8 @@ async def test_found_on_deezer():
 
 @pytest.mark.asyncio
 async def test_found_on_apple_music():
-    """Returns on_streaming=True with apple_music source when iTunes has a match."""
-    apple = AsyncMock()
-    apple.search_album = AsyncMock(return_value=[_make_apple_result()])
+    """An Apple Music match → on_streaming=True; result is wired to sources.apple_music."""
+    apple = _mock_client(SourceMatch(url="https://music.apple.com/album/123", confidence=90.0))
 
     result = await check_streaming_availability("Stereolab", "Aluminum Tunes", apple_music=apple)
 
@@ -94,10 +73,10 @@ async def test_found_on_apple_music():
 
 @pytest.mark.asyncio
 async def test_found_on_bandcamp():
-    """Returns on_streaming=True with bandcamp source when Bandcamp has a match."""
-    bandcamp = AsyncMock()
-    bandcamp.search_artist = AsyncMock(return_value=[_make_bandcamp_artist()])
-    bandcamp.fetch_artist_catalog = AsyncMock(return_value=[_make_bandcamp_album()])
+    """A Bandcamp match → on_streaming=True; result is wired to sources.bandcamp."""
+    bandcamp = _mock_client(
+        SourceMatch(url="https://stereolab.bandcamp.com/album/aluminum-tunes", confidence=92.0)
+    )
 
     result = await check_streaming_availability("Stereolab", "Aluminum Tunes", bandcamp=bandcamp)
 
@@ -108,11 +87,9 @@ async def test_found_on_bandcamp():
 
 @pytest.mark.asyncio
 async def test_not_found_on_any_service():
-    """Returns on_streaming=False when all services return no match."""
-    spotify = AsyncMock()
-    spotify.search_album = AsyncMock(return_value=[])
-    deezer = AsyncMock()
-    deezer.search_album = AsyncMock(return_value=[])
+    """Every adapter returns None → on_streaming=False, no errored_sources."""
+    spotify = _mock_client(None)
+    deezer = _mock_client(None)
 
     result = await check_streaming_availability(
         "Stereolab", "Aluminum Tunes", spotify=spotify, deezer=deezer
@@ -129,7 +106,7 @@ async def test_not_found_on_any_service():
 
 @pytest.mark.asyncio
 async def test_no_clients_returns_inconclusive():
-    """Returns on_streaming=None when no clients are provided."""
+    """No clients dispatched → on_streaming=None with empty errored_sources."""
     result = await check_streaming_availability("Stereolab", "Aluminum Tunes")
 
     assert result.on_streaming is None
@@ -142,28 +119,23 @@ async def test_no_clients_returns_inconclusive():
 
 @pytest.mark.asyncio
 async def test_all_clients_error_returns_inconclusive():
-    """Returns on_streaming=None when all client checks raise exceptions."""
-    spotify = AsyncMock()
-    spotify.search_album = AsyncMock(side_effect=Exception("network error"))
-    deezer = AsyncMock()
-    deezer.search_album = AsyncMock(side_effect=Exception("timeout"))
+    """Every adapter raises → on_streaming=None; errored_sources lists both, sorted."""
+    spotify = _mock_client(Exception("network error"))
+    deezer = _mock_client(Exception("timeout"))
 
     result = await check_streaming_availability(
         "Stereolab", "Aluminum Tunes", spotify=spotify, deezer=deezer
     )
 
     assert result.on_streaming is None
-    # Both services errored — both surface in errored_sources, sorted.
     assert result.errored_sources == ["deezer", "spotify"]
 
 
 @pytest.mark.asyncio
 async def test_partial_error_still_returns_result():
-    """One service errors, another succeeds — returns on_streaming=True."""
-    spotify = AsyncMock()
-    spotify.search_album = AsyncMock(side_effect=Exception("network error"))
-    deezer = AsyncMock()
-    deezer.search_album = AsyncMock(return_value=[_make_deezer_result()])
+    """One adapter errors, another matches → on_streaming=True; errored_sources records the flake."""
+    spotify = _mock_client(Exception("network error"))
+    deezer = _mock_client(SourceMatch(url="https://www.deezer.com/album/123", confidence=90.0))
 
     result = await check_streaming_availability(
         "Stereolab", "Aluminum Tunes", spotify=spotify, deezer=deezer
@@ -179,17 +151,16 @@ async def test_partial_error_still_returns_result():
 
 @pytest.mark.asyncio
 async def test_partial_error_with_no_match_is_inconclusive():
-    """One service errors, another returns no match — returns on_streaming=None (LML#376).
+    """One adapter errors, the other returns no match → on_streaming=None (LML#376).
 
-    Before the fix this collapsed to `False`: the no-match success flipped `any_checked`
-    to True so the verdict followed the "all-checked, none-found" branch and ignored the
-    error. Persisted as `library.on_streaming=false` forever, with no retry path. After
-    the fix, any-error → None so consumers' `!== null` guards skip the write.
+    Before LML#376's fix this collapsed to ``False``: the no-match success
+    flipped ``any_checked`` to True so the verdict followed the
+    "all-checked, none-found" branch and ignored the error. Persisted as
+    ``library.on_streaming=false`` forever, with no retry path. After the
+    fix, any-error → None so consumers' ``!== null`` guards skip the write.
     """
-    spotify = AsyncMock()
-    spotify.search_album = AsyncMock(side_effect=Exception("network error"))
-    deezer = AsyncMock()
-    deezer.search_album = AsyncMock(return_value=[])
+    spotify = _mock_client(Exception("network error"))
+    deezer = _mock_client(None)
 
     result = await check_streaming_availability(
         "Stereolab", "Aluminum Tunes", spotify=spotify, deezer=deezer
@@ -203,30 +174,16 @@ async def test_partial_error_with_no_match_is_inconclusive():
 
 
 @pytest.mark.asyncio
-async def test_low_confidence_match_rejected():
-    """A result with a poor fuzzy match is not accepted."""
-    spotify = AsyncMock()
-    spotify.search_album = AsyncMock(
-        return_value=[
-            _make_spotify_result(artist="Completely Different Artist", title="Unrelated Album")
-        ]
-    )
-
-    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", spotify=spotify)
-
-    assert result.on_streaming is False
-    assert result.sources.spotify is None
-
-
-@pytest.mark.asyncio
 async def test_multiple_services_all_match():
-    """All sources populated when multiple services find the album."""
-    spotify = AsyncMock()
-    spotify.search_album = AsyncMock(return_value=[_make_spotify_result()])
-    deezer = AsyncMock()
-    deezer.search_album = AsyncMock(return_value=[_make_deezer_result()])
-    apple = AsyncMock()
-    apple.search_album = AsyncMock(return_value=[_make_apple_result()])
+    """Three adapters all match → all sources populated; on_streaming=True.
+
+    Pins the LML#392 acceptance criterion: the orchestrator gathers over the
+    ``find_album_match`` interface with no per-service branch, so multi-source
+    composition is name-driven by the kwarg → field mapping only.
+    """
+    spotify = _mock_client(SourceMatch(url="https://open.spotify.com/album/x", confidence=95.0))
+    deezer = _mock_client(SourceMatch(url="https://www.deezer.com/album/y", confidence=90.0))
+    apple = _mock_client(SourceMatch(url="https://music.apple.com/album/z", confidence=88.0))
 
     result = await check_streaming_availability(
         "Stereolab",
@@ -240,30 +197,3 @@ async def test_multiple_services_all_match():
     assert result.sources.spotify is not None
     assert result.sources.deezer is not None
     assert result.sources.apple_music is not None
-
-
-@pytest.mark.asyncio
-async def test_bandcamp_no_artist_match():
-    """Returns None for bandcamp when artist autocomplete finds no match."""
-    bandcamp = AsyncMock()
-    bandcamp.search_artist = AsyncMock(return_value=[])
-
-    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", bandcamp=bandcamp)
-
-    assert result.on_streaming is False
-    assert result.sources.bandcamp is None
-
-
-@pytest.mark.asyncio
-async def test_bandcamp_artist_match_no_album():
-    """Returns None for bandcamp when artist is found but album is not in catalog."""
-    bandcamp = AsyncMock()
-    bandcamp.search_artist = AsyncMock(return_value=[_make_bandcamp_artist()])
-    bandcamp.fetch_artist_catalog = AsyncMock(
-        return_value=[_make_bandcamp_album(title="Completely Different Album")]
-    )
-
-    result = await check_streaming_availability("Stereolab", "Aluminum Tunes", bandcamp=bandcamp)
-
-    assert result.on_streaming is False
-    assert result.sources.bandcamp is None


### PR DESCRIPTION
## Summary

Closes [#392](https://github.com/WXYC/library-metadata-lookup/issues/392). Replaces the four hand-dispatched `_check_<service>` functions in `streaming/orchestrator.py` with a single `find_album_match(artist, title) -> SourceMatch | None` interface on `BaseStreamingClient`. Each provider adapter (Spotify, Deezer, Apple Music, Bandcamp) absorbs its own response-shape adaptation; the orchestrator gathers over the interface with no per-service branch.

## Why

The pre-refactor orchestrator carried JSON-shape knowledge for four services inline (Spotify's `x["artists"][0]["name"]`, Deezer's `x["artist"]["name"]`, Apple's `x["artistName"]`, plus Bandcamp's two-phase autocomplete + catalog scrape). Adding a fifth provider meant editing the orchestrator. The deletion test from #392's body: delete any `_check_*` and its leverage vanishes — it adapts exactly one shape. Behind a real interface, that logic reappears inside each client, where it earns locality.

## Behavior parity

- Verdict matrix (LML#376) unchanged: positive evidence wins, any error in absence of positive evidence escalates to None, False reserved for strict "checked-all, none-found, none-errored". Pinned by `test_streaming_check_orchestrator.py::test_partial_error_with_no_match_is_inconclusive`.
- Apple Music wrong-artist verification (LML#389) preserved: it lives in the shared `is_acceptable_match` floor inside `find_best_match`, which both the old and new code path use.
- Per-service JSON-shape adaptation is byte-identical to the deleted `_check_<service>` functions — verbatim port of the lambda fields.

## What moved where

| Code | Before | After |
|---|---|---|
| `_check_spotify` | `streaming/orchestrator.py:103-120` | `SpotifyClient.find_album_match` |
| `_check_deezer` | `streaming/orchestrator.py:123-139` | `DeezerClient.find_album_match` |
| `_check_apple_music` | `streaming/orchestrator.py:142-160` | `AppleMusicClient.find_album_match` |
| `_check_bandcamp` (two-phase) | `streaming/orchestrator.py:163-199` | `BandcampClient.find_album_match` |
| Per-service shape adaptation tests | `test_streaming_check_orchestrator.py` (mocking `search_album`) | Each `test_<service>_client.py::TestFindAlbumMatch` |
| Orchestrator gather + verdict tests | `test_streaming_check_orchestrator.py` (raw API dicts) | `test_streaming_check_orchestrator.py` (mock `find_album_match`, normalized `SourceMatch`) |

## Acceptance criteria walk (#392)

- [x] One `find_album_match` interface; orchestrator gathers over `dict[str, client]` with no per-service branch.
- [x] No service-specific JSON field access remains in `streaming/orchestrator.py` (verified by grep).
- [x] A mock adapter drives an orchestrator unit test — the new `_mock_client(SourceMatch | None | Exception)` helper in `test_streaming_check_orchestrator.py` is exactly this; multiple adapter mocks compose in `test_multiple_services_all_match`.
- [x] Existing streaming-check tests pass; behavior unchanged for the current four services.
- [x] LML#376 verdict matrix unchanged (sequence-after-#376 constraint).
- [x] LML#389 wrong-artist verification preserved (in `find_best_match`'s shared floor; new test pin in `test_apple_music_client.py::test_returns_none_for_wrong_artist_match`).

## Diff shape

- `streaming/orchestrator.py`: 200 → 100 lines (50% reduction; `_check_*` functions deleted)
- `BaseStreamingClient` gains `find_album_match` (NotImplementedError default — missing override fails loudly)
- Each adapter gains a ~15-line `find_album_match` override (verbatim ports)
- One test file rewritten (orchestrator tests now mock `find_album_match` directly), four extended with `TestFindAlbumMatch` classes carrying the per-service shape coverage

## Test plan

- [x] Full unit suite: 2040/2040 pass.
- [x] `ruff check` + `ruff format --check` + `mypy` on all touched source files: all green.
- [x] Per-client `TestFindAlbumMatch` covers the four response shapes (Spotify, Deezer, Apple Music, Bandcamp's two-phase) plus reject-on-low-confidence and reject-on-empty paths.

Closes #392
