### PR TITLE
feat(cache): filter release_track_artist to main credits (#333)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -234,6 +234,7 @@ class DiscogsCacheService:
                 LEFT JOIN release_track_artist rta
                     ON rta.release_id = mt.release_id
                     AND rta.track_sequence = mt.sequence
+                    AND rta.extra = 0
                 WHERE (
                     $3::text IS NULL
                     OR lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3))
@@ -1146,7 +1147,13 @@ class DiscogsCacheService:
                     release_id,
                 ),
                 self.pool.fetch(
-                    "SELECT track_sequence, artist_name FROM release_track_artist WHERE release_id = $1",
+                    # `extra = 0` keeps the read tight on main-artist credits;
+                    # extra credits (writer/producer/performer) live with
+                    # `extra = 1` and would otherwise cross-pollinate a
+                    # precision match here. The release-level fallback below
+                    # remains as defense-in-depth for legitimate misses.
+                    "SELECT track_sequence, artist_name FROM release_track_artist "
+                    "WHERE release_id = $1 AND extra = 0",
                     release_id,
                 ),
                 self.pool.fetchrow(

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -231,6 +231,15 @@ class DiscogsCacheService:
                 FROM matching_tracks mt
                 JOIN release r ON r.id = mt.release_id
                 JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+                -- `rta.extra = 0` constrains the LEFT JOIN to main-artist
+                -- credits (mirrors validate_track_on_release after #333).
+                -- Note: unlike validate_track_on_release, this query has no
+                -- Python-side release-level fuzz fallback — a release where
+                -- the only matching credit is `extra = 1` (featuring guest,
+                -- composer, remixer) drops from the candidate ranking. The
+                -- fallthrough seam's API leg will surface it at the cost of
+                -- Discogs quota. See PR #471 body for the documented recall
+                -- trade-off and follow-up tickets.
                 LEFT JOIN release_track_artist rta
                     ON rta.release_id = mt.release_id
                     AND rta.track_sequence = mt.sequence
@@ -1198,14 +1207,17 @@ class DiscogsCacheService:
                     ):
                         return True
 
-                # Release-level artist. Always consulted when per-track
-                # credits haven't matched — ``release_track_artist`` has no
-                # role column, so writer / producer / member credits land
-                # alongside main-artist credits (e.g., Live 93 by The Orb
-                # credits Paterson / Weston / Fehlmann on every track), and
-                # the release-level credit is the last word on "is this
-                # track by this artist." Mirrors the API path in
-                # ``discogs/service.py``.
+                # Release-level fallback, consulted when no per-track main
+                # credit matched. After #333 the per-track read above is
+                # filtered to ``extra = 0``, so this branch rescues two
+                # legitimate cases: (a) the band-member shape — Live 93 /
+                # The Orb credits Paterson / Weston / Fehlmann as the only
+                # per-track main artists; the release-level credit "The
+                # Orb" is the last word; (b) any release where the per-
+                # track main credit substring-missed the requested artist
+                # but the release-level credit fuzz-matches. Mirrors the
+                # API path in ``discogs/service.py``. Do not remove without
+                # replacing both rescue paths.
                 if release_artist_clean and (
                     artist_lower in release_artist_clean or release_artist_clean in artist_lower
                 ):

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -214,6 +214,18 @@ class DiscogsCacheService:
         Raises:
             CacheUnavailableError: If database is unreachable
         """
+        # `rta.extra = 0` constrains the LEFT JOIN to main-artist credits
+        # (mirrors validate_track_on_release after #333). Unlike
+        # validate_track_on_release, this query has no Python-side release-
+        # level fuzz fallback — a release where the only matching credit is
+        # `extra = 1` (featuring guest, composer, remixer) drops from the
+        # candidate ranking. The fallthrough seam's API leg will surface it
+        # at the cost of Discogs quota. See #333 for the documented recall
+        # trade-off; #472-#475 track the parallel filters in sibling read
+        # sites (get_release_metadata, va_disambiguate, match_compilations,
+        # track_streaming). Keep the rationale here (not in `--` comments
+        # inside the SQL) so it stays out of pg_stat_statements and PG
+        # logs.
         try:
             query = """
                 WITH matching_tracks AS (
@@ -231,15 +243,6 @@ class DiscogsCacheService:
                 FROM matching_tracks mt
                 JOIN release r ON r.id = mt.release_id
                 JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
-                -- `rta.extra = 0` constrains the LEFT JOIN to main-artist
-                -- credits (mirrors validate_track_on_release after #333).
-                -- Note: unlike validate_track_on_release, this query has no
-                -- Python-side release-level fuzz fallback — a release where
-                -- the only matching credit is `extra = 1` (featuring guest,
-                -- composer, remixer) drops from the candidate ranking. The
-                -- fallthrough seam's API leg will surface it at the cost of
-                -- Discogs quota. See PR #471 body for the documented recall
-                -- trade-off and follow-up tickets.
                 LEFT JOIN release_track_artist rta
                     ON rta.release_id = mt.release_id
                     AND rta.track_sequence = mt.sequence
@@ -1209,15 +1212,15 @@ class DiscogsCacheService:
 
                 # Release-level fallback, consulted when no per-track main
                 # credit matched. After #333 the per-track read above is
-                # filtered to ``extra = 0``, so this branch rescues two
-                # legitimate cases: (a) the band-member shape — Live 93 /
-                # The Orb credits Paterson / Weston / Fehlmann as the only
-                # per-track main artists; the release-level credit "The
-                # Orb" is the last word; (b) any release where the per-
-                # track main credit substring-missed the requested artist
-                # but the release-level credit fuzz-matches. Mirrors the
-                # API path in ``discogs/service.py``. Do not remove without
-                # replacing both rescue paths.
+                # filtered to ``extra = 0``; this branch is what rescues
+                # the legitimate case where the per-track main credit
+                # exists but didn't substring/fuzz-match the requested
+                # artist string, AND the release-level credit does. Common
+                # shape: band-member-only per-track credits with the band
+                # name at the release level — see #333 acceptance criteria
+                # for the canonical Live 93 / The Orb walkthrough.
+                # Mirrors the API path in ``discogs/service.py``. Do not
+                # remove without replacing the rescue path.
                 if release_artist_clean and (
                     artist_lower in release_artist_clean or release_artist_clean in artist_lower
                 ):

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -1210,17 +1210,17 @@ class DiscogsCacheService:
                     ):
                         return True
 
-                # Release-level fallback, consulted when no per-track main
-                # credit matched. After #333 the per-track read above is
-                # filtered to ``extra = 0``; this branch is what rescues
-                # the legitimate case where the per-track main credit
-                # exists but didn't substring/fuzz-match the requested
-                # artist string, AND the release-level credit does. Common
-                # shape: band-member-only per-track credits with the band
-                # name at the release level — see #333 acceptance criteria
-                # for the canonical Live 93 / The Orb walkthrough.
-                # Mirrors the API path in ``discogs/service.py``. Do not
-                # remove without replacing the rescue path.
+                # Release-level fallback, consulted whenever the per-track
+                # main credits (post-#333 ``extra = 0`` filter) didn't
+                # close the match — either no per-track main credit exists
+                # for this row at all, or one exists but didn't substring/
+                # fuzz-match the requested artist. Rescued by a
+                # release-level credit that does match. The band-member
+                # shape (per-track main credits list only members, release-
+                # level is the band) is one canonical case; see #333
+                # acceptance criteria. Mirrors the API path in
+                # ``discogs/service.py``. Do not remove without replacing
+                # the rescue path.
                 if release_artist_clean and (
                     artist_lower in release_artist_clean or release_artist_clean in artist_lower
                 ):

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -157,6 +157,26 @@ class TestSearchReleasesByTrack:
         assert "rta.artist_name" in sql
 
     @pytest.mark.asyncio
+    async def test_query_filters_rta_to_extra_zero(self, cache_service, mock_asyncpg_pool):
+        """The rta join must restrict to main-artist credits.
+
+        Mirrors the per-track filter in ``validate_track_on_release``: the
+        candidate-release ranking should not surface a release just because
+        a producer or writer name on the track happens to look like the
+        requested artist. ``release_track_artist`` rows with ``extra = 1``
+        are extra credits (writer / producer / performer) and must not
+        participate in the candidate-artist match. See #333.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+
+        await cache_service.search_releases_by_track("Song", "Artist")
+
+        sql = mock_asyncpg_pool.fetch.call_args[0][0]
+        assert "rta.extra = 0" in sql, (
+            f"Expected `rta.extra = 0` constraint in rta join; got: {sql!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_deduplicates_multiple_track_artists(self, cache_service, mock_asyncpg_pool):
         """Multiple rows from LEFT JOIN (different track artists) are deduplicated."""
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -950,6 +970,87 @@ class TestValidateTrackOnRelease:
         mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Orb"})
         result = await cache_service.validate_track_on_release(13938, "Towers of Dub", "Stereolab")
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_main_credit_validates_but_extra_credit_request_does_not(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Characterize the post-#333 filtered shape on a real example.
+
+        Live 93 / Towers Of Dub has Discogs credits like ``The Orb`` as the
+        main per-track credit (``extra = 0``) and members ``Alex Paterson``
+        et al. as extra per-track credits (``extra = 1``). After the SQL
+        adds ``AND extra = 0`` to the per-track read, the DB returns only
+        the main credit. The mock here mirrors that post-filter state.
+
+        Pins two behaviors at once:
+
+        1. ``("The Orb", "Towers of Dub")`` → True via the surviving main
+           credit. The existing release-level fallback isn't exercised.
+        2. ``("Alex Paterson", "Towers of Dub")`` → False. The extra credit
+           that previously would have validated this request has been
+           filtered at the DB; the release-level fallback (``The Orb``)
+           doesn't fuzz-match ``Alex Paterson``, so the request fails.
+
+        Documents the intended post-filter contract; a future change that
+        re-introduces extra credits into the per-track path or relaxes the
+        release-level fuzz threshold should break this test.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                # Post-filter: only the main credit comes back.
+                release_track_artist=[{"track_sequence": 5, "artist_name": "The Orb"}],
+                release_track=[{"sequence": 5, "title": "Towers Of Dub"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Orb"})
+
+        orb_result = await cache_service.validate_track_on_release(
+            13938, "Towers of Dub", "The Orb"
+        )
+        assert orb_result is True
+
+        paterson_result = await cache_service.validate_track_on_release(
+            13938, "Towers of Dub", "Alex Paterson"
+        )
+        assert paterson_result is False
+
+    @pytest.mark.asyncio
+    async def test_query_filters_release_track_artist_to_extra_zero(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """The per-track credit query must restrict to main-artist credits.
+
+        After WXYC/discogs-etl#221 + WXYC/discogs-xml-converter#55 (2026-05-14),
+        ``release_track_artist`` has an ``extra`` column that distinguishes
+        main credits (``extra = 0``) from extra credits — writer, producer,
+        performer (``extra = 1``). The per-track read must only consider
+        main credits so a producer or performer name can't cross-pollinate
+        a precision match; the release-level fallback added in #328 stays
+        as defense-in-depth for legitimate per-track credit misses.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        captured_queries: list[str] = []
+
+        async def capture_fetch(query, *args):
+            captured_queries.append(query)
+            return []
+
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=capture_fetch)
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=None)
+
+        await cache_service.validate_track_on_release(1, "Song", "Artist")
+
+        rta_queries = [q for q in captured_queries if "release_track_artist" in q]
+        assert rta_queries, (
+            f"Expected a query against release_track_artist; got: {captured_queries!r}"
+        )
+        rta_query = rta_queries[0]
+        assert "extra = 0" in rta_query, (
+            "Expected `extra = 0` filter in release_track_artist query "
+            f"(see #333); got: {rta_query!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1051,9 +1051,14 @@ class TestValidateTrackOnRelease:
         # ``extra = 0`` (which could co-occur in an unrelated CTE branch,
         # whitespace-different variant, or even a `-- extra = 0` comment).
         # The intent is: this specific table's WHERE includes both predicates.
-        assert "WHERE release_id = $1 AND extra = 0" in rta_query, (
-            "Expected exact `WHERE release_id = $1 AND extra = 0` clause in "
-            f"release_track_artist query (see #333); got: {rta_query!r}"
+        # Include the leading space before WHERE so a future delete-the-
+        # trailing-space typo on the adjacent string literal in
+        # cache_service.py (which would produce
+        # ``release_track_artistWHERE`` — a PG parse error at runtime) also
+        # fails this unit test instead of slipping through.
+        assert "release_track_artist WHERE release_id = $1 AND extra = 0" in rta_query, (
+            "Expected exact `release_track_artist WHERE release_id = $1 AND extra = 0` "
+            f"clause in release_track_artist query (see #333); got: {rta_query!r}"
         )
 
 

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1047,9 +1047,13 @@ class TestValidateTrackOnRelease:
             f"Expected a query against release_track_artist; got: {captured_queries!r}"
         )
         rta_query = rta_queries[0]
-        assert "extra = 0" in rta_query, (
-            "Expected `extra = 0` filter in release_track_artist query "
-            f"(see #333); got: {rta_query!r}"
+        # Pin the *complete* WHERE clause adjacency, not just the substring
+        # ``extra = 0`` (which could co-occur in an unrelated CTE branch,
+        # whitespace-different variant, or even a `-- extra = 0` comment).
+        # The intent is: this specific table's WHERE includes both predicates.
+        assert "WHERE release_id = $1 AND extra = 0" in rta_query, (
+            "Expected exact `WHERE release_id = $1 AND extra = 0` clause in "
+            f"release_track_artist query (see #333); got: {rta_query!r}"
         )
 
 


### PR DESCRIPTION
## Summary

`discogs/cache_service.py:validate_track_on_release` previously treated every row in `release_track_artist` as a candidate per-track credit, regardless of credit role. After WXYC/discogs-etl#221 + WXYC/discogs-xml-converter#55 (merged 2026-05-14), that table has a new `extra integer DEFAULT 0` column that distinguishes main-artist credits (`extra = 0`) from extra credits — writer, producer, performer (`extra = 1`). Add the filter to both the per-track fetch and the `rta` join in `search_releases_by_track` so producer/writer names can't cross-pollinate a precision match or pollute candidate-release ranking on a VA-compilation track.

The release-level fallback added in #328 stays as defense-in-depth: a legitimate per-track credit miss (band-member-only credits on a track whose release artist is the band) still validates via the release-level artist.

## ⚠️ Merge gate — DO NOT MERGE before 2026-06-04 06:00 UTC

Railway prod discogs-cache has no `extra = 1` rows until the next monthly rebuild cron tick. Until that runs, `AND extra = 0` is a no-op against the live data and the SQL change is safe — but the intended precision improvement only materializes once the rebuild populates extra credits. WXYC/discogs-etl#222 must land before 2026-06-04 or the rebuild will fail at the `release_track_artist` COPY. Before flipping this PR out of draft, verify:

```bash
psql $DATABASE_URL_DISCOGS -c "SELECT COUNT(*) FROM release_track_artist WHERE extra = 1;"
```

Must return a nonzero count.

## Documented recall trade-off

The filter is a precision improvement, not free. For the search side (`search_releases_by_track`) it surfaces fewer releases when the requested artist appears only as an extra credit on a track. Concrete classes:

- **Featuring artists** (`Common - Respiration` on a Black Star release where Common is credited via `Featuring` extra).
- **Composer credits** (`Burt Bacharach - The Look of Love` on a Dusty Springfield release where Bacharach is `Written-By`).
- **Remixer credits** (`Masters at Work - Around the World` on a Daft Punk release where MAW is `Remix`).

For these cases the cache layer now drops the release from the candidate ranking; the fallthrough seam's Discogs API leg still surfaces them, at the cost of quota and latency. `validate_track_on_release` has an explicit release-level fuzz fallback in Python that compensates for some misses; `search_releases_by_track` has no equivalent post-SQL fallback (inline comment added in this PR). Per #333's framing this is the intended trade-off for VA-compilation precision; follow-up tickets will explore a search-side fuzz fallback if recall regression surfaces in observability.

## Test plan (TDD vertical slices, each RED → GREEN)

- **Slice 1** — SQL pin: `test_query_filters_release_track_artist_to_extra_zero` asserts the `validate_track_on_release` query for `release_track_artist` contains exact `WHERE release_id = \$1 AND extra = 0` adjacency. Failed before impl, passes after.
- **Slice 2** — SQL pin: `test_query_filters_rta_to_extra_zero` asserts the `search_releases_by_track` rta join contains `rta.extra = 0`. Failed before impl, passes after.
- **Slice 3** — Behavior characterization: `test_main_credit_validates_but_extra_credit_request_does_not` — post-filter fixture surfaces only the main credit \"The Orb\" on `(\"Towers of Dub\", seq=5)`, release artist \"The Orb\". `(\"The Orb\", \"Towers of Dub\")` returns True via the surviving main credit; `(\"Alex Paterson\", \"Towers of Dub\")` returns False because the extra credit was filtered at the DB and the release-level fuzz against \"The Orb\" doesn't catch it.

Existing `TestValidateTrackOnRelease` tests (the band-member-credit fallback case in #328) still pass — release-level fallback covers them.

- [x] `pytest tests/unit/test_cache_service.py` — 69 passed
- [x] `pytest tests/unit/` — 2088 passed, 1 unrelated pre-existing teardown flake in `test_no_module_level_asyncio_lock_in_dependencies`
- [x] `ruff check .` + `ruff format --check .` clean

## Code review (max effort)

Findings from `/code-review max` clustered into 5 groups. In-PR fixes applied:

- **Stale comment at L1201-1208** — rewritten to describe the post-#333 rationale for the release-level fallback (band-member shape, substring-miss fallback). Anchored as do-not-remove.
- **Loose substring test pin** — tightened to assert exact `WHERE release_id = \$1 AND extra = 0` adjacency.
- **Search-vs-validate asymmetry** — added inline SQL comment explaining that `search_releases_by_track` has no release-level fuzz fallback, and pointing at this PR's body for the recall trade-off.

Follow-up tickets filed:

- #472 — `get_release_metadata` returns extras-polluted `TrackItem.artists` vs API path (cache/API shape divergence).
- #473 — `scripts/va_disambiguate`: 4 `release_track_artist` JOINs missing `extra = 0` filter.
- #474 — `scripts/match_compilations`: `enrich_with_track_artists` missing filter; stale heuristic comment.
- #475 — `scripts/track_streaming`: asymmetric filter — track-side COALESCE indexes under wrong artist.
- #476 — Cache schema-skew hardening: `UndefinedColumnError` → `CacheUnavailableError` arms process-wide cool-down.

## Related

- WXYC/library-metadata-lookup#327 — root user-visible bug (Towers of Dub / The Orb)
- WXYC/library-metadata-lookup#328 — release-level fallback shipped 2026-05-14
- WXYC/discogs-etl#221 — alembic 0005 adds `extra` + `role` columns
- WXYC/discogs-xml-converter#55 — emits the new columns
- WXYC/discogs-etl#222 — rebuild-cache.sh alembic upgrade fix (gates this PR)

Closes #333.