### PR TITLE
chore(deps): consolidate _strip_nul onto wxyc_etl.pg.to_pg_text_form (0.8.0)

### DIFF
--- a/entity/store.py
+++ b/entity/store.py
@@ -10,27 +10,11 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from wxyc_etl.pg import to_pg_text_form
+
 from entity.sources import PgSource
 
 logger = logging.getLogger(__name__)
-
-
-def _strip_nul(value: str | None) -> str | None:
-    """Strip U+0000 from a string before any PostgreSQL TEXT op.
-
-    PostgreSQL TEXT cannot carry U+0000 (the SQL standard forbids it;
-    psycopg/asyncpg surface it as ``CharacterNotInRepertoireError``). Per
-    WXYC/docs#18 the org-wide policy is to strip at every PG TEXT boundary —
-    U+0000 in artist metadata is always corruption, never intent. Applied to
-    INSERT/UPDATE writes AND to SELECT-by-name lookups so a caller looking
-    up a value it just upserted finds the stored row.
-
-    Preserves ``None`` so COALESCE-based upserts continue to skip absent
-    fields rather than overwriting them with the empty string. Idempotent.
-    """
-    if value is None:
-        return None
-    return value.replace("\x00", "")
 
 
 @dataclass
@@ -261,9 +245,12 @@ class EntityStore:
         Uses ``ON CONFLICT ... DO UPDATE`` with ``COALESCE`` so that populated
         fields are never overwritten with NULL.
 
-        Every TEXT-bound argument is passed through ``_strip_nul`` before the
-        query — same WX-3.B boundary policy as the read paths in this class
-        (see ``_strip_nul`` for the rationale).
+        Every TEXT-bound argument is passed through
+        ``wxyc_etl.pg.to_pg_text_form`` before the query — same WX-3.B
+        boundary policy as the read paths in this class. The upstream helper
+        preserves ``None`` so the ``COALESCE(EXCLUDED.col, entity.identity.col)``
+        upsert continues to skip absent fields rather than overwriting them
+        with the empty string. See WXYC/docs#18 for the rationale.
 
         Storage note: this method writes ``library_name`` verbatim. The
         bulk-resolve-libraries handler reads via the three-leg
@@ -278,13 +265,13 @@ class EntityStore:
         """
         record = await self._pg.fetchone(
             _UPSERT_IDENTITY_SQL,
-            _strip_nul(library_name),
+            to_pg_text_form(library_name),
             discogs_artist_id,
-            _strip_nul(wikidata_qid),
-            _strip_nul(musicbrainz_artist_id),
-            _strip_nul(spotify_artist_id),
-            _strip_nul(apple_music_artist_id),
-            _strip_nul(bandcamp_id),
+            to_pg_text_form(wikidata_qid),
+            to_pg_text_form(musicbrainz_artist_id),
+            to_pg_text_form(spotify_artist_id),
+            to_pg_text_form(apple_music_artist_id),
+            to_pg_text_form(bandcamp_id),
         )
         if record is None:
             return None
@@ -300,7 +287,7 @@ class EntityStore:
         Returns:
             The matching Identity, or None if not found.
         """
-        record = await self._pg.fetchone(_GET_IDENTITY_SQL, _strip_nul(library_name))
+        record = await self._pg.fetchone(_GET_IDENTITY_SQL, to_pg_text_form(library_name))
         if record is None:
             return None
         return _record_to_identity(record)
@@ -343,7 +330,7 @@ class EntityStore:
         # path for store consumers that don't use this method.
         from identity.normalize import canonicalize_for_identity_lookup
 
-        verbatim = _strip_nul(library_name) or ""
+        verbatim = to_pg_text_form(library_name) or ""
 
         # Leg 1: exact match (verbatim, uses unique index).
         record = await self._pg.fetchone(_GET_IDENTITY_SQL, verbatim)
@@ -387,7 +374,7 @@ class EntityStore:
         Returns:
             List of matching identities (empty list if none or on failure).
         """
-        records = await self._pg.fetchall(_GET_BY_STATUS_SQL, _strip_nul(status))
+        records = await self._pg.fetchall(_GET_BY_STATUS_SQL, to_pg_text_form(status))
         if records is None:
             return []
         return [_record_to_identity(r) for r in records]
@@ -399,7 +386,7 @@ class EntityStore:
             identity_id: The ``entity.identity.id`` to update.
             status: New reconciliation status value.
         """
