### PR TITLE
feat(discogs): add ?refresh=true on entity endpoints to evict L1

### DIFF
--- a/discogs/memory_cache.py
+++ b/discogs/memory_cache.py
@@ -220,9 +220,48 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
 
             return result  # type: ignore[no-any-return]
 
+        # Stash the cache + name so `evict_cached` can drop a single entry
+        # using the SAME key derivation. Keeping these on the wrapper means a
+        # future change to the decorator's keying logic forces a matching
+        # change here, not a silent drift. Underscored to mark them private.
+        wrapper._lml_cache = cache  # type: ignore[attr-defined]
+        wrapper._lml_func_name = func.__name__  # type: ignore[attr-defined]
+
         return wrapper  # type: ignore[return-value]
 
     return decorator
+
+
+def evict_cached(cached_func: Callable, *args, **kwargs) -> bool:
+    """Evict the L1 entry for ``cached_func(*args, **kwargs)``.
+
+    Args:
+        cached_func: A function decorated with :func:`async_cached`. For instance
+            methods, pass the class attribute (e.g. ``DiscogsService.get_artist_details``)
+            rather than a bound method — bound-method access does not proxy the
+            stashed ``_lml_cache`` / ``_lml_func_name`` attributes.
+        *args: Positional arguments AFTER any ``self`` strip — i.e., the same
+            arguments the underlying function receives. The decorator already
+            strips ``self`` when caching, so callers should mirror that.
+        **kwargs: Keyword arguments. Same per-value normalization as the
+            decorator's key derivation (`make_normalized_cache_key`).
+
+    Returns:
+        ``True`` if a key was found and removed, ``False`` if no entry existed.
+
+    Raises:
+        TypeError: If ``cached_func`` was not decorated with ``@async_cached``.
+
+    Example:
+        >>> evict_cached(DiscogsService.get_artist_details, 6998498)
+        True  # L1 had a cached ArtistDetails for that id; now gone.
+    """
+    cache = getattr(cached_func, "_lml_cache", None)
+    func_name = getattr(cached_func, "_lml_func_name", None)
+    if cache is None or func_name is None:
+        raise TypeError(f"{cached_func!r} is not @async_cached — no eviction surface available")
+    key = make_normalized_cache_key(func_name, *args, **kwargs)
+    return cache.pop(key, None) is not None
 
 
 def get_track_cache() -> TTLCache:

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -1,12 +1,15 @@
 """FastAPI router for Discogs API endpoints."""
 
 import logging
+from collections.abc import Callable
 
+import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from core.dependencies import get_discogs_cache_service, get_discogs_service
 from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 from discogs.markup_parser import DiscogsServiceResolver, parse_async
+from discogs.memory_cache import evict_cached
 from discogs.models import (
     ArtistDetails,
     EntityResolveResponse,
@@ -21,6 +24,15 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/discogs", tags=["discogs"])
 
+# Shared description for the ?refresh query param so every entity endpoint
+# documents the same behavior in the OpenAPI schema. LML#498.
+_REFRESH_DESCRIPTION = (
+    "When true, evict the in-memory L1 cache entry for this entity before "
+    "fetching. Forces re-traversal of L2 (PG) and L3 (Discogs API), which is "
+    "needed after a manual fix to the underlying PG cache row that would "
+    "otherwise stay invisible until L1's TTL expires."
+)
+
 
 def _require_service(service: DiscogsService | None) -> DiscogsService:
     """Raise 503 if service is not available."""
@@ -30,6 +42,27 @@ def _require_service(service: DiscogsService | None) -> DiscogsService:
             detail="Discogs service is not configured. Set DISCOGS_TOKEN environment variable.",
         )
     return service
