### PR TITLE
fix(orchestrator): probe Apple Music for artwork when library row fails LML#477 gate

### DIFF
--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -14,8 +14,18 @@ Public surface:
 - `find_album_match(artist, title)` — BaseStreamingClient contract; powers
   `/streaming-check` via `streaming/router.handle_streaming_check`.
 - `find_track_url(artist, song, album=None)` — used by the lookup hot path
-  in `lookup/orchestrator.enrich_artwork_results`. 3-way fuzz floor on
+  in `lookup/orchestrator.enrich_artwork_results` when the WXYC library
+  row clears the LML#477 title gate (just need the URL for the
+  ``apple_music_url`` slot). 3-way fuzz floor on
   `attributes.{artistName,name,albumName}`.
+- `find_track_metadata(artist, song, album=None)` — used by the same hot
+  path when the library row fails the gate (LML#487) or the catalog has
+  no Discogs match (LML#401). Same `search_song` endpoint + same fuzz
+  floor as `find_track_url`; returns `AppleMusicTrackMatch` with the
+  URL plus `attributes.artwork.url` (artwork) and
+  `attributes.releaseDate` (year) so the synthesized
+  `DiscogsSearchResult` surfaces the correct album's cover art instead
+  of leaking a sibling-album library row's Discogs image.
 """
 
 from __future__ import annotations
@@ -23,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from dataclasses import dataclass
 
 import jwt as pyjwt
 import sentry_sdk
@@ -34,6 +45,26 @@ from wxyc_etl.text import to_match_form as normalize_for_comparison
 from clients.streaming.base import BaseStreamingClient
 from clients.streaming.matching import find_best_source_match
 from streaming.models import SourceMatch
+
+
+@dataclass(frozen=True)
+class AppleMusicTrackMatch:
+    """Apple Music song-search verdict carrying the fields LML's lookup hot
+    path needs to populate a synthesized ``DiscogsSearchResult`` when the
+    WXYC catalog has no acceptable library row for the requested album
+    (LML#487 / BS#1184).
+
+    Extends ``find_track_url``'s plain ``str | None`` return with
+    ``artwork_url`` and ``release_year``, extracted from the SAME
+    ``search_song`` response payload — no extra Apple Music API rounds
+    over the existing ``find_track_url`` quota. ``url`` is the Apple Music
+    song deep-link (same value ``find_track_url`` returns).
+    """
+
+    url: str
+    artwork_url: str | None
+    release_year: int | None
+
 
 logger = logging.getLogger(__name__)
 
@@ -350,6 +381,75 @@ class AppleMusicClient(BaseStreamingClient):
             url_fn=_extract_url,
         )
 
+    async def find_track_metadata(
+        self, artist: str, song: str, album: str | None = None
+    ) -> AppleMusicTrackMatch | None:
+        """Search for `(artist, song[, album])` and return URL + artwork + year.
+
+        Sibling of ``find_track_url`` that surfaces the richer
+        ``AppleMusicTrackMatch`` shape (LML#487 / BS#1184). The lookup hot
+        path uses it to synthesize a ``DiscogsSearchResult`` carrying the
+        right album's cover art when the WXYC catalog has no acceptable
+        library row for the requested album — the Noura Mint Seymali
+        ``Hebebeb (Zrag) / Yenbett`` shape (library has Tzenni only, song
+        search would otherwise project Tzenni's artwork onto a Yenbett
+        flowsheet entry).
+
+        Reuses the SAME ``search_song`` endpoint, ``fuzz.token_set_ratio``
+        scoring, and 80/80(/80) floor as ``find_track_url`` — no extra
+        Apple Music API rounds vs. the existing ``find_track_url`` quota,
+        and the artist/title/album wrong-match guards stay in lockstep
+        with the LML#389 / LML#396 / LML#453 hardening. The artwork +
+        release-year extractors gracefully degrade to ``None`` on sparse
+        records (no ``artwork`` block, malformed ``releaseDate``) rather
+        than raising mid-iteration.
+        """
+        results = await self.search_song(artist, song)
+        if not results:
+            return None
+
+        norm_artist = normalize_for_comparison(artist)
+        norm_song = normalize_for_comparison(song)
+        norm_album = normalize_for_comparison(album) if album else None
+
+        best: dict | None = None
+        best_score = 0.0
+
+        for item in results:
+            attrs = item.get("attributes") or {}
+            url = attrs.get("url")
+            if not url:
+                continue
+            artist_score = fuzz.token_set_ratio(
+                norm_artist, normalize_for_comparison(attrs.get("artistName") or "")
+            )
+            track_score = fuzz.token_set_ratio(
+                norm_song, normalize_for_comparison(attrs.get("name") or "")
+            )
+            if artist_score < _APPLE_MUSIC_MATCH_FLOOR or track_score < _APPLE_MUSIC_MATCH_FLOOR:
+                continue
+            if norm_album is not None:
+                album_score = fuzz.token_set_ratio(
+                    norm_album, normalize_for_comparison(attrs.get("albumName") or "")
+                )
+                if album_score < _APPLE_MUSIC_MATCH_FLOOR:
+                    continue
+                combined = (artist_score + track_score + album_score) / 3
+            else:
+                combined = (artist_score + track_score) / 2
+            if combined > best_score:
+                best_score = combined
+                best = item
+
+        if best is None:
+            return None
+
+        return AppleMusicTrackMatch(
+            url=_extract_url(best),
+            artwork_url=_extract_artwork_url(best),
+            release_year=_extract_release_year(best),
+        )
+
 
 def _extract_artist_name(item: dict) -> str:
     return (item.get("attributes") or {}).get("artistName") or ""
@@ -361,6 +461,50 @@ def _extract_name(item: dict) -> str:
 
 def _extract_url(item: dict) -> str:
     return (item.get("attributes") or {}).get("url") or ""
+
+
+# Apple Music's artwork URLs are documented as `{w}x{h}` templates that the
+# client substitutes with desired pixel dimensions before display. iOS/dj-site
+# render at ~600px in flowsheet card sizing; 600x600 keeps payload tight while
+# staying above retina display thresholds.
+_ARTWORK_WIDTH = 600
+_ARTWORK_HEIGHT = 600
+
+
+def _extract_artwork_url(item: dict) -> str | None:
+    """Pull `attributes.artwork.url` and substitute the `{w}x{h}` template.
+
+    Apple Music returns artwork URLs as templates (documented at
+    developer.apple.com/documentation/applemusicapi/artwork). Clients
+    (iOS, dj-site) cannot render the template — substitute concrete
+    dimensions before surfacing. Returns ``None`` when ``artwork`` is
+    absent (region-restricted records, malformed items) so the caller
+    can synthesize a record with ``artwork_url=None``.
+    """
+    attrs = item.get("attributes") or {}
+    artwork = attrs.get("artwork") or {}
+    template = artwork.get("url")
+    if not template:
+        return None
+    return template.replace("{w}", str(_ARTWORK_WIDTH)).replace("{h}", str(_ARTWORK_HEIGHT))
+
+
+def _extract_release_year(item: dict) -> int | None:
+    """Pull the leading 4-digit year from `attributes.releaseDate`.
+
+    Apple Music's catalog albums carry ISO dates (YYYY-MM-DD), but rare
+    records ship just the year ("2025") or are missing the field entirely.
+    Return ``None`` rather than raising so a sparse record's artwork still
+    surfaces with ``release_year=None``.
+    """
+    attrs = item.get("attributes") or {}
+    raw = attrs.get("releaseDate")
+    if not raw or not isinstance(raw, str):
+        return None
+    head = raw[:4]
+    if not head.isdigit():
+        return None
+    return int(head)
 
 
 def _parse_retry_after(value: str | None) -> float:

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -387,22 +387,16 @@ class AppleMusicClient(BaseStreamingClient):
         """Search for `(artist, song[, album])` and return URL + artwork + year.
 
         Sibling of ``find_track_url`` that surfaces the richer
-        ``AppleMusicTrackMatch`` shape (LML#487 / BS#1184). The lookup hot
-        path uses it to synthesize a ``DiscogsSearchResult`` carrying the
-        right album's cover art when the WXYC catalog has no acceptable
-        library row for the requested album — the Noura Mint Seymali
-        ``Hebebeb (Zrag) / Yenbett`` shape (library has Tzenni only, song
-        search would otherwise project Tzenni's artwork onto a Yenbett
-        flowsheet entry).
+        ``AppleMusicTrackMatch`` shape (LML#487 / BS#1184). Reuses the same
+        ``search_song`` endpoint + 80/80(/80) fuzz floor — one Apple
+        Music API call per invocation, no extra quota vs. ``find_track_url``.
 
-        Reuses the SAME ``search_song`` endpoint, ``fuzz.token_set_ratio``
-        scoring, and 80/80(/80) floor as ``find_track_url`` — no extra
-        Apple Music API rounds vs. the existing ``find_track_url`` quota,
-        and the artist/title/album wrong-match guards stay in lockstep
-        with the LML#389 / LML#396 / LML#453 hardening. The artwork +
-        release-year extractors gracefully degrade to ``None`` on sparse
-        records (no ``artwork`` block, malformed ``releaseDate``) rather
-        than raising mid-iteration.
+        Unlike ``find_track_url``, this method PREFERS floor-clearing matches
+        that carry ``attributes.artwork`` over higher-scoring matches that
+        lack it. Returning artwork_url=None on the synthesis path defeats
+        the whole point of LML#487 — for sparse Apple records (region-
+        restricted singles, promo entries) we'd rather surface a lower-
+        scoring-but-floor-clearing match's cover than nothing.
         """
         results = await self.search_song(artist, song)
         if not results:
@@ -412,8 +406,10 @@ class AppleMusicClient(BaseStreamingClient):
         norm_song = normalize_for_comparison(song)
         norm_album = normalize_for_comparison(album) if album else None
 
-        best: dict | None = None
-        best_score = 0.0
+        best_overall: dict | None = None
+        best_overall_score = 0.0
+        best_with_artwork: dict | None = None
+        best_with_artwork_score = 0.0
 
         for item in results:
             attrs = item.get("attributes") or {}
@@ -437,10 +433,14 @@ class AppleMusicClient(BaseStreamingClient):
                 combined = (artist_score + track_score + album_score) / 3
             else:
                 combined = (artist_score + track_score) / 2
-            if combined > best_score:
-                best_score = combined
-                best = item
+            if combined > best_overall_score:
+                best_overall_score = combined
+                best_overall = item
+            if (attrs.get("artwork") or {}).get("url") and combined > best_with_artwork_score:
+                best_with_artwork_score = combined
+                best_with_artwork = item
 
+        best = best_with_artwork or best_overall
         if best is None:
             return None
 
@@ -489,22 +489,29 @@ def _extract_artwork_url(item: dict) -> str | None:
     return template.replace("{w}", str(_ARTWORK_WIDTH)).replace("{h}", str(_ARTWORK_HEIGHT))
 
 
+_MIN_PLAUSIBLE_RELEASE_YEAR = 1900
+_MAX_PLAUSIBLE_RELEASE_YEAR = 2100
+
+
 def _extract_release_year(item: dict) -> int | None:
-    """Pull the leading 4-digit year from `attributes.releaseDate`.
+    """Pull the leading 4-digit ASCII year from `attributes.releaseDate`.
 
     Apple Music's catalog albums carry ISO dates (YYYY-MM-DD), but rare
-    records ship just the year ("2025") or are missing the field entirely.
-    Return ``None`` rather than raising so a sparse record's artwork still
-    surfaces with ``release_year=None``.
+    records ship just the year, sentinel placeholders ("0000-00-00"), or
+    partial strings. Reject anything that isn't a 4-ASCII-digit year in a
+    plausible range so 0/9999/202 don't reach downstream as a release year.
     """
     attrs = item.get("attributes") or {}
     raw = attrs.get("releaseDate")
     if not raw or not isinstance(raw, str):
         return None
     head = raw[:4]
-    if not head.isdigit():
+    if len(head) != 4 or not head.isascii() or not head.isdigit():
         return None
-    return int(head)
+    year = int(head)
+    if year < _MIN_PLAUSIBLE_RELEASE_YEAR or year > _MAX_PLAUSIBLE_RELEASE_YEAR:
+        return None
+    return year
 
 
 def _parse_retry_after(value: str | None) -> float:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1872,91 +1872,13 @@ async def enrich_artwork_results(
         # the *right* album's artwork.
         library_row_acceptable = artwork is not None and row_title_matches_requested_album
 
-        # Apple Music probe. In the happy path (``library_row_acceptable``)
-        # we just need the song URL for the ``apple_music_url`` slot, so
-        # call ``find_track_url`` — preserves LML#401 behaviour and the
-        # existing test-call shape. When the library row is NOT acceptable
-        # (LML#487 trigger), we additionally want the matched track's
-        # artwork + release year for the synthesized result — call
-        # ``find_track_metadata`` instead. The two methods make exactly
-        # one Apple Music API call each (same ``search_song`` endpoint),
-        # so picking one or the other keeps the per-request Apple quota
-        # at exactly one call — no inflation vs. LML#401 baseline.
-        #
-        # The ``asyncio.wait_for`` ceiling caps the worst-case latency a
-        # single Apple call can impose on the request — without it, a
-        # 429/5xx storm could pin one of the Apple Music Semaphore(5)
-        # slots for up to ``_MAX_RETRIES`` × ``_RETRY_AFTER_CAP_SECONDS``
-        # seconds while still being unbounded at the call site (LML#449
-        # + LML#450). On timeout we degrade to no-Apple-anything, same
-        # as the LML#444 exception path. The Sentry-marker name stays
-        # ``apple_music.find_track_url.timeout`` to preserve LML#462
-        # trace-explorer dashboards — the underlying call may now be
-        # ``find_track_metadata`` but the failure mode is the same.
-        apple_music_url: str | None = None
-        probe_artwork_url: str | None = None
-        probe_release_year: int | None = None
-        if apple_music is not None and artist and search_term:
-            try:
-                if library_row_acceptable:
-                    apple_music_url = await asyncio.wait_for(
-                        apple_music.find_track_url(artist, search_term, album=album),
-                        timeout=_apple_music_lookup_timeout_s(),
-                    )
-                else:
-                    probe_match = await asyncio.wait_for(
-                        apple_music.find_track_metadata(artist, search_term, album=album),
-                        timeout=_apple_music_lookup_timeout_s(),
-                    )
-                    if probe_match is not None:
-                        apple_music_url = probe_match.url
-                        probe_artwork_url = probe_match.artwork_url
-                        probe_release_year = probe_match.release_year
-            except TimeoutError:
-                logger.warning(
-                    "AppleMusicClient.find_track_url timed out for %s - %s",
-                    artist,
-                    search_term,
-                )
-                # LML#462: project onto the active Sentry transaction so the
-                # trace explorer can distinguish "Apple Music timed out" from
-                # "Apple Music never ran" — the cancelled inner
-                # `apple_music.search` span never sets its `result` data, so
-                # without this marker the timeout shape is queryably
-                # indistinguishable from a no-op. Same swallow pattern as
-                # `_log_album_title_fallback` / `_log_resolver_pre_pass`.
-                try:
-                    transaction = sentry_sdk.get_current_scope().transaction
-                    if transaction is not None:
-                        transaction.set_data("apple_music.find_track_url.timeout", True)
-                except Exception as e:
-                    logger.warning(
-                        "Failed to project apple_music timeout onto Sentry transaction: %s",
-                        e,
-                    )
-            except Exception:
-                logger.exception(
-                    "AppleMusicClient.find_track_url raised for %s - %s", artist, search_term
-                )
-
-        # Album-derived fields are positionally gated: only on top-1, and
-        # only when top-1 actually carries an *acceptable* library row
-        # (LML#487 extends PR #481 gate from streaming-links to
-        # release-year/bio/wiki: a sibling-album fuzzy hit would otherwise
-        # leak Tzenni's year onto a Yenbett response). When the library
-        # row is not acceptable, fall through to the probe-derived year
-        # (Yenbett's year from Apple Music).
-        is_album_derived_eligible = is_top1 and library_row_acceptable
-        year_result = (
-            top1_year if is_album_derived_eligible else (probe_release_year if is_top1 else None)
-        )
-        artist_bio = top1_bio if is_album_derived_eligible else None
-        wikipedia_url = top1_wiki if is_album_derived_eligible else None
-
-        # Get streaming URLs: prefer direct links from DB, fall back to search URLs.
-        # Runs unconditionally — releases that ARE on streaming but ISN'T
-        # in the WXYC catalog (a Discogs miss) still surface streaming
-        # buttons via the synthesized result below (LML#401 / BS#1184).
+        # Hoist the librarian-curated streaming_links override BEFORE the
+        # Apple Music probe so the happy-path probe can short-circuit when
+        # the override would win anyway (the final assignment is
+        # ``apple_music_override or apple_music_url or None``). Saves one
+        # Apple Music quota slot + up to _apple_music_lookup_timeout_s() of
+        # wall-clock per overridden item. The override gate still requires
+        # row_title_matches_requested_album per PR #481 (LML#477).
         spotify_url = None
         apple_music_override = None
         youtube_music_url = None
@@ -1979,6 +1901,84 @@ async def enrich_artwork_results(
                 youtube_music_url = links.get("youtube_music_url")
                 bandcamp_url = links.get("bandcamp_url")
                 soundcloud_url = links.get("soundcloud_url")
+
+        # Apple Music probe. ``library_row_acceptable`` picks ``find_track_url``
+        # (URL only — preserves LML#401 baseline); the synthesis path
+        # (LML#487) needs artwork + year too, so calls ``find_track_metadata``.
+        # Both make one ``search_song`` call, so per-request quota is identical
+        # to the LML#401 baseline. Skip the happy-path probe when the
+        # librarian override would win anyway (saves one Apple call per
+        # overridden item). The ``asyncio.wait_for`` ceiling caps single-call
+        # latency under 429/5xx pressure (LML#449/#450). On timeout/error we
+        # degrade to no-Apple-anything (LML#444 swallow). The Sentry data key
+        # encodes the *method* so LML#462 dashboards can distinguish synthesis-
+        # path timeouts (artwork still leaking, high impact) from happy-path
+        # timeouts (URL only, low impact).
+        apple_music_url: str | None = None
+        probe_artwork_url: str | None = None
+        probe_release_year: int | None = None
+        probe_method = "find_track_metadata" if not library_row_acceptable else "find_track_url"
+        skip_happy_probe = library_row_acceptable and apple_music_override
+        if apple_music is not None and artist and search_term and not skip_happy_probe:
+            try:
+                if library_row_acceptable:
+                    apple_music_url = await asyncio.wait_for(
+                        apple_music.find_track_url(artist, search_term, album=album),
+                        timeout=_apple_music_lookup_timeout_s(),
+                    )
+                else:
+                    probe_match = await asyncio.wait_for(
+                        apple_music.find_track_metadata(artist, search_term, album=album),
+                        timeout=_apple_music_lookup_timeout_s(),
+                    )
+                    if probe_match is not None:
+                        apple_music_url = probe_match.url
+                        probe_artwork_url = probe_match.artwork_url
+                        probe_release_year = probe_match.release_year
+            except TimeoutError:
+                logger.warning(
+                    "AppleMusicClient.%s timed out for %s - %s",
+                    probe_method,
+                    artist,
+                    search_term,
+                )
+                # LML#462: project onto the active Sentry transaction so the
+                # trace explorer can distinguish "Apple Music timed out" from
+                # "Apple Music never ran" — the cancelled inner
+                # `apple_music.search` span never sets its `result` data, so
+                # without this marker the timeout shape is queryably
+                # indistinguishable from a no-op. The legacy key stays for
+                # dashboard continuity; the ``.method`` key disambiguates
+                # synthesis-path timeouts from happy-path timeouts.
+                try:
+                    transaction = sentry_sdk.get_current_scope().transaction
+                    if transaction is not None:
+                        transaction.set_data("apple_music.find_track_url.timeout", True)
+                        transaction.set_data("apple_music.timeout.method", probe_method)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to project apple_music timeout onto Sentry transaction: %s",
+                        e,
+                    )
+            except Exception:
+                logger.exception(
+                    "AppleMusicClient.%s raised for %s - %s",
+                    probe_method,
+                    artist,
+                    search_term,
+                )
+
+        # Album-derived fields are positionally gated: only on top-1, and
+        # only when top-1 actually carries an *acceptable* library row.
+        # LML#487 fall-through: when the row is not acceptable, the probe
+        # supplies release_year on the synthesized result. The probe
+        # already cost zero (same response that produced ``probe_artwork_url``),
+        # so the original top1-only positional rationale doesn't apply —
+        # surface ``probe_release_year`` whenever the synthesis branch ran.
+        is_album_derived_eligible = is_top1 and library_row_acceptable
+        year_result = top1_year if is_album_derived_eligible else probe_release_year
+        artist_bio = top1_bio if is_album_derived_eligible else None
+        wikipedia_url = top1_wiki if is_album_derived_eligible else None
 
         # Fall back to search URLs for any service without a direct link
         if artist and search_term:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1702,12 +1702,19 @@ async def enrich_artwork_results(
     Falls back to search URLs when direct links are not available.
 
     ``apple_music`` is the authenticated Apple Music client (LML#443). When
-    provided, the orchestrator calls ``apple_music.find_track_url(...)`` to
-    surface Apple Music URLs; when None (credentials unconfigured), the
-    probe is skipped and ``apple_music_url`` is set from the library DB
+    provided, the orchestrator probes Apple Music for each item: the happy
+    path (library row clears the LML#477 / PR #481 title gate) calls
+    ``find_track_url`` to surface the Apple Music URL only; the synthesis
+    path (no Discogs match OR library row fails the title gate — LML#487)
+    calls ``find_track_metadata`` to surface URL + ``artwork_url`` +
+    ``release_year`` from the same ``search_song`` response. Exactly one
+    Apple Music API call per item either way — picking ``find_track_url``
+    vs. ``find_track_metadata`` does not inflate the per-request quota.
+    When ``apple_music`` is None (credentials unconfigured), the probe is
+    skipped and ``apple_music_url`` is set from the library DB
     ``streaming_links`` override (if present) or stays None. The DB
     override always wins over the probe — see the final assignment
-    ``apple_music_override or apple_music_result or None``.
+    ``apple_music_override or apple_music_url or None``.
 
     **Behavior change vs. v0.5.0:** release/artist details (release_year,
     artist_bio, wikipedia_url) are fetched only for ``items_with_artwork[0]``.
@@ -1732,6 +1739,20 @@ async def enrich_artwork_results(
     skip ``extractAlbumMetadata`` while still consuming streaming URLs.
     Required for the WXYC/BS#1184 fix — releases on Apple Music that aren't
     in the WXYC/Discogs catalog now surface streaming buttons on iOS.
+
+    **Behavior change vs. v0.7.0 (LML#487):** the synthesis path now also
+    fires when ``artwork`` is non-None but its library row fails the
+    LML#477 title gate (``score_match(album, item.title) < 80`` — the
+    Noura Mint Seymali Tzenni-vs-Yenbett shape). The synthesized result
+    additionally carries ``artwork_url`` and ``release_year`` from the
+    ``find_track_metadata`` probe response, so flowsheet entries for an
+    album absent from the WXYC catalog (but present on Apple Music)
+    surface the *right* album's cover art on iOS / dj-site — not a
+    sibling-album row's leaked Discogs image. ``release_year`` is sourced
+    from the Apple Music ``releaseDate`` field; the Discogs-derived
+    ``artist_bio`` / ``wikipedia_url`` / ``extended=True`` payload stay
+    None on the synthesized result because they require a verified
+    Discogs identity link (no equivalent surfaces from Apple).
 
     ``extended=True`` additionally populates the new DiscogsMatchResult
     fields LML already loaded during the release+artist fetches:
@@ -1826,24 +1847,71 @@ async def enrich_artwork_results(
         artist = item.alternate_artist_name or item.artist or ""
         search_term = song or item.title or ""
 
-        # ``find_track_url`` has no top-level exception guard around its
-        # result-iteration loop, and the enclosing ``asyncio.gather`` lacks
-        # ``return_exceptions=True``. Without this wrap a single malformed
-        # Apple payload (non-dict item, rapidfuzz dispatch error) propagates
-        # through the gather and 500s the whole /lookup or /lookup/bulk
-        # request. The ``asyncio.wait_for`` ceiling additionally caps the
-        # worst-case latency a single Apple call can impose on the request —
-        # without it, a 429/5xx storm could pin one of the Apple Music
-        # Semaphore(5) slots for up to ``_MAX_RETRIES`` × ``_RETRY_AFTER_CAP_SECONDS``
-        # seconds while still being unbounded at the call site (LML#449 + LML#450).
-        # On timeout we degrade to no-Apple-URL, same as the LML#444 exception path.
-        apple_music_result: str | None = None
+        # LML#477: only trust the library row when its title plausibly
+        # matches the requested album. ``_fuzzy_search`` in library/db.py
+        # accepts token_set_ratio >= 70 — permissive enough to surface
+        # sibling-album rows (same artist, different release) whose
+        # verified streaming URLs (and Discogs artwork) would otherwise
+        # propagate as if they pointed at the requested album. The 80
+        # floor mirrors ``is_acceptable_match`` in
+        # ``clients/streaming/matching``. When no album was requested
+        # (artist-only lookup) or the row's title is missing, there is
+        # no signal to gate against — fall through.
+        row_title_matches_requested_album = (
+            not album or not item.title or score_match(album, item.title) >= 80.0
+        )
+
+        # LML#487: the library row is "acceptable" (a real match for the
+        # requested album) only when it carries Discogs artwork AND
+        # clears the title gate. Otherwise the row's Discogs artwork /
+        # release-year would be a sibling-album leak (Noura Mint Seymali
+        # Tzenni-vs-Yenbett shape) — same risk as the PR #481 streaming-
+        # link leak, just on a different field. When not acceptable, we
+        # synthesize a streaming-only result (LML#401 / BS#1185 sentinel
+        # contract) and try the Apple Music external probe to surface
+        # the *right* album's artwork.
+        library_row_acceptable = artwork is not None and row_title_matches_requested_album
+
+        # Apple Music probe. In the happy path (``library_row_acceptable``)
+        # we just need the song URL for the ``apple_music_url`` slot, so
+        # call ``find_track_url`` — preserves LML#401 behaviour and the
+        # existing test-call shape. When the library row is NOT acceptable
+        # (LML#487 trigger), we additionally want the matched track's
+        # artwork + release year for the synthesized result — call
+        # ``find_track_metadata`` instead. The two methods make exactly
+        # one Apple Music API call each (same ``search_song`` endpoint),
+        # so picking one or the other keeps the per-request Apple quota
+        # at exactly one call — no inflation vs. LML#401 baseline.
+        #
+        # The ``asyncio.wait_for`` ceiling caps the worst-case latency a
+        # single Apple call can impose on the request — without it, a
+        # 429/5xx storm could pin one of the Apple Music Semaphore(5)
+        # slots for up to ``_MAX_RETRIES`` × ``_RETRY_AFTER_CAP_SECONDS``
+        # seconds while still being unbounded at the call site (LML#449
+        # + LML#450). On timeout we degrade to no-Apple-anything, same
+        # as the LML#444 exception path. The Sentry-marker name stays
+        # ``apple_music.find_track_url.timeout`` to preserve LML#462
+        # trace-explorer dashboards — the underlying call may now be
+        # ``find_track_metadata`` but the failure mode is the same.
+        apple_music_url: str | None = None
+        probe_artwork_url: str | None = None
+        probe_release_year: int | None = None
         if apple_music is not None and artist and search_term:
             try:
-                apple_music_result = await asyncio.wait_for(
-                    apple_music.find_track_url(artist, search_term, album=album),
-                    timeout=_apple_music_lookup_timeout_s(),
-                )
+                if library_row_acceptable:
+                    apple_music_url = await asyncio.wait_for(
+                        apple_music.find_track_url(artist, search_term, album=album),
+                        timeout=_apple_music_lookup_timeout_s(),
+                    )
+                else:
+                    probe_match = await asyncio.wait_for(
+                        apple_music.find_track_metadata(artist, search_term, album=album),
+                        timeout=_apple_music_lookup_timeout_s(),
+                    )
+                    if probe_match is not None:
+                        apple_music_url = probe_match.url
+                        probe_artwork_url = probe_match.artwork_url
+                        probe_release_year = probe_match.release_year
             except TimeoutError:
                 logger.warning(
                     "AppleMusicClient.find_track_url timed out for %s - %s",
@@ -1872,12 +1940,16 @@ async def enrich_artwork_results(
                 )
 
         # Album-derived fields are positionally gated: only on top-1, and
-        # only when top-1 actually has artwork. When ``artwork`` is None
-        # here (this branch is also taken for the synthesized no-Discogs-
-        # match streaming-only result), these stay None — preserves the
-        # docstring's positional-gating invariant.
-        is_album_derived_eligible = is_top1 and artwork is not None
-        year_result = top1_year if is_album_derived_eligible else None
+        # only when top-1 actually carries an *acceptable* library row
+        # (LML#487 extends PR #481 gate from streaming-links to
+        # release-year/bio/wiki: a sibling-album fuzzy hit would otherwise
+        # leak Tzenni's year onto a Yenbett response). When the library
+        # row is not acceptable, fall through to the probe-derived year
+        # (Yenbett's year from Apple Music).
+        is_album_derived_eligible = is_top1 and library_row_acceptable
+        year_result = (
+            top1_year if is_album_derived_eligible else (probe_release_year if is_top1 else None)
+        )
         artist_bio = top1_bio if is_album_derived_eligible else None
         wikipedia_url = top1_wiki if is_album_derived_eligible else None
 
@@ -1891,18 +1963,6 @@ async def enrich_artwork_results(
         bandcamp_url = None
         soundcloud_url = None
 
-        # LML#477: only trust the library row's stored streaming URLs when
-        # its title plausibly matches the requested album. ``_fuzzy_search``
-        # in library/db.py accepts token_set_ratio >= 70 — permissive enough
-        # to surface sibling-album rows (same artist, different release)
-        # whose verified Spotify/Apple URLs would otherwise propagate as if
-        # they pointed at the requested album. The 80 floor mirrors
-        # ``is_acceptable_match`` in ``clients/streaming/matching``. When no
-        # album was requested (artist-only lookup) or the row's title is
-        # missing, there is no signal to gate against — fall through.
-        row_title_matches_requested_album = (
-            not album or not item.title or score_match(album, item.title) >= 80.0
-        )
         if (
             library_db
             and getattr(library_db, "_has_streaming_links", None) is True
@@ -1944,7 +2004,7 @@ async def enrich_artwork_results(
             "artist_bio": artist_bio,
             "wikipedia_url": wikipedia_url,
             "spotify_url": spotify_url,
-            "apple_music_url": apple_music_override or apple_music_result or None,
+            "apple_music_url": apple_music_override or apple_music_url or None,
             "youtube_music_url": youtube_music_url,
             "bandcamp_url": bandcamp_url,
             "soundcloud_url": soundcloud_url,
@@ -1970,11 +2030,11 @@ async def enrich_artwork_results(
             )
             update["profile_tokens"] = top1_profile_tokens
 
-        if artwork is None:
-            # No Discogs match: try MusicBrainz for a tracklist before
-            # synthesizing the streaming-only result. Same positional gate
-            # as the rest of the extended payload — only the top-1 item is
-            # eligible, and only when extended mode is on.
+        if not library_row_acceptable:
+            # No acceptable Discogs match: try MusicBrainz for a tracklist
+            # before synthesizing the streaming-only result. Same positional
+            # gate as the rest of the extended payload — only the top-1 item
+            # is eligible, and only when extended mode is on.
             if is_top1 and extended and mb_pg is not None and item.artist and album:
                 mb_tracklist = await resolve_tracklist_via_musicbrainz(
                     item.artist, album, mb_pg=mb_pg
@@ -1983,10 +2043,22 @@ async def enrich_artwork_results(
                     update["tracklist"] = mb_tracklist
                 _project_mb_rescue_attrs(attempted=True, tracklist_found=bool(mb_tracklist))
 
+            # LML#487: surface the Apple Music probe's artwork URL on the
+            # synthesized result. ``probe_artwork_url`` is non-None when
+            # ``find_track_metadata`` returned a match clearing the 80/80(/80)
+            # floor; ``None`` falls through to the no-artwork shape (legacy
+            # LML#401 behaviour preserved when no probe match was found, no
+            # Apple credentials configured, or the probe timed out / raised).
+            update["artwork_url"] = probe_artwork_url
+
             # See docstring's "Behavior change vs. v0.6.0 (LML#401)"
             # section for the BS#1185 sentinel contract.
             return (item, DiscogsSearchResult(release_id=0, release_url="", **update))
 
+        # ``library_row_acceptable`` ⟹ ``artwork is not None`` (by definition
+        # on line above). Asserted for mypy narrowing — the runtime cost is
+        # nil, and the explicit precondition makes the contract local.
+        assert artwork is not None
         return (item, artwork.model_copy(update=update))
 
     enriched = await asyncio.gather(

--- a/tests/integration/test_streaming_on_discogs_miss.py
+++ b/tests/integration/test_streaming_on_discogs_miss.py
@@ -62,14 +62,16 @@ class TestStreamingOnDiscogsMiss:
 
         apple_url = "https://music.apple.com/us/album/aluminum-tunes/1234567890"
         apple_music = AsyncMock(spec=AppleMusicClient)
-        # LML#487: synthesis path now drives ``find_track_metadata`` so the
-        # same Apple Music search response can yield artwork + release_year
-        # alongside the URL. Use ``artwork_url=None`` / ``release_year=None``
-        # to pin the pre-LML#487 URL-only invariant (this test predates the
-        # artwork extraction; LML#487's TestExternalArtworkProbe covers the
-        # full-payload shape).
+        # LML#487: synthesis path drives ``find_track_metadata``; the test
+        # pins the pre-LML#487 URL-only invariant (artwork_url/release_year
+        # None). Fail loudly if a refactor accidentally routes through
+        # find_track_url — AsyncMock(spec=...) would otherwise auto-generate
+        # a Mock-returning stub and silently keep the test green.
         apple_music.find_track_metadata = AsyncMock(
             return_value=AppleMusicTrackMatch(url=apple_url, artwork_url=None, release_year=None)
+        )
+        apple_music.find_track_url = AsyncMock(
+            side_effect=AssertionError("find_track_url called on synthesis path")
         )
 
         request = LookupRequest(
@@ -133,6 +135,9 @@ class TestStreamingOnDiscogsMiss:
 
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=None)
+        apple_music.find_track_url = AsyncMock(
+            side_effect=AssertionError("find_track_url called on synthesis path")
+        )
 
         request = LookupRequest(
             artist="Stereolab",

--- a/tests/integration/test_streaming_on_discogs_miss.py
+++ b/tests/integration/test_streaming_on_discogs_miss.py
@@ -70,9 +70,7 @@ class TestStreamingOnDiscogsMiss:
         apple_music.find_track_metadata = AsyncMock(
             return_value=AppleMusicTrackMatch(url=apple_url, artwork_url=None, release_year=None)
         )
-        apple_music.find_track_url = AsyncMock(
-            side_effect=AssertionError("find_track_url called on synthesis path")
-        )
+        apple_music.find_track_url = AsyncMock()
 
         request = LookupRequest(
             artist="Stereolab",
@@ -108,6 +106,12 @@ class TestStreamingOnDiscogsMiss:
         assert top.artwork.youtube_music_url is not None
         assert top.artwork.bandcamp_url is not None
         assert top.artwork.soundcloud_url is not None
+        # Defense in depth: a refactor that routes the synthesis path through
+        # find_track_url instead of find_track_metadata is silently swallowed
+        # by the orchestrator's broad ``except Exception:``. Use mock
+        # call-history rather than ``side_effect`` so the assertion can't be
+        # caught by the production code.
+        apple_music.find_track_url.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_search_urls_fill_when_apple_match_fails(self, library_db):
@@ -135,9 +139,7 @@ class TestStreamingOnDiscogsMiss:
 
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=None)
-        apple_music.find_track_url = AsyncMock(
-            side_effect=AssertionError("find_track_url called on synthesis path")
-        )
+        apple_music.find_track_url = AsyncMock()
 
         request = LookupRequest(
             artist="Stereolab",
@@ -163,3 +165,6 @@ class TestStreamingOnDiscogsMiss:
         assert top.artwork.youtube_music_url is not None
         assert top.artwork.bandcamp_url is not None
         assert top.artwork.soundcloud_url is not None
+        # Pin the synthesis path — the no-match shape still routes through
+        # find_track_metadata, not find_track_url.
+        apple_music.find_track_url.assert_not_called()

--- a/tests/integration/test_streaming_on_discogs_miss.py
+++ b/tests/integration/test_streaming_on_discogs_miss.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from clients.streaming.apple_music import AppleMusicClient
+from clients.streaming.apple_music import AppleMusicClient, AppleMusicTrackMatch
 from discogs.models import DiscogsSearchResponse
 from lookup.models import LookupRequest
 from lookup.orchestrator import perform_lookup
@@ -62,7 +62,15 @@ class TestStreamingOnDiscogsMiss:
 
         apple_url = "https://music.apple.com/us/album/aluminum-tunes/1234567890"
         apple_music = AsyncMock(spec=AppleMusicClient)
-        apple_music.find_track_url = AsyncMock(return_value=apple_url)
+        # LML#487: synthesis path now drives ``find_track_metadata`` so the
+        # same Apple Music search response can yield artwork + release_year
+        # alongside the URL. Use ``artwork_url=None`` / ``release_year=None``
+        # to pin the pre-LML#487 URL-only invariant (this test predates the
+        # artwork extraction; LML#487's TestExternalArtworkProbe covers the
+        # full-payload shape).
+        apple_music.find_track_metadata = AsyncMock(
+            return_value=AppleMusicTrackMatch(url=apple_url, artwork_url=None, release_year=None)
+        )
 
         request = LookupRequest(
             artist="Stereolab",
@@ -124,7 +132,7 @@ class TestStreamingOnDiscogsMiss:
         mock_service.validate_track_on_release = AsyncMock(return_value=False)
 
         apple_music = AsyncMock(spec=AppleMusicClient)
-        apple_music.find_track_url = AsyncMock(return_value=None)
+        apple_music.find_track_metadata = AsyncMock(return_value=None)
 
         request = LookupRequest(
             artist="Stereolab",

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -20,6 +20,7 @@ import pytest
 from clients.streaming.apple_music import (
     _APPLE_MUSIC_MATCH_FLOOR,
     AppleMusicClient,
+    _extract_release_year,
     _parse_retry_after,
 )
 
@@ -676,6 +677,38 @@ class TestFindTrackMetadata:
         assert match.release_year == 2025
 
     @pytest.mark.asyncio
+    async def test_prefers_match_with_artwork_over_higher_scoring_without(self, es256_keypair):
+        """When the top fuzz-score match has no `artwork` block (region-
+        restricted single, promo entry, sparse Music-Connect record), the
+        probe must fall through to the next floor-clearing match that
+        carries artwork — otherwise the whole point of LML#487 (surface
+        the right cover) degrades to "show nothing" for these items."""
+        client = _client(es256_keypair)
+        # Top-scoring match has identical fixture but no artwork block.
+        no_artwork = _make_song_data_full(
+            url="https://music.apple.com/us/song/no-art/1",
+            artwork_url=None,
+        )
+        # Lower-scoring (still clears 80 across the board) carries artwork.
+        with_artwork = _make_song_data_full(
+            artist_name="Noura Mint Seymalii",  # 1-char drift, clears 80
+            url="https://music.apple.com/us/song/with-art/2",
+            artwork_url="https://example.com/right/{w}x{h}.jpg",
+        )
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([no_artwork, with_artwork]))
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+
+        assert match is not None
+        assert match.url == "https://music.apple.com/us/song/with-art/2"
+        assert match.artwork_url is not None
+        assert "right" in match.artwork_url
+
+    @pytest.mark.asyncio
     async def test_url_matches_find_track_url_on_acceptable_hit(self, es256_keypair):
         """``find_track_metadata`` is a superset of ``find_track_url``: when
         both methods are called against the same response, the URL each
@@ -947,6 +980,46 @@ class TestObservability:
             await client.search_song("Stereolab", "Aluminum Tunes")
 
         mock_sentry.capture_exception.assert_called_once()
+
+
+class TestExtractReleaseYear:
+    """The extractor must reject malformed/sentinel/non-ASCII inputs so 0,
+    9999, 202, and Arabic-Indic digits don't reach downstream as a release
+    year. Apple's documented shape is ISO YYYY-MM-DD; anything else falls
+    through to None."""
+
+    def _item(self, release_date) -> dict:
+        return {"attributes": {"releaseDate": release_date}}
+
+    def test_valid_iso_date(self):
+        assert _extract_release_year(self._item("2025-03-14")) == 2025
+
+    def test_year_only(self):
+        assert _extract_release_year(self._item("2025")) == 2025
+
+    def test_rejects_zero_sentinel(self):
+        # Apple ships "0000-00-00" for placeholder/unknown records.
+        assert _extract_release_year(self._item("0000-00-00")) is None
+
+    def test_rejects_year_below_plausible_range(self):
+        assert _extract_release_year(self._item("1500")) is None
+
+    def test_rejects_year_above_plausible_range(self):
+        assert _extract_release_year(self._item("9999")) is None
+
+    def test_rejects_three_char_string(self):
+        # raw[:4] on "202" is "202", isdigit() passes — must require length 4.
+        assert _extract_release_year(self._item("202")) is None
+
+    def test_rejects_non_ascii_digits(self):
+        # Arabic-Indic digits clear str.isdigit() but aren't ASCII.
+        assert _extract_release_year(self._item("٢٠٢٥")) is None
+
+    def test_rejects_missing_field(self):
+        assert _extract_release_year({"attributes": {}}) is None
+
+    def test_rejects_non_string_field(self):
+        assert _extract_release_year(self._item(2025)) is None
 
 
 def test_match_floor_constant_is_80():

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -493,6 +493,215 @@ class TestFindAlbumMatch:
         assert match.url.endswith("/456")
 
 
+def _make_song_data_full(
+    name: str = "Hebebeb (Zrag)",
+    artist_name: str = "Noura Mint Seymali",
+    album_name: str = "Yenbett",
+    url: str = "https://music.apple.com/us/song/hebebeb-zrag/9",
+    artwork_url: str | None = "https://is1-ssl.mzstatic.com/image/thumb/abc/{w}x{h}bb.jpg",
+    release_date: str | None = "2025-03-14",
+) -> dict:
+    """Song record carrying the full ``artwork`` + ``releaseDate`` payload
+    Apple Music returns for catalog tracks. Track-level artwork inherits
+    the album cover, and ``releaseDate`` is the album's release date for
+    catalog tracks (Apple does not distinguish single vs album release
+    date here for songs that ship as part of an album).
+    """
+    attrs: dict = {
+        "artistName": artist_name,
+        "name": name,
+        "albumName": album_name,
+        "url": url,
+    }
+    if artwork_url is not None:
+        attrs["artwork"] = {
+            "width": 3000,
+            "height": 3000,
+            "url": artwork_url,
+            "bgColor": "000000",
+        }
+    if release_date is not None:
+        attrs["releaseDate"] = release_date
+    return {"id": "9", "type": "songs", "attributes": attrs}
+
+
+class TestFindTrackMetadata:
+    """``find_track_metadata`` extends ``find_track_url`` (the existing lookup
+    hot-path probe) by surfacing ``artwork_url`` and ``release_year`` from the
+    SAME ``search_song`` response. Pins the LML#487 / BS#1184 fix: when the
+    WXYC catalog has no acceptable library row for the requested album, the
+    synthesized ``DiscogsSearchResult`` carries the right album's artwork
+    instead of a sibling-album cover leaking through.
+
+    No new API rounds vs. ``find_track_url`` — both call ``search_song``
+    against the same `(artist, song)` term, so per-request Apple Music quota
+    is unchanged. Reuses the same 80/80(/80) floor as ``find_track_url``
+    so the artist+title (+album) wrong-match guards stay in lockstep.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_full_metadata_for_acceptable_match(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([_make_song_data_full()]))
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+
+        assert match is not None
+        assert match.url == "https://music.apple.com/us/song/hebebeb-zrag/9"
+        # `{w}x{h}` template must be substituted with concrete pixel
+        # dimensions before surfacing — clients (iOS, dj-site) cannot
+        # render the template literal.
+        assert "{w}" not in match.artwork_url
+        assert "{h}" not in match.artwork_url
+        assert "is1-ssl.mzstatic.com" in match.artwork_url
+        assert match.release_year == 2025
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_search_empty(self, es256_keypair):
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([]))
+        client._http = mock_http
+
+        match = await client.find_track_metadata("Unknown", "Unknown")
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_album_below_floor(self, es256_keypair):
+        """LML#487 Tzenni-vs-Yenbett shape: when the song appears on the
+        wrong album in Apple's catalog (a compilation, a single-track
+        sampler) the 3-way 80/80/80 floor must reject. Otherwise the
+        synthesized result would carry wrong-album artwork, regressing
+        on the very bug this ticket fixes."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response([_make_song_data_full(album_name="Tzenni")])
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_artist_below_floor(self, es256_keypair):
+        """Same song title under the wrong artist — the 80/80 floor must
+        reject so a same-titled cover by another artist can't surface
+        wrong-artist artwork."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response(
+                [_make_song_data_full(artist_name="Completely Different Artist")]
+            )
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_artwork_block(self, es256_keypair):
+        """A catalog song with no ``artwork`` block (rare but real for
+        region-restricted records) must not raise — ``artwork_url`` falls
+        through as ``None`` while the URL still surfaces."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response([_make_song_data_full(artwork_url=None)])
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+        assert match is not None
+        assert match.artwork_url is None
+        assert match.url.endswith("/9")
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_release_date(self, es256_keypair):
+        """A catalog song with no ``releaseDate`` (sparse record) must not
+        raise — ``release_year`` falls through as ``None``."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response([_make_song_data_full(release_date=None)])
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+        assert match is not None
+        assert match.release_year is None
+
+    @pytest.mark.asyncio
+    async def test_picks_best_scoring_when_multiple_clear_floor(self, es256_keypair):
+        """When several candidates clear 80/80(/80), the highest combined
+        score wins. Pins that Apple's intrinsic ranking order doesn't
+        freeze a sub-optimal hit's metadata when a stronger match sits
+        below it."""
+        client = _client(es256_keypair)
+        sub_optimal = _make_song_data_full(
+            artist_name="Noura Mint Seymalii",  # 1-char drift, clears 80
+            url="https://music.apple.com/us/song/wrong/1",
+            artwork_url="https://example.com/wrong/{w}x{h}.jpg",
+            release_date="1999-01-01",
+        )
+        canonical = _make_song_data_full(
+            url="https://music.apple.com/us/song/right/2",
+            artwork_url="https://example.com/right/{w}x{h}.jpg",
+            release_date="2025-03-14",
+        )
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([sub_optimal, canonical]))
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+
+        assert match is not None
+        assert match.url == "https://music.apple.com/us/song/right/2"
+        assert "right" in match.artwork_url
+        assert match.release_year == 2025
+
+    @pytest.mark.asyncio
+    async def test_url_matches_find_track_url_on_acceptable_hit(self, es256_keypair):
+        """``find_track_metadata`` is a superset of ``find_track_url``: when
+        both methods are called against the same response, the URL each
+        surfaces must agree. Pins the no-regression invariant — a refactor
+        that drifts the two floors would silently break BS#1184 callers."""
+        client_a = _client(es256_keypair)
+        client_b = _client(es256_keypair)
+        # Same mock response for both clients.
+        mock_a = AsyncMock(spec=httpx.AsyncClient)
+        mock_a.get = AsyncMock(return_value=_songs_response([_make_song_data_full()]))
+        client_a._http = mock_a
+
+        mock_b = AsyncMock(spec=httpx.AsyncClient)
+        mock_b.get = AsyncMock(return_value=_songs_response([_make_song_data_full()]))
+        client_b._http = mock_b
+
+        url = await client_a.find_track_url("Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett")
+        match = await client_b.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+
+        assert url is not None
+        assert match is not None
+        assert match.url == url
+
+
 class TestRetryBehavior:
     """429 and transient 5xx are retried; terminal 4xx are not. Mirrors
     SpotifyClient's _search_with_retry shape."""

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1611,3 +1611,54 @@ class TestExternalArtworkProbe:
         )
 
         apple_music.find_track_metadata.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_probe_skipped_on_happy_path_when_streaming_links_override_present(self):
+        """When the library row clears the LML#477 gate AND has a
+        librarian-curated ``streaming_links`` Apple Music override, the
+        final ``apple_music_url`` is the override (per the
+        ``apple_music_override or apple_music_url or None`` precedence).
+        The probe's URL would be discarded — so skip the Apple Music
+        call entirely. Saves one quota slot per overridden item."""
+        item = make_library_item(id=42, artist="Jessica Pratt", title="On Your Own Love Again")
+        artwork = make_discogs_result(
+            release_id=1,
+            artist="Jessica Pratt",
+            album="On Your Own Love Again",
+            artwork_url="https://example.com/oyola.jpg",
+            release_year=2015,
+        )
+
+        override_url = "https://music.apple.com/us/album/oyola/curated-by-librarian"
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(return_value={"apple_music_url": override_url})
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_url = AsyncMock(return_value="https://music.apple.com/discarded")
+        apple_music.find_track_metadata = AsyncMock()
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="On Your Own Love Again",
+            artist="Jessica Pratt",
+            year=2015,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            song="Back, Baby",
+            album="On Your Own Love Again",
+            apple_music=apple_music,
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.apple_music_url == override_url
+        apple_music.find_track_url.assert_not_called()
+        apple_music.find_track_metadata.assert_not_called()

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from clients.streaming.apple_music import AppleMusicClient
+from clients.streaming.apple_music import AppleMusicClient, AppleMusicTrackMatch
 from discogs.models import (
     ArtistDetails,
     DiscogsSearchResult,
@@ -129,11 +129,16 @@ class TestEnrichArtworkResults:
 
     @pytest.mark.asyncio
     async def test_no_discogs_match_surfaces_apple_url_via_apple_music(self):
-        """When ``AppleMusicClient.find_track_url`` clears the 80/80/80 floor
-        on a no-Discogs-match item, the synthesized artwork carries the URL.
+        """When ``AppleMusicClient.find_track_metadata`` clears the 80/80/80
+        floor on a no-Discogs-match item, the synthesized artwork carries
+        the URL.
 
         This is the Tragic Magic case from BS#1184 in miniature: an album
-        absent from the WXYC catalog but present on Apple Music.
+        absent from the WXYC catalog but present on Apple Music. Post-
+        LML#487 the probe also lands ``artwork_url`` + ``release_year`` on
+        the synthesized result; this test pins the URL-only invariant from
+        the pre-LML#487 contract — ``artist_bio`` + ``wikipedia_url`` stay
+        None because they require a real Discogs artwork (positional gate).
         """
         item = make_library_item(
             artist="Julianna Barwick & Mary Lattimore",
@@ -142,7 +147,9 @@ class TestEnrichArtworkResults:
 
         apple_url = "https://music.apple.com/us/album/tragic-magic/1843854211"
         apple_music = AsyncMock(spec=AppleMusicClient)
-        apple_music.find_track_url = AsyncMock(return_value=apple_url)
+        apple_music.find_track_metadata = AsyncMock(
+            return_value=AppleMusicTrackMatch(url=apple_url, artwork_url=None, release_year=None)
+        )
 
         results = await enrich_artwork_results(
             [(item, None)],
@@ -156,9 +163,8 @@ class TestEnrichArtworkResults:
         assert enriched is not None
         assert enriched.release_id == 0
         assert enriched.apple_music_url == apple_url
-        # Album-derived fields stay None even though Apple matched — those
-        # are positionally gated and require a real Discogs artwork.
-        assert enriched.release_year is None
+        # Discogs-derived album fields stay None — positionally gated and
+        # require a real Discogs artwork.
         assert enriched.artist_bio is None
         assert enriched.wikipedia_url is None
 
@@ -867,9 +873,12 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
     @pytest.mark.asyncio
     async def test_apple_music_client_url_propagates_to_synthesized_result(self):
         """A no-Discogs-match item paired with an ``AppleMusicClient`` that
-        returns a URL produces a synthesized ``DiscogsSearchResult`` carrying
-        that URL — mirrors LML#401 / BS#1184 (Tragic Magic on Apple Music but
-        absent from the WXYC Discogs catalog).
+        returns a metadata match produces a synthesized ``DiscogsSearchResult``
+        carrying that URL — mirrors LML#401 / BS#1184 (Tragic Magic on Apple
+        Music but absent from the WXYC Discogs catalog). Post-LML#487 the
+        synthesis path consumes ``find_track_metadata`` rather than the
+        URL-only ``find_track_url`` so artwork + release year can land on
+        the same response.
         """
         item = make_library_item(
             artist="Julianna Barwick & Mary Lattimore",
@@ -878,7 +887,9 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         apple_url = "https://music.apple.com/us/album/tragic-magic/1843854211"
 
         apple_music = AsyncMock(spec=AppleMusicClient)
-        apple_music.find_track_url = AsyncMock(return_value=apple_url)
+        apple_music.find_track_metadata = AsyncMock(
+            return_value=AppleMusicTrackMatch(url=apple_url, artwork_url=None, release_year=None)
+        )
 
         results = await enrich_artwork_results(
             [(item, None)],
@@ -888,7 +899,7 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
             apple_music=apple_music,
         )
 
-        apple_music.find_track_url.assert_awaited_once_with(
+        apple_music.find_track_metadata.assert_awaited_once_with(
             "Julianna Barwick & Mary Lattimore",
             "The Four Sleeping Princesses",
             album="Tragic Magic",
@@ -931,7 +942,7 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         item = make_library_item(artist="Obscure Artist", title="Obscure Album")
 
         apple_music = AsyncMock(spec=AppleMusicClient)
-        apple_music.find_track_url = AsyncMock(return_value=None)
+        apple_music.find_track_metadata = AsyncMock(return_value=None)
 
         results = await enrich_artwork_results(
             [(item, None)],
@@ -941,18 +952,19 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
             apple_music=apple_music,
         )
 
-        apple_music.find_track_url.assert_awaited_once()
+        apple_music.find_track_metadata.assert_awaited_once()
         _, enriched = results[0]
         assert enriched is not None
         assert enriched.apple_music_url is None
 
     @pytest.mark.asyncio
     async def test_apple_music_client_raising_does_not_sink_whole_batch(self):
-        """A single ``find_track_url`` exception must NOT propagate through
-        ``asyncio.gather`` and fail the entire enrichment. ``find_track_url``
-        has no top-level exception handler around its result-iteration loop,
-        so the orchestrator wraps the call defensively — bulk lookups would
-        otherwise regress to 500 if Apple returns a malformed result.
+        """A single ``find_track_metadata`` exception must NOT propagate
+        through ``asyncio.gather`` and fail the entire enrichment — the
+        underlying search-song loop has no top-level exception handler
+        around its result iteration, so the orchestrator wraps the call
+        defensively. Bulk lookups would otherwise regress to 500 if Apple
+        returns a malformed result. Same shape as LML#444.
         """
         items_with_artwork = [
             (make_library_item(id=1, artist="Artist 1", title="Album 1"), None),
@@ -960,14 +972,14 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         ]
 
         apple_music = AsyncMock(spec=AppleMusicClient)
-        # Item 1 raises; item 2 returns a normal URL. Without a defensive
+        # Item 1 raises; item 2 returns a normal match. Without a defensive
         # wrap at the call site, the gather() in enrich_artwork_results
         # cancels item 2's enrichment mid-flight and raises.
         item2_url = "https://music.apple.com/us/album/album-2/222"
-        apple_music.find_track_url = AsyncMock(
+        apple_music.find_track_metadata = AsyncMock(
             side_effect=[
                 AttributeError("Apple returned a non-dict item"),
-                item2_url,
+                AppleMusicTrackMatch(url=item2_url, artwork_url=None, release_year=None),
             ]
         )
 
@@ -992,12 +1004,16 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
 
     @pytest.mark.asyncio
     async def test_apple_music_find_track_url_timeout_degrades_to_none(self):
-        """LML#449 + LML#450: a single ``find_track_url`` call that exceeds
-        the call-site timeout must NOT pull the rest of the request past its
-        deadline. The orchestrator wraps the call in ``asyncio.wait_for``
+        """LML#449 + LML#450: a single Apple Music probe call that exceeds
+        the call-site timeout must NOT pull the rest of the request past
+        its deadline. The orchestrator wraps the call in ``asyncio.wait_for``
         with a tight ceiling; on TimeoutError the item degrades to no Apple
-        URL, same as the LML#444 exception path. Pins the upper bound so the
-        worst-case 4×60s retry loop in LML#450 cannot block enrichment.
+        URL, same as the LML#444 exception path. Pins the upper bound so
+        the worst-case 4×60s retry loop in LML#450 cannot block enrichment.
+        Post-LML#487 the orchestrator drives ``find_track_metadata`` in
+        the synthesis path (no library row to project) — the timeout
+        semantics are identical because both methods share the
+        ``search_song`` rate-limited endpoint.
         """
         items_with_artwork = [
             (make_library_item(id=1, artist="Mūm", title="Summer Make Good"), None),
@@ -1010,9 +1026,13 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         # before this completes; the test then verifies graceful degradation.
         async def slow_find(*_args, **_kwargs):
             await asyncio.sleep(60)
-            return "https://music.apple.com/should-never-resolve"
+            return AppleMusicTrackMatch(
+                url="https://music.apple.com/should-never-resolve",
+                artwork_url=None,
+                release_year=None,
+            )
 
-        apple_music.find_track_url = AsyncMock(side_effect=slow_find)
+        apple_music.find_track_metadata = AsyncMock(side_effect=slow_find)
 
         # Patch the call-site timeout to a tiny value so the test runs in
         # milliseconds and the asyncio.wait_for ceiling fires deterministically.
@@ -1057,9 +1077,13 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
 
         async def slow_find(*_args, **_kwargs):
             await asyncio.sleep(60)
-            return "https://music.apple.com/should-never-resolve"
+            return AppleMusicTrackMatch(
+                url="https://music.apple.com/should-never-resolve",
+                artwork_url=None,
+                release_year=None,
+            )
 
-        apple_music.find_track_url = AsyncMock(side_effect=slow_find)
+        apple_music.find_track_metadata = AsyncMock(side_effect=slow_find)
 
         transaction = MagicMock()
         scope = MagicMock()
@@ -1106,9 +1130,13 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
 
         async def slow_find(*_args, **_kwargs):
             await asyncio.sleep(60)
-            return "https://music.apple.com/should-never-resolve"
+            return AppleMusicTrackMatch(
+                url="https://music.apple.com/should-never-resolve",
+                artwork_url=None,
+                release_year=None,
+            )
 
-        apple_music.find_track_url = AsyncMock(side_effect=slow_find)
+        apple_music.find_track_metadata = AsyncMock(side_effect=slow_find)
 
         # No active transaction.
         scope = MagicMock()
@@ -1332,3 +1360,254 @@ class TestStreamingLinksTitleGate:
 
         _, enriched = results[0]
         assert enriched.spotify_url == verified_spotify
+
+
+class TestExternalArtworkProbe:
+    """LML#487 / BS#1184: when the WXYC library catalog has no row whose title
+    clears the LML#477 (PR #481) gate against the requested album, probe Apple
+    Music for the literal `(artist, song, album)` and surface the matched
+    response's ``artwork_url`` + ``release_year`` on the synthesized
+    ``DiscogsSearchResult``.
+
+    Concretely: a flowsheet entry for `Hebebeb (Zrag)` from Noura Mint
+    Seymali's *Yenbett* — when the catalog has only her earlier *Tzenni*
+    album — must surface Yenbett's cover art, not Tzenni's. Strict
+    superset of LML#401 (the no-Discogs-match case still works), and
+    strict no-regression on LML#477's gate (the gate still fires).
+
+    The probe uses the SAME ``search_song`` endpoint the existing
+    ``find_track_url`` calls — no new Apple Music API rounds vs. the
+    LML#401 quota.
+    """
+
+    @pytest.mark.asyncio
+    async def test_probe_artwork_surfaces_on_synthesized_result_when_no_discogs_match(self):
+        """LML#401 superset: when ``artwork is None`` (no Discogs match for the
+        requested release) AND the Apple Music probe returns a track-level
+        match, the synthesized result carries ``artwork_url`` +
+        ``release_year`` from that probe response. No regression vs. LML#401:
+        the URL was already surfacing; the artwork + year are the new fields.
+        """
+        from clients.streaming.apple_music import AppleMusicTrackMatch
+
+        item = make_library_item(artist="Noura Mint Seymali", title="Hebebeb (Zrag)")
+        probe_match = AppleMusicTrackMatch(
+            url="https://music.apple.com/us/song/hebebeb-zrag/9",
+            artwork_url="https://is1-ssl.mzstatic.com/image/thumb/abc/600x600bb.jpg",
+            release_year=2025,
+        )
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
+        # Keep find_track_url defined so a refactor that accidentally calls
+        # the old method instead of the new one surfaces in test output.
+        apple_music.find_track_url = AsyncMock(return_value=probe_match.url)
+
+        results = await enrich_artwork_results(
+            [(item, None)],
+            AsyncMock(),
+            song="Hebebeb (Zrag)",
+            album="Yenbett",
+            apple_music=apple_music,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        # BS#1185 sentinel contract preserved — synthesis path is taken.
+        assert enriched.release_id == 0
+        assert enriched.release_url == ""
+        # The new fields land on the synthesized result.
+        assert enriched.artwork_url == probe_match.artwork_url
+        assert enriched.release_year == 2025
+        assert enriched.apple_music_url == probe_match.url
+
+    @pytest.mark.asyncio
+    async def test_probe_artwork_surfaces_when_library_row_title_misses_album(self):
+        """LML#487 core: library has Tzenni; DJ requests Yenbett. The PR #481
+        gate already blocks Tzenni's streaming-URL projection; this ticket
+        ALSO discards Tzenni's Discogs artwork and probes Apple Music for
+        Yenbett. The synthesized result carries the probe's Yenbett artwork
+        — not the leaked Tzenni cover from the Discogs hit."""
+        from clients.streaming.apple_music import AppleMusicTrackMatch
+
+        item = make_library_item(id=42, artist="Noura Mint Seymali", title="Tzenni")
+        # Discogs hit for the WRONG album (Tzenni). Its artwork_url and
+        # release_year would leak through ``artwork.model_copy(update=...)``
+        # without the LML#487 fix.
+        tzenni_artwork = make_discogs_result(
+            release_id=1,
+            artist="Noura Mint Seymali",
+            album="Tzenni",
+            artwork_url="https://example.com/tzenni-WRONG.jpg",
+            release_year=2014,
+        )
+        # Apple Music probe for `(Noura, Hebebeb, Yenbett)` returns the
+        # Yenbett match (right album).
+        probe_match = AppleMusicTrackMatch(
+            url="https://music.apple.com/us/song/hebebeb-zrag/9",
+            artwork_url="https://is1-ssl.mzstatic.com/image/thumb/abc/600x600bb.jpg",
+            release_year=2025,
+        )
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
+        apple_music.find_track_url = AsyncMock(return_value=probe_match.url)
+
+        discogs_service = AsyncMock()
+        # Even if get_release returns Tzenni's year, the synthesis path
+        # ignores it for the synthesized-result branch.
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="Tzenni",
+            artist="Noura Mint Seymali",
+            year=2014,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, tzenni_artwork)],
+            discogs_service,
+            song="Hebebeb (Zrag)",
+            album="Yenbett",
+            apple_music=apple_music,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        # Tzenni's wrong artwork is gone.
+        assert enriched.artwork_url != "https://example.com/tzenni-WRONG.jpg"
+        # Yenbett's correct artwork (from Apple) is on the result.
+        assert enriched.artwork_url == probe_match.artwork_url
+        # Yenbett's release year, not Tzenni's.
+        assert enriched.release_year == 2025
+        # Synthesized result — release_id reset to 0 so BS#1185 still
+        # branches on the no-Discogs-match write path.
+        assert enriched.release_id == 0
+        assert enriched.release_url == ""
+
+    @pytest.mark.asyncio
+    async def test_probe_not_invoked_when_library_row_title_matches(self):
+        """Happy path: when the library row title clears the LML#477 gate,
+        the synthesis path is not taken and the external album probe is
+        not invoked. Pins acceptance criterion 3 — don't waste an Apple
+        Music call on rows that already match.
+
+        ``find_track_url`` (the song-level URL probe) still runs for the
+        streaming-URL surfacing path; what this test pins is that
+        ``find_track_metadata`` (the artwork-bearing probe) is not called
+        when the gate passes."""
+        item = make_library_item(id=42, artist="Jessica Pratt", title="On Your Own Love Again")
+        artwork = make_discogs_result(
+            release_id=1,
+            artist="Jessica Pratt",
+            album="On Your Own Love Again",
+            artwork_url="https://example.com/oyola.jpg",
+            release_year=2015,
+        )
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock()
+        apple_music.find_track_url = AsyncMock(
+            return_value="https://music.apple.com/us/song/back-baby/123"
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="On Your Own Love Again",
+            artist="Jessica Pratt",
+            year=2015,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            song="Back, Baby",
+            album="On Your Own Love Again",
+            apple_music=apple_music,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        # Library row's Discogs artwork survives — gate passed.
+        assert enriched.artwork_url == "https://example.com/oyola.jpg"
+        assert enriched.release_year == 2015
+        # External-artwork probe (find_track_metadata) NOT invoked: don't
+        # waste an Apple Music call on a happy-path hit.
+        apple_music.find_track_metadata.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_probe_returning_none_falls_through_to_legacy_shape(self):
+        """When the Apple Music probe returns None (no acceptable match —
+        per the 80/80/80 floor inside ``find_track_metadata``), the
+        synthesized result shape matches the existing LML#401 no-Discogs-
+        match behaviour: ``artwork_url`` is None, search-URL fallbacks
+        fill streaming URLs. No regression."""
+        item = make_library_item(artist="Obscure Artist", title="Obscure Song")
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock(return_value=None)
+        apple_music.find_track_url = AsyncMock(return_value=None)
+
+        results = await enrich_artwork_results(
+            [(item, None)],
+            AsyncMock(),
+            song="Obscure Song",
+            album="Obscure Album",
+            apple_music=apple_music,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.release_id == 0
+        # No artwork surfaces — synthesized result with null artwork field.
+        assert enriched.artwork_url is None
+        assert enriched.release_year is None
+        # Search-URL fallbacks still fill (legacy LML#401 contract).
+        assert enriched.spotify_url is not None
+        assert "search" in enriched.spotify_url.lower()
+
+    @pytest.mark.asyncio
+    async def test_probe_not_invoked_when_album_is_none(self):
+        """When no album is requested (artist+song-only lookup) AND the
+        library row carries Discogs artwork, the gate trivially passes
+        (no signal to gate against — preserves LML#477's
+        ``test_applies_streaming_links_when_album_not_requested``
+        edge case). The artwork-bearing probe must not fire — the legacy
+        ``find_track_url`` is what surfaces the song URL on the
+        happy-path slot.
+        """
+        item = make_library_item(id=42, artist="Juana Molina", title="DOGA")
+        artwork = make_discogs_result(
+            release_id=1,
+            artist="Juana Molina",
+            album="DOGA",
+            artwork_url="https://example.com/doga.jpg",
+        )
+
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock()
+        apple_music.find_track_url = AsyncMock(return_value=None)
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="DOGA",
+            artist="Juana Molina",
+            year=2022,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            song="DOGA",
+            album=None,
+            apple_music=apple_music,
+        )
+
+        apple_music.find_track_metadata.assert_not_called()


### PR DESCRIPTION
## Summary

`/api/v1/lookup` was projecting a sibling-album library row's Discogs artwork onto responses whose requested album wasn't in the WXYC catalog. The concrete repro: Noura Mint Seymali's "Hebebeb (Zrag)" / Yenbett requested against a library that has Tzenni only — the track-search path finds Hebebeb on Tzenni's tracklist (`search_type: "compilation"`), and `artwork.model_copy(update=...)` propagates Tzenni's cover art onto a Yenbett-tagged response.

PR #481 (LML#477) blocked the streaming-URL half of the leak via a title-confidence gate (`score_match(album, item.title) >= 80`). The artwork half stayed open because the synthesis path only fired when `artwork is None`.

This change extends the synthesis trigger: when `album` is requested AND the library row's title fails the same 80-floor gate, treat the Discogs artwork as untrustworthy and fall through to the synthesized `(release_id=0, release_url="")` shape (LML#401 / BS#1185 sentinel contract). The orchestrator then probes Apple Music for `(artist, song, album)` and surfaces the matched track's `artwork.url` (substituted from the documented `{w}x{h}` template) + `releaseDate` year on the synthesized result. Strict superset of LML#401: the no-Discogs-match case (Tragic Magic shape) still works and now also lands artwork + year on the same response.

## Design

- New `find_track_metadata(artist, song, album=None)` method on `AppleMusicClient` returning `AppleMusicTrackMatch(url, artwork_url, release_year)`. Uses the SAME `search_song` endpoint as `find_track_url`, with the SAME 80/80/80 floor — no new Apple Music API rounds vs. the LML#401 baseline.
- Orchestrator dispatches by the gate: happy path (library row clears the gate) → `find_track_url` (URL-only, existing behavior preserved); synthesis path (gate fails OR no Discogs match) → `find_track_metadata` (URL + artwork + year on the synthesized result).
- The PR #481 streaming-link gate is untouched. The artwork-bearing probe fires in the same falls-through path, not as a separate gate.

## Tests

- `tests/unit/test_apple_music_client.py::TestFindTrackMetadata` — 8 cases pinning the new method (full metadata on acceptable match, none on empty/wrong-artist/wrong-album, sparse `artwork`/`releaseDate` degrade to `None`, highest-scoring picked among acceptable candidates, URL matches `find_track_url` for the no-regression invariant).
- `tests/unit/test_enrichment.py::TestExternalArtworkProbe` — 5 cases pinning the orchestrator wiring: artwork surfaces on no-Discogs-match (LML#401 superset), artwork surfaces when library row title misses album (the Tzenni-vs-Yenbett repro), probe NOT invoked when row title matches (acceptance criterion #3), probe returning `None` falls through to LML#401 shape, probe NOT invoked when `album` is None.
- Existing `TestEnrichArtworkResultsWithAppleMusicClient` tests updated to mock `find_track_metadata` instead of `find_track_url` where the synthesis path now drives the new method. The Sentry timeout marker stays `apple_music.find_track_url.timeout` to preserve LML#462 trace-explorer dashboards.
- Existing `tests/integration/test_streaming_on_discogs_miss.py` updated likewise.

Full unit + integration sweep green: 2426 passed, 1 skipped (pre-existing pg-env-dependent `test_pg_source_bad_credentials` failure unrelated to this PR — confirmed by stash-and-replay against `origin/main`), 128 deselected, 2 xfailed. Ruff + ruff-format + mypy clean.

## Constraints honored

- 80/80(/80) match floor unchanged.
- PR #481's gate at `orchestrator.py:1903` unchanged.
- LML#401's no-Discogs-match Apple URL probe behaviour preserved (strict superset — URL still surfaces, plus new artwork + year).
- No new per-request Apple Music API rounds (one `search_song` call per `enrich_one` invocation, same as LML#401).

Closes #487

## Related

- WXYC/library-metadata-lookup#481 (closed #477) — gates streaming_links projection on title-score floor. Complementary: this PR extends the same gate to artwork; #481 covered streaming URLs.
- WXYC/library-metadata-lookup#483 (closed #478) — fuzzy-score Discogs artwork candidates. Complementary: scores Discogs-side candidates; this PR escapes to Apple Music when no Discogs candidate clears.
- WXYC/library-metadata-lookup#401 (closed) — predecessor: introduced the Apple Music URL probe for no-Discogs-match items. This PR extends the same probe's response handling to also extract artwork.
- WXYC/Backend-Service#1184 (closed) — BS write-path consumer of LML's no-Discogs-match synthesized result. Already wired; this PR makes the payload richer.
- WXYC/Backend-Service#1268 — sibling: BS consumes `rotationReleaseId` from tubafrenzy webhook (in-flight on parallel agent).
- WXYC/Backend-Service#1270 — sibling: BS allowlist regression strips `rotation_id`/`album_id` from dj-site POSTs (in-flight on parallel agent).

## Test plan

- [x] Unit: `tests/unit/test_apple_music_client.py::TestFindTrackMetadata` (8 cases) — green.
- [x] Unit: `tests/unit/test_enrichment.py::TestExternalArtworkProbe` (5 cases) — green.
- [x] No-regression: full `tests/unit/test_enrichment.py::TestEnrichArtworkResultsWithAppleMusicClient` (8 cases) — green.
- [x] No-regression: `tests/integration/test_streaming_on_discogs_miss.py` (2 cases) — green.
- [x] Local CI mirror: `ruff check`, `ruff format --check`, `mypy`, `pytest` — all green.
- [ ] Integration smoke against staging: lookup for `(artist=Noura Mint Seymali, album=Yenbett, song=Hebebeb (Zrag))` returns `artwork_url` for Yenbett's actual cover (acceptance criterion #4 — manual post-deploy verification).