### PR TITLE
test(discogs): pin fetched_at writer invariant and bulk-path stub semantics

### DIFF
--- a/tests/integration/test_cache_service_artist_writer.py
+++ b/tests/integration/test_cache_service_artist_writer.py
@@ -1,0 +1,186 @@
+"""Integration tests for ``DiscogsCacheService.write_artist_details``'s
+``fetched_at`` invariant against real PostgreSQL.
+
+The cache-hit discriminator in ``DiscogsService.get_artist_details``
+(discogs/service.py) keys on ``ArtistDetails.fetched_at`` -- any row written
+by LML has a non-NULL ``fetched_at``; rows with ``fetched_at IS NULL`` are
+rebuild-created stubs that need to be re-fetched. The unit-level pin in
+``tests/unit/test_cache_service.py::TestWriteArtistDetailsFetchedAtInvariant``
+catches the column being dropped from the SQL text, but a future writer
+that binds the value as a parameter (and lets a caller pass ``None``) or
+swaps ``now()`` for a functionally-identical-but-textually-different
+alternative would slip past a substring check.
+
+This module asserts the post-write database state instead:
+
+* INSERT path: a fresh id is written with a non-NULL ``fetched_at``.
+* ON CONFLICT UPDATE path: a pre-seeded row with ``fetched_at = '2000-01-01'``
+  has its timestamp advanced past the seed value after the write.
+
+Run with: ``pytest -m pg -v tests/integration/test_cache_service_artist_writer.py``
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from discogs.cache_service import DiscogsCacheService
+from discogs.models import ArtistDetails
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def pg_pool():
+    try:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+    yield pool
+    await pool.close()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def fresh_artist_schema(pg_pool):
+    """Bring up the artist parent + child tables LML writes through.
+
+    Mirrors the production discogs-cache shape: ``fetched_at`` is nullable
+    (rebuild stubs land here as NULL) and ``not_found`` defaults to FALSE
+    (LML#510 tombstone column). The writer is responsible for populating
+    ``fetched_at`` on every write -- this fixture deliberately does NOT
+    default it server-side so the test catches any writer that fails to
+    stamp it.
+    """
+    async with pg_pool.acquire() as conn:
+        for child in (
+            "artist_alias",
+            "artist_name_variation",
+            "artist_member",
+            "artist_url",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {child} CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist CASCADE")
+        await conn.execute(
+            """
+            CREATE TABLE artist (
+                id         integer PRIMARY KEY,
+                name       text NOT NULL,
+                profile    text,
+                image_url  text,
+                fetched_at timestamptz,
+                not_found  boolean NOT NULL DEFAULT FALSE
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE artist_alias (
+                artist_id  integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                alias_id   integer,
+                alias_name text NOT NULL
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE artist_name_variation (
+                artist_id integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                name      text NOT NULL
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE artist_member (
+                artist_id   integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                member_id   integer NOT NULL,
+                member_name text NOT NULL,
+                active      boolean DEFAULT true
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE artist_url (
+                artist_id integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                url       text NOT NULL
+            )
+            """
+        )
+    yield
+    async with pg_pool.acquire() as conn:
+        for t in (
+            "artist_alias",
+            "artist_name_variation",
+            "artist_member",
+            "artist_url",
+            "artist",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {t} CASCADE")
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_insert_path_stamps_fetched_at_non_null(pg_pool):
+    """A fresh artist write lands with ``fetched_at`` non-NULL.
+
+    Catches any writer that omits the column or binds it as a nullable
+    parameter -- the substring unit test would still see ``fetched_at``
+    in the SQL, but the row would have ``NULL`` in the column.
+    """
+    cache = DiscogsCacheService(pg_pool)
+    await cache.write_artist_details(ArtistDetails(artist_id=2154, name="Stereolab"))
+
+    async with pg_pool.acquire() as conn:
+        fetched_at = await conn.fetchval("SELECT fetched_at FROM artist WHERE id = 2154")
+
+    assert fetched_at is not None, (
+        "INSERT branch of write_artist_details must stamp fetched_at; the "
+        "cache-hit discriminator in DiscogsService.get_artist_details (#503) "
+        "treats fetched_at IS NULL as a rebuild stub and re-fetches every call."
+    )
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_on_conflict_path_advances_fetched_at(pg_pool):
+    """An UPDATE against a stale row advances ``fetched_at`` past the seed.
+
+    This is the assertion the substring unit test can't make. A writer that
+    binds ``fetched_at`` to a parameter and lets the caller pass an old
+    timestamp (or ``None``) would still emit ``fetched_at = $5`` in the SQL,
+    passing the substring check while leaving the column stuck at the seed.
+    Asserting strict-greater-than against a wall-clock-old seed catches that
+    class of regression.
+    """
+    seed = datetime(2000, 1, 1, tzinfo=UTC)
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO artist (id, name, fetched_at) VALUES (305253, 'Juana Molina', $1)",
+            seed,
+        )
+
+    cache = DiscogsCacheService(pg_pool)
+    await cache.write_artist_details(
+        ArtistDetails(artist_id=305253, name="Juana Molina", profile="Argentinian artist")
+    )
+
+    async with pg_pool.acquire() as conn:
+        fetched_at = await conn.fetchval("SELECT fetched_at FROM artist WHERE id = 305253")
+
+    assert fetched_at is not None, "ON CONFLICT branch must stamp fetched_at non-NULL on update"
+    assert fetched_at > seed, (
+        "ON CONFLICT branch must advance fetched_at past the previous value; "
+        f"got {fetched_at!r} <= seed {seed!r}. A writer that binds fetched_at "
+        "as a parameter and is passed a stale value (or None) would pass the "
+        "substring SQL check but leave the row stuck in the past."
+    )

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -171,17 +171,20 @@ async def set_up_schemas(pg_pool):
         # nothing" case). 305253 IS in artist so cache lookup hits; we just
         # leave the child tables empty for that row.
         #
-        # ``fetched_at`` is intentionally left NULL on both rows -- the
-        # ``TestGetArtistDetailsBulkFetchedAt`` class below relies on the
-        # stub-row shape and selectively advances ``fetched_at`` per-test.
-        # Writer-side stamping of ``fetched_at`` is pinned in
-        # ``tests/integration/test_cache_service_artist_writer.py``.
+        # ``fetched_at = now()`` matches the shape ``write_artist_details``
+        # produces in production (any row LML writes has it stamped). The
+        # stub-row edge case (``fetched_at IS NULL``, the monthly-rebuild
+        # leftover) is exercised by NULL-ing the column per-test in
+        # ``TestGetArtistDetailsBulkFetchedAt`` below -- the fixture defaults
+        # to the common case so a new endpoint test added here inherits the
+        # production shape, not the edge case. Writer-side stamping is
+        # pinned in ``tests/integration/test_cache_service_artist_writer.py``.
         await conn.execute(
             """
-            INSERT INTO artist (id, name, profile, image_url)
+            INSERT INTO artist (id, name, profile, image_url, fetched_at)
             VALUES
-                (2154, 'Stereolab', NULL, NULL),
-                (305253, 'Juana Molina', NULL, NULL)
+                (2154, 'Stereolab', NULL, NULL, now()),
+                (305253, 'Juana Molina', NULL, NULL, now())
             """
         )
         await conn.execute(
@@ -404,13 +407,18 @@ class TestGetArtistDetailsBulkFetchedAt:
 
     @pytest.mark.asyncio
     async def test_stub_row_returns_null_fetched_at(self, pg_pool):
-        """A row inserted without ``fetched_at`` (monthly rebuild stub) reads
-        back through ``get_artist_details_bulk`` with ``fetched_at = None``.
+        """A row with ``fetched_at IS NULL`` (monthly rebuild stub shape)
+        reads back through ``get_artist_details_bulk`` carrying the NULL.
         """
         from discogs.cache_service import DiscogsCacheService
 
-        # `set_up_schemas` already seeds 2154 (Stereolab) with NULL `fetched_at`
-        # — the INSERT specifies only id, name, profile, image_url.
+        # Fixture seeds 2154 with ``fetched_at = now()`` (production shape).
+        # Roll it back to the stub shape for this test only -- the stub is
+        # the edge case, so it owns its own setup rather than relying on a
+        # fixture default that would silently apply to unrelated tests.
+        async with pg_pool.acquire() as conn:
+            await conn.execute("UPDATE artist SET fetched_at = NULL WHERE id = 2154")
+
         cache = DiscogsCacheService(pg_pool)
         bundle = await cache.get_artist_details_bulk([2154])
 
@@ -419,12 +427,13 @@ class TestGetArtistDetailsBulkFetchedAt:
 
     @pytest.mark.asyncio
     async def test_hydrated_row_returns_non_null_fetched_at(self, pg_pool):
-        """A row with ``fetched_at = now()`` reads back through
-        ``get_artist_details_bulk`` carrying that stamp."""
-        from discogs.cache_service import DiscogsCacheService
+        """A row with ``fetched_at = now()`` (production write shape) reads
+        back through ``get_artist_details_bulk`` carrying that stamp.
 
-        async with pg_pool.acquire() as conn:
-            await conn.execute("UPDATE artist SET fetched_at = now() WHERE id = 305253")
+        Relies on the fixture default; the production-shape case is what
+        the fixture is for, so no per-test setup is needed.
+        """
+        from discogs.cache_service import DiscogsCacheService
 
         cache = DiscogsCacheService(pg_pool)
         bundle = await cache.get_artist_details_bulk([305253])
@@ -439,8 +448,9 @@ class TestGetArtistDetailsBulkFetchedAt:
         from discogs.cache_service import DiscogsCacheService
 
         async with pg_pool.acquire() as conn:
-            # 2154 stays a stub (NULL). 305253 becomes hydrated.
-            await conn.execute("UPDATE artist SET fetched_at = now() WHERE id = 305253")
+            # Fixture seeds both as hydrated (production shape). Roll 2154
+            # back to stub shape; 305253 stays hydrated.
+            await conn.execute("UPDATE artist SET fetched_at = NULL WHERE id = 2154")
 
         cache = DiscogsCacheService(pg_pool)
         bundle = await cache.get_artist_details_bulk([2154, 305253])

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -170,12 +170,19 @@ async def set_up_schemas(pg_pool):
         # ``artist`` table but has no children (the "ran the leg, found
         # nothing" case). 305253 IS in artist so cache lookup hits; we just
         # leave the child tables empty for that row.
+        #
+        # ``fetched_at = now()`` mirrors what ``write_artist_details`` would
+        # produce in production -- the cache-hit discriminator (#502) treats
+        # rows with ``fetched_at IS NULL`` as rebuild-created stubs. Leaving
+        # this column NULL here would test the stub case instead of the
+        # production-write case. Stub-vs-real bulk semantics are pinned in
+        # tests/unit/test_cache_service.py::TestGetArtistDetailsBulkStubSemantics.
         await conn.execute(
             """
-            INSERT INTO artist (id, name, profile, image_url)
+            INSERT INTO artist (id, name, profile, image_url, fetched_at)
             VALUES
-                (2154, 'Stereolab', NULL, NULL),
-                (305253, 'Juana Molina', NULL, NULL)
+                (2154, 'Stereolab', NULL, NULL, now()),
+                (305253, 'Juana Molina', NULL, NULL, now())
             """
         )
         await conn.execute(

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -171,18 +171,17 @@ async def set_up_schemas(pg_pool):
         # nothing" case). 305253 IS in artist so cache lookup hits; we just
         # leave the child tables empty for that row.
         #
-        # ``fetched_at = now()`` mirrors what ``write_artist_details`` would
-        # produce in production -- the cache-hit discriminator (#502) treats
-        # rows with ``fetched_at IS NULL`` as rebuild-created stubs. Leaving
-        # this column NULL here would test the stub case instead of the
-        # production-write case. Stub-vs-real bulk semantics are pinned in
-        # tests/unit/test_cache_service.py::TestGetArtistDetailsBulkStubSemantics.
+        # ``fetched_at`` is intentionally left NULL on both rows -- the
+        # ``TestGetArtistDetailsBulkFetchedAt`` class below relies on the
+        # stub-row shape and selectively advances ``fetched_at`` per-test.
+        # Writer-side stamping of ``fetched_at`` is pinned in
+        # ``tests/integration/test_cache_service_artist_writer.py``.
         await conn.execute(
             """
-            INSERT INTO artist (id, name, profile, image_url, fetched_at)
+            INSERT INTO artist (id, name, profile, image_url)
             VALUES
-                (2154, 'Stereolab', NULL, NULL, now()),
-                (305253, 'Juana Molina', NULL, NULL, now())
+                (2154, 'Stereolab', NULL, NULL),
+                (305253, 'Juana Molina', NULL, NULL)
             """
         )
         await conn.execute(

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1329,49 +1329,44 @@ class TestWriteArtistDetailsFetchedAtInvariant:
 
 
 class TestGetArtistDetailsBulkStubSemantics:
-    """Pin the bulk path's stub-vs-real semantics.
+    """Pin the bulk path's stub-vs-real semantics post-#520.
 
-    `get_artist_details_bulk` (used by the artist-search-alias composer) does
-    NOT project `fetched_at` from the artist table -- the SELECT at
-    cache_service.py:1076 reads `id, name, profile, image_url` only. The pydantic
-    default on `ArtistDetails.fetched_at` is None, so EVERY row the bulk path
-    returns -- stub or fully-fetched -- arrives at the caller with
-    `fetched_at is None`.
+    `get_artist_details_bulk` projects `fetched_at` from the artist table
+    (cache_service.py:1154) and threads the value onto each returned
+    `ArtistDetails`. The bulk path stays a faithful cache read -- both stub
+    and hydrated rows appear in the result dict -- but the caller can now
+    tell them apart using the same `fetched_at is None` discriminator the
+    singular `get_artist_details` path exposes (#503).
 
-    The decision locked in here: **the bulk path surfaces stubs as cache hits.**
-    Stubs and real rows are indistinguishable through this entrypoint, and
-    that's deliberate -- the only consumer (`search_artists_by_name` alias
-    expansion) doesn't need the discriminator. The per-id `get_artist_details`
-    is the only path that distinguishes the two, via the projected
-    `fetched_at` and the service-layer `is_pg_hit` predicate at
-    discogs/service.py:939.
+    Locked semantics:
 
-    If we ever want the bulk path to treat stubs as misses, the SELECT must
-    add `fetched_at` and the assembly loop must skip rows where it's NULL --
-    this test would then need updating, signalling the semantic shift.
+    * Stub row (DB: ``fetched_at IS NULL``) -> result entry with
+      ``fetched_at is None``. Caller treats as a stub-shaped cache hit; the
+      "is this hydrated?" judgement remains a service-layer policy.
+    * Hydrated row (DB: ``fetched_at IS NOT NULL``) -> result entry with the
+      row's actual timestamp.
+    * Both ids are present in the returned dict. Stubs are never filtered
+      out at the cache layer; that decision belongs to callers (composer
+      currently ignores the discriminator; future callers don't have to).
 
-    See WXYC/library-metadata-lookup#502 (discriminator), #511 (this pin).
+    See WXYC/library-metadata-lookup#503 (discriminator), #520 (bulk SELECT
+    projects fetched_at), #511 (this pin).
     """
 
     @pytest.mark.asyncio
-    async def test_stub_row_surfaces_as_cached_with_null_fetched_at(
-        self, cache_service, mock_asyncpg_pool
-    ):
-        """A row written by the rebuild stub path comes back as if cached.
-
-        Rebuild-created stub rows have `fetched_at IS NULL` in the DB. The
-        bulk SELECT doesn't project that column, so the assembled
-        `ArtistDetails` falls back to the model default (None) and the
-        artist_id appears in the result dict -- caller has no way to tell
-        the row is a stub.
-        """
+    async def test_stub_row_surfaces_with_null_fetched_at(self, cache_service, mock_asyncpg_pool):
+        """A stub row written by the rebuild path comes back with ``fetched_at=None``."""
         mock_asyncpg_pool.fetch = AsyncMock(
             side_effect=make_fetch_router(
                 **{
-                    # Stub row from the rebuild path -- no `fetched_at` in
-                    # the SELECT result because the query doesn't project it.
                     "FROM artist ": [
-                        {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
+                        {
+                            "id": 2154,
+                            "name": "Stereolab",
+                            "profile": None,
+                            "image_url": None,
+                            "fetched_at": None,
+                        },
                     ],
                     "artist_alias": [],
                     "artist_name_variation": [],
@@ -1382,35 +1377,46 @@ class TestGetArtistDetailsBulkStubSemantics:
 
         result = await cache_service.get_artist_details_bulk([2154])
 
-        assert 2154 in result, "stub row must be surfaced (not treated as a miss)"
+        assert 2154 in result, "stub row must be surfaced (not filtered as a miss)"
         assert result[2154].fetched_at is None, (
-            "bulk SELECT does not project fetched_at; model defaults to None"
+            "bulk SELECT projects fetched_at; stub rows carry NULL through"
         )
         assert result[2154].cached is True, "bulk path tags every row cached=True"
 
     @pytest.mark.asyncio
-    async def test_stub_and_real_indistinguishable_by_caller(
+    async def test_stub_and_hydrated_distinguishable_by_fetched_at(
         self, cache_service, mock_asyncpg_pool
     ):
-        """Stub rows and fully-fetched rows look identical to bulk callers.
+        """Bulk callers CAN tell stubs from hydrated rows via ``fetched_at``.
 
-        Locks in the foot-gun: don't try to use `fetched_at` from a bulk
-        result as a discriminator -- it's always None regardless of the
-        underlying row's state. Discriminating between stubs and real rows
-        requires the per-id `get_artist_details` path.
+        Post-#520, the bulk SELECT carries the column through, so the same
+        ``fetched_at is None`` predicate that the singular ``is_pg_hit`` uses
+        (discogs/service.py:1014) works on bulk results too. Both rows are
+        still present in the returned dict -- filtering remains a
+        service-layer decision.
         """
+        from datetime import datetime
+
+        hydrated_ts = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
         mock_asyncpg_pool.fetch = AsyncMock(
             side_effect=make_fetch_router(
                 **{
                     "FROM artist ": [
                         # Stub (DB: fetched_at IS NULL).
-                        {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
+                        {
+                            "id": 2154,
+                            "name": "Stereolab",
+                            "profile": None,
+                            "image_url": None,
+                            "fetched_at": None,
+                        },
                         # Fully-fetched (DB: fetched_at IS NOT NULL).
                         {
                             "id": 305253,
                             "name": "Juana Molina",
                             "profile": "Argentinian artist...",
                             "image_url": "https://example.com/jm.jpg",
+                            "fetched_at": hydrated_ts,
                         },
                     ],
                     "artist_alias": [],
@@ -1422,19 +1428,24 @@ class TestGetArtistDetailsBulkStubSemantics:
 
         result = await cache_service.get_artist_details_bulk([2154, 305253])
 
-        # Both surface; both report fetched_at=None; both report cached=True.
-        # Caller has no signal to tell them apart from the bulk path.
-        assert result[2154].fetched_at == result[305253].fetched_at is None
-        assert result[2154].cached == result[305253].cached is True
+        # Both surface (no cache-layer filtering)...
+        assert set(result.keys()) == {2154, 305253}
+        # ...but the caller can distinguish them by fetched_at.
+        assert result[2154].fetched_at is None
+        assert result[305253].fetched_at == hydrated_ts
+        assert result[2154].cached is True
+        assert result[305253].cached is True
 
     @pytest.mark.asyncio
-    async def test_bulk_select_does_not_project_fetched_at(self, cache_service, mock_asyncpg_pool):
-        """SQL contract: the bulk artist SELECT omits `fetched_at`.
+    async def test_bulk_select_projects_fetched_at(self, cache_service, mock_asyncpg_pool):
+        """SQL contract: the bulk artist SELECT projects ``fetched_at``.
 
-        This is the structural cause of the semantics pinned above. If a
-        future change adds `fetched_at` to the projection, that's a signal
-        the bulk path is about to start distinguishing stubs from real --
-        update the semantics tests above to reflect the new behavior.
+        The bulk path's stub-vs-real discriminator (pinned above) depends on
+        this column being present in the projection. If a future change drops
+        it, every bulk row would silently look like a stub -- exactly the
+        asymmetry #520 fixed. Catching the regression at the SQL layer is
+        cheap; the seed-and-advance assertion against real PG lives in
+        ``tests/integration/test_cache_service_artist_writer.py``.
         """
         mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
         await cache_service.get_artist_details_bulk([2154])
@@ -1444,10 +1455,10 @@ class TestGetArtistDetailsBulkStubSemantics:
             for call in mock_asyncpg_pool.fetch.await_args_list
             if "FROM artist " in call.args[0]
         )
-        assert "fetched_at" not in artist_table_sql, (
-            "Bulk artist SELECT must not project fetched_at -- the bulk path's "
-            "stub-vs-real semantics depend on this. If you intentionally added "
-            "the column, update TestGetArtistDetailsBulkStubSemantics."
+        assert "fetched_at" in artist_table_sql, (
+            "Bulk artist SELECT must project fetched_at so callers can carry "
+            "the stub-vs-hydrated discriminator (#503, #520). Dropping it "
+            "silently regresses every bulk row to looking like a stub."
         )
 
 

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1226,6 +1226,231 @@ class TestWriteArtistDetails:
         conn._mock_tx_ctx.__aexit__.assert_awaited()
 
 
+class TestWriteArtistDetailsFetchedAtInvariant:
+    """Pin the cache-hit discriminator invariant for the artist row writer.
+
+    `DiscogsService.get_artist_details` distinguishes a stub row (created by
+    the out-of-repo monthly rebuild's stub-from-`release_artist` path) from a
+    fully-fetched row using `ArtistDetails.fetched_at is not None`. The
+    invariant the discriminator depends on: any row written by LML has
+    `fetched_at` set; only rebuild-created stubs have `fetched_at IS NULL`.
+
+    `write_artist_details` is the only in-repo writer; both its INSERT and
+    its ON CONFLICT UPDATE branches must stamp `fetched_at`. If a future
+    overload or sibling writer omits it, the discriminator silently regresses
+    into cache thrash (real rows treated as stubs and re-fetched on every
+    call) -- a bug that wouldn't show up in functional tests. These SQL
+    introspections fail the moment the column drops out of either branch.
+
+    See WXYC/library-metadata-lookup#502 (discriminator) and #511 (this pin).
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "clause_marker",
+        [
+            # INSERT branch -- fresh row written by LML.
+            "INSERT INTO artist",
+            # ON CONFLICT branch -- row was already present (typically a
+            # rebuild-created stub) and LML is hydrating it.
+            "ON CONFLICT",
+        ],
+    )
+    async def test_artist_upsert_sets_fetched_at(
+        self, cache_service, mock_asyncpg_pool, clause_marker
+    ):
+        """The single UPSERT statement must stamp `fetched_at` on BOTH branches.
+
+        We rely on this statement being a single INSERT ... ON CONFLICT (id) DO
+        UPDATE -- parameterising the marker keeps each branch's failure mode
+        distinct: drop the INSERT column and the first parametrisation fails;
+        drop the UPDATE-clause assignment and the second fails. Either way,
+        the discriminator is broken and this test catches it.
+        """
+        details = ArtistDetails(artist_id=77, name="Autechre")
+
+        await cache_service.write_artist_details(details)
+
+        conn = mock_asyncpg_pool._mock_conn
+        all_sql = [call.args[0] for call in conn.execute.call_args_list]
+        artist_upsert = next(
+            (sql for sql in all_sql if "INSERT INTO artist" in sql and "ON CONFLICT" in sql),
+            None,
+        )
+        assert artist_upsert is not None, (
+            "Expected a single INSERT INTO artist ... ON CONFLICT statement; "
+            f"got execute calls: {all_sql!r}"
+        )
+
+        # Locate the slice of SQL that corresponds to the branch under test.
+        branch_start = artist_upsert.index(clause_marker)
+        if clause_marker == "INSERT INTO artist":
+            branch_sql = artist_upsert[branch_start : artist_upsert.index("ON CONFLICT")]
+        else:
+            branch_sql = artist_upsert[branch_start:]
+
+        assert "fetched_at" in branch_sql, (
+            f"write_artist_details must stamp fetched_at on the {clause_marker} "
+            f"branch of the artist UPSERT -- the cache-hit discriminator in "
+            f"DiscogsService.get_artist_details depends on it (#502). "
+            f"Branch SQL: {branch_sql!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_artist_upsert_stamps_fetched_at_with_now(self, cache_service, mock_asyncpg_pool):
+        """`fetched_at` must be stamped server-side (`now()`), not bound as a parameter.
+
+        If a future refactor binds `fetched_at` as a positional arg, a caller
+        could pass None and silently revive the stub-row foot-gun the
+        discriminator was meant to close. Forcing the value to live in SQL
+        keeps it impossible to write a row with `fetched_at IS NULL` from
+        this method.
+        """
+        details = ArtistDetails(artist_id=77, name="Autechre")
+
+        await cache_service.write_artist_details(details)
+
+        conn = mock_asyncpg_pool._mock_conn
+        all_sql = [call.args[0] for call in conn.execute.call_args_list]
+        artist_upsert = next(
+            sql for sql in all_sql if "INSERT INTO artist" in sql and "ON CONFLICT" in sql
+        )
+
+        # `fetched_at = now()` (UPDATE branch) and `... now())` (INSERT branch
+        # value list) -- both compact forms are acceptable. The point is that
+        # `now()` appears at least twice in the statement: once per branch.
+        # Whitespace-tolerant: collapse runs of whitespace before counting.
+        compact = " ".join(artist_upsert.split())
+        assert compact.count("now()") >= 2, (
+            "fetched_at must be stamped with now() on both INSERT and ON "
+            "CONFLICT UPDATE branches -- expected at least two now() calls "
+            f"in the artist UPSERT, got: {artist_upsert!r}"
+        )
+
+
+class TestGetArtistDetailsBulkStubSemantics:
+    """Pin the bulk path's stub-vs-real semantics.
+
+    `get_artist_details_bulk` (used by the artist-search-alias composer) does
+    NOT project `fetched_at` from the artist table -- the SELECT at
+    cache_service.py:1076 reads `id, name, profile, image_url` only. The pydantic
+    default on `ArtistDetails.fetched_at` is None, so EVERY row the bulk path
+    returns -- stub or fully-fetched -- arrives at the caller with
+    `fetched_at is None`.
+
+    The decision locked in here: **the bulk path surfaces stubs as cache hits.**
+    Stubs and real rows are indistinguishable through this entrypoint, and
+    that's deliberate -- the only consumer (`search_artists_by_name` alias
+    expansion) doesn't need the discriminator. The per-id `get_artist_details`
+    is the only path that distinguishes the two, via the projected
+    `fetched_at` and the service-layer `is_pg_hit` predicate at
+    discogs/service.py:939.
+
+    If we ever want the bulk path to treat stubs as misses, the SELECT must
+    add `fetched_at` and the assembly loop must skip rows where it's NULL --
+    this test would then need updating, signalling the semantic shift.
+
+    See WXYC/library-metadata-lookup#502 (discriminator), #511 (this pin).
+    """
+
+    @pytest.mark.asyncio
+    async def test_stub_row_surfaces_as_cached_with_null_fetched_at(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """A row written by the rebuild stub path comes back as if cached.
+
+        Rebuild-created stub rows have `fetched_at IS NULL` in the DB. The
+        bulk SELECT doesn't project that column, so the assembled
+        `ArtistDetails` falls back to the model default (None) and the
+        artist_id appears in the result dict -- caller has no way to tell
+        the row is a stub.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                **{
+                    # Stub row from the rebuild path -- no `fetched_at` in
+                    # the SELECT result because the query doesn't project it.
+                    "FROM artist ": [
+                        {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
+                    ],
+                    "artist_alias": [],
+                    "artist_name_variation": [],
+                    "artist_member": [],
+                }
+            )
+        )
+
+        result = await cache_service.get_artist_details_bulk([2154])
+
+        assert 2154 in result, "stub row must be surfaced (not treated as a miss)"
+        assert result[2154].fetched_at is None, (
+            "bulk SELECT does not project fetched_at; model defaults to None"
+        )
+        assert result[2154].cached is True, "bulk path tags every row cached=True"
+
+    @pytest.mark.asyncio
+    async def test_stub_and_real_indistinguishable_by_caller(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Stub rows and fully-fetched rows look identical to bulk callers.
+
+        Locks in the foot-gun: don't try to use `fetched_at` from a bulk
+        result as a discriminator -- it's always None regardless of the
+        underlying row's state. Discriminating between stubs and real rows
+        requires the per-id `get_artist_details` path.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                **{
+                    "FROM artist ": [
+                        # Stub (DB: fetched_at IS NULL).
+                        {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
+                        # Fully-fetched (DB: fetched_at IS NOT NULL).
+                        {
+                            "id": 305253,
+                            "name": "Juana Molina",
+                            "profile": "Argentinian artist...",
+                            "image_url": "https://example.com/jm.jpg",
+                        },
+                    ],
+                    "artist_alias": [],
+                    "artist_name_variation": [],
+                    "artist_member": [],
+                }
+            )
+        )
+
+        result = await cache_service.get_artist_details_bulk([2154, 305253])
+
+        # Both surface; both report fetched_at=None; both report cached=True.
+        # Caller has no signal to tell them apart from the bulk path.
+        assert result[2154].fetched_at == result[305253].fetched_at is None
+        assert result[2154].cached == result[305253].cached is True
+
+    @pytest.mark.asyncio
+    async def test_bulk_select_does_not_project_fetched_at(self, cache_service, mock_asyncpg_pool):
+        """SQL contract: the bulk artist SELECT omits `fetched_at`.
+
+        This is the structural cause of the semantics pinned above. If a
+        future change adds `fetched_at` to the projection, that's a signal
+        the bulk path is about to start distinguishing stubs from real --
+        update the semantics tests above to reflect the new behavior.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.get_artist_details_bulk([2154])
+
+        artist_table_sql = next(
+            call.args[0]
+            for call in mock_asyncpg_pool.fetch.await_args_list
+            if "FROM artist " in call.args[0]
+        )
+        assert "fetched_at" not in artist_table_sql, (
+            "Bulk artist SELECT must not project fetched_at -- the bulk path's "
+            "stub-vs-real semantics depend on this. If you intentionally added "
+            "the column, update TestGetArtistDetailsBulkStubSemantics."
+        )
+
+
 class TestSearchArtistsByName:
     @pytest.mark.asyncio
     async def test_returns_canonical_artist(self, cache_service, mock_asyncpg_pool):


### PR DESCRIPTION
## Summary

Tests-only follow-up to #503 (the singular path's `fetched_at` cache-hit discriminator) and #520 (the bulk SELECT now projects `fetched_at`, fixed in #524). Pins the invariants both depend on so future refactors cannot silently regress them.

### Writer invariant (unit + integration)

Two layers cover this — substring on SQL text plus a real PG round-trip — because each catches a regression class the other misses.

- **Unit** (`tests/unit/test_cache_service.py::TestWriteArtistDetailsFetchedAtInvariant`): parametrised over the INSERT and ON CONFLICT branches of `write_artist_details`'s UPSERT. Asserts each branch carries `fetched_at` and stamps it server-side via `now()`. Drop the column from either branch → two parametrisations fail; replace `now()` → `test_artist_upsert_stamps_fetched_at_with_now` fails. Verified locally by mutation.
- **Integration** (`tests/integration/test_cache_service_artist_writer.py`, new file, `@pytest.mark.pg`): two cases against real PG, per #511's acceptance criteria.
  - INSERT path → write a fresh id → assert `fetched_at IS NOT NULL`.
  - ON CONFLICT path → seed with `fetched_at = '2000-01-01'` → write → assert `fetched_at > seed`. Catches a writer that binds `fetched_at` as a parameter and is handed a stale value — the substring grep would pass but the row would stay stuck in the past.

### Bulk-path stub semantics

Pins the contract `get_artist_details_bulk` exposes post-#524: the bulk SELECT (`cache_service.py:1154`) projects `fetched_at`, and callers can use the same `fetched_at is None` discriminator the singular path uses (`is_pg_hit` at `discogs/service.py:1014`).

Unit-level pins in `tests/unit/test_cache_service.py::TestGetArtistDetailsBulkStubSemantics`:

- `test_stub_row_surfaces_with_null_fetched_at` — a row with `fetched_at IS NULL` comes back with `fetched_at=None` (not filtered; bulk stays a faithful cache read).
- `test_stub_and_hydrated_distinguishable_by_fetched_at` — in a mixed batch, both rows surface but the caller can tell them apart.
- `test_bulk_select_projects_fetched_at` — substring check on the projection so a future change that drops the column is forced to update the semantics suite.

End-to-end coverage against real PG already lives in `TestGetArtistDetailsBulkFetchedAt` (added in #524); no duplication here.

### Fixture cleanup

`tests/integration/test_search_aliases_bulk.py` now seeds both Stereolab and Juana Molina with `fetched_at = now()`, matching the production write shape (#511 acceptance criterion #4). The stub-row edge case is exercised by `TestGetArtistDetailsBulkFetchedAt::test_stub_row_returns_null_fetched_at` and `test_mixed_batch_preserves_per_row_fetched_at`, which now NULL the column per-test. The fixture defaults to the common case so a new endpoint test added here inherits production shape, not the rebuild-stub edge case it would have silently picked up before.

## Test plan

- [x] New unit tests pass: `uv run pytest tests/unit/test_cache_service.py::TestWriteArtistDetailsFetchedAtInvariant tests/unit/test_cache_service.py::TestGetArtistDetailsBulkStubSemantics -v` (6 passed)
- [x] Affected PG integration suite passes: `uv run pytest -m pg tests/integration/test_search_aliases_bulk.py tests/integration/test_cache_service_artist_writer.py -v` (12 passed — endpoint suite + bulk-path fetched_at suite + writer-invariant integration)
- [x] Mutation verified: removing `fetched_at` from both UPSERT branches in `discogs/cache_service.py` fails the two substring parametrisations; replacing `now()` fails `test_artist_upsert_stamps_fetched_at_with_now`.
- [x] Full unit suite green: `uv run pytest tests/unit/`
- [x] Ruff lint + format clean on the full repo
- [ ] CI green on this branch

## Refs

- Closes #511
- Builds on #503 (singular-path discriminator) and #524 (bulk SELECT now projects `fetched_at`, addresses issue #520)
- Downstream: WXYC/Backend-Service#1361 relies on the discriminator behaviour pinned here