### PR TITLE
fix: album=None synth-gate + collapse find_track_url onto find_track_metadata (LML#487 follow-up)

### DIFF
--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -424,6 +424,17 @@ class AppleMusicClient(BaseStreamingClient):
         if best is None:
             return None
 
+        # When ``album`` was not supplied the 80/80(/80) floor collapses to
+        # 80/80 — any artist+song match clears regardless of album, and
+        # Apple typically returns the most popular album containing this
+        # song title. The match's URL is per-track so it stays, but the
+        # album-derived fields (``artwork_url``, ``release_year``) describe
+        # whatever album Apple ranked highest; surfacing them on the
+        # synthesized result would be a wrong-album leak. ~40% of
+        # request-o-matic traffic is artist+song-only.
+        if album is None:
+            return AppleMusicTrackMatch(url=_extract_url(best), artwork_url=None, release_year=None)
+
         return AppleMusicTrackMatch(
             url=_extract_url(best),
             artwork_url=_extract_artwork_url(best),

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -13,16 +13,18 @@ Public surface:
 
 - `find_album_match(artist, title)` — BaseStreamingClient contract; powers
   `/streaming-check` via `streaming/router.handle_streaming_check`.
-- `find_track_url(artist, song, album=None)` — used by the lookup hot path
-  in `lookup/orchestrator.enrich_artwork_results` when the WXYC library
+- `find_track_url(artist, song, album=None)` — thin wrapper around
+  `find_track_metadata` (LML#500). Used by the lookup hot path in
+  `lookup/orchestrator.enrich_artwork_results` when the WXYC library
   row clears the LML#477 title gate (just need the URL for the
-  ``apple_music_url`` slot). 3-way fuzz floor on
-  `attributes.{artistName,name,albumName}`.
+  ``apple_music_url`` slot). Inherits `find_track_metadata`'s 3-way
+  fuzz floor + artwork-preference tie-break so the two methods cannot
+  drift on a multi-record response.
 - `find_track_metadata(artist, song, album=None)` — used by the same hot
   path when the library row fails the gate (LML#487) or the catalog has
-  no Discogs match (LML#401). Same `search_song` endpoint + same fuzz
-  floor as `find_track_url`; returns `AppleMusicTrackMatch` with the
-  URL plus `attributes.artwork.url` (artwork) and
+  no Discogs match (LML#401). 3-way fuzz floor on
+  `attributes.{artistName,name,albumName}`; returns `AppleMusicTrackMatch`
+  with the URL plus `attributes.artwork.url` (artwork) and
   `attributes.releaseDate` (year) so the synthesized
   `DiscogsSearchResult` surfaces the correct album's cover art instead
   of leaking a sibling-album library row's Discogs image.
@@ -313,53 +315,26 @@ class AppleMusicClient(BaseStreamingClient):
         return [], last_status
 
     async def find_track_url(self, artist: str, song: str, album: str | None = None) -> str | None:
-        """Search for `(artist, song[, album])` and return the highest-scoring
-        Apple Music track URL clearing the 80/80(/80) fuzz floor, else `None`.
+        """Search for `(artist, song[, album])` and return the Apple Music track
+        URL of the best floor-clearing match, else `None`.
 
-        Uses `fuzz.token_set_ratio` (not the batch matcher's `token_sort_ratio`)
-        so extra tokens — "The", "feat. X", "(Remastered)" — don't sink an
-        otherwise-correct match. Iterates the full result list and picks the
-        best-scoring URL so an early sub-optimal match in Apple's ranking
-        order doesn't freeze the wrong link onto a flowsheet row.
+        Thin wrapper around ``find_track_metadata`` (LML#500): both methods
+        score against the same ``search_song`` response with the same
+        80/80(/80) ``token_set_ratio`` floor — keeping two scorers meant
+        their match selection could drift silently (the artwork-preference
+        tie-break iter-1 review added to ``find_track_metadata`` did not
+        propagate here, so a multi-record response could surface two
+        different URLs). Collapsing onto ``find_track_metadata`` puts the
+        two methods in lockstep by construction.
+
+        Returns only the ``url`` slot of the match — the happy path
+        (``library_row_acceptable=True`` in ``enrich_artwork_results``)
+        does not consume ``artwork_url`` or ``release_year`` (the
+        Discogs-derived library row supplies those), so dropping them
+        here keeps the existing call-site shape.
         """
-        results = await self.search_song(artist, song)
-        if not results:
-            return None
-
-        norm_artist = normalize_for_comparison(artist)
-        norm_song = normalize_for_comparison(song)
-        norm_album = normalize_for_comparison(album) if album else None
-
-        best_url: str | None = None
-        best_score = 0.0
-
-        for item in results:
-            attrs = item.get("attributes") or {}
-            url = attrs.get("url")
-            if not url:
-                continue
-            artist_score = fuzz.token_set_ratio(
-                norm_artist, normalize_for_comparison(attrs.get("artistName") or "")
-            )
-            track_score = fuzz.token_set_ratio(
-                norm_song, normalize_for_comparison(attrs.get("name") or "")
-            )
-            if artist_score < _APPLE_MUSIC_MATCH_FLOOR or track_score < _APPLE_MUSIC_MATCH_FLOOR:
-                continue
-            if norm_album is not None:
-                album_score = fuzz.token_set_ratio(
-                    norm_album, normalize_for_comparison(attrs.get("albumName") or "")
-                )
-                if album_score < _APPLE_MUSIC_MATCH_FLOOR:
-                    continue
-                combined = (artist_score + track_score + album_score) / 3
-            else:
-                combined = (artist_score + track_score) / 2
-            if combined > best_score:
-                best_score = combined
-                best_url = url
-
-        return best_url
+        match = await self.find_track_metadata(artist, song, album=album)
+        return match.url if match is not None else None
 
     async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
         """Search Apple Music for `(artist, title)` and return the best match.
@@ -386,17 +361,22 @@ class AppleMusicClient(BaseStreamingClient):
     ) -> AppleMusicTrackMatch | None:
         """Search for `(artist, song[, album])` and return URL + artwork + year.
 
-        Sibling of ``find_track_url`` that surfaces the richer
-        ``AppleMusicTrackMatch`` shape (LML#487 / BS#1184). Reuses the same
-        ``search_song`` endpoint + 80/80(/80) fuzz floor — one Apple
-        Music API call per invocation, no extra quota vs. ``find_track_url``.
+        Surfaces the richer ``AppleMusicTrackMatch`` shape (LML#487 /
+        BS#1184) — URL + artwork + year from the same ``search_song``
+        response. Single Apple Music API call per invocation; the
+        URL-only ``find_track_url`` wrapper delegates here so both
+        methods scoring/selecting from the same record set is enforced
+        by construction (LML#500).
 
-        Unlike ``find_track_url``, this method PREFERS floor-clearing matches
-        that carry ``attributes.artwork`` over higher-scoring matches that
-        lack it. Returning artwork_url=None on the synthesis path defeats
-        the whole point of LML#487 — for sparse Apple records (region-
-        restricted singles, promo entries) we'd rather surface a lower-
-        scoring-but-floor-clearing match's cover than nothing.
+        PREFERS floor-clearing matches that carry ``attributes.artwork``
+        over higher-scoring matches that lack it. Returning
+        artwork_url=None on the synthesis path defeats the whole point
+        of LML#487 — for sparse Apple records (region-restricted
+        singles, promo entries) we'd rather surface a lower-scoring-but-
+        floor-clearing match's cover than nothing. The same preference
+        carries over to ``find_track_url`` (post-collapse): the happy
+        path doesn't consume artwork, but the URL it returns now comes
+        from a likely-more-canonical record.
         """
         results = await self.search_song(artist, song)
         if not results:

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -677,6 +677,37 @@ class TestFindTrackMetadata:
         assert match.release_year == 2025
 
     @pytest.mark.asyncio
+    async def test_album_none_strips_album_derived_fields(self, es256_keypair):
+        """When ``album`` is None (artist+song-only lookup — request-o-matic's
+        canonical shape, ~40% of its traffic), the matching floor collapses
+        from 80/80/80 to 80/80 — any artist+song match clears regardless of
+        album, and Apple typically returns the most popular album containing
+        the song title. Surfacing that album's artwork on the synthesized
+        result is a wrong-album leak.
+
+        Strip ``artwork_url`` and ``release_year`` from the returned match
+        when ``album`` is None so the synthesized result drops back to the
+        LML#401 baseline (URL only, no album-derived fields). The URL itself
+        is per-track and stays.
+        """
+        client = _client(es256_keypair)
+        # The Apple Music response carries full artwork + releaseDate, but
+        # we can't trust either when no album was requested — they describe
+        # whatever album Apple's ranking surfaced for this song title.
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([_make_song_data_full()]))
+        client._http = mock_http
+
+        match = await client.find_track_metadata("Noura Mint Seymali", "Hebebeb (Zrag)", album=None)
+
+        assert match is not None
+        # URL still surfaces — it's per-track, not per-album.
+        assert match.url == "https://music.apple.com/us/song/hebebeb-zrag/9"
+        # Album-derived fields stripped when album is None.
+        assert match.artwork_url is None
+        assert match.release_year is None
+
+    @pytest.mark.asyncio
     async def test_prefers_match_with_artwork_over_higher_scoring_without(self, es256_keypair):
         """When the top fuzz-score match has no `artwork` block (region-
         restricted single, promo entry, sparse Music-Connect record), the

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -709,6 +709,58 @@ class TestFindTrackMetadata:
         assert "right" in match.artwork_url
 
     @pytest.mark.asyncio
+    async def test_url_agrees_with_find_track_metadata_under_artwork_preference(
+        self, es256_keypair
+    ):
+        """LML#500 (post-collapse): the multi-record artwork-preference
+        tie-break in ``find_track_metadata`` must propagate to
+        ``find_track_url`` so both methods surface the SAME URL for the
+        same response. Pre-collapse the two methods could drift —
+        ``find_track_url`` returned the top scorer while
+        ``find_track_metadata`` fell through to a lower-scoring
+        artwork-bearing runner-up. Collapsing ``find_track_url`` to a
+        ``find_track_metadata`` wrapper puts them in lockstep by
+        construction; this test pins that lockstep on the only fixture
+        shape (multi-record, one with artwork) where they ever diverged.
+
+        The companion single-record parity test
+        (``test_url_matches_find_track_url_on_acceptable_hit``) covers
+        the no-tie-break case."""
+        client_a = _client(es256_keypair)
+        client_b = _client(es256_keypair)
+
+        # Record A: top fuzz score (exact match on every axis), no artwork block.
+        top_no_artwork = _make_song_data_full(
+            url="https://music.apple.com/us/song/top-no-art/1",
+            artwork_url=None,
+        )
+        # Record B: lower-but-floor-clearing score, artwork block present.
+        runner_with_artwork = _make_song_data_full(
+            artist_name="Noura Mint Seymalii",  # 1-char drift, clears 80
+            url="https://music.apple.com/us/song/runner-with-art/2",
+            artwork_url="https://example.com/runner/{w}x{h}.jpg",
+        )
+        results = [top_no_artwork, runner_with_artwork]
+
+        mock_a = AsyncMock(spec=httpx.AsyncClient)
+        mock_a.get = AsyncMock(return_value=_songs_response(results))
+        client_a._http = mock_a
+
+        mock_b = AsyncMock(spec=httpx.AsyncClient)
+        mock_b.get = AsyncMock(return_value=_songs_response(results))
+        client_b._http = mock_b
+
+        url = await client_a.find_track_url("Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett")
+        match = await client_b.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+
+        # Both methods fall through to the artwork-bearing runner-up.
+        assert match is not None
+        assert url == match.url
+        assert url == "https://music.apple.com/us/song/runner-with-art/2"
+
+    @pytest.mark.asyncio
     async def test_url_matches_find_track_url_on_acceptable_hit(self, es256_keypair):
         """``find_track_metadata`` is a superset of ``find_track_url``: when
         both methods are called against the same response, the URL each


### PR DESCRIPTION
Follow-up to PR #500 (LML#487). Two corrective changes that the code-review loop on #500 surfaced after the merge.

## Why this PR

A post-merge investigation against prod (Railway HTTP logs over a 2.68 h window) measured the album=None call rate at /lookup at ~9.5% — about ~600 to ~1,400 calls/day fire the synthesis path with no album in the request. With the 3-way 80/80/80 floor collapsing to 80/80, the matched track can be from any album that Apple's catalog happens to rank highest for the (artist, song) pair. The synthesized DiscogsSearchResult then carries the wrong album's artwork_url and release_year, and Backend-Service write paths (apps/backend/services/metadata/metadata.service.ts, enrichment.service.ts, library.service.ts:enrichWithArtwork, library.controller.ts:addAlbum) currently persist the artwork_url unconditionally to flowsheet.artwork_url, album_metadata.artwork_url, and library.artwork_url with no synthesis-sentinel gate. Wrong artwork persists indefinitely until manual SQL.

This PR stops the upstream emission. A complementary Backend-Service PR will add the downstream gate at the highest-volume write site so already-shipped pollution stops compounding (BS#1355 covers the broader cleanup).

## Two changes

**1. Strip album-derived fields from the probe when album is None.** ``clients/streaming/apple_music.py:find_track_metadata`` now returns ``AppleMusicTrackMatch(url=..., artwork_url=None, release_year=None)`` when the caller omits album. The URL stays — it's per-track and the orchestrator wants it for the apple_music_url slot — but the album-derived fields fall back to the LML#401 baseline. Pinned by ``TestFindTrackMetadata.test_album_none_strips_album_derived_fields``.

**2. Collapse find_track_url onto find_track_metadata.** The iter-1 review of PR #500 added a prefer-artwork tie-break to find_track_metadata but not to find_track_url. For multi-record Apple responses where the top scorer lacks artwork and a runner-up has it, the two methods returned different URLs. find_track_url is now a thin wrapper over find_track_metadata, returning ``match.url if match else None``. Drift demonstrated and refuted by ``TestFindTrackMetadata.test_url_agrees_with_find_track_metadata_under_artwork_preference``.

## Test results

- Full suite: 2443 passed, 2 skipped, 127 deselected, 2 xfailed
- New tests: 2 (album=None gate, post-collapse parity)
- ruff format + ruff check: clean

## Related

- PR #500 / LML#487 — introduced the synthesis path this PR hardens
- LML#504, #505, #506, #507 — follow-up tickets from the PR #500 review
- BS#1355 — Backend-Service consumer-side gate proliferation (companion work)