### PR TITLE
feat(lookup): delete legacy iTunes Search code (PR-4 of 4)

### DIFF
--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -9,14 +9,12 @@ lifetime, header `kid=Key ID`, claims `iss=Team ID`, `iat`, `exp`. Apple
 validates the signature against the public half registered to the MusicKit
 identifier `media.org.wxyc.lml`.
 
-Surface area mirrors the previous iTunes client so the migration of the two
-call sites (`lookup/orchestrator._fetch_apple_music_url` and
-`streaming/router.handle_streaming_check`) is mechanical:
+Public surface:
 
 - `find_album_match(artist, title)` — BaseStreamingClient contract; powers
-  /streaming-check.
-- `find_track_url(artist, song, album=None)` — replaces the inline
-  `_fetch_apple_music_url` in the lookup hot path. 3-way fuzz floor on
+  `/streaming-check` via `streaming/router.handle_streaming_check`.
+- `find_track_url(artist, song, album=None)` — used by the lookup hot path
+  in `lookup/orchestrator.enrich_artwork_results`. 3-way fuzz floor on
   `attributes.{artistName,name,albumName}`.
 """
 
@@ -271,8 +269,7 @@ class AppleMusicClient(BaseStreamingClient):
         """Search for `(artist, song[, album])` and return the highest-scoring
         Apple Music track URL clearing the 80/80(/80) fuzz floor, else `None`.
 
