### PR TITLE
feat(discogs): tombstone Discogs 404s in PG cache (LML#510)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -496,13 +496,34 @@ class DiscogsCacheService:
         """
         try:
             release_row = await self.pool.fetchrow(
-                "SELECT id, title, release_year, artwork_url, released, artwork_checked_at "
+                "SELECT id, title, release_year, artwork_url, released, "
+                "artwork_checked_at, not_found "
                 "FROM release WHERE id = $1",
                 release_id,
             )
 
             if release_row is None:
                 return None
+
+            # LML#510: tombstone short-circuit. The parent row's `not_found`
+            # flag is authoritative — there are no child rows for a
+            # tombstone (the tombstone branch in write_release skips the
+            # cascade), so the 4-7 PG round-trips below would all be empty
+            # selects. Returning a tombstone-shaped model keeps the
+            # `is_pg_hit` predicate at the public boundary happy (the
+            # `artwork_checked_at` stamp is set, so the seam treats it as
+            # a hit) and the public method's tombstone translation
+            # converts it back to None for the caller.
+            if release_row["not_found"]:
+                return ReleaseMetadataResponse(
+                    release_id=release_id,
+                    title="",
+                    artist="",
+                    release_url=f"https://www.discogs.com/release/{release_id}",
+                    not_found=True,
+                    artwork_checked_at=release_row["artwork_checked_at"],
+                    cached=True,
+                )
 
             # Fetch all child tables in parallel (independent queries)
             artist_rows, label_rows, track_rows, track_artist_rows = await asyncio.gather(
@@ -670,6 +691,36 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
+            # LML#510: tombstone branch. A 404-shaped write doesn't have any
+            # rich content to cascade — and crucially, we must NOT clobber
+            # any prior hydrated row's identifier columns (title / year /
+            # artwork) nor wipe the child cascade. The narrow UPSERT below
+            # only touches `not_found` + `artwork_checked_at`; the
+            # ``ON CONFLICT DO UPDATE SET`` clause intentionally OMITS
+            # title / year / artwork_url / released so a 404 after a 200
+            # leaves the parent's identifier columns intact, and the early
+            # `return` skips the child DELETE+INSERT cascade so existing
+            # `release_artist` / `release_label` / `release_track` /
+            # `release_track_artist` / `release_genre` / `release_style` /
+            # `release_video` rows survive a tombstone overwrite.
+            if release.not_found:
+                async with self.pool.acquire() as conn:
+                    await conn.execute(
+                        """
+                        INSERT INTO release (
+                            id, title, release_year, artwork_url, released,
+                            artwork_checked_at, not_found
+                        )
+                        VALUES ($1, '', NULL, NULL, NULL, now(), TRUE)
+                        ON CONFLICT (id) DO UPDATE SET
+                            artwork_checked_at = EXCLUDED.artwork_checked_at,
+                            not_found = TRUE
+                        """,
+                        release.release_id,
+                    )
+                logger.debug(f"Tombstoned release {release.release_id}")
+                return
+
             async with self.pool.acquire() as conn, conn.transaction():
                 # Wrap the entire DELETE+INSERT cascade in a single transaction.
                 # Without this, asyncpg autocommits each statement and a
@@ -686,19 +737,24 @@ class DiscogsCacheService:
                 # avoid re-fetching genuinely-imageless releases
                 # (WXYC/library-metadata-lookup#423, backed by the schema
                 # column from WXYC/discogs-etl#239).
+                #
+                # `not_found = FALSE` in the SET clause (LML#510) clears any
+                # prior tombstone in one statement so a recovered 200 makes
+                # the row reachable again without an admin intervention.
                 await conn.execute(
                     """
                     INSERT INTO release (
                         id, title, release_year, artwork_url, released,
-                        artwork_checked_at
+                        artwork_checked_at, not_found
                     )
-                    VALUES ($1, $2, $3, $4, $5, now())
+                    VALUES ($1, $2, $3, $4, $5, now(), FALSE)
                     ON CONFLICT (id) DO UPDATE SET
                         title = EXCLUDED.title,
                         release_year = EXCLUDED.release_year,
                         artwork_url = EXCLUDED.artwork_url,
                         released = EXCLUDED.released,
-                        artwork_checked_at = EXCLUDED.artwork_checked_at
+                        artwork_checked_at = EXCLUDED.artwork_checked_at,
+                        not_found = FALSE
                     """,
                     release.release_id,
                     release.title,
@@ -986,13 +1042,29 @@ class DiscogsCacheService:
             # predicate can distinguish stub rows (rebuild-created, never
             # hydrated from Discogs) from rows we've actually fetched. See
             # `DiscogsService.get_artist_details` and WXYC#502.
+            #
+            # `not_found` (LML#510) is the tombstone discriminator — see
+            # the short-circuit just below.
             artist_row = await self.pool.fetchrow(
-                "SELECT id, name, profile, image_url, fetched_at FROM artist WHERE id = $1",
+                "SELECT id, name, profile, image_url, fetched_at, not_found "
+                "FROM artist WHERE id = $1",
                 artist_id,
             )
 
             if artist_row is None:
                 return None
+
+            # LML#510: tombstone short-circuit. Same rationale as the
+            # release path — no child rows exist for a tombstone, so
+            # the asyncio.gather below would just be empty selects.
+            if artist_row["not_found"]:
+                return ArtistDetails(
+                    artist_id=artist_id,
+                    name="",
+                    not_found=True,
+                    fetched_at=artist_row["fetched_at"],
+                    cached=True,
+                )
 
             # Fetch all child tables in parallel (independent queries)
             alias_rows, nv_rows, member_rows, url_rows = await asyncio.gather(
@@ -1143,21 +1215,46 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
+            # LML#510: tombstone branch. Same shape as write_release —
+            # narrow UPSERT, early return before the child cascade so a
+            # 404 doesn't wipe rich catalog metadata; `ON CONFLICT DO
+            # UPDATE SET` intentionally omits name / profile / image_url
+            # so a 404 after a 200 leaves identifier columns intact.
+            if details.not_found:
+                async with self.pool.acquire() as conn:
+                    await conn.execute(
+                        """
+                        INSERT INTO artist (id, name, profile, image_url, fetched_at, not_found)
+                        VALUES ($1, '', NULL, NULL, now(), TRUE)
+                        ON CONFLICT (id) DO UPDATE SET
+                            fetched_at = now(),
+                            not_found = TRUE
+                        """,
+                        details.artist_id,
+                    )
+                logger.debug(f"Tombstoned artist {details.artist_id}")
+                return
+
             async with self.pool.acquire() as conn, conn.transaction():
                 # Wrap the UPSERT + 4×(DELETE+INSERT) cascade in a single
                 # transaction so a cancellation mid-write doesn't leave the
                 # artist row updated with empty child tables. See WXYC#375.
 
-                # Upsert artist row
+                # Upsert artist row.
+                #
+                # `not_found = FALSE` in the SET clause (LML#510) clears
+                # any prior tombstone in one statement, so a recovered 200
+                # makes the row reachable again without admin intervention.
                 await conn.execute(
                     """
-                    INSERT INTO artist (id, name, profile, image_url, fetched_at)
-                    VALUES ($1, $2, $3, $4, now())
+                    INSERT INTO artist (id, name, profile, image_url, fetched_at, not_found)
+                    VALUES ($1, $2, $3, $4, now(), FALSE)
                     ON CONFLICT (id) DO UPDATE SET
                         name = EXCLUDED.name,
                         profile = EXCLUDED.profile,
                         image_url = EXCLUDED.image_url,
-                        fetched_at = now()
+                        fetched_at = now(),
+                        not_found = FALSE
                     """,
                     details.artist_id,
                     details.name,
@@ -1223,6 +1320,49 @@ class DiscogsCacheService:
         except Exception as e:
             logger.error(f"Cache write_artist_details failed: {e}")
             raise CacheUnavailableError(f"Cache write_artist_details failed: {e}") from e
+
+    async def delete_tombstone(self, entity_type: str, entity_id: int) -> str:
+        """Delete a tombstoned row so the next API call re-fetches it.
+
+        Backs the admin recovery endpoint (`DELETE /admin/discogs/tombstone/...`).
+        The `WHERE id = $1 AND not_found = TRUE` guard means a real row can
+        never be deleted through this surface — even with a typo'd id.
+
+        Args:
+            entity_type: `"release"` or `"artist"`.
+            entity_id: Discogs id.
+
+        Returns:
+            ``"deleted"`` — a tombstoned row matched and was removed.
+            ``"exists_not_tombstone"`` — `entity_id` exists but
+                ``not_found = FALSE``; refusing to delete (real data).
+            ``"not_found"`` — no row at all.
+        """
+        if entity_type not in ("release", "artist"):
+            raise ValueError(f"entity_type must be 'release' or 'artist', got {entity_type!r}")
+        table = entity_type
+        try:
+            async with self.pool.acquire() as conn:
+                # Probe the row's existence and tombstone state in one query
+                # so the response code is unambiguous. A separate DELETE …
+                # RETURNING would conflate "no row" and "row not tombstone".
+                row = await conn.fetchrow(
+                    f"SELECT not_found FROM {table} WHERE id = $1",
+                    entity_id,
+                )
+                if row is None:
+                    return "not_found"
+                if not row["not_found"]:
+                    return "exists_not_tombstone"
+                await conn.execute(
+                    f"DELETE FROM {table} WHERE id = $1 AND not_found = TRUE",
+                    entity_id,
+                )
+            logger.info("Tombstone deleted: %s/%s", entity_type, entity_id)
+            return "deleted"
+        except Exception as e:
+            logger.error("Cache delete_tombstone failed: %s", e)
+            raise CacheUnavailableError(f"Cache delete_tombstone failed: {e}") from e
 
     async def validate_track_on_release(
         self, release_id: int, track: str, artist: str

--- a/discogs/markup_parser.py
+++ b/discogs/markup_parser.py
@@ -466,14 +466,23 @@ class CachedOnlyResolver:
     async def resolve_artist(self, id: int) -> str | None:
         try:
             details = await self._cache.get_artist_details(id)
-            return details.name if details else None
+            # LML#510: tombstones carry `name = ""` as an identifier sentinel.
+            # Without this guard the markup parser emits an `artistLink` token
+            # with `display_name=""` for any tombstoned id — not None, which
+            # is what every consumer here expects.
+            if details is None or details.not_found:
+                return None
+            return details.name
         except Exception:
             return None
 
     async def resolve_release(self, id: int) -> str | None:
         try:
             release = await self._cache.get_release(id)
-            return release.title if release else None
+            # LML#510: same tombstone guard as resolve_artist.
+            if release is None or release.not_found:
+                return None
+            return release.title
         except Exception:
             return None
 

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -152,6 +152,15 @@ class ArtistDetails(BaseModel):
     # the API returned a profile. Used as the cache-hit discriminator in
     # `DiscogsService.get_artist_details` (#502).
     fetched_at: datetime | None = None
+    # Tombstone marker for Discogs 404s on `get_artist_details` (#510).
+    # `True` means LML hit the live API for this id and got a 404; subsequent
+    # reads short-circuit on this flag so callers don't re-burn the
+    # rate-limit budget on the same 404. Tombstone rows carry `name = ""` and
+    # otherwise-default fields — consumers of the public `DiscogsService`
+    # surface never see them (the boundary translates to `None`), but direct
+    # `cache_service` callers (`CachedOnlyResolver`, `get_artist_details_bulk`)
+    # must explicitly guard.
+    not_found: bool = False
     cached: bool = False
 
 

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -30,7 +30,9 @@ _REFRESH_DESCRIPTION = (
     "When true, evict the in-memory L1 cache entry for this entity before "
     "fetching. Forces re-traversal of L2 (PG) and L3 (Discogs API), which is "
     "needed after a manual fix to the underlying PG cache row that would "
-    "otherwise stay invisible until L1's TTL expires."
+    "otherwise stay invisible until L1's TTL expires. NOTE: does NOT clear "
+    "LML#510 tombstones (`not_found = TRUE`) in L2 — use "
+    "`DELETE /admin/discogs/tombstone/{type}/{id}` for that recovery surface."
 )
 
 

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -67,6 +67,7 @@ logger = logging.getLogger(__name__)
 
 DISCOGS_API_BASE = "https://api.discogs.com"
 
+
 # Cap individual retry sleeps. Discogs's per-token rate-limit window is 60
 # seconds; once we cross that, the bucket has reset and there's no benefit to
 # waiting longer for the same 429.
@@ -744,6 +745,29 @@ class DiscogsService:
                     return None
 
                 get_cache_stats_recorder().record_api_call()
+
+                # LML#510: discriminate 404 from other failures before
+                # raise_for_status. A 404 means "Discogs confirms no such
+                # release id" — turn it into a tombstone-shaped row so the
+                # fallthrough seam's pg_write lands it and subsequent calls
+                # short-circuit on the cache instead of re-hitting the API.
+                if response.status_code == 404:
+                    get_cache_stats_recorder().record("release_404_tombstone_written")
+                    return ReleaseMetadataResponse(
+                        release_id=release_id,
+                        title="",
+                        artist="",
+                        release_url=f"https://www.discogs.com/release/{release_id}",
+                        not_found=True,
+                    )
+
+                # LML#510: split out 5xx so Discogs-outage signal stays
+                # legible separately from tombstone activity. Counted at
+                # the discrimination point so we measure raw incidence
+                # (not the post-retry view).
+                if 500 <= response.status_code < 600:
+                    get_cache_stats_recorder().record("release_5xx_passthrough")
+
                 response.raise_for_status()
                 data = response.json()
 
@@ -840,26 +864,52 @@ class DiscogsService:
                 return None
 
         cache = self.cache_service
+        value: ReleaseMetadataResponse | None
         if cache is None:
-            return await _api_fetch()
-        return await fallthrough(
-            label="get_release",
-            pg_read=lambda: cache.get_release(release_id),
-            api_fetch=_api_fetch,
-            pg_write=cache.write_release,
-            # `artwork_url IS NULL AND artwork_checked_at IS NULL` is the
-            # "never asked" state — the bulk loader populated the row but
-            # LML has not yet asked Discogs (~48% of release rows are like
-            # this; see WXYC/library-metadata-lookup#414 and
-            # WXYC/discogs-etl#239). Falling through to the API is the
-            # back-fill path. Once `artwork_checked_at` is set, both
-            # "asked, got a cover" and "asked, no cover" are full hits —
-            # we don't re-ask Discogs about the no-cover tail.
-            is_pg_hit=lambda v: (
-                v is not None and (v.artwork_url is not None or v.artwork_checked_at is not None)
-            ),
-            breadcrumb_data={"release_id": release_id},
-        )
+            value = await _api_fetch()
+        else:
+            value = await fallthrough(
+                label="get_release",
+                pg_read=lambda: cache.get_release(release_id),
+                api_fetch=_api_fetch,
+                # LML#510: mypy widens fallthrough's generic `T` to
+                # `T | None` when the result is assigned to a variable
+                # instead of directly returned, so `cache.write_release`
+                # (which takes `ReleaseMetadataResponse`, not the wider
+                # `ReleaseMetadataResponse | None`) trips arg-type
+                # validation. Pre-510, the call was `return await
+                # fallthrough(...)` and the return-type annotation
+                # bidirectionally constrained `T`. The runtime contract is
+                # unchanged.
+                pg_write=cache.write_release,  # type: ignore[arg-type]
+                # `artwork_url IS NULL AND artwork_checked_at IS NULL` is the
+                # "never asked" state — the bulk loader populated the row but
+                # LML has not yet asked Discogs (~48% of release rows are like
+                # this; see WXYC/library-metadata-lookup#414 and
+                # WXYC/discogs-etl#239). Falling through to the API is the
+                # back-fill path. Once `artwork_checked_at` is set, both
+                # "asked, got a cover" and "asked, no cover" are full hits —
+                # we don't re-ask Discogs about the no-cover tail.
+                #
+                # LML#510 tombstones (not_found=True) carry
+                # artwork_checked_at=now() so they satisfy this predicate too;
+                # the boundary translation below converts them to None for
+                # the public caller. Keeping the predicate type-opaque (no
+                # `not_found` check here) means the fallthrough seam stays
+                # generic — only the public `DiscogsService` methods
+                # understand the tombstone shape.
+                is_pg_hit=lambda v: (
+                    v is not None
+                    and (v.artwork_url is not None or v.artwork_checked_at is not None)
+                ),
+                breadcrumb_data={"release_id": release_id},
+            )
+        # LML#510 boundary: tombstone → None. Counter keeps the
+        # `pg_cache_hit - tombstone_returned` dashboard math interpretable.
+        if value is not None and value.not_found:
+            get_cache_stats_recorder().record("tombstone_returned")
+            return None
+        return value
 
     @async_cached(ARTIST_CACHE)
     async def get_artist_details(self, artist_id: int) -> ArtistDetails | None:
@@ -885,6 +935,20 @@ class DiscogsService:
                     return None
                 get_cache_stats_recorder().record_api_call()
                 add_discogs_breadcrumb("get_artist_details", {"artist_id": artist_id})
+
+                # LML#510: discriminate 404 from other failures. The
+                # tombstone-shaped row carries `name = ""` as the identifier
+                # sentinel; the fallthrough seam's pg_write stamps
+                # `fetched_at = now()` via cache_service so subsequent reads
+                # short-circuit on `is_pg_hit` (fetched_at != None).
+                if response.status_code == 404:
+                    get_cache_stats_recorder().record("artist_404_tombstone_written")
+                    return ArtistDetails(
+                        artist_id=artist_id,
+                        name="",
+                        not_found=True,
+                    )
+
                 response.raise_for_status()
                 data = response.json()
 
@@ -916,29 +980,44 @@ class DiscogsService:
                 )
 
             except Exception as e:
-                logger.warning(f"Failed to fetch artist details for {artist_id}: {e}")
+                # LML#510: promoted from warning → error so Sentry's default
+                # `error+` filter captures artist 404s post-deploy. The
+                # tombstone counter above counts the write side; this log
+                # is the Sentry corroboration surface.
+                logger.error(f"Failed to fetch artist details for {artist_id}: {e}")
                 return None
 
         cache = self.cache_service
+        value: ArtistDetails | None
         if cache is None:
-            return await _api_fetch()
-        return await fallthrough(
-            label="get_artist_details",
-            pg_read=lambda: cache.get_artist_details(artist_id),
-            api_fetch=_api_fetch,
-            pg_write=cache.write_artist_details,
-            # `fetched_at IS NULL` marks a stub row created by the monthly
-            # rebuild's stub-from-`release_artist` path — `(id, name)` only,
-            # no profile / aliases / members / urls / variations. Falling
-            # through to the API + write-back is the back-fill path. Once
-            # `fetched_at` is set, both "asked, got a profile" and "asked,
-            # no profile" are full hits — we don't re-ask Discogs about the
-            # no-profile tail. Same shape of fix as the `get_release`
-            # artwork discriminator above. See WXYC#502 (and #497 for the
-            # rebuild-path fix that creates these stubs in the first place).
-            is_pg_hit=lambda v: v is not None and v.fetched_at is not None,
-            breadcrumb_data={"artist_id": artist_id},
-        )
+            value = await _api_fetch()
+        else:
+            value = await fallthrough(
+                label="get_artist_details",
+                pg_read=lambda: cache.get_artist_details(artist_id),
+                api_fetch=_api_fetch,
+                # LML#510: see the note on `get_release` above.
+                pg_write=cache.write_artist_details,  # type: ignore[arg-type]
+                # `fetched_at IS NULL` marks a stub row created by the monthly
+                # rebuild's stub-from-`release_artist` path — `(id, name)` only,
+                # no profile / aliases / members / urls / variations. Falling
+                # through to the API + write-back is the back-fill path. Once
+                # `fetched_at` is set, both "asked, got a profile" and "asked,
+                # no profile" are full hits — we don't re-ask Discogs about the
+                # no-profile tail. Same shape of fix as the `get_release`
+                # artwork discriminator above. See WXYC#502 (and #497 for the
+                # rebuild-path fix that creates these stubs in the first place).
+                #
+                # LML#510 tombstones land here with `fetched_at = now()` so
+                # they hit-fall-through correctly; the boundary translation
+                # below converts `not_found=True` back to None for callers.
+                is_pg_hit=lambda v: v is not None and v.fetched_at is not None,
+                breadcrumb_data={"artist_id": artist_id},
+            )
+        if value is not None and value.not_found:
+            get_cache_stats_recorder().record("tombstone_returned")
+            return None
+        return value
 
     async def get_artist_image(self, artist_id: int) -> str | None:
         """Fetch primary image for a Discogs artist.

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1131,6 +1131,10 @@ class DiscogsReleaseMetadata(BaseModel):
         None,
         description="Timestamp of the most recent live Discogs API call that resolved\nthis release's artwork. `null` means LML's bulk loader populated\nthe row but the live API has not been queried yet (the \"never\nasked\" state); a value means LML hit the live API and either\npopulated `artwork_url` or confirmed Discogs has no cover. LML\nuses this to distinguish bulk-loader gaps (which it back-fills)\nfrom genuinely-imageless releases (which it does not refetch).\nSee WXYC/discogs-etl#239 + WXYC/library-metadata-lookup#423.\n",
     )
