### PR TITLE
perf(search): parallelize SONG_AS_TRACK validate loop

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -112,6 +112,28 @@ refs each still leave headroom for the read path.
 _warm_cache_semaphore: asyncio.Semaphore | None = None
 """Lazily-constructed (needs a running event loop). Re-bind on the first call."""
 
+_SONG_AS_TRACK_VALIDATE_CONCURRENCY: int = 5
+"""Per-request cap on concurrent ``validate_track_on_release`` calls inside
+``search_song_as_track``.
+
+The original SONG_AS_TRACK loop (commit ``2c913da``) awaited
+``validate_track_on_release`` once per Discogs candidate serially. With ~7
+candidates per lookup at ~1.2s each, that's an 8-10s serial chain on the
+``/api/v1/lookup`` p95/p99 hot path — the dominant slow path identified in
+the early-May regression review. Compounding: when the PG cache write path
+is degraded (Sentry LIBRARY-METADATA-LOOKUP-9), most validate calls fall
+through to the live Discogs API, amplifying the cost further.
+
+Sized to match the global Discogs semaphore in ``discogs/service.py``
+(``get_semaphore()`` returns a 5-permit semaphore — see
+``_request_with_retry``'s comment at line 377). The orchestrator-local
+semaphore here gates *fan-out per request*; the global rate limiter +
+semaphore in ``discogs/service.py`` sits underneath and gates *cross-request
+total load*. The two are compatible: a single request fans out up to 5
+validate tasks; the global limiter then serializes their underlying HTTP
+calls when concurrent requests stack up.
+"""
+
 _ProbeResult = TrackReleasesResponse | tuple[TrackReleasesResponse | None, str | None]
 """Heterogeneous return type for the gathered probes in ``search_compilations_for_track``.
 
@@ -903,19 +925,31 @@ async def search_song_as_track(
     matched_items: list[LibraryItem] = []
     matched_via_by_id: dict[int, list[TrackMatchHint]] = {}
 
-    for release in raw_releases:
+    # Bound per-request fan-out. The global Discogs rate limiter sits
+    # underneath this semaphore — see _SONG_AS_TRACK_VALIDATE_CONCURRENCY.
+    semaphore = asyncio.Semaphore(_SONG_AS_TRACK_VALIDATE_CONCURRENCY)
+
+    async def _validate_one(release: ReleaseInfo) -> list[LibraryItem] | None:
+        """Library-match + validate one Discogs release.
+
+        Returns the list of eligible library rows for this release when the
+        track is validated on it, or None when the release should be dropped
+        (too-short album title, no library hits, no eligible rows, or
+        validation rejected). Order-preserving dedup happens in the caller's
+        post-gather walk; this helper is order-agnostic.
+        """
         if not release.album or len(release.album.strip()) < 3:
-            continue
+            return None
 
         matches = await search_album_fuzzy(db, release.album)
         if not matches and release.is_compilation:
             matches = await search_album_fuzzy(db, f"Various {release.album}")
         if not matches:
-            continue
+            return None
 
         eligible = [m for m in matches if _release_matches_library_row(release, m)]
         if not eligible:
-            continue
+            return None
 
         # Validate the track actually appears on this release before surfacing
         # — Discogs's release-search index is keyword-driven and returns hits
@@ -923,23 +957,40 @@ async def search_song_as_track(
         # after library matching so we only pay the API cost for releases we'd
         # actually return, mirroring search_compilations_for_track.
         if release.release_id:
-            _validation_start = time.monotonic()
-            is_valid = await discogs_service.validate_track_on_release(
-                release.release_id, song, release.artist
-            )
-            _log_track_validation(
-                source="song_as_track",
-                release_id=release.release_id,
-                song=song,
-                artist=release.artist,
-                verdict=is_valid,
-                latency_ms=(time.monotonic() - _validation_start) * 1000,
-            )
+            async with semaphore:
+                _validation_start = time.monotonic()
+                is_valid = await discogs_service.validate_track_on_release(
+                    release.release_id, song, release.artist
+                )
+                _log_track_validation(
+                    source="song_as_track",
+                    release_id=release.release_id,
+                    song=song,
+                    artist=release.artist,
+                    verdict=is_valid,
+                    latency_ms=(time.monotonic() - _validation_start) * 1000,
+                )
             if not is_valid:
                 logger.debug(
                     f"SONG_AS_TRACK: skipping '{release.album}' — track not validated on release"
                 )
-                continue
+                return None
+
+        return eligible
+
+    # Fan out per-release library-match + validation. Order preservation comes
+    # from the post-gather walk below, NOT from gather's completion order —
+    # ``asyncio.gather(..., return_exceptions=False)`` does preserve the input
+    # order of *results*, but accumulating into ``matched_items`` /
+    # ``matched_via_by_id`` in input-index order is what guarantees that a
+    # later release's hint never gets recorded before an earlier release's.
+    per_release_eligible = await asyncio.gather(
+        *[_validate_one(release) for release in raw_releases]
+    )
+
+    for release, eligible in zip(raw_releases, per_release_eligible, strict=True):
+        if eligible is None:
+            continue
 
         for item in eligible:
             hint = TrackMatchHint(

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1916,6 +1916,299 @@ class TestSearchSongAsTrack:
         queries = [call.kwargs["query"] for call in db.search.await_args_list]
         assert any(q.startswith("Various ") for q in queries)
 
+    @pytest.mark.asyncio
+    async def test_validate_track_calls_run_concurrently(self):
+        """The per-release validate_track_on_release calls must run concurrently.
+
+        Early-May regression: the original SONG_AS_TRACK loop awaited
+        ``validate_track_on_release`` per release serially. With ~7 candidates
+        per lookup at ~1.2s each, that's an 8-10s serial chain on the
+        ``/api/v1/lookup`` p95/p99 hot path. This test pins the parallelization:
+        with 5 candidates each sleeping 200ms, the wall time must be much closer
+        to 200ms than to 1000ms (5 * 200ms).
+        """
+        import asyncio as _asyncio
+        import time as _time
+
+        db = AsyncMock()
+        releases = [
+            DiscogsReleaseInfo(
+                album=f"Album {i}",
+                artist=f"Artist {i}",
+                release_id=1000 + i,
+                release_url=f"https://discogs.com/release/{1000 + i}",
+                is_compilation=False,
+            )
+            for i in range(5)
+        ]
+        # All library rows must match all releases (per the
+        # release_matches_library_row predicate's artist prefix match) so the
+        # validate step actually fires for every release.
+        items = [
+            make_library_item(id=2000 + i, artist=f"Artist {i}", title=f"Album {i}")
+            for i in range(5)
+        ]
+
+        async def search_side_effect(query, **kwargs):
+            # Library FTS returns the row whose title matches the album query.
+            for item in items:
+                if (item.title or "").lower() == query.lower():
+                    return [item]
+            return []
+
+        db.search.side_effect = search_side_effect
+
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="t", releases=releases, total=len(releases)
+        )
+
+        async def slow_validate(release_id, track, artist):
+            await _asyncio.sleep(0.2)
+            return True
+
+        svc.validate_track_on_release.side_effect = slow_validate
+
+        start = _time.perf_counter()
+        results, _matched_via = await search_song_as_track(db, "t", discogs_service=svc)
+        elapsed = _time.perf_counter() - start
+
+        # Serial would be ~1.0s; concurrent should be ~0.2s. The 0.5s ceiling
+        # gives headroom for scheduler jitter while still catching a serial
+        # regression with comfortable margin.
+        assert elapsed < 0.5, (
+            f"validate_track_on_release calls ran serially "
+            f"(elapsed={elapsed:.3f}s, expected near 0.2s)"
+        )
+        # All releases validated true, so all rows surface (capped at MAX_SEARCH_RESULTS).
+        assert len(results) >= 1
+
+    @pytest.mark.asyncio
+    async def test_output_order_follows_input_not_completion(self):
+        """Output ``matched_items`` order must follow input order, not completion order.
+
+        Discogs returns its release-search candidates pre-sorted by relevance,
+        so the surfaced library rows must preserve that relevance ranking even
+        when the underlying validate calls finish out-of-order. With releases
+        A (slow validate, valid), B (fast validate, invalid), C (medium
+        validate, valid), the output must be [A_row, C_row] — not [C_row]
+        alone, not [C_row, A_row].
+        """
+        import asyncio as _asyncio
+
+        item_a = make_library_item(id=101, artist="Artist A", title="Album A")
+        item_c = make_library_item(id=103, artist="Artist C", title="Album C")
+        item_b = make_library_item(id=102, artist="Artist B", title="Album B")
+
+        db = AsyncMock()
+
+        async def search_side_effect(query, **kwargs):
+            q = query.lower()
+            if "album a" in q:
+                return [item_a]
+            if "album b" in q:
+                return [item_b]
+            if "album c" in q:
+                return [item_c]
+            return []
+
+        db.search.side_effect = search_side_effect
+
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="t",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Album A",
+                    artist="Artist A",
+                    release_id=1,
+                    release_url="https://discogs.com/release/1",
+                    is_compilation=False,
+                ),
+                DiscogsReleaseInfo(
+                    album="Album B",
+                    artist="Artist B",
+                    release_id=2,
+                    release_url="https://discogs.com/release/2",
+                    is_compilation=False,
+                ),
+                DiscogsReleaseInfo(
+                    album="Album C",
+                    artist="Artist C",
+                    release_id=3,
+                    release_url="https://discogs.com/release/3",
+                    is_compilation=False,
+                ),
+            ],
+            total=3,
+        )
+
+        async def validate_side_effect(release_id, track, artist):
+            # A: slow + valid, B: fast + invalid (finishes first), C: medium + valid.
+            if release_id == 1:
+                await _asyncio.sleep(0.20)
+                return True
+            if release_id == 2:
+                await _asyncio.sleep(0.02)
+                return False
+            await _asyncio.sleep(0.10)
+            return True
+
+        svc.validate_track_on_release.side_effect = validate_side_effect
+
+        results, _matched_via = await search_song_as_track(db, "t", discogs_service=svc)
+
+        # Input order is [A, B, C]; B drops on validation; output must be [A, C].
+        assert results == [item_a, item_c], (
+            f"Expected input-order [A, C], got {[r.title for r in results]}. "
+            "Output order must follow input (relevance) order, not completion order."
+        )
+
+    @pytest.mark.asyncio
+    async def test_matched_via_hint_order_follows_input(self):
+        """When one library row matches across multiple releases, the hint order
+        in ``matched_via_by_id[id]`` must follow input (relevance) order — not
+        the completion order of the underlying validate calls.
+
+        Same WXYC row referenced by releases X (slow) and Y (fast), both valid:
+        hints must be [X_hint, Y_hint], matching the input candidate order.
+        """
+        import asyncio as _asyncio
+
+        confield = make_library_item(id=60359, artist="Autechre", title="Confield")
+        db = AsyncMock()
+        db.search.return_value = [confield]
+
+        # Use the compilation path so we can vary artist_credit per release
+        # (the load-bearing distinguisher) while keeping a single library row.
+        # For compilations, the library row's artist is the VA marker and the
+        # release-level artist becomes the hint's ``artist_credit`` — that's
+        # what we read back to assert input-order accumulation.
+        va_album = make_library_item(id=60359, artist="Various Artists", title="Confield Comp")
+        db = AsyncMock()
+        db.search.return_value = [va_album]
+
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="vi scose poise",
+            releases=[
+                DiscogsReleaseInfo(
+                    album="Confield Comp",
+                    artist="Credit X",  # first in input
+                    release_id=8434,
+                    release_url="https://discogs.com/release/8434",
+                    is_compilation=True,
+                ),
+                DiscogsReleaseInfo(
+                    album="Confield Comp",
+                    artist="Credit Y",  # second in input
+                    release_id=999,
+                    release_url="https://discogs.com/release/999",
+                    is_compilation=True,
+                ),
+            ],
+            total=2,
+        )
+
+        async def validate_side_effect(release_id, track, artist):
+            if release_id == 8434:
+                await _asyncio.sleep(0.10)  # X finishes second
+            else:
+                await _asyncio.sleep(0.01)  # Y finishes first
+            return True
+
+        svc.validate_track_on_release.side_effect = validate_side_effect
+
+        results, matched_via = await search_song_as_track(db, "vi scose poise", discogs_service=svc)
+
+        assert results == [va_album]
+        hints = matched_via[60359]
+        assert len(hints) == 2
+        # Input order is [X, Y]; Y completes first but the post-gather walk
+        # must preserve input order, so the hint sequence is [X-credit, Y-credit].
+        assert [h.artist_credit for h in hints] == ["Credit X", "Credit Y"]
+
+    @pytest.mark.asyncio
+    async def test_validate_concurrency_is_bounded(self):
+        """No more than the configured cap of validate calls may be in-flight
+        at once.
+
+        Counters the naive ``asyncio.gather(*all_releases)`` shape, which can
+        explode parallelism when Discogs returns 50+ candidates. The
+        orchestrator-local semaphore bounds in-flight validate calls; the
+        global Discogs rate limiter sits underneath.
+        """
+        import asyncio as _asyncio
+
+        n_candidates = 20
+        db = AsyncMock()
+
+        # Each release maps to a distinct library row that prefix-matches it,
+        # so validate fires for every one.
+        items = [
+            make_library_item(id=5000 + i, artist=f"Artist {i}", title=f"Album {i}")
+            for i in range(n_candidates)
+        ]
+        releases = [
+            DiscogsReleaseInfo(
+                album=f"Album {i}",
+                artist=f"Artist {i}",
+                release_id=10000 + i,
+                release_url=f"https://discogs.com/release/{10000 + i}",
+                is_compilation=False,
+            )
+            for i in range(n_candidates)
+        ]
+
+        async def search_side_effect(query, **kwargs):
+            for item in items:
+                if (item.title or "").lower() == query.lower():
+                    return [item]
+            return []
+
+        db.search.side_effect = search_side_effect
+
+        svc = AsyncMock()
+        svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
+            track="t", releases=releases, total=n_candidates
+        )
+
+        in_flight = 0
+        peak_in_flight = 0
+        lock = _asyncio.Lock()
+
+        async def validate_side_effect(release_id, track, artist):
+            nonlocal in_flight, peak_in_flight
+            async with lock:
+                in_flight += 1
+                if in_flight > peak_in_flight:
+                    peak_in_flight = in_flight
+            try:
+                await _asyncio.sleep(0.05)
+                return True
+            finally:
+                async with lock:
+                    in_flight -= 1
+
+        svc.validate_track_on_release.side_effect = validate_side_effect
+
+        # Import the cap so the test tracks the constant rather than a magic
+        # number — if the value is tuned later, this test still pins the
+        # invariant "peak_in_flight <= cap".
+        from lookup.orchestrator import _SONG_AS_TRACK_VALIDATE_CONCURRENCY as _CAP
+
+        await search_song_as_track(db, "t", discogs_service=svc)
+
+        assert peak_in_flight <= _CAP, (
+            f"validate_track_on_release ran with {peak_in_flight} in-flight; "
+            f"the orchestrator-local cap is {_CAP}."
+        )
+        # Sanity: parallelism > 1 (otherwise we accidentally serialized).
+        assert peak_in_flight > 1, (
+            f"Peak in-flight was {peak_in_flight}; the validate calls did not "
+            "run concurrently at all."
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: _log_track_validation (A7 / LML#344 audit instrumentation)


### PR DESCRIPTION
Closes #534.

## Summary

- `search_song_as_track` awaited `discogs_service.validate_track_on_release` once per Discogs candidate serially — with ~7 candidates per lookup at ~1.2s each (worse when the PG cache write path is degraded, Sentry LIBRARY-METADATA-LOOKUP-9), an 8-10s serial chain on `/api/v1/lookup`'s hot path.
- Mirror the `search_compilations_for_track` pattern: extract per-release library-match + validate into `_validate_one(release)`, fan out with `asyncio.gather`, walk results in input-index order for the dedup pass so relevance ranking and `matched_via_by_id` hint order are preserved.
- Orchestrator-local `Semaphore(5)` caps per-request fan-out at the same size as the global Discogs semaphore (`discogs/service.py:373`); the global rate limiter still sits underneath.
- Bench: 5 candidates × 200ms validate → serial 1.007s, parallel 0.20s (5x).

## Test plan

- [x] Concurrency: 5 fake validate calls × 200ms → wall time near 200ms not 1000ms
- [x] Input order preservation: releases [A, B, C] where B drops on validation → output `[A, C]` even when B finishes first
- [x] Hint accumulation order: same WXYC row referenced by [X (slow), Y (fast)] → `matched_via_by_id[id]` is `[X_hint, Y_hint]`
- [x] Semaphore bound: 20 candidates → peak in-flight ≤ 5
- [x] All 10 pre-existing `TestSearchSongAsTrack` tests still pass
- [x] Full default unit suite (2630 tests) green
- [x] `ruff check .` / `ruff format --check .` / `mypy . --ignore-missing-imports` all clean