### PR TITLE
feat(lookup): orchestrator hot path uses authenticated AppleMusicClient (PR-3 of 4)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1703,9 +1703,13 @@ async def enrich_artwork_results(
     ``apple_music`` is the authenticated Apple Music client (LML#443). When
     provided, the orchestrator calls ``apple_music.find_track_url(...)`` to
     surface Apple Music URLs; when None (credentials unconfigured), the
-    apple_music_url field stays None — matching the Spotify L1 degradation
-    pattern. ``http_client`` is retained for the not-yet-migrated legacy
-    iTunes probe in ``_fetch_apple_music_url``; PR-4 deletes both.
+    probe is skipped and ``apple_music_url`` is set from the library DB
+    ``streaming_links`` override (if present) or stays None. The DB
+    override always wins over the probe — see the final assignment
+    ``apple_music_override or apple_music_result or None``.
+
+    ``http_client`` is retained for the not-yet-migrated legacy iTunes
+    probe in ``_fetch_apple_music_url``; PR-4 deletes both.
 
     **Behavior change vs. v0.5.0:** release/artist details (release_year,
     artist_bio, wikipedia_url) are fetched only for ``items_with_artwork[0]``.
@@ -1824,11 +1828,23 @@ async def enrich_artwork_results(
         artist = item.alternate_artist_name or item.artist or ""
         search_term = song or item.title or ""
 
-        apple_music_result = (
-            await apple_music.find_track_url(artist, search_term, album=album)
-            if (apple_music is not None and artist and search_term)
-            else None
-        )
+        # Mirror the legacy ``_fetch_apple_music_url`` blanket-swallow:
+        # ``find_track_url`` has no top-level exception guard around its
+        # result-iteration loop, and the enclosing ``asyncio.gather`` lacks
+        # ``return_exceptions=True``. Without this wrap a single malformed
+        # Apple payload (non-dict item, rapidfuzz dispatch error) propagates
+        # through the gather and 500s the whole /lookup or /lookup/bulk
+        # request.
+        apple_music_result: str | None = None
+        if apple_music is not None and artist and search_term:
+            try:
+                apple_music_result = await apple_music.find_track_url(
+                    artist, search_term, album=album
+                )
+            except Exception:
+                logger.exception(
+                    "AppleMusicClient.find_track_url raised for %s - %s", artist, search_term
+                )
 
         # Album-derived fields are positionally gated: only on top-1, and
         # only when top-1 actually has artwork. When ``artwork`` is None

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -22,6 +22,7 @@ from wxyc_etl.text import is_compilation_artist
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats_recorder
 
+from clients.streaming.apple_music import AppleMusicClient
 from config.settings import get_settings
 from core.search import (
     execute_search_pipeline,
@@ -1692,15 +1693,19 @@ async def enrich_artwork_results(
     warm_cache: bool = False,
     discogs_cache: DiscogsCacheService | None = None,
     mb_pg: PgSourceProtocol | None = None,
+    apple_music: AppleMusicClient | None = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Enrich artwork results with release year, artist details, and streaming links.
 
     When library_db has a streaming_links table, uses direct URLs from the database.
     Falls back to search URLs when direct links are not available.
 
-    ``http_client`` is the shared ``httpx.AsyncClient`` used for the iTunes
-    Search probe. Passing ``None`` skips the Apple Music lookup — the
-    orchestrator never instantiates its own client (issue #241).
+    ``apple_music`` is the authenticated Apple Music client (LML#443). When
+    provided, the orchestrator calls ``apple_music.find_track_url(...)`` to
+    surface Apple Music URLs; when None (credentials unconfigured), the
+    apple_music_url field stays None — matching the Spotify L1 degradation
+    pattern. ``http_client`` is retained for the not-yet-migrated legacy
+    iTunes probe in ``_fetch_apple_music_url``; PR-4 deletes both.
 
     **Behavior change vs. v0.5.0:** release/artist details (release_year,
     artist_bio, wikipedia_url) are fetched only for ``items_with_artwork[0]``.
@@ -1820,8 +1825,8 @@ async def enrich_artwork_results(
         search_term = song or item.title or ""
 
         apple_music_result = (
-            await _fetch_apple_music_url(artist, search_term, album=album, http_client=http_client)
-            if (artist and search_term)
+            await apple_music.find_track_url(artist, search_term, album=album)
+            if (apple_music is not None and artist and search_term)
             else None
         )
 
@@ -2048,6 +2053,7 @@ async def perform_lookup(
     discogs_cache: DiscogsCacheService | None = None,
     mb_pg: PgSourceProtocol | None = None,
     http_client: httpx.AsyncClient | None = None,
+    apple_music: AppleMusicClient | None = None,
     caller_budget_ms: int | None = None,
 ) -> LookupResponse:
     """Orchestrate the full lookup pipeline.
@@ -2211,6 +2217,7 @@ async def perform_lookup(
                 warm_cache=warm_cache_mode,
                 discogs_cache=discogs_cache,
                 mb_pg=mb_pg,
+                apple_music=apple_music,
             )
 
     # Project the request-side flags onto the active Sentry transaction so

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import ValidationError
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
 
+from clients.streaming.apple_music import AppleMusicClient
 from core.dependencies import (
     get_apple_music_http_client,
     get_discogs_cache_service,
@@ -39,6 +40,7 @@ from lookup.models import (
     LookupResponse,
 )
 from lookup.orchestrator import perform_lookup
+from streaming.dependencies import get_apple_music_client
 
 if TYPE_CHECKING:
     from posthog import Posthog
@@ -115,6 +117,7 @@ async def handle_lookup(
     entity_store: EntityStore | None = Depends(get_entity_store),
     posthog_client: Posthog | None = Depends(get_posthog_client),
     http_client: httpx.AsyncClient = Depends(get_apple_music_http_client),
+    apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     skip_cache: bool = False,
     x_caller_budget_ms: int | None = Header(
         default=None,
@@ -147,6 +150,7 @@ async def handle_lookup(
             discogs_cache=discogs_cache,
             mb_pg=mb_pg,
             http_client=http_client,
+            apple_music=apple_music,
             caller_budget_ms=x_caller_budget_ms,
         )
 
@@ -269,6 +273,7 @@ async def handle_bulk_lookup(
     entity_store: EntityStore | None = Depends(get_entity_store),
     posthog_client: Posthog | None = Depends(get_posthog_client),
     http_client: httpx.AsyncClient = Depends(get_apple_music_http_client),
+    apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     skip_cache: bool = False,
     x_caller_budget_ms: int | None = Header(
         default=None,
@@ -351,6 +356,7 @@ async def handle_bulk_lookup(
                         discogs_cache=discogs_cache,
                         mb_pg=mb_pg,
                         http_client=http_client,
+                        apple_music=apple_music,
                         caller_budget_ms=x_caller_budget_ms,
                     )
             except Exception as e:

--- a/tests/integration/test_streaming_on_discogs_miss.py
+++ b/tests/integration/test_streaming_on_discogs_miss.py
@@ -15,10 +15,11 @@ Backend-Service (BS#1185) "no Discogs match, but streaming URLs are
 valid; do NOT call ``extractAlbumMetadata``".
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
+from clients.streaming.apple_music import AppleMusicClient
 from discogs.models import DiscogsSearchResponse
 from lookup.models import LookupRequest
 from lookup.orchestrator import perform_lookup
@@ -29,7 +30,7 @@ class TestStreamingOnDiscogsMiss:
     @pytest.mark.asyncio
     async def test_apple_music_url_populated_when_discogs_returns_no_artwork(self, library_db):
         """End-to-end: artist+album+song hit the library, Discogs returns
-        empty (no artwork), iTunes Search matches → top-1 result carries
+        empty (no artwork), Apple Music matches → top-1 result carries
         the Apple Music URL via the synthesized streaming-only artwork.
 
         Uses the seeded Stereolab entries (per CLAUDE.md fixture preference)
@@ -60,22 +61,22 @@ class TestStreamingOnDiscogsMiss:
         mock_service.validate_track_on_release = AsyncMock(return_value=False)
 
         apple_url = "https://music.apple.com/us/album/aluminum-tunes/1234567890"
-        with patch(
-            "lookup.orchestrator._fetch_apple_music_url",
-            return_value=apple_url,
-        ):
-            request = LookupRequest(
-                artist="Stereolab",
-                album="Aluminum Tunes",
-                song="Cybele's Reverie",
-                raw_message="Stereolab - Aluminum Tunes - Cybele's Reverie",
-            )
-            response = await perform_lookup(
-                request,
-                library_db,
-                mock_service,
-                make_lml_telemetry(),
-            )
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_url = AsyncMock(return_value=apple_url)
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Aluminum Tunes",
+            song="Cybele's Reverie",
+            raw_message="Stereolab - Aluminum Tunes - Cybele's Reverie",
+        )
+        response = await perform_lookup(
+            request,
+            library_db,
+            mock_service,
+            make_lml_telemetry(),
+            apple_music=apple_music,
+        )
 
         assert len(response.results) >= 1, "Expected at least one library result"
 
@@ -100,7 +101,7 @@ class TestStreamingOnDiscogsMiss:
 
     @pytest.mark.asyncio
     async def test_search_urls_fill_when_apple_match_fails(self, library_db):
-        """When iTunes Search has no clearable match either, the synthesized
+        """When Apple Music has no clearable match either, the synthesized
         artwork still carries the Spotify/YT/BC/SC search URLs so iOS isn't
         stuck with all-greyed streaming buttons.
         """
@@ -122,25 +123,28 @@ class TestStreamingOnDiscogsMiss:
         mock_service.get_release = AsyncMock(return_value=None)
         mock_service.validate_track_on_release = AsyncMock(return_value=False)
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            request = LookupRequest(
-                artist="Stereolab",
-                album="Aluminum Tunes",
-                song="Cybele's Reverie",
-                raw_message="Stereolab - Aluminum Tunes - Cybele's Reverie",
-            )
-            response = await perform_lookup(
-                request,
-                library_db,
-                mock_service,
-                make_lml_telemetry(),
-            )
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_url = AsyncMock(return_value=None)
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Aluminum Tunes",
+            song="Cybele's Reverie",
+            raw_message="Stereolab - Aluminum Tunes - Cybele's Reverie",
+        )
+        response = await perform_lookup(
+            request,
+            library_db,
+            mock_service,
+            make_lml_telemetry(),
+            apple_music=apple_music,
+        )
 
         assert len(response.results) >= 1
         top = response.results[0]
         assert top.artwork is not None
         assert top.artwork.release_id == 0
-        assert top.artwork.apple_music_url is None  # iTunes had no match
+        assert top.artwork.apple_music_url is None  # Apple Music had no match
         # But search-URL fallbacks still fill — iOS gets at least four buttons.
         assert top.artwork.spotify_url is not None
         assert top.artwork.youtube_music_url is not None

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from clients.streaming.apple_music import AppleMusicClient
 from discogs.models import (
     ArtistDetails,
     DiscogsSearchResult,
@@ -338,9 +339,9 @@ class TestEnrichArtworkResults:
         assert enriched.soundcloud_url is not None
 
     @pytest.mark.asyncio
-    async def test_no_discogs_match_surfaces_apple_url_via_itunes(self):
-        """When ``_fetch_apple_music_url`` clears the 80/80/80 floor on a
-        no-Discogs-match item, the synthesized artwork carries the URL.
+    async def test_no_discogs_match_surfaces_apple_url_via_apple_music(self):
+        """When ``AppleMusicClient.find_track_url`` clears the 80/80/80 floor
+        on a no-Discogs-match item, the synthesized artwork carries the URL.
 
         This is the Tragic Magic case from BS#1184 in miniature: an album
         absent from the WXYC catalog but present on Apple Music.
@@ -351,16 +352,16 @@ class TestEnrichArtworkResults:
         )
 
         apple_url = "https://music.apple.com/us/album/tragic-magic/1843854211"
-        with patch(
-            "lookup.orchestrator._fetch_apple_music_url",
-            return_value=apple_url,
-        ):
-            results = await enrich_artwork_results(
-                [(item, None)],
-                AsyncMock(),
-                song="The Four Sleeping Princesses",
-                album="Tragic Magic",
-            )
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_url = AsyncMock(return_value=apple_url)
+
+        results = await enrich_artwork_results(
+            [(item, None)],
+            AsyncMock(),
+            song="The Four Sleeping Princesses",
+            album="Tragic Magic",
+            apple_music=apple_music,
+        )
 
         _, enriched = results[0]
         assert enriched is not None
@@ -1112,3 +1113,148 @@ class TestMbTracklistRescue:
         assert enriched.release_id == 0
         # Either absent or an empty/None-equivalent tracklist — both fine.
         assert not enriched.tracklist
+
+
+class TestEnrichArtworkResultsWithAppleMusicClient:
+    """PR-3 / LML#443: orchestrator hot path consumes ``AppleMusicClient.find_track_url``
+    instead of the iTunes Search probe in ``_fetch_apple_music_url``.
+
+    These tests pin the new contract — ``enrich_artwork_results`` accepts an
+    ``apple_music`` client and threads the call. The legacy
+    ``_fetch_apple_music_url`` function (and the ``http_client`` parameter
+    backing it) survives PR-3 for backward compatibility with the not-yet-
+    migrated batch backfill script; PR-4 removes both.
+    """
+
+    @pytest.mark.asyncio
+    async def test_apple_music_client_url_propagates_to_synthesized_result(self):
+        """A no-Discogs-match item paired with an ``AppleMusicClient`` that
+        returns a URL produces a synthesized ``DiscogsSearchResult`` carrying
+        that URL — mirrors LML#401 / BS#1184 (Tragic Magic on Apple Music but
+        absent from the WXYC Discogs catalog).
+        """
+        item = make_library_item(
+            artist="Julianna Barwick & Mary Lattimore",
+            title="The Four Sleeping Princesses",
+        )
+        apple_url = "https://music.apple.com/us/album/tragic-magic/1843854211"
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_url = AsyncMock(return_value=apple_url)
+
+        # The legacy iTunes path must NOT be reached — patch so a regression
+        # back to the old call site surfaces as a failed assertion rather
+        # than a silently-wrong URL.
+        with patch(
+            "lookup.orchestrator._fetch_apple_music_url",
+            new=AsyncMock(return_value="https://itunes.example/should-not-appear"),
+        ) as legacy_itunes:
+            results = await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                song="The Four Sleeping Princesses",
+                album="Tragic Magic",
+                apple_music=apple_music,
+            )
+
+        legacy_itunes.assert_not_awaited()
+        apple_music.find_track_url.assert_awaited_once_with(
+            "Julianna Barwick & Mary Lattimore",
+            "The Four Sleeping Princesses",
+            album="Tragic Magic",
+        )
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.release_id == 0
+        assert enriched.apple_music_url == apple_url
+
+    @pytest.mark.asyncio
+    async def test_apple_music_client_none_degrades_gracefully(self):
+        """When ``apple_music`` is None (creds unconfigured), the lookup
+        produces a result with ``apple_music_url`` None instead of raising.
+        Matches the Spotify L1 degradation pattern in
+        ``streaming/dependencies.py:get_spotify_client``.
+        """
+        item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
+
+        results = await enrich_artwork_results(
+            [(item, None)],
+            AsyncMock(),
+            song="French Disko",
+            album="Aluminum Tunes",
+            apple_music=None,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.apple_music_url is None
+        # Search-URL fallbacks for the OTHER services still fill.
+        assert enriched.spotify_url is not None
+
+    @pytest.mark.asyncio
+    async def test_apple_music_client_returning_none_leaves_url_unset(self):
+        """An ``AppleMusicClient`` that scores no result below the floor
+        returns None — the synthesized result's ``apple_music_url`` stays
+        None, mirroring the legacy iTunes path's behavior for unmatched
+        queries.
+        """
+        item = make_library_item(artist="Obscure Artist", title="Obscure Album")
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_url = AsyncMock(return_value=None)
+
+        results = await enrich_artwork_results(
+            [(item, None)],
+            AsyncMock(),
+            song="Obscure Song",
+            album="Obscure Album",
+            apple_music=apple_music,
+        )
+
+        apple_music.find_track_url.assert_awaited_once()
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.apple_music_url is None
+
+    @pytest.mark.asyncio
+    async def test_apple_music_url_does_not_override_db_streaming_link(self):
+        """Direct streaming-links from the library DB take precedence over the
+        AppleMusicClient probe — preserves the existing
+        ``apple_music_override or apple_music_result or None`` priority.
+        """
+        item = make_library_item(id=42, artist="Jessica Pratt", title="On Your Own Love Again")
+        artwork = make_discogs_result(
+            release_id=1, artist="Jessica Pratt", album="On Your Own Love Again"
+        )
+
+        db_url = "https://music.apple.com/us/album/db-override/111"
+        probe_url = "https://music.apple.com/us/album/probe-result/222"
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_url = AsyncMock(return_value=probe_url)
+
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(return_value={"apple_music_url": db_url})
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="On Your Own Love Again",
+            artist="Jessica Pratt",
+            year=2015,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            song="Back, Baby",
+            album="On Your Own Love Again",
+            library_db=library_db,
+            apple_music=apple_music,
+        )
+
+        _, enriched = results[0]
+        assert enriched.apple_music_url == db_url

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1217,6 +1217,52 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         assert enriched.apple_music_url is None
 
     @pytest.mark.asyncio
+    async def test_apple_music_client_raising_does_not_sink_whole_batch(self):
+        """A single ``find_track_url`` exception must NOT propagate through
+        ``asyncio.gather`` and fail the entire enrichment. Mirrors the legacy
+        ``_fetch_apple_music_url`` blanket ``try: ... except Exception: return
+        None`` guarantee — bulk lookups regress to 500 without this wrap if
+        Apple returns a malformed result that trips ``find_track_url``'s
+        result-iteration loop (which itself has no top-level exception
+        handler).
+        """
+        items_with_artwork = [
+            (make_library_item(id=1, artist="Artist 1", title="Album 1"), None),
+            (make_library_item(id=2, artist="Artist 2", title="Album 2"), None),
+        ]
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        # Item 1 raises; item 2 returns a normal URL. Without a defensive
+        # wrap at the call site, the gather() in enrich_artwork_results
+        # cancels item 2's enrichment mid-flight and raises.
+        item2_url = "https://music.apple.com/us/album/album-2/222"
+        apple_music.find_track_url = AsyncMock(
+            side_effect=[
+                AttributeError("Apple returned a non-dict item"),
+                item2_url,
+            ]
+        )
+
+        results = await enrich_artwork_results(
+            items_with_artwork,
+            AsyncMock(),
+            song="Song",
+            album="Album",
+            apple_music=apple_music,
+        )
+
+        assert len(results) == 2
+        _, enriched_1 = results[0]
+        _, enriched_2 = results[1]
+        # Item 1 degraded to no Apple URL but did not crash the request.
+        assert enriched_1 is not None
+        assert enriched_1.apple_music_url is None
+        # Item 2's enrichment was not collateral-damaged by item 1's raise.
+        # (Top-1 positional gating means album-derived fields are still
+        # None, but the streaming URL itself survives.)
+        assert enriched_2 is not None
+
+    @pytest.mark.asyncio
     async def test_apple_music_url_does_not_override_db_streaming_link(self):
         """Direct streaming-links from the library DB take precedence over the
         AppleMusicClient probe — preserves the existing


### PR DESCRIPTION
## Summary

User-visible cliff fix for the 2026-05-28 Railway egress 403 (#443). The lookup orchestrator hot path now consumes `AppleMusicClient.find_track_url` instead of the unauthenticated `itunes.apple.com/search` probe in `_fetch_apple_music_url`, so Apple Music URLs return on new flowsheet entries again.

`enrich_artwork_results` and `perform_lookup` gain an `apple_music: AppleMusicClient | None = None` parameter, wired in `lookup/router.py` via `streaming.dependencies.get_apple_music_client`. When the client is None (credentials unconfigured), `apple_music_url` stays None — matching the existing Spotify L1 degradation pattern.

## Stacking

3rd of 4 PRs in the [authenticated Apple Music migration](https://github.com/WXYC/library-metadata-lookup/blob/main/docs/adr/0001-authenticated-apple-music-api.md):

- [x] PR-1 #446 — `AppleMusicClient` + settings + tests
- [x] PR-2 #447 — End-to-end test for `/streaming-check`
- [x] **PR-3 (this) — Orchestrator hot path replaces `_fetch_apple_music_url` with `find_track_url`; closes #443**
- [ ] PR-4 — Delete `_fetch_apple_music_url`, `_APPLE_MUSIC_MATCH_FLOOR` (orchestrator copy), `get_apple_music_http_client`, and the unused `http_client` parameter; closes #444 as superseded

## Scope discipline

The legacy `_fetch_apple_music_url` function and the `http_client` parameter on `enrich_artwork_results` / `perform_lookup` deliberately survive this commit so reviewers can verify the call-site swap in isolation. PR-4 removes the dead code.

## Test plan

- [x] TDD: new `TestEnrichArtworkResultsWithAppleMusicClient` (4 tests in `tests/unit/test_enrichment.py`) covers URL propagation, graceful degrade when `apple_music=None`, no-match handling, and DB-streaming-link priority
- [x] Updated `test_no_discogs_match_surfaces_apple_url_via_apple_music` (renamed from `_via_itunes`) to use the new path
- [x] Pre-existing FD-leak invariant in `test_fd_leak_regression_241.py` continues to pass (orchestrator still owns no transient httpx clients)
- [x] Full unit suite green locally (2074 passed; one pre-existing teardown-order flake in `test_no_module_level_asyncio_lock_in_dependencies` that also fires on `origin/main` and passes in isolation)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy lookup/orchestrator.py lookup/router.py` clean
- [ ] Staging smoke: confirm `apple_music_url` returns on `/api/v1/lookup` once `APPLE_MUSIC_*` env vars land on the staging Railway service

Closes #443