### PR TITLE
fix(orchestrator): guard release_id=0 sentinel before Discogs API call

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1700,7 +1700,16 @@ async def find_library_albums_with_cached_track(
 
 
 async def _resolve_fallback_artwork(discogs_service: DiscogsService, release_id: int) -> str | None:
-    """Try the release's own cover (images[0]), then artist image, then label image."""
+    """Try the release's own cover (images[0]), then artist image, then label image.
+
+    Structurally invalid ids (``release_id <= 0``) short-circuit before the
+    Discogs round-trip — the LML#401 synthesis pattern produces a
+    ``release_id=0`` sentinel that any future caller could leak in here (see
+    issue #518). Discogs release ids start at 1, so the strict gate is also a
+    correctness check against malformed upstream payloads.
+    """
+    if release_id <= 0:
+        return None
     release = await discogs_service.get_release(release_id)
     if not release:
         return None
@@ -1932,7 +1941,12 @@ async def enrich_artwork_results(
         fields without re-fetching.
         """
         top_artwork = items_with_artwork[0][1]
-        if top_artwork is None:
+        # `release_id <= 0` short-circuits the LML#401 streaming-only
+        # synthesis sentinel (see issue #518): the synthesized result
+        # carries `release_id=0` as a BS#1185 cross-service contract,
+        # and round-tripping it through Discogs hits `/releases/0` (404)
+        # before the `if not release` branch silently swallows the response.
+        if top_artwork is None or top_artwork.release_id <= 0:
             return None, None, None, None, None
         try:
             release = await discogs_service.get_release(top_artwork.release_id)

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -320,20 +320,20 @@ class TestTop1SentinelGuard:
         Also pins the invocation count at 1 so a regression that double-fetches
         the release (e.g. fallback-artwork resolution leaking into the top-1
         enrichment path) doesn't slip through."""
-        item = make_library_item(artist="Kate Bush", title="The Kick Inside")
-        artwork = make_discogs_result(release_id=12345, artist="Kate Bush", album="The Kick Inside")
+        item = make_library_item(artist="Cat Power", title="Moon Pix")
+        artwork = make_discogs_result(release_id=12345, artist="Cat Power", album="Moon Pix")
 
         discogs_service = AsyncMock()
         discogs_service.get_release.return_value = ReleaseMetadataResponse(
             release_id=12345,
-            title="The Kick Inside",
-            artist="Kate Bush",
-            year=1978,
+            title="Moon Pix",
+            artist="Cat Power",
+            year=1998,
             artist_id=None,  # short-circuits before get_artist_details
             release_url="https://discogs.com/release/12345",
         )
 
-        await enrich_artwork_results([(item, artwork)], discogs_service, song="Wuthering Heights")
+        await enrich_artwork_results([(item, artwork)], discogs_service, song="Cross Bones Style")
 
         discogs_service.get_release.assert_called_once_with(12345)
 

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -292,6 +292,52 @@ class TestEnrichArtworkResults:
         assert called_ids == {1}
 
 
+class TestTop1SentinelGuard:
+    """`fetch_top1_release_details` must short-circuit when the top-1 artwork
+    carries the LML#401 `release_id=0` sentinel — otherwise it round-trips
+    `discogs_service.get_release(0)` which hits the Discogs API at
+    `/releases/0` (404) before the `if not release` branch swallows the
+    response. The sentinel is a documented cross-service contract; the
+    orchestrator owns the per-call-site gating (see issue #518)."""
+
+    @pytest.mark.asyncio
+    async def test_top1_artwork_with_release_id_zero_skips_get_release(self):
+        item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
+        # The synthesized sentinel as it would arrive from LML#401's
+        # streaming-only no-Discogs-match path.
+        sentinel = DiscogsSearchResult(release_id=0, release_url="")
+
+        discogs_service = AsyncMock()
+
+        await enrich_artwork_results([(item, sentinel)], discogs_service, song="French Disko")
+
+        discogs_service.get_release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_top1_artwork_with_real_release_id_calls_get_release_once(self):
+        """Paired positive case: the guard must not fire on a real id.
+
+        Also pins the invocation count at 1 so a regression that double-fetches
+        the release (e.g. fallback-artwork resolution leaking into the top-1
+        enrichment path) doesn't slip through."""
+        item = make_library_item(artist="Kate Bush", title="The Kick Inside")
+        artwork = make_discogs_result(release_id=12345, artist="Kate Bush", album="The Kick Inside")
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=12345,
+            title="The Kick Inside",
+            artist="Kate Bush",
+            year=1978,
+            artist_id=None,  # short-circuits before get_artist_details
+            release_url="https://discogs.com/release/12345",
+        )
+
+        await enrich_artwork_results([(item, artwork)], discogs_service, song="Wuthering Heights")
+
+        discogs_service.get_release.assert_called_once_with(12345)
+
+
 class TestEnrichArtworkResultsExtended:
     """Coverage for the ``extended=True`` path: populates the additional
     DiscogsMatchResult fields LML already loads but normally discards.

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -27,6 +27,7 @@ from generated.api_models import (
 )
 from lookup.orchestrator import (
     _log_track_validation,
+    _resolve_fallback_artwork,
     artist_matches_item,
     build_context_message,
     fetch_artwork_for_items,
@@ -1627,6 +1628,34 @@ class TestFetchArtworkFallback:
         assert results[0][1].artwork_url == "https://i.discogs.com/release-cover.jpg"
         mock_discogs_service.get_artist_image.assert_not_called()
         mock_discogs_service.get_label_image.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _resolve_fallback_artwork sentinel guard (LML#518)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFallbackArtworkSentinelGuard:
+    """`_resolve_fallback_artwork` must reject structurally invalid release_ids
+    (the synthesized `release_id=0` sentinel from LML#401, and any negative id
+    that could arrive from a malformed upstream payload) before issuing the
+    Discogs API call. The downstream `if not release: return None` after
+    `get_release` would swallow the 404 silently — the symptom is only wasted
+    API budget and Sentry noise on `/releases/0`."""
+
+    @pytest.mark.asyncio
+    async def test_release_id_zero_returns_none_without_api_call(self, mock_discogs_service):
+        result = await _resolve_fallback_artwork(mock_discogs_service, 0)
+
+        assert result is None
+        mock_discogs_service.get_release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_negative_release_id_returns_none_without_api_call(self, mock_discogs_service):
+        result = await _resolve_fallback_artwork(mock_discogs_service, -1)
+
+        assert result is None
+        mock_discogs_service.get_release.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_resolve_fallback_artwork` and `fetch_top1_release_details` now short-circuit before `discogs_service.get_release(0)` so the LML#401 `release_id=0` synthesis sentinel can't reach the Discogs API. Closes #518.
- Both call sites previously round-tripped the sentinel to `/releases/0` (404) and the `if not release: return None` post-call branch silently swallowed the response — symptom was wasted API budget and Sentry noise on `release/0` (~15 hits per 18h).
- `_resolve_fallback_artwork` uses `release_id <= 0`, which also rejects negative ids that the existing truthy-check pattern at `:745`/`:1205`/`:1466` would pass through.

## Test plan

- [x] Red: new tests in `tests/unit/test_orchestrator_helpers.py::TestResolveFallbackArtworkSentinelGuard` and `tests/unit/test_enrichment.py::TestTop1SentinelGuard` fail against `main`.
- [x] Green: same tests pass after the guards land. Paired positive case (`release_id=12345`) asserts `get_release` is called exactly once — pins the count so a future regression that double-fetches the release can't slip through.
- [x] Full unit suite: `pytest tests/unit/` — 2228 passed.
- [x] `ruff check` + `ruff format --check` clean on the diff.
- [x] `mypy lookup/orchestrator.py` clean.

## Sequencing vs. #510

Land this first so the underlying caller bug is fixed at the right layer. #510 (PG-side `release/0` tombstoning) would otherwise mask the Sentry signal and leave the orchestrator's own bug only discoverable by code-reading.

## Not the fix

- Did not tighten the public `DiscogsService.get_release` boundary — `/discogs/release/0` is also reachable from external callers, and the router's 404 is the correct surface there. Tightening the boundary would mask other LML-internal callers' bugs instead of routing fix-effort to the right layer.
- Did not change the `(release_id=0, release_url="")` synthesis sentinel — it's a documented cross-service contract with BS#1184/#1185 (see `orchestrator.py` docstring at the synthesis site).

## Related

- WXYC/Backend-Service#1184 / #1185 — introduced the `release_id=0` synthesis sentinel and the BS-side contract.
- #510 — server-side `release/0` tombstoning that would otherwise mask this signal.
- #401 — original PR introducing the `(release_id=0, release_url="")` pattern.