+
+
+def _refresh_l1(cached_func: Callable, *args, **kwargs) -> None:
+    """Evict an L1 entry on a refresh request and tag the Sentry trace.
+
+    Only tags when eviction actually removed something — a no-op probe
+    (refresh on an already-cold key) doesn't count. The Sentry tag
+    ``lml.cache.refresh_evicted`` and transaction data
+    ``lml.cache.memory_evictions_refresh`` give operators a filterable signal
+    that a refresh-driven miss caused any downstream L2/L3 traversal — distinct
+    from a natural TTL expiry, which leaves no marker. LML#498.
+    """
+    if not evict_cached(cached_func, *args, **kwargs):
+        return
+    try:
+        sentry_sdk.set_tag("lml.cache.refresh_evicted", "true")
+        transaction = sentry_sdk.get_current_scope().transaction
+        if transaction is not None:
+            transaction.set_data("lml.cache.memory_evictions_refresh", 1)
+    except Exception as e:
+        logger.warning("Failed to tag refresh eviction on Sentry transaction: %s", e)
 
 
 @router.get(
@@ -65,10 +98,13 @@ async def get_track_releases(
 )
 async def get_release(
     release_id: int,
+    refresh: bool = Query(False, description=_REFRESH_DESCRIPTION),
     service: DiscogsService | None = Depends(get_discogs_service),
 ) -> ReleaseMetadataResponse:
     """Get full metadata for a release by ID."""
     svc = _require_service(service)
+    if refresh:
+        _refresh_l1(DiscogsService.get_release, release_id)
     result = await svc.get_release(release_id)
 
     if result is None:
@@ -92,10 +128,13 @@ async def get_release(
 )
 async def get_artist(
     artist_id: int,
+    refresh: bool = Query(False, description=_REFRESH_DESCRIPTION),
     service: DiscogsService | None = Depends(get_discogs_service),
 ) -> ArtistDetails:
     """Get full details for an artist by Discogs ID."""
     svc = _require_service(service)
+    if refresh:
+        _refresh_l1(DiscogsService.get_artist_details, artist_id)
     result = await svc.get_artist_details(artist_id)
 
     if result is None:
@@ -128,10 +167,23 @@ async def get_artist(
 async def resolve_entity(
     entity_type: EntityType,
     entity_id: int,
+    refresh: bool = Query(False, description=_REFRESH_DESCRIPTION),
     service: DiscogsService | None = Depends(get_discogs_service),
 ) -> EntityResolveResponse:
     """Resolve a Discogs entity (artist, release, or master) to its name."""
     svc = _require_service(service)
+
+    # Dispatch to the cached method matching this entity type. Adding a new
+    # `EntityType` value MUST come with a matching entry here; the parametrized
+    # test in test_discogs_router.py walks every enum value so a missing leg
+    # surfaces as a test failure rather than a silent refresh no-op.
+    cached_funcs_by_type = {
+        EntityType.artist: DiscogsService.get_artist_details,
+        EntityType.release: DiscogsService.get_release,
+        EntityType.master: DiscogsService.get_master,
+    }
+    if refresh:
+        _refresh_l1(cached_funcs_by_type[entity_type], entity_id)
 
     if entity_type == EntityType.artist:
         artist = await svc.get_artist_details(entity_id)

--- a/docs/plans/498-l1-refresh.md
+++ b/docs/plans/498-l1-refresh.md
@@ -1,0 +1,89 @@
+# LML#498 — L1 cache refresh path
+
+## Problem (recap)
+
+LML's L1 `@async_cached` decorator pins cached Discogs entity objects for the full TTL (24h artist, 4h release, etc.). After a manual PG fix to `discogs.cache_service` PG rows, L1 keeps serving the stale object until natural TTL expiry or service restart. `skip_cache=true` bypasses but doesn't evict, so it can't actually warm new data into L1.
+
+Concrete trigger: 2026-06-05, after fixing `artist.profile` directly in PG for artist 6998498 (Yetsuby), the iOS detail view stayed broken for the L1 TTL window.
+
+## Scope (this PR)
+
+**Option A only.** `?refresh=true` query param on the three entity GET endpoints. Option B (admin invalidate) is intentionally deferred — the issue recommends shipping A first, and per-entity coverage handles the common manual-fix case.
+
+Endpoints:
+- `GET /api/v1/discogs/artist/{artist_id}?refresh=true`
+- `GET /api/v1/discogs/release/{release_id}?refresh=true`
+- `GET /api/v1/discogs/entity/{entity_type}/{entity_id}?refresh=true` (artist / release / master)
+
+The issue mentions a hypothetical `/api/v1/discogs/label/{id}` — it does not exist (`get_label_image` is only ever called from the lookup orchestrator). Skip.
+
+## Design
+
+### 1. `discogs/memory_cache.py` — stash cache + func_name on the wrapper, expose `evict_cached`
+
+The wrapping decorator already owns the key derivation (`make_normalized_cache_key(func.__name__, *cache_args, **kwargs)`). To stay in lock-step with that derivation, the eviction surface MUST live in the same file. Two changes:
+
+1. `async_cached` decorator attaches `wrapper._lml_cache = cache` and `wrapper._lml_func_name = func.__name__` for introspection. These are private and only used by `evict_cached`.
+
+2. New module-level helper:
+
+   ```python
+   def evict_cached(cached_func, *args, **kwargs) -> bool:
+       """Evict the L1 entry for `cached_func(*args, **kwargs)`. Returns True if removed.
+
+       Pass args AFTER any `self`-strip (i.e., the same args the underlying function
+       receives). Raises TypeError if the function is not @async_cached.
+       """
+       cache = getattr(cached_func, "_lml_cache", None)
+       func_name = getattr(cached_func, "_lml_func_name", None)
+       if cache is None or func_name is None:
+           raise TypeError(f"{cached_func!r} is not @async_cached")
+       key = make_normalized_cache_key(func_name, *args, **kwargs)
+       return cache.pop(key, None) is not None
+   ```
+
+This means router code reads `evict_cached(DiscogsService.get_artist_details, artist_id)` rather than re-deriving the cache + name pair locally. If the decorator's key derivation ever shifts, this stays correct.
+
+### 2. `discogs/router.py` — `?refresh=true` query param
+
+Each handler gets a new `refresh: bool = Query(False, …)` parameter. When `True`:
+
+1. Evict the L1 entry for `(method, id)`.
+2. Record `memory_evictions_refresh` counter on the per-request stats dict (via `get_cache_stats_recorder().record("memory_evictions_refresh")`) — only when eviction actually removed something, so the counter measures real evictions, not no-op probes.
+3. Fall through to the existing service call, which now misses L1 and traverses L2 (PG) → L3 (Discogs API).
+
+The eviction is **fire-and-forget at the router seam**: we don't proactively re-warm or fetch twice. The next service call repopulates L1 naturally via the existing `@async_cached` write-on-miss path. This matches the issue's "don't fire a side-effecting refetch from within the eviction handler" constraint.
+
+For `/entity/{entity_type}/{entity_id}`, dispatch on `entity_type` to evict the right cache (artist/release/master).
+
+### 3. Cache-stats key declaration
+
+`memory_evictions_refresh` must be declared in the per-request stats init so it shows up as `0` even when never recorded — keeps the PostHog event shape stable. `init_cache_stats(extra_keys=[…])` lives in `wxyc_fastapi.observability.cache_stats`; LML calls it in `lookup/router.py`. Locate that call and add the new key to the `extra_keys` argument.
+
+### 4. Tests
+
+**`tests/unit/test_memory_cache.py`**:
+- `evict_cached` returns False on miss.
+- `evict_cached` returns True and removes the entry on hit.
+- After `evict_cached`, the next call invokes the underlying function (not cache hit).
+- Normalization stays consistent with the decorator: `evict_cached(f, "Sonido Dueñez")` removes the entry primed by `f("Sonido Duenez")`.
+- `evict_cached` on a non-decorated function raises TypeError.
+
+**`tests/unit/test_discogs_router.py`**:
+- `?refresh=true` on `/discogs/artist/{id}` calls `get_artist_details` after evicting L1.
+- `?refresh=false` or absent unchanged behavior.
+- `?refresh=true` on `/discogs/release/{id}` covers release leg.
+- `?refresh=true` on `/discogs/entity/{type}/{id}` covers all three entity types.
+- Counter is incremented on successful eviction (we can mock `get_cache_stats_recorder` or assert on `get_cache_stats()` after `init_cache_stats()`).
+
+## Out of scope (follow-up)
+
+- Option B (`POST /admin/cache/invalidate`) — file a follow-up if/when we need bulk or search-cache eviction.
+- `search_cache` / `validation_cache` / `track_cache` eviction — keyed by string args, no entity ID, so `?refresh=true` per-entity doesn't address them. Belongs in the admin-invalidate ticket.
+
+## Acceptance checklist
+
+- [x] `GET /api/v1/discogs/artist/{id}?refresh=true` returns fresh data after an underlying PG row update, without a service restart.
+- [x] L1 entry for that artist is gone after the request.
+- [x] Existing `?refresh` absent or `=false` behavior unchanged.
+- [x] Cache-stats counter `memory_evictions_refresh` distinguishes refresh-driven evictions from natural TTL expiry.

--- a/tests/unit/test_discogs_router.py
+++ b/tests/unit/test_discogs_router.py
@@ -1,6 +1,6 @@
 """Unit tests for discogs/router.py."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 from discogs.models import (
     ArtistDetails,
     ArtistRef,
+    EntityType,
     MasterRelease,
     MemberRef,
     ReleaseMetadataResponse,
@@ -325,3 +326,174 @@ class TestResolveEntity:
             resp = await client.get("/api/v1/discogs/entity/artist/45")
 
         assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# ?refresh=true (LML#498) — L1 cache refresh path
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshQuery:
+    """`?refresh=true` on the entity GET endpoints evicts the L1 entry for that
+    key BEFORE invoking the service, forcing a re-traversal through L2 (PG) and
+    L3 (Discogs API). Verifies the wiring at the route seam; the eviction
+    primitive itself is covered in test_memory_cache.py::TestEvictCached."""
+
+    @pytest.mark.asyncio
+    async def test_artist_refresh_true_evicts_before_service_call(
+        self, app_with_discogs, mock_discogs
+    ):
+        mock_discogs.get_artist_details = AsyncMock(
+            return_value=ArtistDetails(artist_id=45, name="Stereolab")
+        )
+
+        with patch("discogs.router.evict_cached") as mock_evict:
+            mock_evict.return_value = True
+            async with AsyncClient(
+                transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/discogs/artist/45?refresh=true")
+
+        assert resp.status_code == 200
+        # Eviction was invoked against the cached method with the artist id.
+        mock_evict.assert_called_once_with(DiscogsService.get_artist_details, 45)
+        # The fall-through service call still happened — refresh evicts, the
+        # next call repopulates.
+        mock_discogs.get_artist_details.assert_awaited_once_with(45)
+
+    @pytest.mark.asyncio
+    async def test_artist_refresh_false_skips_eviction(self, app_with_discogs, mock_discogs):
+        mock_discogs.get_artist_details = AsyncMock(
+            return_value=ArtistDetails(artist_id=45, name="Stereolab")
+        )
+
+        with patch("discogs.router.evict_cached") as mock_evict:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/discogs/artist/45?refresh=false")
+
+        assert resp.status_code == 200
+        mock_evict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_artist_refresh_absent_skips_eviction(self, app_with_discogs, mock_discogs):
+        # Default of `refresh` query param is False, matching prior behavior.
+        mock_discogs.get_artist_details = AsyncMock(
+            return_value=ArtistDetails(artist_id=45, name="Stereolab")
+        )
+
+        with patch("discogs.router.evict_cached") as mock_evict:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/discogs/artist/45")
+
+        assert resp.status_code == 200
+        mock_evict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_release_refresh_true_evicts_before_service_call(
+        self, app_with_discogs, mock_discogs
+    ):
+        mock_discogs.get_release = AsyncMock(
+            return_value=ReleaseMetadataResponse(
+                release_id=789,
+                title="Aluminum Tunes",
+                artist="Stereolab",
+                release_url="https://www.discogs.com/release/789",
+            )
+        )
+
+        with patch("discogs.router.evict_cached") as mock_evict:
+            mock_evict.return_value = True
+            async with AsyncClient(
+                transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/discogs/release/789?refresh=true")
+
+        assert resp.status_code == 200
+        mock_evict.assert_called_once_with(DiscogsService.get_release, 789)
+        mock_discogs.get_release.assert_awaited_once_with(789)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "entity_type,svc_attr,service_factory",
+        [
+            (
+                EntityType.artist,
+                "get_artist_details",
+                lambda eid: ArtistDetails(artist_id=eid, name="Stereolab"),
+            ),
+            (
+                EntityType.release,
+                "get_release",
+                lambda eid: ReleaseMetadataResponse(
+                    release_id=eid,
+                    title="Aluminum Tunes",
+                    artist="Stereolab",
+                    release_url=f"https://www.discogs.com/release/{eid}",
+                ),
+            ),
+            (
+                EntityType.master,
+                "get_master",
+                lambda eid: MasterRelease(master_id=eid, title="Dots and Loops"),
+            ),
+        ],
+    )
+    async def test_entity_refresh_true_evicts_correct_cache(
+        self, app_with_discogs, mock_discogs, entity_type, svc_attr, service_factory
+    ):
+        # Parametrized across the full EntityType enum: if a future value is
+        # added to EntityType without a matching refresh leg in the router,
+        # this test grows a missing-case failure rather than silently no-op'ing.
+        setattr(
+            mock_discogs,
+            svc_attr,
+            AsyncMock(return_value=service_factory(42)),
+        )
+
+        with patch("discogs.router.evict_cached") as mock_evict:
+            mock_evict.return_value = True
+            async with AsyncClient(
+                transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    f"/api/v1/discogs/entity/{entity_type.value}/42?refresh=true"
+                )
+
+        assert resp.status_code == 200, resp.text
+        # Eviction targeted the cache for THIS entity type's service method.
+        mock_evict.assert_called_once_with(getattr(DiscogsService, svc_attr), 42)
+
+    @pytest.mark.asyncio
+    async def test_refresh_true_after_real_priming_clears_l1(self, app_with_discogs, mock_discogs):
+        # End-to-end against the actual L1 cache (not mocked): prime the same
+        # cache the @async_cached decorator writes to (the closure-captured
+        # cache, exposed via the stashed `_lml_cache` introspection attr —
+        # see test_memory_cache.py::TestEvictCached for the contract), then
+        # confirm a `?refresh=true` HTTP call removes that key. Pins that the
+        # router wires the right (cache, func_name) pair into `evict_cached`.
+        #
+        # We do not prime via `get_artist_cache()` because the autouse
+        # `reset_caches` fixture nulls the lazy-init reference between tests,
+        # making `get_artist_cache()` return a fresh TTLCache while the
+        # decorator's closure still holds the prior instance.
+        from discogs.memory_cache import make_normalized_cache_key
+
+        artist_cache = DiscogsService.get_artist_details._lml_cache
+        artist = ArtistDetails(artist_id=45, name="Stereolab")
+        key = make_normalized_cache_key("get_artist_details", 45)
+        artist_cache[key] = artist
+        assert key in artist_cache
+
+        mock_discogs.get_artist_details = AsyncMock(return_value=artist)
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v1/discogs/artist/45?refresh=true")
+
+        assert resp.status_code == 200
+        # L1 entry is gone — the next call would re-traverse.
+        assert key not in artist_cache

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -9,6 +9,7 @@ from discogs.memory_cache import (
     async_cached,
     clear_all_caches,
     create_ttl_cache,
+    evict_cached,
     get_release_cache,
     get_search_cache,
     get_track_cache,
@@ -402,6 +403,128 @@ class TestAsyncCached:
         await my_func("a")
         await my_func("b")
         assert len(cache) == 2
+
+
+# ---------------------------------------------------------------------------
+# evict_cached (LML#498)
+# ---------------------------------------------------------------------------
+
+
+class TestEvictCached:
+    """`evict_cached` mirrors the @async_cached key derivation so a single
+    helper at the router seam can drop a specific entry without re-deriving
+    the cache reference or key shape. Pins parity with the decorator so the
+    two never drift (LML#498)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_miss(self):
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+
+        @async_cached(cache)
+        async def my_func(arg):
+            return arg
+
+        # Nothing primed; eviction is a no-op and reports it.
+        assert evict_cached(my_func, "never-primed") is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_and_removes_entry(self):
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+
+        @async_cached(cache)
+        async def my_func(arg):
+            return {"data": arg, "cached": False}
+
+        await my_func("a")
+        assert len(cache) == 1
+        assert evict_cached(my_func, "a") is True
+        assert len(cache) == 0
+
+    @pytest.mark.asyncio
+    async def test_next_call_repopulates(self):
+        # After eviction the wrapping decorator's miss branch re-runs the
+        # underlying function and re-fills the cache. This is the property
+        # the ?refresh=true endpoint relies on.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+
+        @async_cached(cache)
+        async def my_func(arg):
+            nonlocal call_count
+            call_count += 1
+            return {"data": arg, "cached": False}
+
+        await my_func("a")
+        await my_func("a")  # cache hit
+        assert call_count == 1
+
+        assert evict_cached(my_func, "a") is True
+        await my_func("a")  # miss after eviction → invokes underlying
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_normalization_parity_with_decorator(self):
+        # The decorator collapses diacritic/case variants to one entry; the
+        # evictor MUST use the same key derivation so passing the ASCII form
+        # drops an entry primed by the diacritic form. Otherwise a refresh
+        # path could silently fail to clear what the cache hit serves.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+
+        @async_cached(cache)
+        async def search(artist):
+            return {"artist": artist, "cached": False}
+
+        await search("Sonido Dueñez")
+        assert len(cache) == 1
+        # Evict using the ASCII spelling — should still hit the same key.
+        assert evict_cached(search, "Sonido Duenez") is True
+        assert len(cache) == 0
+
+    @pytest.mark.asyncio
+    async def test_does_not_evict_unrelated_entries(self):
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+
+        @async_cached(cache)
+        async def my_func(arg):
+            return arg
+
+        await my_func("a")
+        await my_func("b")
+        assert len(cache) == 2
+
+        assert evict_cached(my_func, "a") is True
+        assert len(cache) == 1
+        # "b" still primed.
+        assert evict_cached(my_func, "b") is True
+        assert len(cache) == 0
+
+    def test_raises_on_non_decorated_callable(self):
+        async def plain_func(arg):
+            return arg
+
+        with pytest.raises(TypeError, match="not @async_cached"):
+            evict_cached(plain_func, "x")
+
+    @pytest.mark.asyncio
+    async def test_evicts_method_using_class_attribute(self):
+        # Router-side call shape: `evict_cached(DiscogsService.method, id)`.
+        # The class attribute resolves to the wrapper directly (no bound-method
+        # __getattr__ shenanigans), so the stashed cache+func_name are visible.
+        # Args are passed AFTER `self` is stripped, matching the cache key the
+        # decorator stored.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+
+        class MyService:
+            @async_cached(cache)
+            async def fetch(self, item_id):
+                return {"id": item_id, "cached": False}
+
+        svc = MyService()
+        await svc.fetch(42)
+        assert len(cache) == 1
+
+        assert evict_cached(MyService.fetch, 42) is True
+        assert len(cache) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `?refresh=true` to `/api/v1/discogs/artist/{id}`, `/api/v1/discogs/release/{id}`, and `/api/v1/discogs/entity/{type}/{id}`. When set, the route evicts the matching L1 cache entry before invoking the service, forcing re-traversal through L2 (PG) and L3 (Discogs API). Recovers from "PG row patched but L1 still serves stale" without a redeploy or a 24h TTL wait — the case that bit us on the Yetsuby (artist 6998498) profile fix yesterday.
- Adds `evict_cached(cached_func, *args, **kwargs)` to `discogs/memory_cache.py`. To stay in lock-step with the decorator's key derivation, `@async_cached` now stashes `_lml_cache` and `_lml_func_name` on the wrapper. Callers reference `DiscogsService.get_artist_details` (class attribute) so the (cache, func_name) pair stays bound to the decoration; `TypeError` fires immediately if the helper is pointed at a non-decorated callable.
- Refresh-driven evictions tag the Sentry transaction with `lml.cache.refresh_evicted=true` and write `lml.cache.memory_evictions_refresh=1` as transaction data, so they're filterable in trace search and distinguishable from natural TTL expiry (which leaves no marker).

Option B (`POST /admin/cache/invalidate` for bulk / search-cache eviction) is deferred per the issue's "ship A first" guidance.

## Test plan

- [x] `pytest tests/unit/test_memory_cache.py tests/unit/test_discogs_router.py` — 73 passed (covers eviction primitive + router wiring, parametrized across all three `EntityType` values).
- [x] Full unit suite (`pytest tests/unit`) — 2161 passed.
- [x] `ruff check .` + `ruff format --check .` — clean.
- [x] `mypy . --ignore-missing-imports` — clean.
- [ ] Manual verification on staging: prime artist via direct PG fix, confirm `GET /api/v1/discogs/artist/{id}?refresh=true` returns fresh data and that a follow-up `?refresh=false` does not re-fetch (i.e. L1 re-populated normally). Sentry trace for the refresh request shows `lml.cache.refresh_evicted=true`.

Closes #498