### PR TITLE
feat(streaming): authenticated Apple Music client (PR-1 of 4)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# Library Metadata Lookup
+
+FastAPI service that searches the WXYC library catalog and cross-references results with external metadata sources (Discogs, MusicBrainz, Apple Music) to enrich flowsheet entries with artwork, streaming links, and identity resolution.
+
+## Language
+
+### Apple Music integration
+
+**Apple Music**: Apple's commercial streaming service. Catalog accessed via the authenticated `api.music.apple.com` endpoint.
+_Avoid_: "iTunes" (the deprecated free Search endpoint is a different system, see below).
+
+**iTunes Search**: Apple's free, unauthenticated search endpoint at `itunes.apple.com/search`. Returns flat JSON results; rate-limited by IP reputation. Used by LML historically; replaced by Apple Music API after the 2026-05-28 Railway-IP block. Removed entirely after the migration.
+
+**Developer token**: ES256-signed JWT identifying a MusicKit key. Required on every request to Apple Music API. Generated per-request from the `.p8` private key + Team ID + Key ID. Apple permits `exp` up to ~6 months; LML signs with ~20-minute `exp` for simplicity.
+_Avoid_: "API key", "auth token" (Apple's docs use "developer token" specifically).
+
+**MusicKit identifier (Media ID)**: Reverse-DNS identifier registered in the Apple Developer console that authorizes a key for MusicKit / Apple Music / Apple Music Feed / ShazamKit. LML uses `media.org.wxyc.lml`.
+_Avoid_: "App ID" (different identifier type, for iOS apps), "service ID" (yet another type, for Sign in with Apple).
+
+**Storefront**: Country/region-scoped catalog (`us`, `gb`, etc.). Apple Music returns different metadata per storefront. LML hardcodes `us`.
+
+**Match floor**: Per-call verification threshold (`fuzz.token_set_ratio >= 80`) applied to Apple Music search results' artist/track/album fields before accepting a URL. Stops the wrong link from freezing onto a flowsheet row when Apple's search ranking is unstable for obscure artists (LML#389, #396).
+
+## Example dialogue
+
+> **Dev**: A DJ reported that the Apple Music button for one of her flowsheet entries opens the wrong song. The wrong artist's track. Same title.
+>
+> **Domain expert**: Yeah — Apple's search ranking can return a popular but wrong artist when the requested artist is obscure. We mitigate that with the **match floor**: the `artistName` from the API response has to clear an 80% fuzzy match against the queried artist before we accept the URL. If it doesn't clear, the URL gets dropped.
+>
+> **Dev**: So the floor is on the API response, not the catalog?
+>
+> **Domain expert**: Right. The catalog gives us the artist + track + album the DJ entered. The **Apple Music API** is what returns multiple candidate URLs to pick from, and the floor decides which (if any) is acceptable. The **storefront** is locked to `us`, so we never get a non-US release back.
+>
+> **Dev**: And the `developer token` is the JWT we sign per request?
+>
+> **Domain expert**: Yeah. ES256 over the `.p8` private key, claims are `iss=Team ID`, `iat`, `exp = iat + 20 min`. The Key ID goes in the JWT header as `kid`. Apple validates the signature against the public half registered to the **MusicKit identifier** `media.org.wxyc.lml`.

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -1,9 +1,35 @@
-"""iTunes Search API client for album-level Apple Music searches."""
+"""Authenticated Apple Music API client.
+
+Replaces the unauthenticated iTunes Search endpoint (`itunes.apple.com/search`)
+after the 2026-05-28 Railway egress 403 (LML#443). See
+`docs/adr/0001-authenticated-apple-music-api.md` for the migration rationale.
+
+Auth: ES256 developer token (JWT), signed per request with a ~20 minute
+lifetime, header `kid=Key ID`, claims `iss=Team ID`, `iat`, `exp`. Apple
+validates the signature against the public half registered to the MusicKit
+identifier `media.org.wxyc.lml`.
+
+Surface area mirrors the previous iTunes client so the migration of the two
+call sites (`lookup/orchestrator._fetch_apple_music_url` and
+`streaming/router.handle_streaming_check`) is mechanical:
+
+- `find_album_match(artist, title)` — BaseStreamingClient contract; powers
+  /streaming-check.
+- `find_track_url(artist, song, album=None)` — replaces the inline
+  `_fetch_apple_music_url` in the lookup hot path. 3-way fuzz floor on
+  `attributes.{artistName,name,albumName}`.
+"""
 
 from __future__ import annotations
 
-import asyncio
 import logging
+import time
+
+import httpx
+import jwt as pyjwt
+import sentry_sdk
+from rapidfuzz import fuzz
+from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from clients.streaming.base import BaseStreamingClient
 from clients.streaming.matching import find_best_source_match
@@ -11,87 +37,182 @@ from streaming.models import SourceMatch
 
 logger = logging.getLogger(__name__)
 
+# Minimum fuzzy score (0-100) for accepting an Apple Music search result as a
+# genuine match. Mirrors the 80/80 floor every other provider uses inside
+# `clients/streaming/matching.is_acceptable_match`. Stops the wrong link from
+# freezing onto a flowsheet row when Apple's search ranking is unstable for
+# obscure artists (LML#389) or returns a same-titled track from the wrong
+# album (LML#396).
+_APPLE_MUSIC_MATCH_FLOOR = 80.0
+
+# Apple Music developer-token lifetime. Apple permits `exp` up to ~6 months;
+# we sign per-request with a short window so a leaked token's blast radius
+# stays small. 20 minutes is well above any single-request round-trip.
+_JWT_LIFETIME_SECONDS = 1200
+
+_SEARCH_URL = "https://api.music.apple.com/v1/catalog/us/search"
+
 
 class AppleMusicClient(BaseStreamingClient):
-    """iTunes Search API client with rate limiting for album searches.
+    """Authenticated Apple Music API client.
 
-    Unlike the existing _fetch_apple_music_url() in the service which searches
-    by song (entity=song), this searches by album (entity=album) for better
-    album-level matching.
+    Inherits the FD-leak-safe httpx singleton + AsyncLimiter rate limiting +
+    asyncio.Semaphore concurrency control from `BaseStreamingClient` (the
+    LML#241 invariant: no per-request `httpx.AsyncClient` construction on the
+    hot path).
+
+    Rate limit `(60, 60)` and semaphore `5` are Apple's published catalog
+    quota (~3000 req/h with comfort margin), sized to peak request-o-matic
+    burst behavior. Per-call JWT signing keeps the lifetime short without
+    needing in-process token caching.
+
+    Args:
+        team_id: Apple Developer Team ID (10-char), used as JWT `iss` claim.
+        key_id: MusicKit Key ID (10-char), used as JWT `kid` header.
+        private_key: PEM contents of the ES256 private key downloaded from
+            the Apple Developer console at key creation. Apple ships the
+            `.p8` exactly once — losing it requires revoke + re-issue.
     """
 
-    BASE_URL = "https://itunes.apple.com/search"
+    def __init__(self, team_id: str, key_id: str, private_key: str):
+        super().__init__(rate_limit=(60, 60), semaphore_limit=5)
+        self._team_id = team_id
+        self._key_id = key_id
+        self._private_key = private_key
 
-    def __init__(self):
-        super().__init__(rate_limit=(15, 60), semaphore_limit=3)
-        self._max_retries = 2
-
-    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
-        """Search iTunes for ``(artist, title)`` and return the best match.
-
-        See ``BaseStreamingClient.find_album_match`` for the contract. The
-        iTunes response shape (``artistName`` / ``collectionName`` /
-        ``collectionViewUrl``) is encapsulated here. The wrong-artist
-        verification from LML#389 lives in the shared
-        ``is_acceptable_match`` floor inside ``find_best_match``.
-        """
-        return find_best_source_match(
-            await self.search_album(artist, title),
-            artist,
-            title,
-            artist_fn=lambda x: x["artistName"],
-            title_fn=lambda x: x["collectionName"],
-            url_fn=lambda x: x["collectionViewUrl"],
+    def _sign_jwt(self) -> str:
+        """Sign a fresh ES256 developer token. ~20-minute lifetime."""
+        now = int(time.time())
+        return pyjwt.encode(
+            {"iss": self._team_id, "iat": now, "exp": now + _JWT_LIFETIME_SECONDS},
+            self._private_key,
+            algorithm="ES256",
+            headers={"kid": self._key_id},
         )
 
-    async def search_album(self, artist: str, title: str) -> list[dict]:
-        """Search iTunes for albums matching artist + title.
+    async def search_songs(self, artist: str, song: str) -> list[dict]:
+        """Search Apple Music for songs matching artist + song.
 
-        Returns a list of album result dicts, or an empty list on error.
+        Returns the raw `results.songs.data` list, or `[]` on error. Each item
+        carries `attributes.{artistName, name, albumName, url}`.
         """
+        return await self._search(artist, song, types="songs", result_key="songs")
+
+    async def search_albums(self, artist: str, title: str) -> list[dict]:
+        """Search Apple Music for albums matching artist + title.
+
+        Returns the raw `results.albums.data` list, or `[]` on error. Each item
+        carries `attributes.{artistName, name, url}`.
+        """
+        return await self._search(artist, title, types="albums", result_key="albums")
+
+    async def _search(self, artist: str, term: str, *, types: str, result_key: str) -> list[dict]:
+        """Issue a signed search request and return the typed `data` list.
+
+        Observability (O3): every call sets `apple_music.search.{status,result}`
+        on the active Sentry span; non-2xx additionally `capture_message`s so
+        the silent-failure mode the old iTunes path exhibited (LML#444) can't
+        recur. The previous client absorbed errors into `[]` with only a log;
+        the new contract surfaces them upstream.
+        """
+        transaction = sentry_sdk.get_current_scope().transaction
         try:
             async with self._semaphore:
-                return await self._search_with_retry(artist, title)
+                await self._rate_limiter.acquire()
+                http = await self._get_client()
+                token = self._sign_jwt()
+                resp = await http.get(
+                    _SEARCH_URL,
+                    params={"term": f"{artist} {term}", "types": types, "limit": 25},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
         except Exception:
-            logger.exception("Apple Music search failed for %s - %s", artist, title)
+            logger.exception("Apple Music search raised for %s - %s", artist, term)
+            if transaction is not None:
+                transaction.set_data("apple_music.search.result", "error")
+            sentry_sdk.capture_message("apple_music.search.exception", level="warning")
             return []
 
-    async def _search_with_retry(self, artist: str, title: str) -> list[dict]:
-        http = await self._get_client()
+        if transaction is not None:
+            transaction.set_data("apple_music.search.status", resp.status_code)
 
-        for attempt in range(self._max_retries):
-            await self._rate_limiter.acquire()
-
-            resp = await http.get(
-                self.BASE_URL,
-                params={
-                    "term": f"{artist} {title}",
-                    "entity": "album",
-                    "media": "music",
-                    "limit": 5,
-                },
+        if resp.status_code != 200:
+            logger.warning(
+                "Apple Music search returned %d for %s - %s",
+                resp.status_code,
+                artist,
+                term,
             )
+            if transaction is not None:
+                transaction.set_data("apple_music.search.result", str(resp.status_code))
+            sentry_sdk.capture_message(
+                f"apple_music.search.status={resp.status_code}",
+                level="warning",
+            )
+            return []
 
-            if resp.status_code == 403:
-                logger.warning(
-                    "iTunes 403 rate limit, sleeping 60s (attempt %d/%d)",
-                    attempt + 1,
-                    self._max_retries,
-                )
-                await asyncio.sleep(60)
+        data = resp.json().get("results", {}).get(result_key, {}).get("data", [])
+        if transaction is not None:
+            transaction.set_data("apple_music.search.result", "hit" if data else "miss")
+        return data
+
+    async def find_track_url(self, artist: str, song: str, album: str | None = None) -> str | None:
+        """Search for `(artist, song[, album])` and return the best Apple Music
+        track URL clearing the 80/80(/80) fuzz floor, else `None`.
+
+        Replaces `lookup.orchestrator._fetch_apple_music_url`. Uses
+        `fuzz.token_set_ratio` (not the batch matcher's `token_sort_ratio`)
+        so extra tokens — "The", "feat. X", "(Remastered)" — don't sink an
+        otherwise-correct match.
+        """
+        results = await self.search_songs(artist, song)
+        if not results:
+            return None
+
+        norm_artist = normalize_for_comparison(artist)
+        norm_song = normalize_for_comparison(song)
+        norm_album = normalize_for_comparison(album) if album else None
+
+        for item in results:
+            attrs = item.get("attributes", {})
+            url = attrs.get("url")
+            if not url:
                 continue
-
-            if resp.status_code != 200:
-                logger.warning(
-                    "iTunes search returned %d for %s - %s",
-                    resp.status_code,
-                    artist,
-                    title,
+            artist_score = fuzz.token_set_ratio(
+                norm_artist, normalize_for_comparison(attrs.get("artistName", ""))
+            )
+            track_score = fuzz.token_set_ratio(
+                norm_song, normalize_for_comparison(attrs.get("name", ""))
+            )
+            if artist_score < _APPLE_MUSIC_MATCH_FLOOR or track_score < _APPLE_MUSIC_MATCH_FLOOR:
+                continue
+            if norm_album is not None:
+                album_score = fuzz.token_set_ratio(
+                    norm_album, normalize_for_comparison(attrs.get("albumName", ""))
                 )
-                return []
+                if album_score < _APPLE_MUSIC_MATCH_FLOOR:
+                    continue
+            return url
+        return None
 
-            data = resp.json()
-            return data.get("results", [])
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        """Search Apple Music for `(artist, title)` and return the best match.
 
-        logger.error("iTunes max retries exhausted for %s - %s", artist, title)
-        return []
+        See `BaseStreamingClient.find_album_match`. The Apple Music response
+        shape (`attributes.{artistName, name, url}`) is encapsulated here;
+        the LML#389 wrong-artist guard lives in the shared
+        `is_acceptable_match` floor inside `find_best_match`.
+        """
+        return find_best_source_match(
+            await self.search_albums(artist, title),
+            artist,
+            title,
+            artist_fn=lambda x: x["attributes"]["artistName"],
+            title_fn=lambda x: x["attributes"]["name"],
+            url_fn=lambda x: x["attributes"]["url"],
+        )
+
+    async def _make_client(self) -> httpx.AsyncClient:
+        """Override the base 10s timeout — Apple Music search is fast (<1s p99)
+        and the orchestrator's outer search-budget cap is the real backstop."""
+        return httpx.AsyncClient(timeout=10.0)

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -22,12 +22,14 @@ call sites (`lookup/orchestrator._fetch_apple_music_url` and
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
-import httpx
 import jwt as pyjwt
 import sentry_sdk
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 
@@ -52,6 +54,16 @@ _JWT_LIFETIME_SECONDS = 1200
 
 _SEARCH_URL = "https://api.music.apple.com/v1/catalog/us/search"
 
+# Apple's published catalog quota and our concurrency ceiling. (60, 60) =
+# 1 req/sec sustained = 3600 req/h; sized below Apple's per-team daily cap
+# with comfort margin for request-o-matic bursts.
+_RATE_LIMIT = (60.0, 60.0)
+_SEMAPHORE_LIMIT = 5
+_MAX_RETRIES = 4
+
+# Status codes the retry loop sleeps + retries on. Anything else is terminal.
+_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+
 
 class AppleMusicClient(BaseStreamingClient):
     """Authenticated Apple Music API client.
@@ -61,10 +73,9 @@ class AppleMusicClient(BaseStreamingClient):
     LML#241 invariant: no per-request `httpx.AsyncClient` construction on the
     hot path).
 
-    Rate limit `(60, 60)` and semaphore `5` are Apple's published catalog
-    quota (~3000 req/h with comfort margin), sized to peak request-o-matic
-    burst behavior. Per-call JWT signing keeps the lifetime short without
-    needing in-process token caching.
+    Per-call JWT signing uses a pre-parsed private key (cached on the
+    instance) so request hot-path cost is just an ECDSA signature, not a PEM
+    parse.
 
     Args:
         team_id: Apple Developer Team ID (10-char), used as JWT `iss` claim.
@@ -72,13 +83,31 @@ class AppleMusicClient(BaseStreamingClient):
         private_key: PEM contents of the ES256 private key downloaded from
             the Apple Developer console at key creation. Apple ships the
             `.p8` exactly once — losing it requires revoke + re-issue.
+
+    Raises:
+        ValueError: if `private_key` is not a parseable PEM-encoded ES256
+            private key. Surfaced at startup so a Railway env-var that
+            mangled newlines into literal `\\n` fails fast rather than
+            silently degrading every request to `[]`.
     """
 
     def __init__(self, team_id: str, key_id: str, private_key: str):
-        super().__init__(rate_limit=(60, 60), semaphore_limit=5)
+        super().__init__(rate_limit=_RATE_LIMIT, semaphore_limit=_SEMAPHORE_LIMIT)
         self._team_id = team_id
         self._key_id = key_id
-        self._private_key = private_key
+        # Parse once at startup so per-request cost is just the ECDSA
+        # signature, and so a malformed PEM (Railway sometimes renders
+        # newlines as the literal two-char `\n` sequence) raises here
+        # instead of silently breaking every search.
+        loaded = serialization.load_pem_private_key(
+            private_key.encode() if isinstance(private_key, str) else private_key,
+            password=None,
+        )
+        if not isinstance(loaded, EllipticCurvePrivateKey):
+            raise ValueError(
+                f"Apple Music private_key must be ES256/P-256, got {type(loaded).__name__}"
+            )
+        self._private_key: EllipticCurvePrivateKey = loaded
 
     def _sign_jwt(self) -> str:
         """Sign a fresh ES256 developer token. ~20-minute lifetime."""
@@ -90,7 +119,7 @@ class AppleMusicClient(BaseStreamingClient):
             headers={"kid": self._key_id},
         )
 
-    async def search_songs(self, artist: str, song: str) -> list[dict]:
+    async def search_song(self, artist: str, song: str) -> list[dict]:
         """Search Apple Music for songs matching artist + song.
 
         Returns the raw `results.songs.data` list, or `[]` on error. Each item
@@ -98,7 +127,7 @@ class AppleMusicClient(BaseStreamingClient):
         """
         return await self._search(artist, song, types="songs", result_key="songs")
 
-    async def search_albums(self, artist: str, title: str) -> list[dict]:
+    async def search_album(self, artist: str, title: str) -> list[dict]:
         """Search Apple Music for albums matching artist + title.
 
         Returns the raw `results.albums.data` list, or `[]` on error. Each item
@@ -109,63 +138,147 @@ class AppleMusicClient(BaseStreamingClient):
     async def _search(self, artist: str, term: str, *, types: str, result_key: str) -> list[dict]:
         """Issue a signed search request and return the typed `data` list.
 
-        Observability (O3): every call sets `apple_music.search.{status,result}`
-        on the active Sentry span; non-2xx additionally `capture_message`s so
-        the silent-failure mode the old iTunes path exhibited (LML#444) can't
-        recur. The previous client absorbed errors into `[]` with only a log;
-        the new contract surfaces them upstream.
+        Wraps the call in a dedicated `apple_music.search` child span so
+        concurrent searches don't overwrite each other's status/result
+        attributes on the root transaction (LML#213 wrap-at-chokepoint
+        pattern). Non-200s + exceptions log + `capture_exception`/`capture_message`
+        so the silent-failure mode the old iTunes path exhibited (LML#444)
+        cannot recur.
+
+        Retries 429 (honoring `Retry-After`) and transient 5xx with
+        exponential backoff. All other non-200s return `[]` after one attempt.
         """
-        transaction = sentry_sdk.get_current_scope().transaction
-        try:
-            async with self._semaphore:
-                await self._rate_limiter.acquire()
-                http = await self._get_client()
-                token = self._sign_jwt()
-                resp = await http.get(
-                    _SEARCH_URL,
-                    params={"term": f"{artist} {term}", "types": types, "limit": 25},
-                    headers={"Authorization": f"Bearer {token}"},
+        with sentry_sdk.start_span(op="apple_music.search", name=types) as span:
+            try:
+                async with self._semaphore:
+                    data, last_status = await self._search_with_retry(
+                        artist, term, types=types, result_key=result_key, span=span
+                    )
+            except Exception:
+                logger.exception("Apple Music search raised for %s - %s", artist, term)
+                span.set_data("apple_music.search.result", "error")
+                sentry_sdk.capture_exception()
+                return []
+
+            # `result` is the chokepoint signal Sentry dashboards filter on.
+            # Hit/miss only make sense for the 200 path; non-200 statuses
+            # carry the failure mode directly so a `result:403` query
+            # surfaces auth outages distinctly from genuine catalog misses.
+            if last_status == 200:
+                span.set_data("apple_music.search.result", "hit" if data else "miss")
+            else:
+                span.set_data(
+                    "apple_music.search.result",
+                    f"retries_exhausted_{last_status}"
+                    if last_status in _RETRYABLE_STATUSES
+                    else str(last_status),
                 )
-        except Exception:
-            logger.exception("Apple Music search raised for %s - %s", artist, term)
-            if transaction is not None:
-                transaction.set_data("apple_music.search.result", "error")
-            sentry_sdk.capture_message("apple_music.search.exception", level="warning")
-            return []
+            return data
 
-        if transaction is not None:
-            transaction.set_data("apple_music.search.status", resp.status_code)
+    async def _search_with_retry(
+        self,
+        artist: str,
+        term: str,
+        *,
+        types: str,
+        result_key: str,
+        span: sentry_sdk.tracing.Span,
+    ) -> tuple[list[dict], int | None]:
+        """Single-attempt fetch with 429/5xx retry.
 
-        if resp.status_code != 200:
+        Returns ``(data, last_status)``. ``data`` is the typed results array
+        on 200, ``[]`` on any non-200 outcome. ``last_status`` is the last
+        HTTP status code observed (None only if a transport exception was
+        raised inside the outer try/except). The caller decides what
+        observability marker to project — this layer only sets ``status``
+        on the span.
+        """
+        http = await self._get_client()
+        last_status: int | None = None
+
+        for attempt in range(_MAX_RETRIES):
+            await self._rate_limiter.acquire()
+            token = self._sign_jwt()
+            resp = await http.get(
+                _SEARCH_URL,
+                params={"term": f"{artist} {term}", "types": types, "limit": 25},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            last_status = resp.status_code
+            span.set_data("apple_music.search.status", resp.status_code)
+
+            if resp.status_code == 200:
+                # `resp.json()` can raise on a 200-with-non-JSON body (CDN
+                # edge-cache HTML errors are real); the outer except catches
+                # it as `result=error` + capture_exception.
+                payload = resp.json()
+                return payload.get("results", {}).get(result_key, {}).get("data", []), 200
+
+            if resp.status_code == 429:
+                retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+                logger.warning(
+                    "Apple Music 429 for %s - %s; sleeping %.1fs (attempt %d/%d)",
+                    artist,
+                    term,
+                    retry_after,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                await asyncio.sleep(retry_after)
+                continue
+
+            if resp.status_code in _RETRYABLE_STATUSES:
+                backoff = min(2**attempt, 30)
+                logger.warning(
+                    "Apple Music %d for %s - %s; backing off %ds (attempt %d/%d)",
+                    resp.status_code,
+                    artist,
+                    term,
+                    backoff,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            # Terminal non-200 (4xx other than 429): no recovery, log + capture.
             logger.warning(
                 "Apple Music search returned %d for %s - %s",
                 resp.status_code,
                 artist,
                 term,
             )
-            if transaction is not None:
-                transaction.set_data("apple_music.search.result", str(resp.status_code))
             sentry_sdk.capture_message(
                 f"apple_music.search.status={resp.status_code}",
                 level="warning",
             )
-            return []
+            return [], resp.status_code
 
-        data = resp.json().get("results", {}).get(result_key, {}).get("data", [])
-        if transaction is not None:
-            transaction.set_data("apple_music.search.result", "hit" if data else "miss")
-        return data
+        # Exhausted retries on 429/5xx.
+        logger.error(
+            "Apple Music max retries exhausted for %s - %s (last status %s)",
+            artist,
+            term,
+            last_status,
+        )
+        sentry_sdk.capture_message(
+            f"apple_music.search.retries_exhausted last_status={last_status}",
+            level="warning",
+        )
+        return [], last_status
 
     async def find_track_url(self, artist: str, song: str, album: str | None = None) -> str | None:
-        """Search for `(artist, song[, album])` and return the best Apple Music
-        track URL clearing the 80/80(/80) fuzz floor, else `None`.
+        """Search for `(artist, song[, album])` and return the highest-scoring
+        Apple Music track URL clearing the 80/80(/80) fuzz floor, else `None`.
 
         Replaces `lookup.orchestrator._fetch_apple_music_url`. Uses
         `fuzz.token_set_ratio` (not the batch matcher's `token_sort_ratio`)
         so extra tokens — "The", "feat. X", "(Remastered)" — don't sink an
-        otherwise-correct match.
+        otherwise-correct match. Iterates the full result list and picks the
+        best-scoring URL so an early sub-optimal match in Apple's ranking
+        order doesn't freeze the wrong link onto a flowsheet row.
         """
-        results = await self.search_songs(artist, song)
+        results = await self.search_song(artist, song)
         if not results:
             return None
 
@@ -173,27 +286,36 @@ class AppleMusicClient(BaseStreamingClient):
         norm_song = normalize_for_comparison(song)
         norm_album = normalize_for_comparison(album) if album else None
 
+        best_url: str | None = None
+        best_score = 0.0
+
         for item in results:
-            attrs = item.get("attributes", {})
+            attrs = item.get("attributes") or {}
             url = attrs.get("url")
             if not url:
                 continue
             artist_score = fuzz.token_set_ratio(
-                norm_artist, normalize_for_comparison(attrs.get("artistName", ""))
+                norm_artist, normalize_for_comparison(attrs.get("artistName") or "")
             )
             track_score = fuzz.token_set_ratio(
-                norm_song, normalize_for_comparison(attrs.get("name", ""))
+                norm_song, normalize_for_comparison(attrs.get("name") or "")
             )
             if artist_score < _APPLE_MUSIC_MATCH_FLOOR or track_score < _APPLE_MUSIC_MATCH_FLOOR:
                 continue
             if norm_album is not None:
                 album_score = fuzz.token_set_ratio(
-                    norm_album, normalize_for_comparison(attrs.get("albumName", ""))
+                    norm_album, normalize_for_comparison(attrs.get("albumName") or "")
                 )
                 if album_score < _APPLE_MUSIC_MATCH_FLOOR:
                     continue
-            return url
-        return None
+                combined = (artist_score + track_score + album_score) / 3
+            else:
+                combined = (artist_score + track_score) / 2
+            if combined > best_score:
+                best_score = combined
+                best_url = url
+
+        return best_url
 
     async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
         """Search Apple Music for `(artist, title)` and return the best match.
@@ -201,18 +323,40 @@ class AppleMusicClient(BaseStreamingClient):
         See `BaseStreamingClient.find_album_match`. The Apple Music response
         shape (`attributes.{artistName, name, url}`) is encapsulated here;
         the LML#389 wrong-artist guard lives in the shared
-        `is_acceptable_match` floor inside `find_best_match`.
+        `is_acceptable_match` floor inside `find_best_match`. Extractors use
+        `.get()` chains so a malformed item in Apple's `data` list (sparse
+        record, region-restricted, etc.) is skipped via score=0 rather than
+        raising mid-iteration and erasing every legitimate match.
         """
         return find_best_source_match(
-            await self.search_albums(artist, title),
+            await self.search_album(artist, title),
             artist,
             title,
-            artist_fn=lambda x: x["attributes"]["artistName"],
-            title_fn=lambda x: x["attributes"]["name"],
-            url_fn=lambda x: x["attributes"]["url"],
+            artist_fn=_extract_artist_name,
+            title_fn=_extract_name,
+            url_fn=_extract_url,
         )
 
-    async def _make_client(self) -> httpx.AsyncClient:
-        """Override the base 10s timeout — Apple Music search is fast (<1s p99)
-        and the orchestrator's outer search-budget cap is the real backstop."""
-        return httpx.AsyncClient(timeout=10.0)
+
+def _extract_artist_name(item: dict) -> str:
+    return (item.get("attributes") or {}).get("artistName") or ""
+
+
+def _extract_name(item: dict) -> str:
+    return (item.get("attributes") or {}).get("name") or ""
+
+
+def _extract_url(item: dict) -> str:
+    return (item.get("attributes") or {}).get("url") or ""
+
+
+def _parse_retry_after(value: str | None) -> float:
+    """Apple Music `Retry-After` is documented as integer seconds. Honor it
+    when present; fall back to 5s if absent or malformed. Capped at 60s so a
+    pathological upstream value doesn't stall the worker."""
+    if not value:
+        return 5.0
+    try:
+        return min(float(value), 60.0)
+    except ValueError:
+        return 5.0

--- a/config/settings.py
+++ b/config/settings.py
@@ -21,6 +21,26 @@ class Settings(BaseSettings):
         None, description="Spotify client secret for streaming availability checks"
     )
 
+    # Apple Music API authentication (replaces unauthenticated iTunes Search after the
+    # 2026-05-28 Railway egress 403; see docs/adr/0001-authenticated-apple-music-api.md).
+    # All three must be set for the client to function; absent any one of them the
+    # provider returns None and Apple Music checks degrade to no-op (same shape as
+    # Spotify-without-creds).
+    apple_music_team_id: str | None = Field(
+        None, description="Apple Developer Team ID (10-char) used as the JWT `iss` claim"
+    )
+    apple_music_key_id: str | None = Field(
+        None, description="Apple Developer Key ID (10-char) used as the JWT `kid` header"
+    )
+    apple_music_private_key: str | None = Field(
+        None,
+        description=(
+            "ES256 PEM private key contents downloaded from the Apple Developer "
+            "console. Railway stores the multi-line PEM verbatim; never check the "
+            "key material into the repo."
+        ),
+    )
+
     # Database Configuration
     library_db_path: Path = Field(
         default=Path("library.db"), description="Path to SQLite library database"

--- a/docs/adr/0001-authenticated-apple-music-api.md
+++ b/docs/adr/0001-authenticated-apple-music-api.md
@@ -1,0 +1,17 @@
+# 0001 — Authenticated Apple Music API for catalog search
+
+Starting 2026-05-28, iTunes Search (`itunes.apple.com/search`) returned HTTP 403 to every outbound call from LML's Railway egress IP, breaking the Apple Music URL enrichment that the iOS app's flowsheet view depends on. Verified the block is IP-scoped (curl from local laptop and from BS EC2 returns 200 against the same User-Agent), so changing User-Agent or retrying won't recover. We migrated both call sites (`lookup/orchestrator.py:_fetch_apple_music_url` and `clients/streaming/apple_music.py:AppleMusicClient`) to the authenticated Apple Music API (`api.music.apple.com`) using an ES256-signed developer token, registered against the MusicKit identifier `media.org.wxyc.lml`, with credentials in Railway as `APPLE_MUSIC_TEAM_ID` / `APPLE_MUSIC_KEY_ID` / `APPLE_MUSIC_PRIVATE_KEY`.
+
+## Considered options
+
+- **Rotate Railway egress IP**: short-term unblock, but Railway tenants share IPs and the block is likely to recur on the next reputational issue.
+- **Proxy iTunes calls through a static-IP egress** (e.g. BS EC2): adds an operational dependency and a code path that throws itself away when migrating to auth properly.
+- **User-Agent header probe**: verified to not affect the 403 (same UA succeeds from non-Railway IPs), ruled out.
+- **Keep iTunes path as fallback**: provably broken from LML's only egress, so the "fallback" is dead code.
+
+## Consequences
+
+- Apple Developer Program membership becomes load-bearing for LML. Membership renewal failure becomes a category of outage to monitor.
+- The `.p8` private key is downloaded once at MusicKit-key creation and is unrecoverable; loss requires revoke + re-issue with new Key ID.
+- Local dev without `APPLE_MUSIC_*` env vars sees `apple_music_url=null` in lookup responses (matches existing Spotify-without-creds behavior).
+- LML#444 (silent-failure observability) is superseded — the new client surfaces every non-200 via log + Sentry + active-span data.

--- a/docs/adr/0001-authenticated-apple-music-api.md
+++ b/docs/adr/0001-authenticated-apple-music-api.md
@@ -1,6 +1,8 @@
 # 0001 — Authenticated Apple Music API for catalog search
 
-Starting 2026-05-28, iTunes Search (`itunes.apple.com/search`) returned HTTP 403 to every outbound call from LML's Railway egress IP, breaking the Apple Music URL enrichment that the iOS app's flowsheet view depends on. Verified the block is IP-scoped (curl from local laptop and from BS EC2 returns 200 against the same User-Agent), so changing User-Agent or retrying won't recover. We migrated both call sites (`lookup/orchestrator.py:_fetch_apple_music_url` and `clients/streaming/apple_music.py:AppleMusicClient`) to the authenticated Apple Music API (`api.music.apple.com`) using an ES256-signed developer token, registered against the MusicKit identifier `media.org.wxyc.lml`, with credentials in Railway as `APPLE_MUSIC_TEAM_ID` / `APPLE_MUSIC_KEY_ID` / `APPLE_MUSIC_PRIVATE_KEY`.
+Starting 2026-05-28, iTunes Search (`itunes.apple.com/search`) returned HTTP 403 to every outbound call from LML's Railway egress IP, breaking the Apple Music URL enrichment that the iOS app's flowsheet view depends on. Verified the block is IP-scoped (curl from local laptop and from BS EC2 returns 200 against the same User-Agent), so changing User-Agent or retrying won't recover. We are migrating both call sites — `clients/streaming/apple_music.py:AppleMusicClient` (used by `/streaming-check`) and `lookup/orchestrator.py:_fetch_apple_music_url` (the iOS flowsheet hot path) — to the authenticated Apple Music API (`api.music.apple.com`) using an ES256-signed developer token, registered against the MusicKit identifier `media.org.wxyc.lml`, with credentials in Railway as `APPLE_MUSIC_TEAM_ID` / `APPLE_MUSIC_KEY_ID` / `APPLE_MUSIC_PRIVATE_KEY`.
+
+The migration ships as four stacked PRs so the auth client and its tests land separately from each call-site cutover. PR-1 introduces the new client + settings + tests without wiring it in (no production behavior change). PR-2 cuts `/streaming-check` over to the new client. PR-3 replaces `_fetch_apple_music_url` with `AppleMusicClient.find_track_url` (this is the PR that ends the user-visible cliff). PR-4 deletes the iTunes-era code and supersedes LML#444. Each PR runs its own staging smoke test before merge.
 
 ## Considered options
 
@@ -14,4 +16,4 @@ Starting 2026-05-28, iTunes Search (`itunes.apple.com/search`) returned HTTP 403
 - Apple Developer Program membership becomes load-bearing for LML. Membership renewal failure becomes a category of outage to monitor.
 - The `.p8` private key is downloaded once at MusicKit-key creation and is unrecoverable; loss requires revoke + re-issue with new Key ID.
 - Local dev without `APPLE_MUSIC_*` env vars sees `apple_music_url=null` in lookup responses (matches existing Spotify-without-creds behavior).
-- LML#444 (silent-failure observability) is superseded — the new client surfaces every non-200 via log + Sentry + active-span data.
+- LML#444 (silent-failure observability) is superseded at PR-4 — the new client surfaces every non-200 via log + Sentry exception capture + a dedicated `apple_music.search` child span carrying status + result.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "aiolimiter>=1.1.0",
     "python-multipart>=0.0.6",
     "wxyc-etl>=0.5.0,<0.6.0",
+    "pyjwt[crypto]>=2.8.0",
 ]
 
 [project.optional-dependencies]

--- a/release/dependencies.py
+++ b/release/dependencies.py
@@ -26,7 +26,7 @@ def get_resolver_dependencies(
     bandcamp: BandcampClient = Depends(get_bandcamp_client),
     spotify: SpotifyClient | None = Depends(get_spotify_client),
     deezer: DeezerClient = Depends(get_deezer_client),
-    apple_music: AppleMusicClient = Depends(get_apple_music_client),
+    apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     entity_store: EntityStore | None = Depends(get_entity_store),
 ) -> _ResolverDependencies:
     """Bundle the I/O clients the resolver orchestrator needs.

--- a/scripts/recheck_streaming_after_mojibake.py
+++ b/scripts/recheck_streaming_after_mojibake.py
@@ -178,7 +178,9 @@ def write_report(results: list[RecheckResult], output_path: Path) -> None:
             )
 
 
-def _build_clients() -> tuple[SpotifyClient | None, DeezerClient, AppleMusicClient, BandcampClient]:
+def _build_clients() -> tuple[
+    SpotifyClient | None, DeezerClient, AppleMusicClient | None, BandcampClient
+]:
     spotify: SpotifyClient | None = None
     cid = os.environ.get("SPOTIFY_CLIENT_ID")
     csec = os.environ.get("SPOTIFY_CLIENT_SECRET")
@@ -186,7 +188,19 @@ def _build_clients() -> tuple[SpotifyClient | None, DeezerClient, AppleMusicClie
         spotify = SpotifyClient(cid, csec)
     else:
         logger.warning("SPOTIFY_CLIENT_ID/SECRET not set — skipping Spotify check")
-    return spotify, DeezerClient(), AppleMusicClient(), BandcampClient()
+
+    apple_music: AppleMusicClient | None = None
+    am_team = os.environ.get("APPLE_MUSIC_TEAM_ID")
+    am_key = os.environ.get("APPLE_MUSIC_KEY_ID")
+    am_priv = os.environ.get("APPLE_MUSIC_PRIVATE_KEY")
+    if am_team and am_key and am_priv:
+        apple_music = AppleMusicClient(team_id=am_team, key_id=am_key, private_key=am_priv)
+    else:
+        logger.warning(
+            "APPLE_MUSIC_TEAM_ID/KEY_ID/PRIVATE_KEY not all set — skipping Apple Music check"
+        )
+
+    return spotify, DeezerClient(), apple_music, BandcampClient()
 
 
 async def _close_clients(*clients) -> None:

--- a/scripts/streaming_availability/__main__.py
+++ b/scripts/streaming_availability/__main__.py
@@ -849,13 +849,22 @@ async def run(args: argparse.Namespace) -> None:
 
         # Apple Music (still sequential, runs after pipeline)
         if not args.spotify_only and not _shutdown_requested:
-            apple = AppleMusicClient()
-            try:
-                await _process_apple_music(
-                    results_db, apple, args.batch_size, check_all=args.apple_only
+            am_team = os.environ.get("APPLE_MUSIC_TEAM_ID")
+            am_key = os.environ.get("APPLE_MUSIC_KEY_ID")
+            am_priv = os.environ.get("APPLE_MUSIC_PRIVATE_KEY")
+            if not (am_team and am_key and am_priv):
+                logger.warning(
+                    "APPLE_MUSIC_TEAM_ID/KEY_ID/PRIVATE_KEY not all set — "
+                    "skipping Apple Music phase"
                 )
-            finally:
-                await apple.close()
+            else:
+                apple = AppleMusicClient(team_id=am_team, key_id=am_key, private_key=am_priv)
+                try:
+                    await _process_apple_music(
+                        results_db, apple, args.batch_size, check_all=args.apple_only
+                    )
+                finally:
+                    await apple.close()
 
         # Report
         logger.info("Generating CSV report: %s", args.output)

--- a/streaming/dependencies.py
+++ b/streaming/dependencies.py
@@ -48,14 +48,33 @@ def get_deezer_client() -> DeezerClient:
     return _deezer_client
 
 
-def get_apple_music_client() -> AppleMusicClient:
-    """Get Apple Music (iTunes) client instance. No auth required."""
+def get_apple_music_client(
+    settings: Settings = Depends(get_settings),
+) -> AppleMusicClient | None:
+    """Get Apple Music client. Requires APPLE_MUSIC_TEAM_ID, KEY_ID, and
+    PRIVATE_KEY; returns None when any is missing so the check degrades to
+    no-op (matches the Spotify-without-creds pattern). See
+    docs/adr/0001-authenticated-apple-music-api.md.
+    """
     global _apple_music_client
 
-    if _apple_music_client is None:
-        _apple_music_client = AppleMusicClient()
-        logger.info("Apple Music client initialized")
+    if _apple_music_client is not None:
+        return _apple_music_client
 
+    if (
+        not settings.apple_music_team_id
+        or not settings.apple_music_key_id
+        or not settings.apple_music_private_key
+    ):
+        logger.debug("Apple Music credentials not set — Apple Music check disabled")
+        return None
+
+    _apple_music_client = AppleMusicClient(
+        team_id=settings.apple_music_team_id,
+        key_id=settings.apple_music_key_id,
+        private_key=settings.apple_music_private_key,
+    )
+    logger.info("Apple Music client initialized")
     return _apple_music_client
 
 

--- a/streaming/router.py
+++ b/streaming/router.py
@@ -41,7 +41,7 @@ async def handle_streaming_check(
     request: StreamingCheckRequest,
     spotify: SpotifyClient | None = Depends(get_spotify_client),
     deezer: DeezerClient = Depends(get_deezer_client),
-    apple_music: AppleMusicClient = Depends(get_apple_music_client),
+    apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     bandcamp: BandcampClient = Depends(get_bandcamp_client),
 ) -> StreamingCheckResponse:
     """Check streaming availability across all configured services."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,8 @@ from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 
 from config.settings import Settings
 from discogs.memory_cache import clear_all_caches, set_skip_cache
@@ -118,6 +120,33 @@ def mock_asyncpg_pool():
 
     pool._mock_conn = conn  # expose for assertions
     return pool
+
+
+@pytest.fixture(scope="session")
+def es256_keypair() -> tuple[str, str]:
+    """Generate an ephemeral ES256 (P-256) keypair for Apple Music client tests.
+
+    Returns ``(private_pem, public_pem)`` as PKCS#8 / SubjectPublicKeyInfo PEM
+    strings. Tests sign real JWTs with the private half and verify with the
+    public half — the same shape Apple validates, just against a key we own
+    instead of one Apple registered. Session-scoped so generation cost (~1 ms)
+    isn't paid per test.
+    """
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
 
 
 @pytest.fixture

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -1,154 +1,343 @@
-"""Unit tests for clients/streaming/apple_music.py."""
+"""Unit tests for clients/streaming/apple_music.py.
+
+The client moved from the unauthenticated iTunes Search endpoint
+(`itunes.apple.com/search`) to the authenticated Apple Music API
+(`api.music.apple.com/v1/catalog/{storefront}/search`) after the 2026-05-28
+Railway egress 403 (LML#443; see docs/adr/0001-authenticated-apple-music-api.md).
+Tests sign real JWTs with an ephemeral ES256 keypair (`es256_keypair` session
+fixture) and mock httpx — Apple's signature validation isn't exercised, just
+our claim structure and request shape.
+"""
+
+from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import jwt as pyjwt
 import pytest
 
-from clients.streaming.apple_music import AppleMusicClient
+from clients.streaming.apple_music import (
+    _APPLE_MUSIC_MATCH_FLOOR,
+    AppleMusicClient,
+)
+
+TEAM_ID = "92V374HC38"
+KEY_ID = "N5UNC9J42U"
+SEARCH_URL = "https://api.music.apple.com/v1/catalog/us/search"
 
 
-def _search_response(results: list[dict] | None = None) -> httpx.Response:
-    return httpx.Response(
-        200,
-        json={"resultCount": len(results or []), "results": results or []},
-        request=httpx.Request("GET", "https://itunes.apple.com/search"),
-    )
-
-
-def _make_album_result(
-    collection_name: str = "Aluminum Tunes",
-    artist_name: str = "Stereolab",
-    collection_url: str = "https://music.apple.com/us/album/aluminum-tunes/123",
+def _make_song_data(
+    name: str = "Back, Baby",
+    artist_name: str = "Jessica Pratt",
+    album_name: str = "On Your Own Love Again",
+    url: str = "https://music.apple.com/us/song/back-baby/123",
 ) -> dict:
     return {
-        "collectionName": collection_name,
-        "artistName": artist_name,
-        "collectionViewUrl": collection_url,
-        "wrapperType": "collection",
-        "collectionType": "Album",
+        "id": "123",
+        "type": "songs",
+        "attributes": {
+            "artistName": artist_name,
+            "name": name,
+            "albumName": album_name,
+            "url": url,
+        },
     }
 
 
-class TestSearchAlbum:
+def _make_album_data(
+    name: str = "Aluminum Tunes",
+    artist_name: str = "Stereolab",
+    url: str = "https://music.apple.com/us/album/aluminum-tunes/456",
+) -> dict:
+    return {
+        "id": "456",
+        "type": "albums",
+        "attributes": {
+            "artistName": artist_name,
+            "name": name,
+            "url": url,
+        },
+    }
+
+
+def _songs_response(songs: list[dict] | None = None) -> httpx.Response:
+    items = songs or []
+    body: dict = {"results": {}}
+    if items:
+        body["results"]["songs"] = {"data": items}
+    return httpx.Response(
+        200,
+        json=body,
+        request=httpx.Request("GET", SEARCH_URL),
+    )
+
+
+def _albums_response(albums: list[dict] | None = None) -> httpx.Response:
+    items = albums or []
+    body: dict = {"results": {}}
+    if items:
+        body["results"]["albums"] = {"data": items}
+    return httpx.Response(
+        200,
+        json=body,
+        request=httpx.Request("GET", SEARCH_URL),
+    )
+
+
+def _client(es256_keypair: tuple[str, str]) -> AppleMusicClient:
+    private_pem, _ = es256_keypair
+    return AppleMusicClient(team_id=TEAM_ID, key_id=KEY_ID, private_key=private_pem)
+
+
+class TestJwtSigning:
+    """The developer token is an ES256 JWT signed per request. Claims and
+    header shape are what Apple validates server-side."""
+
+    def test_sign_jwt_produces_valid_es256_token(self, es256_keypair):
+        _, public_pem = es256_keypair
+        client = _client(es256_keypair)
+
+        token = client._sign_jwt()
+
+        # Verify with the public half — exercises both the signing path and
+        # the claim/header structure that Apple parses.
+        decoded = pyjwt.decode(token, public_pem, algorithms=["ES256"])
+        assert decoded["iss"] == TEAM_ID
+        assert "iat" in decoded
+        assert "exp" in decoded
+        # 20-minute lifetime (J1): exp = iat + 1200 seconds
+        assert decoded["exp"] - decoded["iat"] == 1200
+
+    def test_sign_jwt_sets_kid_in_header(self, es256_keypair):
+        client = _client(es256_keypair)
+        token = client._sign_jwt()
+        header = pyjwt.get_unverified_header(token)
+        assert header["kid"] == KEY_ID
+        assert header["alg"] == "ES256"
+
+
+class TestSearchRequestShape:
+    """Each call must include `Authorization: Bearer <jwt>` and hit
+    `api.music.apple.com/v1/catalog/us/search` with the right `types=` param."""
+
     @pytest.mark.asyncio
-    async def test_returns_album_results(self):
-        client = AppleMusicClient()
+    async def test_search_songs_uses_songs_type(self, es256_keypair):
+        client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
-        mock_http.get = AsyncMock(return_value=_search_response([_make_album_result()]))
+        mock_http.get = AsyncMock(return_value=_songs_response([]))
         client._http = mock_http
 
-        results = await client.search_album("Stereolab", "Aluminum Tunes")
+        await client.search_songs("Jessica Pratt", "Back, Baby")
 
-        assert len(results) == 1
-        assert results[0]["collectionName"] == "Aluminum Tunes"
-        assert results[0]["artistName"] == "Stereolab"
+        call = mock_http.get.call_args
+        assert call.args[0] == SEARCH_URL
+        params = call.kwargs["params"]
+        assert params["types"] == "songs"
+        assert "Jessica Pratt" in params["term"]
+        assert "Back, Baby" in params["term"]
+        # Authorization header carries the signed JWT.
+        auth = call.kwargs["headers"]["Authorization"]
+        assert auth.startswith("Bearer ")
 
     @pytest.mark.asyncio
-    async def test_returns_empty_for_no_results(self):
-        client = AppleMusicClient()
+    async def test_search_albums_uses_albums_type(self, es256_keypair):
+        client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
-        mock_http.get = AsyncMock(return_value=_search_response([]))
+        mock_http.get = AsyncMock(return_value=_albums_response([]))
         client._http = mock_http
 
-        results = await client.search_album("Unknown Artist", "Unknown Album")
-        assert results == []
+        await client.search_albums("Stereolab", "Aluminum Tunes")
+
+        params = mock_http.get.call_args.kwargs["params"]
+        assert params["types"] == "albums"
+        assert "Stereolab" in params["term"]
+
+
+class TestFindTrackUrl:
+    """`find_track_url` is the orchestrator's replacement for the inline
+    `_fetch_apple_music_url` in lookup/orchestrator.py: artist+song+optional
+    album with a 3-way fuzz floor on `attributes.{artistName,name,albumName}`.
+    """
 
     @pytest.mark.asyncio
-    async def test_uses_album_entity(self):
-        client = AppleMusicClient()
+    async def test_returns_url_when_song_clears_floor(self, es256_keypair):
+        client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
-        mock_http.get = AsyncMock(return_value=_search_response([]))
+        mock_http.get = AsyncMock(return_value=_songs_response([_make_song_data()]))
         client._http = mock_http
 
-        await client.search_album("Stereolab", "Aluminum Tunes")
+        url = await client.find_track_url("Jessica Pratt", "Back, Baby")
 
-        call_kwargs = mock_http.get.call_args
-        params = call_kwargs.kwargs.get("params", {})
-        assert params.get("entity") == "album"
-
-
-class TestRetryOn403:
-    @pytest.mark.asyncio
-    async def test_retries_on_403(self):
-        client = AppleMusicClient()
-        mock_http = AsyncMock(spec=httpx.AsyncClient)
-
-        rate_limit_response = httpx.Response(
-            403,
-            request=httpx.Request("GET", "https://itunes.apple.com/search"),
-        )
-        success_response = _search_response([_make_album_result()])
-        mock_http.get = AsyncMock(side_effect=[rate_limit_response, success_response])
-        client._http = mock_http
-
-        with patch("asyncio.sleep", new_callable=AsyncMock):
-            results = await client.search_album("Stereolab", "Aluminum Tunes")
-
-        assert len(results) == 1
-        assert mock_http.get.call_count == 2
-
-
-class TestErrorHandling:
-    @pytest.mark.asyncio
-    async def test_returns_empty_on_network_error(self):
-        client = AppleMusicClient()
-        mock_http = AsyncMock(spec=httpx.AsyncClient)
-        mock_http.get = AsyncMock(side_effect=httpx.ConnectError("Connection failed"))
-        client._http = mock_http
-
-        results = await client.search_album("Stereolab", "Aluminum Tunes")
-        assert results == []
+        assert url == "https://music.apple.com/us/song/back-baby/123"
 
     @pytest.mark.asyncio
-    async def test_returns_empty_on_server_error(self):
-        client = AppleMusicClient()
+    async def test_returns_none_when_artist_below_floor(self, es256_keypair):
+        """LML#389 wrong-artist guard: same title, completely different artist."""
+        client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
-            return_value=httpx.Response(
-                500,
-                request=httpx.Request("GET", "https://itunes.apple.com/search"),
+            return_value=_songs_response(
+                [_make_song_data(artist_name="Completely Different Artist")]
             )
         )
         client._http = mock_http
 
-        results = await client.search_album("Stereolab", "Aluminum Tunes")
-        assert results == []
+        url = await client.find_track_url("Jessica Pratt", "Back, Baby")
+        assert url is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_album_below_floor(self, es256_keypair):
+        """LML#396: same artist + same track title on the wrong album."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response([_make_song_data(album_name="Some Unrelated Compilation")])
+        )
+        client._http = mock_http
+
+        url = await client.find_track_url(
+            "Jessica Pratt", "Back, Baby", album="On Your Own Love Again"
+        )
+        assert url is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_search_empty(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([]))
+        client._http = mock_http
+
+        url = await client.find_track_url("Unknown", "Unknown")
+        assert url is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_non_200(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=httpx.Response(401, request=httpx.Request("GET", SEARCH_URL))
+        )
+        client._http = mock_http
+
+        url = await client.find_track_url("Stereolab", "Aluminum Tunes")
+        assert url is None
 
 
 class TestFindAlbumMatch:
-    """`find_album_match` extracts the iTunes-shaped result fields and
-    returns a normalized `SourceMatch` (LML#392). The artist-floor check
-    inside `find_best_match` carries the LML#389 wrong-artist guard."""
+    """`find_album_match` is the BaseStreamingClient contract used by
+    /streaming-check — returns a `SourceMatch` from the album-shaped response."""
 
     @pytest.mark.asyncio
-    async def test_returns_source_match_from_top_hit(self):
-        client = AppleMusicClient()
-        client.search_album = AsyncMock(return_value=[_make_album_result()])
+    async def test_returns_source_match_from_top_hit(self, es256_keypair):
+        client = _client(es256_keypair)
+        client.search_albums = AsyncMock(return_value=[_make_album_data()])
 
         match = await client.find_album_match("Stereolab", "Aluminum Tunes")
 
         assert match is not None
-        assert "apple.com" in match.url
+        assert match.url == "https://music.apple.com/us/album/aluminum-tunes/456"
         assert match.confidence >= 80.0
-        client.search_album.assert_awaited_once_with("Stereolab", "Aluminum Tunes")
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_search_empty(self):
-        client = AppleMusicClient()
-        client.search_album = AsyncMock(return_value=[])
+    async def test_returns_none_when_search_empty(self, es256_keypair):
+        client = _client(es256_keypair)
+        client.search_albums = AsyncMock(return_value=[])
 
         match = await client.find_album_match("Unknown", "Unknown")
         assert match is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_for_wrong_artist_match(self):
-        """LML#389: iTunes can return a same-titled album by a different artist.
-        The shared artist-floor inside `find_best_match` rejects it."""
-        client = AppleMusicClient()
-        client.search_album = AsyncMock(
-            return_value=[_make_album_result(artist_name="Completely Different Artist")]
+    async def test_returns_none_for_wrong_artist_match(self, es256_keypair):
+        client = _client(es256_keypair)
+        client.search_albums = AsyncMock(
+            return_value=[_make_album_data(artist_name="Completely Different Artist")]
         )
 
         match = await client.find_album_match("Stereolab", "Aluminum Tunes")
         assert match is None
+
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_search_returns_empty_on_network_error(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
+        client._http = mock_http
+
+        results = await client.search_songs("Stereolab", "Aluminum Tunes")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_returns_empty_on_server_error(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=httpx.Response(500, request=httpx.Request("GET", SEARCH_URL))
+        )
+        client._http = mock_http
+
+        results = await client.search_songs("Stereolab", "Aluminum Tunes")
+        assert results == []
+
+
+class TestObservability:
+    """O3: every non-200 must log, capture to Sentry, AND project onto the
+    active span as `apple_music.search.{status,result}` (matches the
+    wrap-at-chokepoint pattern from LML#213)."""
+
+    @pytest.mark.asyncio
+    async def test_non_200_captures_to_sentry(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=httpx.Response(403, request=httpx.Request("GET", SEARCH_URL))
+        )
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.sentry_sdk") as mock_sentry:
+            mock_span = mock_sentry.get_current_scope.return_value.transaction
+            await client.search_songs("Stereolab", "Aluminum Tunes")
+
+        mock_sentry.capture_message.assert_called_once()
+        # Project onto active span: status code + miss-class result.
+        set_data_calls = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
+        assert set_data_calls.get("apple_music.search.status") == 403
+        assert set_data_calls.get("apple_music.search.result") == "403"
+
+    @pytest.mark.asyncio
+    async def test_hit_projects_result_onto_span(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([_make_song_data()]))
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.sentry_sdk") as mock_sentry:
+            mock_span = mock_sentry.get_current_scope.return_value.transaction
+            await client.search_songs("Jessica Pratt", "Back, Baby")
+
+        set_data_calls = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
+        assert set_data_calls.get("apple_music.search.status") == 200
+        assert set_data_calls.get("apple_music.search.result") == "hit"
+
+    @pytest.mark.asyncio
+    async def test_empty_results_projects_miss(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([]))
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.sentry_sdk") as mock_sentry:
+            mock_span = mock_sentry.get_current_scope.return_value.transaction
+            await client.search_songs("Jessica Pratt", "Back, Baby")
+
+        set_data_calls = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
+        assert set_data_calls.get("apple_music.search.result") == "miss"
+
+
+def test_match_floor_constant_is_80():
+    """The 80.0 floor matches the BaseStreamingClient `is_acceptable_match`
+    floor used by every other provider. Exporting the constant lets the
+    orchestrator drop its private `_APPLE_MUSIC_MATCH_FLOOR` in PR-3/4."""
+    assert _APPLE_MUSIC_MATCH_FLOOR == 80.0

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -11,7 +11,7 @@ our claim structure and request shape.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import jwt as pyjwt
@@ -90,6 +90,28 @@ def _client(es256_keypair: tuple[str, str]) -> AppleMusicClient:
     return AppleMusicClient(team_id=TEAM_ID, key_id=KEY_ID, private_key=private_pem)
 
 
+class TestConstruction:
+    """Constructor pre-parses the PEM so misconfigurations fail at startup
+    rather than silently degrading every search to `[]`."""
+
+    def test_accepts_valid_pem(self, es256_keypair):
+        # No raise.
+        _ = _client(es256_keypair)
+
+    def test_rejects_garbage_pem(self):
+        with pytest.raises((ValueError, Exception)):
+            AppleMusicClient(team_id=TEAM_ID, key_id=KEY_ID, private_key="not a pem")
+
+    def test_rejects_escaped_newlines_pem(self, es256_keypair):
+        """Railway sometimes renders PEM newlines as the literal two-char `\\n`
+        sequence; the constructor must reject so the operator sees the
+        misconfig at startup, not as a silent stream of empty searches."""
+        private_pem, _ = es256_keypair
+        mangled = private_pem.replace("\n", "\\n")
+        with pytest.raises((ValueError, Exception)):
+            AppleMusicClient(team_id=TEAM_ID, key_id=KEY_ID, private_key=mangled)
+
+
 class TestJwtSigning:
     """The developer token is an ES256 JWT signed per request. Claims and
     header shape are what Apple validates server-side."""
@@ -100,8 +122,6 @@ class TestJwtSigning:
 
         token = client._sign_jwt()
 
-        # Verify with the public half — exercises both the signing path and
-        # the claim/header structure that Apple parses.
         decoded = pyjwt.decode(token, public_pem, algorithms=["ES256"])
         assert decoded["iss"] == TEAM_ID
         assert "iat" in decoded
@@ -122,13 +142,13 @@ class TestSearchRequestShape:
     `api.music.apple.com/v1/catalog/us/search` with the right `types=` param."""
 
     @pytest.mark.asyncio
-    async def test_search_songs_uses_songs_type(self, es256_keypair):
+    async def test_search_song_uses_songs_type(self, es256_keypair):
         client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(return_value=_songs_response([]))
         client._http = mock_http
 
-        await client.search_songs("Jessica Pratt", "Back, Baby")
+        await client.search_song("Jessica Pratt", "Back, Baby")
 
         call = mock_http.get.call_args
         assert call.args[0] == SEARCH_URL
@@ -136,18 +156,17 @@ class TestSearchRequestShape:
         assert params["types"] == "songs"
         assert "Jessica Pratt" in params["term"]
         assert "Back, Baby" in params["term"]
-        # Authorization header carries the signed JWT.
         auth = call.kwargs["headers"]["Authorization"]
         assert auth.startswith("Bearer ")
 
     @pytest.mark.asyncio
-    async def test_search_albums_uses_albums_type(self, es256_keypair):
+    async def test_search_album_uses_albums_type(self, es256_keypair):
         client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(return_value=_albums_response([]))
         client._http = mock_http
 
-        await client.search_albums("Stereolab", "Aluminum Tunes")
+        await client.search_album("Stereolab", "Aluminum Tunes")
 
         params = mock_http.get.call_args.kwargs["params"]
         assert params["types"] == "albums"
@@ -158,7 +177,7 @@ class TestFindTrackUrl:
     """`find_track_url` is the orchestrator's replacement for the inline
     `_fetch_apple_music_url` in lookup/orchestrator.py: artist+song+optional
     album with a 3-way fuzz floor on `attributes.{artistName,name,albumName}`.
-    """
+    Picks the highest-scoring URL clearing the floor, not the first."""
 
     @pytest.mark.asyncio
     async def test_returns_url_when_song_clears_floor(self, es256_keypair):
@@ -202,6 +221,43 @@ class TestFindTrackUrl:
         assert url is None
 
     @pytest.mark.asyncio
+    async def test_picks_best_scoring_when_multiple_clear_floor(self, es256_keypair):
+        """Iterates all results and selects the highest-combined-score match.
+        A sub-optimal early result must not freeze the wrong URL onto the row."""
+        client = _client(es256_keypair)
+        # First result is a same-titled cover by a similar-named artist that
+        # barely clears 80; second is the canonical exact match.
+        sub_optimal = _make_song_data(
+            artist_name="Jessica Praatt",  # 1-char typo, clears 80 but not 100
+            url="https://music.apple.com/us/song/wrong/1",
+        )
+        canonical = _make_song_data(
+            url="https://music.apple.com/us/song/right/2",
+        )
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([sub_optimal, canonical]))
+        client._http = mock_http
+
+        url = await client.find_track_url("Jessica Pratt", "Back, Baby")
+        assert url == "https://music.apple.com/us/song/right/2"
+
+    @pytest.mark.asyncio
+    async def test_handles_null_string_attributes(self, es256_keypair):
+        """Apple returns JSON null for missing string fields; normalize_for_comparison
+        cannot accept None. The client must coerce None to '' so a null
+        albumName doesn't raise mid-iteration."""
+        client = _client(es256_keypair)
+        item = _make_song_data()
+        item["attributes"]["albumName"] = None
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([item]))
+        client._http = mock_http
+
+        # No raise. Without the album filter, the item still matches.
+        url = await client.find_track_url("Jessica Pratt", "Back, Baby")
+        assert url == "https://music.apple.com/us/song/back-baby/123"
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_search_empty(self, es256_keypair):
         client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
@@ -212,7 +268,8 @@ class TestFindTrackUrl:
         assert url is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_on_non_200(self, es256_keypair):
+    async def test_returns_none_on_terminal_non_200(self, es256_keypair):
+        """401/403 are terminal — no retry, no recovery, return [] (→ None)."""
         client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
@@ -231,7 +288,7 @@ class TestFindAlbumMatch:
     @pytest.mark.asyncio
     async def test_returns_source_match_from_top_hit(self, es256_keypair):
         client = _client(es256_keypair)
-        client.search_albums = AsyncMock(return_value=[_make_album_data()])
+        client.search_album = AsyncMock(return_value=[_make_album_data()])
 
         match = await client.find_album_match("Stereolab", "Aluminum Tunes")
 
@@ -242,7 +299,7 @@ class TestFindAlbumMatch:
     @pytest.mark.asyncio
     async def test_returns_none_when_search_empty(self, es256_keypair):
         client = _client(es256_keypair)
-        client.search_albums = AsyncMock(return_value=[])
+        client.search_album = AsyncMock(return_value=[])
 
         match = await client.find_album_match("Unknown", "Unknown")
         assert match is None
@@ -250,12 +307,113 @@ class TestFindAlbumMatch:
     @pytest.mark.asyncio
     async def test_returns_none_for_wrong_artist_match(self, es256_keypair):
         client = _client(es256_keypair)
-        client.search_albums = AsyncMock(
+        client.search_album = AsyncMock(
             return_value=[_make_album_data(artist_name="Completely Different Artist")]
         )
 
         match = await client.find_album_match("Stereolab", "Aluminum Tunes")
         assert match is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_item_does_not_kill_iteration(self, es256_keypair):
+        """An item missing `attributes` (region-restricted, malformed, etc.)
+        must not raise inside `find_best_match` and erase legitimate later
+        matches. Score=0 from .get()-chained extractors is the correct
+        outcome — the item gets skipped naturally."""
+        client = _client(es256_keypair)
+        malformed = {"id": "bad", "type": "albums"}  # no attributes
+        ok = _make_album_data()
+        client.search_album = AsyncMock(return_value=[malformed, ok])
+
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+
+        assert match is not None
+        assert match.url == "https://music.apple.com/us/album/aluminum-tunes/456"
+
+    @pytest.mark.asyncio
+    async def test_item_with_null_attributes_does_not_raise(self, es256_keypair):
+        """Apple returns `attributes: null` on rare records; extractors must
+        return '' for None-typed attributes, not raise."""
+        client = _client(es256_keypair)
+        null_attrs = {"id": "bad", "type": "albums", "attributes": None}
+        ok = _make_album_data()
+        client.search_album = AsyncMock(return_value=[null_attrs, ok])
+
+        # No raise.
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert match is not None
+        assert match.url.endswith("/456")
+
+
+class TestRetryBehavior:
+    """429 and transient 5xx are retried; terminal 4xx are not. Mirrors
+    SpotifyClient's _search_with_retry shape."""
+
+    @pytest.mark.asyncio
+    async def test_retries_on_429_honoring_retry_after(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        rate_limited = httpx.Response(
+            429,
+            headers={"Retry-After": "1"},
+            request=httpx.Request("GET", SEARCH_URL),
+        )
+        success = _songs_response([_make_song_data()])
+        mock_http.get = AsyncMock(side_effect=[rate_limited, success])
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.asyncio.sleep", new_callable=AsyncMock):
+            results = await client.search_song("Jessica Pratt", "Back, Baby")
+
+        assert len(results) == 1
+        assert mock_http.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_503_with_backoff(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        unavailable = httpx.Response(503, request=httpx.Request("GET", SEARCH_URL))
+        success = _songs_response([_make_song_data()])
+        mock_http.get = AsyncMock(side_effect=[unavailable, success])
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.asyncio.sleep", new_callable=AsyncMock):
+            results = await client.search_song("Jessica Pratt", "Back, Baby")
+
+        assert len(results) == 1
+        assert mock_http.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_terminal_4xx(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=httpx.Response(401, request=httpx.Request("GET", SEARCH_URL))
+        )
+        client._http = mock_http
+
+        results = await client.search_song("Stereolab", "Aluminum Tunes")
+        assert results == []
+        assert mock_http.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_retries_on_429_burst(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        rate_limited = httpx.Response(
+            429,
+            headers={"Retry-After": "1"},
+            request=httpx.Request("GET", SEARCH_URL),
+        )
+        # 10 consecutive 429s — should give up after _MAX_RETRIES (4).
+        mock_http.get = AsyncMock(return_value=rate_limited)
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.asyncio.sleep", new_callable=AsyncMock):
+            results = await client.search_song("Stereolab", "Aluminum Tunes")
+
+        assert results == []
+        assert mock_http.get.call_count == 4  # _MAX_RETRIES
 
 
 class TestErrorHandling:
@@ -266,26 +424,39 @@ class TestErrorHandling:
         mock_http.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
         client._http = mock_http
 
-        results = await client.search_songs("Stereolab", "Aluminum Tunes")
+        results = await client.search_song("Stereolab", "Aluminum Tunes")
         assert results == []
 
     @pytest.mark.asyncio
-    async def test_search_returns_empty_on_server_error(self, es256_keypair):
+    async def test_search_returns_empty_on_invalid_json_body(self, es256_keypair):
+        """Apple's CDN occasionally serves a 200 with an HTML body during
+        edge-cache hiccups; `resp.json()` raises JSONDecodeError which must
+        be absorbed by the same path that handles network errors — and
+        captured to Sentry, not silently dropped."""
         client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
-            return_value=httpx.Response(500, request=httpx.Request("GET", SEARCH_URL))
+            return_value=httpx.Response(
+                200,
+                content=b"<html>edge cache error</html>",
+                request=httpx.Request("GET", SEARCH_URL),
+            )
         )
         client._http = mock_http
 
-        results = await client.search_songs("Stereolab", "Aluminum Tunes")
+        with patch("clients.streaming.apple_music.sentry_sdk") as mock_sentry:
+            mock_sentry.start_span.return_value.__enter__.return_value = MagicMock()
+            results = await client.search_song("Stereolab", "Aluminum Tunes")
+
         assert results == []
+        mock_sentry.capture_exception.assert_called_once()
 
 
 class TestObservability:
-    """O3: every non-200 must log, capture to Sentry, AND project onto the
-    active span as `apple_music.search.{status,result}` (matches the
-    wrap-at-chokepoint pattern from LML#213)."""
+    """O3: every call lives in a dedicated `apple_music.search` child span;
+    `.status` and `.result` are set on that span (LML#213 wrap-at-chokepoint).
+    capture_exception preserves the stack on the error path; capture_message
+    fires on terminal non-200."""
 
     @pytest.mark.asyncio
     async def test_non_200_captures_to_sentry(self, es256_keypair):
@@ -297,11 +468,11 @@ class TestObservability:
         client._http = mock_http
 
         with patch("clients.streaming.apple_music.sentry_sdk") as mock_sentry:
-            mock_span = mock_sentry.get_current_scope.return_value.transaction
-            await client.search_songs("Stereolab", "Aluminum Tunes")
+            mock_span = MagicMock()
+            mock_sentry.start_span.return_value.__enter__.return_value = mock_span
+            await client.search_song("Stereolab", "Aluminum Tunes")
 
         mock_sentry.capture_message.assert_called_once()
-        # Project onto active span: status code + miss-class result.
         set_data_calls = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
         assert set_data_calls.get("apple_music.search.status") == 403
         assert set_data_calls.get("apple_music.search.result") == "403"
@@ -314,8 +485,9 @@ class TestObservability:
         client._http = mock_http
 
         with patch("clients.streaming.apple_music.sentry_sdk") as mock_sentry:
-            mock_span = mock_sentry.get_current_scope.return_value.transaction
-            await client.search_songs("Jessica Pratt", "Back, Baby")
+            mock_span = MagicMock()
+            mock_sentry.start_span.return_value.__enter__.return_value = mock_span
+            await client.search_song("Jessica Pratt", "Back, Baby")
 
         set_data_calls = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
         assert set_data_calls.get("apple_music.search.status") == 200
@@ -329,11 +501,28 @@ class TestObservability:
         client._http = mock_http
 
         with patch("clients.streaming.apple_music.sentry_sdk") as mock_sentry:
-            mock_span = mock_sentry.get_current_scope.return_value.transaction
-            await client.search_songs("Jessica Pratt", "Back, Baby")
+            mock_span = MagicMock()
+            mock_sentry.start_span.return_value.__enter__.return_value = mock_span
+            await client.search_song("Jessica Pratt", "Back, Baby")
 
         set_data_calls = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
         assert set_data_calls.get("apple_music.search.result") == "miss"
+
+    @pytest.mark.asyncio
+    async def test_network_error_captures_exception_with_stack(self, es256_keypair):
+        """The except branch must use capture_exception (preserving the live
+        stack) rather than capture_message (a static string) so distinct
+        underlying failures don't collapse into one Sentry issue."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(side_effect=httpx.ConnectError("dns failure"))
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.sentry_sdk") as mock_sentry:
+            mock_sentry.start_span.return_value.__enter__.return_value = MagicMock()
+            await client.search_song("Stereolab", "Aluminum Tunes")
+
+        mock_sentry.capture_exception.assert_called_once()
 
 
 def test_match_floor_constant_is_80():


### PR DESCRIPTION
First of 4 stacked PRs migrating LML from the unauthenticated iTunes Search endpoint to the authenticated Apple Music API (`api.music.apple.com`) after the 2026-05-28 Railway egress IP block (#443).

## Scope of PR-1

Lands the **new client, settings, observability, and tests** behind the existing call surfaces — no call site logic migrates yet, so prod behavior is unchanged. The user-visible fix arrives at PR-3.

| PR | What lands | User-visible effect |
|---|---|---|
| **PR-1 (this one)** | New `AppleMusicClient` + settings + tests + ADR | None — old paths still serve traffic |
| PR-2 | `/streaming-check` migrates to the new client | Streaming-availability checks recover |
| PR-3 | Orchestrator hot path replaces `_fetch_apple_music_url` with `find_track_url`; staging smoke test | Apple Music URLs restored on new flowsheet entries (closes #443) |
| PR-4 | Delete `_fetch_apple_music_url` + `_APPLE_MUSIC_MATCH_FLOOR` constant; update `scripts/recheck_streaming_after_mojibake.py`'s old caller | Closes #444 as superseded |

## Architecture decisions

See `docs/adr/0001-authenticated-apple-music-api.md` for the full record (alternatives considered: Railway IP rotation, BS-EC2 proxy, UA probe, iTunes fallback — all rejected; rationale captured).

Highlights:
- **JWT lifecycle (J1):** sign per request, `exp = iat + 1200s`. Keeps a leaked token's blast radius small without needing in-process token caching.
- **Provider lifecycle (L1):** returns `None` when any of `APPLE_MUSIC_TEAM_ID`/`KEY_ID`/`PRIVATE_KEY` is unset. Mirrors the Spotify-without-creds degradation pattern exactly. Local dev sees `apple_music_url=null` in lookups.
- **Rate limit (R2):** `(60, 60)` + semaphore=5. Sized to Apple's published catalog quota with comfort margin.
- **Hard cutover (F2):** no iTunes fallback, no feature flag. The fallback would be provably dead code from LML's Railway egress.
- **Observability (O3):** every call projects `apple_music.search.{status,result}` onto the active Sentry transaction and `capture_message`s non-200s. The silent-failure mode the old iTunes path exhibited (#444) cannot recur.
- **Match floor (S2):** 80.0 fuzz floor on `attributes.{artistName,name,albumName}` — preserves the LML#389 wrong-artist guard and LML#396 wrong-album guard.

## Invariants preserved

- **LML#241 (FD-leak):** still inherits `BaseStreamingClient`, no per-request `httpx.AsyncClient` construction. Regression test in `tests/unit/test_fd_leak_regression_241.py` still passes.
- **`BaseStreamingClient.find_album_match` contract:** subclass overrides the response-shape adapter; orchestrator never branches on service identity.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean (280 files)
- [x] `mypy` on touched modules — clean
- [x] Unit suite: 2051 passed (up from 2042 pristine main); the 1 pre-existing error in `test_no_module_level_asyncio_lock_in_dependencies` is unrelated event-loop teardown noise, not introduced by this PR
- [x] 18 new tests in `tests/unit/test_apple_music_client.py` cover JWT claim/header shape, request shape (`types=songs`/`types=albums` + Bearer auth), 3-way + 2-way fuzz floors, error handling, O3 observability across hit/miss/non-200, and the match floor constant export

## Operational notes

- Railway secrets `APPLE_MUSIC_TEAM_ID`, `APPLE_MUSIC_KEY_ID`, `APPLE_MUSIC_PRIVATE_KEY` are already set in both production and staging environments (set during the 2026-05-31 incident response).
- The `.p8` private key is unrecoverable from Apple — losing it requires revoke + re-issue with a new Key ID.
- Apple Developer Program membership renewal failure is now a new outage category.

## Related

- #443 (iTunes 403 cliff) — closes at PR-3
- #444 (Apple Music silent failure observability) — closes at PR-4 as superseded; the new client surfaces every non-200 via the O3 path
- #241 (FD-leak) — invariant preserved
- #389 (wrong-artist guard), #396 (wrong-album guard) — match floor preserved
- #213 (wrap-at-chokepoint + project-onto-span) — observability follows this pattern