-        await self._pg.execute(_UPDATE_STATUS_SQL, identity_id, _strip_nul(status))
+        await self._pg.execute(_UPDATE_STATUS_SQL, identity_id, to_pg_text_form(status))
 
     async def get_latest_provenance_by_source(self, identity_id: int) -> dict[str, ProvenanceRow]:
         """Return the most-recent reconciliation_log row per source.
@@ -449,10 +436,10 @@ class EntityStore:
         await self._pg.execute(
             _LOG_RECONCILIATION_SQL,
             identity_id,
-            _strip_nul(source),
-            _strip_nul(external_id),
+            to_pg_text_form(source),
+            to_pg_text_form(external_id),
             confidence,
-            _strip_nul(method),
+            to_pg_text_form(method),
         )
 
     async def fetch_all_identity_library_names(self) -> set[str]:
@@ -478,7 +465,7 @@ class EntityStore:
         Returns the count of ``entity.reconciliation_log`` rows removed.
         Returns 0 (no-op) if no identity row matches ``library_name``.
         """
-        verbatim = _strip_nul(library_name)
+        verbatim = to_pg_text_form(library_name)
         async with self._pg.acquire() as conn, conn.transaction():
             row = await conn.fetchrow(_GET_IDENTITY_SQL, verbatim)
             if row is None:
