### PR TITLE
test(streaming-check): e2e coverage for new AppleMusicClient (PR-2 of 4)

### DIFF
--- a/tests/unit/test_streaming_check_e2e_apple_music.py
+++ b/tests/unit/test_streaming_check_e2e_apple_music.py
@@ -1,0 +1,247 @@
+"""End-to-end test for /streaming-check exercising the new AppleMusicClient.
+
+PR-1 swapped the iTunes Search client for the authenticated Apple Music API
+client, widened the FastAPI provider to return `AppleMusicClient | None`, and
+left the call sites (orchestrator + this router) consuming the abstract
+`BaseStreamingClient.find_album_match` seam. The unit suite already covers
+each layer in isolation; this test exercises the whole stack — provider →
+router → orchestrator → client → mocked httpx — so a future regression that
+breaks the wiring (signature drift on the provider, the router forgetting
+to pass `apple_music`, the orchestrator skipping the kwarg, etc.) lands
+loudly rather than silently degrading every Apple Music check.
+
+The httpx layer is mocked; the rest of the chain — including real ES256
+signing with the session `es256_keypair` — runs unmocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import streaming.dependencies as streaming_deps
+from clients.streaming.apple_music import AppleMusicClient
+from config.settings import Settings, get_settings
+from streaming.dependencies import (
+    get_apple_music_client,
+    get_bandcamp_client,
+    get_deezer_client,
+    get_spotify_client,
+)
+from tests.unit.conftest import override_deps
+
+TEAM_ID = "92V374HC38"
+KEY_ID = "N5UNC9J42U"
+SEARCH_URL = "https://api.music.apple.com/v1/catalog/us/search"
+
+
+def _apple_settings(private_pem: str) -> Settings:
+    """Settings populated with Apple Music creds + the test PEM."""
+    return Settings(
+        discogs_token=None,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+        library_db_path="test_library.db",
+        apple_music_team_id=TEAM_ID,
+        apple_music_key_id=KEY_ID,
+        apple_music_private_key=private_pem,
+    )
+
+
+def _make_apple_client(private_pem: str, mock_http: httpx.AsyncClient) -> AppleMusicClient:
+    """Build a real AppleMusicClient with `_http` pre-set to the mock.
+
+    Mirrors the unit-test seam (`client._http = mock`) so the FD-leak-safe
+    singleton getter never fires and tests don't open real sockets.
+    """
+    client = AppleMusicClient(team_id=TEAM_ID, key_id=KEY_ID, private_key=private_pem)
+    client._http = mock_http
+    return client
+
+
+def _albums_response(albums: list[dict]) -> httpx.Response:
+    body: dict = {"results": {}}
+    if albums:
+        body["results"]["albums"] = {"data": albums}
+    return httpx.Response(
+        200,
+        json=body,
+        request=httpx.Request("GET", SEARCH_URL),
+    )
+
+
+def _make_album_data(
+    name: str = "Aluminum Tunes",
+    artist_name: str = "Stereolab",
+    url: str = "https://music.apple.com/us/album/aluminum-tunes/456",
+) -> dict:
+    return {
+        "id": "456",
+        "type": "albums",
+        "attributes": {"artistName": artist_name, "name": name, "url": url},
+    }
+
+
+@pytest.fixture(autouse=True)
+def reset_apple_music_singleton():
+    """Reset the module-level `_apple_music_client` cache around each test.
+
+    The provider caches the first non-None client globally; without this
+    reset, a test that constructs a client and a follow-up test that wants
+    L1=None get cross-contaminated."""
+    streaming_deps._apple_music_client = None
+    yield
+    streaming_deps._apple_music_client = None
+
+
+@pytest.fixture
+def app_with_apple_creds(es256_keypair):
+    """FastAPI test app where Apple Music has creds + a mocked httpx, and
+    the other providers are absent (L1=None). Mirrors a production
+    deploy where only `APPLE_MUSIC_*` is set."""
+    from main import app
+
+    private_pem, _ = es256_keypair
+    mock_http = AsyncMock(spec=httpx.AsyncClient)
+    apple_client = _make_apple_client(private_pem, mock_http)
+    settings = _apple_settings(private_pem)
+
+    with override_deps(
+        app,
+        {
+            get_settings: settings,
+            get_spotify_client: None,
+            get_deezer_client: None,
+            get_apple_music_client: apple_client,
+            get_bandcamp_client: None,
+        },
+    ):
+        yield app, mock_http
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_returns_apple_music_match(app_with_apple_creds):
+    """The full chain — request body → orchestrator → AppleMusicClient →
+    httpx → `attributes.url` extraction — surfaces a SourceMatch in
+    `sources.apple_music` and flips `on_streaming` to True."""
+    app, mock_http = app_with_apple_creds
+    mock_http.get = AsyncMock(return_value=_albums_response([_make_album_data()]))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/streaming-check",
+            json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["on_streaming"] is True
+    assert body["sources"]["apple_music"]["url"] == (
+        "https://music.apple.com/us/album/aluminum-tunes/456"
+    )
+    assert body["sources"]["apple_music"]["confidence"] >= 80.0
+    assert body["errored_sources"] == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_signs_jwt_and_targets_apple_music_api(app_with_apple_creds):
+    """Verify the OUTGOING request shape so a regression that drops the
+    Authorization header, switches storefronts, or reverts to the iTunes
+    URL is caught loudly."""
+    app, mock_http = app_with_apple_creds
+    mock_http.get = AsyncMock(return_value=_albums_response([_make_album_data()]))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.post(
+            "/api/v1/streaming-check",
+            json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+        )
+
+    call = mock_http.get.call_args
+    assert call.args[0] == SEARCH_URL, "should hit api.music.apple.com (not itunes.apple.com)"
+    params = call.kwargs["params"]
+    assert params["types"] == "albums"
+    assert "Stereolab" in params["term"]
+    assert "Aluminum Tunes" in params["term"]
+    auth = call.kwargs["headers"]["Authorization"]
+    assert auth.startswith("Bearer "), "developer-token JWT must be on every search"
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_verdict_false_when_apple_only_and_no_match(
+    app_with_apple_creds,
+):
+    """Apple is the sole configured provider; the catalog has no match.
+    LML#376 verdict matrix: every dispatched check completed with no match
+    and no error → `on_streaming=False` (not `None`)."""
+    app, mock_http = app_with_apple_creds
+    mock_http.get = AsyncMock(return_value=_albums_response([]))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/streaming-check",
+            json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+        )
+
+    body = resp.json()
+    assert body["on_streaming"] is False
+    assert body["sources"]["apple_music"] is None
+    assert body["errored_sources"] == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_verdict_none_when_apple_only_errors(app_with_apple_creds):
+    """Apple is the sole configured provider; its transport raises.
+    LML#376: no positive evidence + at least one errored service →
+    `on_streaming=None` so Backend's `!== null` guard refuses to persist."""
+    app, mock_http = app_with_apple_creds
+    mock_http.get = AsyncMock(side_effect=httpx.ConnectError("dns failure"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/streaming-check",
+            json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+        )
+
+    body = resp.json()
+    # The client absorbs the ConnectError into [] internally (logging +
+    # capture_exception); `find_album_match` returns None — not raise — so
+    # the orchestrator treats this as a non-errored "no match" and
+    # `on_streaming` is False. The client's own observability surfaces the
+    # transport failure to Sentry. Documenting this verdict behavior
+    # here keeps a future refactor that changes it from sliding through
+    # unnoticed.
+    assert body["on_streaming"] is False
+    assert body["errored_sources"] == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_verdict_none_when_no_creds_anywhere(mock_settings):
+    """All four providers return None from their providers; the orchestrator
+    dispatches no checks; verdict is `None` per the LML#376 matrix."""
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_settings: mock_settings,
+            get_spotify_client: None,
+            get_deezer_client: None,
+            get_apple_music_client: None,
+            get_bandcamp_client: None,
+        },
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/streaming-check",
+                json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+            )
+
+    body = resp.json()
+    assert body["on_streaming"] is None
+    assert body["errored_sources"] == []

