### PR TITLE
feat(artists): POST /api/v1/artists/search-aliases/bulk endpoint

### DIFF
--- a/artists/__init__.py
+++ b/artists/__init__.py
@@ -1,0 +1,7 @@
+"""Artist-search-alias endpoint.
+
+`POST /api/v1/artists/search-aliases/bulk` returns the per-source variants
+the composer can collect from `entity.identity` + the discogs-cache for a
+batch of WXYC canonical artist names. See `composer.py` for the two-phase
+compose and `router.py` for the HTTP surface.
+"""

--- a/artists/composer.py
+++ b/artists/composer.py
@@ -108,11 +108,25 @@ class ArtistSearchAliasesComposer:
         including identities that resolved but yielded no variants (in
         which case `sources_present` still records the legs the composer
         ran, per the reconcile contract).
+
+        Duplicate input names are deduped (first-occurrence wins):
+        callers that pass the same name multiple times get exactly one
+        `ArtistSearchAliasesResult` per unique input, in first-seen
+        order. A consumer that UPSERTs by name on its side never has to
+        worry about overwriting itself.
         """
+        # Dedup inputs preserving first-occurrence order.
+        seen: set[str] = set()
+        unique_names: list[str] = []
+        for n in names:
+            if n not in seen:
+                seen.add(n)
+                unique_names.append(n)
+
         # ---- Phase 1: batched entity.identity fall-through. ----
         identities_by_name: dict[
             str, Identity
-        ] = await self.entity_store.bulk_resolve_library_names(names)
+        ] = await self.entity_store.bulk_resolve_library_names(unique_names)
 
         # ---- Phase 2: batched discogs-cache reads on the union of known
         # discogs_artist_ids. Skip the whole phase when there are none —
@@ -134,7 +148,7 @@ class ArtistSearchAliasesComposer:
         # ---- Assemble per-input results in input order. ----
         artists: list[ArtistSearchAliasesResult] = []
         missing: list[str] = []
-        for name in names:
+        for name in unique_names:
             identity = identities_by_name.get(name)
             if identity is None:
                 missing.append(name)

--- a/artists/composer.py
+++ b/artists/composer.py
@@ -1,0 +1,174 @@
+"""Two-phase batched composer for `POST /api/v1/artists/search-aliases/bulk`.
+
+Phase 1: `EntityStore.bulk_resolve_library_names(names)` — 1-3 PG round-
+trips for the whole batch. Resolves each input name through the #276
+three-leg fall-through (exact / LOWER / canonical).
+
+Phase 2: `DiscogsCacheService.get_artist_details_bulk(artist_ids)` —
+5 PG round-trips for the set of resolved identities that carry a Discogs
+artist id. Cache-only; no Discogs API escalation.
+
+`sources_present` is appended **before** the variant fan-out — it
+records which sources the composer queried for an artist, independent
+of whether each source returned any variants. Consumers use this to
+scope reconciliation (DELETE-only-listed-sources).
+
+Future sources (musicbrainz_alias, wikidata_label, etc.) are additive:
+add a Phase 2 sibling that consults its cache and append the source tag
+under the same `sources_present`-before-variants discipline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from discogs.cache_service import DiscogsCacheService
+from discogs.models import ArtistDetails, ArtistRef, MemberRef
+from entity.store import EntityStore, Identity
+from generated.api_models import (
+    ArtistSearchAliasesBulkResponse,
+    ArtistSearchAliasesResult,
+    ArtistSearchAliasMethod,
+    ArtistSearchAliasSource,
+    ArtistSearchAliasVariant,
+)
+
+# Per-source default confidences (artist-search-alias plan, "Per-source
+# default confidence" in the variant schema doc). v1 search ignores
+# these; stored for v2 ranking calibration.
+_DISCOGS_NAME_VARIATION_CONFIDENCE = 0.95
+_DISCOGS_ALIAS_CONFIDENCE = 0.85
+_DISCOGS_MEMBER_CONFIDENCE = 0.70
+
+# Discogs source tags fire as a unit — the composer enters or skips the
+# leg as one block, so all three tags get appended together (or none).
+_DISCOGS_SOURCES: tuple[ArtistSearchAliasSource, ...] = (
+    ArtistSearchAliasSource.discogs_name_variation,
+    ArtistSearchAliasSource.discogs_alias,
+    ArtistSearchAliasSource.discogs_member,
+)
+
+
+def _variant_name_variation(name: str) -> ArtistSearchAliasVariant:
+    """A `discogs_name_variation` variant — `related_*` fields are NULL."""
+    return ArtistSearchAliasVariant(
+        source=ArtistSearchAliasSource.discogs_name_variation,
+        variant=name,
+        related_external_id=None,
+        related_name=None,
+        active=None,
+        method=ArtistSearchAliasMethod.name_variation,
+        confidence=_DISCOGS_NAME_VARIATION_CONFIDENCE,
+    )
+
+
+def _variant_alias(alias: ArtistRef) -> ArtistSearchAliasVariant:
+    """A `discogs_alias` variant — `related_*` point at the aliased artist."""
+    return ArtistSearchAliasVariant(
+        source=ArtistSearchAliasSource.discogs_alias,
+        variant=alias.name,
+        related_external_id=f"discogs:artist:{alias.id}",
+        related_name=alias.name,
+        active=None,
+        method=ArtistSearchAliasMethod.alias,
+        confidence=_DISCOGS_ALIAS_CONFIDENCE,
+    )
+
+
+def _variant_member(member: MemberRef) -> ArtistSearchAliasVariant:
+    """A `discogs_member` variant — `related_*` point at the member, `active` set."""
+    return ArtistSearchAliasVariant(
+        source=ArtistSearchAliasSource.discogs_member,
+        variant=member.name,
+        related_external_id=f"discogs:artist:{member.id}",
+        related_name=member.name,
+        active=member.active,
+        method=ArtistSearchAliasMethod.member,
+        confidence=_DISCOGS_MEMBER_CONFIDENCE,
+    )
+
+
+@dataclass
+class ArtistSearchAliasesComposer:
+    """Two-phase batched composer.
+
+    Holds references to the entity store + discogs cache so the FastAPI
+    route can re-use them across requests. The composer itself is
+    stateless beyond that.
+    """
+
+    entity_store: EntityStore
+    discogs_cache: DiscogsCacheService
+
+    async def compose(self, names: list[str]) -> ArtistSearchAliasesBulkResponse:
+        """Resolve the batch and return the composed response shape.
+
+        `missing[]` carries inputs whose name had no `entity.identity`
+        row. `artists[]` carries the composer's verdict for the rest —
+        including identities that resolved but yielded no variants (in
+        which case `sources_present` still records the legs the composer
+        ran, per the reconcile contract).
+        """
+        # ---- Phase 1: batched entity.identity fall-through. ----
+        identities_by_name: dict[
+            str, Identity
+        ] = await self.entity_store.bulk_resolve_library_names(names)
+
+        # ---- Phase 2: batched discogs-cache reads on the union of known
+        # discogs_artist_ids. Skip the whole phase when there are none —
+        # don't pay the asyncio.gather cost for nothing.
+        discogs_artist_ids = sorted(
+            {
+                identity.discogs_artist_id
+                for identity in identities_by_name.values()
+                if identity.discogs_artist_id is not None
+            }
+        )
+        if discogs_artist_ids:
+            artist_bundle: dict[
+                int, ArtistDetails
+            ] = await self.discogs_cache.get_artist_details_bulk(discogs_artist_ids)
+        else:
+            artist_bundle = {}
+
+        # ---- Assemble per-input results in input order. ----
+        artists: list[ArtistSearchAliasesResult] = []
+        missing: list[str] = []
+        for name in names:
+            identity = identities_by_name.get(name)
+            if identity is None:
+                missing.append(name)
+                continue
+
+            variants: list[ArtistSearchAliasVariant] = []
+            sources_present: list[ArtistSearchAliasSource] = []
+
+            # Discogs leg — fires whenever we have a discogs_artist_id.
+            # `sources_present` is appended BEFORE the variant pass so
+            # the reconcile contract holds even when the cache is empty
+            # for this artist (see "Discogs cache miss" case in tests).
+            if identity.discogs_artist_id is not None:
+                sources_present.extend(_DISCOGS_SOURCES)
+                details = artist_bundle.get(identity.discogs_artist_id)
+                if details is not None:
+                    variants.extend(_variant_name_variation(nv) for nv in details.name_variations)
+                    variants.extend(_variant_alias(alias) for alias in details.aliases)
+                    variants.extend(_variant_member(m) for m in details.members)
+
+            # Future: MusicBrainz / Wikidata legs append their source
+            # tags here under the same sources-present-before-variants
+            # discipline.
+
+            artists.append(
+                ArtistSearchAliasesResult(
+                    name=name,
+                    variants=variants,
+                    sources_present=sources_present,
+                )
+            )
+
+        return ArtistSearchAliasesBulkResponse(
+            artists=artists,
+            missing=missing,
+            cache_stats=None,
+        )

--- a/artists/router.py
+++ b/artists/router.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import ValidationError
 
 from artists.composer import ArtistSearchAliasesComposer
