### PR TITLE
test(streaming): asyncio.Lock pin + DI-override docstring polish (#459)

### DIFF
--- a/streaming/dependencies.py
+++ b/streaming/dependencies.py
@@ -94,6 +94,15 @@ async def get_apple_music_client(
     The ``settings`` argument is preserved for FastAPI DI compatibility —
     the underlying singleton factory reads from ``get_settings()`` directly
     so concurrent cold-start callers see a single, race-free init (LML#451).
+
+    Testing note (LML#459): because the factory bypasses FastAPI DI and
+    calls ``get_settings()`` (an ``@lru_cache``'d module-level function)
+    directly, ``app.dependency_overrides[get_settings] = ...`` does NOT
+    reach the Apple Music branch. Integration tests that need to swap
+    Apple Music credentials must
+    ``patch("streaming.dependencies.get_settings", ...)`` directly —
+    mirroring the cold-start race test in
+    ``tests/unit/test_fd_leak_regression_241.py::TestGetAppleMusicClientRace``.
     """
     return await _get_apple_music_client()
 

--- a/tests/unit/test_fd_leak_regression_241.py
+++ b/tests/unit/test_fd_leak_regression_241.py
@@ -286,3 +286,29 @@ def test_no_global_apple_music_client_in_streaming_dependencies():
         "pool + MusicBrainz PgSource pattern in core/dependencies.py). See "
         "LML#451."
     )
+
+
+def test_no_module_level_asyncio_lock_in_streaming_dependencies():
+    """LML#459 (LML#451 follow-up): race-prone hand-rolled ``asyncio.Lock()``
+    plumbing must stay out of ``streaming/dependencies.py``. The lock +
+    double-check belongs inside ``wxyc_fastapi.http.async_singleton``;
+    reintroducing one at the module level (a) duplicates the contract and
+    (b) means a future author could write a new lazy-init that re-races the
+    FD-leak fix from #242.
+
+    Mirrors ``tests/unit/test_dependencies.py::
+    test_no_module_level_asyncio_lock_in_dependencies`` for symmetry — the
+    Apple Music singleton pin (above) catches the ``global X`` re-introduction
+    shape, this pin catches the ``asyncio.Lock()`` re-introduction shape.
+    """
+    from streaming import dependencies as streaming_deps_module
+
+    src = Path(streaming_deps_module.__file__).read_text()
+    assert "asyncio.Lock()" not in src, (
+        "streaming/dependencies.py contains a module-level `asyncio.Lock()` "
+        "instance — async singletons in this module must use "
+        "`wxyc_fastapi.http.async_singleton(factory)` instead, which owns "
+        "the lock and the double-check together. See "
+        "WXYC/library-metadata-lookup#451 and "
+        "WXYC/library-metadata-lookup#241."
+    )


### PR DESCRIPTION
## Summary

- Add `test_no_module_level_asyncio_lock_in_streaming_dependencies` to `tests/unit/test_fd_leak_regression_241.py`, mirroring the existing pin on `core/dependencies.py`. The PR #454 pin only catches `global _apple_music_client` re-introduction; this catches a future refactor that reaches for `asyncio.Lock()` directly instead of `async_singleton`.
- Expand the `get_apple_music_client` docstring with a testing note: because the factory bypasses FastAPI DI and calls the `@lru_cache`'d `get_settings()` directly, `app.dependency_overrides[get_settings]` does not reach the Apple Music branch. Integration tests must `patch("streaming.dependencies.get_settings", ...)` instead — the same pattern the cold-start race test in this file already uses.

## Context

Surfaced during PR #454 review. Both findings are pin/docstring polish; no behavior change.

## Test plan

- [x] `pytest tests/unit/test_fd_leak_regression_241.py` — 6 passed (including the new pin)
- [x] `pytest tests/unit/test_streaming_check_router.py tests/unit/test_streaming_check_e2e_apple_music.py` — 11 passed
- [x] `ruff check .` + `ruff format --check .` clean
- [x] Verified pin trips on a synthetic `asyncio.Lock()` insertion

Closes #459.