### PR TITLE
fix(orchestrator): gate streaming_links projection on title-score floor (#477)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -23,6 +23,7 @@ from wxyc_etl.text import to_match_form as normalize_for_comparison
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats_recorder
 
 from clients.streaming.apple_music import AppleMusicClient
+from clients.streaming.matching import score_match
 from config.settings import get_settings
 from core.search import (
     execute_search_pipeline,
@@ -1855,7 +1856,24 @@ async def enrich_artwork_results(
         bandcamp_url = None
         soundcloud_url = None
 
-        if library_db and getattr(library_db, "_has_streaming_links", None) is True and item.id:
+        # LML#477: only trust the library row's stored streaming URLs when
+        # its title plausibly matches the requested album. ``_fuzzy_search``
+        # in library/db.py accepts token_set_ratio >= 70 — permissive enough
+        # to surface sibling-album rows (same artist, different release)
+        # whose verified Spotify/Apple URLs would otherwise propagate as if
+        # they pointed at the requested album. The 80 floor mirrors
+        # ``is_acceptable_match`` in ``clients/streaming/matching``. When no
+        # album was requested (artist-only lookup) or the row's title is
+        # missing, there is no signal to gate against — fall through.
+        row_title_matches_requested_album = (
+            not album or not item.title or score_match(album, item.title) >= 80.0
+        )
+        if (
+            library_db
+            and getattr(library_db, "_has_streaming_links", None) is True
+            and item.id
+            and row_title_matches_requested_album
+        ):
             try:
                 links = await library_db.get_streaming_links(item.id)
             except Exception:

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1176,3 +1176,159 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
 
         _, enriched = results[0]
         assert enriched.apple_music_url == db_url
+
+
+class TestStreamingLinksTitleGate:
+    """LML#477: gate library_db.streaming_links projection on a title-confidence
+    floor against the requested album.
+
+    Library search's fuzzy fallback (``_fuzzy_search`` in ``library/db.py``)
+    accepts ``token_set_ratio >= 70`` — permissive enough to surface
+    sibling-artist rows where the artist matches but the album doesn't
+    (e.g. requesting "Yenbett" returns "Tzenni" because both are Noura
+    Mint Seymali albums). Without a gate at the orchestrator's
+    streaming-link projection site, those rows' verified Spotify/Apple
+    URLs would propagate into the response as if they pointed at the
+    requested album. The 80 floor mirrors ``is_acceptable_match`` in
+    ``clients/streaming/matching.py``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_skips_streaming_links_when_row_title_mismatches_album(self):
+        # Sibling-album fuzzy hit: artist matches, title doesn't — the
+        # row's stored streaming URLs point at the sibling, not the
+        # requested album.
+        item = make_library_item(id=42, artist="Noura Mint Seymali", title="Tzenni")
+        artwork = make_discogs_result(release_id=1, artist="Noura Mint Seymali", album="Tzenni")
+
+        wrong_spotify = "https://open.spotify.com/album/tzenni-id"
+        wrong_apple = "https://music.apple.com/us/album/tzenni/111"
+
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": wrong_spotify,
+                "apple_music_url": wrong_apple,
+                "youtube_music_url": "https://music.youtube.com/wrong",
+                "bandcamp_url": "https://wrong.bandcamp.com/album/tzenni",
+                "soundcloud_url": "https://soundcloud.com/wrong/tzenni",
+            }
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="Tzenni",
+            artist="Noura Mint Seymali",
+            year=2014,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            album="Yenbett",
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        # No wrong-album URLs propagated.
+        assert enriched.spotify_url != wrong_spotify
+        assert enriched.apple_music_url != wrong_apple
+        assert enriched.youtube_music_url != "https://music.youtube.com/wrong"
+        assert enriched.bandcamp_url != "https://wrong.bandcamp.com/album/tzenni"
+        assert enriched.soundcloud_url != "https://soundcloud.com/wrong/tzenni"
+        # Synthesized search-URL fallback fills in instead.
+        assert enriched.spotify_url is not None
+        assert "search" in enriched.spotify_url.lower()
+        # And we never even queried the DB for streaming links — the gate
+        # short-circuits before the lookup.
+        library_db.get_streaming_links.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_applies_streaming_links_when_row_title_matches_album(self):
+        # Happy path: library row title matches the requested album.
+        item = make_library_item(id=42, artist="Jessica Pratt", title="On Your Own Love Again")
+        artwork = make_discogs_result(
+            release_id=1, artist="Jessica Pratt", album="On Your Own Love Again"
+        )
+
+        verified_spotify = "https://open.spotify.com/album/oyola-id"
+        verified_apple = "https://music.apple.com/us/album/oyola/222"
+
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": verified_spotify,
+                "apple_music_url": verified_apple,
+                "youtube_music_url": None,
+                "bandcamp_url": None,
+                "soundcloud_url": None,
+            }
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="On Your Own Love Again",
+            artist="Jessica Pratt",
+            year=2015,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            album="On Your Own Love Again",
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched.spotify_url == verified_spotify
+        assert enriched.apple_music_url == verified_apple
+
+    @pytest.mark.asyncio
+    async def test_applies_streaming_links_when_album_not_requested(self):
+        # No requested album → no signal to gate against; preserve
+        # legacy behavior of trusting the library row.
+        item = make_library_item(id=42, artist="Juana Molina", title="DOGA")
+        artwork = make_discogs_result(release_id=1, artist="Juana Molina", album="DOGA")
+
+        verified_spotify = "https://open.spotify.com/album/doga-id"
+
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": verified_spotify,
+                "apple_music_url": None,
+                "youtube_music_url": None,
+                "bandcamp_url": None,
+                "soundcloud_url": None,
+            }
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="DOGA",
+            artist="Juana Molina",
+            year=2022,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            album=None,
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched.spotify_url == verified_spotify


### PR DESCRIPTION
## Summary
- Library search's `_fuzzy_search` accepts `token_set_ratio >= 70`, permissive enough to surface sibling-album rows (same artist, different release) when the requested album isn't in the catalog. Without a gate, `enrich_artwork_results` then projects that wrong row's verified `streaming_links` into the response — flowsheet ends up with Tzenni's Spotify URL on Yenbett entries.
- Add a title-confidence gate before calling `library_db.get_streaming_links(item.id)`: require `score_match(album, item.title) >= 80` (mirrors `is_acceptable_match` floor). On miss, fall through to the existing synthesized search-URL fallback. When no album was requested or the row has no title, there's no signal to gate against — preserve legacy behavior.
- Does not tighten `_fuzzy_search` itself — fuzzy matches remain legitimate for the projected artist-bio / release-year / wiki fields, which are bound to the matched row's identity, not the request.

## Test plan
- [x] Red test: requesting "Yenbett" with a fuzzy-fallback row for "Tzenni" (same artist) no longer leaks Tzenni's `streaming_links` into the response; synthesized search URLs fill instead.
- [x] Happy-path no-regression: matching row title (`score_match >= 80`) still propagates verified URLs.
- [x] `album=None` edge case (artist-only lookup): no gate, legacy behavior preserved.
- [x] `tests/unit/` full suite: 2089 passed.
- [x] `ruff check` + `ruff format --check` clean.

Closes #477