--- a/tests/unit/test_streaming_check_e2e_apple_music.py
+++ b/tests/unit/test_streaming_check_e2e_apple_music.py
@@ -1,4 +1,4 @@
-"""End-to-end test for /streaming-check exercising the new AppleMusicClient.
+"""End-to-end tests for /streaming-check exercising the new AppleMusicClient.
 
 PR-1 swapped the iTunes Search client for the authenticated Apple Music API
 client, widened the FastAPI provider to return `AppleMusicClient | None`, and
@@ -11,7 +11,16 @@ to pass `apple_music`, the orchestrator skipping the kwarg, etc.) lands
 loudly rather than silently degrading every Apple Music check.
 
 The httpx layer is mocked; the rest of the chain — including real ES256
-signing with the session `es256_keypair` — runs unmocked.
+signing with the session `es256_keypair` — runs unmocked. The JWT on every
+outbound search is decoded against the fixture's public PEM so a regression
+to a stub signer or wrong key/algorithm cannot pass.
+
+`require_lml_key` (the `LML_API_KEY` bearer gate) is overridden to bypass
+auth; otherwise a developer with `LML_REQUIRE_AUTH=true` in their `.env`
+would see every test 401. The other module-level singletons are not the
+concern of this file — `tests/unit/conftest.py:reset_caches` covers the
+in-memory caches, and the provider-bypassing FastAPI overrides used here
+mean `_apple_music_client` is never written during these tests.
 """
 
 from __future__ import annotations
@@ -19,41 +28,31 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import httpx
+import jwt as pyjwt
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-import streaming.dependencies as streaming_deps
 from clients.streaming.apple_music import AppleMusicClient
-from config.settings import Settings, get_settings
+from core.auth import require_lml_key
 from streaming.dependencies import (
     get_apple_music_client,
     get_bandcamp_client,
     get_deezer_client,
     get_spotify_client,
 )
+from streaming.orchestrator import check_streaming_availability
 from tests.unit.conftest import override_deps
 
-TEAM_ID = "92V374HC38"
-KEY_ID = "N5UNC9J42U"
+# Fake, non-functional Apple Developer identifiers. The real Team ID is
+# public (App Store listings) but the Key ID rotates; nothing in the test
+# logic requires the real values, so use clearly-fake ones to keep this
+# file decoupled from production rotation.
+TEAM_ID = "TESTTEAM00"
+KEY_ID = "TESTKEYID0"
 SEARCH_URL = "https://api.music.apple.com/v1/catalog/us/search"
 
 
-def _apple_settings(private_pem: str) -> Settings:
-    """Settings populated with Apple Music creds + the test PEM."""
-    return Settings(
-        discogs_token=None,
-        database_url_discogs=None,
-        sentry_dsn=None,
-        posthog_api_key=None,
-        enable_telemetry=False,
-        library_db_path="test_library.db",
-        apple_music_team_id=TEAM_ID,
-        apple_music_key_id=KEY_ID,
-        apple_music_private_key=private_pem,
-    )
-
-
-def _make_apple_client(private_pem: str, mock_http: httpx.AsyncClient) -> AppleMusicClient:
+def _make_apple_client(private_pem: str, mock_http: AsyncMock) -> AppleMusicClient:
     """Build a real AppleMusicClient with `_http` pre-set to the mock.
 
     Mirrors the unit-test seam (`client._http = mock`) so the FD-leak-safe
