### PR TITLE
feat(lookup): project results_count + match_type onto Sentry transaction

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -2276,14 +2276,18 @@ async def perform_lookup(
                 apple_music=apple_music,
             )
 
-    # Project the request-side flags onto the active Sentry transaction so
-    # the trace can be filtered by request mode (lml.lookup.extended,
-    # lml.lookup.warm_cache).
+    # Project the request-side flags and result-quality signals onto the
+    # active Sentry transaction so the trace can be filtered by request mode
+    # (lml.lookup.extended, lml.lookup.warm_cache) and by match outcome
+    # (lookup.results_count, lookup.match_type — LML#158). Mirrors the
+    # cache_stats projection pattern (LML#213).
     try:
         scope = sentry_sdk.get_current_scope()
         if scope.transaction is not None:
             scope.transaction.set_data("lml.lookup.extended", extended_mode)
             scope.transaction.set_data("lml.lookup.warm_cache", warm_cache_mode)
+            scope.transaction.set_data("lookup.results_count", len(library_results))
+            scope.transaction.set_data("lookup.match_type", search_type)
     except Exception:
         # Observability must not break the request path.
         pass

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -1,6 +1,6 @@
 """Integration tests for the lookup pipeline with real LibraryDB."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -147,6 +147,115 @@ class TestLookupPipeline:
         # Should have corrected the artist
         if body.get("corrected_artist"):
             assert body["corrected_artist"] == "Living Colour"
+
+
+class TestLookupResultAttributesProjection:
+    """LML#158: result-quality attributes on the /api/v1/lookup transaction.
+
+    Mirrors the LML#213 cache_stats projection pattern. After the orchestrator
+    runs its full pipeline, it must attach `lookup.results_count` and
+    `lookup.match_type` to the active Sentry transaction so trace explorer can
+    diagnose "right artist, wrong album" failures (the Underscores → fishmonger
+    class) without per-caller instrumentation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_direct_match_projects_results_count_and_match_type(self, app_client):
+        """A direct artist+album match projects the count and match_type onto the txn."""
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with patch("lookup.orchestrator.sentry_sdk.get_current_scope", return_value=mock_scope):
+            resp = await app_client.post(
+                "/api/v1/lookup",
+                json={
+                    "artist": "Stereolab",
+                    "album": "Dots and Loops",
+                    "raw_message": "Stereolab - Dots and Loops",
+                },
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        # Existing projection still fires.
+        assert "lml.lookup.extended" in calls
+        assert "lml.lookup.warm_cache" in calls
+        # New result-quality attributes.
+        assert calls["lookup.results_count"] == len(body["results"])
+        assert calls["lookup.match_type"] == body["search_type"]
+        # match_type is a SearchType slug, not a python-repr.
+        assert isinstance(calls["lookup.match_type"], str)
+        assert calls["lookup.match_type"] in {
+            "direct",
+            "fallback",
+            "alternative",
+            "compilation",
+            "song_as_artist",
+            "none",
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_results_projects_zero_count(self, app_client):
+        """A miss still projects results_count=0 and match_type, so traces filter cleanly."""
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with patch("lookup.orchestrator.sentry_sdk.get_current_scope", return_value=mock_scope):
+            resp = await app_client.post(
+                "/api/v1/lookup",
+                json={
+                    "artist": "ZZZNONEXISTENT",
+                    "raw_message": "ZZZNONEXISTENT",
+                },
+            )
+
+        assert resp.status_code == 200
+        calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert calls["lookup.results_count"] == 0
+        # Even on miss, match_type is set (likely "none" or a fallback slug).
+        assert "lookup.match_type" in calls
+        assert isinstance(calls["lookup.match_type"], str)
+
+    @pytest.mark.asyncio
+    async def test_projection_no_op_without_active_transaction(self, app_client):
+        """No active Sentry transaction -> projection is a no-op (no crash)."""
+        mock_scope = Mock()
+        mock_scope.transaction = None
+
+        with patch("lookup.orchestrator.sentry_sdk.get_current_scope", return_value=mock_scope):
+            resp = await app_client.post(
+                "/api/v1/lookup",
+                json={
+                    "artist": "Stereolab",
+                    "album": "Dots and Loops",
+                    "raw_message": "Stereolab - Dots and Loops",
+                },
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_projection_failure_does_not_break_request(self, app_client):
+        """A raising set_data must not break the lookup. Observability is not load-bearing."""
+        mock_transaction = Mock()
+        mock_transaction.set_data = Mock(side_effect=RuntimeError("boom"))
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with patch("lookup.orchestrator.sentry_sdk.get_current_scope", return_value=mock_scope):
+            resp = await app_client.post(
+                "/api/v1/lookup",
+                json={
+                    "artist": "Stereolab",
+                    "album": "Dots and Loops",
+                    "raw_message": "Stereolab - Dots and Loops",
+                },
+            )
+
+        assert resp.status_code == 200
 
 
 class TestSelfTitledAlbumMatching:


### PR DESCRIPTION
## Summary

Extends the existing transaction-projection block in `perform_lookup` ([`lookup/orchestrator.py`](https://github.com/WXYC/library-metadata-lookup/blob/main/lookup/orchestrator.py#L2279-L2289)) so traces carry two result-quality signals:

- `lookup.results_count` — `len(library_results)` after `limit_results` / track-validation / Discogs cross-check have run.
- `lookup.match_type` — the search-type slug returned by `get_search_type_from_state` (a string already; the `SearchType` enum is a `StrEnum`).

Together with the existing `lml.lookup.extended` / `lml.lookup.warm_cache`, this lets Sentry trace-explorer filter the "right artist, wrong album" failures (the Underscores → fishmonger class) by match outcome without per-caller instrumentation. Mirrors the LML#213 `lml.cache.*` projection: wrap-at-chokepoint, project-onto-transaction, observability never raises.

Uses `transaction.set_data(...)` (not `set_attribute`) per the existing pattern and the typing-trap lesson — numeric attributes set via `set_attribute` after span creation index as strings and break aggregation.

## Deferred: `lookup.top_score`

The plan also called for `lookup.top_score` if a numeric confidence was already in scope. There is none at the projection point:

- `LibraryItem` has no score field.
- `SearchState.results` is `list[LibraryItem]`.
- The orchestrator computes intermediate trigram and fuzz scores (e.g. resolver pre-pass, artwork match floor) but does not carry them through to ranked output.

Inventing one would mislead trace queries. Exposing a real per-result `confidence` is the open work of issue #158 itself; this PR addresses the diagnostic-instrumentation half so the calibration work can begin against real production traces.

## Test plan

- [x] New `TestLookupResultAttributesProjection` class in `tests/integration/test_lookup_pipeline.py` — four cases:
  - direct match projects `results_count` matching response body + valid `match_type` slug
  - empty-result lookup projects `results_count == 0` and a `match_type`
  - no active transaction: projection is a no-op (no crash)
  - `set_data` raising does not break the request
- [x] Tests verified red without the orchestrator change, green with it (KeyError on `lookup.results_count`).
- [x] `ruff check` + `ruff format --check` clean.
- [x] Full default-marker suite: 2394 passed, 2 skipped, 127 deselected (pg/external_api), 2 xfailed.

Closes #158