### PR TITLE
fix(discogs): project fetched_at in get_artist_details_bulk SELECT

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -1145,7 +1145,14 @@ class DiscogsCacheService:
                 member_rows,
             ) = await asyncio.gather(
                 self.pool.fetch(
-                    "SELECT id, name, profile, image_url FROM artist WHERE id = ANY($1::int[])",
+                    # `fetched_at` is projected so the bulk path can carry
+                    # the LML#503 stub-vs-hydrated discriminator on the
+                    # returned `ArtistDetails`, matching the singular
+                    # `get_artist_details` shape. Bulk stays cache-only
+                    # by design (LML#520) — this is information-level
+                    # parity, not an API-escalation change.
+                    "SELECT id, name, profile, image_url, fetched_at "
+                    "FROM artist WHERE id = ANY($1::int[])",
                     artist_ids,
                 ),
                 self.pool.fetch(
@@ -1197,6 +1204,7 @@ class DiscogsCacheService:
                     name_variations=nvs_by_id.get(artist_id, []),
                     members=members_by_id.get(artist_id, []),
                     urls=[],
+                    fetched_at=row["fetched_at"],
                     cached=True,
                 )
             return result

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -1149,7 +1149,7 @@ class DiscogsCacheService:
                     # the LML#503 stub-vs-hydrated discriminator on the
                     # returned `ArtistDetails`, matching the singular
                     # `get_artist_details` shape. Bulk stays cache-only
-                    # by design (LML#520) — this is information-level
+                    # by design (LML#503) — this is information-level
                     # parity, not an API-escalation change.
                     "SELECT id, name, profile, image_url, fetched_at "
                     "FROM artist WHERE id = ANY($1::int[])",

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -383,3 +383,61 @@ class TestSearchAliasesBulkEndpoint:
                 "discogs_alias",
                 "discogs_member",
             }
