### PR TITLE
fix(streaming): migrate Spotify/Deezer/Bandcamp deps to async_singleton

### DIFF
--- a/streaming/dependencies.py
+++ b/streaming/dependencies.py
@@ -4,51 +4,66 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import Depends
 from wxyc_fastapi.http import async_singleton
 
 from clients.bandcamp import BandcampClient
 from clients.streaming.apple_music import AppleMusicClient
 from clients.streaming.deezer import DeezerClient
 from clients.streaming.spotify import SpotifyClient
-from config.settings import Settings, get_settings
+from config.settings import get_settings
 
 logger = logging.getLogger(__name__)
 
-# Module-level instances for lifecycle management. Apple Music is wired through
-# `async_singleton` below (LML#451) and so does NOT appear here — its closure-
+# All four streaming clients are wired through `wxyc_fastapi.http.async_singleton`
+# (LML#451 for Apple Music; LML#457 for Spotify, Deezer, Bandcamp). The closure-
 # owned state plus an explicit closer guarantees one-instance-per-process even
-# under concurrent cold-start callers from FastAPI's threadpool.
-_spotify_client: SpotifyClient | None = None
-_deezer_client: DeezerClient | None = None
-_bandcamp_client: BandcampClient | None = None
+# under concurrent cold-start callers from FastAPI's threadpool. Each client
+# inherits BaseStreamingClient (AsyncLimiter + asyncio.Semaphore at construction),
+# so an orphaned instance would silently halve the effective per-service rate
+# budget; Spotify additionally would re-trigger its OAuth bearer-token fetch.
 
 
-def get_spotify_client(settings: Settings = Depends(get_settings)) -> SpotifyClient | None:
-    """Get Spotify client instance. Requires SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET."""
-    global _spotify_client
-
-    if _spotify_client is not None:
-        return _spotify_client
-
+async def _build_spotify_client() -> SpotifyClient | None:
+    """Build the Spotify client, or ``None`` when credentials are missing."""
+    settings = get_settings()
     if not settings.spotify_client_id or not settings.spotify_client_secret:
         logger.debug("Spotify credentials not set — Spotify streaming check disabled")
         return None
-
-    _spotify_client = SpotifyClient(settings.spotify_client_id, settings.spotify_client_secret)
+    client = SpotifyClient(settings.spotify_client_id, settings.spotify_client_secret)
     logger.info("Spotify client initialized")
-    return _spotify_client
+    return client
 
 
-def get_deezer_client() -> DeezerClient:
-    """Get Deezer client instance. No auth required."""
-    global _deezer_client
+_get_spotify_client, _close_spotify_client = async_singleton(_build_spotify_client)
 
-    if _deezer_client is None:
-        _deezer_client = DeezerClient()
-        logger.info("Deezer client initialized")
 
-    return _deezer_client
+async def get_spotify_client() -> SpotifyClient | None:
+    """Get Spotify client. Requires SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET;
+    returns None when either is missing so the check degrades to no-op.
+
+    The underlying singleton factory reads from ``get_settings()`` directly so
+    concurrent cold-start callers see a single, race-free init (LML#457).
+    """
+    return await _get_spotify_client()
+
+
+async def _build_deezer_client() -> DeezerClient:
+    """Build the Deezer client. No auth required."""
+    client = DeezerClient()
+    logger.info("Deezer client initialized")
+    return client
+
+
+_get_deezer_client, _close_deezer_client = async_singleton(_build_deezer_client)
+
+
+async def get_deezer_client() -> DeezerClient:
+    """Get Deezer client. No auth required.
+
+    Concurrent cold-start callers share a single instance via
+    ``async_singleton`` (LML#457).
+    """
+    return await _get_deezer_client()
 
 
 async def _build_apple_music_client() -> AppleMusicClient | None:
@@ -83,17 +98,14 @@ async def _build_apple_music_client() -> AppleMusicClient | None:
 _get_apple_music_client, _close_apple_music_client = async_singleton(_build_apple_music_client)
 
 