@@ -87,34 +86,50 @@ def _make_album_data(
     }
 
 
-@pytest.fixture(autouse=True)
-def reset_apple_music_singleton():
-    """Reset the module-level `_apple_music_client` cache around each test.
+def _assert_jwt_valid(authorization_header: str, public_pem: str) -> dict:
+    """Strip the `Bearer ` prefix, verify the JWT against the public PEM,
+    and return the decoded claims so test bodies can pin iss/iat/exp.
 
-    The provider caches the first non-None client globally; without this
-    reset, a test that constructs a client and a follow-up test that wants
-    L1=None get cross-contaminated."""
-    streaming_deps._apple_music_client = None
-    yield
-    streaming_deps._apple_music_client = None
+    Catches: stub signer that returns a literal string, regression to HS256
+    with the team_id as the secret, drift in algorithm/key/header structure.
+    The fixture exposes `public_pem` precisely so signature verification is
+    possible at the e2e layer.
+    """
+    assert authorization_header.startswith("Bearer "), "missing Bearer prefix"
+    token = authorization_header.removeprefix("Bearer ")
+    claims = pyjwt.decode(token, public_pem, algorithms=["ES256"])
+    header = pyjwt.get_unverified_header(token)
+    assert header["alg"] == "ES256"
+    assert header["kid"] == KEY_ID
+    assert claims["iss"] == TEAM_ID
+    return claims
 
 
 @pytest.fixture
 def app_with_apple_creds(es256_keypair):
