### PR TITLE
test(bulk-lookup): tighten exit-log + http.target pins; hoist route constant (#420)

### DIFF
--- a/lookup/router.py
+++ b/lookup/router.py
@@ -53,6 +53,12 @@ _BULK_LOOKUP_INPUT_CAP = 100
 
 _BULK_LOOKUP_DEFAULT_CONCURRENCY = 10
 
+# Canonical full path for the bulk endpoint. Referenced by the explicit
+# `http.server` span (name + `http.target` data field) so the two stay in
+# lockstep; the FastAPI route decorator below uses the relative `/lookup/bulk`
+# form because the router prefix `/api/v1` is applied at mount time.
+_BULK_LOOKUP_ROUTE = "/api/v1/lookup/bulk"
+
 
 def _project_cache_stats_to_transaction(stats: dict | None) -> None:
     """Attach numeric cache_stats fields to the current Sentry transaction.
@@ -379,9 +385,9 @@ async def handle_bulk_lookup(
     # in-flight bulk requests despite the handler running. With this wrap, any
     # Sentry trace explorer query for `op:http.server span.description:*lookup/bulk*`
     # will surface bulk-route traffic.
-    with sentry_sdk.start_span(op="http.server", name="POST /api/v1/lookup/bulk") as http_span:
+    with sentry_sdk.start_span(op="http.server", name=f"POST {_BULK_LOOKUP_ROUTE}") as http_span:
         http_span.set_data("http.method", "POST")
-        http_span.set_data("http.target", "/api/v1/lookup/bulk")
+        http_span.set_data("http.target", _BULK_LOOKUP_ROUTE)
         http_span.set_data("lml.bulk.size", len(request.items))
         http_span.set_data("lml.bulk.max_concurrent", max_concurrent)
 

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -9,7 +9,7 @@ are isolated so one item cannot poison the batch.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 import sentry_sdk
@@ -510,8 +510,11 @@ class TestBulkLookupObservability:
         )
         entry_msg = entry_records[0].message
         # Pin the shape: size of the batch must be in the log line so operators
-        # can correlate Railway log entries with caller-side batch sizes.
-        assert "3" in entry_msg, f"Entry log missing batch size: {entry_msg!r}"
+        # can correlate Railway log entries with caller-side batch sizes. Match
+        # the `size=N` prefix (not just the bare digit) so a future format change
+        # that drops the key — or a timestamp containing the digit — can't
+        # silently pass this assertion.
+        assert "size=3" in entry_msg, f"Entry log missing batch size: {entry_msg!r}"
 
     @pytest.mark.asyncio
     async def test_exit_log_includes_status_counts(self, app_client, caplog):
@@ -535,11 +538,16 @@ class TestBulkLookupObservability:
                 transport=ASGITransport(app=app_client), base_url="http://test"
             ) as ac:
                 with caplog.at_level(logging.INFO, logger="lookup.router"):
+                    # Distinct count distribution (match=2, no_match=1, error=1) so
+                    # a regression that swaps the order of `counts["match"]` and
+                    # `counts["error"]` in the format args produces a *different*
+                    # log line; an all-1s fixture would mask that swap entirely.
                     resp = await ac.post(
                         "/api/v1/lookup/bulk",
                         json={
                             "items": [
                                 {"artist": "Juana Molina", "album": "DOGA"},
+                                {"artist": "Cat Power", "album": "Moon Pix"},
                                 {"artist": "miss", "album": "X"},
                                 {"artist": "boom", "album": "Y"},
                             ]
@@ -554,6 +562,15 @@ class TestBulkLookupObservability:
             "Expected an INFO log at bulk handler exit; got logs: "
             f"{[r.message for r in caplog.records]}"
         )
+        exit_msg = exit_records[0].message
+        # Pin each count by its key=value pair (not bare digit) so a regression
+        # that drops a key, garbles the format string, or swaps two count
+        # positions all fail loudly. The distinct distribution above is what
+        # makes the swap detectable.
+        assert "size=4" in exit_msg, f"Exit log missing batch size: {exit_msg!r}"
+        assert "match=2" in exit_msg, f"Exit log missing match count: {exit_msg!r}"
+        assert "no_match=1" in exit_msg, f"Exit log missing no_match count: {exit_msg!r}"
+        assert "error=1" in exit_msg, f"Exit log missing error count: {exit_msg!r}"
 
     @pytest.mark.asyncio
     async def test_http_server_span_emitted_for_bulk(self, app_client):
@@ -565,12 +582,21 @@ class TestBulkLookupObservability:
         the production logs at 22:21-22:34 on 2026-05-24 showed was not firing
         for hung handlers (the album-level-backfill case in #371).
         """
+        # Replace `start_span` with a factory that hands back a fresh MagicMock
+        # per call — including the inner `lml.bulk.batch` / `lml.bulk.item`
+        # spans the handler also opens. Each mock self-enters as its own
+        # context manager and records every `set_data(...)` call so the
+        # assertions below can pin both the span name and the `http.target`
+        # data field. (The previous version returned the real span, which made
+        # the data calls untestable.)
         captured_spans: list[dict] = []
-        original_start_span = sentry_sdk.start_span
 
         def capture_start_span(*args, **kwargs):
-            captured_spans.append({"args": args, "kwargs": kwargs})
-            return original_start_span(*args, **kwargs)
+            span_mock = MagicMock()
+            span_mock.__enter__ = MagicMock(return_value=span_mock)
+            span_mock.__exit__ = MagicMock(return_value=False)
+            captured_spans.append({"args": args, "kwargs": kwargs, "span": span_mock})
+            return span_mock
 
         with (
             patch(
@@ -594,11 +620,22 @@ class TestBulkLookupObservability:
             "Expected at least one Sentry span with op='http.server'; got: "
             f"{[s['kwargs'].get('op') for s in captured_spans]}"
         )
-        # The span's name must identify the bulk route so operators can filter
-        # for `span.description: POST /api/v1/lookup/bulk` in the trace explorer.
+        # The span name must be exactly the canonical route string so operators
+        # can filter for `span.description:"POST /api/v1/lookup/bulk"` in the
+        # trace explorer. A substring match would not catch a drift to e.g.
+        # `/api/v2/lookup/bulk` if the constant ever gets out of sync with the
+        # route registration.
         span_name = http_server_spans[0]["kwargs"].get("name", "")
-        assert "lookup/bulk" in span_name, (
-            f"Expected http.server span name to include 'lookup/bulk'; got {span_name!r}"
+        assert span_name == "POST /api/v1/lookup/bulk", (
+            f"Expected http.server span name 'POST /api/v1/lookup/bulk'; got {span_name!r}"
+        )
+        # Pin the `http.target` data field — the second canonical-route usage
+        # in the handler. Together with the span-name pin above, this proves
+        # both call sites stay in sync (e.g. after the constant is hoisted).
+        set_data_calls = http_server_spans[0]["span"].set_data.call_args_list
+        http_target_args = [c.args for c in set_data_calls if c.args and c.args[0] == "http.target"]
+        assert http_target_args == [("http.target", "/api/v1/lookup/bulk")], (
+            f"Expected http.target set to '/api/v1/lookup/bulk' exactly once; got {http_target_args!r}"
         )
 
 


### PR DESCRIPTION
## Summary

- **Gap 1** — `test_exit_log_includes_status_counts` only checked that `"complete"` appeared in the log line; the count values weren't pinned. Bump the fixture to a distinct `match=2 / no_match=1 / error=1` distribution and assert `size=4`, `match=2`, `no_match=1`, `error=1`. The distinct distribution catches a count-position swap an all-1s fixture would miss.
- **Gap 1 (bonus)** — Same shape of weakness in the sibling entry-log test: `"3" in entry_msg` is a single digit that matches anywhere (timestamps, ports). Tightened to `"size=3" in entry_msg`.
- **Gap 2** — Hoisted `_BULK_LOOKUP_ROUTE = "/api/v1/lookup/bulk"` alongside the other `_BULK_LOOKUP_*` constants in `lookup/router.py`. Both `start_span(name=...)` and `set_data("http.target", ...)` now reference the constant.
- **Gap 2 test pin** — `test_http_server_span_emitted_for_bulk` did a substring check on the span name and ignored `http.target` entirely, so the hoist had no behavioral pin. Swapped the `capture_start_span` callback to return a fresh `MagicMock` per call (self-entering context manager) and tightened the assertions to exact equality on the span name + a new `set_data.call_args_list` assertion for `http.target`.

## Mutation verification

Each of these regressions was applied to production code, the relevant test confirmed failing, then reverted:

| # | Mutation | Pin that catches it |
| --- | --- | --- |
| M1 | swap `counts["match"]` / `counts["error"]` positions in format args | exit-log `match=2` / `error=1` |
| M2 | drop `match=%d` from format string | exit-log `match=2` |
| M3 | drop `size=` prefix from entry log | entry-log `size=3` |
| M4 | change span name to `/api/v2/lookup/bulk` | span-name equality |
| M5 | change `http.target` value to `/api/v2/lookup/bulk` | new `http.target` assertion |

## Test plan

- [x] `pytest tests/unit/test_bulk_lookup_endpoint.py` — 20 passed
- [x] `ruff check .` + `ruff format --check .` clean
- [x] All 5 mutations verified to fail their respective pin before being reverted

Closes #420.