### PR TITLE
fix(discogs): treat stub artist rows as cache misses via fetched_at

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -982,8 +982,12 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
+            # `fetched_at` is projected so the service-layer `is_pg_hit`
+            # predicate can distinguish stub rows (rebuild-created, never
+            # hydrated from Discogs) from rows we've actually fetched. See
+            # `DiscogsService.get_artist_details` and WXYC#502.
             artist_row = await self.pool.fetchrow(
-                "SELECT id, name, profile, image_url FROM artist WHERE id = $1",
+                "SELECT id, name, profile, image_url, fetched_at FROM artist WHERE id = $1",
                 artist_id,
             )
 
@@ -1026,6 +1030,7 @@ class DiscogsCacheService:
                     for r in member_rows
                 ],
                 urls=[r["url"] for r in url_rows],
+                fetched_at=artist_row["fetched_at"],
                 cached=True,
             )
 

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Literal
 
@@ -145,6 +146,12 @@ class ArtistDetails(BaseModel):
     aliases: list[ArtistRef] = []
     members: list[MemberRef] = []
     urls: list[str] = []
+    # Stamped only by `write_artist_details` (`now()` in SQL). NULL marks a
+    # rebuild-created stub row that has never been hydrated from Discogs;
+    # non-NULL means "we asked Discogs at least once," regardless of whether
+    # the API returned a profile. Used as the cache-hit discriminator in
+    # `DiscogsService.get_artist_details` (#502).
+    fetched_at: datetime | None = None
     cached: bool = False
 
 

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -927,6 +927,16 @@ class DiscogsService:
             pg_read=lambda: cache.get_artist_details(artist_id),
             api_fetch=_api_fetch,
             pg_write=cache.write_artist_details,
+            # `fetched_at IS NULL` marks a stub row created by the monthly
+            # rebuild's stub-from-`release_artist` path — `(id, name)` only,
+            # no profile / aliases / members / urls / variations. Falling
+            # through to the API + write-back is the back-fill path. Once
+            # `fetched_at` is set, both "asked, got a profile" and "asked,
+            # no profile" are full hits — we don't re-ask Discogs about the
+            # no-profile tail. Same shape of fix as the `get_release`
+            # artwork discriminator above. See WXYC#502 (and #497 for the
+            # rebuild-path fix that creates these stubs in the first place).
+            is_pg_hit=lambda v: v is not None and v.fetched_at is not None,
             breadcrumb_data={"artist_id": artist_id},
         )
 

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1,6 +1,7 @@
 """Unit tests for discogs/cache_service.py."""
 
 import asyncio
+from datetime import UTC
 from unittest.mock import AsyncMock
 
 import pytest
@@ -1076,12 +1077,15 @@ class TestGetArtistDetails:
 
     @pytest.mark.asyncio
     async def test_full_details(self, cache_service, mock_asyncpg_pool):