@@ -520,7 +507,7 @@ class EntityStore:
         the from row, the into row, and the log rows all in their original
         state — never partial.
         """
-        verbatim = _strip_nul(from_name)
+        verbatim = to_pg_text_form(from_name)
         async with self._pg.acquire() as conn, conn.transaction():
             from_row = await conn.fetchrow(_GET_IDENTITY_SQL, verbatim)
             if from_row is None:
@@ -599,7 +586,7 @@ class EntityStore:
         # falls all the way through.
         verbatim_by_input: dict[str, str] = {}
         for raw in names:
-            verbatim_by_input[raw] = _strip_nul(raw) or ""
+            verbatim_by_input[raw] = to_pg_text_form(raw) or ""
 
         results: dict[str, Identity] = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "wxyc-fastapi[posthog]>=1.0.0,<2.0.0",
     "aiolimiter>=1.1.0",
     "python-multipart>=0.0.6",
-    "wxyc-etl>=0.6.0,<0.7.0",
+    "wxyc-etl>=0.8.0,<0.9.0",
     "pyjwt[crypto]>=2.8.0",
 ]
 

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -7,32 +7,7 @@ import pytest
 from entity.store import (
     _GET_IDENTITY_LOWER_SQL,
     EntityStore,
-    _strip_nul,
 )
-
-
-class TestStripNul:
-    """Locks the WX-3.B boundary contract on the private helper."""
-
-    def test_returns_none_for_none(self) -> None:
-        assert _strip_nul(None) is None
-
-    def test_returns_input_unchanged_when_no_nul(self) -> None:
-        assert _strip_nul("Stereolab") == "Stereolab"
-
-    def test_strips_single_nul(self) -> None:
-        assert _strip_nul("a\x00b") == "ab"
-
-    def test_strips_all_nuls(self) -> None:
-        assert _strip_nul("\x00a\x00b\x00") == "ab"
-
-    def test_empty_string_passthrough(self) -> None:
-        assert _strip_nul("") == ""
-
-    def test_idempotent(self) -> None:
-        once = _strip_nul("a\x00b\x00c")
-        twice = _strip_nul(once)
-        assert once == twice == "abc"
 
 
 @pytest.fixture
@@ -109,6 +84,45 @@ class TestUpsertIdentity:
         # Verify COALESCE is used in the UPDATE clause
         call_args = mock_pg.fetchone.call_args
         assert "COALESCE" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_upsert_with_none_external_id_does_not_clobber_existing(self, store, mock_pg):
+        """Regression: an upsert that omits an external ID must bind SQL NULL,
+        not the empty string, so ``COALESCE(EXCLUDED.col, entity.identity.col)``
+        skips the column and the previously-stored value survives.
+
+        This is the load-bearing contract that WXYC/wxyc-etl#142 changed the
+        Python boundary helper for. The old `None -> ""` coercion would have
+        bound the empty string here, causing `COALESCE('', existing)` to
+        return `''` and silently clobber every stored external ID on any
+        upsert that didn't carry one. The new ``wxyc_etl.pg.to_pg_text_form``
+        contract preserves ``None``, which asyncpg binds as SQL ``NULL``.
+        """
+        mock_pg.fetchone = AsyncMock(
+            return_value={
+                "id": 1,
+                "library_name": "Autechre",
+                "discogs_artist_id": None,
+                "wikidata_qid": "Q378288",
+                "musicbrainz_artist_id": None,
+                "spotify_artist_id": None,
+                "apple_music_artist_id": None,
+                "bandcamp_id": None,
+                "reconciliation_status": "unreconciled",
+            }
+        )
+        await store.upsert_identity(library_name="Autechre")
+        # The bound external-ID args must be exactly None, not "" or any other
+        # falsy value. positional args after `_UPSERT_IDENTITY_SQL` are:
+        #   library_name, discogs_artist_id, wikidata_qid, mb_id, spotify_id,
+        #   apple_id, bandcamp_id
+        args = mock_pg.fetchone.call_args[0]
+        # args[0] is SQL, args[1] is library_name. Indices 2..=7 are the IDs.
+        for bound in args[3:8]:
+            assert bound is None, (
+                f"upsert bound external-ID arg as {bound!r}, expected None to "
+                "preserve COALESCE-skip behavior"
+            )
 
 
 class TestGetIdentity:


### PR DESCRIPTION
## Summary

Step 3 of the WX-3.B follow-up consumer sweep ([WXYC/wxyc-etl#142](https://github.com/WXYC/wxyc-etl/issues/142)). Replaces `entity.store._strip_nul` with `wxyc_etl.pg.to_pg_text_form` so the WXYC/docs#18 PG TEXT U+0000 strip policy lives in one place.

**Draft** — opens against the unpublished wxyc-etl 0.8.0 contract. Local tests pass against a maturin-built wheel; CI will resolve cleanly once [WXYC/wxyc-etl#143](https://github.com/WXYC/wxyc-etl/pull/143) merges and `v0.8.0` ships to PyPI.

## Why this needed an upstream contract fix first

The 0.7.0 Python binding coerced `None -> ""`. This consumer's `_UPSERT_IDENTITY_SQL` uses `COALESCE(EXCLUDED.col, entity.identity.col)` on every external ID column. Migrating to `to_pg_text_form` under the 0.7.0 contract would have made every upsert that omits an external ID clobber the previously-stored value with `''` — `COALESCE('', existing)` returns `''`, not `existing`. Data-corruption-grade silent break, not caught by the WX-1 charset-torture detector. [WXYC/wxyc-etl#143](https://github.com/WXYC/wxyc-etl/pull/143) changes the contract to `Option<&str> -> Option<String>` so `None` passes through and the COALESCE-skip works as intended.

## What changed

- `entity/store.py` — `_strip_nul` deleted; `from wxyc_etl.pg import to_pg_text_form` added; all 16 call-sites swept (6 in `_UPSERT_IDENTITY_SQL` binding, 10 across the read / log / cleanup paths). Upsert docstring updated to reference the upstream helper and the new contract.
- `tests/unit/test_entity_store.py` — `TestStripNul` (6 cases) deleted; that contract is now tested upstream in `wxyc-etl-python/tests/test_pg.py`. **Added a `test_upsert_with_none_external_id_does_not_clobber_existing` regression** that pins the COALESCE-skip behavior at the consumer boundary by asserting the bound external-ID args are exactly `None` (not `\"\"` or any other falsy value). This matches the issue's acceptance bullet: \"add one explicit 'upsert with `wikidata_qid=None` does not clobber existing value' regression if not already present\".
- `pyproject.toml` — `wxyc-etl>=0.6.0,<0.7.0` → `>=0.8.0,<0.9.0`.

## Test plan

- [x] `pytest tests/unit/test_entity_store.py -v` — 28/28 pass against locally-built wxyc-etl 0.8.0 wheel, including the new regression
- [x] `pytest tests/unit/ -q` — 2218 pass (one unrelated pre-existing event-loop teardown flake in `test_dependencies.py` that passes in isolation)
- [x] `ruff check entity/ tests/unit/test_entity_store.py` clean
- [x] `ruff format --check entity/ tests/unit/test_entity_store.py` clean
- [x] `mypy entity/store.py` clean
- [ ] CI green after [WXYC/wxyc-etl#143](https://github.com/WXYC/wxyc-etl/pull/143) publishes to PyPI

Closes the LML portion of [WXYC/wxyc-etl#142](https://github.com/WXYC/wxyc-etl/issues/142) acceptance.