### PR TITLE
feat(orchestrator): project Apple Music timeout onto Sentry transaction (#462)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1814,6 +1814,22 @@ async def enrich_artwork_results(
                     artist,
                     search_term,
                 )
+                # LML#462: project onto the active Sentry transaction so the
+                # trace explorer can distinguish "Apple Music timed out" from
+                # "Apple Music never ran" — the cancelled inner
+                # `apple_music.search` span never sets its `result` data, so
+                # without this marker the timeout shape is queryably
+                # indistinguishable from a no-op. Same swallow pattern as
+                # `_log_album_title_fallback` / `_log_resolver_pre_pass`.
+                try:
+                    transaction = sentry_sdk.get_current_scope().transaction
+                    if transaction is not None:
+                        transaction.set_data("apple_music.find_track_url.timeout", True)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to project apple_music timeout onto Sentry transaction: %s",
+                        e,
+                    )
             except Exception:
                 logger.exception(
                     "AppleMusicClient.find_track_url raised for %s - %s", artist, search_term

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1,7 +1,7 @@
 """Tests for metadata enrichment (release year, artist details, streaming links)."""
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1034,6 +1034,105 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         assert enriched_1.apple_music_url is None
         assert enriched_2 is not None
         assert enriched_2.apple_music_url is None
+
+    @pytest.mark.asyncio
+    async def test_apple_music_find_track_url_timeout_projects_sentry_marker(self):
+        """LML#462: on TimeoutError, the active Sentry transaction must carry
+        a `data.apple_music.find_track_url.timeout = True` attribute so trace
+        explorer can distinguish 'Apple Music timed out' from 'Apple Music
+        never ran' — the LML#444 silent-failure shape, just for a different
+        failure mode.
+
+        Mirrors the `_log_resolver_pre_pass` / `_log_album_title_fallback`
+        shape (lookup/orchestrator.py:262-298, 393-415): project onto
+        `sentry_sdk.get_current_scope().transaction.set_data(...)` with a
+        try/except so observability never breaks /lookup. The logger.warning
+        line stays — this test only pins the additional Sentry projection.
+        """
+        items_with_artwork = [
+            (make_library_item(id=1, artist="Mūm", title="Summer Make Good"), None),
+        ]
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+
+        async def slow_find(*_args, **_kwargs):
+            await asyncio.sleep(60)
+            return "https://music.apple.com/should-never-resolve"
+
+        apple_music.find_track_url = AsyncMock(side_effect=slow_find)
+
+        transaction = MagicMock()
+        scope = MagicMock()
+        scope.transaction = transaction
+
+        with (
+            patch("lookup.orchestrator._apple_music_lookup_timeout_s", return_value=0.05),
+            patch(
+                "lookup.orchestrator.sentry_sdk.get_current_scope",
+                return_value=scope,
+            ),
+        ):
+            results = await enrich_artwork_results(
+                items_with_artwork,
+                AsyncMock(),
+                song="Song",
+                album="Album",
+                apple_music=apple_music,
+            )
+
+        # User-visible behavior unchanged: item still degrades to no Apple URL.
+        assert len(results) == 1
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.apple_music_url is None
+
+        # AND the timeout was projected onto the active transaction so trace
+        # explorer can filter for it.
+        transaction.set_data.assert_any_call("apple_music.find_track_url.timeout", True)
+
+    @pytest.mark.asyncio
+    async def test_apple_music_find_track_url_timeout_survives_no_active_transaction(
+        self,
+    ):
+        """LML#462: when there is no active Sentry transaction (or the SDK
+        raises), the timeout marker projection must NOT break /lookup. Same
+        swallow pattern as `_log_album_title_fallback` / `_log_resolver_pre_pass`.
+        """
+        items_with_artwork = [
+            (make_library_item(id=1, artist="Mūm", title="Summer Make Good"), None),
+        ]
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+
+        async def slow_find(*_args, **_kwargs):
+            await asyncio.sleep(60)
+            return "https://music.apple.com/should-never-resolve"
+
+        apple_music.find_track_url = AsyncMock(side_effect=slow_find)
+
+        # No active transaction.
+        scope = MagicMock()
+        scope.transaction = None
+
+        with (
+            patch("lookup.orchestrator._apple_music_lookup_timeout_s", return_value=0.05),
+            patch(
+                "lookup.orchestrator.sentry_sdk.get_current_scope",
+                return_value=scope,
+            ),
+        ):
+            results = await enrich_artwork_results(
+                items_with_artwork,
+                AsyncMock(),
+                song="Song",
+                album="Album",
+                apple_music=apple_music,
+            )
+
+        # Degradation still works; no crash from the missing transaction.
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.apple_music_url is None
 
     @pytest.mark.asyncio
     async def test_apple_music_url_does_not_override_db_streaming_link(self):


### PR DESCRIPTION
## Summary

PR #456 wrapped `AppleMusicClient.find_track_url` in `asyncio.wait_for` to bound the per-call latency, but the `TimeoutError` branch only emitted `logger.warning(...)`. With no transaction marker:

- The inner `apple_music.search` span (opened in `_search` at `clients/streaming/apple_music.py:159`) gets cancelled mid-`async with`.
- Its `__exit__` runs with `CancelledError` as the exception.
- `apple_music.search.result` is **never** set on the timeout path.

Net Sentry effect: a cancelled inner span with no `result` data + zero parent-transaction marker. Operators can't distinguish "Apple Music timed out" from "Apple Music never ran" — the LML#444 silent-failure shape that motivated wrapping this call to begin with, just for a different failure mode. Exactly the blind spot that masked the 2026-05-14 iOS v2 artwork outage RCA.

## Change

Add a `set_data("apple_music.find_track_url.timeout", True)` projection alongside the existing `logger.warning` line in the `TimeoutError` branch of `enrich_one`, mirroring the `_log_resolver_pre_pass` / `_log_album_title_fallback` shape:

- Try/except wraps the projection so observability never breaks /lookup
- No-op when no transaction is active (`transaction is None`)
- SDK errors are swallowed with a warning log

User-visible behavior unchanged — item still degrades to `apple_music_url=None`.

## Tests

Two new tests in `TestEnrichArtworkResultsWithAppleMusicClient`:

1. `test_apple_music_find_track_url_timeout_projects_sentry_marker` — pins `transaction.set_data("apple_music.find_track_url.timeout", True)` on the timeout path. Was RED before the implementation, GREEN after.
2. `test_apple_music_find_track_url_timeout_survives_no_active_transaction` — pins graceful no-op when `transaction is None`.

The existing `test_apple_music_find_track_url_timeout_degrades_to_none` still passes — user-visible behavior is unchanged.

## Test plan

- [x] `pytest tests/unit/test_enrichment.py` — 36 passed locally
- [x] `pytest tests/unit` — 2084 passed (pre-existing teardown flake in `test_no_module_level_asyncio_lock_in_dependencies`, unrelated)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green

Closes #462