+        from datetime import datetime
+
         mock_asyncpg_pool.fetchrow = AsyncMock(
             return_value={
                 "id": 77,
                 "name": "Autechre",
                 "profile": "Electronic duo from Rochdale.",
                 "image_url": "https://i.discogs.com/autechre.jpg",
+                "fetched_at": datetime(2026, 1, 1, tzinfo=UTC),
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -1106,6 +1110,60 @@ class TestGetArtistDetails:
         assert result.members[0].name == "Rob Brown"
         assert result.urls == ["https://autechre.ws"]
         assert result.cached is True
+
+    @pytest.mark.asyncio
+    async def test_projects_fetched_at_for_stub_discrimination(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """SELECT must project `fetched_at` so callers can distinguish stub
+        rows (rebuild-created, never asked Discogs) from fully-fetched rows.
+
+        See WXYC/library-metadata-lookup#502.
+        """
+        from datetime import datetime
+
+        stamp = datetime(2026, 1, 1, tzinfo=UTC)
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 77,
+                "name": "Stereolab",
+                "profile": "Anglo-French band.",
+                "image_url": None,
+                "fetched_at": stamp,
+            }
+        )
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=make_fetch_router())
+
+        result = await cache_service.get_artist_details(77)
+        assert result is not None
+        assert result.fetched_at == stamp
+
+        sql = mock_asyncpg_pool.fetchrow.call_args.args[0]
+        assert "fetched_at" in sql, (
+            f"get_artist_details SELECT must project fetched_at; got: {sql!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stub_row_has_null_fetched_at(self, cache_service, mock_asyncpg_pool):
+        """A stub row created by the monthly rebuild has `fetched_at IS NULL`;
+        the cache surfaces that as `ArtistDetails.fetched_at is None` so the
+        service-layer predicate can treat it as a miss (#502).
+        """
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 6998498,
+                "name": "Yetsuby",
+                "profile": None,
+                "image_url": None,
+                "fetched_at": None,
+            }
+        )
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=make_fetch_router())
+
+        result = await cache_service.get_artist_details(6998498)
+        assert result is not None
+        assert result.fetched_at is None
+        assert result.profile is None
 
 
 class TestWriteArtistDetails:

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -2201,15 +2201,101 @@ class TestGetArtistDetails:
 
     @pytest.mark.asyncio
     async def test_cache_hit(self, service_with_cache):
+        from datetime import datetime
+
         from discogs.models import ArtistDetails
 
-        cached_details = ArtistDetails(artist_id=77, name="Autechre", cached=True)
+        # `fetched_at` non-NULL marks the row as fully fetched — the
+        # cache-hit discriminator added in #502. Without it the seam
+        # treats the row as a rebuild-stub and falls through to the API.
+        cached_details = ArtistDetails(
+            artist_id=77,
+            name="Autechre",
+            fetched_at=datetime(2026, 1, 1, tzinfo=UTC),
+            cached=True,
+        )
         service_with_cache.cache_service.get_artist_details = AsyncMock(return_value=cached_details)
 
         result = await service_with_cache.get_artist_details(77)
         assert result is not None
         assert result.artist_id == 77
         assert result.cached is True
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_when_fetched_but_no_profile(self, service_with_cache):
+        """Discogs answered, no profile text — still a hit, no re-fetch.
+
+        Guards against accidentally treating every Discogs-confirmed-empty
+        profile as a permanent miss, which would cost a round-trip per
+        flowsheet lookup against the no-profile tail. See #502.
+        """
+        from datetime import datetime
+
+        from discogs.models import ArtistDetails
+
+        cached_details = ArtistDetails(
+            artist_id=77,
+            name="Yetsuby",
+            profile=None,
+            fetched_at=datetime(2026, 1, 1, tzinfo=UTC),
+            cached=True,
+        )
+        service_with_cache.cache_service.get_artist_details = AsyncMock(return_value=cached_details)
+        service_with_cache.cache_service.write_artist_details = AsyncMock()
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+        ) as request_mock:
+            result = await service_with_cache.get_artist_details(77)
+
+        assert result is not None
+        assert result.cached is True
+        request_mock.assert_not_called()
+        service_with_cache.cache_service.write_artist_details.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stub_row_falls_through_to_api(self, service_with_cache):
+        """A stub row (fetched_at IS NULL, profile IS NULL — created by the
+        monthly rebuild's stub-from-release_artist path) is treated as a
+        cache miss. The seam fires `_api_fetch` + write-back so subsequent
+        calls return populated data. See #502 and #497.
+        """
+        from discogs.models import ArtistDetails
+
+        stub = ArtistDetails(
+            artist_id=6998498,
+            name="Yetsuby",
+            profile=None,
+            fetched_at=None,
+            cached=True,
+        )
+        service_with_cache.cache_service.get_artist_details = AsyncMock(return_value=stub)
+        service_with_cache.cache_service.write_artist_details = AsyncMock()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "id": 6998498,
+            "name": "Yetsuby",
+            "profile": "Live show.",
+            "images": [],
+        }
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ) as request_mock:
+            result = await service_with_cache.get_artist_details(6998498)
+
+        request_mock.assert_awaited_once()
+        service_with_cache.cache_service.write_artist_details.assert_called_once()
+        assert result is not None
+        assert result.profile == "Live show."
 
     @pytest.mark.asyncio
     async def test_writes_back_to_cache(self, service_with_cache):