+    not_found: bool | None = Field(
+        False,
+        description='Tombstone marker for Discogs 404s on `get_release`. `true` means\nLML hit the live Discogs API for this release id and Discogs\nreturned 404; subsequent reads short-circuit on this flag rather\nthan re-burning the rate-limit budget. The tombstone row carries\n`title = ""` and `artist = ""` as identifier sentinels;\nconsumers must guard against rendering those empty strings as\nreal values. `release_url` is identifier-derived\n(`https://www.discogs.com/release/{release_id}`) and remains\nvalid even on a tombstone. LML\'s public boundary translates\n`not_found = true` back to `None` for direct callers; this flag\nis observable only by consumers that read the cache row\ndirectly (none of which exist in LML\'s public API today, but\nthe contract is exposed here for future cross-service readers).\nSee WXYC/library-metadata-lookup#510.\n',
+    )
     release_url: str
     cached: bool | None = False
     artists: list[DiscogsArtistCredit] | None = Field([], validate_default=True)

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -6,13 +6,21 @@ import os
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, UploadFile
+from fastapi import Path as PathParam
 from fastapi.responses import FileResponse, JSONResponse
 
 from config.settings import Settings, get_settings
-from core.dependencies import close_library_db
+from core.dependencies import (
+    close_library_db,
+    get_discogs_cache_service_from_pool,
+)
+from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
+from discogs.memory_cache import evict_cached
+from discogs.service import DiscogsService
 
 logger = logging.getLogger(__name__)
 
