### PR TITLE
fix(discogs): include exception type, method, and path in request-failure log

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -411,7 +411,14 @@ class DiscogsService:
                     return response
 
                 except httpx.RequestError as e:
-                    logger.error(f"Discogs request failed: {e}")
+                    logger.error(
+                        "Discogs request failed: %s %s -> %s: %r",
+                        method,
+                        path,
+                        type(e).__name__,
+                        e,
+                        exc_info=True,
+                    )
                     return None
         finally:
             semaphore.release()

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -298,6 +298,32 @@ class TestRequestWithRetry:
         assert resp is None
 
     @pytest.mark.asyncio
+    async def test_request_error_log_includes_exception_type_and_request(self, service, caplog):
+        """LIBRARY-METADATA-LOOKUP-7: when an httpx.RequestError with an empty
+        message bubbles out of the request, the log line `Discogs request
+        failed: {e}` produces `Discogs request failed:` with no diagnostic
+        tail. The Sentry issue title is then unactionable. Capture the
+        exception class name, the method/path being requested, and exc_info
+        so the next outage is triage-able.
+        """
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=httpx.ConnectError(""))
+        service._client = mock_client
+
+        with caplog.at_level("ERROR", logger="discogs.service"):
+            resp = await service._request_with_retry("GET", "/database/search", max_retries=0)
+
+        assert resp is None
+        records = [r for r in caplog.records if "Discogs request failed" in r.getMessage()]
+        assert len(records) == 1, "expected exactly one Discogs request failed log line"
+        record = records[0]
+        msg = record.getMessage()
+        assert "ConnectError" in msg, f"log message missing exception class name: {msg!r}"
+        assert "GET" in msg, f"log message missing HTTP method: {msg!r}"
+        assert "/database/search" in msg, f"log message missing request path: {msg!r}"
+        assert record.exc_info is not None, "log record should carry exc_info for Sentry traceback"
+
+    @pytest.mark.asyncio
     async def test_429_honors_retry_after_header(self, service):
         """When Discogs sends Retry-After, sleep that long instead of exponential backoff."""
         mock_client = AsyncMock()


### PR DESCRIPTION
## Summary

- `discogs/service.py:413` previously logged `f"Discogs request failed: {e}"`, which on `httpx.ConnectError`/`ReadError`/`RemoteProtocolError` (frequently empty `str(e)`) produced `Discogs request failed:` with no diagnostic tail and no traceback — exactly what Sentry issue [LIBRARY-METADATA-LOOKUP-7](https://wxyc.sentry.io/issues/LIBRARY-METADATA-LOOKUP-7) surfaced.
- Capture the exception class name and `repr(e)` alongside the failing method and path, and pass `exc_info=True` so Sentry retains the traceback.
- No behavior change — still returns `None` on `httpx.RequestError`.

## Test plan

- [x] New unit test `test_request_error_log_includes_exception_type_and_request` reproduces the empty-message case with `httpx.ConnectError("")` and fails on the old log line (`'Discogs request failed: '`).
- [x] `pytest tests/unit/test_discogs_service.py` — 136/136 pass with the fix.
- [x] `ruff check` + `ruff format --check` clean on the touched files.

Closes #491