+
+
+@pytest.mark.pg
+class TestGetArtistDetailsBulkFetchedAt:
+    """LML#520: the bulk cache read must surface ``fetched_at`` faithfully.
+
+    The singular-path ``get_artist_details`` already projects ``fetched_at``
+    so the LML#503 stub-vs-hydrated discriminator works. The bulk path
+    did not, so every ``ArtistDetails`` came back with ``fetched_at = None``
+    regardless of the row's actual state. This suite pins both halves of
+    the contract through the real PG fixture.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stub_row_returns_null_fetched_at(self, pg_pool):
+        """A row inserted without ``fetched_at`` (monthly rebuild stub) reads
+        back through ``get_artist_details_bulk`` with ``fetched_at = None``.
+        """
+        from discogs.cache_service import DiscogsCacheService
+
+        # `set_up_schemas` already seeds 2154 (Stereolab) with NULL `fetched_at`
+        # — the INSERT specifies only id, name, profile, image_url.
+        cache = DiscogsCacheService(pg_pool)
+        bundle = await cache.get_artist_details_bulk([2154])
+
+        assert 2154 in bundle
+        assert bundle[2154].fetched_at is None
+
+    @pytest.mark.asyncio
+    async def test_hydrated_row_returns_non_null_fetched_at(self, pg_pool):
+        """A row with ``fetched_at = now()`` reads back through
+        ``get_artist_details_bulk`` carrying that stamp."""
+        from discogs.cache_service import DiscogsCacheService
+
+        async with pg_pool.acquire() as conn:
+            await conn.execute("UPDATE artist SET fetched_at = now() WHERE id = 305253")
+
+        cache = DiscogsCacheService(pg_pool)
+        bundle = await cache.get_artist_details_bulk([305253])
+
+        assert 305253 in bundle
+        assert bundle[305253].fetched_at is not None
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_preserves_per_row_fetched_at(self, pg_pool):
+        """In a single batch, a stub and a hydrated row each reflect their
+        own ``fetched_at`` state. The discriminator is per-row, not global."""
+        from discogs.cache_service import DiscogsCacheService
+
+        async with pg_pool.acquire() as conn:
+            # 2154 stays a stub (NULL). 305253 becomes hydrated.
+            await conn.execute("UPDATE artist SET fetched_at = now() WHERE id = 305253")
+
+        cache = DiscogsCacheService(pg_pool)
+        bundle = await cache.get_artist_details_bulk([2154, 305253])
+
+        assert bundle[2154].fetched_at is None
+        assert bundle[305253].fetched_at is not None

--- a/tests/unit/test_discogs_cache_get_artist_details_bulk.py
+++ b/tests/unit/test_discogs_cache_get_artist_details_bulk.py
@@ -18,6 +18,7 @@ Contract:
 
 from __future__ import annotations
 
+from datetime import UTC
 from unittest.mock import AsyncMock
 
 import pytest
@@ -66,8 +67,20 @@ class TestGetArtistDetailsBulk:
             side_effect=_make_table_router(
                 **{
                     "FROM artist ": [
-                        {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
-                        {"id": 305253, "name": "Juana Molina", "profile": None, "image_url": None},
+                        {
+                            "id": 2154,
+                            "name": "Stereolab",
+                            "profile": None,
+                            "image_url": None,
+                            "fetched_at": None,
+                        },
+                        {
+                            "id": 305253,
+                            "name": "Juana Molina",
+                            "profile": None,
+                            "image_url": None,
+                            "fetched_at": None,
+                        },
                     ],
                     "artist_alias": [
                         {"artist_id": 2154, "alias_id": 500, "alias_name": "Stereolab Variant"},
@@ -99,7 +112,13 @@ class TestGetArtistDetailsBulk:
             side_effect=_make_table_router(
                 **{
                     "FROM artist ": [
-                        {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
+                        {
+                            "id": 2154,
+                            "name": "Stereolab",
+                            "profile": None,
+                            "image_url": None,
+                            "fetched_at": None,
+                        },
                     ],
                     "artist_alias": [],
                     "artist_name_variation": [],
@@ -139,8 +158,20 @@ class TestGetArtistDetailsBulk:
     ):
         """Same ids in different orders → same dict (set equality + identical values)."""
         artist_rows = [
-            {"id": 2154, "name": "Stereolab", "profile": None, "image_url": None},
-            {"id": 305253, "name": "Juana Molina", "profile": None, "image_url": None},
+            {
+                "id": 2154,
+                "name": "Stereolab",
+                "profile": None,
+                "image_url": None,
+                "fetched_at": None,
+            },
+            {
+                "id": 305253,
+                "name": "Juana Molina",
+                "profile": None,
+                "image_url": None,
+                "fetched_at": None,
+            },
         ]
         mock_asyncpg_pool.fetch = AsyncMock(
             side_effect=_make_table_router(
@@ -188,3 +219,68 @@ class TestGetArtistDetailsBulk:
             bound = call[0][1]
             assert isinstance(bound, list)
             assert set(bound) == {2154, 305253}
+
+    @pytest.mark.asyncio
+    async def test_artist_select_projects_fetched_at(self, cache_service, mock_asyncpg_pool):
+        """LML#520: the bulk artist SELECT must project ``fetched_at``.
+
+        Without this projection the bulk constructor leaves
+        ``ArtistDetails.fetched_at`` at its default ``None``, so every
+        result reads as a stub regardless of the underlying row state —
+        a foot-gun for the LML#503 stub-vs-hydrated discriminator.
+        Mirrors the singular-path
+        ``test_projects_fetched_at_for_stub_discrimination``.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.get_artist_details_bulk([2154])
+
+        all_sql = [call[0][0] for call in mock_asyncpg_pool.fetch.await_args_list]
+        artist_sql = next(sql for sql in all_sql if "FROM artist " in sql)
+        assert "fetched_at" in artist_sql, (
+            f"get_artist_details_bulk artist SELECT must project fetched_at; got: {artist_sql!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_passes_fetched_at_through_to_artist_details(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """LML#520: the row's ``fetched_at`` reaches the returned
+        ``ArtistDetails``. Stub row → ``None``; hydrated row → the stamp.
+
+        Pins the wiring between SELECT projection and constructor — a
+        SELECT that projects ``fetched_at`` but a constructor that
+        forgets to pass it through is the same bug from a caller's
+        perspective.
+        """
+        from datetime import datetime
+
+        stamp = datetime(2026, 1, 1, tzinfo=UTC)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=_make_table_router(
+                **{
+                    "FROM artist ": [
+                        {
+                            "id": 2154,
+                            "name": "Stereolab",
+                            "profile": None,
+                            "image_url": None,
+                            "fetched_at": stamp,
+                        },
+                        {
+                            "id": 6998498,
+                            "name": "Yetsuby",
+                            "profile": None,
+                            "image_url": None,
+                            "fetched_at": None,
+                        },
+                    ],
+                    "artist_alias": [],
+                    "artist_name_variation": [],
+                    "artist_member": [],
+                }
+            )
+        )
+
+        result = await cache_service.get_artist_details_bulk([2154, 6998498])
+        assert result[2154].fetched_at == stamp
+        assert result[6998498].fetched_at is None


### PR DESCRIPTION
## Summary

- Extend the bulk artist `SELECT` in `discogs/cache_service.py` to project `fetched_at`, and pass it through the `ArtistDetails(...)` constructor.
- Add a unit test that pins the projection on the mocked SQL and asserts the stamp reaches the returned `ArtistDetails` (stub → `None`, hydrated → the stamp).
- Add three integration tests that exercise the contract through the real PG fixture: stub-only, hydrated-only, mixed batch.

The bulk path previously returned `fetched_at = None` on every row regardless of the underlying PG state, so any caller using the LML#503 stub-vs-hydrated discriminator off `ArtistDetails.fetched_at` would treat every bulk-returned row as a stub.

Today's only consumer (`artists/composer.py`, the artist-search-aliases endpoint) does not read `fetched_at`, so the regression is silent — but the fix lands before a future "refresh stubs in bulk" caller hits a 100% false-positive rate, and unblocks #511's bulk-stub-semantics tests.

The unit test lives in `tests/unit/test_discogs_cache_get_artist_details_bulk.py` (the dedicated bulk-test file) rather than `tests/unit/test_cache_service.py` (where the singular-path test lives), to stay consistent with the codebase's per-method test-file layout.

## Non-goals

- Not changing bulk's API-escalation behavior — bulk stays cache-only (LML#503's deliberate position). Information-level parity only.
- Not filtering stubs from the bulk result dict — that remains a service-layer judgment.

## Test plan

- [ ] CI: lint (`ruff check`), format check, mypy, default tests (`pytest -m "not pg and not external_api"`), PG tests (`pytest -m pg`).
- [ ] Local: `pytest tests/unit/test_discogs_cache_get_artist_details_bulk.py` — 9/9 pass.
- [ ] Local: `pytest -m pg tests/integration/test_search_aliases_bulk.py tests/integration/test_cache_service_tombstones.py` — 24/24 pass.

Closes #520