-async def get_apple_music_client(
-    settings: Settings = Depends(get_settings),
-) -> AppleMusicClient | None:
+async def get_apple_music_client() -> AppleMusicClient | None:
     """Get Apple Music client. Requires APPLE_MUSIC_TEAM_ID, KEY_ID, and
     PRIVATE_KEY; returns None when any is missing so the check degrades to
     no-op (matches the Spotify-without-creds pattern). See
     ``docs/adr/0001-authenticated-apple-music-api.md``.
 
-    The ``settings`` argument is preserved for FastAPI DI compatibility —
-    the underlying singleton factory reads from ``get_settings()`` directly
-    so concurrent cold-start callers see a single, race-free init (LML#451).
+    The underlying singleton factory reads from ``get_settings()`` directly so
+    concurrent cold-start callers see a single, race-free init (LML#451).
 
     Testing note (LML#459): because the factory bypasses FastAPI DI and
     calls ``get_settings()`` (an ``@lru_cache``'d module-level function)
@@ -107,34 +119,32 @@ async def get_apple_music_client(
     return await _get_apple_music_client()
 
 
-def get_bandcamp_client() -> BandcampClient:
-    """Get Bandcamp client instance. No auth required."""
-    global _bandcamp_client
+async def _build_bandcamp_client() -> BandcampClient:
+    """Build the Bandcamp client. No auth required."""
+    client = BandcampClient()
+    logger.info("Bandcamp client initialized")
+    return client
 
-    if _bandcamp_client is None:
-        _bandcamp_client = BandcampClient()
-        logger.info("Bandcamp client initialized")
 
-    return _bandcamp_client
+_get_bandcamp_client, _close_bandcamp_client = async_singleton(_build_bandcamp_client)
+
+
+async def get_bandcamp_client() -> BandcampClient:
+    """Get Bandcamp client. No auth required.
+
+    Concurrent cold-start callers share a single instance via
+    ``async_singleton`` (LML#457).
+    """
+    return await _get_bandcamp_client()
 
 
 async def close_streaming_clients() -> None:
-    """Close all streaming clients. Called during application shutdown."""
-    global _spotify_client, _deezer_client, _bandcamp_client
+    """Close all streaming clients. Called during application shutdown.
 
-    for name, client in [
-        ("Spotify", _spotify_client),
-        ("Deezer", _deezer_client),
-        ("Bandcamp", _bandcamp_client),
-    ]:
-        if client is not None:
-            await client.close()
-            logger.info("%s client closed", name)
-
-    # Apple Music lives inside `async_singleton`; its closer owns the
-    # close-and-clear so a future cold-start re-runs `_build_apple_music_client`.
+    Each ``async_singleton`` closer owns the close-and-clear so a future
+    cold-start re-runs the matching builder.
+    """
+    await _close_spotify_client()
+    await _close_deezer_client()
     await _close_apple_music_client()
-
-    _spotify_client = None
-    _deezer_client = None
-    _bandcamp_client = None
+    await _close_bandcamp_client()

--- a/tests/unit/test_fd_leak_regression_241.py
+++ b/tests/unit/test_fd_leak_regression_241.py
@@ -244,8 +244,7 @@ class TestGetAppleMusicClientRace:
                 ),
             ):
                 tasks = [
-                    asyncio.create_task(dependencies.get_apple_music_client(settings))
-                    for _ in range(8)
+                    asyncio.create_task(dependencies.get_apple_music_client()) for _ in range(8)
                 ]
                 results = await asyncio.gather(*tasks)
         finally:
@@ -269,6 +268,175 @@ class TestGetAppleMusicClientRace:
         )
 
 
+class TestGetSpotifyClientRace:
+    """Hypothesis #2d: ``streaming.dependencies.get_spotify_client`` is racy.
+
+    Same shape as the Apple Music race that #451 closed: the pre-fix getter is
+    a sync FastAPI dep with a ``global _spotify_client`` + ``is None`` check +
+    assign. The dep runs in FastAPI's threadpool, so concurrent cold-start
+    callers can each observe ``None``, each construct a fresh
+    ``SpotifyClient`` (AsyncLimiter + asyncio.Semaphore from
+    ``BaseStreamingClient``), and orphan all but one.
+
+    Spotify is materially the worst of the three siblings because its first
+    request also lazy-fetches an OAuth bearer token; two orphaned clients
+    means two OAuth token fetches before GC.
+
+    Post-#457 the singleton is provided by `wxyc_fastapi.http.async_singleton`,
+    which owns the double-check + `asyncio.Lock` together. The test drives the
+    public getter end-to-end so a future refactor that bypasses
+    `async_singleton` would re-introduce the race and re-fail this test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_start_creates_one_client(self):
+        """Concurrent cold-start callers in ``get_spotify_client`` must share
+        a single ``SpotifyClient`` instance.
+        """
+        from config.settings import Settings
+        from streaming import dependencies
+
+        await dependencies.close_streaming_clients()
+
+        settings = Settings(
+            spotify_client_id="fake-id",
+            spotify_client_secret="fake-secret",
+        )
+
+        init_calls: list[tuple] = []
+        fake_client = AsyncMock(name="spotify-client")
+
+        def fake_constructor(*args, **kwargs):
+            init_calls.append((args, kwargs))
+            return fake_client
+
+        try:
+            with (
+                patch("streaming.dependencies.get_settings", return_value=settings),
+                patch(
+                    "streaming.dependencies.SpotifyClient",
+                    side_effect=fake_constructor,
+                ),
+            ):
+                tasks = [asyncio.create_task(dependencies.get_spotify_client()) for _ in range(8)]
+                results = await asyncio.gather(*tasks)
+        finally:
+            await dependencies.close_streaming_clients()
+
+        assert len(init_calls) == 1, (
+            f"SpotifyClient was constructed {len(init_calls)} times for the "
+            "same Spotify singleton. Concurrent cold-start callers race in "
+            "get_spotify_client, orphaning all but one client — each orphan "
+            "holds an AsyncLimiter + asyncio.Semaphore AND triggers its own "
+            "OAuth bearer-token fetch on first request. The lazy init must "
+            "go through `wxyc_fastapi.http.async_singleton` (issue #241 / "
+            "#457)."
+        )
+        assert all(r is fake_client for r in results), (
+            "Concurrent cold-start callers received different SpotifyClient "
+            "instances. async_singleton must return the same instance to "
+            "every caller after the factory completes (issue #457)."
+        )
+
+
+class TestGetDeezerClientRace:
+    """Hypothesis #2e: ``streaming.dependencies.get_deezer_client`` is racy.
+
+    Identical shape to the Apple Music / Spotify races: pre-fix sync FastAPI
+    dep with a ``global _deezer_client`` + ``is None`` check + assign.
+    Concurrent cold-start callers race, orphaning all but one
+    ``DeezerClient``. Each orphan holds an AsyncLimiter + asyncio.Semaphore.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_start_creates_one_client(self):
+        """Concurrent cold-start callers in ``get_deezer_client`` must share
+        a single ``DeezerClient`` instance.
+        """
+        from streaming import dependencies
+
+        await dependencies.close_streaming_clients()
+
+        init_calls: list[tuple] = []
+        fake_client = AsyncMock(name="deezer-client")
+
+        def fake_constructor(*args, **kwargs):
+            init_calls.append((args, kwargs))
+            return fake_client
+
+        try:
+            with patch(
+                "streaming.dependencies.DeezerClient",
+                side_effect=fake_constructor,
+            ):
+                tasks = [asyncio.create_task(dependencies.get_deezer_client()) for _ in range(8)]
+                results = await asyncio.gather(*tasks)
+        finally:
+            await dependencies.close_streaming_clients()
+
+        assert len(init_calls) == 1, (
+            f"DeezerClient was constructed {len(init_calls)} times for the "
+            "same Deezer singleton. Concurrent cold-start callers race in "
+            "get_deezer_client, orphaning all but one client. The lazy init "
+            "must go through `wxyc_fastapi.http.async_singleton` (issue "
+            "#241 / #457)."
+        )
+        assert all(r is fake_client for r in results), (
+            "Concurrent cold-start callers received different DeezerClient "
+            "instances. async_singleton must return the same instance to "
+            "every caller after the factory completes (issue #457)."
+        )
+
+
+class TestGetBandcampClientRace:
+    """Hypothesis #2f: ``streaming.dependencies.get_bandcamp_client`` is racy.
+
+    Identical shape to the Apple Music / Spotify / Deezer races: pre-fix sync
+    FastAPI dep with a ``global _bandcamp_client`` + ``is None`` check +
+    assign. Concurrent cold-start callers race, orphaning all but one
+    ``BandcampClient``. Each orphan holds an AsyncLimiter + asyncio.Semaphore.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_start_creates_one_client(self):
+        """Concurrent cold-start callers in ``get_bandcamp_client`` must share
+        a single ``BandcampClient`` instance.
+        """
+        from streaming import dependencies
+
+        await dependencies.close_streaming_clients()
+
+        init_calls: list[tuple] = []
+        fake_client = AsyncMock(name="bandcamp-client")
+
+        def fake_constructor(*args, **kwargs):
+            init_calls.append((args, kwargs))
+            return fake_client
+
+        try:
+            with patch(
+                "streaming.dependencies.BandcampClient",
+                side_effect=fake_constructor,
+            ):
+                tasks = [asyncio.create_task(dependencies.get_bandcamp_client()) for _ in range(8)]
+                results = await asyncio.gather(*tasks)
+        finally:
+            await dependencies.close_streaming_clients()
+
+        assert len(init_calls) == 1, (
+            f"BandcampClient was constructed {len(init_calls)} times for "
+            "the same Bandcamp singleton. Concurrent cold-start callers "
+            "race in get_bandcamp_client, orphaning all but one client. "
+            "The lazy init must go through "
+            "`wxyc_fastapi.http.async_singleton` (issue #241 / #457)."
+        )
+        assert all(r is fake_client for r in results), (
+            "Concurrent cold-start callers received different BandcampClient "
+            "instances. async_singleton must return the same instance to "
+            "every caller after the factory completes (issue #457)."
+        )
+
+
 def test_no_global_apple_music_client_in_streaming_dependencies():
     """LML#451: race-prone ``global _apple_music_client`` lazy-init must be
     gone from ``streaming/dependencies.py``. The lock + double-check belongs
@@ -285,6 +453,51 @@ def test_no_global_apple_music_client_in_streaming_dependencies():
         "`async_singleton(_build_apple_music_client)` (mirroring the Discogs "
         "pool + MusicBrainz PgSource pattern in core/dependencies.py). See "
         "LML#451."
+    )
+
+
+def test_no_global_spotify_client_in_streaming_dependencies():
+    """LML#457: race-prone ``global _spotify_client`` lazy-init must be gone
+    from ``streaming/dependencies.py``. Mirrors the Apple Music pin above —
+    the Spotify, Deezer, and Bandcamp getters all share the same hand-rolled
+    lazy-init shape and must all migrate to ``async_singleton``.
+    """
+    from streaming import dependencies as streaming_deps_module
+
+    src = Path(streaming_deps_module.__file__).read_text()
+    assert "global _spotify_client" not in src, (
+        "streaming/dependencies.py uses `global _spotify_client` — the "
+        "lock-free lazy-init pattern that LML#457 closed for the three "
+        "siblings of the Apple Music getter. Migrate to "
+        "`async_singleton(_build_spotify_client)`."
+    )
+
+
+def test_no_global_deezer_client_in_streaming_dependencies():
+    """LML#457: race-prone ``global _deezer_client`` lazy-init must be gone
+    from ``streaming/dependencies.py``.
+    """
+    from streaming import dependencies as streaming_deps_module
+
+    src = Path(streaming_deps_module.__file__).read_text()
+    assert "global _deezer_client" not in src, (
+        "streaming/dependencies.py uses `global _deezer_client` — the "
+        "lock-free lazy-init pattern that LML#457 closed. Migrate to "
+        "`async_singleton(_build_deezer_client)`."
+    )
+
+
+def test_no_global_bandcamp_client_in_streaming_dependencies():
+    """LML#457: race-prone ``global _bandcamp_client`` lazy-init must be gone
+    from ``streaming/dependencies.py``.
+    """
+    from streaming import dependencies as streaming_deps_module
+
+    src = Path(streaming_deps_module.__file__).read_text()
+    assert "global _bandcamp_client" not in src, (
+        "streaming/dependencies.py uses `global _bandcamp_client` — the "
+        "lock-free lazy-init pattern that LML#457 closed. Migrate to "
+        "`async_singleton(_build_bandcamp_client)`."
     )
 
 


### PR DESCRIPTION
## Summary

- Apply the LML#451 `async_singleton` migration pattern to the three sibling streaming-client getters (`get_spotify_client`, `get_deezer_client`, `get_bandcamp_client`) in `streaming/dependencies.py`. All three previously used the pre-fix sync FastAPI dep shape — `global _X_client` + `is None` + assign — that LML#241/#283/#435/#451 closed in matching surfaces. Concurrent cold-start callers running in FastAPI's threadpool could each observe `None`, each construct a fresh client (`AsyncLimiter` + `asyncio.Semaphore` at construction via `BaseStreamingClient`), and orphan all but one. Effect: silent ~2x rate-budget drift until GC; on Spotify specifically, an additional orphaned OAuth bearer-token fetch.
- Drop the vestigial `settings = Depends(get_settings)` parameter from `get_apple_music_client` for consistency — the factory has always read from `get_settings()` directly, and FastAPI `dependency_overrides` keys on the function reference, not its signature. `close_streaming_clients` collapses to four `await _close_X()` calls; module-level singletons and the `global X = None` resets disappear.
- TDD: three race tests (`TestGetSpotifyClientRace` / `TestGetDeezerClientRace` / `TestGetBandcampClientRace`) plus three static-scan pins added to `tests/unit/test_fd_leak_regression_241.py`. All six fail RED on `main`, pass post-migration. Full unit suite passes (2082 tests).

## Test plan

- [x] `ruff check streaming/dependencies.py tests/unit/test_fd_leak_regression_241.py`
- [x] `ruff format --check streaming/dependencies.py tests/unit/test_fd_leak_regression_241.py`
- [x] `pytest tests/unit/test_fd_leak_regression_241.py` (12 passed)
- [x] `pytest tests/unit/test_streaming_check_router.py tests/unit/test_streaming_check_e2e_apple_music.py tests/unit/test_dependencies.py` (32 passed)
- [x] `pytest tests/unit/` (2082 passed; pre-existing teardown flake in `test_no_module_level_asyncio_lock_in_dependencies` unrelated to this PR)
- [ ] Verify staging `/health` after deploy

Closes #457.