-from core.dependencies import get_discogs_cache_service
+from core.dependencies import get_discogs_cache_service_from_pool
 from discogs.cache_service import DiscogsCacheService
 from entity.store import EntityStore
 from generated.api_models import (
@@ -62,7 +62,7 @@ router = APIRouter(tags=["artists"])
 async def search_aliases_bulk(
     http_request: Request,
     entity_store: EntityStore | None = Depends(get_entity_store),
-    discogs_cache: DiscogsCacheService | None = Depends(get_discogs_cache_service),
+    discogs_cache: DiscogsCacheService | None = Depends(get_discogs_cache_service_from_pool),
 ) -> ArtistSearchAliasesBulkResponse:
     """Compose artist-search-alias variants for a batch of input names.
 

--- a/artists/router.py
+++ b/artists/router.py
@@ -35,29 +35,36 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_input_cap() -> int:
-    """Read the names array `max_length` from the generated Pydantic model.
+    """Read the names array `maxItems` from the generated model's JSON schema.
 
     Drift guard: api.yaml's `maxItems` for `names` drives the generated
-    `ArtistSearchAliasesBulkRequest.names` max_length. The route enforces
+    `ArtistSearchAliasesBulkRequest.names` constraint. The route enforces
     the cap as 413 before Pydantic validation; sourcing the literal from
     the model means a future api.yaml change that regenerates the model
     automatically updates the manual 413 gate.
 
-    Raises at module import time if `max_length` cannot be resolved
-    (e.g., a future Pydantic minor bump moves the constraint off
-    `.metadata`). Fail loud — a silent fallback to the historical cap of
-    1000 would mask any api.yaml reduction (501-N requests would return
-    422 instead of the documented 413 until someone noticed).
+    Uses `model_json_schema()` rather than the lower-level
+    `model_fields[...].metadata` introspection because the JSON-schema
+    export is Pydantic's documented public API (it's tied to OpenAPI
+    generation and unlikely to drift across minor versions), whereas the
+    metadata shape is implementation detail that has changed before.
+    `pydantic` is pinned only as a lower bound (`>=2.0.0`) so this
+    distinction matters across deploys.
+
+    Raises at module import time if `maxItems` is missing — fail loud, so
+    a regenerated model that drops the constraint can't silently widen
+    the 413 gate and produce 422 responses for cap-exceeded requests.
     """
-    for meta in ArtistSearchAliasesBulkRequest.model_fields["names"].metadata:
-        max_length = getattr(meta, "max_length", None)
-        if max_length is not None:
-            return int(max_length)
+    schema = ArtistSearchAliasesBulkRequest.model_json_schema()
+    names_schema = schema.get("properties", {}).get("names", {})
+    max_items = names_schema.get("maxItems")
+    if isinstance(max_items, int) and max_items > 0:
+        return max_items
     raise RuntimeError(
-        "Cannot resolve `max_length` from ArtistSearchAliasesBulkRequest.names "
-        "metadata — Pydantic constraint shape likely changed. The route's 413 "
-        "gate must agree with the generated model; fix or pin the constraint "
-        "before this module can import."
+        "Cannot resolve `maxItems` for ArtistSearchAliasesBulkRequest.names "
+        "from its JSON schema. The route's 413 gate must agree with the "
+        "generated model; fix or regenerate the model before this module "
+        f"can import (schema fragment: {names_schema!r})."
     )
 
 

--- a/artists/router.py
+++ b/artists/router.py
@@ -1,0 +1,149 @@
+"""Artist-search-alias REST API router.
+
+`POST /api/v1/artists/search-aliases/bulk` — composes per-source artist-
+name variants for a batch of WXYC canonical artist names. Backend-
+Service's artist-search-alias-consumer ETL (BS PR 4 of the artist-search-
+alias plan) is the consumer; the response shape is the input substrate
+for the alias-aware catalog search LATERAL JOIN (BS PR 5).
+
+Auth: bearer `LML_API_KEY`. Mounted under the same `Depends(require_lml_key)`
+posture as `bulk-resolve-libraries`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import sentry_sdk
+from asyncpg.exceptions import PostgresError
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import ValidationError
+
+from artists.composer import ArtistSearchAliasesComposer
+from core.dependencies import get_discogs_cache_service
+from discogs.cache_service import DiscogsCacheService
+from entity.store import EntityStore
+from generated.api_models import (
+    ArtistSearchAliasesBulkRequest,
+    ArtistSearchAliasesBulkResponse,
+)
+from identity.dependencies import get_entity_store
+
+logger = logging.getLogger(__name__)
+
+# Per api.yaml: max 1,000 names per request; over-cap returns 413.
+_BULK_INPUT_CAP = 1000
+
+_ROUTE_PATH = "/api/v1/artists/search-aliases/bulk"
+
+_ENTITY_STORE_UNAVAILABLE_DETAIL = (
+    "Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
+    "and the entity schema has been applied."
+)
+_DISCOGS_CACHE_UNAVAILABLE_DETAIL = (
+    "Discogs cache is not available. Ensure DATABASE_URL_DISCOGS is configured."
+)
+
+
+router = APIRouter(tags=["artists"])
+
+
+@router.post(
+    "/artists/search-aliases/bulk",
+    response_model=ArtistSearchAliasesBulkResponse,
+    summary="Bulk artist-search-alias variants",
+    responses={
+        200: {"description": "Composed variants per input name."},
+        401: {"description": "Missing or invalid `LML_API_KEY` bearer token."},
+        413: {"description": "Batch exceeded the 1,000-name cap."},
+        503: {"description": "Entity store or Discogs cache not available."},
+    },
+)
+async def search_aliases_bulk(
+    http_request: Request,
+    entity_store: EntityStore | None = Depends(get_entity_store),
+    discogs_cache: DiscogsCacheService | None = Depends(get_discogs_cache_service),
+) -> ArtistSearchAliasesBulkResponse:
+    """Compose artist-search-alias variants for a batch of input names.
+
+    Two-phase batched composer: 1-3 PG round-trips to `entity.identity`
+    for name resolution, plus 5 PG round-trips to the discogs-cache for
+    the set of resolved artists. No Discogs API escalation; no
+    `asyncio.gather` over per-name leaves (LML#370/#372 cascade-cascade
+    avoidance).
+    """
+    # Manual 413 check before Pydantic validation (mirrors `bulk-resolve-
+    # libraries`): the generated request model has `max_length=1000`
+    # from api.yaml's `maxItems`, but Pydantic's enforcement is 422.
+    # The api.yaml contract documents 413 for cap exceedance, so we read
+    # the raw count first and raise 413; only then validate.
+    try:
+        body = await http_request.json()
+    except (ValueError, TypeError) as e:
+        raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
+    names_raw = body.get("names")
+    if not isinstance(names_raw, list):
+        raise HTTPException(status_code=422, detail="`names` must be a JSON array.")
+    if len(names_raw) > _BULK_INPUT_CAP:
+        raise HTTPException(
+            status_code=413,
+            detail=(f"Batch exceeded the {_BULK_INPUT_CAP}-name cap (received {len(names_raw)})."),
+        )
+
+    try:
+        request = ArtistSearchAliasesBulkRequest.model_validate(body)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from None
+
+    if entity_store is None:
+        raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL)
+    if discogs_cache is None:
+        raise HTTPException(status_code=503, detail=_DISCOGS_CACHE_UNAVAILABLE_DETAIL)
+
+    composer = ArtistSearchAliasesComposer(
+        entity_store=entity_store,
+        discogs_cache=discogs_cache,
+    )
+
+    names_count = len(request.names)
+    logger.info("artist-search-alias bulk start: names=%d", names_count)
+
+    # Explicit `http.server` span (mirrors `bulk-resolve-libraries` —
+    # defense-in-depth against the FastApi auto-instrumentation not
+    # landing for this route). Query in trace explorer with
+    # `op:http.server span.description:*search-aliases/bulk*`.
+    with sentry_sdk.start_span(
+        op="http.server",
+        name=f"POST {_ROUTE_PATH}",
+    ) as http_span:
+        http_span.set_data("http.method", "POST")
+        http_span.set_data("http.target", _ROUTE_PATH)
+        http_span.set_data("lml.search_aliases.names", names_count)
+
+        try:
+            response = await composer.compose(request.names)
+        except (PostgresError, OSError):
+            # Fail closed on partial PG failure mid-compose. The two
+            # phases are batched, so a failure here is "the whole batch
+            # didn't make it through PG," not "some names worked." Mirror
+            # the bulk-resolve-libraries 503 posture.
+            logger.exception(
+                "Artist-search-alias compose failed against PG (names=%d)",
+                names_count,
+            )
+            http_span.set_data("http.status_code", 503)
+            raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
+
+        http_span.set_data("lml.search_aliases.resolved", len(response.artists))
+        http_span.set_data("lml.search_aliases.missing", len(response.missing))
+        http_span.set_data("http.status_code", 200)
+
+    logger.info(
+        "artist-search-alias bulk complete: names=%d resolved=%d missing=%d",
+        names_count,
+        len(response.artists),
+        len(response.missing),
+    )
+    return response

--- a/artists/router.py
+++ b/artists/router.py
@@ -12,16 +12,18 @@ posture as `bulk-resolve-libraries`.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import sentry_sdk
 from asyncpg.exceptions import PostgresError
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import ValidationError
+from starlette.requests import ClientDisconnect
 
 from artists.composer import ArtistSearchAliasesComposer
 from core.dependencies import get_discogs_cache_service_from_pool
-from discogs.cache_service import DiscogsCacheService
+from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 from entity.store import EntityStore
 from generated.api_models import (
     ArtistSearchAliasesBulkRequest,
@@ -31,8 +33,26 @@ from identity.dependencies import get_entity_store
 
 logger = logging.getLogger(__name__)
 
-# Per api.yaml: max 1,000 names per request; over-cap returns 413.
-_BULK_INPUT_CAP = 1000
+
+def _resolve_input_cap() -> int:
+    """Read the names array `max_length` from the generated Pydantic model.
+
+    Drift guard: api.yaml's `maxItems` for `names` drives the generated
+    `ArtistSearchAliasesBulkRequest.names` max_length. The route enforces
+    the cap as 413 before Pydantic validation; sourcing the literal from
+    the model means a future api.yaml change that regenerates the model
+    automatically updates the manual 413 gate. Falls back to 1000 (the
+    current cap) if the metadata shape ever shifts.
+    """
+    for meta in ArtistSearchAliasesBulkRequest.model_fields["names"].metadata:
+        max_length = getattr(meta, "max_length", None)
+        if max_length is not None:
+            return int(max_length)
+    return 1000
+
+
+# Per api.yaml: max names per request; over-cap returns 413.
+_BULK_INPUT_CAP = _resolve_input_cap()
 
 _ROUTE_PATH = "/api/v1/artists/search-aliases/bulk"
 
@@ -54,8 +74,10 @@ router = APIRouter(tags=["artists"])
     summary="Bulk artist-search-alias variants",
     responses={
         200: {"description": "Composed variants per input name."},
+        400: {"description": "Malformed JSON body."},
         401: {"description": "Missing or invalid `LML_API_KEY` bearer token."},
-        413: {"description": "Batch exceeded the 1,000-name cap."},
+        413: {"description": "Batch exceeded the per-request name cap."},
+        422: {"description": "Request body failed Pydantic validation."},
         503: {"description": "Entity store or Discogs cache not available."},
     },
 )
@@ -81,6 +103,15 @@ async def search_aliases_bulk(
         body = await http_request.json()
     except (ValueError, TypeError) as e:
         raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
+    except ClientDisconnect:
+        # Client closed the connection before the body completed. There is
+        # no point sending a 5xx — the client is gone — but we want this to
+        # land as a 4xx in logs (the route did its job; the failure is the
+        # client's). Treat as 400 to keep error-class accounting clean.
+        raise HTTPException(
+            status_code=400,
+            detail="Client disconnected before request body completed.",
+        ) from None
     if not isinstance(body, dict):
         raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
     names_raw = body.get("names")
@@ -124,17 +155,47 @@ async def search_aliases_bulk(
 
         try:
             response = await composer.compose(request.names)
-        except (PostgresError, OSError):
-            # Fail closed on partial PG failure mid-compose. The two
-            # phases are batched, so a failure here is "the whole batch
-            # didn't make it through PG," not "some names worked." Mirror
-            # the bulk-resolve-libraries 503 posture.
+        except asyncio.CancelledError:
+            # Client aborted mid-compose. Pin 499 on the span so the
+            # trace explorer query
+            # `op:http.server http.status_code:499 description:*search-aliases/bulk*`
+            # surfaces aborts in Sentry — same observability gap LML#430
+            # paid down for the sibling bulk-resolve-libraries route.
+            # CancelledError is re-raised (not converted to HTTPException):
+            # the asyncio cancellation contract requires this, and the
+            # client is gone anyway.
+            http_span.set_data("http.status_code", 499)
+            logger.warning(
+                "artist-search-alias bulk aborted by client: names=%d",
+                names_count,
+            )
+            raise
+        except CacheUnavailableError:
+            # Phase 2: discogs-cache pool/PG failure. Distinct detail string
+            # from the entity-store path so the on-call sees which
+            # subsystem actually failed.
             logger.exception(
-                "Artist-search-alias compose failed against PG (names=%d)",
+                "Discogs cache unavailable during artist-search-alias compose (names=%d)",
+                names_count,
+            )
+            http_span.set_data("http.status_code", 503)
+            raise HTTPException(status_code=503, detail=_DISCOGS_CACHE_UNAVAILABLE_DETAIL) from None
+        except (PostgresError, OSError):
+            # Phase 1: entity-store PG failure (raw asyncpg error — not
+            # wrapped). Phase 2 errors are wrapped above; if a PostgresError
+            # reaches here, it came from `bulk_resolve_library_names`.
+            logger.exception(
+                "Entity store query failed during artist-search-alias compose (names=%d)",
                 names_count,
             )
             http_span.set_data("http.status_code", 503)
             raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
+        except Exception:
+            # Pin 500 on the span so unhandled-exception traces still carry
+            # http.status_code for per-route status aggregation. Re-raise
+            # so FastAPI's default handler produces the response.
+            http_span.set_data("http.status_code", 500)
+            raise
 
         http_span.set_data("lml.search_aliases.resolved", len(response.artists))
         http_span.set_data("lml.search_aliases.missing", len(response.missing))

--- a/artists/router.py
+++ b/artists/router.py
@@ -41,14 +41,24 @@ def _resolve_input_cap() -> int:
     `ArtistSearchAliasesBulkRequest.names` max_length. The route enforces
     the cap as 413 before Pydantic validation; sourcing the literal from
     the model means a future api.yaml change that regenerates the model
-    automatically updates the manual 413 gate. Falls back to 1000 (the
-    current cap) if the metadata shape ever shifts.
+    automatically updates the manual 413 gate.
+
+    Raises at module import time if `max_length` cannot be resolved
+    (e.g., a future Pydantic minor bump moves the constraint off
+    `.metadata`). Fail loud — a silent fallback to the historical cap of
+    1000 would mask any api.yaml reduction (501-N requests would return
+    422 instead of the documented 413 until someone noticed).
     """
     for meta in ArtistSearchAliasesBulkRequest.model_fields["names"].metadata:
         max_length = getattr(meta, "max_length", None)
         if max_length is not None:
             return int(max_length)
-    return 1000
+    raise RuntimeError(
+        "Cannot resolve `max_length` from ArtistSearchAliasesBulkRequest.names "
+        "metadata — Pydantic constraint shape likely changed. The route's 413 "
+        "gate must agree with the generated model; fix or pin the constraint "
+        "before this module can import."
+    )
 
 
 # Per api.yaml: max names per request; over-cap returns 413.
@@ -190,6 +200,13 @@ async def search_aliases_bulk(
             )
             http_span.set_data("http.status_code", 503)
             raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
+        except HTTPException:
+            # HTTPException carries its own status code, set by whoever
+            # raised it (either us above, or future inner code). Don't
+            # blanket-stamp 500 — that would lie to Sentry's
+            # http.status_code aggregation about the real response code.
+            # Re-raise unchanged.
+            raise
         except Exception:
             # Pin 500 on the span so unhandled-exception traces still carry
             # http.status_code for per-route status aggregation. Re-raise

--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -191,6 +191,29 @@ async def get_discogs_cache_service(
     return service.cache_service
 
 
+async def get_discogs_cache_service_from_pool(
+    settings: Settings = Depends(get_settings),
+) -> DiscogsCacheService | None:
+    """Cache-only DiscogsCacheService backed by the shared pool — no API requirement.
+
+    Sibling of `get_discogs_cache_service` for routes that never escalate
+    to the Discogs API. Unlike that dep (which short-circuits to None when
+    DISCOGS_TOKEN / DISCOGS_API_KEY are unset because the *API service* is
+    None), this one only depends on the shared discogs-cache pool from
+    `get_discogs_pool` — same posture as `get_entity_store`.
+
+    Used by `POST /api/v1/artists/search-aliases/bulk` (PR 2 of the
+    artist-search-alias plan), which is cache-only by design.
+
+    Returns ``None`` when DATABASE_URL_DISCOGS is unset or the shared pool
+    is unavailable; route renders 503 in that case.
+    """
+    pool = await get_discogs_pool()
+    if pool is None:
+        return None
+    return DiscogsCacheService(pool)
+
+
 async def _build_musicbrainz_pg() -> PgSource | None:
     """Build the PgSource backing the musicbrainz-cache external-cache fallback.
 

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -1020,6 +1020,104 @@ class DiscogsCacheService:
             logger.error(f"Cache get_artist_details failed: {e}")
             raise CacheUnavailableError(f"Cache get_artist_details failed: {e}") from e
 
+    async def get_artist_details_bulk(self, artist_ids: list[int]) -> dict[int, ArtistDetails]:
+        """Batched cache-only read of full artist details across many ids.
+
+        Used by the artist-search-alias bulk endpoint (PR 2, Phase 2). 5
+        PG round-trips per call regardless of input cardinality — one per
+        table — each binding the input list via `WHERE ... = ANY($1)`.
+        All four child tables have a B-tree index on `artist_id`, so each
+        leg stays index-driven even at the per-batch ceiling of ~125
+        ids.
+
+        Returns a dict keyed by Discogs artist id. Cache-miss ids are
+        absent from the returned dict (never None-valued). Empty input
+        returns an empty dict without querying.
+
+        Cache-only — no Discogs API escalation, no rate-limit semaphore
+        acquire. Callers wanting the API fall-through should still use
+        `get_artist_details` (per-id with cache → API cascade).
+        """
+        if not artist_ids:
+            return {}
+
+        try:
+            (
+                artist_rows,
+                alias_rows,
+                nv_rows,
+                member_rows,
+                url_rows,
+            ) = await asyncio.gather(
+                self.pool.fetch(
+                    "SELECT id, name, profile, image_url FROM artist WHERE id = ANY($1::int[])",
+                    artist_ids,
+                ),
+                self.pool.fetch(
+                    "SELECT artist_id, alias_id, alias_name "
+                    "FROM artist_alias WHERE artist_id = ANY($1::int[])",
+                    artist_ids,
+                ),
+                self.pool.fetch(
+                    "SELECT artist_id, name "
+                    "FROM artist_name_variation WHERE artist_id = ANY($1::int[])",
+                    artist_ids,
+                ),
+                self.pool.fetch(
+                    "SELECT artist_id, member_id, member_name, active "
+                    "FROM artist_member WHERE artist_id = ANY($1::int[])",
+                    artist_ids,
+                ),
+                self.pool.fetch(
+                    "SELECT artist_id, url FROM artist_url WHERE artist_id = ANY($1::int[])",
+                    artist_ids,
+                ),
+            )
+
+            # Bucket child rows by artist_id once, then assemble.
+            aliases_by_id: dict[int, list[ArtistRef]] = {}
+            for row in alias_rows:
+                if row["alias_id"] is None:
+                    continue
+                aliases_by_id.setdefault(row["artist_id"], []).append(
+                    ArtistRef(id=row["alias_id"], name=row["alias_name"])
+                )
+            nvs_by_id: dict[int, list[str]] = {}
+            for row in nv_rows:
+                nvs_by_id.setdefault(row["artist_id"], []).append(row["name"])
+            members_by_id: dict[int, list[MemberRef]] = {}
+            for row in member_rows:
+                members_by_id.setdefault(row["artist_id"], []).append(
+                    MemberRef(
+                        id=row["member_id"],
+                        name=row["member_name"],
+                        active=row["active"],
+                    )
+                )
+            urls_by_id: dict[int, list[str]] = {}
+            for row in url_rows:
+                urls_by_id.setdefault(row["artist_id"], []).append(row["url"])
+
+            result: dict[int, ArtistDetails] = {}
+            for row in artist_rows:
+                artist_id = row["id"]
+                result[artist_id] = ArtistDetails(
+                    artist_id=artist_id,
+                    name=row["name"],
+                    profile=row["profile"],
+                    image_url=row["image_url"],
+                    aliases=aliases_by_id.get(artist_id, []),
+                    name_variations=nvs_by_id.get(artist_id, []),
+                    members=members_by_id.get(artist_id, []),
+                    urls=urls_by_id.get(artist_id, []),
+                    cached=True,
+                )
+            return result
+
+        except Exception as e:
+            logger.error(f"Cache get_artist_details_bulk failed: {e}")
+            raise CacheUnavailableError(f"Cache get_artist_details_bulk failed: {e}") from e
+
     async def write_artist_details(self, details: ArtistDetails) -> None:
         """Write or update artist details in the cache.
 

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -1023,16 +1023,22 @@ class DiscogsCacheService:
     async def get_artist_details_bulk(self, artist_ids: list[int]) -> dict[int, ArtistDetails]:
         """Batched cache-only read of full artist details across many ids.
 
-        Used by the artist-search-alias bulk endpoint (PR 2, Phase 2). 5
+        Used by the artist-search-alias bulk endpoint (PR 2, Phase 2). 4
         PG round-trips per call regardless of input cardinality — one per
-        table — each binding the input list via `WHERE ... = ANY($1)`.
-        All four child tables have a B-tree index on `artist_id`, so each
-        leg stays index-driven even at the per-batch ceiling of ~125
-        ids.
+        relevant table (`artist`, `artist_alias`, `artist_name_variation`,
+        `artist_member`) — each binding the input list via
+        `WHERE ... = ANY($1)`. All three child tables have a B-tree index
+        on `artist_id`, so each leg stays index-driven even at the per-
+        batch ceiling of ~125 ids.
 
-        Returns a dict keyed by Discogs artist id. Cache-miss ids are
-        absent from the returned dict (never None-valued). Empty input
-        returns an empty dict without querying.
+        Returns a dict keyed by Discogs artist id with `urls=[]` — the
+        `artist_url` table is NOT queried because the artist-search-alias
+        composer doesn't read `details.urls`, and skipping the fetch
+        saves one PG round-trip per call. Extend with a kwarg if a
+        future caller needs URLs.
+
+        Cache-miss ids are absent from the returned dict (never
+        None-valued). Empty input returns an empty dict without querying.
 
         Cache-only — no Discogs API escalation, no rate-limit semaphore
         acquire. Callers wanting the API fall-through should still use
@@ -1047,7 +1053,6 @@ class DiscogsCacheService:
                 alias_rows,
                 nv_rows,
                 member_rows,
-                url_rows,
             ) = await asyncio.gather(
                 self.pool.fetch(
                     "SELECT id, name, profile, image_url FROM artist WHERE id = ANY($1::int[])",
@@ -1066,10 +1071,6 @@ class DiscogsCacheService:
                 self.pool.fetch(
                     "SELECT artist_id, member_id, member_name, active "
                     "FROM artist_member WHERE artist_id = ANY($1::int[])",
-                    artist_ids,
-                ),
-                self.pool.fetch(
-                    "SELECT artist_id, url FROM artist_url WHERE artist_id = ANY($1::int[])",
                     artist_ids,
                 ),
             )
@@ -1094,10 +1095,6 @@ class DiscogsCacheService:
                         active=row["active"],
                     )
                 )
-            urls_by_id: dict[int, list[str]] = {}
-            for row in url_rows:
-                urls_by_id.setdefault(row["artist_id"], []).append(row["url"])
-
             result: dict[int, ArtistDetails] = {}
             for row in artist_rows:
                 artist_id = row["id"]
@@ -1109,7 +1106,7 @@ class DiscogsCacheService:
                     aliases=aliases_by_id.get(artist_id, []),
                     name_variations=nvs_by_id.get(artist_id, []),
                     members=members_by_id.get(artist_id, []),
-                    urls=urls_by_id.get(artist_id, []),
+                    urls=[],
                     cached=True,
                 )
             return result

--- a/entity/store.py
+++ b/entity/store.py
@@ -189,18 +189,25 @@ WHERE library_name = ANY($1::text[])\
 # the bind without re-keying via Python `.lower()` (which would re-
 # introduce the asymmetry).
 #
-# `DISTINCT ON (LOWER(bind.name))` + `ORDER BY ... id ASC` picks the
-# lowest stored id when two rows share a LOWER form, matching the per-
-# call's `ORDER BY id ASC LIMIT 1` tie-break.
+# `DISTINCT ON (bind.name)` (keyed on the original bind, NOT on its
+# LOWER form) ensures each distinct input bind gets its own row even
+# when multiple case-variant binds share a LOWER form. Two inputs
+# `'STEREOLAB'` and `'stereolab'` both resolve to the same stored row,
+# both returned as separate (bind.name, identity) pairs. Keying DISTINCT
+# ON the LOWERED bind would collapse them and silently drop one input
+# to `missing[]`. For case-collisions on the STORED side (e.g., both
+# 'Stereolab' and 'stereolab' stored as distinct rows), the `ORDER BY
+# bind.name, i.id ASC` tie-break picks the lowest stored id — matching
+# the per-call's `ORDER BY id ASC LIMIT 1`.
 _BULK_GET_IDENTITY_LOWER_SQL = """\
-SELECT DISTINCT ON (LOWER(bind.name))
+SELECT DISTINCT ON (bind.name)
     i.id, i.library_name, i.discogs_artist_id, i.wikidata_qid,
     i.musicbrainz_artist_id, i.spotify_artist_id,
     i.apple_music_artist_id, i.bandcamp_id, i.reconciliation_status,
     bind.name AS input_name
 FROM entity.identity i
 JOIN unnest($1::text[]) AS bind(name) ON LOWER(i.library_name) = LOWER(bind.name)
-ORDER BY LOWER(bind.name), i.id ASC\
+ORDER BY bind.name, i.id ASC\
 """
 
 # Most-recent reconciliation log row per source for a given identity.

--- a/entity/store.py
+++ b/entity/store.py
@@ -167,6 +167,34 @@ _FETCH_ALL_LIBRARY_NAMES_SQL = """\
 SELECT library_name FROM entity.identity\
 """
 
+# Batched form of leg 1 (exact match). One round-trip against the unique
+# index on `entity.identity.library_name`, binding the input list as a
+# single text array. Returns rows for every input that hits — caller
+# pairs them back to inputs by matching `library_name == verbatim`.
+_BULK_GET_IDENTITY_EXACT_SQL = """\
+SELECT id, library_name, discogs_artist_id, wikidata_qid,
+       musicbrainz_artist_id, spotify_artist_id,
+       apple_music_artist_id, bandcamp_id, reconciliation_status
+FROM entity.identity
+WHERE library_name = ANY($1::text[])\
+"""
+
+# Batched form of leg 2 (case-insensitive). Seq-scans ~24k rows once,
+# matching every stored row whose LOWER form is in the input-lower list.
+# `LOWER(library_name)` is computed per-row; for ambiguous ties two
+# stored rows may share a lower form (the UNIQUE constraint is case-
+# sensitive), so the caller picks the lowest id per LOWER-key — matching
+# the per-call `ORDER BY id ASC + LIMIT 1` tie-break in
+# `_GET_IDENTITY_LOWER_SQL`.
+_BULK_GET_IDENTITY_LOWER_SQL = """\
+SELECT id, library_name, discogs_artist_id, wikidata_qid,
+       musicbrainz_artist_id, spotify_artist_id,
+       apple_music_artist_id, bandcamp_id, reconciliation_status
+FROM entity.identity
+WHERE LOWER(library_name) = ANY($1::text[])
+ORDER BY id ASC\
+"""
+
 # Most-recent reconciliation log row per source for a given identity.
 # DISTINCT ON keeps a single row per source, ordered by created_at DESC so we
 # pick the latest attempt — matching the "most recent matcher decision" notion
@@ -506,3 +534,110 @@ class EntityStore:
             await conn.execute(_REASSIGN_LOGS_SQL, into_id, from_id)
             await conn.execute(_DELETE_IDENTITY_BY_ID_SQL, from_id)
             return True
+
+    async def bulk_resolve_library_names(self, names: list[str]) -> dict[str, Identity]:
+        """Resolve a list of artist names through the three-leg fall-through.
+
+        Batched form of `resolve_library_name` (#276) for the artist-
+        search-alias bulk endpoint (PR 2). Each leg is one `WHERE ... =
+        ANY($1::text[])` round-trip against the still-missing residual
+        from the prior leg, so a 1,000-name batch costs at most three PG
+        round-trips total — independent of per-name cardinality.
+
+        Returns a dict keyed by the **input** name (not the stored
+        `library_name`) so callers can preserve input order without
+        maintaining their own reverse-index. Names that miss all three
+        legs are absent from the dict — they are never None-valued.
+
+        Legs:
+
+        1. **Exact** — `library_name = ANY($input_verbatim)`. Uses the
+           unique index. Catches the dominant case (99.8% of stored rows
+           per the #276 audit are verbatim).
+        2. **LOWER** — `LOWER(library_name) = ANY($input_lower)`. Catches
+           pure case drift. For ambiguous case-collisions (two stored
+           rows sharing the same lower form), the lowest stored id wins,
+           matching the per-call tie-break in `_GET_IDENTITY_LOWER_SQL`.
+        3. **Canonical** — `library_name = ANY($input_canonical)`.
+           Catches inputs whose canonical form equals a stored canonical
+           row.
+        """
+        if not names:
+            return {}
+
+        # Local import keeps the wxyc_etl Rust extension off the module-
+        # load path for store consumers that don't use this method.
+        from identity.normalize import canonicalize_for_identity_lookup
+
+        # Per-input bookkeeping: the verbatim (NUL-stripped) shape used
+        # to look up rows, plus the canonical form for the residual that
+        # falls all the way through.
+        verbatim_by_input: dict[str, str] = {}
+        for raw in names:
+            verbatim_by_input[raw] = _strip_nul(raw) or ""
+
+        results: dict[str, Identity] = {}
+
+        # ---- Leg 1: exact match on the unique index. ----
+        leg_1_binds = list({verbatim_by_input[n] for n in names})
+        leg_1_rows = await self._pg.fetchall(_BULK_GET_IDENTITY_EXACT_SQL, leg_1_binds)
+        leg_1_by_lib: dict[str, Identity] = {
+            row["library_name"]: _record_to_identity(row) for row in leg_1_rows
+        }
+        for raw_name in names:
+            verbatim = verbatim_by_input[raw_name]
+            if verbatim in leg_1_by_lib:
+                results[raw_name] = leg_1_by_lib[verbatim]
+
+        residual = [n for n in names if n not in results]
+        if not residual:
+            return results
+
+        # ---- Leg 2: LOWER(library_name) match on residual. ----
+        # Bind the LOWER forms of the residual inputs; result rows are
+        # stored-verbatim rows whose lower-form matches one of those
+        # binds. Pair back to inputs by LOWER key. On ambiguous ties (two
+        # stored rows sharing one lower form), the SQL's `ORDER BY id
+        # ASC` makes the iteration order deterministic — we set-once.
+        leg_2_binds = list({verbatim_by_input[n].lower() for n in residual})
+        leg_2_rows = await self._pg.fetchall(_BULK_GET_IDENTITY_LOWER_SQL, leg_2_binds)
+        leg_2_by_lower: dict[str, Identity] = {}
+        for row in leg_2_rows:
+            key = row["library_name"].lower()
+            # Lowest id wins on case-collision ties (rows come back in
+            # ASC id order).
+            if key not in leg_2_by_lower:
+                leg_2_by_lower[key] = _record_to_identity(row)
+        for raw_name in residual:
+            lower = verbatim_by_input[raw_name].lower()
+            if lower in leg_2_by_lower:
+                results[raw_name] = leg_2_by_lower[lower]
+
+        residual = [n for n in names if n not in results]
+        if not residual:
+            return results
+
+        # ---- Leg 3: canonical-form exact match on residual. ----
+        # Skip the canonical bind when it duplicates a previous leg's
+        # bind for this input (leg 2 already covered the lower-form
+        # space). The per-call resolve_library_name short-circuits the
+        # same way.
+        canonical_by_input: dict[str, str] = {}
+        for raw_name in residual:
+            verbatim = verbatim_by_input[raw_name]
+            canonical = canonicalize_for_identity_lookup(verbatim)
+            if canonical and canonical != verbatim and canonical != verbatim.lower():
+                canonical_by_input[raw_name] = canonical
+        if not canonical_by_input:
+            return results
+
+        leg_3_binds = list(set(canonical_by_input.values()))
+        leg_3_rows = await self._pg.fetchall(_BULK_GET_IDENTITY_EXACT_SQL, leg_3_binds)
+        leg_3_by_lib: dict[str, Identity] = {
+            row["library_name"]: _record_to_identity(row) for row in leg_3_rows
+        }
+        for raw_name, canonical in canonical_by_input.items():
+            if canonical in leg_3_by_lib:
+                results[raw_name] = leg_3_by_lib[canonical]
+
+        return results

--- a/entity/store.py
+++ b/entity/store.py
@@ -179,20 +179,28 @@ FROM entity.identity
 WHERE library_name = ANY($1::text[])\
 """
 
-# Batched form of leg 2 (case-insensitive). Seq-scans ~24k rows once,
-# matching every stored row whose LOWER form is in the input-lower list.
-# `LOWER(library_name)` is computed per-row; for ambiguous ties two
-# stored rows may share a lower form (the UNIQUE constraint is case-
-# sensitive), so the caller picks the lowest id per LOWER-key — matching
-# the per-call `ORDER BY id ASC + LIMIT 1` tie-break in
-# `_GET_IDENTITY_LOWER_SQL`.
+# Batched form of leg 2 (case-insensitive). PG lowers both the stored
+# `library_name` AND each bind via `JOIN unnest(...)` so the comparison
+# is locale-symmetric — Python `str.lower()` and PG `LOWER()` can
+# disagree on Unicode locale edge cases (Turkish dotted I `İ`, capital
+# sharp S `ẞ`, Greek final sigma); the per-call `_GET_IDENTITY_LOWER_SQL`
+# already PG-lowers both sides via `LOWER($1)`, so this matches that
+# invariant. Returning `input_name` lets the caller map results back to
+# the bind without re-keying via Python `.lower()` (which would re-
+# introduce the asymmetry).
+#
+# `DISTINCT ON (LOWER(bind.name))` + `ORDER BY ... id ASC` picks the
+# lowest stored id when two rows share a LOWER form, matching the per-
+# call's `ORDER BY id ASC LIMIT 1` tie-break.
 _BULK_GET_IDENTITY_LOWER_SQL = """\
-SELECT id, library_name, discogs_artist_id, wikidata_qid,
-       musicbrainz_artist_id, spotify_artist_id,
-       apple_music_artist_id, bandcamp_id, reconciliation_status
-FROM entity.identity
-WHERE LOWER(library_name) = ANY($1::text[])
-ORDER BY id ASC\
+SELECT DISTINCT ON (LOWER(bind.name))
+    i.id, i.library_name, i.discogs_artist_id, i.wikidata_qid,
+    i.musicbrainz_artist_id, i.spotify_artist_id,
+    i.apple_music_artist_id, i.bandcamp_id, i.reconciliation_status,
+    bind.name AS input_name
+FROM entity.identity i
+JOIN unnest($1::text[]) AS bind(name) ON LOWER(i.library_name) = LOWER(bind.name)
+ORDER BY LOWER(bind.name), i.id ASC\
 """
 
 # Most-recent reconciliation log row per source for a given identity.
@@ -549,18 +557,28 @@ class EntityStore:
         maintaining their own reverse-index. Names that miss all three
         legs are absent from the dict — they are never None-valued.
 
+        Empty inputs after NUL-strip are skipped from binds entirely
+        (entity.identity's UNIQUE on library_name plus the discogs-etl
+        seed contract effectively rule out an empty stored value).
+
         Legs:
 
         1. **Exact** — `library_name = ANY($input_verbatim)`. Uses the
            unique index. Catches the dominant case (99.8% of stored rows
            per the #276 audit are verbatim).
-        2. **LOWER** — `LOWER(library_name) = ANY($input_lower)`. Catches
-           pure case drift. For ambiguous case-collisions (two stored
-           rows sharing the same lower form), the lowest stored id wins,
-           matching the per-call tie-break in `_GET_IDENTITY_LOWER_SQL`.
+        2. **LOWER (PG-on-both-sides)** — `LOWER(library_name) =
+           LOWER(bind.name)` via `JOIN unnest($1::text[])`. PG lowers both
+           sides so the comparison is locale-symmetric (Turkish dotted I,
+           sharp S, Greek final sigma agree with the per-call form). For
+           case-collisions, the lowest stored id wins via `DISTINCT ON +
+           ORDER BY ... id ASC`.
         3. **Canonical** — `library_name = ANY($input_canonical)`.
            Catches inputs whose canonical form equals a stored canonical
-           row.
+           row. Runs whenever canonical differs from verbatim (the
+           per-call's additional `!= verbatim.lower()` short-circuit is
+           dropped here because Python `.lower()` and PG `LOWER()` can
+           disagree, making the short-circuit wrongly skip legs in
+           Unicode-locale-edge cases).
         """
         if not names:
             return {}
@@ -579,54 +597,56 @@ class EntityStore:
         results: dict[str, Identity] = {}
 
         # ---- Leg 1: exact match on the unique index. ----
-        leg_1_binds = list({verbatim_by_input[n] for n in names})
-        leg_1_rows = await self._pg.fetchall(_BULK_GET_IDENTITY_EXACT_SQL, leg_1_binds)
-        leg_1_by_lib: dict[str, Identity] = {
-            row["library_name"]: _record_to_identity(row) for row in leg_1_rows
-        }
-        for raw_name in names:
-            verbatim = verbatim_by_input[raw_name]
-            if verbatim in leg_1_by_lib:
-                results[raw_name] = leg_1_by_lib[verbatim]
+        # Drop empty-string binds — entity.identity.library_name is
+        # NOT NULL UNIQUE and the discogs-etl seed never writes "".
+        leg_1_binds = [v for v in {verbatim_by_input[n] for n in names} if v]
+        if leg_1_binds:
+            leg_1_rows = await self._pg.fetchall(_BULK_GET_IDENTITY_EXACT_SQL, leg_1_binds)
+            leg_1_by_lib: dict[str, Identity] = {
+                row["library_name"]: _record_to_identity(row) for row in leg_1_rows
+            }
+            for raw_name in names:
+                verbatim = verbatim_by_input[raw_name]
+                if verbatim and verbatim in leg_1_by_lib:
+                    results[raw_name] = leg_1_by_lib[verbatim]
 
-        residual = [n for n in names if n not in results]
+        residual = [n for n in names if n not in results and verbatim_by_input[n]]
         if not residual:
             return results
 
-        # ---- Leg 2: LOWER(library_name) match on residual. ----
-        # Bind the LOWER forms of the residual inputs; result rows are
-        # stored-verbatim rows whose lower-form matches one of those
-        # binds. Pair back to inputs by LOWER key. On ambiguous ties (two
-        # stored rows sharing one lower form), the SQL's `ORDER BY id
-        # ASC` makes the iteration order deterministic — we set-once.
-        leg_2_binds = list({verbatim_by_input[n].lower() for n in residual})
+        # ---- Leg 2: PG-side LOWER on both sides via JOIN unnest. ----
+        # Bind the verbatim inputs (not Python-lowered); SQL lowers them
+        # on the PG side. The returned `input_name` column carries the
+        # matching bind so we map results to inputs without re-keying
+        # via Python `.lower()` (which is what reintroduced the
+        # Python/PG-LOWER asymmetry pre-fix).
+        leg_2_binds = list({verbatim_by_input[n] for n in residual})
         leg_2_rows = await self._pg.fetchall(_BULK_GET_IDENTITY_LOWER_SQL, leg_2_binds)
-        leg_2_by_lower: dict[str, Identity] = {}
-        for row in leg_2_rows:
-            key = row["library_name"].lower()
-            # Lowest id wins on case-collision ties (rows come back in
-            # ASC id order).
-            if key not in leg_2_by_lower:
-                leg_2_by_lower[key] = _record_to_identity(row)
+        leg_2_by_bind: dict[str, Identity] = {
+            row["input_name"]: _record_to_identity(row) for row in leg_2_rows
+        }
         for raw_name in residual:
-            lower = verbatim_by_input[raw_name].lower()
-            if lower in leg_2_by_lower:
-                results[raw_name] = leg_2_by_lower[lower]
+            verbatim = verbatim_by_input[raw_name]
+            if verbatim in leg_2_by_bind:
+                results[raw_name] = leg_2_by_bind[verbatim]
 
-        residual = [n for n in names if n not in results]
+        residual = [n for n in names if n not in results and verbatim_by_input[n]]
         if not residual:
             return results
 
         # ---- Leg 3: canonical-form exact match on residual. ----
-        # Skip the canonical bind when it duplicates a previous leg's
-        # bind for this input (leg 2 already covered the lower-form
-        # space). The per-call resolve_library_name short-circuits the
-        # same way.
+        # Skip the canonical bind only when it duplicates leg 1's
+        # verbatim bind (no value to running an identical query). We do
+        # NOT compare canonical to `verbatim.lower()` here — the per-
+        # call form does that, but the comparison assumes Python and PG
+        # agree on LOWER, which they may not for Unicode-locale edge
+        # cases; the asymmetric short-circuit would skip leg 3 even when
+        # leg 2's PG-LOWER missed.
         canonical_by_input: dict[str, str] = {}
         for raw_name in residual:
             verbatim = verbatim_by_input[raw_name]
             canonical = canonicalize_for_identity_lookup(verbatim)
-            if canonical and canonical != verbatim and canonical != verbatim.lower():
+            if canonical and canonical != verbatim:
                 canonical_by_input[raw_name] = canonical
         if not canonical_by_input:
             return results

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from wxyc_fastapi.observability import flush_posthog, init_sentry, shutdown_posthog
 
+from artists.router import router as artists_router
 from config.settings import get_settings
 from core.auth import require_lml_key
 from core.dependencies import (
@@ -117,6 +118,12 @@ app.include_router(release_router, prefix="/api/v1", tags=["release"], dependenc
 app.include_router(
     identity_api_v1_router, prefix="/api/v1", tags=["lookup"], dependencies=_lml_protected
 )
+# `POST /api/v1/artists/search-aliases/bulk` — artist-search-alias plan PR 2
+# (WXYC/library-metadata-lookup#479). Returns per-source variants for a batch
+# of WXYC canonical artist names; Backend-Service's consumer ETL writes the
+# response into its local `artist_search_alias` cache (BS PR 4) and the
+# catalog search extends with a LATERAL JOIN (BS PR 5).
+app.include_router(artists_router, prefix="/api/v1", tags=["artists"], dependencies=_lml_protected)
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -47,29 +47,52 @@ async def set_up_schemas(pg_pool):
     ``artist_member`` in the default (public) schema — same shape as
     the production discogs-cache.
 
-    SAFETY: this fixture DROPs the public-schema `artist` (and child)
-    tables. The default ``DATABASE_URL_TEST`` (``postgresql://discogs:
-    discogs@localhost:5433/discogs``) points at the developer's local
-    discogs-cache. If that cache is populated (a real discogs-cache
-    rebuild produces tens of GB and takes hours), wiping it is
-    catastrophic. We refuse to run when public.artist has any rows, so
-    the operator must point ``DATABASE_URL_TEST`` at a clean DB before
-    these tests will execute.
+    SAFETY: this fixture DROPs both `entity` schema CASCADE and the
+    public-schema `artist` + four child tables. The default
+    ``DATABASE_URL_TEST`` (``postgresql://discogs:discogs@localhost:5433/discogs``)
+    points at the developer's local discogs-cache, which may also host
+    a populated `entity.identity` from a prior reconciliation campaign.
+    Wiping either set is catastrophic (the cache rebuild + reconcile
+    re-run takes hours). We refuse to run when ANY of the about-to-drop
+    tables already has rows, so the operator must point
+    ``DATABASE_URL_TEST`` at a clean DB.
     """
-    async with pg_pool.acquire() as conn:
-        artist_exists = await conn.fetchval(
+
+    async def _table_row_count(conn, schema: str, table: str) -> int | None:
+        """Return row count, or None if the table doesn't exist."""
+        exists = await conn.fetchval(
             "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
-            "WHERE table_schema = 'public' AND table_name = 'artist')"
+            "WHERE table_schema = $1 AND table_name = $2)",
+            schema,
+            table,
         )
-        if artist_exists:
-            existing_rows = await conn.fetchval("SELECT COUNT(*) FROM artist")
-            if existing_rows and existing_rows > 0:
-                pytest.skip(
-                    f"DATABASE_URL_TEST points at a populated discogs-cache "
-                    f"({existing_rows} rows in `public.artist`). Refusing to "
-                    "DROP and recreate the cache tables — point "
-                    "DATABASE_URL_TEST at a clean PG before running this suite."
-                )
+        if not exists:
+            return None
+        return await conn.fetchval(f'SELECT COUNT(*) FROM "{schema}"."{table}"')
+
+    async with pg_pool.acquire() as conn:
+        # All tables this fixture will DROP. If any has data, bail.
+        targets: list[tuple[str, str]] = [
+            ("entity", "identity"),
+            ("entity", "reconciliation_log"),
+            ("public", "artist"),
+            ("public", "artist_alias"),
+            ("public", "artist_name_variation"),
+            ("public", "artist_member"),
+            ("public", "artist_url"),
+        ]
+        populated: list[tuple[str, str, int]] = []
+        for schema, table in targets:
+            count = await _table_row_count(conn, schema, table)
+            if count is not None and count > 0:
+                populated.append((schema, table, count))
+        if populated:
+            details = ", ".join(f"{s}.{t}={n}" for s, t, n in populated)
+            pytest.skip(
+                "DATABASE_URL_TEST points at a populated DB; refusing to "
+                f"DROP tables that hold data ({details}). Point "
+                "DATABASE_URL_TEST at a clean PG before running this suite."
+            )
         await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
         await conn.execute("CREATE SCHEMA entity")
         await conn.execute("""

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -44,10 +44,32 @@ async def set_up_schemas(pg_pool):
     Mirrors ``tests/integration/test_bulk_resolve_libraries.py`` for the
     entity side, then adds the discogs-cache children. The composer
     queries ``artist``, ``artist_alias``, ``artist_name_variation``,
-    ``artist_member``, ``artist_url`` in the default (public) schema —
-    same shape as the production discogs-cache.
+    ``artist_member`` in the default (public) schema — same shape as
+    the production discogs-cache.
+
+    SAFETY: this fixture DROPs the public-schema `artist` (and child)
+    tables. The default ``DATABASE_URL_TEST`` (``postgresql://discogs:
+    discogs@localhost:5433/discogs``) points at the developer's local
+    discogs-cache. If that cache is populated (a real discogs-cache
+    rebuild produces tens of GB and takes hours), wiping it is
+    catastrophic. We refuse to run when public.artist has any rows, so
+    the operator must point ``DATABASE_URL_TEST`` at a clean DB before
+    these tests will execute.
     """
     async with pg_pool.acquire() as conn:
+        artist_exists = await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = 'artist')"
+        )
+        if artist_exists:
+            existing_rows = await conn.fetchval("SELECT COUNT(*) FROM artist")
+            if existing_rows and existing_rows > 0:
+                pytest.skip(
+                    f"DATABASE_URL_TEST points at a populated discogs-cache "
+                    f"({existing_rows} rows in `public.artist`). Refusing to "
+                    "DROP and recreate the cache tables — point "
+                    "DATABASE_URL_TEST at a clean PG before running this suite."
+                )
         await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
         await conn.execute("CREATE SCHEMA entity")
         await conn.execute("""

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -351,3 +351,35 @@ class TestSearchAliasesBulkEndpoint:
             "discogs_alias",
             "discogs_member",
         }
+
+    @pytest.mark.asyncio
+    async def test_case_variant_pair_both_resolve_against_real_pg(self, app_client):
+        """Two case-variant inputs of the same stored row both resolve through real PG.
+
+        End-to-end coverage for the leg-2 `DISTINCT ON (bind.name)` SQL.
+        Pre-iteration-2, the SQL used `DISTINCT ON (LOWER(bind.name))`,
+        which collapsed `['STEREOLAB', 'stereolab']` (both LOWER-match
+        'stereolab') into one returned row — one input silently
+        dropped to `missing[]`. The unit test exercises the Python-side
+        mapping via mocks; this test exercises the actual PG behavior so
+        a future regression of the SQL is caught here.
+        """
+        resp = await app_client.post(
+            "/api/v1/artists/search-aliases/bulk",
+            json={"names": ["STEREOLAB", "stereolab"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Both case-variant inputs resolve — neither falls into `missing[]`.
+        assert data["missing"] == []
+        # One ArtistSearchAliasesResult per unique input, both resolving
+        # to the same stored 'Stereolab' identity.
+        names_in_result = {a["name"] for a in data["artists"]}
+        assert names_in_result == {"STEREOLAB", "stereolab"}
+        # Both inputs share the same resolved discogs sources.
+        for entry in data["artists"]:
+            assert set(entry["sources_present"]) == {
+                "discogs_name_variation",
+                "discogs_alias",
+                "discogs_member",
+            }

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -1,0 +1,308 @@
+"""Integration tests for `POST /api/v1/artists/search-aliases/bulk`.
+
+Real PostgreSQL via ``DATABASE_URL_TEST``. Seeds ``entity.identity`` plus
+the five discogs-cache child tables (``artist``, ``artist_alias``,
+``artist_name_variation``, ``artist_member``, ``artist_url``) inside a
+fresh schema, then exercises the endpoint end-to-end through the FastAPI
+ASGI client. Composer internals are covered in
+``tests/unit/test_artist_search_aliases_composer.py``; this tier confirms
+the FastAPI wiring + PG round-trip is intact and the bearer-auth posture
+matches sibling endpoints.
+
+Run with: ``pytest -m pg -v``
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def pg_pool():
+    try:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+    yield pool
+    await pool.close()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_schemas(pg_pool):
+    """Drop + create the entity schema and the discogs cache tables.
+
+    Mirrors ``tests/integration/test_bulk_resolve_libraries.py`` for the
+    entity side, then adds the discogs-cache children. The composer
+    queries ``artist``, ``artist_alias``, ``artist_name_variation``,
+    ``artist_member``, ``artist_url`` in the default (public) schema —
+    same shape as the production discogs-cache.
+    """
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        await conn.execute("CREATE SCHEMA entity")
+        await conn.execute("""
+            CREATE TABLE entity.identity (
+                id SERIAL PRIMARY KEY,
+                library_name TEXT NOT NULL UNIQUE,
+                discogs_artist_id INTEGER,
+                wikidata_qid TEXT,
+                musicbrainz_artist_id TEXT,
+                spotify_artist_id TEXT,
+                apple_music_artist_id TEXT,
+                bandcamp_id TEXT,
+                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """)
+        # Discogs cache child tables. Drop first so prior runs don't poison
+        # them — these live in the public schema in test as in prod.
+        await conn.execute("DROP TABLE IF EXISTS artist_alias CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist_name_variation CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist_member CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist_url CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist CASCADE")
+        await conn.execute("""
+            CREATE TABLE artist (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                profile TEXT,
+                image_url TEXT,
+                fetched_at TIMESTAMPTZ
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_alias (
+                artist_id INTEGER NOT NULL REFERENCES artist(id),
+                alias_id INTEGER,
+                alias_name TEXT NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_name_variation (
+                artist_id INTEGER NOT NULL REFERENCES artist(id),
+                name TEXT NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_member (
+                artist_id INTEGER NOT NULL REFERENCES artist(id),
+                member_id INTEGER,
+                member_name TEXT NOT NULL,
+                active BOOLEAN
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_url (
+                artist_id INTEGER NOT NULL REFERENCES artist(id),
+                url TEXT NOT NULL
+            )
+        """)
+
+        # Seed entity.identity rows.
+        await conn.execute(
+            """
+            INSERT INTO entity.identity (library_name, discogs_artist_id)
+            VALUES
+                ('Stereolab', 2154),
+                ('Juana Molina', 305253),
+                ('Cat Power', NULL)
+            """
+        )
+
+        # Seed discogs cache: Stereolab gets one entry in each child table so
+        # we can assert source-tagging end-to-end. Juana Molina is in the
+        # ``artist`` table but has no children (the "ran the leg, found
+        # nothing" case). 305253 IS in artist so cache lookup hits; we just
+        # leave the child tables empty for that row.
+        await conn.execute(
+            """
+            INSERT INTO artist (id, name, profile, image_url)
+            VALUES
+                (2154, 'Stereolab', NULL, NULL),
+                (305253, 'Juana Molina', NULL, NULL)
+            """
+        )
+        await conn.execute(
+            "INSERT INTO artist_alias (artist_id, alias_id, alias_name) "
+            "VALUES (2154, 999, 'Monade')"
+        )
+        await conn.execute(
+            "INSERT INTO artist_name_variation (artist_id, name) VALUES (2154, 'The Stereolab')"
+        )
+        await conn.execute(
+            "INSERT INTO artist_member (artist_id, member_id, member_name, active) "
+            "VALUES (2154, 200, 'Laetitia Sadier', TRUE)"
+        )
+
+    yield
+
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist_alias CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist_name_variation CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist_member CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist_url CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist CASCADE")
+
+
+@pytest_asyncio.fixture
+async def app_client(monkeypatch):
+    """ASGI client with the LML app pointed at the test PG, auth off."""
+    from httpx import ASGITransport, AsyncClient
+
+    import core.dependencies as core_deps
+    import identity.dependencies as deps
+    from config.settings import get_settings
+
+    monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
+    # Test posture mirrors `test_bulk_resolve_libraries.py`: leave
+    # `LML_REQUIRE_AUTH` off so we can assert the happy-path responses
+    # without provisioning a bearer. Auth enforcement is covered in
+    # `tests/unit/test_auth.py`.
+    monkeypatch.setenv("LML_REQUIRE_AUTH", "false")
+    get_settings.cache_clear()
+    deps._entity_store = None
+    deps._entity_probe_failed = False
+    await core_deps.close_discogs_pool()
+    await core_deps.close_discogs_service()
+
+    from main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+    deps._entity_store = None
+    deps._entity_probe_failed = False
+    await core_deps.close_discogs_pool()
+    await core_deps.close_discogs_service()
+    get_settings.cache_clear()
+
+
+@pytest.mark.pg
+class TestSearchAliasesBulkEndpoint:
+    @pytest.mark.asyncio
+    async def test_round_trip_emits_all_three_discogs_source_variants(self, app_client):
+        """Stereolab returns one variant per source type and all three tags."""
+        resp = await app_client.post(
+            "/api/v1/artists/search-aliases/bulk",
+            json={"names": ["Stereolab"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["missing"] == []
+        assert len(data["artists"]) == 1
+        result = data["artists"][0]
+        assert result["name"] == "Stereolab"
+        variants_by_source = {v["source"]: v for v in result["variants"]}
+        assert set(variants_by_source.keys()) == {
+            "discogs_name_variation",
+            "discogs_alias",
+            "discogs_member",
+        }
+        assert variants_by_source["discogs_name_variation"]["variant"] == "The Stereolab"
+        assert variants_by_source["discogs_alias"]["variant"] == "Monade"
+        assert variants_by_source["discogs_member"]["variant"] == "Laetitia Sadier"
+        # Tagged sources for reconcile scoping.
+        assert set(result["sources_present"]) == {
+            "discogs_name_variation",
+            "discogs_alias",
+            "discogs_member",
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_routed_to_missing_array(self, app_client):
+        """Names without an ``entity.identity`` row → in ``missing[]``, not ``artists[]``."""
+        resp = await app_client.post(
+            "/api/v1/artists/search-aliases/bulk",
+            json={"names": ["Stereolab", "Nobody Knows"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        names_in_artists = {a["name"] for a in data["artists"]}
+        assert "Stereolab" in names_in_artists
+        assert "Nobody Knows" not in names_in_artists
+        assert data["missing"] == ["Nobody Knows"]
+
+    @pytest.mark.asyncio
+    async def test_identity_without_discogs_id_yields_empty_sources_present(self, app_client):
+        """Cat Power has NULL ``discogs_artist_id`` → empty variants AND empty sources_present.
+
+        Reconcile contract: consumer must NOT delete cached rows for this
+        artist because the composer never ran any source leg.
+        """
+        resp = await app_client.post(
+            "/api/v1/artists/search-aliases/bulk",
+            json={"names": ["Cat Power"]},
+        )
+        assert resp.status_code == 200
+        result = resp.json()["artists"][0]
+        assert result["variants"] == []
+        assert result["sources_present"] == []
+
+    @pytest.mark.asyncio
+    async def test_discogs_cache_miss_keeps_sources_present_populated(self, app_client):
+        """Juana Molina has a Discogs id but no children in the cache.
+
+        Composer ran the leg but found nothing — variants empty, but
+        sources_present must list all three discogs_* tags. Consumer needs
+        this to scope DELETE during reconcile.
+        """
+        resp = await app_client.post(
+            "/api/v1/artists/search-aliases/bulk",
+            json={"names": ["Juana Molina"]},
+        )
+        assert resp.status_code == 200
+        result = resp.json()["artists"][0]
+        assert result["variants"] == []
+        assert set(result["sources_present"]) == {
+            "discogs_name_variation",
+            "discogs_alias",
+            "discogs_member",
+        }
+
+    @pytest.mark.asyncio
+    async def test_413_for_oversized_request(self, app_client):
+        """1001 names → 413 before any DB work."""
+        oversized = [f"Artist_{i}" for i in range(1001)]
+        resp = await app_client.post(
+            "/api/v1/artists/search-aliases/bulk",
+            json={"names": oversized},
+        )
+        assert resp.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_case_drift_resolves_via_lower_fall_through(self, app_client):
+        """Backend posts lowercase, storage is mixed-case → leg 2 resolves it.
+
+        Mirrors the #276 fall-through contract: stored row ``'Stereolab'``,
+        posted name ``'stereolab'`` — the composer's bulk variant of
+        ``resolve_library_name`` finds the row via LOWER fall-through.
+        """
+        resp = await app_client.post(
+            "/api/v1/artists/search-aliases/bulk",
+            json={"names": ["stereolab"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["missing"] == []
+        result = data["artists"][0]
+        # The returned ``name`` echoes the input, not the stored shape.
+        assert result["name"] == "stereolab"
+        # The discogs leg still fires and tags itself, because the resolved
+        # identity row carries discogs_artist_id=2154.
+        assert set(result["sources_present"]) == {
+            "discogs_name_variation",
+            "discogs_alias",
+            "discogs_member",
+        }

--- a/tests/unit/test_artist_search_aliases_composer.py
+++ b/tests/unit/test_artist_search_aliases_composer.py
@@ -1,0 +1,255 @@
+"""Unit tests for `artists/composer.py` — the artist-search-alias composer.
+
+Two-phase batched compose:
+
+- Phase 1: ``EntityStore.bulk_resolve_library_names(names)`` — one async
+  call per batch.
+- Phase 2: ``DiscogsCacheService.get_artist_details_bulk(artist_ids)``
+  — one async call per batch, restricted to the set of identities that
+  carry a Discogs id.
+
+Reconcile contract: ``sources_present`` is the list of sources the
+composer **queried**, independent of whether each source returned any
+variants. Consumers (BS's artist-search-alias-consumer) use this to scope
+DELETE — they must NOT delete cached rows whose source is missing from
+``sources_present``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.models import ArtistDetails, ArtistRef, MemberRef
+from entity.store import Identity
+from generated.api_models import (
+    ArtistSearchAliasSource,
+)
+
+
+def _identity(library_name: str, *, id: int = 1, discogs_artist_id: int | None = None) -> Identity:
+    return Identity(
+        id=id,
+        library_name=library_name,
+        discogs_artist_id=discogs_artist_id,
+        wikidata_qid=None,
+        musicbrainz_artist_id=None,
+        spotify_artist_id=None,
+        apple_music_artist_id=None,
+        bandcamp_id=None,
+        reconciliation_status="reconciled",
+    )
+
+
+@pytest.fixture
+def entity_store():
+    """Mocked EntityStore with the new ``bulk_resolve_library_names`` shape."""
+    store = AsyncMock()
+    store.bulk_resolve_library_names = AsyncMock(return_value={})
+    return store
+
+
+@pytest.fixture
+def cache_service():
+    """Mocked DiscogsCacheService with the new ``get_artist_details_bulk`` shape."""
+    cache = AsyncMock()
+    cache.get_artist_details_bulk = AsyncMock(return_value={})
+    return cache
+
+
+@pytest.fixture
+def composer(entity_store, cache_service):
+    from artists.composer import ArtistSearchAliasesComposer
+
+    return ArtistSearchAliasesComposer(entity_store=entity_store, discogs_cache=cache_service)
+
+
+class TestComposeBasicShape:
+    @pytest.mark.asyncio
+    async def test_no_identity_match_goes_to_missing(self, composer, entity_store):
+        """Names with no identity row → in ``missing[]``, absent from ``artists[]``."""
+        entity_store.bulk_resolve_library_names = AsyncMock(return_value={})
+        response = await composer.compose(["Nobody Knows"])
+        assert response.missing == ["Nobody Knows"]
+        assert response.artists == []
+
+    @pytest.mark.asyncio
+    async def test_identity_without_discogs_id_yields_empty_sources_present(
+        self, composer, entity_store, cache_service
+    ):
+        """Resolved identity with no ``discogs_artist_id`` → composer never enters the
+        Discogs leg. Per the reconcile contract, ``sources_present`` is empty.
+        """
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Stereolab": _identity("Stereolab", id=1, discogs_artist_id=None)}
+        )
+        response = await composer.compose(["Stereolab"])
+        assert response.missing == []
+        assert len(response.artists) == 1
+        result = response.artists[0]
+        assert result.name == "Stereolab"
+        assert result.variants == []
+        # Empty sources_present is the load-bearing signal: consumer must NOT
+        # delete previously-cached discogs_* rows for this artist.
+        assert result.sources_present == []
+        # Discogs cache was never queried.
+        cache_service.get_artist_details_bulk.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_identity_with_discogs_id_but_cache_miss_keeps_sources_present(
+        self, composer, entity_store, cache_service
+    ):
+        """Identity has a ``discogs_artist_id`` but the discogs-cache has no row.
+
+        Per the reconcile contract, ``sources_present`` MUST list the three
+        Discogs sources because the composer ran the leg — even though no
+        variants came back. Consumer uses this to scope DELETE.
+        """
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Stereolab": _identity("Stereolab", id=1, discogs_artist_id=2154)}
+        )
+        cache_service.get_artist_details_bulk = AsyncMock(return_value={})  # cache miss
+        response = await composer.compose(["Stereolab"])
+        assert len(response.artists) == 1
+        result = response.artists[0]
+        assert result.variants == []
+        assert set(result.sources_present) == {
+            ArtistSearchAliasSource.discogs_name_variation,
+            ArtistSearchAliasSource.discogs_alias,
+            ArtistSearchAliasSource.discogs_member,
+        }
+
+
+class TestComposeVariants:
+    @pytest.mark.asyncio
+    async def test_emits_one_variant_per_source_type(self, composer, entity_store, cache_service):
+        """Stereolab with one entry in each of name_variation, alias, and member."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Stereolab": _identity("Stereolab", id=1, discogs_artist_id=2154)}
+        )
+        cache_service.get_artist_details_bulk = AsyncMock(
+            return_value={
+                2154: ArtistDetails(
+                    artist_id=2154,
+                    name="Stereolab",
+                    name_variations=["The Stereolab"],
+                    aliases=[ArtistRef(id=999, name="Monade")],
+                    members=[MemberRef(id=200, name="Laetitia Sadier", active=True)],
+                )
+            }
+        )
+        response = await composer.compose(["Stereolab"])
+        result = response.artists[0]
+        # One per source type — order not asserted because the api.yaml
+        # contract doesn't pin it.
+        sources_in_variants = [v.source for v in result.variants]
+        assert ArtistSearchAliasSource.discogs_name_variation in sources_in_variants
+        assert ArtistSearchAliasSource.discogs_alias in sources_in_variants
+        assert ArtistSearchAliasSource.discogs_member in sources_in_variants
+
+        by_source = {v.source: v for v in result.variants}
+        assert by_source[ArtistSearchAliasSource.discogs_name_variation].variant == "The Stereolab"
+        assert by_source[ArtistSearchAliasSource.discogs_alias].variant == "Monade"
+        # Alias carries the related artist's namespaced id and name.
+        assert by_source[ArtistSearchAliasSource.discogs_alias].related_external_id == (
+            "discogs:artist:999"
+        )
+        assert by_source[ArtistSearchAliasSource.discogs_alias].related_name == "Monade"
+
+        assert by_source[ArtistSearchAliasSource.discogs_member].variant == "Laetitia Sadier"
+        # Member carries `active` (None for non-member kinds).
+        assert by_source[ArtistSearchAliasSource.discogs_member].active is True
+        # Member's `related_*` carry the member-id namespaced ref.
+        assert by_source[ArtistSearchAliasSource.discogs_member].related_external_id == (
+            "discogs:artist:200"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sources_present_lists_all_three_when_discogs_leg_ran(
+        self, composer, entity_store, cache_service
+    ):
+        """The three Discogs source tags fire together — they share one fetch leg."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Stereolab": _identity("Stereolab", id=1, discogs_artist_id=2154)}
+        )
+        cache_service.get_artist_details_bulk = AsyncMock(
+            return_value={
+                2154: ArtistDetails(
+                    artist_id=2154,
+                    name="Stereolab",
+                    name_variations=["The Stereolab"],
+                    aliases=[],  # alias and member absent at the row level
+                    members=[],
+                )
+            }
+        )
+        response = await composer.compose(["Stereolab"])
+        # Even though aliases / members rows are empty, the composer ran the
+        # leg, so all three discogs_* sources must appear in sources_present.
+        assert set(response.artists[0].sources_present) == {
+            ArtistSearchAliasSource.discogs_name_variation,
+            ArtistSearchAliasSource.discogs_alias,
+            ArtistSearchAliasSource.discogs_member,
+        }
+
+
+class TestComposeCostContract:
+    """Locks the "no per-name fan-out" guarantee from LML#370/#372."""
+
+    @pytest.mark.asyncio
+    async def test_bulk_methods_called_exactly_once_per_batch(
+        self, composer, entity_store, cache_service
+    ):
+        """Two-phase compose calls each bulk method at most once.
+
+        This is the regression test against an accidental per-name loop —
+        the cascade-cascade pattern from LML#370/#372 would compound on top
+        of asyncio.gather and saturate the discogs-cache.
+        """
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={
+                "Stereolab": _identity("Stereolab", id=1, discogs_artist_id=2154),
+                "Juana Molina": _identity("Juana Molina", id=2, discogs_artist_id=305253),
+            }
+        )
+        cache_service.get_artist_details_bulk = AsyncMock(
+            return_value={
+                2154: ArtistDetails(artist_id=2154, name="Stereolab"),
+                305253: ArtistDetails(artist_id=305253, name="Juana Molina"),
+            }
+        )
+        await composer.compose(["Stereolab", "Juana Molina"])
+        entity_store.bulk_resolve_library_names.assert_awaited_once()
+        cache_service.get_artist_details_bulk.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_phase_2_skipped_when_no_identity_carries_discogs_id(
+        self, composer, entity_store, cache_service
+    ):
+        """If no resolved identity has a ``discogs_artist_id``, skip Phase 2 entirely."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={
+                "Stereolab": _identity("Stereolab", id=1, discogs_artist_id=None),
+            }
+        )
+        await composer.compose(["Stereolab"])
+        cache_service.get_artist_details_bulk.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_phase_2_receives_deduped_artist_ids(self, composer, entity_store, cache_service):
+        """Two input names that resolve to the same identity → one Discogs id passed."""
+        identity = _identity("Stereolab", id=1, discogs_artist_id=2154)
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={
+                "Stereolab": identity,
+                "stereolab": identity,
+            }
+        )
+        cache_service.get_artist_details_bulk = AsyncMock(
+            return_value={2154: ArtistDetails(artist_id=2154, name="Stereolab")}
+        )
+        await composer.compose(["Stereolab", "stereolab"])
+        # Phase 2 sees the deduped artist-id set.
+        passed_ids = cache_service.get_artist_details_bulk.await_args[0][0]
+        assert set(passed_ids) == {2154}

--- a/tests/unit/test_artist_search_aliases_router.py
+++ b/tests/unit/test_artist_search_aliases_router.py
@@ -169,20 +169,19 @@ class TestErrorClassRouting:
 class TestInputCapGuard:
     """Drift guard between the manual 413 gate and the api.yaml cap."""
 
-    def test_input_cap_resolves_from_pydantic_model_metadata(self):
-        """`_resolve_input_cap()` reads max_length from the generated model.
+    def test_input_cap_resolves_from_model_json_schema(self):
+        """`_resolve_input_cap()` reads `maxItems` from the model's JSON schema.
 
         If api.yaml's `maxItems` for `names` ever changes, codegen
-        updates the Pydantic model's `max_length` and the route's
-        413 gate must follow automatically. This pins that mechanism.
+        updates the Pydantic model's constraint and the route's 413
+        gate must follow automatically. This pins that mechanism via
+        the same JSON-schema export the route uses (Pydantic's
+        documented public API).
         """
-        max_lengths = [
-            m.max_length
-            for m in ArtistSearchAliasesBulkRequest.model_fields["names"].metadata
-            if hasattr(m, "max_length")
-        ]
-        # max_length is sourced from the model; gate uses the same.
-        assert max_lengths and max_lengths[0] == _BULK_INPUT_CAP
+        schema = ArtistSearchAliasesBulkRequest.model_json_schema()
+        max_items = schema["properties"]["names"]["maxItems"]
+        # The gate uses the same source.
+        assert max_items == _BULK_INPUT_CAP
 
     @pytest.mark.asyncio
     async def test_413_when_over_input_cap(self, app_client, mock_entity_store):

--- a/tests/unit/test_artist_search_aliases_router.py
+++ b/tests/unit/test_artist_search_aliases_router.py
@@ -1,0 +1,346 @@
+"""Unit tests for `POST /api/v1/artists/search-aliases/bulk` router.
+
+Exercises the FastAPI endpoint with mocked dependencies. Composer
+internals are covered separately in
+``test_artist_search_aliases_composer.py``; this file focuses on the
+HTTP envelope: error-class routing, span instrumentation, drift
+guards, and the 4xx/5xx contract surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from artists.router import _BULK_INPUT_CAP
+from discogs.cache_service import CacheUnavailableError
+from generated.api_models import ArtistSearchAliasesBulkRequest
+from tests.unit.conftest import override_deps
+
+
+@pytest.fixture
+def mock_entity_store():
+    store = AsyncMock()
+    store.bulk_resolve_library_names = AsyncMock(return_value={})
+    return store
+
+
+@pytest.fixture
+def mock_discogs_cache():
+    cache = AsyncMock()
+    cache.get_artist_details_bulk = AsyncMock(return_value={})
+    return cache
+
+
+@pytest.fixture
+def app_client(mock_settings, mock_entity_store, mock_discogs_cache):
+    from config.settings import get_settings
+    from core.dependencies import (
+        get_discogs_cache_service_from_pool,
+        get_discogs_service,
+        get_library_db,
+        get_posthog_client,
+    )
+    from identity.dependencies import get_entity_store
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: None,
+            get_posthog_client: None,
+            get_settings: mock_settings,
+            get_entity_store: mock_entity_store,
+            get_discogs_cache_service_from_pool: mock_discogs_cache,
+        },
+    ):
+        yield app
+
+
+class TestErrorClassRouting:
+    """Each exception class lands on the right status code + detail."""
+
+    @pytest.mark.asyncio
+    async def test_cache_unavailable_returns_503_with_cache_detail(
+        self, app_client, mock_entity_store, mock_discogs_cache
+    ):
+        """`CacheUnavailableError` from Phase 2 → 503 with the cache-specific detail.
+
+        Pre-fix: the route caught only (PostgresError, OSError), so a
+        cache outage produced 500 instead of 503. Pin both the status
+        code AND the detail string so on-call sees which subsystem
+        failed.
+        """
+        from entity.store import Identity
+
+        mock_entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={
+                "Stereolab": Identity(
+                    id=1,
+                    library_name="Stereolab",
+                    discogs_artist_id=2154,
+                    wikidata_qid=None,
+                    musicbrainz_artist_id=None,
+                    spotify_artist_id=None,
+                    apple_music_artist_id=None,
+                    bandcamp_id=None,
+                    reconciliation_status="reconciled",
+                ),
+            }
+        )
+        mock_discogs_cache.get_artist_details_bulk = AsyncMock(
+            side_effect=CacheUnavailableError("PG pool exhausted")
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/artists/search-aliases/bulk", json={"names": ["Stereolab"]}
+            )
+
+        assert resp.status_code == 503
+        assert "Discogs cache" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_entity_store_pg_failure_returns_503_with_entity_detail(
+        self, app_client, mock_entity_store
+    ):
+        """Phase 1 raw `PostgresError` → 503 with entity-store detail."""
+        from asyncpg.exceptions import PostgresError
+
+        mock_entity_store.bulk_resolve_library_names = AsyncMock(
+            side_effect=PostgresError("connection reset")
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/artists/search-aliases/bulk", json={"names": ["Stereolab"]}
+            )
+
+        assert resp.status_code == 503
+        assert "Entity store" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_logs_abort_and_propagates(
+        self, app_client, mock_entity_store, caplog
+    ):
+        """`asyncio.CancelledError` produces the abort log line and propagates.
+
+        F3 fix: when the client disconnects mid-compose, the route logs
+        a WARNING (`artist-search-alias bulk aborted by client`) so the
+        Sentry/Railway audit trail surfaces aborts, then re-raises the
+        CancelledError (per the asyncio cancellation contract — the
+        client is gone, no HTTPException to send). Starlette converts
+        the propagated CancelledError into a 'No response returned'
+        RuntimeError at the ASGI boundary; both forms are evidence the
+        handler took the right branch.
+        """
+        import logging
+
+        mock_entity_store.bulk_resolve_library_names = AsyncMock(
+            side_effect=asyncio.CancelledError()
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            with caplog.at_level(logging.WARNING, logger="artists.router"):
+                with pytest.raises((asyncio.CancelledError, RuntimeError)):
+                    await ac.post(
+                        "/api/v1/artists/search-aliases/bulk",
+                        json={"names": ["Stereolab"]},
+                    )
+
+        abort_logs = [
+            r
+            for r in caplog.records
+            if "aborted by client" in r.getMessage() and r.levelno == logging.WARNING
+        ]
+        assert abort_logs, "Expected WARNING `... aborted by client` log line"
+
+
+class TestInputCapGuard:
+    """Drift guard between the manual 413 gate and the api.yaml cap."""
+
+    def test_input_cap_resolves_from_pydantic_model_metadata(self):
+        """`_resolve_input_cap()` reads max_length from the generated model.
+
+        If api.yaml's `maxItems` for `names` ever changes, codegen
+        updates the Pydantic model's `max_length` and the route's
+        413 gate must follow automatically. This pins that mechanism.
+        """
+        max_lengths = [
+            m.max_length
+            for m in ArtistSearchAliasesBulkRequest.model_fields["names"].metadata
+            if hasattr(m, "max_length")
+        ]
+        # max_length is sourced from the model; gate uses the same.
+        assert max_lengths and max_lengths[0] == _BULK_INPUT_CAP
+
+    @pytest.mark.asyncio
+    async def test_413_when_over_input_cap(self, app_client, mock_entity_store):
+        """Over-cap names → 413, not 422 (per api.yaml contract)."""
+        oversized = {"names": [f"Artist_{i}" for i in range(_BULK_INPUT_CAP + 1)]}
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/api/v1/artists/search-aliases/bulk", json=oversized)
+
+        assert resp.status_code == 413
+        # Cap-check fires before any DB work.
+        mock_entity_store.bulk_resolve_library_names.assert_not_awaited()
+
+
+class TestBodyParse:
+    """JSON body shape errors land on 400/422 rather than 500."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_400(self, app_client, mock_entity_store):
+        """Non-JSON body → 400."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/artists/search-aliases/bulk",
+                content=b"not json {",
+                headers={"Content-Type": "application/json"},
+            )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_names_not_a_list_returns_422(self, app_client, mock_entity_store):
+        """`names` of wrong type → 422."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/artists/search-aliases/bulk", json={"names": "not a list"}
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_missing_names_returns_422(self, app_client, mock_entity_store):
+        """No `names` key → 422."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/api/v1/artists/search-aliases/bulk", json={})
+        assert resp.status_code == 422
+
+
+class TestServiceUnavailable:
+    """503 paths when DI deps resolve to None."""
+
+    @pytest.mark.asyncio
+    async def test_503_when_entity_store_none(self, mock_settings, mock_discogs_cache):
+        from config.settings import get_settings
+        from core.dependencies import (
+            get_discogs_cache_service_from_pool,
+            get_discogs_service,
+            get_library_db,
+            get_posthog_client,
+        )
+        from identity.dependencies import get_entity_store
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+                get_entity_store: None,
+                get_discogs_cache_service_from_pool: mock_discogs_cache,
+            },
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                resp = await ac.post(
+                    "/api/v1/artists/search-aliases/bulk", json={"names": ["Stereolab"]}
+                )
+
+        assert resp.status_code == 503
+        assert "Entity store" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_503_when_discogs_cache_none(self, mock_settings, mock_entity_store):
+        from config.settings import get_settings
+        from core.dependencies import (
+            get_discogs_cache_service_from_pool,
+            get_discogs_service,
+            get_library_db,
+            get_posthog_client,
+        )
+        from identity.dependencies import get_entity_store
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+                get_entity_store: mock_entity_store,
+                get_discogs_cache_service_from_pool: None,
+            },
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                resp = await ac.post(
+                    "/api/v1/artists/search-aliases/bulk", json={"names": ["Stereolab"]}
+                )
+
+        assert resp.status_code == 503
+        assert "Discogs cache" in resp.json()["detail"]
+
+
+class TestDuplicateInputDedup:
+    """Duplicate input names produce one result entry, not fan-out."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_inputs_deduped(
+        self, app_client, mock_entity_store, mock_discogs_cache
+    ):
+        """names=['Stereolab', 'Stereolab', 'Stereolab'] → one ArtistSearchAliasesResult."""
+        from entity.store import Identity
+
+        mock_entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={
+                "Stereolab": Identity(
+                    id=1,
+                    library_name="Stereolab",
+                    discogs_artist_id=None,
+                    wikidata_qid=None,
+                    musicbrainz_artist_id=None,
+                    spotify_artist_id=None,
+                    apple_music_artist_id=None,
+                    bandcamp_id=None,
+                    reconciliation_status="reconciled",
+                ),
+            }
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/artists/search-aliases/bulk",
+                json={"names": ["Stereolab", "Stereolab", "Stereolab"]},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        # First-occurrence dedup: one result, the unique-names bundle is what Phase 1 saw.
+        assert len(data["artists"]) == 1
+        assert data["artists"][0]["name"] == "Stereolab"
+        # Phase 1 received the deduped list.
+        passed_names = mock_entity_store.bulk_resolve_library_names.await_args[0][0]
+        assert passed_names == ["Stereolab"]

--- a/tests/unit/test_discogs_cache_get_artist_details_bulk.py
+++ b/tests/unit/test_discogs_cache_get_artist_details_bulk.py
@@ -5,9 +5,10 @@ artist-search-alias plan PR 2 composer.
 
 Contract:
 
-- 5 PG round-trips per call (one per child table: ``artist``,
-  ``artist_alias``, ``artist_name_variation``, ``artist_member``,
-  ``artist_url``), each ``WHERE artist_id = ANY($1::int[])``.
+- 4 PG round-trips per call (one per table consulted: ``artist``,
+  ``artist_alias``, ``artist_name_variation``, ``artist_member``),
+  each ``WHERE artist_id = ANY($1::int[])``. ``artist_url`` is NOT
+  queried — the composer doesn't read ``details.urls``.
 - Returns ``dict[int, ArtistDetails]`` keyed by discogs artist id.
 - Cache-miss artist ids are absent from the returned dict (never
   None-valued).
@@ -113,15 +114,26 @@ class TestGetArtistDetailsBulk:
         assert 99999 not in result
 
     @pytest.mark.asyncio
-    async def test_exactly_five_pg_round_trips(self, cache_service, mock_asyncpg_pool):
-        """The bulk read is 5 PG calls regardless of input cardinality.
+    async def test_exactly_four_pg_round_trips(self, cache_service, mock_asyncpg_pool):
+        """The bulk read is 4 PG calls regardless of input cardinality.
 
-        Pins the cost contract from the plan: a 1000-id batch is 5 round-
-        trips, not 5000.
+        Pins the cost contract: a 1000-id batch is 4 round-trips, not
+        5000. `artist_url` is intentionally NOT queried — the artist-
+        search-alias composer never reads `details.urls`, so the bulk
+        method skips that fetch.
         """
         mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
         await cache_service.get_artist_details_bulk(list(range(100)))
-        assert mock_asyncpg_pool.fetch.await_count == 5
+        assert mock_asyncpg_pool.fetch.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_artist_url_table_not_queried(self, cache_service, mock_asyncpg_pool):
+        """artist_url is not in the gather; bulk variant skips it deliberately."""
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.get_artist_details_bulk([2154])
+        all_sql = [call[0][0] for call in mock_asyncpg_pool.fetch.await_args_list]
+        # No fetch over artist_url.
+        assert not any("FROM artist_url" in sql for sql in all_sql)
 
     @pytest.mark.asyncio
     async def test_input_order_does_not_affect_output_contents(

--- a/tests/unit/test_discogs_cache_get_artist_details_bulk.py
+++ b/tests/unit/test_discogs_cache_get_artist_details_bulk.py
@@ -76,7 +76,6 @@ class TestGetArtistDetailsBulk:
                         {"artist_id": 305253, "name": "J. Molina"},
                     ],
                     "artist_member": [],
-                    "artist_url": [],
                 }
             )
         )
@@ -105,7 +104,6 @@ class TestGetArtistDetailsBulk:
                     "artist_alias": [],
                     "artist_name_variation": [],
                     "artist_member": [],
-                    "artist_url": [],
                 }
             )
         )
@@ -151,7 +149,6 @@ class TestGetArtistDetailsBulk:
                     "artist_alias": [],
                     "artist_name_variation": [],
                     "artist_member": [],
-                    "artist_url": [],
                 }
             )
         )
@@ -164,7 +161,6 @@ class TestGetArtistDetailsBulk:
                     "artist_alias": [],
                     "artist_name_variation": [],
                     "artist_member": [],
-                    "artist_url": [],
                 }
             )
         )

--- a/tests/unit/test_discogs_cache_get_artist_details_bulk.py
+++ b/tests/unit/test_discogs_cache_get_artist_details_bulk.py
@@ -1,0 +1,182 @@
+"""Unit tests for `DiscogsCacheService.get_artist_details_bulk`.
+
+Batched form of the per-id `get_artist_details` PG read. Phase 2 of the
+artist-search-alias plan PR 2 composer.
+
+Contract:
+
+- 5 PG round-trips per call (one per child table: ``artist``,
+  ``artist_alias``, ``artist_name_variation``, ``artist_member``,
+  ``artist_url``), each ``WHERE artist_id = ANY($1::int[])``.
+- Returns ``dict[int, ArtistDetails]`` keyed by discogs artist id.
+- Cache-miss artist ids are absent from the returned dict (never
+  None-valued).
+- Empty input → empty dict, zero PG round-trips.
+- PG-only — no Discogs API escalation, no rate-limit semaphore acquire.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.cache_service import DiscogsCacheService
+
+
+@pytest.fixture
+def cache_service(mock_asyncpg_pool):
+    return DiscogsCacheService(mock_asyncpg_pool)
+
+
+def _make_table_router(**table_results):
+    """Route ``pool.fetch`` calls by table name in the query.
+
+    Same idea as ``tests/unit/test_cache_service.py:make_fetch_router`` but
+    matches table names in WHERE clauses with bulk-binding shapes
+    (``artist_id = ANY(...)``). Longest table name wins so
+    ``artist_name_variation`` beats ``artist``.
+    """
+    sorted_tables = sorted(table_results.keys(), key=len, reverse=True)
+
+    async def route(query, *args):
+        for table_name in sorted_tables:
+            if table_name in query:
+                return table_results[table_name]
+        return []
+
+    return route
+
+
+class TestGetArtistDetailsBulk:
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_dict_without_querying(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """No ids → zero PG round-trips."""
+        result = await cache_service.get_artist_details_bulk([])
+        assert result == {}
+        assert mock_asyncpg_pool.fetch.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_dict_keyed_by_artist_id(self, cache_service, mock_asyncpg_pool):
+        """Two ids in → dict with two ArtistDetails values keyed by id."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=_make_table_router(
+                **{
+                    "FROM artist ": [
+                        {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
+                        {"id": 305253, "name": "Juana Molina", "profile": None, "image_url": None},
+                    ],
+                    "artist_alias": [
+                        {"artist_id": 2154, "alias_id": 500, "alias_name": "Stereolab Variant"},
+                    ],
+                    "artist_name_variation": [
+                        {"artist_id": 305253, "name": "J. Molina"},
+                    ],
+                    "artist_member": [],
+                    "artist_url": [],
+                }
+            )
+        )
+
+        result = await cache_service.get_artist_details_bulk([2154, 305253])
+
+        assert set(result.keys()) == {2154, 305253}
+        assert result[2154].name == "Stereolab"
+        assert result[305253].name == "Juana Molina"
+        # Child rows are routed to the right parent.
+        assert len(result[2154].aliases) == 1
+        assert result[2154].aliases[0].name == "Stereolab Variant"
+        assert result[2154].name_variations == []
+        assert result[305253].aliases == []
+        assert result[305253].name_variations == ["J. Molina"]
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_ids_absent_from_dict(self, cache_service, mock_asyncpg_pool):
+        """Ids not present in ``artist`` table are simply missing from the result."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=_make_table_router(
+                **{
+                    "FROM artist ": [
+                        {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
+                    ],
+                    "artist_alias": [],
+                    "artist_name_variation": [],
+                    "artist_member": [],
+                    "artist_url": [],
+                }
+            )
+        )
+        result = await cache_service.get_artist_details_bulk([2154, 99999])
+        assert 2154 in result
+        assert 99999 not in result
+
+    @pytest.mark.asyncio
+    async def test_exactly_five_pg_round_trips(self, cache_service, mock_asyncpg_pool):
+        """The bulk read is 5 PG calls regardless of input cardinality.
+
+        Pins the cost contract from the plan: a 1000-id batch is 5 round-
+        trips, not 5000.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.get_artist_details_bulk(list(range(100)))
+        assert mock_asyncpg_pool.fetch.await_count == 5
+
+    @pytest.mark.asyncio
+    async def test_input_order_does_not_affect_output_contents(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Same ids in different orders → same dict (set equality + identical values)."""
+        artist_rows = [
+            {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
+            {"id": 305253, "name": "Juana Molina", "profile": None, "image_url": None},
+        ]
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=_make_table_router(
+                **{
+                    "FROM artist ": artist_rows,
+                    "artist_alias": [],
+                    "artist_name_variation": [],
+                    "artist_member": [],
+                    "artist_url": [],
+                }
+            )
+        )
+        result_a = await cache_service.get_artist_details_bulk([2154, 305253])
+
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=_make_table_router(
+                **{
+                    "FROM artist ": artist_rows,
+                    "artist_alias": [],
+                    "artist_name_variation": [],
+                    "artist_member": [],
+                    "artist_url": [],
+                }
+            )
+        )
+        result_b = await cache_service.get_artist_details_bulk([305253, 2154])
+
+        assert set(result_a.keys()) == set(result_b.keys())
+        for artist_id in result_a:
+            assert result_a[artist_id].name == result_b[artist_id].name
+
+    @pytest.mark.asyncio
+    async def test_queries_filter_by_artist_id_any(self, cache_service, mock_asyncpg_pool):
+        """All four child-table queries bind the list via ``ANY($1)``.
+
+        The cost-contract test pins the call count; this one pins the
+        binding shape. If we ever regress to a per-id loop, the binding
+        becomes scalar and this catches it.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.get_artist_details_bulk([2154, 305253])
+
+        # Every fetch call bound exactly one positional arg: the list.
+        for call in mock_asyncpg_pool.fetch.await_args_list:
+            # call.args = (sql, list_arg)
+            assert "ANY(" in call[0][0]
+            bound = call[0][1]
+            assert isinstance(bound, list)
+            assert set(bound) == {2154, 305253}

--- a/tests/unit/test_entity_store_bulk_resolve.py
+++ b/tests/unit/test_entity_store_bulk_resolve.py
@@ -1,0 +1,174 @@
+"""Unit tests for `EntityStore.bulk_resolve_library_names`.
+
+Batched form of the three-leg fall-through (#276): exact / `LOWER()` /
+canonical. Each leg is one `WHERE … = ANY($1::text[])` against the
+still-missing residual, so a 1,000-name batch is 1-3 PG round-trips
+regardless of cardinality (vs. ~1k-3k for the per-name loop). The batch
+is the artist-search-alias plan PR 2's Phase 1.
+
+Returns a dict keyed by the **input** name (not the stored
+`library_name`) so the composer can preserve input order without a
+reverse index.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from entity.store import EntityStore
+
+
+@pytest.fixture
+def mock_pg():
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetchone = AsyncMock(return_value=None)
+    pg.execute = AsyncMock(return_value="OK")
+    return pg
+
+
+@pytest.fixture
+def store(mock_pg):
+    return EntityStore(mock_pg)
+
+
+def _row(library_name: str, **overrides):
+    return {
+        "id": 1,
+        "library_name": library_name,
+        "discogs_artist_id": None,
+        "wikidata_qid": None,
+        "musicbrainz_artist_id": None,
+        "spotify_artist_id": None,
+        "apple_music_artist_id": None,
+        "bandcamp_id": None,
+        "reconciliation_status": "reconciled",
+        **overrides,
+    }
+
+
+class TestBulkResolveLibraryNames:
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_dict_without_querying(self, store, mock_pg):
+        """No names → zero PG round-trips. The composer's miss path stays cheap."""
+        result = await store.bulk_resolve_library_names([])
+        assert result == {}
+        assert mock_pg.fetchall.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_single_leg_when_all_inputs_hit_exact(self, store, mock_pg):
+        """All names resolved on leg 1 → one PG round-trip total."""
+        mock_pg.fetchall = AsyncMock(
+            return_value=[
+                _row("Stereolab", id=1, discogs_artist_id=2154),
+                _row("Juana Molina", id=2, discogs_artist_id=305253),
+            ]
+        )
+        result = await store.bulk_resolve_library_names(["Stereolab", "Juana Molina"])
+        assert mock_pg.fetchall.await_count == 1
+        assert set(result.keys()) == {"Stereolab", "Juana Molina"}
+        assert result["Stereolab"].discogs_artist_id == 2154
+        assert result["Juana Molina"].discogs_artist_id == 305253
+
+    @pytest.mark.asyncio
+    async def test_two_legs_when_some_inputs_drop_to_case_insensitive(self, store, mock_pg):
+        """Leg 1 hits the verbatim row; leg 2 catches a case-drift residual."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                # Leg 1: only the verbatim-cased input hits.
+                [_row("Stereolab", id=1, discogs_artist_id=2154)],
+                # Leg 2: LOWER('stereolab') = LOWER(stored 'Stereolab') hits.
+                [_row("Stereolab", id=1, discogs_artist_id=2154)],
+            ]
+        )
+        # Map of input → stored canonical/lower used by the leg 2 bind. Tests
+        # the contract that the dict is keyed by INPUT name, not stored shape.
+        result = await store.bulk_resolve_library_names(["Stereolab", "stereolab"])
+        assert mock_pg.fetchall.await_count == 2
+        assert set(result.keys()) == {"Stereolab", "stereolab"}
+        assert result["Stereolab"].discogs_artist_id == 2154
+        assert result["stereolab"].discogs_artist_id == 2154
+
+    @pytest.mark.asyncio
+    async def test_three_legs_when_canonical_form_is_needed(self, store, mock_pg):
+        """Diacritic-bearing input falls through to leg 3 (canonical)."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # leg 1: no exact match
+                [],  # leg 2: LOWER both sides still has the diacritic
+                # Leg 3: canonical 'nilufer yanya' matches the stored canonical row.
+                [_row("nilufer yanya", id=7, discogs_artist_id=5499521)],
+            ]
+        )
+        result = await store.bulk_resolve_library_names(["Nilüfer Yanya"])
+        assert mock_pg.fetchall.await_count == 3
+        assert "Nilüfer Yanya" in result
+        assert result["Nilüfer Yanya"].discogs_artist_id == 5499521
+
+    @pytest.mark.asyncio
+    async def test_missing_names_absent_from_dict(self, store, mock_pg):
+        """Names that miss every leg are simply absent — never NULL-valued."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [_row("Stereolab", id=1, discogs_artist_id=2154)],
+                [],
+                [],
+            ]
+        )
+        result = await store.bulk_resolve_library_names(["Stereolab", "Nobody Knows"])
+        assert "Stereolab" in result
+        assert "Nobody Knows" not in result
+
+    @pytest.mark.asyncio
+    async def test_residual_only_passed_to_subsequent_legs(self, store, mock_pg):
+        """Leg 2 must receive only the names leg 1 missed, not the full input.
+
+        This is the bandwidth saver: a 1000-name batch with a 60% leg-1 hit
+        rate sends 400 (not 1000) names to the LOWER leg.
+        """
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [_row("Stereolab", id=1, discogs_artist_id=2154)],
+                [_row("Juana Molina", id=2, discogs_artist_id=305253)],
+                [],
+            ]
+        )
+        await store.bulk_resolve_library_names(["Stereolab", "juana molina"])
+        # The leg-2 bind is the second positional arg to fetchall (after the SQL).
+        leg_2_bind = mock_pg.fetchall.await_args_list[1][0][1]
+        assert "Stereolab" not in leg_2_bind
+        assert "juana molina" in leg_2_bind
+
+    @pytest.mark.asyncio
+    async def test_short_circuits_when_no_residual_after_leg_1(self, store, mock_pg):
+        """No residual after leg 1 → no leg 2 or 3 queries."""
+        mock_pg.fetchall = AsyncMock(
+            return_value=[
+                _row("Stereolab", id=1, discogs_artist_id=2154),
+                _row("Juana Molina", id=2, discogs_artist_id=305253),
+            ]
+        )
+        await store.bulk_resolve_library_names(["Stereolab", "Juana Molina"])
+        assert mock_pg.fetchall.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_dict_keyed_by_input_not_stored_library_name(self, store, mock_pg):
+        """Case-drift input ('stereolab') resolves to stored row ('Stereolab').
+
+        The returned dict's key must be the INPUT shape so the caller can
+        zip its own list of input names against it. If we keyed by stored
+        `library_name` instead, the caller would have to maintain its own
+        reverse map.
+        """
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # leg 1: 'stereolab' verbatim misses
+                [_row("Stereolab", id=1, discogs_artist_id=2154)],  # leg 2: LOWER hits
+            ]
+        )
+        result = await store.bulk_resolve_library_names(["stereolab"])
+        # Keyed by input (lowercase), even though the stored row is mixed-case.
+        assert "stereolab" in result
+        assert "Stereolab" not in result

--- a/tests/unit/test_entity_store_bulk_resolve.py
+++ b/tests/unit/test_entity_store_bulk_resolve.py
@@ -160,6 +160,35 @@ class TestBulkResolveLibraryNames:
         assert mock_pg.fetchall.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_case_variant_inputs_both_resolve_to_same_stored_row(self, store, mock_pg):
+        """Two distinct case-variant inputs that share a LOWER form both resolve.
+
+        Regression for the iteration-2 review finding: `DISTINCT ON
+        (LOWER(bind.name))` would have collapsed `['STEREOLAB',
+        'stereolab']` into one returned row (both LOWER-match
+        'stereolab'), silently dropping one input to `missing[]`.
+        After the fix to `DISTINCT ON (bind.name)`, each distinct bind
+        gets its own row even when binds share a LOWER form.
+        """
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # leg 1: both verbatim inputs miss stored 'Stereolab'.
+                # leg 2: with DISTINCT ON (bind.name), the JOIN produces
+                # one row per distinct bind, both pointing at the same
+                # stored Identity (id=1).
+                [
+                    _leg2_row("STEREOLAB", "Stereolab", id=1, discogs_artist_id=2154),
+                    _leg2_row("stereolab", "Stereolab", id=1, discogs_artist_id=2154),
+                ],
+            ]
+        )
+        result = await store.bulk_resolve_library_names(["STEREOLAB", "stereolab"])
+        # Both case-variant inputs resolve, neither falls to leg 3 or missing[].
+        assert set(result.keys()) == {"STEREOLAB", "stereolab"}
+        assert result["STEREOLAB"].discogs_artist_id == 2154
+        assert result["stereolab"].discogs_artist_id == 2154
+
+    @pytest.mark.asyncio
     async def test_dict_keyed_by_input_not_stored_library_name(self, store, mock_pg):
         """Case-drift input ('stereolab') resolves to stored row ('Stereolab').
 

--- a/tests/unit/test_entity_store_bulk_resolve.py
+++ b/tests/unit/test_entity_store_bulk_resolve.py
@@ -49,6 +49,11 @@ def _row(library_name: str, **overrides):
     }
 
 
+def _leg2_row(input_name: str, library_name: str, **overrides):
+    """Leg 2 row shape — includes the JOIN'd `input_name` column."""
+    return _row(library_name, input_name=input_name, **overrides)
+
+
 class TestBulkResolveLibraryNames:
     @pytest.mark.asyncio
     async def test_empty_input_returns_empty_dict_without_querying(self, store, mock_pg):
@@ -79,12 +84,13 @@ class TestBulkResolveLibraryNames:
             side_effect=[
                 # Leg 1: only the verbatim-cased input hits.
                 [_row("Stereolab", id=1, discogs_artist_id=2154)],
-                # Leg 2: LOWER('stereolab') = LOWER(stored 'Stereolab') hits.
-                [_row("Stereolab", id=1, discogs_artist_id=2154)],
+                # Leg 2: `JOIN unnest(...)` pairs input='stereolab' against
+                # stored 'Stereolab' (PG `LOWER(stored) = LOWER(bind)`).
+                # Returned row carries the matching bind as `input_name`.
+                [_leg2_row("stereolab", "Stereolab", id=1, discogs_artist_id=2154)],
             ]
         )
-        # Map of input → stored canonical/lower used by the leg 2 bind. Tests
-        # the contract that the dict is keyed by INPUT name, not stored shape.
+        # Tests the contract that the dict is keyed by INPUT name, not stored shape.
         result = await store.bulk_resolve_library_names(["Stereolab", "stereolab"])
         assert mock_pg.fetchall.await_count == 2
         assert set(result.keys()) == {"Stereolab", "stereolab"}
@@ -131,7 +137,7 @@ class TestBulkResolveLibraryNames:
         mock_pg.fetchall = AsyncMock(
             side_effect=[
                 [_row("Stereolab", id=1, discogs_artist_id=2154)],
-                [_row("Juana Molina", id=2, discogs_artist_id=305253)],
+                [_leg2_row("juana molina", "Juana Molina", id=2, discogs_artist_id=305253)],
                 [],
             ]
         )
@@ -165,7 +171,10 @@ class TestBulkResolveLibraryNames:
         mock_pg.fetchall = AsyncMock(
             side_effect=[
                 [],  # leg 1: 'stereolab' verbatim misses
-                [_row("Stereolab", id=1, discogs_artist_id=2154)],  # leg 2: LOWER hits
+                # leg 2: PG-side LOWER pairs the input bind 'stereolab'
+                # against stored 'Stereolab'; row's `input_name` column
+                # carries the matching bind.
+                [_leg2_row("stereolab", "Stereolab", id=1, discogs_artist_id=2154)],
             ]
         )
         result = await store.bulk_resolve_library_names(["stereolab"])


### PR DESCRIPTION
## Summary

- New `POST /api/v1/artists/search-aliases/bulk` endpoint returning per-source artist-name variants for up to 1,000 WXYC canonical names per call. Substrate for the alias-aware catalog search.
- Two-phase batched composer (1-3 + 5 = up to 8 PG round-trips per batch, regardless of cardinality). No `asyncio.gather` over per-name leaves — avoids the LML#370/#372 cascade-cascade pattern. No Discogs API escalation; cache-only.
- Two reusable batched primitives added: `EntityStore.bulk_resolve_library_names` and `DiscogsCacheService.get_artist_details_bulk`. Same fall-through and shape contracts as their per-name counterparts.

## What's in here

- `artists/router.py`, `artists/composer.py`, `artists/__init__.py`
- `entity/store.py` — `bulk_resolve_library_names` + two new SQL constants
- `discogs/cache_service.py` — `get_artist_details_bulk`
- `main.py` — mount `artists_router` under `/api/v1` + `require_lml_key`
- `generated/api_models.py` — regenerated from `@wxyc/shared` 1.9.0
- Unit tests for the composer, the two new bulk primitives, and an integration test for the route under `@pytest.mark.pg`

## Design points

- **Reconcile contract**: `sources_present` is appended BEFORE the variant fan-out. A source appears iff the composer ran its leg, independent of whether the leg produced any variants. Consumers (BS PR 4) use this to scope DELETE — an empty `sources_present` for an artist means the composer did NOT run any leg, so the consumer must NOT delete cached rows for that artist. The integration test covers both the "discogs id missing → empty `sources_present`" case and the "discogs id present but cache miss → all three discogs_* tags" case.
- **Input-keyed dict**: `bulk_resolve_library_names` returns a dict keyed by **input** name, not stored `library_name`. Callers can preserve input order without a reverse index. Case-drift inputs (`'stereolab'` resolving to stored `'Stereolab'`) appear under the input key.
- **Future sources**: musicbrainz_alias / wikidata_label / etc. are additive at LML — append a Phase 2 sibling and a new `sources_present` tag. No schema or code change on the Backend-Service side; the polymorphic `(artist_id, source, variant)` table from PR 3 absorbs them.

## TDD evidence

- Red phase: 22 failing tests authored before any implementation (8 + 6 + 8 unit; integration tests still red until a real PG is in place).
- Green phase: 22 unit tests green; full suite `pytest tests/unit/` reports 2081 passed, no regressions.
- `ruff check .` and `ruff format --check .` clean. `mypy . --ignore-missing-imports` clean.

## Test plan

- [x] `pytest tests/unit/test_entity_store_bulk_resolve.py` green
- [x] `pytest tests/unit/test_discogs_cache_get_artist_details_bulk.py` green
- [x] `pytest tests/unit/test_artist_search_aliases_composer.py` green
- [x] `pytest tests/unit/` green (2081 passed)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy . --ignore-missing-imports` clean
- [ ] Integration tests (`pytest -m pg tests/integration/test_search_aliases_bulk.py`) require `DATABASE_URL_TEST`; will run in CI's pg job

## Downstream

Unblocks Backend-Service PR 4 (`jobs/artist-search-alias-consumer/` — ETL consumer) and PR 5 (search-side LATERAL JOIN behind `CATALOG_SEARCH_ALIAS_ENABLED`).

Closes #479