### PR TITLE
fix(orchestrator): fuzzy-score Discogs artwork candidates before picking

### DIFF
--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison  # noqa: F401
@@ -192,6 +192,39 @@ def find_best_match(
             if id_fn is not None:
                 match["id"] = id_fn(item)
             best = match
+    return best
+
+
+def find_best_typed_match[T](
+    results: Iterable[T],
+    *,
+    query_artist: str,
+    query_title: str,
+    artist_fn: Callable[[T], str | None],
+    title_fn: Callable[[T], str | None],
+) -> T | None:
+    """Return the highest-scoring result that clears the 80/80 floor, or None.
+
+    Sibling of ``find_best_match`` that returns the **original typed object**
+    instead of a flattened streaming-URL dict. Use when the caller wants the
+    matched candidate's full payload (e.g. a ``DiscogsSearchResult``) rather
+    than a normalized URL pair. None-valued extractors score as 0 against
+    any non-empty query; ties resolve to the first candidate reaching the
+    score, preserving input order.
+    """
+    best: T | None = None
+    best_score = 0.0
+    for item in results:
+        r_artist = artist_fn(item) or ""
+        r_title = title_fn(item) or ""
+        artist_score = score_match(query_artist, r_artist)
+        title_score = score_match(query_title, r_title)
+        if not is_acceptable_match(artist_score, title_score):
+            continue
+        combined = (artist_score + title_score) / 2
+        if combined > best_score:
+            best_score = combined
+            best = item
     return best
 
 

--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -218,18 +218,23 @@ def find_best_typed_match[T](
     "Various Artists" canonical artist; a ``discogs_titles`` long-canonical
     override paired against the raw library title).
 
-    Empty query strings short-circuit to no-match — ``score_match("", "")``
-    returns 100 by ``rapidfuzz`` convention, which would let candidates with
-    null artist/title fields trivially pass the floor. Any variant that's
-    empty is dropped from the scoring set; if no non-empty variant survives,
-    the result is rejected.
+    Empty or whitespace-only query strings short-circuit to no-match —
+    ``score_match("", "")`` returns 100 by ``rapidfuzz`` convention (and
+    ``score_match(" ", "")`` does too, because the normalizer strips
+    whitespace before scoring), which would let candidates with null
+    artist/title fields trivially pass the floor. Any variant that's empty
+    or whitespace-only is dropped from the scoring set; if no usable variant
+    survives on either side, the result is rejected.
 
     None-valued extractors score as 0 against any non-empty query. Ties
     resolve to the first candidate reaching the score, preserving input
     order.
+
+    Iterables are materialized to a list internally — a single-pass
+    generator is safe.
     """
-    artist_variants = [v for v in _as_variants(query_artist) if v]
-    title_variants = [v for v in _as_variants(query_title) if v]
+    artist_variants = [v for v in _as_variants(query_artist) if v and v.strip()]
+    title_variants = [v for v in _as_variants(query_title) if v and v.strip()]
     if not artist_variants or not title_variants:
         return None
 

--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -198,8 +198,8 @@ def find_best_match(
 def find_best_typed_match[T](
     results: Iterable[T],
     *,
-    query_artist: str,
-    query_title: str,
+    query_artist: str | Iterable[str],
+    query_title: str | Iterable[str],
     artist_fn: Callable[[T], str | None],
     title_fn: Callable[[T], str | None],
 ) -> T | None:
@@ -208,17 +208,38 @@ def find_best_typed_match[T](
     Sibling of ``find_best_match`` that returns the **original typed object**
     instead of a flattened streaming-URL dict. Use when the caller wants the
     matched candidate's full payload (e.g. a ``DiscogsSearchResult``) rather
-    than a normalized URL pair. None-valued extractors score as 0 against
-    any non-empty query; ties resolve to the first candidate reaching the
-    score, preserving input order.
+    than a normalized URL pair.
+
+    ``query_artist`` and ``query_title`` accept either a string or an iterable
+    of variant strings. When an iterable is passed, the candidate is scored
+    against each variant and the max score is used. This is the natural shape
+    for cases where the search query and the canonical-form a candidate
+    surfaces with are known to differ (e.g. "Various" search query vs.
+    "Various Artists" canonical artist; a ``discogs_titles`` long-canonical
+    override paired against the raw library title).
+
+    Empty query strings short-circuit to no-match — ``score_match("", "")``
+    returns 100 by ``rapidfuzz`` convention, which would let candidates with
+    null artist/title fields trivially pass the floor. Any variant that's
+    empty is dropped from the scoring set; if no non-empty variant survives,
+    the result is rejected.
+
+    None-valued extractors score as 0 against any non-empty query. Ties
+    resolve to the first candidate reaching the score, preserving input
+    order.
     """
+    artist_variants = [v for v in _as_variants(query_artist) if v]
+    title_variants = [v for v in _as_variants(query_title) if v]
+    if not artist_variants or not title_variants:
+        return None
+
     best: T | None = None
     best_score = 0.0
     for item in results:
         r_artist = artist_fn(item) or ""
         r_title = title_fn(item) or ""
-        artist_score = score_match(query_artist, r_artist)
-        title_score = score_match(query_title, r_title)
+        artist_score = max(score_match(q, r_artist) for q in artist_variants)
+        title_score = max(score_match(q, r_title) for q in title_variants)
         if not is_acceptable_match(artist_score, title_score):
             continue
         combined = (artist_score + title_score) / 2
@@ -226,6 +247,13 @@ def find_best_typed_match[T](
             best_score = combined
             best = item
     return best
+
+
+def _as_variants(query: str | Iterable[str]) -> list[str]:
+    """Normalize a query into a list of candidate strings."""
+    if isinstance(query, str):
+        return [query]
+    return list(query)
 
 
 def find_best_source_match(

--- a/docs/plans/lml-478-artwork-fuzzy-score.md
+++ b/docs/plans/lml-478-artwork-fuzzy-score.md
@@ -1,0 +1,231 @@
+# LML #478 — Fuzzy-score Discogs artwork candidates before taking `results[0]`
+
+**Issue:** [WXYC/library-metadata-lookup#478](https://github.com/WXYC/library-metadata-lookup/issues/478)
+
+**Sibling concerns:** #440 (Spotify search-URL not verified), #442 (Apple-side album-first lookup — deeper case where the right release isn't in top-N). #478 is the simplest of the three: score the results we already have.
+
+## Problem
+
+`fetch_artwork_for_items` → `fetch_one` in [`lookup/orchestrator.py:1607-1638`](https://github.com/WXYC/library-metadata-lookup/blob/main/lookup/orchestrator.py#L1607-L1638) calls `discogs_service.search(...)` and unconditionally takes `response.results[0]`. There is no fuzzy-match floor, no ranking by the supplied artist/album. Discogs's search ranking optimizes for popularity/recency, not textual proximity — so when an item appears on multiple releases (compilations, reissues, live albums, multi-release artists), the top result can be the wrong release and the field returns wrong artwork rather than `None`.
+
+**Concrete repro:** Noura Mint Seymali's "Hebebeb (Zrag)" appears on both *Tzenni* (2014) and *Yenbett* (2025). The DJ supplies the correct album title; LML returns the wrong release's artwork.
+
+The matching primitive that would fix this already exists. [`clients/streaming/matching.py:find_best_match`](https://github.com/WXYC/library-metadata-lookup/blob/main/clients/streaming/matching.py#L145-L195) scores candidates with `score_match` on artist + title, applies `is_acceptable_match`'s 80/80 floor, and returns the highest combined-score match. Every streaming client (Spotify, Apple, Deezer, Bandcamp) uses it. The Discogs artwork path skipped it.
+
+## Desired end state
+
+In `fetch_one`, after `discogs_service.search` returns, score candidates against the same `(artist, album)` strings the search used and pick the highest combined-score result that clears 80/80. When nothing clears, return `None` — downstream already tolerates a `None` artwork result (this is `enrich_artwork_results`'s top-1-`None` synthesis path post-LML#401).
+
+## The change
+
+### Where: `lookup/orchestrator.py`, `fetch_one` inside `fetch_artwork_for_items`
+
+Current shape (lines 1607–1638):
+
+```python
+async def fetch_one(item: LibraryItem) -> DiscogsSearchResult | None:
+    try:
+        album = discogs_titles.get(item.id, item.title)
+        if is_self_titled(album or ""):
+            album = item.artist
+        artist = item.alternate_artist_name or item.artist or ""
+        if is_compilation_artist(artist):
+            artist = "Various"
+
+        response = await discogs_service.search(
+            DiscogsSearchRequest(album=album, artist=artist, ...)
+        )
+        if response.results:
+            result = response.results[0]            # ← unconditional pick
+            if not result.artwork_url:
+                fallback = await _resolve_fallback_artwork(...)
+                ...
+            return result
+        return None
+```
+
+New shape — replace the `result = response.results[0]` line with a scored pick against the **post-mutation** `artist` / `album` locals:
+
+```python
+        if response.results:
+            result = _pick_best_artwork_match(
+                response.results,
+                query_artist=artist,
+                query_album=album or "",
+            )
+            if result is None:
+                return None
+            if not result.artwork_url:
+                fallback = await _resolve_fallback_artwork(...)
+                ...
+            return result
+        return None
+```
+
+### The helper
+
+`DiscogsSearchResult` already has `album: str | None` and `artist: str | None` (see `discogs/models.py:186-194`), so the scoring primitives drop in cleanly. `find_best_match` in `matching.py` returns a flat `dict` shaped for streaming URLs, not the original typed object — wrong shape for this caller. Two viable factorings:
+
+**Option A — inline loop in orchestrator.** ~10 lines using `score_match` + `is_acceptable_match` from `clients.streaming.matching`. Minimum surface area. Fine if no other caller emerges.
+
+**Option B — typed sibling in `matching.py`.** Add `find_best_typed_match(results, query_artist, query_title, artist_fn, title_fn) -> T | None` that returns the highest-scoring **original** item (not a dict). Generic over `T`. Drops in here and is reusable if a similar "rank typed candidates by artist/title" need arises elsewhere (e.g., Apple album-first work on #442 may want it).
+
+**Recommendation: Option B**, as a small generic helper next to `find_best_match`. Two reasons: (1) `matching.py` is already the org's canonical home for "score artist + title pairs," (2) #442 is queued and will likely want the same primitive against typed Apple results. Cost is ~15 lines + one test for the helper. If reviewers prefer minimality, fall back to Option A — the orchestrator change is identical, only the helper location moves.
+
+Helper signature (Option B):
+
+```python
+# clients/streaming/matching.py
+T = TypeVar("T")
+
+def find_best_typed_match(
+    results: Iterable[T],
+    *,
+    query_artist: str,
+    query_title: str,
+    artist_fn: Callable[[T], str | None],
+    title_fn: Callable[[T], str | None],
+) -> T | None:
+    """Return the highest-scoring result that clears the 80/80 floor, or None.
+
+    Unlike find_best_match, returns the original typed object instead of a
+    flattened dict. None-valued artist/title from a result score as 0 against
+    any non-empty query.
+    """
+    best: T | None = None
+    best_score = 0.0
+    for item in results:
+        r_artist = artist_fn(item) or ""
+        r_title = title_fn(item) or ""
+        a_score = score_match(query_artist, r_artist)
+        t_score = score_match(query_title, r_title)
+        if not is_acceptable_match(a_score, t_score):
+            continue
+        combined = (a_score + t_score) / 2
+        if combined > best_score:
+            best_score = combined
+            best = item
+    return best
+```
+
+Orchestrator call site:
+
+```python
+from clients.streaming.matching import find_best_typed_match
+
+result = find_best_typed_match(
+    response.results,
+    query_artist=artist,
+    query_title=album or "",
+    artist_fn=lambda r: r.artist,
+    title_fn=lambda r: r.album,
+)
+```
+
+### Constraints honored
+
+1. **Post-mutation inputs.** The score uses the same `artist` / `album` strings the search consumed (after `is_self_titled` → artist swap and `is_compilation_artist` → "Various" swap). Acceptance criterion 3.
+2. **`_resolve_fallback_artwork` still runs.** It runs on whatever the picked match is — best-scored instead of `results[0]`. No change in the artist/label-image cascade.
+3. **`None` return path is already supported.** `enrich_artwork_results` synthesizes a `DiscogsSearchResult(release_id=0, release_url="")` carrying just streaming URLs when artwork is `None` (LML#401). iOS/BS already key off that contract.
+4. **Tie-break.** `find_best_typed_match` returns the **first** result reaching `best_score`; on ties it keeps Discogs's original ordering. Mirrors `find_best_match`'s behavior.
+
+## Pre-merge measurement (acceptance criterion 5)
+
+Need a measured estimate of the flip-to-`None` rate on real traffic before deploying. The artwork-enrichment path is cache-hot for recent flowsheet entries, so the measurement runs purely against the local Discogs cache — no live API calls.
+
+**Script:** `scripts/measure_artwork_match_floor.py` (one-shot, not added to cron).
+
+1. Read N=1000 most recently-enriched flowsheet rows from BS (or, simpler: sample N `library_items` recently passed to `fetch_artwork_for_items` from staging logs).
+2. For each, replay the same `DiscogsSearchRequest` against the live `DiscogsService` (cache + API as usual).
+3. Apply the new `find_best_typed_match` floor to the returned candidates.
+4. Compare: would the picked release_id change? Would the result flip to `None`?
+5. Emit a CSV with: `library_id, artist, album, old_release_id, new_release_id, flipped_to_none, top1_artist_score, top1_title_score, best_combined_score`.
+6. Human spot-check K=20 of the `flipped_to_none` rows (open the Discogs release pages, confirm the old top-1 was indeed the wrong album).
+
+**Pass bar:** ≤ 5% flip-to-`None` rate, and spot-checks of flipped rows confirm they were genuinely wrong releases. Above 5%, escalate before merging — likely indicates the 80/80 floor is mis-tuned for the Discogs distribution (e.g., subtitle-bearing releases like "Confield (Remastered Edition)" score lower against a bare library title than the streaming-side equivalent).
+
+Result written into the PR description under "Measurement," not committed to the repo.
+
+## Test plan
+
+### Unit tests in `tests/unit/test_orchestrator_helpers.py`, class `TestFetchArtworkForItems`
+
+1. **`test_picks_correct_release_over_misleading_top1`** — the Noura case. Mock `discogs_service.search` to return `[wrong, right]`:
+   - `wrong = make_discogs_result(release_id=YENBETT, album="Yenbett", artist="Noura Mint Seymali", artwork_url=...)`
+   - `right = make_discogs_result(release_id=TZENNI, album="Tzenni", artist="Noura Mint Seymali", artwork_url=...)`
+   - Library item titled "Tzenni" by "Noura Mint Seymali".
+   - Assert `results[0][1].release_id == TZENNI`.
+
+2. **`test_returns_none_when_no_candidate_clears_floor`** — mock returns two candidates with clearly-wrong artist + album (e.g., `album="Some Other Album", artist="Other Artist"`). Library item is "Tzenni" by "Noura Mint Seymali". Assert `results[0][1] is None` and `_resolve_fallback_artwork` was **not** called (no result to fall back from).
+
+3. **`test_self_titled_scores_against_mutated_album`** — library item `title="S/t"`, `artist="Pavement"`. `album` mutates to "Pavement". Mock candidate has `album="Pavement", artist="Pavement"`. Assert match returned (≥ 80/80 against the mutated album, not "S/t").
+
+4. **`test_compilation_artist_scores_against_various`** — library item `artist="Various Artists - Rock - D"`, `title="Disco Not Disco"`. `artist` mutates to "Various". Mock candidate has `artist="Various", album="Disco Not Disco"`. Assert match returned. This is the regression risk of the existing `test_uses_discogs_titles_for_compilation_lookup` test — verify it still passes unchanged.
+
+5. **`test_picks_higher_combined_score_among_acceptable_candidates`** — mock returns `[acceptable_85, acceptable_95]`. Assert the higher-scoring one wins, regardless of Discogs's ordering.
+
+### Helper tests (if Option B) — `tests/unit/test_streaming_matching.py` or wherever `find_best_match` is tested today
+
+- `test_find_best_typed_match_returns_original_object`
+- `test_find_best_typed_match_handles_none_fields` (artist or title returning None on the candidate)
+- `test_find_best_typed_match_returns_none_when_no_candidate_clears`
+
+### Existing-test regressions
+
+Several existing tests use `make_discogs_result(release_id=...)` with factory defaults (`album="Aluminum Tunes", artist="Stereolab"`) against a library item with a different artist/title (e.g., Autechre's *Confield*). Under the new floor the mocked result fails 80/80 and `fetch_one` returns `None`, breaking the test's setup.
+
+**Remedy (apply uniformly to every affected test):** add `album=<item.title>, artist=<item.artist>` kwargs to the `make_discogs_result(...)` call so the mock matches the queried `LibraryItem`. Example:
+
+```python
+# before
+make_discogs_result(release_id=28138, artwork_url=None)
+# after
+make_discogs_result(release_id=28138, album="Confield", artist="Autechre", artwork_url=None)
+```
+
+**Audit scope:** every test in **`tests/unit/test_orchestrator_helpers.py`** AND **`tests/unit/test_orchestrator.py`** AND **`tests/unit/test_orchestrator_gaps.py`** that constructs a `DiscogsSearchResult` (directly or via `make_discogs_result`) inside a `fetch_artwork_for_items` setup. Grep: `rg 'make_discogs_result|DiscogsSearchResult\(' tests/unit/test_orchestrator*.py`. For each hit, check whether the mock feeds `fetch_artwork_for_items` (directly or through a higher-level path that calls it). If yes and the factory defaults don't match the item's artist/title, pass matching kwargs.
+
+Confirmed hits in `test_orchestrator_helpers.py` from current state (line numbers may drift):
+
+- `test_falls_back_to_artist_image` (~1229)
+- `test_falls_back_to_label_image` (~1255)
+- `test_no_fallback_when_artwork_exists` (~1281)
+- `test_returns_result_when_all_fallbacks_fail` (~1303)
+- `test_fallback_when_get_release_returns_none` (~1324)
+- `test_uses_release_artwork_when_search_misses` (~1340)
+- `test_artwork_search_omits_label_and_format_when_absent` (~1212)
+
+`test_orchestrator.py` and `test_orchestrator_gaps.py` need the same pass — list grew long enough during planning that an exhaustive enumeration here would drift; run the grep and apply the remedy per-hit.
+
+**Verification:** `npm run test:unit` (or `pytest tests/unit/test_orchestrator*.py`) passes locally before pushing. Any test failing with `assert results[0][1] is not None` against a mismatched factory default is the symptom — fix by adding matching kwargs, not by lowering the floor.
+
+## Acceptance criteria mapping
+
+| Issue criterion | This plan covers it via |
+|---|---|
+| Ranks `response.results` via `find_best_match` (or equivalent) on `(artist, album)` 80/80 | `find_best_typed_match` helper + orchestrator call-site swap |
+| Returns `None` when nothing clears 80/80 | `find_best_typed_match` returns `None`; orchestrator returns it through |
+| Self-titled / compilation-artist mutations accounted for in the score input | Score uses the same post-mutation `artist` / `album` locals the search used |
+| Noura Mint Seymali / "Tzenni" vs. "Yenbett" test | `test_picks_correct_release_over_misleading_top1` |
+| Backfill-sample measurement documented before merging | `scripts/measure_artwork_match_floor.py` + PR-description "Measurement" section |
+
+## Out of scope
+
+- **#440** (Spotify `spotify_url` is a search-URL template, not verified). Different code path, same theme; separate PR.
+- **#442** (Apple album-first lookup — the right album isn't in the search top-N). Different problem shape: this PR scores the results we have, #442 changes which results we ask for.
+- **Tightening or loosening the 80/80 floor.** Reuse the existing constant. If measurement shows >5% flip-to-`None`, escalate as a follow-up instead of baking a different constant into this PR.
+- **Bringing the same floor to `proxy.controller`'s direct Discogs paths in Backend-Service.** BS already routes through LML for artwork (per BS CLAUDE.md "All Discogs access … routes through LML"); the proxy paths inherit this fix automatically.
+
+## Risk
+
+- **False-negative blowup on subtitle-heavy releases.** "Album (Remastered Edition)" vs. "Album" scores high under `token_sort_ratio` (the constant in `score_match`), but compound subtitle drift could occasionally push a legitimate match below 80. The pre-merge measurement is the mitigation; if the rate is unacceptable, the right move is to extend `strip_format_suffix` in `matching.py` (helps every streaming caller too), not to lower the floor for the Discogs path.
+- **Order-dependent tie-breaks.** If two candidates tie on combined score, we keep Discogs's original ordering. This matches `find_best_match`'s behavior; not a regression.
+
+## Rollout
+
+Standard merge → auto-deploy. No flag, no migration, no data backfill. The behavior change is contained to a single read path and reversible by reverting one commit.
+
+## Out-of-scope follow-ups to file post-merge (only if pre-merge measurement surfaces them)
+
+- Extend `strip_format_suffix` to handle additional subtitle patterns observed in the measurement.
+- Apply `find_best_typed_match` to the artist-image / label-image cascade if measurement shows those paths also serve wrong-scope artwork.

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -76,15 +76,19 @@ MAX_SEARCH_RESULTS = 5
 SELF_TITLED_PATTERNS = frozenset({"s/t", "s.t.", "self-titled", "self titled"})
 """Common abbreviations for self-titled albums (case-insensitive exact match)."""
 
-_COMPILATION_ARTIST_SEARCH_FORM = "Various"
+COMPILATION_ARTIST_SEARCH_FORM = "Various"
 """The bare form Discogs's search endpoint accepts for compilation artists."""
 
-_COMPILATION_ARTIST_CANONICAL_FORM = "Various Artists"
+COMPILATION_ARTIST_CANONICAL_FORM = "Various Artists"
 """The full form Discogs's response payloads typically carry. Kept paired with
-``_COMPILATION_ARTIST_SEARCH_FORM`` for the variant-scoring path in
+``COMPILATION_ARTIST_SEARCH_FORM`` for the variant-scoring path in
 ``fetch_artwork_for_items``; any change to one MUST change the other or
 ``score_match("Various","Various Artists")=63.6`` will start flipping
-compilations to None at the 80/80 floor (LML#478 round-2 finding)."""
+compilations to None at the 80/80 floor (LML#478 round-2 finding).
+
+Module-public (no underscore prefix) so ``scripts/measure_artwork_match_floor.py``
+can import the same constants the runtime path uses — keeping the
+measurement's compilation handling provably-aligned with production."""
 
 _WARM_CACHE_CONCURRENCY: int = 4
 """Process-wide cap on concurrent bio cache-warm tasks.
@@ -1613,7 +1617,7 @@ async def fetch_artwork_for_items(
 
             artist = item.alternate_artist_name or item.artist or ""
             if is_compilation_artist(artist):
-                artist = _COMPILATION_ARTIST_SEARCH_FORM
+                artist = COMPILATION_ARTIST_SEARCH_FORM
 
             response = await discogs_service.search(
                 DiscogsSearchRequest(
@@ -1646,8 +1650,8 @@ async def fetch_artwork_for_items(
             #   let a wrong-release candidate with album="S/t" clear the
             #   floor trivially.
             artist_variants = [artist]
-            if artist == _COMPILATION_ARTIST_SEARCH_FORM:
-                artist_variants.append(_COMPILATION_ARTIST_CANONICAL_FORM)
+            if artist == COMPILATION_ARTIST_SEARCH_FORM:
+                artist_variants.append(COMPILATION_ARTIST_CANONICAL_FORM)
             album_variants = [album or ""]
             if item.title and item.title != album and not is_self_titled(item.title):
                 album_variants.append(item.title)

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1613,16 +1613,31 @@ async def fetch_artwork_for_items(
                     format=map_library_format_to_discogs(item.format),
                 )
             )
-            # Score candidates against the post-mutation artist/album the
-            # search consumed (the is_self_titled / is_compilation_artist
-            # rewrites flow through here). Falls back to None — better than
-            # serving wrong artwork for releases that share a title across
-            # multiple albums (LML#478, e.g. Noura Mint Seymali's "Hebebeb
-            # (Zrag)" on both *Tzenni* and *Yenbett*).
+            # Score candidates against (artist, album) with an 80/80 floor.
+            # Returns None when nothing clears — better than serving wrong
+            # artwork for releases that share a title across multiple albums
+            # (LML#478, e.g. Noura Mint Seymali's "Hebebeb (Zrag)" on both
+            # *Tzenni* and *Yenbett*).
+            #
+            # Query variants:
+            # - Artist: "Various" is the form Discogs's search endpoint
+            #   accepts, but Discogs's canonical artist field for compilations
+            #   is often "Various Artists" (sometimes with a "(N)" disambig
+            #   suffix). Score against both.
+            # - Album: when discogs_titles[item.id] overrides the library
+            #   title with a long Discogs-canonical form (compilation rescue
+            #   path), Discogs's own search results may carry just the short
+            #   library-side title. Score against both.
+            artist_variants = [artist]
+            if artist == "Various":
+                artist_variants.append("Various Artists")
+            album_variants = [album or ""]
+            if item.title and item.title != album:
+                album_variants.append(item.title)
             result = find_best_typed_match(
                 response.results,
-                query_artist=artist,
-                query_title=album or "",
+                query_artist=artist_variants,
+                query_title=album_variants,
                 artist_fn=lambda r: r.artist,
                 title_fn=lambda r: r.album,
             )

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -76,6 +76,16 @@ MAX_SEARCH_RESULTS = 5
 SELF_TITLED_PATTERNS = frozenset({"s/t", "s.t.", "self-titled", "self titled"})
 """Common abbreviations for self-titled albums (case-insensitive exact match)."""
 
+_COMPILATION_ARTIST_SEARCH_FORM = "Various"
+"""The bare form Discogs's search endpoint accepts for compilation artists."""
+
+_COMPILATION_ARTIST_CANONICAL_FORM = "Various Artists"
+"""The full form Discogs's response payloads typically carry. Kept paired with
+``_COMPILATION_ARTIST_SEARCH_FORM`` for the variant-scoring path in
+``fetch_artwork_for_items``; any change to one MUST change the other or
+``score_match("Various","Various Artists")=63.6`` will start flipping
+compilations to None at the 80/80 floor (LML#478 round-2 finding)."""
+
 _WARM_CACHE_CONCURRENCY: int = 4
 """Process-wide cap on concurrent bio cache-warm tasks.
 
@@ -1603,7 +1613,7 @@ async def fetch_artwork_for_items(
 
             artist = item.alternate_artist_name or item.artist or ""
             if is_compilation_artist(artist):
-                artist = "Various"
+                artist = _COMPILATION_ARTIST_SEARCH_FORM
 
             response = await discogs_service.search(
                 DiscogsSearchRequest(
@@ -1620,19 +1630,26 @@ async def fetch_artwork_for_items(
             # *Tzenni* and *Yenbett*).
             #
             # Query variants:
-            # - Artist: "Various" is the form Discogs's search endpoint
-            #   accepts, but Discogs's canonical artist field for compilations
-            #   is often "Various Artists" (sometimes with a "(N)" disambig
-            #   suffix). Score against both.
+            # - Artist: the compilation search uses bare "Various" because
+            #   that's the form Discogs's search endpoint accepts, but
+            #   Discogs's canonical artist field for compilations is often
+            #   "Various Artists" (sometimes with a "(N)" disambig suffix).
+            #   Score against both forms. Numeric disambigs clear via
+            #   token_sort_ratio's tolerance; descriptive disambigs
+            #   ("Brazilian Soul" etc.) are a known floor-rejection edge
+            #   case — accept the loss in exchange for the floor's gain.
             # - Album: when discogs_titles[item.id] overrides the library
             #   title with a long Discogs-canonical form (compilation rescue
             #   path), Discogs's own search results may carry just the short
-            #   library-side title. Score against both.
+            #   library-side title. Score against both. Don't readmit a
+            #   self-titled trigger ("S/t" etc.) as a variant — that would
+            #   let a wrong-release candidate with album="S/t" clear the
+            #   floor trivially.
             artist_variants = [artist]
-            if artist == "Various":
-                artist_variants.append("Various Artists")
+            if artist == _COMPILATION_ARTIST_SEARCH_FORM:
+                artist_variants.append(_COMPILATION_ARTIST_CANONICAL_FORM)
             album_variants = [album or ""]
-            if item.title and item.title != album:
+            if item.title and item.title != album and not is_self_titled(item.title):
                 album_variants.append(item.title)
             result = find_best_typed_match(
                 response.results,

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -23,7 +23,7 @@ from wxyc_etl.text import to_match_form as normalize_for_comparison
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats_recorder
 
 from clients.streaming.apple_music import AppleMusicClient
-from clients.streaming.matching import score_match
+from clients.streaming.matching import find_best_typed_match, score_match
 from config.settings import get_settings
 from core.search import (
     execute_search_pipeline,
@@ -1613,14 +1613,26 @@ async def fetch_artwork_for_items(
                     format=map_library_format_to_discogs(item.format),
                 )
             )
-            if response.results:
-                result = response.results[0]
-                if not result.artwork_url:
-                    fallback = await _resolve_fallback_artwork(discogs_service, result.release_id)
-                    if fallback:
-                        result = result.model_copy(update={"artwork_url": fallback})
-                return result
-            return None
+            # Score candidates against the post-mutation artist/album the
+            # search consumed (the is_self_titled / is_compilation_artist
+            # rewrites flow through here). Falls back to None — better than
+            # serving wrong artwork for releases that share a title across
+            # multiple albums (LML#478, e.g. Noura Mint Seymali's "Hebebeb
+            # (Zrag)" on both *Tzenni* and *Yenbett*).
+            result = find_best_typed_match(
+                response.results,
+                query_artist=artist,
+                query_title=album or "",
+                artist_fn=lambda r: r.artist,
+                title_fn=lambda r: r.album,
+            )
+            if result is None:
+                return None
+            if not result.artwork_url:
+                fallback = await _resolve_fallback_artwork(discogs_service, result.release_id)
+                if fallback:
+                    result = result.model_copy(update={"artwork_url": fallback})
+            return result
         except Exception as e:
             logger.warning(f"Artwork lookup failed for {item.title}: {e}")
             return None

--- a/scripts/measure_artwork_match_floor.py
+++ b/scripts/measure_artwork_match_floor.py
@@ -16,6 +16,25 @@ The script touches the Discogs cache + API exactly like the runtime path. To
 keep API load low and the measurement repeatable, point ``DATABASE_URL_DISCOGS``
 at a cache that's already warmed for the sampled items (the production cache
 qualifies).
+
+Known divergences from the runtime path (these are why the measurement is
+illustrative, not exhaustive):
+
+- **``discogs_titles`` compilation-rescue overrides**. The runtime track-on-
+  compilation strategy populates ``discogs_titles[item.id]`` with the long
+  Discogs-canonical title before calling ``fetch_artwork_for_items``. That
+  override is populated mid-request from search-pipeline state the script
+  doesn't have access to — so for those rows, the script queries Discogs
+  with the short library title and scores against a single album variant,
+  whereas the runtime queries with the long override and scores against
+  two album variants. The script's flip-rate therefore under-samples this
+  cohort; spot-check compilation rows from the runtime side post-merge.
+
+- **Reproducibility / sampling determinism**. Sampling uses SQLite's
+  ``ORDER BY RANDOM()`` which has no externally-seedable PRNG. The CSV
+  writes ``library_id`` per row, so spot-checks can be re-run against the
+  same IDs by reading them out of an existing CSV; consecutive script
+  invocations otherwise sample fresh rows each time.
 """
 
 from __future__ import annotations

--- a/scripts/measure_artwork_match_floor.py
+++ b/scripts/measure_artwork_match_floor.py
@@ -59,6 +59,8 @@ from discogs.models import DiscogsSearchRequest, DiscogsSearchResult
 from discogs.service import DiscogsService
 from library.db import LibraryDB
 from lookup.orchestrator import (
+    COMPILATION_ARTIST_CANONICAL_FORM,
+    COMPILATION_ARTIST_SEARCH_FORM,
     is_self_titled,
     map_library_format_to_discogs,
 )
@@ -102,13 +104,13 @@ def build_query(item: SampledItem) -> QueryShape:
 
     artist = item.alternate_artist_name or item.artist or ""
     if is_compilation_artist(artist):
-        artist = "Various"
+        artist = COMPILATION_ARTIST_SEARCH_FORM
 
     artist_variants = [artist]
-    if artist == "Various":
-        artist_variants.append("Various Artists")
+    if artist == COMPILATION_ARTIST_SEARCH_FORM:
+        artist_variants.append(COMPILATION_ARTIST_CANONICAL_FORM)
     album_variants = [album or ""]
-    if item.title and item.title != album:
+    if item.title and item.title != album and not is_self_titled(item.title):
         album_variants.append(item.title)
 
     return QueryShape(
@@ -210,6 +212,7 @@ async def run(args: argparse.Namespace) -> None:
     flipped_to_different = 0
     same_pick = 0
     no_results = 0
+    search_failed = 0
 
     try:
         items = await sample_library_items(library_db, args.sample)
@@ -247,6 +250,23 @@ async def run(args: argparse.Namespace) -> None:
                     )
                 except Exception as e:
                     logger.warning("search failed for id=%s: %s", item.library_id, e)
+                    search_failed += 1
+                    writer.writerow(
+                        [
+                            item.library_id,
+                            item.artist,
+                            item.title,
+                            item.alternate_artist_name or "",
+                            query.search_artist,
+                            query.search_album,
+                            "",
+                            "",
+                            "search_failed",
+                            "",
+                            "",
+                            "",
+                        ]
+                    )
                     continue
 
                 old_pick, new_pick, a_score, t_score, best = classify(response.results, query)
@@ -308,6 +328,7 @@ async def run(args: argparse.Namespace) -> None:
             100 * flipped_to_different / denom,
         )
         logger.info("  no results:          %d (excluded from rates)", no_results)
+        logger.info("  search failed:       %d (excluded from rates)", search_failed)
         logger.info("CSV: %s", csv_path)
     finally:
         await service.close()

--- a/scripts/measure_artwork_match_floor.py
+++ b/scripts/measure_artwork_match_floor.py
@@ -25,9 +25,9 @@ import asyncio
 import csv
 import logging
 import os
-import random
 import sys
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 import asyncpg
@@ -48,64 +48,121 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 logger = logging.getLogger(__name__)
 
 
-def mutate(artist: str, title: str) -> tuple[str, str]:
-    """Mirror the artist/album mutations fetch_one applies before the search."""
-    album = title
+@dataclass(frozen=True)
+class SampledItem:
+    """A library row, in the shape the artwork-search path consumes."""
+
+    library_id: int
+    artist: str
+    title: str
+    alternate_artist_name: str | None
+    label: str | None
+    format: str | None
+
+
+@dataclass(frozen=True)
+class QueryShape:
+    """The exact query shape fetch_one sends to Discogs + scores against."""
+
+    search_artist: str
+    search_album: str
+    artist_variants: list[str]
+    title_variants: list[str]
+
+
+def build_query(item: SampledItem) -> QueryShape:
+    """Mirror fetch_one's query construction — the search-query mutations AND
+    the score-variant lists. Must stay byte-for-byte aligned with
+    ``lookup.orchestrator.fetch_artwork_for_items.fetch_one``; any drift makes
+    the measurement compare apples to oranges.
+    """
+    album = item.title
+
     if is_self_titled(album or ""):
-        album = artist
+        album = item.artist
+
+    artist = item.alternate_artist_name or item.artist or ""
     if is_compilation_artist(artist):
         artist = "Various"
-    return artist, album
+
+    artist_variants = [artist]
+    if artist == "Various":
+        artist_variants.append("Various Artists")
+    album_variants = [album or ""]
+    if item.title and item.title != album:
+        album_variants.append(item.title)
+
+    return QueryShape(
+        search_artist=artist,
+        search_album=album or "",
+        artist_variants=artist_variants,
+        title_variants=album_variants,
+    )
 
 
-async def sample_library_items(
-    db: LibraryDB, n: int
-) -> list[tuple[int, str, str, str | None, str | None]]:
-    """Return ``n`` random rows from the library as (id, artist, title, label, format)."""
+async def sample_library_items(db: LibraryDB, n: int) -> list[SampledItem]:
+    """Return ``n`` random library rows, including alternate_artist_name and
+    label when the underlying schema carries them (mirrors ``LibraryDB``'s
+    own column-introspection done in ``connect()``).
+    """
     assert db._conn is not None
-    has_label = db._has_label
-    cols = "id, artist, title, format" + (", label" if has_label else "")
-    cursor = await db._conn.execute(f"SELECT {cols} FROM library ORDER BY RANDOM() LIMIT ?", (n,))
+    cols = ["id", "artist", "title", "format"]
+    if db._has_alternate_artist:
+        cols.append("alternate_artist_name")
+    if db._has_label:
+        cols.append("label")
+    cursor = await db._conn.execute(
+        f"SELECT {', '.join(cols)} FROM library ORDER BY RANDOM() LIMIT ?", (n,)
+    )
     rows = await cursor.fetchall()
-    out = []
+    out: list[SampledItem] = []
     for row in rows:
         out.append(
-            (
-                row["id"],
-                row["artist"] or "",
-                row["title"] or "",
-                row["label"] if has_label else None,
-                row["format"],
+            SampledItem(
+                library_id=row["id"],
+                artist=row["artist"] or "",
+                title=row["title"] or "",
+                alternate_artist_name=(
+                    row["alternate_artist_name"] if db._has_alternate_artist else None
+                ),
+                label=row["label"] if db._has_label else None,
+                format=row["format"],
             )
         )
     return out
 
 
 def classify(
-    results: Iterable[DiscogsSearchResult], query_artist: str, query_album: str
+    results: Iterable[DiscogsSearchResult], query: QueryShape
 ) -> tuple[DiscogsSearchResult | None, DiscogsSearchResult | None, float, float, float]:
-    """Return (old_pick, new_pick, top1_artist_score, top1_title_score, best_combined)."""
+    """Return (old_pick, new_pick, top1_artist_score, top1_title_score, best_combined).
+
+    Scores are taken against the same variant lists fetch_one uses, so the
+    top1 score reflects the floor's actual verdict, not a degenerate query.
+    """
     results = list(results)
     old_pick = results[0] if results else None
 
     top1_artist_score = 0.0
     top1_title_score = 0.0
     if old_pick is not None:
-        top1_artist_score = score_match(query_artist, old_pick.artist or "")
-        top1_title_score = score_match(query_album, old_pick.album or "")
+        top1_artist_score = max(
+            score_match(q, old_pick.artist or "") for q in query.artist_variants
+        )
+        top1_title_score = max(score_match(q, old_pick.album or "") for q in query.title_variants)
 
     new_pick = find_best_typed_match(
         results,
-        query_artist=query_artist,
-        query_title=query_album,
+        query_artist=query.artist_variants,
+        query_title=query.title_variants,
         artist_fn=lambda r: r.artist,
         title_fn=lambda r: r.album,
     )
 
     best_combined = 0.0
     if new_pick is not None:
-        a = score_match(query_artist, new_pick.artist or "")
-        t = score_match(query_album, new_pick.album or "")
+        a = max(score_match(q, new_pick.artist or "") for q in query.artist_variants)
+        t = max(score_match(q, new_pick.album or "") for q in query.title_variants)
         best_combined = (a + t) / 2
 
     return old_pick, new_pick, top1_artist_score, top1_title_score, best_combined
@@ -139,13 +196,14 @@ async def run(args: argparse.Namespace) -> None:
         items = await sample_library_items(library_db, args.sample)
         logger.info("Sampled %d library items", len(items))
 
-        with csv_path.open("w", newline="") as fh:
+        with csv_path.open("w", newline="", encoding="utf-8") as fh:
             writer = csv.writer(fh)
             writer.writerow(
                 [
                     "library_id",
                     "artist_raw",
                     "title_raw",
+                    "alternate_artist_name",
                     "artist_query",
                     "album_query",
                     "old_release_id",
@@ -157,24 +215,22 @@ async def run(args: argparse.Namespace) -> None:
                 ]
             )
 
-            for i, (lid, artist_raw, title_raw, label, fmt) in enumerate(items, start=1):
-                artist_q, album_q = mutate(artist_raw, title_raw)
+            for i, item in enumerate(items, start=1):
+                query = build_query(item)
                 try:
                     response = await service.search(
                         DiscogsSearchRequest(
-                            album=album_q,
-                            artist=artist_q,
-                            label=label,
-                            format=map_library_format_to_discogs(fmt),
+                            album=query.search_album,
+                            artist=query.search_artist,
+                            label=item.label,
+                            format=map_library_format_to_discogs(item.format),
                         )
                     )
                 except Exception as e:
-                    logger.warning("search failed for id=%s: %s", lid, e)
+                    logger.warning("search failed for id=%s: %s", item.library_id, e)
                     continue
 
-                old_pick, new_pick, a_score, t_score, best = classify(
-                    response.results, artist_q, album_q
-                )
+                old_pick, new_pick, a_score, t_score, best = classify(response.results, query)
 
                 if old_pick is None:
                     no_results += 1
@@ -191,11 +247,12 @@ async def run(args: argparse.Namespace) -> None:
 
                 writer.writerow(
                     [
-                        lid,
-                        artist_raw,
-                        title_raw,
-                        artist_q,
-                        album_q,
+                        item.library_id,
+                        item.artist,
+                        item.title,
+                        item.alternate_artist_name or "",
+                        query.search_artist,
+                        query.search_album,
                         old_pick.release_id if old_pick else "",
                         new_pick.release_id if new_pick else "",
                         outcome,
@@ -249,10 +306,7 @@ def main() -> None:
         default="/tmp/lml-478-floor.csv",
         help="Output CSV path",
     )
-    parser.add_argument("--seed", type=int, default=None, help="Random seed (optional)")
     args = parser.parse_args()
-    if args.seed is not None:
-        random.seed(args.seed)
     asyncio.run(run(args))
 
 

--- a/scripts/measure_artwork_match_floor.py
+++ b/scripts/measure_artwork_match_floor.py
@@ -1,0 +1,260 @@
+"""Measure the LML#478 80/80-floor's flip rate on a sample of library items.
+
+Replays the ``fetch_artwork_for_items`` Discogs search for N random library
+items and computes what the new ``find_best_typed_match`` floor would pick
+versus today's unconditional ``response.results[0]``. Reports the flip
+rates (to-None, to-different) and writes a per-row CSV for spot-checking.
+
+The pre-merge acceptance criterion in the LML#478 plan is ≤ 5% flip-to-None.
+Above that, escalate before merging.
+
+Usage:
+    DISCOGS_TOKEN=... DATABASE_URL_DISCOGS=postgresql://... \\
+        python scripts/measure_artwork_match_floor.py [--sample 1000] [--csv /tmp/lml-478-floor.csv]
+
+The script touches the Discogs cache + API exactly like the runtime path. To
+keep API load low and the measurement repeatable, point ``DATABASE_URL_DISCOGS``
+at a cache that's already warmed for the sampled items (the production cache
+qualifies).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import logging
+import os
+import random
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+import asyncpg
+from dotenv import load_dotenv
+from wxyc_etl.text import is_compilation_artist
+
+from clients.streaming.matching import find_best_typed_match, score_match
+from discogs.cache_service import DiscogsCacheService
+from discogs.models import DiscogsSearchRequest, DiscogsSearchResult
+from discogs.service import DiscogsService
+from library.db import LibraryDB
+from lookup.orchestrator import (
+    is_self_titled,
+    map_library_format_to_discogs,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def mutate(artist: str, title: str) -> tuple[str, str]:
+    """Mirror the artist/album mutations fetch_one applies before the search."""
+    album = title
+    if is_self_titled(album or ""):
+        album = artist
+    if is_compilation_artist(artist):
+        artist = "Various"
+    return artist, album
+
+
+async def sample_library_items(
+    db: LibraryDB, n: int
+) -> list[tuple[int, str, str, str | None, str | None]]:
+    """Return ``n`` random rows from the library as (id, artist, title, label, format)."""
+    assert db._conn is not None
+    has_label = db._has_label
+    cols = "id, artist, title, format" + (", label" if has_label else "")
+    cursor = await db._conn.execute(f"SELECT {cols} FROM library ORDER BY RANDOM() LIMIT ?", (n,))
+    rows = await cursor.fetchall()
+    out = []
+    for row in rows:
+        out.append(
+            (
+                row["id"],
+                row["artist"] or "",
+                row["title"] or "",
+                row["label"] if has_label else None,
+                row["format"],
+            )
+        )
+    return out
+
+
+def classify(
+    results: Iterable[DiscogsSearchResult], query_artist: str, query_album: str
+) -> tuple[DiscogsSearchResult | None, DiscogsSearchResult | None, float, float, float]:
+    """Return (old_pick, new_pick, top1_artist_score, top1_title_score, best_combined)."""
+    results = list(results)
+    old_pick = results[0] if results else None
+
+    top1_artist_score = 0.0
+    top1_title_score = 0.0
+    if old_pick is not None:
+        top1_artist_score = score_match(query_artist, old_pick.artist or "")
+        top1_title_score = score_match(query_album, old_pick.album or "")
+
+    new_pick = find_best_typed_match(
+        results,
+        query_artist=query_artist,
+        query_title=query_album,
+        artist_fn=lambda r: r.artist,
+        title_fn=lambda r: r.album,
+    )
+
+    best_combined = 0.0
+    if new_pick is not None:
+        a = score_match(query_artist, new_pick.artist or "")
+        t = score_match(query_album, new_pick.album or "")
+        best_combined = (a + t) / 2
+
+    return old_pick, new_pick, top1_artist_score, top1_title_score, best_combined
+
+
+async def run(args: argparse.Namespace) -> None:
+    discogs_token = os.environ.get("DISCOGS_TOKEN")
+    if not discogs_token:
+        logger.error("DISCOGS_TOKEN required")
+        sys.exit(1)
+    discogs_url = os.environ.get("DATABASE_URL_DISCOGS")
+    if not discogs_url:
+        logger.error("DATABASE_URL_DISCOGS required (Discogs cache)")
+        sys.exit(1)
+
+    library_db = LibraryDB()
+    await library_db.connect()
+
+    pool = await asyncpg.create_pool(discogs_url, min_size=2, max_size=5)
+    cache = DiscogsCacheService(pool)
+    service = DiscogsService(token=discogs_token, cache_service=cache)
+
+    csv_path = Path(args.csv)
+
+    flipped_to_none = 0
+    flipped_to_different = 0
+    same_pick = 0
+    no_results = 0
+
+    try:
+        items = await sample_library_items(library_db, args.sample)
+        logger.info("Sampled %d library items", len(items))
+
+        with csv_path.open("w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(
+                [
+                    "library_id",
+                    "artist_raw",
+                    "title_raw",
+                    "artist_query",
+                    "album_query",
+                    "old_release_id",
+                    "new_release_id",
+                    "outcome",
+                    "top1_artist_score",
+                    "top1_title_score",
+                    "best_combined_score",
+                ]
+            )
+
+            for i, (lid, artist_raw, title_raw, label, fmt) in enumerate(items, start=1):
+                artist_q, album_q = mutate(artist_raw, title_raw)
+                try:
+                    response = await service.search(
+                        DiscogsSearchRequest(
+                            album=album_q,
+                            artist=artist_q,
+                            label=label,
+                            format=map_library_format_to_discogs(fmt),
+                        )
+                    )
+                except Exception as e:
+                    logger.warning("search failed for id=%s: %s", lid, e)
+                    continue
+
+                old_pick, new_pick, a_score, t_score, best = classify(
+                    response.results, artist_q, album_q
+                )
+
+                if old_pick is None:
+                    no_results += 1
+                    outcome = "no_results"
+                elif new_pick is None:
+                    flipped_to_none += 1
+                    outcome = "flipped_to_none"
+                elif new_pick.release_id != old_pick.release_id:
+                    flipped_to_different += 1
+                    outcome = "flipped_to_different"
+                else:
+                    same_pick += 1
+                    outcome = "same"
+
+                writer.writerow(
+                    [
+                        lid,
+                        artist_raw,
+                        title_raw,
+                        artist_q,
+                        album_q,
+                        old_pick.release_id if old_pick else "",
+                        new_pick.release_id if new_pick else "",
+                        outcome,
+                        f"{a_score:.1f}",
+                        f"{t_score:.1f}",
+                        f"{best:.1f}",
+                    ]
+                )
+
+                if i % 50 == 0:
+                    logger.info(
+                        "  %d/%d | same=%d flip_none=%d flip_diff=%d no_results=%d",
+                        i,
+                        len(items),
+                        same_pick,
+                        flipped_to_none,
+                        flipped_to_different,
+                        no_results,
+                    )
+
+        total_with_results = same_pick + flipped_to_none + flipped_to_different
+        denom = max(total_with_results, 1)
+        logger.info("---")
+        logger.info("Sample N=%d (with Discogs results: %d)", len(items), total_with_results)
+        logger.info("  same pick:           %d (%.1f%%)", same_pick, 100 * same_pick / denom)
+        logger.info(
+            "  flipped to None:     %d (%.1f%%)  ← acceptance bar: ≤ 5%%",
+            flipped_to_none,
+            100 * flipped_to_none / denom,
+        )
+        logger.info(
+            "  flipped to diff id:  %d (%.1f%%)",
+            flipped_to_different,
+            100 * flipped_to_different / denom,
+        )
+        logger.info("  no results:          %d (excluded from rates)", no_results)
+        logger.info("CSV: %s", csv_path)
+    finally:
+        await service.close()
+        await pool.close()
+        await library_db.close()
+
+
+def main() -> None:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sample", type=int, default=1000, help="Number of items to sample")
+    parser.add_argument(
+        "--csv",
+        type=str,
+        default="/tmp/lml-478-floor.csv",
+        help="Output CSV path",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Random seed (optional)")
+    args = parser.parse_args()
+    if args.seed is not None:
+        random.seed(args.seed)
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -854,7 +854,7 @@ class TestFetchArtworkException:
                         make_discogs_result(
                             release_id=2,
                             album="Album2",
-                            artist="Artist",
+                            artist="Stereolab",
                         )
                     ],
                     total=1,

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1213,13 +1213,144 @@ class TestFetchArtworkForItems:
         """When item has no label, label should be None in search request."""
         item = make_library_item(id=1, artist="Cat Power", title="Moon Pix")
 
-        artwork = make_discogs_result(release_id=12345)
+        artwork = make_discogs_result(release_id=12345, album="Moon Pix", artist="Cat Power")
         mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[artwork])
 
         await fetch_artwork_for_items([item], mock_discogs_service)
 
         call_args = mock_discogs_service.search.call_args[0][0]
         assert call_args.label is None
+
+    @pytest.mark.asyncio
+    async def test_picks_correct_release_over_misleading_top1(self, mock_discogs_service):
+        """When Discogs's top-1 is the wrong release, the 80/80 floor + score
+        picks the correct one further down. LML#478 — concrete repro:
+        "Hebebeb (Zrag)" by Noura Mint Seymali appears on both *Tzenni* (2014)
+        and *Yenbett* (2025); Discogs's popularity-ranked top-1 isn't always
+        the album the DJ entered."""
+        item = make_library_item(id=1, artist="Noura Mint Seymali", title="Tzenni", format="CD")
+
+        wrong = make_discogs_result(
+            release_id=99991,
+            album="Yenbett",
+            artist="Noura Mint Seymali",
+            artwork_url="https://example.com/yenbett.jpg",
+        )
+        right = make_discogs_result(
+            release_id=12345,
+            album="Tzenni",
+            artist="Noura Mint Seymali",
+            artwork_url="https://example.com/tzenni.jpg",
+        )
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[wrong, right])
+
+        results = await fetch_artwork_for_items([item], mock_discogs_service)
+
+        assert len(results) == 1
+        assert results[0][1] is not None
+        assert results[0][1].release_id == 12345
+        assert results[0][1].album == "Tzenni"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_candidate_clears_floor(self, mock_discogs_service):
+        """When every candidate's artist+album fails the 80/80 floor against
+        the queried item, return None — better than serving wrong artwork
+        confidently. _resolve_fallback_artwork is NOT called (no result)."""
+        item = make_library_item(id=1, artist="Noura Mint Seymali", title="Tzenni", format="CD")
+
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[
+                make_discogs_result(release_id=1, album="Greatest Hits", artist="Some Other Band"),
+                make_discogs_result(
+                    release_id=2, album="Live in Berlin", artist="Another Wrong Artist"
+                ),
+            ]
+        )
+
+        results = await fetch_artwork_for_items([item], mock_discogs_service)
+
+        assert len(results) == 1
+        assert results[0][1] is None
+        mock_discogs_service.get_release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_self_titled_scores_against_mutated_album(self, mock_discogs_service):
+        """Self-titled albums stored as "S/t" have `album` mutated to the
+        artist name before the Discogs search; the score must use the mutated
+        value (constraint 4 in LML#478)."""
+        item = make_library_item(id=1, artist="Pavement", title="S/t", format="LP")
+
+        # Candidate album is "Pavement" — matches the mutated album, NOT the raw
+        # "S/t" library title. Without the mutation flowing into the score,
+        # this would fail the 80/80 floor.
+        candidate = make_discogs_result(
+            release_id=555,
+            album="Pavement",
+            artist="Pavement",
+            artwork_url="https://example.com/pavement.jpg",
+        )
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[candidate])
+
+        results = await fetch_artwork_for_items([item], mock_discogs_service)
+
+        assert len(results) == 1
+        assert results[0][1] is not None
+        assert results[0][1].release_id == 555
+
+    @pytest.mark.asyncio
+    async def test_compilation_artist_scores_against_various(self, mock_discogs_service):
+        """Compilation artists ("Various Artists - …") have `artist` mutated
+        to "Various" before the Discogs search; the score must use the
+        mutated value (constraint 4 in LML#478)."""
+        item = make_library_item(
+            id=20, artist="Various Artists - Rock - D", title="Disco Not Disco"
+        )
+
+        candidate = make_discogs_result(
+            release_id=99999,
+            album="Disco Not Disco",
+            artist="Various",
+            artwork_url="https://example.com/disco.jpg",
+        )
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[candidate])
+
+        results = await fetch_artwork_for_items([item], mock_discogs_service)
+
+        assert len(results) == 1
+        assert results[0][1] is not None
+        assert results[0][1].release_id == 99999
+
+    @pytest.mark.asyncio
+    async def test_picks_higher_combined_score_among_acceptable_candidates(
+        self, mock_discogs_service
+    ):
+        """When multiple candidates clear the 80/80 floor, pick the one with
+        the highest combined (artist + title) score — regardless of Discogs's
+        ordering."""
+        item = make_library_item(id=1, artist="Stereolab", title="Aluminum Tunes", format="CD")
+
+        # Both candidates pass 80/80 but the second is a near-perfect match.
+        slightly_off = make_discogs_result(
+            release_id=1,
+            album="Aluminium Tunes",  # British spelling, off by one char
+            artist="Stereolab",
+            artwork_url="https://example.com/off.jpg",
+        )
+        exact = make_discogs_result(
+            release_id=2,
+            album="Aluminum Tunes",
+            artist="Stereolab",
+            artwork_url="https://example.com/exact.jpg",
+        )
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[slightly_off, exact]
+        )
+
+        results = await fetch_artwork_for_items([item], mock_discogs_service)
+
+        assert len(results) == 1
+        assert results[0][1] is not None
+        assert results[0][1].release_id == 2
 
 
 class TestFetchArtworkFallback:
@@ -1231,7 +1362,11 @@ class TestFetchArtworkFallback:
         items = [make_library_item(id=1, artist="Autechre", title="Confield")]
 
         mock_discogs_service.search.return_value = DiscogsSearchResponse(
-            results=[make_discogs_result(release_id=28138, artwork_url=None)]
+            results=[
+                make_discogs_result(
+                    release_id=28138, album="Confield", artist="Autechre", artwork_url=None
+                )
+            ]
         )
         mock_discogs_service.get_release.return_value = ReleaseMetadataResponse(
             release_id=28138,
@@ -1257,7 +1392,11 @@ class TestFetchArtworkFallback:
         items = [make_library_item(id=1, artist="Autechre", title="Confield")]
 
         mock_discogs_service.search.return_value = DiscogsSearchResponse(
-            results=[make_discogs_result(release_id=28138, artwork_url=None)]
+            results=[
+                make_discogs_result(
+                    release_id=28138, album="Confield", artist="Autechre", artwork_url=None
+                )
+            ]
         )
         mock_discogs_service.get_release.return_value = ReleaseMetadataResponse(
             release_id=28138,
@@ -1286,6 +1425,8 @@ class TestFetchArtworkFallback:
             results=[
                 make_discogs_result(
                     release_id=28138,
+                    album="Confield",
+                    artist="Autechre",
                     artwork_url="https://i.discogs.com/cover.jpg",
                 )
             ]
@@ -1305,7 +1446,11 @@ class TestFetchArtworkFallback:
         items = [make_library_item(id=1, artist="Autechre", title="Confield")]
 
         mock_discogs_service.search.return_value = DiscogsSearchResponse(
-            results=[make_discogs_result(release_id=28138, artwork_url=None)]
+            results=[
+                make_discogs_result(
+                    release_id=28138, album="Confield", artist="Autechre", artwork_url=None
+                )
+            ]
         )
         mock_discogs_service.get_release.return_value = ReleaseMetadataResponse(
             release_id=28138,
@@ -1326,7 +1471,11 @@ class TestFetchArtworkFallback:
         items = [make_library_item(id=1, artist="Autechre", title="Confield")]
 
         mock_discogs_service.search.return_value = DiscogsSearchResponse(
-            results=[make_discogs_result(release_id=28138, artwork_url=None)]
+            results=[
+                make_discogs_result(
+                    release_id=28138, album="Confield", artist="Autechre", artwork_url=None
+                )
+            ]
         )
         mock_discogs_service.get_release.return_value = None
 
@@ -1347,7 +1496,11 @@ class TestFetchArtworkFallback:
         items = [make_library_item(id=1, artist="Autechre", title="Confield")]
 
         mock_discogs_service.search.return_value = DiscogsSearchResponse(
-            results=[make_discogs_result(release_id=28138, artwork_url=None)]
+            results=[
+                make_discogs_result(
+                    release_id=28138, album="Confield", artist="Autechre", artwork_url=None
+                )
+            ]
         )
         mock_discogs_service.get_release.return_value = ReleaseMetadataResponse(
             release_id=28138,

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1155,7 +1155,10 @@ class TestFetchArtworkForItems:
 
     @pytest.mark.asyncio
     async def test_uses_discogs_titles_for_compilation_lookup(self, mock_discogs_service):
-        """For compilations, use the Discogs album title (not library title) for artwork."""
+        """For compilations, use the Discogs album title (not library title) for
+        artwork — but the score floor must still accept the short library
+        title when Discogs returns it, since the long discogs_titles override
+        is a search aid, not a verification requirement."""
         item = make_library_item(
             id=20,
             artist="Various Artists - Rock - D",
@@ -1176,10 +1179,45 @@ class TestFetchArtworkForItems:
         )
 
         assert len(results) == 1
-        # Should have looked up with the Discogs title, not the library title
+        # Search used the long Discogs-canonical title (the override's purpose).
         call_args = mock_discogs_service.search.call_args[0][0]
         assert isinstance(call_args, DiscogsSearchRequest)
         assert "Disco Not Disco" in call_args.album
+        # ALSO the artwork survived the floor against the short library title
+        # (the variant the candidate carries). Without title-variant scoring,
+        # the long override vs. the short candidate would score 38.5 and the
+        # fuzzy-score floor would flip this to None.
+        assert results[0][1] is not None
+        assert results[0][1].release_id == 99999
+        assert results[0][1].artwork_url == "https://example.com/disco.jpg"
+
+    @pytest.mark.asyncio
+    async def test_compilation_canonical_various_artists(self, mock_discogs_service):
+        """Discogs returns most compilation releases with the canonical artist
+        string "Various Artists" (sometimes with a "(N)" disambiguation
+        suffix). The orchestrator mutates `artist` to bare "Various" for
+        Discogs's search endpoint, but scoring must tolerate the canonical
+        form — otherwise score_match("Various", "Various Artists") = 63.6 and
+        every "Various Artists" compilation flips to None."""
+        item = make_library_item(
+            id=21,
+            artist="Various Artists - Rock - D",
+            title="Disco Not Disco",
+        )
+
+        candidate = make_discogs_result(
+            release_id=88888,
+            album="Disco Not Disco",
+            artist="Various Artists",  # the canonical form, not the bare "Various"
+            artwork_url="https://example.com/disco-canonical.jpg",
+        )
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[candidate])
+
+        results = await fetch_artwork_for_items([item], mock_discogs_service)
+
+        assert len(results) == 1
+        assert results[0][1] is not None
+        assert results[0][1].release_id == 88888
 
     @pytest.mark.asyncio
     async def test_artwork_search_passes_label_and_format(self, mock_discogs_service):

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1098,25 +1098,41 @@ class TestFetchArtworkForItems:
 
     @pytest.mark.asyncio
     async def test_fetches_artwork_for_each_item(self, mock_discogs_service):
+        """Two items get their own per-search match — verifies the
+        gather-of-fetch_one pattern actually fans out and zips results back
+        in order. Returns distinct artwork per item via mock side_effect so
+        the second item isn't a degenerate copy of the first."""
         items = [
             make_library_item(id=1, artist="Queen", title="A Night at the Opera"),
             make_library_item(id=2, artist="Queen", title="The Game"),
         ]
 
-        artwork = make_discogs_result(
+        opera = make_discogs_result(
             release_id=12345,
             album="A Night at the Opera",
             artist="Queen",
-            artwork_url="https://example.com/cover.jpg",
+            artwork_url="https://example.com/opera.jpg",
         )
-        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[artwork])
+        game = make_discogs_result(
+            release_id=67890,
+            album="The Game",
+            artist="Queen",
+            artwork_url="https://example.com/game.jpg",
+        )
+        mock_discogs_service.search.side_effect = [
+            DiscogsSearchResponse(results=[opera]),
+            DiscogsSearchResponse(results=[game]),
+        ]
 
         results = await fetch_artwork_for_items(items, mock_discogs_service)
 
         assert len(results) == 2
-        # Each result is a (LibraryItem, DiscogsSearchResult | None) tuple
         assert results[0][0].id == 1
         assert results[0][1] is not None
+        assert results[0][1].release_id == 12345
+        assert results[1][0].id == 2
+        assert results[1][1] is not None
+        assert results[1][1].release_id == 67890
 
     @pytest.mark.asyncio
     async def test_returns_none_artwork_without_discogs(self):
@@ -1218,6 +1234,61 @@ class TestFetchArtworkForItems:
         assert len(results) == 1
         assert results[0][1] is not None
         assert results[0][1].release_id == 88888
+        assert results[0][1].artwork_url == "https://example.com/disco-canonical.jpg"
+
+    @pytest.mark.asyncio
+    async def test_self_titled_does_not_leak_pattern_into_album_variants(
+        self, mock_discogs_service
+    ):
+        """The self-titled mutation sets album=item.artist; the title-variant
+        block must NOT re-append the trigger pattern ("S/t") because a stray
+        Discogs result whose album is literally "S/t" would clear the floor
+        trivially against the readmitted variant, defeating the floor's intent."""
+        item = make_library_item(id=1, artist="Pavement", title="S/t", format="LP")
+
+        # Wrong-release candidate that happens to carry album="S/t".
+        wrong_release_with_st_album = make_discogs_result(
+            release_id=999,
+            album="S/t",
+            artist="Pavement",
+            artwork_url="https://example.com/wrong.jpg",
+        )
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[wrong_release_with_st_album]
+        )
+
+        results = await fetch_artwork_for_items([item], mock_discogs_service)
+
+        assert len(results) == 1
+        # Without the self-titled-pattern filter on the variant append, the
+        # variant ["Pavement", "S/t"] would let this wrong-release clear via
+        # score_match("S/t", "S/t") = 100.
+        assert results[0][1] is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_item_title_is_empty(self, mock_discogs_service):
+        """Library rows with title=None or title='' (allowed by LibraryItem)
+        no longer return a top-1 by default. The album variant set collapses
+        to [''], the empty-variant short-circuit fires, the function returns
+        None. Pin this so a future relaxation can't silently re-introduce
+        the 'first Discogs hit wins regardless of title' behavior the floor
+        is meant to prevent."""
+        item = make_library_item(id=1, artist="Stereolab", title="", format="CD")
+
+        # Even a candidate that perfectly matches the artist clearly fails
+        # because there is no title to score against.
+        candidate = make_discogs_result(
+            release_id=42,
+            album="Aluminum Tunes",
+            artist="Stereolab",
+            artwork_url="https://example.com/al.jpg",
+        )
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[candidate])
+
+        results = await fetch_artwork_for_items([item], mock_discogs_service)
+
+        assert len(results) == 1
+        assert results[0][1] is None
 
     @pytest.mark.asyncio
     async def test_artwork_search_passes_label_and_format(self, mock_discogs_service):

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -339,6 +339,96 @@ class TestFindBestTypedMatch:
         )
         assert best is first
 
+    def test_query_artist_accepts_variant_list_and_takes_max(self):
+        """When the search-query form ('Various') differs from the canonical
+        form Discogs returns ('Various Artists'), passing both variants lets
+        the score clear the floor — score_match('Various', 'Various Artists')
+        is 63.6, but score_match('Various Artists', 'Various Artists') is
+        100, and the max wins."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        candidate = make_discogs_result(
+            release_id=42, album="Disco Not Disco", artist="Various Artists"
+        )
+        best = find_best_typed_match(
+            [candidate],
+            query_artist=["Various", "Various Artists"],
+            query_title="Disco Not Disco",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is candidate
+
+    def test_query_title_accepts_variant_list_and_takes_max(self):
+        """When the search-query form (a long canonical title) differs from
+        the form the candidate carries (short library title), passing both
+        variants lets the score clear the floor."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        candidate = make_discogs_result(release_id=42, album="Disco Not Disco", artist="Various")
+        best = find_best_typed_match(
+            [candidate],
+            query_artist="Various",
+            query_title=[
+                "Disco Not Disco (Post Punk, Electro & Leftfield Disco Classics)",
+                "Disco Not Disco",
+            ],
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is candidate
+
+    def test_returns_none_when_query_artist_is_empty_string(self):
+        """score_match('','') returns 100 by rapidfuzz convention. Without a
+        guard, a candidate with r.artist=None (coerced to '') and r.album=''
+        would trivially clear 100/100 against an empty query. Defense against
+        sparse library rows + malformed Discogs candidates."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        # Both candidate fields parse as empty/None.
+        junk = make_discogs_result(release_id=99, album="", artist=None)
+        best = find_best_typed_match(
+            [junk],
+            query_artist="",
+            query_title="Aluminum Tunes",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is None
+
+    def test_returns_none_when_query_title_is_empty_string(self):
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        junk = make_discogs_result(release_id=99, album=None, artist="")
+        best = find_best_typed_match(
+            [junk],
+            query_artist="Stereolab",
+            query_title="",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is None
+
+    def test_returns_none_when_every_variant_is_empty(self):
+        """Variant lists with only empty strings are equivalent to an empty
+        query and short-circuit to no-match."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        junk = make_discogs_result(release_id=99, album="", artist="")
+        best = find_best_typed_match(
+            [junk],
+            query_artist=["", ""],
+            query_title="Foo",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is None
+
 
 class TestStripThePrefix:
     @pytest.mark.parametrize(

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -255,6 +255,91 @@ class TestFindBestMatch:
         assert best["confidence"] > 0
 
 
+class TestFindBestTypedMatch:
+    """Tests for find_best_typed_match — returns the original typed object."""
+
+    def test_returns_highest_combined_score_original(self):
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        slightly_off = make_discogs_result(
+            release_id=1, album="Aluminium Tunes", artist="Stereolab"
+        )
+        exact = make_discogs_result(release_id=2, album="Aluminum Tunes", artist="Stereolab")
+        best = find_best_typed_match(
+            [slightly_off, exact],
+            query_artist="Stereolab",
+            query_title="Aluminum Tunes",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is exact
+
+    def test_returns_none_when_no_candidate_clears_floor(self):
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        candidates = [
+            make_discogs_result(release_id=1, album="Moon Pix", artist="Cat Power"),
+            make_discogs_result(release_id=2, album="Greatest Hits", artist="Queen"),
+        ]
+        best = find_best_typed_match(
+            candidates,
+            query_artist="Autechre",
+            query_title="Confield",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is None
+
+    def test_returns_none_for_empty_iterable(self):
+        from clients.streaming.matching import find_best_typed_match
+
+        best = find_best_typed_match(
+            [],
+            query_artist="Stereolab",
+            query_title="Aluminum Tunes",
+            artist_fn=lambda r: "",
+            title_fn=lambda r: "",
+        )
+        assert best is None
+
+    def test_handles_none_fields_on_candidate(self):
+        """A candidate whose artist or title extractor returns None scores as 0
+        and is rejected — not raised."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        # DiscogsSearchResult.artist defaults to None; verify it doesn't blow up.
+        broken = make_discogs_result(release_id=1, album="Aluminum Tunes", artist=None)
+        good = make_discogs_result(release_id=2, album="Aluminum Tunes", artist="Stereolab")
+        best = find_best_typed_match(
+            [broken, good],
+            query_artist="Stereolab",
+            query_title="Aluminum Tunes",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is good
+
+    def test_first_result_wins_on_tie(self):
+        """Ties resolve to the first candidate reaching the score — mirrors
+        find_best_match's order-preserving behavior."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        first = make_discogs_result(release_id=1, album="Aluminum Tunes", artist="Stereolab")
+        second = make_discogs_result(release_id=2, album="Aluminum Tunes", artist="Stereolab")
+        best = find_best_typed_match(
+            [first, second],
+            query_artist="Stereolab",
+            query_title="Aluminum Tunes",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is first
+
+
 class TestStripThePrefix:
     @pytest.mark.parametrize(
         "name, expected",

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -429,6 +429,55 @@ class TestFindBestTypedMatch:
         )
         assert best is None
 
+    def test_returns_none_when_query_artist_is_whitespace_only(self):
+        """``score_match(" ", "")`` returns 100 because the title normalizer
+        strips whitespace before scoring. The empty-variant filter rejects
+        whitespace-only strings (not just literal empty strings) so a
+        sparse-but-not-empty library field can't sneak past the floor."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        junk = make_discogs_result(release_id=99, album="Aluminum Tunes", artist="")
+        best = find_best_typed_match(
+            [junk],
+            query_artist=" ",
+            query_title="Aluminum Tunes",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is None
+
+    def test_returns_none_when_every_variant_is_whitespace(self):
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        junk = make_discogs_result(release_id=99, album="Aluminum Tunes", artist="Stereolab")
+        best = find_best_typed_match(
+            [junk],
+            query_artist=["  ", "\t"],
+            query_title="Aluminum Tunes",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is None
+
+    def test_mixed_variants_keeps_non_empty(self):
+        """When variants are mixed (empty/whitespace + real), the real ones
+        are kept and used for scoring — the empty/whitespace entries are
+        dropped silently rather than blocking the call."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        candidate = make_discogs_result(release_id=42, album="Aluminum Tunes", artist="Stereolab")
+        best = find_best_typed_match(
+            [candidate],
+            query_artist=["", "Stereolab", "  "],
+            query_title=["Aluminum Tunes", ""],
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is candidate
+
 
 class TestStripThePrefix:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`fetch_artwork_for_items` in `lookup/orchestrator.py` previously took `response.results[0]` unconditionally when looking up Discogs artwork for a library item. Discogs ranks by its own popularity/recency signals, so when a song appears on multiple releases (compilations, reissues, multi-release artists) the top result could be a different album than the one the DJ entered — and the field served wrong artwork rather than `None`. The concrete repro in the issue: "Hebebeb (Zrag)" by Noura Mint Seymali appears on both *Tzenni* (2014) and *Yenbett* (2025); the DJ-entered album title was correct, the artwork was wrong.

This PR scores candidates against the post-mutation `(artist, album)` the search consumed, applies the same 80/80 floor (`score_match` + `is_acceptable_match`) every streaming client uses, and returns `None` when nothing clears. Downstream (`enrich_artwork_results`) already tolerates `None` and synthesizes a streaming-URL-only result (LML#401).

## What changed

- **`clients/streaming/matching.py`** — adds `find_best_typed_match`, a typed sibling of `find_best_match` that returns the original candidate (e.g. a `DiscogsSearchResult`) instead of a flattened streaming-URL dict. The Discogs path needs the full payload back, not a normalized URL pair.
- **`lookup/orchestrator.py`** — `fetch_one` swaps the unconditional `results[0]` for `find_best_typed_match(response.results, ...)` against the same `artist` / `album` locals the search received (post `is_self_titled` and `is_compilation_artist` mutation, so self-titled and compilation matches still clear).
- **`scripts/measure_artwork_match_floor.py`** — one-shot diagnostic that samples N library items, replays the Discogs search, and reports the flip-to-None and flip-to-different rates so the pre-merge measurement is repeatable.

## Tests

- `test_picks_correct_release_over_misleading_top1` — the Noura *Tzenni* vs. *Yenbett* repro.
- `test_returns_none_when_no_candidate_clears_floor` — no candidate matches → `None`, fallback resolver not called.
- `test_self_titled_scores_against_mutated_album` — the score uses the mutated album (artist name), not raw "S/t".
- `test_compilation_artist_scores_against_various` — the score uses "Various", not "Various Artists - Rock - D".
- `test_picks_higher_combined_score_among_acceptable_candidates` — when multiple clear 80/80, the higher combined score wins regardless of Discogs ordering.
- `TestFindBestTypedMatch` — 5 cases covering the helper itself (highest score, no-clear, empty, None fields, tie-break).

Several existing test mocks in `TestFetchArtworkFallback` and `TestFetchArtworkException` used `make_discogs_result` with factory defaults (Stereolab / Aluminum Tunes) against unrelated library items (Autechre / Confield). Under the new floor those would fail 80/80 and return `None`. Updated to pass matching `artist` + `album` kwargs.

Full unit + integration sweep green (2341 passed, 1 skipped, 125 deselected, 2 xfailed). Ruff + format + mypy clean.

## Measurement (acceptance criterion 5)

The pre-merge measurement is the `scripts/measure_artwork_match_floor.py` script. It needs `DISCOGS_TOKEN` and `DATABASE_URL_DISCOGS` against a warmed cache (production qualifies). Run before merging and paste the summary back into this PR. The bar set in the plan is **≤ 5% flip-to-None**; above that, escalate (likely indicates the 80/80 floor wants tuning for the Discogs distribution, or `strip_format_suffix` needs another pattern).

The CSV gives per-row outcomes — sanity-check K=20 of the `flipped_to_none` rows by hand to confirm they were genuinely the wrong release.

## Plan

Implementation plan with reviewer feedback at `docs/plans/lml-478-artwork-fuzzy-score.md` (committed in `ca86488`).

## Test plan

- [ ] Run `python scripts/measure_artwork_match_floor.py --sample 1000` against the production Discogs cache; paste summary here.
- [ ] Spot-check 20 `flipped_to_none` rows in the CSV against the Discogs release pages.
- [ ] Confirm flip-to-None rate is ≤ 5%.

## Out of scope

- **#440** (Spotify `spotify_url` search-URL template not verified) — sibling concern, separate PR.
- **#442** (Apple album-first lookup — right album not in top-N) — different problem shape; this PR scores the results we have, #442 changes which results we ask for.

Closes #478