-        Replaces `lookup.orchestrator._fetch_apple_music_url`. Uses
-        `fuzz.token_set_ratio` (not the batch matcher's `token_sort_ratio`)
+        Uses `fuzz.token_set_ratio` (not the batch matcher's `token_sort_ratio`)
         so extra tokens — "The", "feat. X", "(Remastered)" — don't sink an
         otherwise-correct match. Iterates the full result list and picks the
         best-scoring URL so an early sub-optimal match in Apple's ranking

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING
 
 import asyncpg
-import httpx
 from fastapi import Depends
 from wxyc_fastapi.http import async_singleton
 from wxyc_fastapi.observability import get_posthog_client as _shared_posthog_client
@@ -234,36 +233,6 @@ async def get_musicbrainz_pg(
 async def close_musicbrainz_pg() -> None:
     """Close the musicbrainz-cache PgSource on app shutdown."""
     await _close_musicbrainz_pg_singleton()
-
-
-async def _build_apple_music_http_client() -> httpx.AsyncClient:
-    """Build the process-lifetime httpx client for iTunes Search probes."""
-    client = httpx.AsyncClient(timeout=5.0)
-    logger.info("Apple Music shared HTTP client initialized")
-    return client
-
-
-_get_apple_music_http_client, _close_apple_music_http_client = async_singleton(
-    _build_apple_music_http_client
-)
-
-
-async def get_apple_music_http_client() -> httpx.AsyncClient:
-    """Process-lifetime ``httpx.AsyncClient`` for the iTunes Search probe.
-
-    The lookup orchestrator probes ``itunes.apple.com/search`` once per
-    enriched result item. Constructing a fresh ``httpx.AsyncClient`` per
-    probe (the previous behavior) leaked file descriptors under sustained
-    /api/v1/lookup traffic and exhausted the container's FD limit on
-    2026-05-01 (issue #241). A shared client is returned instead and
-    closed on app shutdown via ``close_apple_music_http_client``.
-    """
-    return await _get_apple_music_http_client()
-
-
-async def close_apple_music_http_client() -> None:
-    """Close the shared Apple Music HTTP client on app shutdown."""
-    await _close_apple_music_http_client()
 
 
 def get_posthog_client(settings: Settings = Depends(get_settings)) -> Posthog | None:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -16,7 +16,6 @@ from functools import partial
 from typing import Any
 from urllib.parse import quote
 
-import httpx
 import sentry_sdk
 from wxyc_etl.text import is_compilation_artist
 from wxyc_etl.text import to_match_form as normalize_for_comparison
@@ -762,15 +761,16 @@ def _release_matches_library_row(release: ReleaseInfo, item: LibraryItem) -> boo
 
 
 # Minimum fuzzy score (0-100) for accepting a library-row title as a genuine
-# album match for the DJ-typed album. Mirrors `_APPLE_MUSIC_MATCH_FLOOR` and
-# the streaming-availability batch matcher. When the artist-fallback branches
+# album match for the DJ-typed album. Mirrors the 80-floor in
+# `clients/streaming/apple_music._APPLE_MUSIC_MATCH_FLOOR` and the
+# streaming-availability batch matcher. When the artist-fallback branches
 # of `search_library_with_fallback` surface a row whose title doesn't clear
 # this floor against the typed album, the row would otherwise carry the
 # matched Discogs release's `release_year` / `apple_music_url` / `spotify_url`
 # / `discogs_url` / `artwork_url` onto a flowsheet row tagged with a
 # completely different album — the contamination shape documented in #400
 # (~184k rows; 16,532 distinct Discogs URLs each attached to many distinct
-# DJ-typed `(artist, album)` pairs). #390 / #398 tightened the iTunes-result
+# DJ-typed `(artist, album)` pairs). #390 / #398 tightened the result
 # verification; this tightens the LML lookup result itself.
 _ALBUM_MATCH_FLOOR = 80.0
 
@@ -1603,91 +1603,12 @@ def _build_streaming_search_url(base: str, artist: str, term: str) -> str:
     return f"{base}{quote(query)}"
 
 
-# Minimum fuzzy score (0-100) for accepting an iTunes Search result as a genuine
-# match for the requested artist + track (+ album, when provided). Mirrors the
-# 80/80 artist+title floor the streaming-availability batch matcher enforces
-# (clients/streaming/matching.py:is_acceptable_match). iTunes
-# Search ranking is non-deterministic for obscure artists, so a bare results[0]
-# intermittently surfaces a popular but wrong artist (e.g. "Pleasure"/"Joyous"
-# -> Sheryl Crow, see #389), and same-named tracks on multiple of an artist's
-# releases can land on the wrong album (e.g. Yenbett's "Hebebeb (Zrag)" -> the
-# track of the same name on Tzenni, see #396). Verification stops the wrong
-# link from freezing onto the flowsheet row.
-_APPLE_MUSIC_MATCH_FLOOR = 80.0
-
-
-async def _fetch_apple_music_url(
-    artist: str,
-    song: str,
-    album: str | None = None,
-    http_client: httpx.AsyncClient | None = None,
-) -> str | None:
-    """Search the iTunes API for an Apple Music link. Free, no auth required.
-
-    Requires a shared ``http_client``; returns ``None`` when one isn't
-    provided so callers can degrade gracefully. Constructing a fresh
-    ``httpx.AsyncClient`` per probe is what leaked FDs in the 2026-05-01
-    LML outage (issue #241), so the per-call fallback was removed.
-
-    Returns the ``trackViewUrl`` of the first result whose ``artistName`` and
-    ``trackName`` (and, when ``album`` is provided, ``collectionName``) all
-    clear ``_APPLE_MUSIC_MATCH_FLOOR`` against the requested ``artist`` /
-    ``song`` / ``album`` (diacritics-folded fuzzy token-set match), else
-    ``None``. iTunes Search ranking is unstable for obscure artists, so a bare
-    ``results[0]`` can confidently return the wrong artist (#389) or — when
-    the same track title appears on multiple of the artist's releases — the
-    wrong album (#396); verifying avoids persisting a wrong link onto the
-    flowsheet row.
-    """
-    if http_client is None:
-        return None
-    from rapidfuzz import fuzz
-
-    try:
-        query = quote(f"{artist} {song}")
-        url = f"https://itunes.apple.com/search?term={query}&entity=song&media=music&limit=5"
-        resp = await http_client.get(url)
-        if resp.status_code != 200:
-            return None
-        results = resp.json().get("results", [])
-
-        norm_artist = normalize_for_comparison(artist)
-        norm_song = normalize_for_comparison(song)
-        norm_album = normalize_for_comparison(album) if album else None
-        # token_set_ratio (not the batch matcher's token_sort_ratio) so extra
-        # tokens on either side — "The", "feat. X", "(Remastered)" — don't sink
-        # an otherwise-correct match.
-        for result in results:
-            track_url = result.get("trackViewUrl")
-            if not track_url:
-                continue
-            artist_score = fuzz.token_set_ratio(
-                norm_artist, normalize_for_comparison(result.get("artistName", ""))
-            )
-            track_score = fuzz.token_set_ratio(
-                norm_song, normalize_for_comparison(result.get("trackName", ""))
-            )
-            if artist_score < _APPLE_MUSIC_MATCH_FLOOR or track_score < _APPLE_MUSIC_MATCH_FLOOR:
-                continue
-            if norm_album is not None:
-                album_score = fuzz.token_set_ratio(
-                    norm_album, normalize_for_comparison(result.get("collectionName", ""))
-                )
-                if album_score < _APPLE_MUSIC_MATCH_FLOOR:
-                    continue
-            return track_url
-        return None
-    except Exception:
-        return None
-
-
 async def enrich_artwork_results(
     items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]],
     discogs_service: DiscogsService | None,
     song: str | None = None,
     album: str | None = None,
     library_db: LibraryDB | None = None,
-    http_client: httpx.AsyncClient | None = None,
     *,
     extended: bool = False,
     warm_cache: bool = False,
@@ -1707,9 +1628,6 @@ async def enrich_artwork_results(
     ``streaming_links`` override (if present) or stays None. The DB
     override always wins over the probe — see the final assignment
     ``apple_music_override or apple_music_result or None``.
-
-    ``http_client`` is retained for the not-yet-migrated legacy iTunes
-    probe in ``_fetch_apple_music_url``; PR-4 deletes both.
 
     **Behavior change vs. v0.5.0:** release/artist details (release_year,
     artist_bio, wikipedia_url) are fetched only for ``items_with_artwork[0]``.
@@ -1828,7 +1746,6 @@ async def enrich_artwork_results(
         artist = item.alternate_artist_name or item.artist or ""
         search_term = song or item.title or ""
 
-        # Mirror the legacy ``_fetch_apple_music_url`` blanket-swallow:
         # ``find_track_url`` has no top-level exception guard around its
         # result-iteration loop, and the enclosing ``asyncio.gather`` lacks
         # ``return_exceptions=True``. Without this wrap a single malformed
@@ -2068,7 +1985,6 @@ async def perform_lookup(
     entity_store: EntityStore | None = None,
     discogs_cache: DiscogsCacheService | None = None,
     mb_pg: PgSourceProtocol | None = None,
-    http_client: httpx.AsyncClient | None = None,
     apple_music: AppleMusicClient | None = None,
     caller_budget_ms: int | None = None,
 ) -> LookupResponse:
@@ -2228,7 +2144,6 @@ async def perform_lookup(
                 song=parsed.song,
                 album=parsed.album,
                 library_db=db,
-                http_client=http_client,
                 extended=extended_mode,
                 warm_cache=warm_cache_mode,
                 discogs_cache=discogs_cache,

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1643,8 +1643,8 @@ async def enrich_artwork_results(
     **Behavior change vs. v0.6.0 (LML#401):** an item entering with
     ``artwork=None`` no longer round-trips as ``(item, None)``. It returns
     a synthesized ``DiscogsSearchResult(release_id=0, release_url="")``
-    carrying only the streaming-URL fields (Apple via iTunes Search +
-    Spotify/YT/BC/SC search-URL fallbacks). Album-derived scalars
+    carrying only the streaming-URL fields (Apple via the authenticated
+    ``AppleMusicClient`` + Spotify/YT/BC/SC search-URL fallbacks). Album-derived scalars
     (release_year, artist_bio, wikipedia_url) and the ``extended=True``
     payload stay None on the synthesized result, preserving the positional-
     gating invariant above. The ``(release_id=0, release_url="")`` pair is

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -9,7 +9,6 @@ import os
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 
-import httpx
 import sentry_sdk
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import ValidationError
@@ -17,7 +16,6 @@ from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_c
 
 from clients.streaming.apple_music import AppleMusicClient
 from core.dependencies import (
-    get_apple_music_http_client,
     get_discogs_cache_service,
     get_discogs_service,
     get_library_db,
@@ -116,7 +114,6 @@ async def handle_lookup(
     mb_pg: PgSource | None = Depends(get_musicbrainz_pg),
     entity_store: EntityStore | None = Depends(get_entity_store),
     posthog_client: Posthog | None = Depends(get_posthog_client),
-    http_client: httpx.AsyncClient = Depends(get_apple_music_http_client),
     apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     skip_cache: bool = False,
     x_caller_budget_ms: int | None = Header(
@@ -149,7 +146,6 @@ async def handle_lookup(
             entity_store=entity_store,
             discogs_cache=discogs_cache,
             mb_pg=mb_pg,
-            http_client=http_client,
             apple_music=apple_music,
             caller_budget_ms=x_caller_budget_ms,
         )
@@ -272,7 +268,6 @@ async def handle_bulk_lookup(
     mb_pg: PgSource | None = Depends(get_musicbrainz_pg),
     entity_store: EntityStore | None = Depends(get_entity_store),
     posthog_client: Posthog | None = Depends(get_posthog_client),
-    http_client: httpx.AsyncClient = Depends(get_apple_music_http_client),
     apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     skip_cache: bool = False,
     x_caller_budget_ms: int | None = Header(
@@ -355,7 +350,6 @@ async def handle_bulk_lookup(
                         entity_store=entity_store,
                         discogs_cache=discogs_cache,
                         mb_pg=mb_pg,
-                        http_client=http_client,
                         apple_music=apple_music,
                         caller_budget_ms=x_caller_budget_ms,
                     )

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ from wxyc_fastapi.observability import flush_posthog, init_sentry, shutdown_post
 from config.settings import get_settings
 from core.auth import require_lml_key
 from core.dependencies import (
-    close_apple_music_http_client,
     close_discogs_service,
     close_library_db,
     close_musicbrainz_pg,
@@ -66,7 +65,6 @@ async def lifespan(app: FastAPI):
     await close_entity_store()
     await close_musicbrainz_pg()
     await close_streaming_clients()
-    await close_apple_music_http_client()
     logger.info("All services shut down")
 
 

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -14,7 +14,6 @@ from discogs.models import (
 )
 from lookup.orchestrator import (
     _build_streaming_search_url,
-    _fetch_apple_music_url,
     enrich_artwork_results,
 )
 from tests.factories import make_discogs_result, make_library_item
@@ -37,212 +36,6 @@ class TestBuildStreamingSearchUrl:
         )
         assert "Bj%C3%B6rk" in url
         assert "J%C3%B3ga" in url
-
-
-class TestFetchAppleMusicUrl:
-    @staticmethod
-    def _mock_client(results: list[dict]):
-        import httpx
-
-        mock_response = httpx.Response(
-            200,
-            json={"results": results},
-            request=httpx.Request("GET", "https://itunes.apple.com/search"),
-        )
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.get = AsyncMock(return_value=mock_response)
-        return mock_client
-
-    @pytest.mark.asyncio
-    async def test_returns_url_on_success(self):
-        mock_client = self._mock_client(
-            [
-                {
-                    "artistName": "Kate Bush",
-                    "trackName": "The Saxophone Song",
-                    "trackViewUrl": "https://music.apple.com/us/album/test/123",
-                }
-            ]
-        )
-
-        result = await _fetch_apple_music_url(
-            "Kate Bush", "The Saxophone Song", http_client=mock_client
-        )
-        assert result == "https://music.apple.com/us/album/test/123"
-
-    @pytest.mark.asyncio
-    async def test_skips_wrong_artist_and_picks_correct_lower_result(self):
-        """Regression for the Pleasure/'Joyous' -> Sheryl Crow mismatch (#389).
-
-        iTunes Search relevance is unstable for obscure artists and can rank a
-        popular but wrong artist first. The correct match must be chosen over a
-        higher-ranked wrong-artist result, not blindly taken from results[0].
-        """
-        mock_client = self._mock_client(
-            [
-                {
-                    "artistName": "Sheryl Crow",
-                    "trackName": "All I Wanna Do",
-                    "trackViewUrl": "https://music.apple.com/us/album/all-i-wanna-do/1440651031",
-                },
-                {
-                    "artistName": "Pleasure",
-                    "trackName": "Joyous",
-                    "trackViewUrl": "https://music.apple.com/us/album/joyous/1568229263",
-                },
-            ]
-        )
-
-        result = await _fetch_apple_music_url("Pleasure", "Joyous", http_client=mock_client)
-        assert result == "https://music.apple.com/us/album/joyous/1568229263"
-
-    @pytest.mark.asyncio
-    async def test_returns_none_when_only_wrong_artist(self):
-        """A confident-but-wrong link is worse than no link: reject, don't return it."""
-        mock_client = self._mock_client(
-            [
-                {
-                    "artistName": "Sheryl Crow",
-                    "trackName": "All I Wanna Do",
-                    "trackViewUrl": "https://music.apple.com/us/album/all-i-wanna-do/1440651031",
-                }
-            ]
-        )
-
-        result = await _fetch_apple_music_url("Pleasure", "Joyous", http_client=mock_client)
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_matches_despite_diacritics(self):
-        """Diacritic-folded comparison: 'Nilüfer Yanya' must match iTunes' 'Nilufer Yanya'."""
-        mock_client = self._mock_client(
-            [
-                {
-                    "artistName": "Nilufer Yanya",
-                    "trackName": "Stabilise",
-                    "trackViewUrl": "https://music.apple.com/us/album/stabilise/1480000000",
-                }
-            ]
-        )
-
-        result = await _fetch_apple_music_url("Nilüfer Yanya", "Stabilise", http_client=mock_client)
-        assert result == "https://music.apple.com/us/album/stabilise/1480000000"
-
-    @pytest.mark.asyncio
-    async def test_skips_result_missing_track_url(self):
-        """A matching result with no trackViewUrl is skipped in favor of a usable one."""
-        mock_client = self._mock_client(
-            [
-                {"artistName": "Pleasure", "trackName": "Joyous"},
-                {
-                    "artistName": "Pleasure",
-                    "trackName": "Joyous",
-                    "trackViewUrl": "https://music.apple.com/us/album/joyous/1568229263",
-                },
-            ]
-        )
-
-        result = await _fetch_apple_music_url("Pleasure", "Joyous", http_client=mock_client)
-        assert result == "https://music.apple.com/us/album/joyous/1568229263"
-
-    @pytest.mark.asyncio
-    async def test_rejects_right_track_on_wrong_album(self):
-        """Regression for the Yenbett -> Tzenni mismatch (#396).
-
-        Same-named track on multiple of the artist's releases: iTunes returns
-        the older more-indexed album's track; without album verification,
-        artist 100 + track 100 slip past #390's floor and persist the
-        wrong-album URL.
-        """
-        mock_client = self._mock_client(
-            [
-                {
-                    "artistName": "Noura Mint Seymali",
-                    "trackName": "Hebebeb (Zrag)",
-                    "collectionName": "Tzenni",
-                    "trackViewUrl": "https://music.apple.com/us/album/hebebeb-zrag/882843574?i=882843707",
-                }
-            ]
-        )
-
-        result = await _fetch_apple_music_url(
-            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett", http_client=mock_client
-        )
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_accepts_when_album_matches(self):
-        """Album verification passes when the requested album matches the result's collection."""
-        mock_client = self._mock_client(
-            [
-                {
-                    "artistName": "Noura Mint Seymali",
-                    "trackName": "Hebebeb (Zrag)",
-                    "collectionName": "Tzenni",
-                    "trackViewUrl": "https://music.apple.com/us/album/tzenni/882843574?i=882843692",
-                }
-            ]
-        )
-
-        result = await _fetch_apple_music_url(
-            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Tzenni", http_client=mock_client
-        )
-        assert result == "https://music.apple.com/us/album/tzenni/882843574?i=882843692"
-
-    @pytest.mark.asyncio
-    async def test_accepts_album_reissue_variant(self):
-        """token_set_ratio handles reissue/edition variants ('Tzenni' vs 'Tzenni (Deluxe Edition)')."""
-        mock_client = self._mock_client(
-            [
-                {
-                    "artistName": "Noura Mint Seymali",
-                    "trackName": "Hebebeb (Zrag)",
-                    "collectionName": "Tzenni (Deluxe Edition)",
-                    "trackViewUrl": "https://music.apple.com/us/album/tzenni-deluxe/9999",
-                }
-            ]
-        )
-
-        result = await _fetch_apple_music_url(
-            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Tzenni", http_client=mock_client
-        )
-        assert result == "https://music.apple.com/us/album/tzenni-deluxe/9999"
-
-    @pytest.mark.asyncio
-    async def test_omitted_album_skips_album_check(self):
-        """Backward compat: when no album context is passed, verification mirrors pre-#396 behavior."""
-        mock_client = self._mock_client(
-            [
-                {
-                    "artistName": "Noura Mint Seymali",
-                    "trackName": "Hebebeb (Zrag)",
-                    "collectionName": "Tzenni",
-                    "trackViewUrl": "https://music.apple.com/us/album/tzenni/882843574?i=882843692",
-                }
-            ]
-        )
-
-        result = await _fetch_apple_music_url(
-            "Noura Mint Seymali", "Hebebeb (Zrag)", http_client=mock_client
-        )
-        assert result == "https://music.apple.com/us/album/tzenni/882843574?i=882843692"
-
-    @pytest.mark.asyncio
-    async def test_returns_none_on_no_results(self):
-        mock_client = self._mock_client([])
-
-        result = await _fetch_apple_music_url(
-            "Obscure Artist", "Obscure Song", http_client=mock_client
-        )
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_returns_none_on_error(self):
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(side_effect=Exception("Network error"))
-
-        result = await _fetch_apple_music_url("Artist", "Song", http_client=mock_client)
-        assert result is None
 
 
 class TestEnrichArtworkResults:
@@ -269,11 +62,9 @@ class TestEnrichArtworkResults:
             urls=["https://en.wikipedia.org/wiki/Kate_Bush", "https://katebush.com"],
         )
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results(
-                [(item, artwork)], discogs_service, song="The Saxophone Song"
-            )
-
+        results = await enrich_artwork_results(
+            [(item, artwork)], discogs_service, song="The Saxophone Song"
+        )
         _, enriched = results[0]
         assert enriched is not None
         assert enriched.release_year == 1978
@@ -299,9 +90,7 @@ class TestEnrichArtworkResults:
             release_url="https://discogs.com/release/123",
         )
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results([(item, artwork)], discogs_service)
-
+        results = await enrich_artwork_results([(item, artwork)], discogs_service)
         _, enriched = results[0]
         assert enriched.release_year == 2020
         assert enriched.artist_bio is None
@@ -311,13 +100,13 @@ class TestEnrichArtworkResults:
     async def test_handles_none_artwork(self):
         """No-Discogs-match items return a synthesized streaming-only
         ``DiscogsSearchResult`` (``release_id=0`` sentinel; see LML#401).
-        With ``http_client=None`` the Apple lookup degrades gracefully and
+        With ``apple_music=None`` the Apple lookup degrades gracefully and
         only the search-URL fallbacks fill.
         """
         item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
 
-        # No ``_fetch_apple_music_url`` patch — exercises the real
-        # ``http_client=None`` graceful-degrade path (function returns None).
+        # No ``apple_music`` argument — exercises the graceful-degrade path
+        # (the orchestrator skips the probe when the client is None).
         results = await enrich_artwork_results([(item, None)], AsyncMock(), song="French Disko")
 
         _, enriched = results[0]
@@ -330,7 +119,7 @@ class TestEnrichArtworkResults:
         assert enriched.release_year is None
         assert enriched.artist_bio is None
         assert enriched.wikipedia_url is None
-        # apple_music_url stays None because http_client is None.
+        # apple_music_url stays None because apple_music is None.
         assert enriched.apple_music_url is None
         # Search-URL fallbacks fill (artist + song are non-empty).
         assert enriched.spotify_url is not None
@@ -409,9 +198,7 @@ class TestEnrichArtworkResults:
             urls=["https://en.wikipedia.org/wiki/Artist_2"],
         )
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results(items_with_artwork, discogs_service, song="Song")
-
+        results = await enrich_artwork_results(items_with_artwork, discogs_service, song="Song")
         # Both items return non-None artwork (synthetic for top-1, real for
         # lower); but neither carries album-derived fields.
         for _, enriched in results:
@@ -438,9 +225,7 @@ class TestEnrichArtworkResults:
         discogs_service = AsyncMock()
         discogs_service.get_release.side_effect = Exception("API error")
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results([(item, artwork)], discogs_service)
-
+        results = await enrich_artwork_results([(item, artwork)], discogs_service)
         _, enriched = results[0]
         # Enriched fields should be None but streaming URLs still generated
         assert enriched.release_year is None
@@ -483,9 +268,7 @@ class TestEnrichArtworkResults:
 
         discogs_service.get_release.side_effect = lambda rid: make_release(rid)
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results(items_with_artwork, discogs_service, song="Song")
-
+        results = await enrich_artwork_results(items_with_artwork, discogs_service, song="Song")
         assert len(results) == 3
         for i, (item, enriched) in enumerate(results, start=1):
             assert item.id == i, f"Item order not preserved at position {i}"
@@ -542,14 +325,12 @@ class TestEnrichArtworkResultsExtended:
             urls=["https://en.wikipedia.org/wiki/Stereolab"],
         )
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results(
-                [(item, artwork)],
-                discogs_service,
-                song="Olv 26",
-                extended=True,
-            )
-
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            song="Olv 26",
+            extended=True,
+        )
         _, enriched = results[0]
         assert enriched is not None
         assert enriched.discogs_artist_id == 42
@@ -594,11 +375,7 @@ class TestEnrichArtworkResultsExtended:
             image_url="https://img.discogs.com/x.jpg",
         )
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results(
-                [(item, artwork)], discogs_service, extended=False
-            )
-
+        results = await enrich_artwork_results([(item, artwork)], discogs_service, extended=False)
         _, enriched = results[0]
         assert enriched.discogs_artist_id is None
         assert enriched.label is None
@@ -643,14 +420,12 @@ class TestEnrichArtworkResultsExtended:
         )
         cache_service.get_release.return_value = None  # unknown
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results(
-                [(item, artwork)],
-                discogs_service,
-                extended=True,
-                discogs_cache=cache_service,
-            )
-
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            extended=True,
+            discogs_cache=cache_service,
+        )
         _, enriched = results[0]
         assert enriched.profile_tokens is not None
         # The artist link resolved against the cache; the release ref didn't.
@@ -693,7 +468,6 @@ class TestEnrichArtworkResultsExtended:
             return task
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
         ):
             await enrich_artwork_results(
@@ -737,7 +511,6 @@ class TestEnrichArtworkResultsExtended:
             return task
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
         ):
             await enrich_artwork_results(
@@ -784,7 +557,6 @@ class TestEnrichArtworkResultsExtended:
             return task
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
         ):
             await enrich_artwork_results(
@@ -820,14 +592,12 @@ class TestEnrichArtworkResultsExtended:
 
         snapshot_before = set(_background_tasks)
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            await enrich_artwork_results(
-                [(item, artwork)],
-                discogs_service,
-                extended=True,
-                warm_cache=True,
-            )
-
+        await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            extended=True,
+            warm_cache=True,
+        )
         # The task is anchored in _background_tasks at scheduling time.
         added = _background_tasks - snapshot_before
         assert len(added) == 1
@@ -864,14 +634,12 @@ class TestEnrichArtworkResultsExtended:
             profile="Members [a=Tim Gane] and [a42]. [b]Active since 1990.[/b]",
         )
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results(
-                [(item, artwork)],
-                discogs_service,
-                extended=True,
-                discogs_cache=None,  # Explicit: no cache available
-            )
-
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            extended=True,
+            discogs_cache=None,  # Explicit: no cache available
+        )
         _, enriched = results[0]
         assert enriched.profile_tokens is not None
         kinds = [type(t).__name__ for t in enriched.profile_tokens]
@@ -908,9 +676,7 @@ class TestEnrichArtworkResultsExtended:
             release_url="https://discogs.com/release/2",
         )
 
