### PR TITLE
chore(codegen): sync generated/api_models.py with FlowsheetCreateSongFreeform.rotation_id

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -163,6 +163,10 @@ class FlowsheetCreateSongFreeform(BaseModel):
     segue: bool | None = None
     record_label: str | None = None
     label_id: int | None = None
+    rotation_id: int | None = Field(
+        None,
+        description="Rotation linkage for a track on a rotation album that isn't in the WXYC library catalog (BS#1308). The Backend snapshot/else branch persists `rotation_id` alongside `album_id IS NULL` so the V2 read path can JOIN back to `rotation` for `rotation_bin` and the iOS rotation-artwork resolver can find the entry. `rotation_bin` is derived on read and intentionally not declared here.\n",
+    )
 
 
 class EntryType(StrEnum):


### PR DESCRIPTION
## Summary

- Upstream `wxyc-shared/api.yaml` gained `FlowsheetCreateSongFreeform.rotation_id` (BS#1308); the committed `generated/api_models.py` never picked it up, so the Codegen Freshness CI gate has been failing on every open PR.
- Regenerate via `scripts/generate_api_models.sh` (fetched `api.yaml` directly from upstream main to bypass any stale sibling clones) — diff is the exact 4 lines CI reports.
- No application code references the new field yet; purely a contract-sync commit.

## Test plan

- [x] Diff matches CI's reported drift exactly (`+rotation_id: int | None = Field(...)` under `FlowsheetCreateSongFreeform`).
- [ ] Codegen Freshness check goes green on this PR.
- [ ] Full suite still passes (no application change expected).

Closes #493