### PR DESCRIPTION
## Summary

`DiscogsService.get_artist_details` wired `fallthrough` with the default `is_pg_hit` predicate (`v is not None`), which treated a rebuild-created stub artist row — `(id, name)` only, profile/aliases/members/urls all empty — as a full cache hit. Per #497, ~97.9% of artist rows in PG are stubs created by the monthly rebuild's stub-from-`release_artist` path, so every flowsheet lookup against a stub artist returned NULL data even when Discogs has rich data live. The iOS detail view shows no bio for these artists, indefinitely.

This PR projects `fetched_at` from the artist SELECT (stamped only by `write_artist_details` via SQL `now()`) and overrides `is_pg_hit` to `v is not None and v.fetched_at is not None`. `fetched_at IS NULL` precisely identifies "stub from rebuild, never asked Discogs"; non-NULL means "asked at least once" regardless of whether the API returned a profile.

Same shape of fix as the `get_release` artwork discriminator at `discogs/service.py:858-860` (originally driven by #414 + WXYC/discogs-etl#239).

## Why `fetched_at` and not `profile IS NULL`

Some artists genuinely have no Discogs profile. Using `profile IS NULL` would mark those as permanent misses and cost a Discogs round-trip on every flowsheet lookup against them. `fetched_at` says "we asked"; `profile` says "Discogs answered with text" — only the first is the right discriminator.

## Bulk path: intentionally left alone

`get_artist_details_bulk` is cache-only by design (no fallthrough seam) and is consumed by `artists/composer.py` for the artist-search-aliases endpoint. When a queried artist is a stub, the composer silently gets `variants=[]` (no aliases / name variations / members) — which is today's behavior. Landing this fix makes the asymmetry sharper: singular `get_artist_details` will start returning rich data for stubs while bulk continues to return empty.

Any future caller that needs full data for a stub should route through singular `get_artist_details`. If bulk needs the same semantics later, the right move is probably a "needs-refresh" return channel rather than fan-out write-backs — best filed as a follow-up if the asymmetry actually bites.

## Files

- `discogs/models.py` — add `fetched_at: datetime | None` to `ArtistDetails`.
- `discogs/cache_service.py` — extend the `get_artist_details` `SELECT` to project `fetched_at`.
- `discogs/service.py` — override `is_pg_hit` in `get_artist_details`.
- `tests/unit/test_cache_service.py` — assert `SELECT` projects `fetched_at`; stub row surfaces as `fetched_at is None`.
- `tests/unit/test_discogs_service.py` — assert stub rows fall through to `_api_fetch` + write-back; non-NULL `fetched_at` with NULL profile stays a hit (no re-fetch).

## Impact

- Discogs traffic increases as natural flowsheet lookups against stub rows now trigger `api_fetch`. With the rebuild path fixed in #497, steady-state is "stub refreshes on first natural hit; second hit onward is cached." Bounded by per-month-rebuild churn × the Discogs 60-req/min ceiling.
- Existing rows populated by `_api_fetch` already carry non-NULL `fetched_at` and remain cache hits. No regression on the currently-working 2.1% slice.
- Makes #501 (rotation-scoped backfill) nearly trivial — the script becomes "enumerate rotation artist ids, call `get_artist_details(id)`, let fallthrough do the rest." Should revise #501's mechanism section to match.

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy . --ignore-missing-imports` passes (290 source files)
- [x] Full unit suite: 2168 passed
- [x] New unit tests cover: stub row falls through to API; non-NULL `fetched_at` + NULL profile is still a hit (regression guard against re-fetching no-profile tail); SELECT projects `fetched_at`.
- [ ] Manually verify on staging: pick a stub artist (`fetched_at IS NULL`), call `/api/v1/artists/{id}/details` once, confirm row is hydrated, second call doesn't hit Discogs.

Closes #502