-        with patch("lookup.orchestrator._fetch_apple_music_url", return_value=None):
-            results = await enrich_artwork_results(items_with_artwork, discogs_service)
-
+        results = await enrich_artwork_results(items_with_artwork, discogs_service)
         # Position 0 is now a synthetic streaming-only result (release_id=0
         # sentinel marks it for BS#1185 to skip extractAlbumMetadata);
         # position 1 keeps its real artwork. Neither carries release_year.
@@ -968,7 +734,6 @@ class TestMbTracklistRescue:
         mb_pg = AsyncMock()
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch(
                 "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
                 new=AsyncMock(return_value=self._track_items()),
@@ -994,7 +759,6 @@ class TestMbTracklistRescue:
         mb_pg = AsyncMock()
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch(
                 "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
                 new=AsyncMock(),
@@ -1015,7 +779,6 @@ class TestMbTracklistRescue:
         item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch(
                 "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
                 new=AsyncMock(),
@@ -1048,7 +811,6 @@ class TestMbTracklistRescue:
         )
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch(
                 "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
                 new=AsyncMock(),
@@ -1070,7 +832,6 @@ class TestMbTracklistRescue:
         mb_pg = AsyncMock()
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch(
                 "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
                 new=AsyncMock(),
@@ -1094,7 +855,6 @@ class TestMbTracklistRescue:
         mb_pg = AsyncMock()
 
         with (
-            patch("lookup.orchestrator._fetch_apple_music_url", return_value=None),
             patch(
                 "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
                 new=AsyncMock(return_value=None),
@@ -1116,14 +876,10 @@ class TestMbTracklistRescue:
 
 
 class TestEnrichArtworkResultsWithAppleMusicClient:
-    """PR-3 / LML#443: orchestrator hot path consumes ``AppleMusicClient.find_track_url``
-    instead of the iTunes Search probe in ``_fetch_apple_music_url``.
+    """LML#443/#444: orchestrator hot path consumes ``AppleMusicClient.find_track_url``.
 
-    These tests pin the new contract — ``enrich_artwork_results`` accepts an
-    ``apple_music`` client and threads the call. The legacy
-    ``_fetch_apple_music_url`` function (and the ``http_client`` parameter
-    backing it) survives PR-3 for backward compatibility with the not-yet-
-    migrated batch backfill script; PR-4 removes both.
+    These tests pin the contract — ``enrich_artwork_results`` accepts an
+    ``apple_music`` client and threads the call.
     """
 
     @pytest.mark.asyncio
@@ -1142,22 +898,14 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_url = AsyncMock(return_value=apple_url)
 
-        # The legacy iTunes path must NOT be reached — patch so a regression
-        # back to the old call site surfaces as a failed assertion rather
-        # than a silently-wrong URL.
-        with patch(
-            "lookup.orchestrator._fetch_apple_music_url",
-            new=AsyncMock(return_value="https://itunes.example/should-not-appear"),
-        ) as legacy_itunes:
-            results = await enrich_artwork_results(
-                [(item, None)],
-                AsyncMock(),
-                song="The Four Sleeping Princesses",
-                album="Tragic Magic",
-                apple_music=apple_music,
-            )
+        results = await enrich_artwork_results(
+            [(item, None)],
+            AsyncMock(),
+            song="The Four Sleeping Princesses",
+            album="Tragic Magic",
+            apple_music=apple_music,
+        )
 
-        legacy_itunes.assert_not_awaited()
         apple_music.find_track_url.assert_awaited_once_with(
             "Julianna Barwick & Mary Lattimore",
             "The Four Sleeping Princesses",
@@ -1219,12 +967,10 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
     @pytest.mark.asyncio
     async def test_apple_music_client_raising_does_not_sink_whole_batch(self):
         """A single ``find_track_url`` exception must NOT propagate through
-        ``asyncio.gather`` and fail the entire enrichment. Mirrors the legacy
-        ``_fetch_apple_music_url`` blanket ``try: ... except Exception: return
-        None`` guarantee — bulk lookups regress to 500 without this wrap if
-        Apple returns a malformed result that trips ``find_track_url``'s
-        result-iteration loop (which itself has no top-level exception
-        handler).
+        ``asyncio.gather`` and fail the entire enrichment. ``find_track_url``
+        has no top-level exception handler around its result-iteration loop,
+        so the orchestrator wraps the call defensively — bulk lookups would
+        otherwise regress to 500 if Apple returns a malformed result.
         """
         items_with_artwork = [
             (make_library_item(id=1, artist="Artist 1", title="Album 1"), None),

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -467,9 +467,7 @@ class TestEnrichArtworkResultsExtended:
             scheduled.append(task)
             return task
 
-        with (
-            patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
-        ):
+        with patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task):
             await enrich_artwork_results(
                 [(item, artwork)],
                 discogs_service,
@@ -510,9 +508,7 @@ class TestEnrichArtworkResultsExtended:
             scheduled.append(task)
             return task
 
-        with (
-            patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
-        ):
+        with patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task):
             await enrich_artwork_results(
                 [(item, artwork)], discogs_service, extended=True, warm_cache=False
             )
@@ -556,9 +552,7 @@ class TestEnrichArtworkResultsExtended:
             scheduled.append(task)
             return task
 
-        with (
-            patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task),
-        ):
+        with patch("lookup.orchestrator.asyncio.create_task", side_effect=spy_create_task):
             await enrich_artwork_results(
                 [(item, artwork)], discogs_service, extended=True, warm_cache=True
             )
@@ -733,12 +727,10 @@ class TestMbTracklistRescue:
         item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
         mb_pg = AsyncMock()
 
-        with (
-            patch(
-                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
-                new=AsyncMock(return_value=self._track_items()),
-            ) as resolver,
-        ):
+        with patch(
+            "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+            new=AsyncMock(return_value=self._track_items()),
+        ) as resolver:
             results = await enrich_artwork_results(
                 [(item, None)],
                 AsyncMock(),
@@ -758,12 +750,10 @@ class TestMbTracklistRescue:
         item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
         mb_pg = AsyncMock()
 
-        with (
-            patch(
-                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
-                new=AsyncMock(),
-            ) as resolver,
-        ):
+        with patch(
+            "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+            new=AsyncMock(),
+        ) as resolver:
             await enrich_artwork_results(
                 [(item, None)],
                 AsyncMock(),
@@ -778,12 +768,10 @@ class TestMbTracklistRescue:
     async def test_no_resolver_call_when_mb_pg_is_none(self):
         item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
 
-        with (
-            patch(
-                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
-                new=AsyncMock(),
-            ) as resolver,
-        ):
+        with patch(
+            "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+            new=AsyncMock(),
+        ) as resolver:
             await enrich_artwork_results(
                 [(item, None)],
                 AsyncMock(),
@@ -810,12 +798,10 @@ class TestMbTracklistRescue:
             release_url="https://discogs.com/release/42",
         )
 
-        with (
-            patch(
-                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
-                new=AsyncMock(),
-            ) as resolver,
-        ):
+        with patch(
+            "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+            new=AsyncMock(),
+        ) as resolver:
             await enrich_artwork_results(
                 [(item, artwork)],
                 discogs_service,
@@ -831,12 +817,10 @@ class TestMbTracklistRescue:
         item = make_library_item(artist="Stereolab", title="Emperor Tomato Ketchup")
         mb_pg = AsyncMock()
 
-        with (
-            patch(
-                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
-                new=AsyncMock(),
-            ) as resolver,
-        ):
+        with patch(
+            "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+            new=AsyncMock(),
+        ) as resolver:
             await enrich_artwork_results(
                 [(item, None)],
                 AsyncMock(),
@@ -854,12 +838,10 @@ class TestMbTracklistRescue:
         item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
         mb_pg = AsyncMock()
 
-        with (
-            patch(
-                "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
-                new=AsyncMock(return_value=None),
-            ) as resolver,
-        ):
+        with patch(
+            "lookup.orchestrator.resolve_tracklist_via_musicbrainz",
+            new=AsyncMock(return_value=None),
+        ) as resolver:
             results = await enrich_artwork_results(
                 [(item, None)],
                 AsyncMock(),

--- a/tests/unit/test_fd_leak_regression_241.py
+++ b/tests/unit/test_fd_leak_regression_241.py
@@ -8,14 +8,13 @@ the container; the leak source survives until something changes.
 These tests encode the two prime hypotheses identified during incident
 investigation as concrete contracts the code should satisfy:
 
-1. ``_fetch_apple_music_url`` is on the request hot path and must NOT
-   construct a fresh ``httpx.AsyncClient`` per call. Every other outbound
-   client in the service (Discogs, Spotify, Deezer, Bandcamp, AppleMusicClient)
-   is a process-lifetime singleton with explicit ``close()`` on shutdown;
-   this one slipped through. Each instantiation opens a fresh transport
-   (DNS resolver socket + connection pool) — under sustained traffic from
-   request-o-matic ``/health/ready`` polls + real iOS DJ requests, those
-   accumulate FDs faster than they can be cleaned up.
+1. The artwork-enrichment hot path must NOT construct ``httpx.AsyncClient``
+   instances. Every outbound client in the service (Discogs, Spotify,
+   Deezer, Bandcamp, AppleMusicClient) is a process-lifetime singleton with
+   explicit ``close()`` on shutdown. The legacy ``_fetch_apple_music_url``
+   used to construct a fresh client per call — that was removed in LML#241
+   and the function itself in LML#444; the orchestrator no longer imports
+   ``httpx`` at all.
 
 2. Two lazy-init asyncpg pools have a TOCTOU race:
    ``entity/sources.py:PgSource._get_pool`` and
@@ -24,8 +23,6 @@ investigation as concrete contracts the code should satisfy:
    first-callers each pass the check, each create a pool, and all but one
    pool is orphaned with no reference to ``close()`` it. Each orphaned pool
    holds up to 5 connections (FDs).
-
-These tests fail today; they should pass after fixes ship.
 """
 
 from __future__ import annotations
@@ -33,88 +30,36 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
 
-from discogs.models import ReleaseMetadataResponse
 
+class TestOrchestratorOwnsNoHttpxClients:
+    """Hypothesis #1: the artwork-enrichment hot path must not own transient
+    ``httpx.AsyncClient`` instances.
 
-class TestFetchAppleMusicUrlNoLeak:
-    """Hypothesis #1: the artwork-enrichment hot path must not instantiate
-    ``httpx.AsyncClient`` per call.
-
-    The desired contract: ``enrich_artwork_results`` accepts (or sources from
-    DI) a shared ``httpx.AsyncClient`` / ``AppleMusicClient`` and threads it
-    down to ``_fetch_apple_music_url``. The orchestrator owns no transient
-    clients of its own.
+    Strongest form of the invariant: ``lookup.orchestrator`` does not import
+    ``httpx`` at all (LML#444 removed the last reference when ``_fetch_apple_music_url``
+    was deleted). Any future regression that re-introduces ``import httpx``
+    into the module — typically the first step toward a per-call client
+    construction — fails this test before it can ship the FD-leak shape from
+    issue #241.
     """
 
-    @pytest.mark.asyncio
-    async def test_enrich_artwork_results_does_not_construct_httpx_client(self):
-        """A full enrich pass over multiple items must not instantiate any
-        ``httpx.AsyncClient`` inside the orchestrator. Every instantiation
-        on the hot path is a leaked-FD risk (issue #241).
+    def test_orchestrator_does_not_import_httpx(self):
+        """The orchestrator's request hot path must source HTTP clients via
+        DI (e.g. ``AppleMusicClient``) rather than construct them. The
+        BaseStreamingClient singleton pattern guarantees one process-lifetime
+        ``httpx.AsyncClient`` per service with explicit shutdown.
         """
-        from lookup.orchestrator import enrich_artwork_results
-        from tests.factories import make_discogs_result, make_library_item
+        import lookup.orchestrator as orchestrator_module
 
-        items_with_artwork = [
-            (
-                make_library_item(id=i, artist=f"Artist {i}", title=f"Album {i}"),
-                make_discogs_result(release_id=i, artist=f"Artist {i}", album=f"Album {i}"),
-            )
-            for i in range(1, 4)
-        ]
-
-        discogs_service = AsyncMock()
-
-        def make_release(release_id: int) -> ReleaseMetadataResponse:
-            return ReleaseMetadataResponse(
-                release_id=release_id,
-                title=f"Album {release_id}",
-                artist=f"Artist {release_id}",
-                year=2000 + release_id,
-                artist_id=None,
-                release_url=f"https://discogs.com/release/{release_id}",
-            )
-
-        discogs_service.get_release.side_effect = lambda rid: make_release(rid)
-
-        instantiations: list[tuple] = []
-
-        class TrackingAsyncClient:
-            """Stand-in for ``httpx.AsyncClient`` that records construction
-            and yields a get-stub returning an empty iTunes response.
-            """
-
-            def __init__(self, *args, **kwargs):
-                instantiations.append((args, kwargs))
-
-            async def __aenter__(self):
-                stub = AsyncMock()
-                stub.get = AsyncMock(
-                    return_value=httpx.Response(
-                        200,
-                        json={"results": []},
-                        request=httpx.Request("GET", "https://itunes.apple.com/search"),
-                    )
-                )
-                return stub
-
-            async def __aexit__(self, exc_type, exc, tb):
-                return None
-
-        with patch("lookup.orchestrator.httpx.AsyncClient", TrackingAsyncClient):
-            await enrich_artwork_results(items_with_artwork, discogs_service, song="Song")
-
-        assert instantiations == [], (
-            f"lookup.orchestrator constructed {len(instantiations)} "
-            f"httpx.AsyncClient(s) during a single enrich pass over "
-            f"{len(items_with_artwork)} items. Each instantiation opens a "
-            "fresh transport (DNS + connection pool); under sustained "
-            "/api/v1/lookup traffic this leaks FDs (issue #241). "
-            "enrich_artwork_results should accept a shared client and "
-            "thread it through to _fetch_apple_music_url."
+        assert not hasattr(orchestrator_module, "httpx"), (
+            "lookup.orchestrator must not import httpx. Every outbound HTTP "
+            "client in this service is a process-lifetime singleton with "
+            "explicit close() on shutdown — the orchestrator sources from "
+            "DI rather than constructing. Re-introducing httpx here is the "
+            "first step toward the per-call construction pattern that "
+            "leaked FDs in issue #241."
         )
 
 


### PR DESCRIPTION
## Summary

Final step of the [authenticated Apple Music migration](https://github.com/WXYC/library-metadata-lookup/blob/main/docs/adr/0001-authenticated-apple-music-api.md). PR-3 (#448) routed the orchestrator hot path through `AppleMusicClient.find_track_url`, so the legacy unauthenticated iTunes Search code path has no remaining call sites. This PR deletes it.

Net: **-436 lines** (+91 / -527).

## What's removed

| Surface | Symbol |
|---|---|
| `lookup/orchestrator.py` | `_fetch_apple_music_url` (function), `_APPLE_MUSIC_MATCH_FLOOR` (constant; survives at `clients/streaming/apple_music._APPLE_MUSIC_MATCH_FLOOR`), `http_client` parameter on `enrich_artwork_results` + `perform_lookup`, the `import httpx` |
| `core/dependencies.py` | `_build_apple_music_http_client`, `_get_apple_music_http_client`, `get_apple_music_http_client`, `close_apple_music_http_client` — the shared `httpx.AsyncClient(timeout=5.0)` that backed the iTunes probe |
| `lookup/router.py` | `http_client` DI from `handle_lookup` and `handle_bulk_lookup` |
| `main.py` | `close_apple_music_http_client()` from lifespan shutdown |
| `tests/unit/test_enrichment.py` | `TestFetchAppleMusicUrl` class (12 tests, ~204 lines); ~20 dead `patch('_fetch_apple_music_url')` sites |

## Strongest form of the LML#241 invariant

`lookup.orchestrator` no longer imports `httpx` at all. `tests/unit/test_fd_leak_regression_241.py::TestOrchestratorOwnsNoHttpxClients` was rewritten as a single static assertion (`not hasattr(orchestrator_module, 'httpx')`) that catches any future regression re-introducing per-call client construction — the original FD-leak shape from the 2026-05-01 prod outage.

## Stacking

- [x] PR-1 #446 — `AppleMusicClient` + settings + tests
- [x] PR-2 #447 — End-to-end test for `/streaming-check`
- [x] PR-3 #448 — Orchestrator hot path migration; closed #443
- [x] **PR-4 (this) — Delete legacy iTunes Search code; closes #444 as superseded**

## Test plan

- [x] Full unit suite green locally (2066 passed; same pre-existing teardown-order flake in `test_no_module_level_asyncio_lock_in_dependencies` that fires on `origin/main` and passes in isolation)
- [x] Integration suite `tests/integration/test_streaming_on_discogs_miss.py` green
- [x] `ruff check` + `ruff format --check` clean across all touched files
- [x] `mypy lookup/orchestrator.py lookup/router.py core/dependencies.py main.py` clean
- [x] `python -c 'import main'` smoke test — service still boots
- [x] `grep -rn '_fetch_apple_music_url\|get_apple_music_http_client'` returns only documentation/historical lineage refs

Closes #444