### PR TITLE
feat(streaming): async_singleton for get_apple_music_client

### DIFF
--- a/streaming/dependencies.py
+++ b/streaming/dependencies.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from fastapi import Depends
+from wxyc_fastapi.http import async_singleton
 
 from clients.bandcamp import BandcampClient
 from clients.streaming.apple_music import AppleMusicClient
@@ -14,10 +15,12 @@ from config.settings import Settings, get_settings
 
 logger = logging.getLogger(__name__)
 
-# Module-level instances for lifecycle management
+# Module-level instances for lifecycle management. Apple Music is wired through
+# `async_singleton` below (LML#451) and so does NOT appear here — its closure-
+# owned state plus an explicit closer guarantees one-instance-per-process even
+# under concurrent cold-start callers from FastAPI's threadpool.
 _spotify_client: SpotifyClient | None = None
 _deezer_client: DeezerClient | None = None
-_apple_music_client: AppleMusicClient | None = None
 _bandcamp_client: BandcampClient | None = None
 
 
@@ -48,19 +51,19 @@ def get_deezer_client() -> DeezerClient:
     return _deezer_client
 
 
-def get_apple_music_client(
-    settings: Settings = Depends(get_settings),
-) -> AppleMusicClient | None:
-    """Get Apple Music client. Requires APPLE_MUSIC_TEAM_ID, KEY_ID, and
-    PRIVATE_KEY; returns None when any is missing so the check degrades to
-    no-op (matches the Spotify-without-creds pattern). See
-    docs/adr/0001-authenticated-apple-music-api.md.
+async def _build_apple_music_client() -> AppleMusicClient | None:
+    """Build the Apple Music client, or ``None`` when credentials are missing.
+
+    Returns ``None`` when ``APPLE_MUSIC_TEAM_ID``, ``APPLE_MUSIC_KEY_ID``, or
+    ``APPLE_MUSIC_PRIVATE_KEY`` is unset so the check degrades to no-op
+    (matches the Spotify-without-creds pattern). See
+    ``docs/adr/0001-authenticated-apple-music-api.md``.
+
+    The race-free wiring lives in ``async_singleton`` (LML#451 closes the
+    same shape as #241/#283/#435): this factory just owns the config-load +
+    log-on-failure shape.
     """
-    global _apple_music_client
-
-    if _apple_music_client is not None:
-        return _apple_music_client
-
+    settings = get_settings()
     if (
         not settings.apple_music_team_id
         or not settings.apple_music_key_id
@@ -68,14 +71,31 @@ def get_apple_music_client(
     ):
         logger.debug("Apple Music credentials not set — Apple Music check disabled")
         return None
-
-    _apple_music_client = AppleMusicClient(
+    client = AppleMusicClient(
         team_id=settings.apple_music_team_id,
         key_id=settings.apple_music_key_id,
         private_key=settings.apple_music_private_key,
     )
     logger.info("Apple Music client initialized")
-    return _apple_music_client
+    return client
+
+
+_get_apple_music_client, _close_apple_music_client = async_singleton(_build_apple_music_client)
+
+
+async def get_apple_music_client(
+    settings: Settings = Depends(get_settings),
+) -> AppleMusicClient | None:
+    """Get Apple Music client. Requires APPLE_MUSIC_TEAM_ID, KEY_ID, and
+    PRIVATE_KEY; returns None when any is missing so the check degrades to
+    no-op (matches the Spotify-without-creds pattern). See
+    ``docs/adr/0001-authenticated-apple-music-api.md``.
+
+    The ``settings`` argument is preserved for FastAPI DI compatibility —
+    the underlying singleton factory reads from ``get_settings()`` directly
+    so concurrent cold-start callers see a single, race-free init (LML#451).
+    """
+    return await _get_apple_music_client()
 
 
 def get_bandcamp_client() -> BandcampClient:
@@ -91,19 +111,21 @@ def get_bandcamp_client() -> BandcampClient:
 
 async def close_streaming_clients() -> None:
     """Close all streaming clients. Called during application shutdown."""
-    global _spotify_client, _deezer_client, _apple_music_client, _bandcamp_client
+    global _spotify_client, _deezer_client, _bandcamp_client
 
     for name, client in [
         ("Spotify", _spotify_client),
         ("Deezer", _deezer_client),
-        ("Apple Music", _apple_music_client),
         ("Bandcamp", _bandcamp_client),
     ]:
         if client is not None:
             await client.close()
             logger.info("%s client closed", name)
 
+    # Apple Music lives inside `async_singleton`; its closer owns the
+    # close-and-clear so a future cold-start re-runs `_build_apple_music_client`.
+    await _close_apple_music_client()
+
     _spotify_client = None
     _deezer_client = None
-    _apple_music_client = None
     _bandcamp_client = None

--- a/tests/unit/test_fd_leak_regression_241.py
+++ b/tests/unit/test_fd_leak_regression_241.py
@@ -28,6 +28,7 @@ investigation as concrete contracts the code should satisfy:
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -178,3 +179,110 @@ class TestGetDiscogsServicePoolRace:
             "holds up to 5 connections. The lazy init must go through "
             "`wxyc_fastapi.http.async_singleton` (issue #241 / #283)."
         )
+
+
+class TestGetAppleMusicClientRace:
+    """Hypothesis #2c: ``streaming.dependencies.get_apple_music_client`` is racy.
+
+    Same shape as the Discogs-pool race: the pre-fix getter is a sync FastAPI
+    dep with a ``global _apple_music_client`` + ``is None`` check + assign. The
+    dep runs in FastAPI's threadpool, so concurrent cold-start callers can
+    each observe ``None``, each construct a fresh ``AppleMusicClient`` (PEM
+    parse + ECDSA key load + AsyncLimiter + asyncio.Semaphore), and orphan
+    all but one. The orphan's HTTP transport itself doesn't leak (the base
+    class wraps that in ``async_singleton``), but the orphan's rate limiter
+    and semaphore are wasted work and a transient drift hazard (two limiters
+    mean ~2x the effective rate budget until the orphan is GC'd).
+
+    Post-#451 the singleton is provided by `wxyc_fastapi.http.async_singleton`,
+    which owns the double-check + `asyncio.Lock` together. The test drives
+    the public getter end-to-end so a future refactor that bypasses
+    `async_singleton` would re-introduce the race and re-fail this test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_start_creates_one_client(self):
+        """Concurrent cold-start callers in ``get_apple_music_client`` must
+        share a single ``AppleMusicClient`` instance.
+
+        Pre-fix the sync FastAPI dep returned the result of a bare
+        ``AppleMusicClient(...)`` call after a ``global _apple_music_client``
+        check. Sync deps run in FastAPI's threadpool, so concurrent cold-
+        starters could each pass the ``is None`` check before any of them
+        assigned the global. Post-#451 the getter is async, the underlying
+        factory runs inside ``wxyc_fastapi.http.async_singleton``'s lock,
+        and every caller observes the same instance.
+        """
+        from config.settings import Settings
+        from streaming import dependencies
+
+        # Reset module-level state via the public closer so the next
+        # `get_apple_music_client` call drives a cold-start through the
+        # `async_singleton` factory (the underlying state lives in a closure
+        # we can't reach directly).
+        await dependencies.close_streaming_clients()
+
+        settings = Settings(
+            apple_music_team_id="TEAMID1234",
+            apple_music_key_id="KEYID12345",
+            apple_music_private_key="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+        )
+
+        init_calls: list[tuple] = []
+        fake_client = AsyncMock(name="apple-music-client")
+
+        def fake_constructor(*args, **kwargs):
+            init_calls.append((args, kwargs))
+            return fake_client
+
+        try:
+            with (
+                patch("streaming.dependencies.get_settings", return_value=settings),
+                patch(
+                    "streaming.dependencies.AppleMusicClient",
+                    side_effect=fake_constructor,
+                ),
+            ):
+                tasks = [
+                    asyncio.create_task(dependencies.get_apple_music_client(settings))
+                    for _ in range(8)
+                ]
+                results = await asyncio.gather(*tasks)
+        finally:
+            await dependencies.close_streaming_clients()
+
+        assert len(init_calls) == 1, (
+            f"AppleMusicClient was constructed {len(init_calls)} times for "
+            "the same Apple Music singleton. Concurrent cold-start callers "
+            "race in get_apple_music_client, orphaning all but one client — "
+            "each orphan holds an AsyncLimiter and asyncio.Semaphore (two "
+            "limiters mean transiently 2x the effective per-team rate "
+            "budget). The lazy init must go through "
+            "`wxyc_fastapi.http.async_singleton` (issue #241 / #451)."
+        )
+        # All callers must observe the same singleton instance.
+        assert all(r is fake_client for r in results), (
+            "Concurrent cold-start callers received different "
+            "AppleMusicClient instances. The async_singleton wrapper must "
+            "return the same instance to every caller after the factory "
+            "completes (issue #451)."
+        )
+
+
+def test_no_global_apple_music_client_in_streaming_dependencies():
+    """LML#451: race-prone ``global _apple_music_client`` lazy-init must be
+    gone from ``streaming/dependencies.py``. The lock + double-check belongs
+    inside ``wxyc_fastapi.http.async_singleton``; reintroducing a hand-rolled
+    sync getter with a module-level singleton + ``is None`` check would
+    re-open the same race that LML#241/#283/#435 closed elsewhere.
+    """
+    from streaming import dependencies as streaming_deps_module
+
+    src = Path(streaming_deps_module.__file__).read_text()
+    assert "global _apple_music_client" not in src, (
+        "streaming/dependencies.py uses `global _apple_music_client` — the "
+        "lock-free lazy-init pattern that LML#451 closed. Migrate to "
+        "`async_singleton(_build_apple_music_client)` (mirroring the Discogs "
+        "pool + MusicBrainz PgSource pattern in core/dependencies.py). See "
+        "LML#451."
+    )


### PR DESCRIPTION
## Summary

- Convert `streaming.dependencies.get_apple_music_client` from a sync FastAPI dep with a hand-rolled `global _apple_music_client` + `is None` + assign lazy-init into an async dep backed by `wxyc_fastapi.http.async_singleton` — same pattern as `_build_discogs_pool` + `_build_musicbrainz_pg` in `core/dependencies.py`.
- Pin the contract with two tests: a concurrent-cold-start race test (8 tasks → one constructor call, same instance) and a static-scan pin against re-introducing the sync getter shape.
- Route Apple Music through the singleton's closer in `close_streaming_clients` so future cold-starts re-run the factory.

## Context

Sync FastAPI deps run in a threadpool, so concurrent cold-start callers of the pre-fix `get_apple_music_client` could each observe `_apple_music_client is None`, each construct a fresh `AppleMusicClient` (PEM parse + ECDSA key load + AsyncLimiter + asyncio.Semaphore), and orphan all but one. The orphan's HTTP transport itself didn't leak (`BaseStreamingClient` wraps that in its own `async_singleton`), but the orphan's rate limiter and semaphore are wasted work and a transient drift hazard — two limiters mean ~2x the effective per-team Apple budget until GC. Same shape as LML#241 / LML#283 / LML#435.

## Test plan

- [x] `pytest tests/unit/test_fd_leak_regression_241.py` — new tests fail pre-fix, pass post-fix
- [x] `pytest tests/unit` — 2066 passed (1 pre-existing unrelated teardown flake in `test_dependencies.py::test_no_module_level_asyncio_lock_in_dependencies`)
- [x] `pytest tests/integration` — 234 passed, 2 xfailed
- [x] `ruff check .` + `ruff format --check .` clean

Closes #451