### PR TITLE
polish(apple-music): log raw Retry-After on 429; lift test import

### DIFF
--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -223,11 +223,17 @@ class AppleMusicClient(BaseStreamingClient):
                 return payload.get("results", {}).get(result_key, {}).get("data", []), 200
 
             if resp.status_code == 429:
-                retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+                raw_retry_after = resp.headers.get("Retry-After")
+                retry_after = _parse_retry_after(raw_retry_after)
+                # Log the raw header so operators can spot when Apple is
+                # quota-pushing (Retry-After: 30+) vs returning routine 1-5s
+                # 429s — the clamp at ``_RETRY_AFTER_CAP_SECONDS`` (LML#450)
+                # is otherwise invisible. See LML#464.
                 logger.warning(
-                    "Apple Music 429 for %s - %s; sleeping %.1fs (attempt %d/%d)",
+                    "Apple Music 429 for %s - %s; Retry-After=%s sleeping %.1fs (attempt %d/%d)",
                     artist,
                     term,
+                    raw_retry_after,
                     retry_after,
                     attempt + 1,
                     _MAX_RETRIES,

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -20,6 +20,7 @@ import pytest
 from clients.streaming.apple_music import (
     _APPLE_MUSIC_MATCH_FLOOR,
     AppleMusicClient,
+    _parse_retry_after,
 )
 
 TEAM_ID = "92V374HC38"
@@ -471,6 +472,40 @@ class TestRetryBehavior:
         assert mock_http.get.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_429_log_records_raw_retry_after_for_clamp_visibility(
+        self, es256_keypair, caplog
+    ):
+        """LML#464: when Apple's ``Retry-After`` exceeds the 5s cap, the WARN
+        log line must show the raw value so operators can distinguish
+        "Apple is quota-pushing at 30s, we clamped" from "normal transient
+        1-5s 429". Without the raw value, sustained Apple quota pressure
+        is invisible until the failure mode escalates."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        rate_limited = httpx.Response(
+            429,
+            headers={"Retry-After": "30"},
+            request=httpx.Request("GET", SEARCH_URL),
+        )
+        success = _songs_response([_make_song_data()])
+        mock_http.get = AsyncMock(side_effect=[rate_limited, success])
+        client._http = mock_http
+
+        import logging as _logging
+
+        with patch("clients.streaming.apple_music.asyncio.sleep", new_callable=AsyncMock):
+            with caplog.at_level(_logging.WARNING, logger="clients.streaming.apple_music"):
+                await client.search_song("Stereolab", "Aluminum Tunes")
+
+        warn_messages = [r.getMessage() for r in caplog.records if r.levelno == _logging.WARNING]
+        clamp_lines = [m for m in warn_messages if "429" in m]
+        assert clamp_lines, f"Expected a 429 WARN log line; got {warn_messages!r}"
+        assert any("30" in line for line in clamp_lines), (
+            "429 WARN log line must include the raw Retry-After value "
+            f"(30) so operators can see the clamp. Got: {clamp_lines!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_gives_up_after_max_retries_on_429_burst(self, es256_keypair):
         """LML#450: ``_MAX_RETRIES=2`` (down from 4). Lookup is latency-
         sensitive; under sustained 429/5xx we degrade to no-Apple immediately
@@ -505,8 +540,6 @@ class TestParseRetryAfter:
     def test_caps_retry_after_at_5s(self):
         """A pathological upstream `Retry-After: 60` (or higher) must clamp
         to 5s so one slow item can't pin a Semaphore slot for a minute."""
-        from clients.streaming.apple_music import _parse_retry_after
-
         assert _parse_retry_after("60") == 5.0
         assert _parse_retry_after("120") == 5.0
 
@@ -514,16 +547,12 @@ class TestParseRetryAfter:
         """A small Retry-After (under the cap) is honored verbatim — Apple
         usually returns ``1`` or ``2`` for transient 429s, and respecting it
         avoids hammering."""
-        from clients.streaming.apple_music import _parse_retry_after
-
         assert _parse_retry_after("1") == 1.0
         assert _parse_retry_after("3") == 3.0
 
     def test_fallback_when_header_absent_or_malformed(self):
         """Missing/garbage headers fall back to the cap (5s) — same as the
         post-fix max so the slow path is bounded either way."""
-        from clients.streaming.apple_music import _parse_retry_after
-
         assert _parse_retry_after(None) == 5.0
         assert _parse_retry_after("") == 5.0
         assert _parse_retry_after("not-a-number") == 5.0


### PR DESCRIPTION
## Summary

Trivial post-merge polish for #456. Two changes:

1. **`_search_with_retry` 429 log line** now records the raw `Retry-After` value alongside the (potentially clamped) sleep duration. PR #456 trimmed `_RETRY_AFTER_CAP_SECONDS` from 60s to 5s; without the raw value visible in logs, operators cannot distinguish "Apple is quota-pushing at 30s and we clamped aggressively" from "routine transient 1–5s 429". That signal is the input to a future `_RATE_LIMIT` retune.

   Before:
   ```
   Apple Music 429 for Stereolab - Aluminum Tunes; sleeping 5.0s (attempt 1/2)
   ```

   After:
   ```
   Apple Music 429 for Stereolab - Aluminum Tunes; Retry-After=30 sleeping 5.0s (attempt 1/2)
   ```

2. **Lifted `_parse_retry_after` import** in `test_apple_music_client.py` to module scope — the three `TestParseRetryAfter` methods each had their own local import.

## Out of scope

- Upper-bound guard on `_apple_music_lookup_timeout_s` (and analogously on `resolve_search_budget_ms` / `resolve_search_hard_timeout_ms`). The underlying helper `_resolve_positive_int_env` in `core/search.py` already covers the lower-bound case for two callers; an upper bound would touch all three. Worth pursuing if a misconfiguration ever fires; out of scope for this trivial bundle.
- Refactoring `_apple_music_lookup_timeout_s` to reuse `core.search._resolve_positive_int_env` — that helper is module-private (underscore-prefixed) and importing it from `lookup/orchestrator.py` crosses a layering line. Promote-then-share if a third consumer makes the cost obvious.

The non-trivial finding from the same review (timeout has no Sentry telemetry) is tracked separately in #462.

## Test plan

- [x] TDD: new `tests/unit/test_apple_music_client.py::TestRetryBehavior::test_429_log_records_raw_retry_after_for_clamp_visibility` — patches sleep, sets `Retry-After: 30`, captures WARN logs, asserts the raw value appears in the line. Red confirmed before the apple_music.py change.
- [x] `pytest tests/unit/test_apple_music_client.py` — 38 passed
- [x] `pytest tests/unit/` — 2074 passed (same 1 pre-existing teardown flake in `test_no_module_level_asyncio_lock_in_dependencies`)
- [x] `ruff check .` + `ruff format --check .` clean

Closes #464