### PR TITLE
chore(deploy): unbuffer Python stdout for real-time Railway logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,11 @@ COPY . .
 # Create logs and data directories
 RUN mkdir -p /app/logs /data && chown -R appuser:appuser /app/logs /data
 
+# Unbuffer Python stdout/stderr so logs reach Railway's collector in real time
+# (otherwise the StreamHandler in core/logging.py is block-buffered on the pipe).
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Expose port
 EXPOSE 8000
 


### PR DESCRIPTION
Closes #532

## Summary

- Set `ENV PYTHONUNBUFFERED=1` in the production `Dockerfile` so the `StreamHandler(sys.stdout)` in `core/logging.py` flushes per-record instead of block-buffering (~8 KB) on Railway's non-TTY stdout pipe.
- Set `ENV PYTHONDONTWRITEBYTECODE=1` alongside it — standard container hygiene; keeps `.pyc` files out of the image layer.
- No application code touched: `entrypoint.sh`, `main.py`, and `core/logging.py` are unchanged.

## Why

Production logs were arriving in Railway about 10 minutes after the Python `emit()` timestamp embedded in each record. The cause was plain stdout block-buffering — once stdout is a pipe (Railway's collector, not a TTY), Python defaults to block-buffered mode, and at our log volume the buffer takes minutes to fill. This made production debugging effectively blind and was one of the reasons earlier passes on the broader LML latency regression failed to make progress.

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `docker buildx build --check -f Dockerfile .` passes (no warnings)
- [ ] After merge and deploy to production, confirm Railway log timestamps align with the embedded record timestamps (within seconds, not minutes).

Production deploy is the canonical validation for an env-var change of this shape — there is no meaningful unit test to write for a Dockerfile `ENV` directive.