@@ -304,3 +312,106 @@ async def download_streaming_db(
         media_type="application/octet-stream",
         filename=STREAMING_DB_FILENAME,
     )
+
+
+# ---------------------------------------------------------------------------
+# Tombstone recovery (LML#510)
+# ---------------------------------------------------------------------------
+#
+# When Discogs returns 404 for a release / artist id, the cache writes a
+# tombstone row (`not_found = TRUE`) so subsequent reads short-circuit
+# instead of re-burning the rate-limit budget on the same 404. False
+# tombstones happen — most plausibly during a Discogs incident that returns
+# 404s for valid ids. The endpoint below lets on-call clear them.
+#
+# The `WHERE id = $1 AND not_found = TRUE` guard at the cache-service layer
+# means a real row can never be deleted through this surface, even with a
+# typo'd id. Auth is via ADMIN_TOKEN — distinct from LML_API_KEY so
+# routine LML callers don't gain incident-grade write access.
+
+TombstoneEntityType = Literal["release", "artist"]
+
+
+@router.delete(
+    "/discogs/tombstone/{entity_type}/{entity_id}",
+    summary="Clear an LML#510 tombstone so the next call re-fetches from Discogs",
+    responses={
+        200: {"description": "Tombstoned row deleted; L1 cache entry evicted"},
+        401: {"description": "Missing authorization"},
+        403: {"description": "Invalid or missing token"},
+        404: {"description": "Row not found, or row exists but is not a tombstone"},
+        503: {"description": "Discogs cache pool not configured"},
+    },
+)
+async def delete_tombstone(
+    entity_type: TombstoneEntityType = PathParam(..., description="`release` or `artist`"),
+    entity_id: int = PathParam(..., description="Discogs id"),
+    settings: Settings = Depends(get_settings),
+    authorization: str | None = Header(None),
+    cache_service: DiscogsCacheService | None = Depends(get_discogs_cache_service_from_pool),
+):
+    """Delete a tombstoned row + evict the L1 entry.
+
+    Three response codes so a recovery script can branch without parsing
+    log volume:
+
+    * `200 {deleted: true, id, type}` — a tombstoned row matched and was
+      deleted; the next request will re-fetch from Discogs.
+    * `404 {detail: "row exists but is not a tombstone", id, type}` — the
+      id exists with `not_found = FALSE`; either the operator typo'd or
+      the tombstone was already cleared.
+    * `404 {detail: "no row for this id", id, type}` — id doesn't exist.
+
+    `?refresh=true` (LML#498) does NOT cover this: refresh evicts L1
+    only, and a tombstone lives in L2 (PG); we read it back and re-serve
+    it. This endpoint is the L2 surface.
+    """
+    _validate_auth(settings, authorization)
+
+    if cache_service is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Discogs cache pool not configured (DATABASE_URL_DISCOGS unset?)",
+        )
+
+    try:
+        outcome = await cache_service.delete_tombstone(entity_type, entity_id)
+    except CacheUnavailableError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+    if outcome == "not_found":
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "detail": "no row for this id",
+                "id": entity_id,
+                "type": entity_type,
+            },
+        )
+    if outcome == "exists_not_tombstone":
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "detail": "row exists but is not a tombstone",
+                "id": entity_id,
+                "type": entity_type,
+            },
+        )
+
+    # outcome == "deleted": L2 row gone, now drop the L1 entry so a
+    # subsequent request actually re-traverses L2/L3 instead of returning
+    # the cached None from before the tombstone was cleared.
+    cached_func = (
+        DiscogsService.get_release
+        if entity_type == "release"
+        else DiscogsService.get_artist_details
+    )
+    try:
+        evict_cached(cached_func, entity_id)
+    except Exception as e:
+        # Don't fail the response — the L2 delete already succeeded, and
+        # L1's TTL will expire naturally. Log so an operator notices if
+        # the decorator surface ever drifts.
+        logger.warning("L1 evict failed after tombstone delete: %s", e)
+
+    return JSONResponse(content={"deleted": True, "id": entity_id, "type": entity_type})