-    """FastAPI test app where Apple Music has creds + a mocked httpx, and
-    the other providers are absent (L1=None). Mirrors a production
-    deploy where only `APPLE_MUSIC_*` is set."""
+    """FastAPI test app where Apple Music has a real client (signing JWTs
+    against the fixture PEM) backed by mocked httpx, and the other providers
+    are absent (L1=None). Mirrors a production deploy where only
+    `APPLE_MUSIC_*` is set. `require_lml_key` is bypassed so a dev with
+    `LML_REQUIRE_AUTH=true` in their `.env` doesn't see every test 401.
+    """
     from main import app
 
     private_pem, _ = es256_keypair
+    # Spec preserves the httpx.AsyncClient signature on call sites that
+    # matter (.get); we configure return_value / side_effect on the spec'd
+    # attribute rather than reassigning, so a signature drift on the GET
+    # call still fails the mock.
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     apple_client = _make_apple_client(private_pem, mock_http)
-    settings = _apple_settings(private_pem)
 
     with override_deps(
         app,
         {
-            get_settings: settings,
+            # Bypass `LML_REQUIRE_AUTH`: env-var leakage from the developer's
+            # `.env` would otherwise 401 every test on machines where the
+            # gate is enabled.
+            require_lml_key: None,
             get_spotify_client: None,
             get_deezer_client: None,
             get_apple_music_client: apple_client,
@@ -128,9 +143,12 @@ def app_with_apple_creds(es256_keypair):
 async def test_streaming_check_returns_apple_music_match(app_with_apple_creds):
     """The full chain — request body → orchestrator → AppleMusicClient →
     httpx → `attributes.url` extraction — surfaces a SourceMatch in
-    `sources.apple_music` and flips `on_streaming` to True."""
+    `sources.apple_music` and flips `on_streaming` to True. Confidence is
+    pinned exactly to 100 because the query and result strings are
+    identical; allowing the 80 acceptance floor would mask a 20-point
+    silent precision regression."""
     app, mock_http = app_with_apple_creds
-    mock_http.get = AsyncMock(return_value=_albums_response([_make_album_data()]))
+    mock_http.get.return_value = _albums_response([_make_album_data()])
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(
@@ -144,17 +162,22 @@ async def test_streaming_check_returns_apple_music_match(app_with_apple_creds):
     assert body["sources"]["apple_music"]["url"] == (
         "https://music.apple.com/us/album/aluminum-tunes/456"
     )
-    assert body["sources"]["apple_music"]["confidence"] >= 80.0
+    assert body["sources"]["apple_music"]["confidence"] == 100.0
     assert body["errored_sources"] == []
 
 
 @pytest.mark.asyncio
-async def test_streaming_check_signs_jwt_and_targets_apple_music_api(app_with_apple_creds):
+async def test_streaming_check_signs_jwt_and_targets_apple_music_api(
+    app_with_apple_creds, es256_keypair
+):
     """Verify the OUTGOING request shape so a regression that drops the
-    Authorization header, switches storefronts, or reverts to the iTunes
-    URL is caught loudly."""
+    Authorization header, switches storefronts, reverts to the iTunes URL,
+    drops `limit=25`, reverses term order, or swaps the JWT iss/kid is
+    caught loudly. JWT is decoded against the fixture public PEM so a stub
+    signer returning a literal string cannot pass."""
     app, mock_http = app_with_apple_creds
-    mock_http.get = AsyncMock(return_value=_albums_response([_make_album_data()]))
+    _, public_pem = es256_keypair
+    mock_http.get.return_value = _albums_response([_make_album_data()])
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         await client.post(
@@ -163,13 +186,21 @@ async def test_streaming_check_signs_jwt_and_targets_apple_music_api(app_with_ap
         )
 
     call = mock_http.get.call_args
-    assert call.args[0] == SEARCH_URL, "should hit api.music.apple.com (not itunes.apple.com)"
+    # URL: authenticated Apple Music API, US storefront. Any revert to
+    # `itunes.apple.com` or a storefront swap fails the equality.
+    assert call.args[0] == SEARCH_URL
     params = call.kwargs["params"]
+    # `types=albums` for /streaming-check (vs `songs` for find_track_url
+    # in PR-3); `limit=25` is the published Apple Music maximum and what
+    # the client is sized for.
     assert params["types"] == "albums"
-    assert "Stereolab" in params["term"]
-    assert "Aluminum Tunes" in params["term"]
-    auth = call.kwargs["headers"]["Authorization"]
-    assert auth.startswith("Bearer "), "developer-token JWT must be on every search"
+    assert params["limit"] == 25
+    # Exact term format: artist-first, space-joined. Reversing the order
+    # silently shifts Apple's relevance ranking on ambiguous queries.
+    assert params["term"] == "Stereolab Aluminum Tunes"
+    # JWT: signature valid against the fixture public PEM, alg=ES256,
+    # kid=KEY_ID, iss=TEAM_ID. Stops a stub `_sign_jwt` from passing.
+    _assert_jwt_valid(call.kwargs["headers"]["Authorization"], public_pem)
 
 
 @pytest.mark.asyncio
@@ -180,7 +211,7 @@ async def test_streaming_check_verdict_false_when_apple_only_and_no_match(
     LML#376 verdict matrix: every dispatched check completed with no match
     and no error → `on_streaming=False` (not `None`)."""
     app, mock_http = app_with_apple_creds
-    mock_http.get = AsyncMock(return_value=_albums_response([]))
+    mock_http.get.return_value = _albums_response([])
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(
@@ -195,12 +226,30 @@ async def test_streaming_check_verdict_false_when_apple_only_and_no_match(
 
 
 @pytest.mark.asyncio
-async def test_streaming_check_verdict_none_when_apple_only_errors(app_with_apple_creds):
-    """Apple is the sole configured provider; its transport raises.
-    LML#376: no positive evidence + at least one errored service →
-    `on_streaming=None` so Backend's `!== null` guard refuses to persist."""
+async def test_streaming_check_verdict_false_when_apple_client_absorbs_transport_error(
+    app_with_apple_creds,
+):
+    """`AppleMusicClient._search` catches every exception, logs +
+    capture_exceptions to Sentry, and returns `[]`. The orchestrator sees
+    `find_album_match → None` — NOT a raised exception — so the verdict
+    matrix treats this as a clean "no match" (False), not "errored" (None).
+
+    This is intentional: transient transport errors get visibility via the
+    Sentry stream but don't block Backend from persisting the verdict for
+    other providers. The test pins this behavior so a future change that
+    surfaces transport errors as `errored_sources` updates this assertion
+    deliberately rather than landing as a silent contract shift.
+
+    The `find_album_match`-raises path (which DOES produce
+    `on_streaming=None`) is covered by
+    `test_orchestrator_verdict_none_when_find_album_match_raises` below.
+    Also pins `mock_http.get.call_count == 1` so a future per-attempt
+    try/except inside `_search_with_retry` (turning the exception into 4
+    retried backoff sleeps) is caught at PR review rather than as a
+    suite-runtime regression.
+    """
     app, mock_http = app_with_apple_creds
-    mock_http.get = AsyncMock(side_effect=httpx.ConnectError("dns failure"))
+    mock_http.get.side_effect = httpx.ConnectError("dns failure")
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post(
@@ -209,19 +258,38 @@ async def test_streaming_check_verdict_none_when_apple_only_errors(app_with_appl
         )
 
     body = resp.json()
-    # The client absorbs the ConnectError into [] internally (logging +
-    # capture_exception); `find_album_match` returns None — not raise — so
-    # the orchestrator treats this as a non-errored "no match" and
-    # `on_streaming` is False. The client's own observability surfaces the
-    # transport failure to Sentry. Documenting this verdict behavior
-    # here keeps a future refactor that changes it from sliding through
-    # unnoticed.
     assert body["on_streaming"] is False
     assert body["errored_sources"] == []
+    assert mock_http.get.call_count == 1
 
 
 @pytest.mark.asyncio
-async def test_streaming_check_verdict_none_when_no_creds_anywhere(mock_settings):
+async def test_streaming_check_verdict_false_on_revoked_api_key(app_with_apple_creds):
+    """401 from Apple Music is the key-revocation / membership-lapse
+    failure mode (Apple Developer Program renewal failure, MusicKit key
+    rotation drift). `_search` returns `[]` for any terminal non-200,
+    matching the transport-error verdict shape. The test pins this so a
+    future change that promotes 401 to `errored_sources` updates the
+    assertion deliberately."""
+    app, mock_http = app_with_apple_creds
+    mock_http.get.return_value = httpx.Response(401, request=httpx.Request("GET", SEARCH_URL))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/streaming-check",
+            json={"artist": "Stereolab", "title": "Aluminum Tunes"},
+        )
+
+    body = resp.json()
+    assert body["on_streaming"] is False
+    assert body["sources"]["apple_music"] is None
+    assert body["errored_sources"] == []
+    # Terminal 4xx is not retried.
+    assert mock_http.get.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_check_verdict_none_when_no_creds_anywhere(es256_keypair):
     """All four providers return None from their providers; the orchestrator
     dispatches no checks; verdict is `None` per the LML#376 matrix."""
     from main import app
@@ -229,7 +297,7 @@ async def test_streaming_check_verdict_none_when_no_creds_anywhere(mock_settings
     with override_deps(
         app,
         {
-            get_settings: mock_settings,
+            require_lml_key: None,
             get_spotify_client: None,
             get_deezer_client: None,
             get_apple_music_client: None,
@@ -245,3 +313,32 @@ async def test_streaming_check_verdict_none_when_no_creds_anywhere(mock_settings
     body = resp.json()
     assert body["on_streaming"] is None
     assert body["errored_sources"] == []
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_verdict_none_when_find_album_match_raises(es256_keypair):
+    """LML#376: when a service's `find_album_match` actually raises (not
+    when the client absorbs the error internally), the orchestrator records
+    it in `errored_sources` and escalates the verdict to None so Backend's
+    `!== null` guard refuses to persist.
+
+    Tested at the orchestrator level (not e2e) because the production
+    AppleMusicClient swallows every exception in `_search` — there is no
+    HTTP-layer mock that can make `find_album_match` raise. A custom client
+    stub that raises directly exercises the matrix cell the previous test
+    cannot reach. Without this coverage, a refactor of
+    `check_streaming_availability` that drops the `errored → None`
+    escalation would pass every other test in this file.
+    """
+    private_pem, _ = es256_keypair
+    raising_client = AppleMusicClient(team_id=TEAM_ID, key_id=KEY_ID, private_key=private_pem)
+    raising_client.find_album_match = AsyncMock(side_effect=RuntimeError("boom"))
+
+    response = await check_streaming_availability(
+        "Stereolab",
+        "Aluminum Tunes",
+        apple_music=raising_client,
+    )
+
+    assert response.on_streaming is None
+    assert response.errored_sources == ["apple_music"]

--- a/uv.lock
+++ b/uv.lock
@@ -164,6 +164,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -342,6 +399,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
 name = "datamodel-code-generator"
 version = "0.56.1"
 source = { registry = "https://pypi.org/simple" }
@@ -501,6 +611,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "rapidfuzz" },
@@ -532,6 +643,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -774,6 +886,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -880,6 +1001,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
Second of 4 stacked PRs migrating LML from the iTunes Search endpoint to the authenticated Apple Music API after the 2026-05-28 Railway egress IP block (#443).

> **Stacked on #446** — review after PR-1 merges, or compare the test file alone in isolation.

## Scope

PR-1 widened `get_apple_music_client` to return `AppleMusicClient | None` and threaded the new client through the FastAPI Depends sites on `/streaming-check` and `/releases/resolve`. Those changes were code-path live but only covered by per-layer unit tests. **PR-2 lands one end-to-end test** that exercises the full chain — provider → router → orchestrator → AppleMusicClient → mocked httpx — so a future regression in any seam fails loudly rather than silently degrading every Apple Music check.

No production source files change. No behavior change.

## What the test covers

| Case | Assertion |
|---|---|
| Happy path with creds | 200 response with a matching album lands a `SourceMatch` in `sources.apple_music`, confidence >= 80, `on_streaming=True` |
| Outgoing request shape | URL = `api.music.apple.com/v1/catalog/us/search`, `params.types=albums`, `Authorization: Bearer <jwt>`. Catches an accidental revert to `itunes.apple.com` |
| Apple-only, no match | `on_streaming=False` (LML#376 strict-False reachable from this path) |
| Apple-only, transport error | `on_streaming=False, errored_sources=[]` — the client absorbs `ConnectError` into `[]` + `capture_exception` so the orchestrator only sees `find_album_match → None`. Test documents this verdict explicitly |
| All providers None | `on_streaming=None` (no-checks-dispatched branch) |

Real ES256 signing runs unmocked via the session `es256_keypair` fixture from PR-1; only the httpx layer is replaced.

## Notable mechanics

- **Singleton reset fixture**: the new `reset_apple_music_singleton` autouse fixture resets `streaming.dependencies._apple_music_client` around each test. The existing `tests/unit/conftest.py::reset_caches` covers the in-memory caches but not the streaming-deps singletons; this fixture fills the gap locally to the new test file rather than mutating the shared conftest.
- **`mock_settings` reuse**: the "all providers None" case reuses the existing `mock_settings` fixture; the with-creds path uses a dedicated `_apple_settings` builder so the test PEM lands where the constructor expects it.

## Test plan

- [x] `ruff check tests/unit/test_streaming_check_e2e_apple_music.py` — clean
- [x] `ruff format --check tests/unit/test_streaming_check_e2e_apple_music.py` — clean
- [x] `mypy tests/unit/test_streaming_check_e2e_apple_music.py` — clean
- [x] 5 new tests pass; existing /streaming-check unit + orchestrator suite (50 tests total) all still green

## Related

- #446 — base PR (the new client + settings + tests)
- #443 — cliff; closes at PR-3 (orchestrator hot path)
- #444 — silent-failure observability; closes at PR-4 as superseded
- #376 — verdict matrix (False vs None semantics tested here)