--- a/tests/integration/test_cache_service_tombstones.py
+++ b/tests/integration/test_cache_service_tombstones.py
@@ -1,0 +1,603 @@
+"""Integration tests for cache_service tombstone read + write paths (LML#510).
+
+These tests bring up a fresh `release` / `artist` schema (mirroring the
+discogs-etl dual-write contract — the `not_found` column lives in both
+`schema/create_database.sql` and `alembic/versions/0010_release_not_found.py`
+in the sibling repo). The tests pin:
+
+* `get_release` / `get_artist_details` SELECT the `not_found` column and
+  short-circuit before fetching child tables when it's `TRUE`. The
+  tombstone-shaped model returned from the short-circuit carries empty
+  identifier columns (`title = ''` / `name = ''`).
+* `write_release` / `write_artist_details` distinguish tombstone payloads
+  (`not_found = True`) from hydrated payloads:
+  - Tombstone path: narrow UPSERT only touches the parent row's
+    `not_found` flag + `_checked_at` / `fetched_at` stamp; the child
+    cascade is skipped entirely so a 404 after a 200 doesn't wipe rich
+    catalog metadata that's expensive to repopulate.
+  - Hydrated path: the existing UPSERT plus `not_found = FALSE` in the
+    `ON CONFLICT DO UPDATE SET` clause clears any prior tombstone in
+    one statement.
+* `get_artist_details_bulk` is intentionally untouched and returns
+  tombstones as empty-fields `ArtistDetails`, parallel to the
+  pre-LML#510 stub policy from PR #503.
+
+Run with: `pytest -m pg -v tests/integration/test_cache_service_tombstones.py`
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from discogs.cache_service import DiscogsCacheService
+from discogs.models import (
+    ArtistCredit,
+    ArtistDetails,
+    ArtistRef,
+    LabelCredit,
+    MemberRef,
+    ReleaseMetadataResponse,
+    TrackItem,
+)
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+@pytest_asyncio.fixture
+async def pg_pool():
+    try:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+    yield pool
+    await pool.close()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def fresh_release_and_artist_schema(pg_pool):
+    """Bring up the parent + child tables LML reads/writes.
+
+    Mirrors the relevant pieces of `discogs-etl/schema/create_database.sql`
+    at HEAD — once the LML PR pins the new wxyc-shared release and the
+    discogs-etl alembic migration is live in staging, these inline
+    definitions are the contract this test pins.
+    """
+    async with pg_pool.acquire() as conn:
+        # Child tables first (FK ON DELETE CASCADE)
+        for child in (
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+            "release_track",
+            "release_track_artist",
+            "release_video",
+            "artist_alias",
+            "artist_name_variation",
+            "artist_member",
+            "artist_url",
+            "cache_metadata",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {child} CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS release CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist CASCADE")
+
+        await conn.execute("""
+            CREATE TABLE release (
+                id                  integer PRIMARY KEY,
+                title               text NOT NULL,
+                release_year        smallint,
+                country             text,
+                artwork_url         text,
+                released            text,
+                format              text,
+                master_id           integer,
+                artwork_checked_at  timestamptz,
+                not_found           boolean NOT NULL DEFAULT FALSE
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_artist (
+                release_id  integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                artist_id   integer,
+                artist_name text NOT NULL,
+                extra       integer DEFAULT 0,
+                role        text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_label (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                label_id   integer,
+                label_name text NOT NULL,
+                catno      text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_genre (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                genre      text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_style (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                style      text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_track (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                sequence   integer NOT NULL,
+                position   text,
+                title      text NOT NULL,
+                duration   text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_track_artist (
+                release_id     integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                track_sequence integer NOT NULL,
+                artist_name    text NOT NULL,
+                extra          integer DEFAULT 0,
+                role           text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_video (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                sequence   integer NOT NULL,
+                src        text NOT NULL,
+                title      text,
+                duration   integer,
+                embed      boolean DEFAULT true
+            )
+        """)
+
+        await conn.execute("""
+            CREATE TABLE artist (
+                id         integer PRIMARY KEY,
+                name       text NOT NULL,
+                profile    text,
+                image_url  text,
+                fetched_at timestamptz NOT NULL DEFAULT now(),
+                not_found  boolean NOT NULL DEFAULT FALSE
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_alias (
+                artist_id  integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                alias_id   integer,
+                alias_name text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_name_variation (
+                artist_id integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                name      text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_member (
+                artist_id   integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                member_id   integer NOT NULL,
+                member_name text NOT NULL,
+                active      boolean DEFAULT true
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_url (
+                artist_id integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                url       text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE cache_metadata (
+                release_id     integer PRIMARY KEY REFERENCES release(id) ON DELETE CASCADE,
+                cached_at      timestamptz NOT NULL DEFAULT now(),
+                source         text NOT NULL,
+                last_validated timestamptz
+            )
+        """)
+    yield
+    async with pg_pool.acquire() as conn:
+        for t in (
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+            "release_track",
+            "release_track_artist",
+            "release_video",
+            "artist_alias",
+            "artist_name_variation",
+            "artist_member",
+            "artist_url",
+            "cache_metadata",
+            "release",
+            "artist",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {t} CASCADE")
+
+
+# ---------------------------------------------------------------------------
+# Read-path short-circuit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_get_release_returns_tombstone_for_not_found_row(pg_pool):
+    """A `not_found = TRUE` row reads back as a tombstone-shaped
+    `ReleaseMetadataResponse`. Child tables are NOT queried."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO release (id, title, not_found, artwork_checked_at) "
+            "VALUES (42, '', TRUE, now())"
+        )
+
+    cache = DiscogsCacheService(pg_pool)
+    result = await cache.get_release(42)
+
+    assert result is not None
+    assert result.not_found is True
+    assert result.title == ""
+    assert result.artist == ""
+    assert result.release_url == "https://www.discogs.com/release/42"
+    # Child fields are empty per the short-circuit
+    assert result.tracklist == []
+    assert result.artists == []
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_get_release_real_row_not_found_false(pg_pool):
+    """Real rows return with `not_found = False`."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO release (id, title, artwork_checked_at) "
+            "VALUES (101, 'Aluminum Tunes', now())"
+        )
+
+    cache = DiscogsCacheService(pg_pool)
+    result = await cache.get_release(101)
+    assert result is not None
+    assert result.not_found is False
+    assert result.title == "Aluminum Tunes"
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_get_artist_details_returns_tombstone_for_not_found_row(pg_pool):
+    async with pg_pool.acquire() as conn:
+        await conn.execute("INSERT INTO artist (id, name, not_found) VALUES (99, '', TRUE)")
+
+    cache = DiscogsCacheService(pg_pool)
+    result = await cache.get_artist_details(99)
+    assert result is not None
+    assert result.not_found is True
+    assert result.name == ""
+    assert result.aliases == []
+    assert result.name_variations == []
+    assert result.members == []
+    assert result.urls == []
+
+
+# ---------------------------------------------------------------------------
+# Write-path: tombstone branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_write_release_tombstone_preserves_hydrated_parent_columns(pg_pool):
+    """A tombstone write against a previously-hydrated row preserves the
+    parent identifier columns and only flips `not_found` to TRUE. Without
+    this, a 404 after a 200 would wipe the title."""
+    cache = DiscogsCacheService(pg_pool)
+
+    # First write: a real, hydrated row.
+    hydrated = ReleaseMetadataResponse(
+        release_id=200,
+        title="Aluminum Tunes",
+        artist="Stereolab",
+        release_url="https://www.discogs.com/release/200",
+        year=1998,
+        artwork_url="https://img.discogs.com/aluminum.jpg",
+        artists=[ArtistCredit(artist_id=2154, name="Stereolab")],
+        labels=[LabelCredit(label_id=1, name="Duophonic", catno="UHF1")],
+        tracklist=[TrackItem(position="A1", title="Cybele's Reverie", duration="3:30")],
+        genres=["Electronic"],
+        styles=["Krautrock"],
+    )
+    await cache.write_release(hydrated)
+
+    # Second write: tombstone.
+    tombstone = ReleaseMetadataResponse(
+        release_id=200,
+        title="",
+        artist="",
+        release_url="https://www.discogs.com/release/200",
+        not_found=True,
+    )
+    await cache.write_release(tombstone)
+
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT title, release_year, artwork_url, not_found, artwork_checked_at "
+            "FROM release WHERE id = 200"
+        )
+    assert row["not_found"] is True
+    assert row["title"] == "Aluminum Tunes", (
+        "Tombstone write must NOT overwrite the parent's identifier columns; "
+        "the EXCLUDED set in the tombstone branch intentionally omits title."
+    )
+    assert row["release_year"] == 1998
+    assert row["artwork_url"] == "https://img.discogs.com/aluminum.jpg"
+    assert row["artwork_checked_at"] is not None
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_write_release_tombstone_preserves_child_cascade(pg_pool):
+    """A tombstone write must NOT wipe the child tables (release_artist /
+    release_label / release_track / etc.) — those rows are expensive to
+    repopulate and a tombstoned row that later recovers via the admin
+    endpoint should re-emerge with intact catalog metadata."""
+    cache = DiscogsCacheService(pg_pool)
+
+    hydrated = ReleaseMetadataResponse(
+        release_id=201,
+        title="Aluminum Tunes",
+        artist="Stereolab",
+        release_url="https://www.discogs.com/release/201",
+        artists=[ArtistCredit(artist_id=2154, name="Stereolab")],
+        labels=[LabelCredit(label_id=1, name="Duophonic", catno="UHF1")],
+        tracklist=[TrackItem(position="A1", title="Cybele's Reverie")],
+        genres=["Electronic"],
+        styles=["Krautrock"],
+    )
+    await cache.write_release(hydrated)
+
+    tombstone = ReleaseMetadataResponse(
+        release_id=201,
+        title="",
+        artist="",
+        release_url="https://www.discogs.com/release/201",
+        not_found=True,
+    )
+    await cache.write_release(tombstone)
+
+    async with pg_pool.acquire() as conn:
+        # Pin every child table from the issue's cascade list.
+        counts = {}
+        for tbl in (
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+            "release_track",
+        ):
+            counts[tbl] = await conn.fetchval(f"SELECT count(*) FROM {tbl} WHERE release_id = 201")
+    for tbl, c in counts.items():
+        assert c >= 1, (
+            f"Tombstone write wiped {tbl} (count={c}); the tombstone branch "
+            "must early-return before the child-table DELETE+INSERT cascade."
+        )
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_write_artist_details_tombstone_preserves_hydrated_parent(pg_pool):
+    cache = DiscogsCacheService(pg_pool)
+
+    hydrated = ArtistDetails(
+        artist_id=300,
+        name="Stereolab",
+        profile="French/British band formed in 1990",
+        image_url="https://img.discogs.com/stereolab.jpg",
+    )
+    await cache.write_artist_details(hydrated)
+
+    tombstone = ArtistDetails(
+        artist_id=300,
+        name="",
+        not_found=True,
+    )
+    await cache.write_artist_details(tombstone)
+
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT name, profile, image_url, not_found FROM artist WHERE id = 300"
+        )
+    assert row["not_found"] is True
+    assert row["name"] == "Stereolab", (
+        "Tombstone write must NOT overwrite name; the EXCLUDED set in the "
+        "tombstone branch intentionally omits name/profile/image_url."
+    )
+    assert row["profile"] == "French/British band formed in 1990"
+    assert row["image_url"] == "https://img.discogs.com/stereolab.jpg"
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_write_artist_details_tombstone_preserves_child_cascade(pg_pool):
+    cache = DiscogsCacheService(pg_pool)
+
+    hydrated = ArtistDetails(
+        artist_id=301,
+        name="Stereolab",
+        aliases=[ArtistRef(id=999, name="Monade")],
+        name_variations=["The Stereolab"],
+        members=[MemberRef(id=200, name="Laetitia Sadier", active=True)],
+        urls=["https://stereolab.com"],
+    )
+    await cache.write_artist_details(hydrated)
+
+    tombstone = ArtistDetails(
+        artist_id=301,
+        name="",
+        not_found=True,
+    )
+    await cache.write_artist_details(tombstone)
+
+    async with pg_pool.acquire() as conn:
+        counts = {}
+        for tbl in ("artist_alias", "artist_name_variation", "artist_member", "artist_url"):
+            counts[tbl] = await conn.fetchval(f"SELECT count(*) FROM {tbl} WHERE artist_id = 301")
+    for tbl, c in counts.items():
+        assert c >= 1, (
+            f"Tombstone write wiped {tbl} (count={c}); the tombstone branch "
+            "must early-return before the child-table DELETE+INSERT cascade."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tombstone clears on recovered 200
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_recovered_200_clears_release_tombstone(pg_pool):
+    """A hydrated write following a tombstone write clears `not_found` to
+    FALSE in the same statement. Without this, a tombstoned id whose
+    Discogs upstream recovers stays unreachable forever."""
+    cache = DiscogsCacheService(pg_pool)
+
+    # Tombstone first.
+    await cache.write_release(
+        ReleaseMetadataResponse(
+            release_id=400,
+            title="",
+            artist="",
+            release_url="https://www.discogs.com/release/400",
+            not_found=True,
+        )
+    )
+    # Now recovered hydrated payload.
+    await cache.write_release(
+        ReleaseMetadataResponse(
+            release_id=400,
+            title="Moon Pix",
+            artist="Cat Power",
+            release_url="https://www.discogs.com/release/400",
+            year=1998,
+        )
+    )
+
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT title, not_found FROM release WHERE id = 400")
+    assert row["title"] == "Moon Pix"
+    assert row["not_found"] is False, (
+        "Non-tombstone write must clear not_found in `ON CONFLICT DO "
+        "UPDATE SET` — otherwise a tombstoned id with a recovered "
+        "Discogs upstream is unreachable forever."
+    )
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_recovered_200_clears_artist_tombstone(pg_pool):
+    cache = DiscogsCacheService(pg_pool)
+
+    await cache.write_artist_details(ArtistDetails(artist_id=401, name="", not_found=True))
+    await cache.write_artist_details(ArtistDetails(artist_id=401, name="Stereolab"))
+
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT name, not_found FROM artist WHERE id = 401")
+    assert row["name"] == "Stereolab"
+    assert row["not_found"] is False
+
+
+# ---------------------------------------------------------------------------
+# Bulk path leaves tombstones alone
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Admin recovery: DELETE tombstone surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_delete_tombstone_release_returns_deleted(pg_pool):
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO release (id, title, not_found, artwork_checked_at) "
+            "VALUES (600, '', TRUE, now())"
+        )
+    cache = DiscogsCacheService(pg_pool)
+    outcome = await cache.delete_tombstone("release", 600)
+    assert outcome == "deleted"
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT id FROM release WHERE id = 600")
+    assert row is None, "Tombstoned row must be physically deleted."
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_delete_tombstone_artist_returns_deleted(pg_pool):
+    async with pg_pool.acquire() as conn:
+        await conn.execute("INSERT INTO artist (id, name, not_found) VALUES (601, '', TRUE)")
+    cache = DiscogsCacheService(pg_pool)
+    outcome = await cache.delete_tombstone("artist", 601)
+    assert outcome == "deleted"
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_delete_tombstone_non_tombstone_row_refuses(pg_pool):
+    """A real (non-tombstone) row must be physically untouchable via this
+    endpoint. The `AND not_found = TRUE` guard is the safety floor."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO release (id, title, not_found, artwork_checked_at) "
+            "VALUES (602, 'Aluminum Tunes', FALSE, now())"
+        )
+    cache = DiscogsCacheService(pg_pool)
+    outcome = await cache.delete_tombstone("release", 602)
+    assert outcome == "exists_not_tombstone"
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT id, title FROM release WHERE id = 602")
+    assert row is not None, "Real row must survive the admin delete probe."
+    assert row["title"] == "Aluminum Tunes"
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_delete_tombstone_missing_row_returns_not_found(pg_pool):
+    cache = DiscogsCacheService(pg_pool)
+    outcome = await cache.delete_tombstone("release", 9_999_999)
+    assert outcome == "not_found"
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_get_artist_details_bulk_returns_tombstone_as_empty_fields(pg_pool):
+    """`get_artist_details_bulk` is cache-only and (per the LML#503 stub
+    policy that LML#510 inherits) does not filter tombstones. It returns
+    them as empty-fields `ArtistDetails` — same shape as a stub row,
+    observationally equivalent to "missing from bundle" for current
+    callers."""
+    cache = DiscogsCacheService(pg_pool)
+    async with pg_pool.acquire() as conn:
+        await conn.execute("INSERT INTO artist (id, name, not_found) VALUES (500, '', TRUE)")
+        await conn.execute("INSERT INTO artist (id, name) VALUES (501, 'Cat Power')")
+
+    bundle = await cache.get_artist_details_bulk([500, 501])
+    assert 500 in bundle
+    assert 501 in bundle
+    # Tombstone returns as empty-fields per the bulk-path policy.
+    assert bundle[500].name == ""
+    assert bundle[500].aliases == []
+    assert bundle[501].name == "Cat Power"

--- a/tests/unit/test_admin_tombstone_router.py
+++ b/tests/unit/test_admin_tombstone_router.py
@@ -1,0 +1,206 @@
+"""Unit tests for `DELETE /admin/discogs/tombstone/{type}/{id}` (LML#510).
+
+These exercise the router-layer plumbing — auth, error mapping, L1
+eviction — against a mocked `DiscogsCacheService`. Integration coverage
+against a real PG (delete actually happens; next API call re-fetches)
+lives in `tests/integration/test_cache_service_tombstones.py` and
+`tests/integration/test_admin_tombstone_endpoint.py`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import Settings, get_settings
+from core.dependencies import get_discogs_cache_service_from_pool
+from routers.admin import router as admin_router
+
+ADMIN_TOKEN = "test-admin-token"
+
+
+@pytest.fixture
+def app_with_mocked_cache():
+    """Build an isolated FastAPI app with `admin_router` mounted and the
+    cache-service dependency overridden by a mock."""
+    app = FastAPI()
+    app.include_router(admin_router, prefix="/admin", tags=["admin"])
+
+    cache = AsyncMock()
+
+    def _override_cache():
+        return cache
+
+    app.dependency_overrides[get_discogs_cache_service_from_pool] = _override_cache
+
+    def _override_settings():
+        return Settings(admin_token=ADMIN_TOKEN, _env_file=None)
+
+    app.dependency_overrides[get_settings] = _override_settings
+
+    return app, cache
+
+
+@pytest_asyncio.fixture
+async def client(app_with_mocked_cache):
+    app, cache = app_with_mocked_cache
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac, cache
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_returns_401(client):
+    ac, _ = client
+    resp = await ac.delete("/admin/discogs/tombstone/release/42")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_token_returns_403(client):
+    ac, _ = client
+    resp = await ac.delete(
+        "/admin/discogs/tombstone/release/42",
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Response code mapping for the three cache_service outcomes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deleted_returns_200_with_body(client):
+    ac, cache = client
+    cache.delete_tombstone = AsyncMock(return_value="deleted")
+    with patch("routers.admin.evict_cached", return_value=True):
+        resp = await ac.delete(
+            "/admin/discogs/tombstone/release/42",
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"deleted": True, "id": 42, "type": "release"}
+    cache.delete_tombstone.assert_awaited_once_with("release", 42)
+
+
+@pytest.mark.asyncio
+async def test_exists_not_tombstone_returns_404_with_distinct_detail(client):
+    ac, cache = client
+    cache.delete_tombstone = AsyncMock(return_value="exists_not_tombstone")
+    resp = await ac.delete(
+        "/admin/discogs/tombstone/release/42",
+        headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+    )
+    assert resp.status_code == 404
+    body = resp.json()["detail"]
+    assert body["detail"] == "row exists but is not a tombstone"
+    assert body["id"] == 42
+    assert body["type"] == "release"
+
+
+@pytest.mark.asyncio
+async def test_not_found_returns_404_with_distinct_detail(client):
+    ac, cache = client
+    cache.delete_tombstone = AsyncMock(return_value="not_found")
+    resp = await ac.delete(
+        "/admin/discogs/tombstone/release/42",
+        headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+    )
+    assert resp.status_code == 404
+    body = resp.json()["detail"]
+    assert body["detail"] == "no row for this id"
+    assert body["id"] == 42
+    assert body["type"] == "release"
+
+
+@pytest.mark.asyncio
+async def test_unknown_entity_type_returns_422(client):
+    ac, _ = client
+    resp = await ac.delete(
+        "/admin/discogs/tombstone/widget/42",
+        headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+    )
+    # FastAPI Literal validation rejects unknown values with 422.
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# L1 eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deleted_release_evicts_l1_get_release(client):
+    """After deleting a tombstoned release, the L1 entry for
+    `DiscogsService.get_release` must be evicted so the next request
+    actually re-traverses L2/L3 rather than returning the cached `None`
+    from before the tombstone was cleared."""
+    ac, cache = client
+    cache.delete_tombstone = AsyncMock(return_value="deleted")
+    with patch("routers.admin.evict_cached", return_value=True) as evict:
+        await ac.delete(
+            "/admin/discogs/tombstone/release/42",
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+    # First positional arg is the decorated function we're evicting from.
+    assert evict.call_count == 1
+    args, _ = evict.call_args
+    from discogs.service import DiscogsService
+
+    assert args[0] is DiscogsService.get_release
+    assert args[1] == 42
+
+
+@pytest.mark.asyncio
+async def test_deleted_artist_evicts_l1_get_artist_details(client):
+    ac, cache = client
+    cache.delete_tombstone = AsyncMock(return_value="deleted")
+    with patch("routers.admin.evict_cached", return_value=True) as evict:
+        await ac.delete(
+            "/admin/discogs/tombstone/artist/42",
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+    args, _ = evict.call_args
+    from discogs.service import DiscogsService
+
+    assert args[0] is DiscogsService.get_artist_details
+
+
+@pytest.mark.asyncio
+async def test_l1_evict_failure_does_not_fail_request(client):
+    """If the L1 eviction surface raises (e.g. a future refactor breaks the
+    decorator metadata), the response stays 200 because the L2 delete
+    already succeeded. The TTL will close out the L1 stale entry."""
+    ac, cache = client
+    cache.delete_tombstone = AsyncMock(return_value="deleted")
+    with patch("routers.admin.evict_cached", side_effect=RuntimeError("boom")):
+        resp = await ac.delete(
+            "/admin/discogs/tombstone/release/42",
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cache_service_unavailable_returns_503(client):
+    """If the discogs cache pool isn't configured the dep yields None
+    and the route returns 503 — same posture as the other admin
+    endpoints that depend on cache services."""
+    ac, _ = client
+    app = ac._transport.app  # type: ignore[attr-defined]
+    app.dependency_overrides[get_discogs_cache_service_from_pool] = lambda: None
+    resp = await ac.delete(
+        "/admin/discogs/tombstone/release/42",
+        headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+    )
+    assert resp.status_code == 503

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -232,6 +232,7 @@ class TestGetRelease:
                 "artwork_url": "https://img.com/a.jpg",
                 "released": None,
                 "artwork_checked_at": None,
+                "not_found": False,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -268,6 +269,7 @@ class TestGetRelease:
                 "artwork_url": None,
                 "released": None,
                 "artwork_checked_at": None,
+                "not_found": False,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -299,6 +301,7 @@ class TestGetRelease:
                 "artwork_url": None,
                 "released": None,
                 "artwork_checked_at": None,
+                "not_found": False,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -350,6 +353,7 @@ class TestGetRelease:
                 "artwork_url": None,
                 "released": None,
                 "artwork_checked_at": None,
+                "not_found": False,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -381,6 +385,7 @@ class TestGetRelease:
                 "artwork_url": None,
                 "released": None,
                 "artwork_checked_at": None,
+                "not_found": False,
             }
         )
 
@@ -721,6 +726,7 @@ class TestGetReleaseEnriched:
                 "artwork_url": "https://img.com/a.jpg",
                 "released": "2001-04-30",
                 "artwork_checked_at": None,
+                "not_found": False,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -1086,6 +1092,7 @@ class TestGetArtistDetails:
                 "profile": "Electronic duo from Rochdale.",
                 "image_url": "https://i.discogs.com/autechre.jpg",
                 "fetched_at": datetime(2026, 1, 1, tzinfo=UTC),
+                "not_found": False,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(
@@ -1130,6 +1137,7 @@ class TestGetArtistDetails:
                 "profile": "Anglo-French band.",
                 "image_url": None,
                 "fetched_at": stamp,
+                "not_found": False,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(side_effect=make_fetch_router())
@@ -1156,6 +1164,7 @@ class TestGetArtistDetails:
                 "profile": None,
                 "image_url": None,
                 "fetched_at": None,
+                "not_found": False,
             }
         )
         mock_asyncpg_pool.fetch = AsyncMock(side_effect=make_fetch_router())

--- a/tests/unit/test_discogs_404_tombstone.py
+++ b/tests/unit/test_discogs_404_tombstone.py
@@ -1,0 +1,362 @@
+"""Tombstone-on-404 behavior for `DiscogsService.get_release` / `get_artist_details` (LML#510).
+
+The `_api_fetch` inner functions previously collapsed 404 to `None`; the
+fallthrough seam refused to write `None` to PG, so every caller re-asked
+Discogs on the next call for the same id and re-burned the rate-limit
+budget. This test module pins the new behavior:
+
+* `_api_fetch` discriminates 404 from other failures and returns a
+  tombstone-shaped model (`not_found = True`, identifier columns set to
+  empty-string sentinels).
+* The fallthrough seam writes the tombstone via the existing `pg_write`.
+* The public `DiscogsService.get_release` / `get_artist_details` translate
+  the tombstone back to `None` so callers' contract (`T | None`) is
+  preserved.
+* `CachedOnlyResolver` (in `discogs.markup_parser`) reads `cache_service`
+  directly and must also guard against the tombstone sentinel; otherwise
+  it renders an empty-string display name.
+* Telemetry: `record("release_404_tombstone_written")` /
+  `record("artist_404_tombstone_written")` on the write side;
+  `record("tombstone_returned")` on the read side;
+  `record("release_5xx_passthrough")` for non-tombstone Discogs outages
+  so the metric stays interpretable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from discogs.markup_parser import CachedOnlyResolver
+from discogs.models import ArtistDetails, ReleaseMetadataResponse
+from discogs.service import DiscogsService
+
+
+@pytest.fixture
+def service():
+    return DiscogsService(token="test-token")
+
+
+@pytest.fixture
+def service_with_cache():
+    cache_svc = AsyncMock()
+    return DiscogsService(token="test-token", cache_service=cache_svc)
+
+
+def _mock_response(status: int) -> MagicMock:
+    """Build a MagicMock httpx-Response-shaped object."""
+    resp = MagicMock()
+    resp.status_code = status
+    # raise_for_status mirrors httpx semantics: only 4xx / 5xx raise.
+    if status >= 400:
+
+        def _raise():
+            import httpx
+
+            req = MagicMock()
+            raise httpx.HTTPStatusError(
+                f"{status}", request=req, response=MagicMock(status_code=status)
+            )
+
+        resp.raise_for_status = _raise
+    else:
+        resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _api_fetch 404 discrimination
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseApiFetch404:
+    """The release `_api_fetch` inner function on a Discogs 404 response."""
+
+    @pytest.mark.asyncio
+    async def test_404_tombstone_no_cache_returns_none(self, service):
+        """Without a cache_service the public method returns `_api_fetch`'s
+        value directly. The boundary translation must run there too so
+        callers always see `None` for a tombstoned id."""
+        resp = _mock_response(404)
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=resp
+        ):
+            result = await service.get_release(999_999_999)
+        assert result is None, (
+            "Public `get_release` must return None on a 404 even when "
+            "cache_service is None (the no-cache early-return path also "
+            "needs the tombstone→None translation)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_404_records_write_counter(self, service):
+        """`record('release_404_tombstone_written')` fires at the
+        discrimination point so we can observe tombstone-write volume in
+        cache_stats."""
+        recorder = MagicMock()
+        resp = _mock_response(404)
+        with (
+            patch.object(service, "_request_with_retry", new_callable=AsyncMock, return_value=resp),
+            patch("discogs.service.get_cache_stats_recorder", return_value=recorder),
+        ):
+            await service.get_release(999_999_999)
+        recorder.record.assert_any_call("release_404_tombstone_written")
+
+    @pytest.mark.asyncio
+    async def test_5xx_records_passthrough_counter(self, service):
+        """5xx is a transient outage, not a tombstone. The passthrough
+        counter keeps Discogs-outage signal legible separately from
+        tombstone activity."""
+        recorder = MagicMock()
+        resp = _mock_response(503)
+        with (
+            patch.object(service, "_request_with_retry", new_callable=AsyncMock, return_value=resp),
+            patch("discogs.service.get_cache_stats_recorder", return_value=recorder),
+        ):
+            result = await service.get_release(123)
+        assert result is None, "5xx must not produce a tombstone."
+        recorder.record.assert_any_call("release_5xx_passthrough")
+
+    @pytest.mark.asyncio
+    async def test_5xx_does_not_record_tombstone_counter(self, service):
+        """Critical: a 5xx must not poison the cache with a false tombstone."""
+        recorder = MagicMock()
+        resp = _mock_response(500)
+        with (
+            patch.object(service, "_request_with_retry", new_callable=AsyncMock, return_value=resp),
+            patch("discogs.service.get_cache_stats_recorder", return_value=recorder),
+        ):
+            await service.get_release(123)
+        for call in recorder.record.call_args_list:
+            assert call.args[0] != "release_404_tombstone_written", (
+                "5xx must not record release_404_tombstone_written — the "
+                "tombstone counter is reserved for actual 404s."
+            )
+
+    @pytest.mark.asyncio
+    async def test_request_error_returns_none_no_tombstone(self, service):
+        """When `_request_with_retry` returns None (network failure, rate
+        limit exhaustion), no tombstone is written and no counter fires."""
+        recorder = MagicMock()
+        with (
+            patch.object(service, "_request_with_retry", new_callable=AsyncMock, return_value=None),
+            patch("discogs.service.get_cache_stats_recorder", return_value=recorder),
+        ):
+            result = await service.get_release(123)
+        assert result is None
+        for call in recorder.record.call_args_list:
+            assert call.args[0] != "release_404_tombstone_written"
+
+
+class TestArtistApiFetch404:
+    """Parallel tests for `get_artist_details`."""
+
+    @pytest.mark.asyncio
+    async def test_404_no_cache_returns_none(self, service):
+        resp = _mock_response(404)
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=resp
+        ):
+            result = await service.get_artist_details(999_999_999)
+        assert result is None, (
+            "Public `get_artist_details` must return None on 404, even on "
+            "the no-cache early-return path."
+        )
+
+    @pytest.mark.asyncio
+    async def test_404_records_write_counter(self, service):
+        recorder = MagicMock()
+        resp = _mock_response(404)
+        with (
+            patch.object(service, "_request_with_retry", new_callable=AsyncMock, return_value=resp),
+            patch("discogs.service.get_cache_stats_recorder", return_value=recorder),
+        ):
+            await service.get_artist_details(999_999_999)
+        recorder.record.assert_any_call("artist_404_tombstone_written")
+
+    @pytest.mark.asyncio
+    async def test_log_level_error_not_warning(self, service, caplog):
+        """The artist bare-except path was previously `logger.warning`,
+        masking artist 404s from Sentry's default `error+` filter. Per the
+        issue's observability gap finding, the artist log must be promoted
+        to `logger.error` so the tombstone write counter has a Sentry
+        corroboration surface."""
+        # Simulate the unhandled-error path (not the 404 path, which now
+        # handles 404 without raising). A non-404 4xx is the easiest probe.
+        resp = _mock_response(418)
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=resp
+        ):
+            import logging
+
+            with caplog.at_level(logging.WARNING, logger="discogs.service"):
+                await service.get_artist_details(123)
+        error_messages = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("artist" in r.message.lower() for r in error_messages), (
+            "Artist failure path must log at ERROR level (was WARNING per "
+            "Sentry observability gap finding in LML#510)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Boundary translation: public method translates `not_found` → None
+# ---------------------------------------------------------------------------
+
+
+class TestReleasePublicBoundary:
+    """The public `DiscogsService.get_release` translates tombstones back
+    to `None` regardless of which leg (PG or API) produced them."""
+
+    @pytest.mark.asyncio
+    async def test_pg_tombstone_returns_none(self, service_with_cache):
+        """When PG returns a tombstone-shaped row, the public method must
+        translate to None so callers' `T | None` contract is preserved."""
+        tombstone = ReleaseMetadataResponse(
+            release_id=42,
+            title="",
+            artist="",
+            release_url="https://www.discogs.com/release/42",
+            not_found=True,
+            artwork_checked_at=datetime.now(UTC),
+        )
+        service_with_cache.cache_service.get_release = AsyncMock(return_value=tombstone)
+        service_with_cache.cache_service.write_release = AsyncMock()
+
+        # API leg should never run because the PG hit is_pg_hit=True (the
+        # tombstone has artwork_checked_at set).
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_request:
+            result = await service_with_cache.get_release(42)
+
+        assert result is None
+        mock_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pg_tombstone_records_returned_counter(self, service_with_cache):
+        """Read-side telemetry: `record('tombstone_returned')` fires when
+        a tombstone is observed at the public boundary so the
+        `pg_cache_hit - tombstone_returned` dashboard math stays correct."""
+        tombstone = ReleaseMetadataResponse(
+            release_id=42,
+            title="",
+            artist="",
+            release_url="https://www.discogs.com/release/42",
+            not_found=True,
+            artwork_checked_at=datetime.now(UTC),
+        )
+        service_with_cache.cache_service.get_release = AsyncMock(return_value=tombstone)
+        service_with_cache.cache_service.write_release = AsyncMock()
+
+        recorder = MagicMock()
+        with patch("discogs.service.get_cache_stats_recorder", return_value=recorder):
+            await service_with_cache.get_release(42)
+        recorder.record.assert_any_call("tombstone_returned")
+
+
+class TestArtistPublicBoundary:
+    @pytest.mark.asyncio
+    async def test_pg_tombstone_returns_none(self, service_with_cache):
+        tombstone = ArtistDetails(
+            artist_id=42,
+            name="",
+            not_found=True,
+            fetched_at=datetime.now(UTC),
+        )
+        service_with_cache.cache_service.get_artist_details = AsyncMock(return_value=tombstone)
+        service_with_cache.cache_service.write_artist_details = AsyncMock()
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_request:
+            result = await service_with_cache.get_artist_details(42)
+
+        assert result is None
+        mock_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pg_tombstone_records_returned_counter(self, service_with_cache):
+        tombstone = ArtistDetails(
+            artist_id=42,
+            name="",
+            not_found=True,
+            fetched_at=datetime.now(UTC),
+        )
+        service_with_cache.cache_service.get_artist_details = AsyncMock(return_value=tombstone)
+        service_with_cache.cache_service.write_artist_details = AsyncMock()
+
+        recorder = MagicMock()
+        with patch("discogs.service.get_cache_stats_recorder", return_value=recorder):
+            await service_with_cache.get_artist_details(42)
+        recorder.record.assert_any_call("tombstone_returned")
+
+
+# ---------------------------------------------------------------------------
+# CachedOnlyResolver boundary: read cache_service directly, guard on tombstone
+# ---------------------------------------------------------------------------
+
+
+class TestCachedOnlyResolverGuards:
+    """`CachedOnlyResolver` bypasses `DiscogsService` and reads
+    `cache_service` directly. After the cache-service short-circuit
+    returns the tombstone shape with `name = ""` / `title = ""`,
+    `resolve_artist` / `resolve_release` would return `""` instead of
+    `None`, causing the markup parser to render an `artistLink` token
+    with `display_name=""`. The resolver must guard."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_artist_returns_none_for_tombstone(self):
+        cache = AsyncMock()
+        cache.get_artist_details = AsyncMock(
+            return_value=ArtistDetails(
+                artist_id=42,
+                name="",
+                not_found=True,
+                fetched_at=datetime.now(UTC),
+            )
+        )
+        resolver = CachedOnlyResolver(cache)
+        result = await resolver.resolve_artist(42)
+        assert result is None, (
+            "Tombstone with name='' must translate to None at this layer; "
+            "otherwise the markup parser emits a token with display_name=''."
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_release_returns_none_for_tombstone(self):
+        cache = AsyncMock()
+        cache.get_release = AsyncMock(
+            return_value=ReleaseMetadataResponse(
+                release_id=42,
+                title="",
+                artist="",
+                release_url="https://www.discogs.com/release/42",
+                not_found=True,
+                artwork_checked_at=datetime.now(UTC),
+            )
+        )
+        resolver = CachedOnlyResolver(cache)
+        result = await resolver.resolve_release(42)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_artist_returns_name_for_real_row(self):
+        """Counter-test: a real artist row still resolves to its name."""
+        cache = AsyncMock()
+        cache.get_artist_details = AsyncMock(
+            return_value=ArtistDetails(
+                artist_id=42,
+                name="Stereolab",
+                not_found=False,
+                fetched_at=datetime.now(UTC),
+            )
+        )
+        resolver = CachedOnlyResolver(cache)
+        result = await resolver.resolve_artist(42)
+        assert result == "Stereolab"


### PR DESCRIPTION
## Summary

- `_api_fetch` in `DiscogsService.get_release` / `get_artist_details` discriminates 404 from other failures and returns a tombstone-shaped model (`not_found = True`, `title=""` / `name=""` as identifier sentinels) instead of falling into the bare `except`. The existing fallthrough seam writes the tombstone via the same `pg_write` it already uses.
- Subsequent reads short-circuit on `not_found = TRUE` at the `cache_service` layer (no child-table `asyncio.gather` round-trips for a tombstoned id). The public `DiscogsService` methods translate the tombstone back to `None` so callers' `T | None` contract is unchanged.
- New tombstone-write branch in `write_release` / `write_artist_details` preserves the parent's identifier columns and the entire child cascade (the `ON CONFLICT DO UPDATE SET` clause omits identifier columns; the early `return` skips the child `DELETE+INSERT` cascade), so a 404 after a 200 doesn't wipe rich catalog metadata. Symmetric: the hydrated-write branch adds `not_found = FALSE` to its UPDATE SET so a recovered 200 clears any prior tombstone in one statement.
- `DELETE /admin/discogs/tombstone/{type}/{id}` recovery endpoint for incident-driven false tombstones. `AND not_found = TRUE` guard at the SQL level means a real row can never be deleted through this surface. Three response codes (`deleted` / `exists_not_tombstone` / `not_found`) so an on-call recovery script can branch without parsing logs. Auth via `ADMIN_TOKEN` (distinct from `LML_API_KEY` — so routine callers don't gain incident-grade write access). Cross-referenced from `?refresh=true`'s description so operators discover the right primitive.
- `CachedOnlyResolver` (in `discogs/markup_parser.py`) reads `cache_service` directly and gets explicit `if details is None or details.not_found: return None` guards — without these, the markup parser would render `artistLink` tokens with `display_name=""` for any tombstoned id.
- `discogs/service.py` logger promotion (`warning` → `error`) on the artist bare-except path: Sentry's default `error+` filter previously masked artist 404s (90-day Sentry scrub showed zero artist 404 events). The new `artist_404_tombstone_written` counter gets a Sentry corroboration surface post-deploy.

## Telemetry

- `release_404_tombstone_written` / `artist_404_tombstone_written` — write-side, at the 404 discrimination point.
- `tombstone_returned` — read-side, at the boundary translation. `pg_cache_hit - tombstone_returned` is the real-data hit rate.
- `release_5xx_passthrough` — splits Discogs-outage signal from tombstone activity, ships in this PR per the Sentry 90d scrub (5% of `get_release` bare-except hits are 5xx, currently lumped).

All flat (no tag dimensions) per the existing `record(key)` precedent (`pg_negative_hits` is the existing example).

## Cross-repo coordination

Sequenced after:
1. WXYC/discogs-etl#277 — alembic migration adding `release.not_found` + `artist.not_found` with `DEFAULT FALSE` (backward-compatible with prod LML running pre-510 code) plus the rebuild + dedup-swap + prune-swap path updates so a tombstoned id can't survive a pipeline refresh.
2. WXYC/wxyc-shared#174 — adds `not_found` to `DiscogsReleaseMetadata` in 1.12.0. `ArtistDetails` is LML-local (per the `discogs/models.py:137` comment) so the artist side grows the field directly in this repo without an api.yaml change.

LML PR pins the new wxyc-shared release, runs `scripts/generate_api_models.sh`, then consumes the new column.

Sequenced after #518 / #519 (release_id=0 sentinel guard at the orchestrator) so this PR's tombstoning doesn't mask the orchestrator bug; that PR is in main as of `3b45379`, this PR rebases onto it cleanly.

## Why this shape (vs. an alternative)

This is the third instance of the same discriminator-column shape — `release.artwork_checked_at` (WXYC#414), `artist.fetched_at` (#503), now `not_found` on both. The codebase has converged on "ambiguity resolved by a state column on the existing row" twice in 90 days; doing it a third time deepens the pattern rather than introducing a parallel `negative_*` table + 4 fallthrough hooks at every call site (~250 LOC alternative the issue's first revision proposed and the reframe rejected).

A sentinel encoded as `name = ""` would leak empty `ArtistDetails` into `get_artist_details_bulk` with no way to distinguish from a real empty-aliased artist. An explicit `not_found` column keeps the bulk path's behavior unambiguous (it still returns tombstones as empty-fields parallel to #503's stub policy, but the policy is now explicit at the schema level).

The seam's `pg_negative_check` / `pg_negative_record` quadrant exists for *search* negatives (where the empty answer is structurally different from the positive answer). For a single-entity 404, `None` IS the negative answer; routing it through a state column on the existing row is the right level.

## Deferred (with reasons)

- `get_master` / `get_label` (`discogs/service.py:992`, `:969`) have the same `_api_fetch`-collapses-404-to-None shape but no PG cache backing — no schema to land tombstones in. Reconsider when either method grows a cache leg or shows up in a tight-loop caller. Documented in the `fallthrough.py:24-25` policy table comment as the design constraint.
- TTL on negatives — admin endpoint covers the incident-driven false-tombstone case; reconsider if telemetry shows sustained churn.
- L1 caching `None` for tombstoned ids — every tombstone hit still pays one PG round-trip (the main win vs. status quo, but not a "free" L1 hit); relax `@async_cached`'s `None`-skip if `pg_cache_hit - tombstone_returned` traces show the PG round-trip cost is material.

## Test plan

- [x] 15 unit tests in `tests/unit/test_discogs_404_tombstone.py`: 404 discrimination, telemetry counters, 5xx passthrough no-tombstone, log level promoted to error, public boundary translation, CachedOnlyResolver guards.
- [x] 10 unit tests in `tests/unit/test_admin_tombstone_router.py`: auth, three-way response code mapping, L1 eviction, 503 on missing pool, 422 on unknown entity type.
- [x] 14 PG integration tests in `tests/integration/test_cache_service_tombstones.py`: read-path short-circuit on `not_found = TRUE`, hydrated-parent identifier preservation across tombstone overwrite, child-cascade preservation, recovery on 200 (in both directions), bulk-path returns tombstones as empty-fields per #503's stub policy, admin DELETE three-outcome behavior.
- [x] Existing `tests/unit/test_cache_service.py` updated for the new SELECT projection — all 71 still green.
- [x] `ruff check` + `ruff format --check` clean across all touched files.
- [x] Full LML unit sweep: 2248 passed (the one flaky `Event loop is closed` error is unrelated, passes in isolation).
- [ ] Staging integration tests pass once discogs-etl migration is live in staging PG (this PR's integration tests need the column live).

Closes #510.