### PR TITLE
diag(cache): four LML#537 probes for Discogs cache hit ratio plateau

### DIFF
--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -120,10 +120,15 @@ def request_context(method: str, cache_state: str = "no_pg") -> Iterator[None]:
 
     Used by ``fallthrough`` itself and by the three production methods that
     bypass the seam (``search_releases_by_album_title``, ``get_label_image``,
-    ``get_master`` — all API-only with no L2 cache leg) plus the four seam
-    methods' ``cache is None`` fallback branches. Default ``cache_state``
-    matches the typical bypass case (no PG cache); the seam overrides with
-    the resolved state from its own taxonomy.
+    ``get_master`` — all API-only with no L2 cache leg) plus the four
+    seam methods that have a ``cache is None`` fallback branch
+    (``search_releases_by_track``, ``get_release``, ``get_artist_details``,
+    ``search``). ``validate_track_on_release`` also has a ``cache is None``
+    branch but it delegates to ``get_release``, whose own ``request_context``
+    wins for the actual HTTP wait span — so wrapping validate would not
+    change the histogram. Default ``cache_state`` matches the typical bypass
+    case (no PG cache); the seam overrides with the resolved state from its
+    own taxonomy.
 
     ``ContextVar.set`` runs *before* the ``try``-block: if it raises, the
     function aborts cleanly and no reset is attempted, sidestepping the
@@ -145,6 +150,24 @@ def get_request_context() -> dict[str, str] | None:
     pattern in ``discogs.memory_cache``.
     """
     return _request_context_var.get()
+
+
+def apply_request_ctx_tags(span: Any) -> None:
+    """Tag a wait span with the LML#537 ``lml.discogs.method`` /
+    ``lml.discogs.cache_state`` labels read from the current context.
+
+    Called from ``DiscogsService._request_with_retry`` for both the
+    semaphore-acquire and per-retry rate-limiter spans. Encapsulated in
+    this module so the dict-key contract (``"method"`` / ``"cache_state"``)
+    AND the Sentry attribute names live next to the contextvar producer —
+    a future rename only has to touch ``fallthrough.py``. No-op when no
+    context is active (direct ``_request_with_retry`` callers from tests).
+    """
+    ctx = _request_context_var.get()
+    if ctx is None:
+        return
+    span.set_data("lml.discogs.method", ctx["method"])
+    span.set_data("lml.discogs.cache_state", ctx["cache_state"])
 
 
 # Default predicate for ``fallthrough(is_pg_hit=...)``. Hoisted to module scope

--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -57,7 +57,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any
 
@@ -104,13 +105,33 @@ _ARMING_EXCEPTIONS: tuple[type[BaseException], ...] = (
 # ``lml.discogs.semaphore`` and ``lml.discogs.rate_limiter`` spans can be tagged
 # without threading kwargs through 9 call sites. Token-paired set/reset
 # guarantees the contextvar resets even under ``CancelledError`` so a cancelled
-# call doesn't leak state. Default is ``None`` because direct callers of
-# ``_request_with_retry`` (the health probe, a handful of legacy tests) live
-# outside the seam and must not blow up if the var is absent. Naming mirrors
-# the local ``_skip_cache_var`` in ``discogs/memory_cache.py``.
+# call doesn't leak state. Default is ``None`` because some test cases drive
+# ``_request_with_retry`` directly without entering the seam — that path must
+# not blow up if the var is absent. Naming mirrors the local ``_skip_cache_var``
+# in ``discogs/memory_cache.py``.
 _request_context_var: ContextVar[dict[str, str] | None] = ContextVar(
     "discogs_request_context", default=None
 )
+
+
+@contextmanager
+def request_context(method: str, cache_state: str) -> Iterator[None]:
+    """Tag downstream ``_request_with_retry`` spans for a non-seam HTTP call.
+
+    Production methods that bypass ``fallthrough`` (``search_releases_by_album_title``,
+    ``get_label_image``, ``get_master`` — all API-only with no L2 cache leg)
+    use this context manager so their wait-time spans participate in the
+    ``cache_state`` / ``method`` histogram. ``fallthrough`` itself does not
+    call this helper — it sets the contextvar inline so its taxonomy
+    computation (``miss``/``skip``/``no_pg``/``cooldown``) stays in one place.
+
+    Token-paired set/reset survives ``CancelledError``.
+    """
+    token = _request_context_var.set({"method": method, "cache_state": cache_state})
+    try:
+        yield
+    finally:
+        _request_context_var.reset(token)
 
 
 # Default predicate for ``fallthrough(is_pg_hit=...)``. Hoisted to module scope
@@ -308,8 +329,11 @@ async def fallthrough[T](
         cache_state = "miss"
 
     # ----- L3 API.
-    token = _request_context_var.set({"method": label, "cache_state": cache_state})
+    # Token assignment is the first statement inside the try so any future
+    # edit that inserts a line between the set() and the try block cannot
+    # leak the contextvar — the reset always runs paired with the set.
     try:
+        token = _request_context_var.set({"method": label, "cache_state": cache_state})
         api_result = await api_fetch()
     finally:
         _request_context_var.reset(token)

--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -58,6 +58,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
 from typing import Any
 
 import asyncpg.exceptions
@@ -94,6 +95,21 @@ _ARMING_EXCEPTIONS: tuple[type[BaseException], ...] = (
     asyncpg.exceptions.InterfaceError,
     asyncpg.exceptions.UndefinedTableError,
     CacheUnavailableError,
+)
+
+
+# Per-call context for the downstream ``DiscogsService._request_with_retry``
+# spans (LML#537). Set right before the API-fetch leg with the seam's ``label``
+# and the resolved ``cache_state``; read inside ``_request_with_retry`` so the
+# ``lml.discogs.semaphore`` and ``lml.discogs.rate_limiter`` spans can be tagged
+# without threading kwargs through 9 call sites. Token-paired set/reset
+# guarantees the contextvar resets even under ``CancelledError`` so a cancelled
+# call doesn't leak state. Default is ``None`` because direct callers of
+# ``_request_with_retry`` (the health probe, a handful of legacy tests) live
+# outside the seam and must not blow up if the var is absent. Naming mirrors
+# the local ``_skip_cache_var`` in ``discogs/memory_cache.py``.
+_request_context_var: ContextVar[dict[str, str] | None] = ContextVar(
+    "discogs_request_context", default=None
 )
 
 
@@ -216,8 +232,17 @@ async def fallthrough[T](
     # ----- Per-request skip flag (benchmarking, A/B). Bypass every cache leg.
     skip = should_skip_cache()
 
+    # Capture cool-down state at entry so the LML#537 ``cache_state`` tag below
+    # reflects the gate that actually fired — not a downstream arming triggered
+    # by *this* call's PG-read exception. ``_arm_cool_down`` runs after a PG
+    # read raises ``_ARMING_EXCEPTIONS``; reading ``_cool_down_active()`` again
+    # after the read leg would conflate "this call's PG errored, fell through
+    # to API" (a ``miss``) with "PG was already down, we skipped the read"
+    # (a ``cooldown``).
+    in_cool_down = _cool_down_active()
+
     # ----- L2 PG read (if configured, not skipped, not cooling down).
-    if pg_read is not None and not skip and not _cool_down_active():
+    if pg_read is not None and not skip and not in_cool_down:
         try:
             _add_discogs_breadcrumb(f"cache_lookup_{label}", bc_data)
             with sentry_sdk.start_span(op="cache.get", name=f"l2:{label}") as span:
@@ -269,8 +294,25 @@ async def fallthrough[T](
             # request through to the API path.
             logger.warning("Negative-cache check failed (%s): %s", label, e)
 
+    # ----- LML#537 telemetry: tag the downstream ``_request_with_retry`` spans
+    # with the seam's label + the resolved cache_state, so Sentry's wait-time
+    # histogram for ``lml.discogs.semaphore`` / ``lml.discogs.rate_limiter``
+    # can be split by which method's miss triggered the wait.
+    if skip:
+        cache_state = "skip"
+    elif pg_read is None:
+        cache_state = "no_pg"
+    elif in_cool_down:
+        cache_state = "cooldown"
+    else:
+        cache_state = "miss"
+
     # ----- L3 API.
-    api_result = await api_fetch()
+    token = _request_context_var.set({"method": label, "cache_state": cache_state})
+    try:
+        api_result = await api_fetch()
+    finally:
+        _request_context_var.reset(token)
 
     # ----- Write-backs (best-effort; only when not bypassing the cache).
     if api_result is not None and not skip:

--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -115,23 +115,36 @@ _request_context_var: ContextVar[dict[str, str] | None] = ContextVar(
 
 
 @contextmanager
-def request_context(method: str, cache_state: str) -> Iterator[None]:
-    """Tag downstream ``_request_with_retry`` spans for a non-seam HTTP call.
+def request_context(method: str, cache_state: str = "no_pg") -> Iterator[None]:
+    """Tag downstream ``_request_with_retry`` spans for the duration of the block.
 
-    Production methods that bypass ``fallthrough`` (``search_releases_by_album_title``,
-    ``get_label_image``, ``get_master`` — all API-only with no L2 cache leg)
-    use this context manager so their wait-time spans participate in the
-    ``cache_state`` / ``method`` histogram. ``fallthrough`` itself does not
-    call this helper — it sets the contextvar inline so its taxonomy
-    computation (``miss``/``skip``/``no_pg``/``cooldown``) stays in one place.
+    Used by ``fallthrough`` itself and by the three production methods that
+    bypass the seam (``search_releases_by_album_title``, ``get_label_image``,
+    ``get_master`` — all API-only with no L2 cache leg) plus the four seam
+    methods' ``cache is None`` fallback branches. Default ``cache_state``
+    matches the typical bypass case (no PG cache); the seam overrides with
+    the resolved state from its own taxonomy.
 
-    Token-paired set/reset survives ``CancelledError``.
+    ``ContextVar.set`` runs *before* the ``try``-block: if it raises, the
+    function aborts cleanly and no reset is attempted, sidestepping the
+    Token-unbound-on-set-failure trap. Token-paired set/reset survives
+    ``CancelledError`` via the generator protocol.
     """
     token = _request_context_var.set({"method": method, "cache_state": cache_state})
     try:
         yield
     finally:
         _request_context_var.reset(token)
+
+
+def get_request_context() -> dict[str, str] | None:
+    """Return the current ``_request_context_var`` value (or ``None``).
+
+    Public reader so ``discogs.service`` doesn't have to reach across module
+    boundaries for the private contextvar — mirrors the ``should_skip_cache``
+    pattern in ``discogs.memory_cache``.
+    """
+    return _request_context_var.get()
 
 
 # Default predicate for ``fallthrough(is_pg_hit=...)``. Hoisted to module scope
@@ -329,14 +342,8 @@ async def fallthrough[T](
         cache_state = "miss"
 
     # ----- L3 API.
-    # Token assignment is the first statement inside the try so any future
-    # edit that inserts a line between the set() and the try block cannot
-    # leak the contextvar — the reset always runs paired with the set.
-    try:
-        token = _request_context_var.set({"method": label, "cache_state": cache_state})
+    with request_context(label, cache_state):
         api_result = await api_fetch()
-    finally:
-        _request_context_var.reset(token)
 
     # ----- Write-backs (best-effort; only when not bypassing the cache).
     if api_result is not None and not skip:

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -20,7 +20,7 @@ from wxyc_fastapi.observability import (
 )
 
 from config.settings import get_settings
-from discogs.fallthrough import fallthrough
+from discogs.fallthrough import _request_context_var, fallthrough
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.memory_cache import (
     ARTIST_CACHE,
@@ -373,6 +373,13 @@ class DiscogsService:
         semaphore = get_semaphore()
         rate_limiter = get_rate_limiter()
 
+        # LML#537: pick up the fallthrough seam's per-call context (label +
+        # resolved cache_state) once, and tag both wait spans below. The seam
+        # is the dominant entry path; direct callers (the health probe, a few
+        # legacy tests) leave the contextvar as ``None`` — we skip tagging in
+        # that case so those callers don't have to know about the seam.
+        request_ctx = _request_context_var.get()
+
         # Explicit acquire/release (not `async with semaphore:`) so the wait
         # is wrapped in a Sentry span. The 5-permit semaphore is the dominant
         # source of pre-request dark time on backfill cascades — sampling the
@@ -380,10 +387,18 @@ class DiscogsService:
         # relative-load signal per call. See WXYC/library-metadata-lookup#358.
         with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.semaphore") as span:
             span.set_data("lml.semaphore.queue_depth", _approx_semaphore_queue_depth(semaphore))
+            if request_ctx is not None:
+                span.set_data("lml.discogs.method", request_ctx["method"])
+                span.set_data("lml.discogs.cache_state", request_ctx["cache_state"])
             await semaphore.acquire()
         try:
             for attempt in range(max_retries + 1):
-                with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.rate_limiter"):
+                with sentry_sdk.start_span(
+                    op="lock.acquire", name="lml.discogs.rate_limiter"
+                ) as span:
+                    if request_ctx is not None:
+                        span.set_data("lml.discogs.method", request_ctx["method"])
+                        span.set_data("lml.discogs.cache_state", request_ctx["cache_state"])
                     await rate_limiter.acquire()
 
                 try:

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -20,7 +20,7 @@ from wxyc_fastapi.observability import (
 )
 
 from config.settings import get_settings
-from discogs.fallthrough import _request_context_var, fallthrough, request_context
+from discogs.fallthrough import fallthrough, get_request_context, request_context
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.memory_cache import (
     ARTIST_CACHE,
@@ -100,6 +100,20 @@ def _approx_semaphore_queue_depth(semaphore: asyncio.Semaphore) -> int:
         return len(waiters) if waiters else 0
     except AttributeError:
         return -1
+
+
+def _apply_request_ctx_tags(span: Any, ctx: dict[str, str] | None) -> None:
+    """Tag a wait span with the LML#537 method / cache_state labels.
+
+    Centralizes the per-span tag application called from both the semaphore
+    and the per-retry rate-limiter spans in ``_request_with_retry``. ``None``
+    means the caller didn't enter a seam or ``request_context`` — leave the
+    span untagged (a small handful of direct-call tests).
+    """
+    if ctx is None:
+        return
+    span.set_data("lml.discogs.method", ctx["method"])
+    span.set_data("lml.discogs.cache_state", ctx["cache_state"])
 
 
 def _compute_retry_delay(attempt: int, retry_after_header: str | None) -> float:
@@ -373,14 +387,14 @@ class DiscogsService:
         semaphore = get_semaphore()
         rate_limiter = get_rate_limiter()
 
-        # LML#537: pick up the seam's per-call context (label + resolved
-        # cache_state) once, and tag both wait spans below. Production callers
-        # enter via ``fallthrough()`` (the dominant path) or via the
+        # LML#537: read the per-call context (label + resolved cache_state)
+        # once, tag both wait spans via _apply_request_ctx_tags. Production
+        # callers enter via ``fallthrough()`` (dominant) or via the
         # ``request_context()`` helper (the three API-only methods that bypass
-        # the seam: ``search_releases_by_album_title``, ``get_label_image``,
-        # ``get_master``). Tests that drive ``_request_with_retry`` directly
-        # leave the contextvar as ``None`` — we skip tagging in that case.
-        request_ctx = _request_context_var.get()
+        # the seam and the four ``cache is None`` fallback branches). Tests
+        # that drive ``_request_with_retry`` directly leave the contextvar as
+        # ``None`` — _apply_request_ctx_tags is a no-op in that case.
+        request_ctx = get_request_context()
 
         # Explicit acquire/release (not `async with semaphore:`) so the wait
         # is wrapped in a Sentry span. The 5-permit semaphore is the dominant
@@ -389,18 +403,14 @@ class DiscogsService:
         # relative-load signal per call. See WXYC/library-metadata-lookup#358.
         with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.semaphore") as span:
             span.set_data("lml.semaphore.queue_depth", _approx_semaphore_queue_depth(semaphore))
-            if request_ctx is not None:
-                span.set_data("lml.discogs.method", request_ctx["method"])
-                span.set_data("lml.discogs.cache_state", request_ctx["cache_state"])
+            _apply_request_ctx_tags(span, request_ctx)
             await semaphore.acquire()
         try:
             for attempt in range(max_retries + 1):
                 with sentry_sdk.start_span(
                     op="lock.acquire", name="lml.discogs.rate_limiter"
                 ) as span:
-                    if request_ctx is not None:
-                        span.set_data("lml.discogs.method", request_ctx["method"])
-                        span.set_data("lml.discogs.cache_state", request_ctx["cache_state"])
+                    _apply_request_ctx_tags(span, request_ctx)
                     await rate_limiter.acquire()
 
                 try:
@@ -595,7 +605,8 @@ class DiscogsService:
             return TrackReleasesResponse(track=track, artist=artist, cached=False)
 
         if cache is None:
-            return await _api_fetch() or _empty_error_response()
+            with request_context("search_releases_by_track"):
+                return await _api_fetch() or _empty_error_response()
 
         # The negative-cache check fires regardless of ``artist_as_keyword``
         # because its key includes that dimension. The PG read is only safe
@@ -678,7 +689,7 @@ class DiscogsService:
         # Fresh per-result set means ``_process_search_result``'s album-dedup
         # branch never triggers across iterations.
         try:
-            with request_context("search_releases_by_album_title", "no_pg"):
+            with request_context("search_releases_by_album_title"):
                 async with timed_api():
                     response = await self._request_with_retry(
                         "GET", "/database/search", params=params
@@ -886,7 +897,8 @@ class DiscogsService:
         cache = self.cache_service
         value: ReleaseMetadataResponse | None
         if cache is None:
-            value = await _api_fetch()
+            with request_context("get_release"):
+                value = await _api_fetch()
         else:
             value = await fallthrough(
                 label="get_release",
@@ -1010,7 +1022,8 @@ class DiscogsService:
         cache = self.cache_service
         value: ArtistDetails | None
         if cache is None:
-            value = await _api_fetch()
+            with request_context("get_artist_details"):
+                value = await _api_fetch()
         else:
             value = await fallthrough(
                 label="get_artist_details",
@@ -1064,7 +1077,7 @@ class DiscogsService:
             Image URI string, or None if unavailable
         """
         try:
-            with request_context("get_label_image", "no_pg"):
+            with request_context("get_label_image"):
                 async with timed_api():
                     response = await self._request_with_retry("GET", f"/labels/{label_id}")
             if response is None:
@@ -1090,7 +1103,7 @@ class DiscogsService:
             MasterRelease with title and year, or None on error
         """
         try:
-            with request_context("get_master", "no_pg"):
+            with request_context("get_master"):
                 async with timed_api():
                     response = await self._request_with_retry("GET", f"/masters/{master_id}")
             if response is None:
@@ -1259,7 +1272,8 @@ class DiscogsService:
 
         cache = self.cache_service
         if cache is None:
-            result = await _api_fetch()
+            with request_context("search"):
+                result = await _api_fetch()
         else:
             result = await fallthrough(
                 label="search",

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -20,7 +20,7 @@ from wxyc_fastapi.observability import (
 )
 
 from config.settings import get_settings
-from discogs.fallthrough import _request_context_var, fallthrough
+from discogs.fallthrough import _request_context_var, fallthrough, request_context
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.memory_cache import (
     ARTIST_CACHE,
@@ -373,11 +373,13 @@ class DiscogsService:
         semaphore = get_semaphore()
         rate_limiter = get_rate_limiter()
 
-        # LML#537: pick up the fallthrough seam's per-call context (label +
-        # resolved cache_state) once, and tag both wait spans below. The seam
-        # is the dominant entry path; direct callers (the health probe, a few
-        # legacy tests) leave the contextvar as ``None`` — we skip tagging in
-        # that case so those callers don't have to know about the seam.
+        # LML#537: pick up the seam's per-call context (label + resolved
+        # cache_state) once, and tag both wait spans below. Production callers
+        # enter via ``fallthrough()`` (the dominant path) or via the
+        # ``request_context()`` helper (the three API-only methods that bypass
+        # the seam: ``search_releases_by_album_title``, ``get_label_image``,
+        # ``get_master``). Tests that drive ``_request_with_retry`` directly
+        # leave the contextvar as ``None`` — we skip tagging in that case.
         request_ctx = _request_context_var.get()
 
         # Explicit acquire/release (not `async with semaphore:`) so the wait
@@ -676,8 +678,11 @@ class DiscogsService:
         # Fresh per-result set means ``_process_search_result``'s album-dedup
         # branch never triggers across iterations.
         try:
-            async with timed_api():
-                response = await self._request_with_retry("GET", "/database/search", params=params)
+            with request_context("search_releases_by_album_title", "no_pg"):
+                async with timed_api():
+                    response = await self._request_with_retry(
+                        "GET", "/database/search", params=params
+                    )
             if response is not None:
                 get_cache_stats_recorder().record_api_call()
                 response.raise_for_status()
@@ -1059,8 +1064,9 @@ class DiscogsService:
             Image URI string, or None if unavailable
         """
         try:
-            async with timed_api():
-                response = await self._request_with_retry("GET", f"/labels/{label_id}")
+            with request_context("get_label_image", "no_pg"):
+                async with timed_api():
+                    response = await self._request_with_retry("GET", f"/labels/{label_id}")
             if response is None:
                 return None
             get_cache_stats_recorder().record_api_call()
@@ -1084,8 +1090,9 @@ class DiscogsService:
             MasterRelease with title and year, or None on error
         """
         try:
-            async with timed_api():
-                response = await self._request_with_retry("GET", f"/masters/{master_id}")
+            with request_context("get_master", "no_pg"):
+                async with timed_api():
+                    response = await self._request_with_retry("GET", f"/masters/{master_id}")
             if response is None:
                 return None
             get_cache_stats_recorder().record_api_call()

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -20,7 +20,7 @@ from wxyc_fastapi.observability import (
 )
 
 from config.settings import get_settings
-from discogs.fallthrough import fallthrough, get_request_context, request_context
+from discogs.fallthrough import apply_request_ctx_tags, fallthrough, request_context
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.memory_cache import (
     ARTIST_CACHE,
@@ -100,20 +100,6 @@ def _approx_semaphore_queue_depth(semaphore: asyncio.Semaphore) -> int:
         return len(waiters) if waiters else 0
     except AttributeError:
         return -1
-
-
-def _apply_request_ctx_tags(span: Any, ctx: dict[str, str] | None) -> None:
-    """Tag a wait span with the LML#537 method / cache_state labels.
-
-    Centralizes the per-span tag application called from both the semaphore
-    and the per-retry rate-limiter spans in ``_request_with_retry``. ``None``
-    means the caller didn't enter a seam or ``request_context`` — leave the
-    span untagged (a small handful of direct-call tests).
-    """
-    if ctx is None:
-        return
-    span.set_data("lml.discogs.method", ctx["method"])
-    span.set_data("lml.discogs.cache_state", ctx["cache_state"])
 
 
 def _compute_retry_delay(attempt: int, retry_after_header: str | None) -> float:
@@ -387,14 +373,12 @@ class DiscogsService:
         semaphore = get_semaphore()
         rate_limiter = get_rate_limiter()
 
-        # LML#537: read the per-call context (label + resolved cache_state)
-        # once, tag both wait spans via _apply_request_ctx_tags. Production
-        # callers enter via ``fallthrough()`` (dominant) or via the
-        # ``request_context()`` helper (the three API-only methods that bypass
-        # the seam and the four ``cache is None`` fallback branches). Tests
-        # that drive ``_request_with_retry`` directly leave the contextvar as
-        # ``None`` — _apply_request_ctx_tags is a no-op in that case.
-        request_ctx = get_request_context()
+        # LML#537: tag both wait spans with the seam's method + cache_state
+        # via ``apply_request_ctx_tags`` (a no-op when no context is active —
+        # the case for the small handful of legacy direct-call tests).
+        # Production callers enter via ``fallthrough()`` (dominant) or via
+        # the ``request_context()`` helper (the three API-only methods that
+        # bypass the seam and the four ``cache is None`` fallback branches).
 
         # Explicit acquire/release (not `async with semaphore:`) so the wait
         # is wrapped in a Sentry span. The 5-permit semaphore is the dominant
@@ -403,14 +387,14 @@ class DiscogsService:
         # relative-load signal per call. See WXYC/library-metadata-lookup#358.
         with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.semaphore") as span:
             span.set_data("lml.semaphore.queue_depth", _approx_semaphore_queue_depth(semaphore))
-            _apply_request_ctx_tags(span, request_ctx)
+            apply_request_ctx_tags(span)
             await semaphore.acquire()
         try:
             for attempt in range(max_retries + 1):
                 with sentry_sdk.start_span(
                     op="lock.acquire", name="lml.discogs.rate_limiter"
                 ) as span:
-                    _apply_request_ctx_tags(span, request_ctx)
+                    apply_request_ctx_tags(span)
                     await rate_limiter.acquire()
 
                 try:

--- a/docs/plans/lml-537-cache-hit-investigation.md
+++ b/docs/plans/lml-537-cache-hit-investigation.md
@@ -1,0 +1,222 @@
+# LML #537 — Discogs cache-hit investigation: probes #1, #2, #3, #6
+
+**Issue:** [WXYC/library-metadata-lookup#537](https://github.com/WXYC/library-metadata-lookup/issues/537) — *Discogs cache hit ratio plateaued at ~50% (`search_releases_by_track` at 34%) after write_release fix*
+
+**Scope:** Implement four of the six concrete next steps from the issue. The remaining two (#4 steady-state estimate — a back-of-envelope calc; #5 PG row-count audit — a daily snapshot to capture over a week) are non-code follow-ups.
+
+| # | Probe | Shape | New file |
+|---|---|---|---|
+| #1 | Cache miss provenance sample | One-shot script: log mine + PG query → CSV | `scripts/cache_miss_provenance.py` |
+| #2 | Dynamic-write contribution histogram | One-shot script: PG aggregate → stdout table | `scripts/cache_warm_histogram.py` |
+| #3 | Ranking-jitter test | One-shot script: live Discogs probe + overlap report | `scripts/discogs_ranking_jitter.py` |
+| #6 | Rate-limiter telemetry tag | Code change: tag `lml.discogs.{semaphore,rate_limiter}` spans | `discogs/service.py`, `discogs/fallthrough.py` |
+
+The three scripts are diagnostic, not part of the request hot path. They live under `scripts/` next to the existing audits (`audit_va_writeback_pollution.py`, `benchmark_cache.py`, `measure_artwork_match_floor.py`) and follow that file's shape: argparse + `DATABASE_URL_DISCOGS` env-driven, CSV / stdout output, dry-run by default where state is touched (none of these write).
+
+The code change is small and behind a contextvar — no behavior change, only Sentry-side observability.
+
+## #6 — Rate-limiter telemetry tag (code change)
+
+### The deepening shape
+
+The issue text asks for `cache_state=hit|miss` on `lml.discogs.rate_limiter` and `lml.discogs.semaphore` spans so the wait-time histogram can be split. But `_request_with_retry` (`discogs/service.py:351`) is only ever entered on a cache miss (or a no-PG-leg method like `get_master`) — at this layer `cache_state` is structurally one of:
+
+- `miss` — PG was checked and missed (the common case)
+- `skip` — `should_skip_cache()` returned true (benchmark / A/B)
+- `cooldown` — PG read short-circuited by `_cool_down_active()` (#324 fallback)
+- `no_pg` — `pg_read is None` by design (`get_master`, `get_label_image`, `search_releases_by_album_title`)
+
+Splitting the histogram by which **method** triggered the API call is the actually-useful signal (see issue: 34% on `search_releases_by_track` vs 97.5% on `get_artist_details` — the slow tail is dominated by one method). So we add **two** tags, not one:
+
+- `lml.discogs.cache_state` — one of the four values above
+- `lml.discogs.method` — the seam's `label` (`get_release`, `search`, `validate_track_on_release`, `search_releases_by_track`, `get_artist_details`, etc.)
+
+Both literal-`miss`-only and the split-by-method case are then queryable in Sentry. The two-tag shape matches the spirit of the issue ("split the wait-time histogram"), while staying truthful at the layer where the spans actually live.
+
+### Mechanism
+
+The `_request_with_retry` method is generic over caller — it doesn't know the seam's label. Two options:
+
+| | Pros | Cons |
+|---|---|---|
+| **A.** Pass `label` / `cache_state` as kwargs into `_request_with_retry` | Explicit at call site; no globals | Touches 9 call sites in `service.py` (lines 509, 539, 665, 741, 933, 1048, 1073, 1152, 1178); breaks any test that calls `_request_with_retry` directly |
+| **B.** ContextVar (`_REQUEST_CONTEXT`) set in the seam, read in `_request_with_retry` | Single read/write site each; mirrors the existing `should_skip_cache()` contextvar pattern in `discogs/memory_cache.py`; no signature churn | Implicit context; can leak if a test forgets to reset |
+
+**Decision: B.** It mirrors `should_skip_cache()` (also lives in `discogs/memory_cache.py` and is read deep inside the seam). The leak risk is bounded by a `contextvars.copy_context()` per call: each `fallthrough()` invocation enters a fresh scope. We use a `Token`-paired set/reset (`contextvars.ContextVar.set()` returns a `Token`; the `finally` resets via that token) so no test can leak.
+
+The contextvar is named `_request_context_var` to match the existing `_skip_cache_var` style in `discogs/memory_cache.py` (lowercase + `_var` suffix), not CONSTANT_CASE.
+
+The flow:
+
+```
+fallthrough(label="get_release", ...)
+  → sets _request_context_var to {"method": "get_release", "cache_state": "miss"|"skip"|"cooldown"|"no_pg"}
+  → calls api_fetch()  (which eventually calls _request_with_retry)
+    → _request_with_retry reads _request_context_var; tags the two spans
+  → finally: _request_context_var.reset(token)
+```
+
+`cache_state` is computed in `fallthrough()`:
+- `skip` if `should_skip_cache()` returned True
+- `no_pg` if `pg_read is None`
+- `cooldown` if PG read was short-circuited by `_cool_down_active()`
+- `miss` otherwise
+
+A cache **hit** never reaches `_request_with_retry` so we don't need a `hit` value at this layer. (If a future caller wants to wrap the L2 read in the same wait-budget instrumentation, the hit value is trivially available — but that's not this PR.)
+
+### TDD
+
+1. **Red:** `tests/unit/test_discogs_request_telemetry.py::test_semaphore_span_tagged_with_method` — patches `sentry_sdk.start_span` to record spans, drives `fallthrough(label="get_release", ...)` with an `api_fetch` that calls `_request_with_retry`, asserts both spans carry `lml.discogs.method = "get_release"` and `lml.discogs.cache_state = "miss"`. Expected failure: tags absent.
+2. **Green:** Add `_request_context_var: ContextVar[dict[str, str] | None]` in `discogs/fallthrough.py`. Set it before the API-fetch leg with the computed `cache_state`. In `_request_with_retry`, after `start_span`, call `span.set_data("lml.discogs.method", ctx["method"])` and `span.set_data("lml.discogs.cache_state", ctx["cache_state"])`. Reset via `Token` in `finally`.
+3. **Coverage:** add four parametrized cases for `cache_state` ∈ {`miss`, `skip`, `no_pg`, `cooldown`}, all in `test_semaphore_span_tagged_with_method`'s parametrize block. The `cooldown` case manipulates `discogs.fallthrough._cool_down_until` directly (mirrors the existing `_reset_cool_down_for_tests` pattern).
+4. **CancelledError reset test:** a separate `test_context_resets_on_cancelled_error` function — drives `fallthrough` with an `api_fetch` that raises `asyncio.CancelledError`, then asserts `_request_context_var.get()` is `None` after the call. Verifies the `finally` resets via `Token` survives cancellation.
+5. **Negative test:** without the contextvar set (direct `_request_with_retry` call from outside the seam, e.g., the existing health probe), the span tags are absent — `span.set_data` is only called when `_request_context_var.get()` is not None. This keeps current direct callers and tests untouched.
+
+### Files touched
+
+- `discogs/fallthrough.py` — add `_REQUEST_CONTEXT` contextvar, set/reset around API-fetch leg.
+- `discogs/service.py` — read contextvar in `_request_with_retry`, tag both spans.
+- `tests/unit/test_discogs_request_telemetry.py` — new test file.
+
+Estimated diff: ~80 lines of code + ~120 lines of test.
+
+## #1 — Cache miss provenance sample script
+
+### Inputs
+
+- Either: a log file (NDJSON or text) on disk — the user `railway logs` exports a window before running.
+- Or: stdin (`cat railway-log.txt | python scripts/cache_miss_provenance.py`).
+- `DATABASE_URL_DISCOGS` env var (mandatory) for the PG side.
+
+Discrimination: log format. The existing `fallthrough.py:236` emits `logger.debug("Cache miss (%s)", label)` and the `_add_discogs_breadcrumb("cache_miss", bc_data)` breadcrumb carries `release_id` / `artist_id` (set at the call site). Production logs run at INFO and won't have the `Cache miss (label)` debug line — but the orchestrator and `cache_service.write_release` calls do log at INFO when an API hit succeeds. The pragmatic source for "miss → API call" events is the `cache_lookup_*` breadcrumb stream, but breadcrumbs aren't in stdout logs by default.
+
+**Decision:** widen the script's input shape to accept multiple forms (regex-driven parsing), and if no input matches in the current production log shape, the script prints a sample of the lines it tried and asks the user to expand `LOG_PATTERNS` for the actual format. This is a one-shot diagnostic — failing loudly with a sample is fine.
+
+The script's tunable: a list of compiled regexes that capture `(timestamp, label, release_id, artist_id?)`. The default set captures:
+- `Cache miss (search_releases_by_track)` (debug — needs `LOG_LEVEL=DEBUG` window)
+- `Discogs API: GET /releases/{id}` (always emitted)
+- `Discogs API: GET /artists/{id}`
+- `Discogs API: GET /database/search?...`
+
+The release/artist-id-bearing API call lines are the actually-reliable proxy.
+
+### Classification
+
+For each captured `release_id`:
+- `release_existed`: `SELECT id FROM release WHERE id = $1` returns a row
+- `release_track_count`: `SELECT count(*) FROM release_track WHERE release_id = $1`
+- `method`: from the regex match (`get_release` / `search_releases_by_track` / `validate_track_on_release` / etc.)
+- `artist_seen_in_window`: any earlier cache-hit line in the same input window for the same `artist_id` (set lookup; `True`/`False`)
+
+Output: CSV at `/tmp/lml-537-cache-miss-provenance.csv` with columns `timestamp,method,release_id,artist_id,release_existed,release_track_count,artist_seen_in_window`.
+
+### Acceptance
+
+- Runs against a Railway log export without code import-time dependence on the cache (uses `psycopg` directly like the sibling `audit_va_writeback_pollution.py`).
+- Dry: no PG writes.
+- A `--limit N` flag for the issue's "50 random events" sample. Defaults to 50.
+- Test: `tests/unit/test_cache_miss_provenance.py` mocks `psycopg.connect` and a synthetic log fixture, asserts CSV row shape. Two cases: release-row-exists-with-tracks vs. release-row-absent.
+
+### Files touched
+
+- `scripts/cache_miss_provenance.py` (new)
+- `tests/unit/test_cache_miss_provenance.py` (new)
+
+Estimated: ~150 lines of script + ~80 lines of test.
+
+## #2 — Dynamic-write contribution histogram script
+
+A direct port of the issue's one-line query:
+
+```sql
+SELECT count(*) AS rows, date_trunc('day', artwork_checked_at) AS day
+FROM release
+WHERE artwork_checked_at IS NOT NULL
+GROUP BY 2
+ORDER BY 2;
+```
+
+Wrapped in a small script for repeatability:
+
+- `DATABASE_URL_DISCOGS` env var
+- Runs the query, prints a stdout table (right-aligned counts, ISO date)
+- A summary line: total rows with `artwork_checked_at IS NOT NULL`, daily mean since `2026-06-07` (post-Alembic-0009 deploy), and the ratio of post-2026-06-07 days to pre.
+- `--since YYYY-MM-DD` flag to override the cutoff (default: 2026-06-07).
+- `--csv` flag to emit machine-readable output.
+
+### Acceptance
+
+- One PG query, idempotent, read-only.
+- Test: `tests/unit/test_cache_warm_histogram.py` mocks `psycopg.connect`, returns a fixture set of (day, count) rows, asserts the printed summary and post-deploy/pre-deploy ratio math.
+
+### Files touched
+
+- `scripts/cache_warm_histogram.py` (new)
+- `tests/unit/test_cache_warm_histogram.py` (new)
+
+Estimated: ~80 lines of script + ~60 lines of test.
+
+## #3 — Ranking-jitter test script
+
+Live probe against the Discogs API (no PG involvement).
+
+- Reads `DISCOGS_TOKEN` (mandatory).
+- Takes `--track TITLE --artist NAME` on the command line. Defaults to a canonical example from the issue (`Moments of Soft Persuasion` and friends).
+- Issues two identical `/database/search?type=release&q=<artist>+<track>` calls separated by `--delay-seconds N` (default 30s — within Discogs's 60s rate-limit window).
+- Captures the full release-ID list from each response, computes:
+  - `len(set_a)`, `len(set_b)`
+  - `overlap = len(set_a & set_b)`
+  - `jaccard = overlap / len(set_a | set_b)`
+  - Position-stability: average rank-delta for IDs present in both calls.
+- Optional `--repeat N` to issue N pairs and emit summary stats.
+
+### Wire format
+
+We can call the live API directly with `httpx.AsyncClient` and the issue's documented base (`api.discogs.com`); no need to spin up the full `DiscogsService` (its semaphore + L1 cache would muddy the test). This is a deliberately *raw* probe.
+
+### Acceptance
+
+- Stdout output: a one-line summary per pair plus a final aggregate.
+- A `--json` flag for machine consumption (so the result is grep-able in a future issue update).
+- Test: `tests/unit/test_discogs_ranking_jitter.py` patches `httpx.AsyncClient.get` with two synthetic Discogs payloads (high overlap and low overlap fixtures), asserts the jaccard math and position-stability calc.
+
+### Files touched
+
+- `scripts/discogs_ranking_jitter.py` (new)
+- `tests/unit/test_discogs_ranking_jitter.py` (new)
+
+Estimated: ~120 lines of script + ~80 lines of test.
+
+## Doc updates
+
+- `docs/scripts.md` gets a one-liner per new script under a new "Cache investigation (LML#537)" section, matching the existing layout (each script gets purpose + run command). Per CLAUDE.md, project-scope docs are maintained alongside the code that adds them.
+
+## Out of scope
+
+- **#4 — Steady-state estimate.** A back-of-envelope math problem, not code. Will be a comment on #537 after this lands and a few days of data accumulate.
+- **#5 — PG row-count audit.** A daily snapshot to capture over a week. The histogram from #2 already gives the cumulative shape; the daily delta is the same data in a different cut. Will be re-run from #2 on a schedule out-of-band.
+- The two operational secret leaks called out in the issue's "Out of scope" — separate issue.
+- The `MAX_SEARCH_RESULTS` early-exit gap (already #536).
+- Cosmetic test nits (already noted in the issue's "Out of scope").
+
+## Risks
+
+- **#6 contextvar leakage.** The seam's `Token`-paired set/reset is correct under cancellation (`finally` always runs). Test coverage includes a CancelledError case to assert the contextvar resets.
+- **#1 log shape divergence.** If production logs don't carry the patterns we expect, the script fails loudly with a sample — not silently. User runs it once, sees the sample, expands `LOG_PATTERNS` for the actual format. Cheaper than guessing.
+- **#3 Discogs rate-limit.** Two consecutive requests within 30s are well within the 60-req/60s limit; `--delay-seconds` is configurable for slower probes. If the script is run repeatedly it could nibble at the LML production token's budget — script logs token usage via the `X-Discogs-Ratelimit-Remaining` header.
+
+## Acceptance criteria
+
+- All four files (3 scripts + 1 code change) land in one PR closing #537.
+- All new tests pass under `pytest tests/unit/`.
+- Pre-commit hook (`ruff check` + `ruff format --check`) clean on staged files.
+- The PR's body summarises which probe each file maps to and what each script's expected output looks like — so future-Jake (or another agent) can re-run them from #537's context without re-reading this plan.
+
+## Order of operations
+
+1. #6 first — smallest, TDD'd, most likely to need iteration on the span-tagging approach.
+2. #2 next — simplest script, validates the PG-connection shape (`psycopg.connect` against `DATABASE_URL_DISCOGS`).
+3. #1 — builds on #2's PG connection pattern; harder because of the log-parsing piece.
+4. #3 — independent of the other three.
+5. Pre-push CI checks.
+6. Issue + PR.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -90,6 +90,47 @@ DATABASE_URL_DISCOGS=postgresql://... \
     --fp-rate-target 0.005
 ```
 
+## Cache Investigation (LML#537)
+
+Three one-shot diagnostic scripts that quantify why the Discogs cache hit ratio plateaued at ~50% (`search_releases_by_track` at 34%) after the `write_release` ON CONFLICT failure was resolved by Alembic 0009. All read-only; none modify state.
+
+### Cache miss provenance sample (`scripts/cache_miss_provenance.py`)
+
+For a sample of cache-miss → API-call events, classifies each by whether the `release` row already existed at miss time and whether it carried `release_track` rows. Separates first-time misses (H1 — ETL coverage gap) from release-row-exists-with-tracks misses (H3' — validate-as-hit poisoning).
+
+**Usage:**
+```bash
+DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_miss_provenance.py --log railway-export.log
+DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_miss_provenance.py --ids sentry-traces.csv --limit 50
+```
+
+Outputs `/tmp/lml-537-cache-miss-provenance.csv` and a summary table to stdout. Accepts either a Railway log file (`--log`) parsed by built-in regex patterns or a CSV of `release_id,method` (`--ids`) from a Sentry trace export.
+
+### Cache warm-up histogram (`scripts/cache_warm_histogram.py`)
+
+Buckets `release.artwork_checked_at` by day and contrasts the pre-Alembic-0009 ETL fill with the post-deploy dynamic warm-up daily mean. A small post-deploy mean confirms the warm-up channel is structurally limited (H1).
+
+**Usage:**
+```bash
+DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_warm_histogram.py
+DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_warm_histogram.py --csv > histogram.csv
+DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_warm_histogram.py --since 2026-06-07
+```
+
+### Discogs ranking jitter (`scripts/discogs_ranking_jitter.py`)
+
+Issues two identical `/database/search?track=...&artist=...` calls separated by a short delay, measures jaccard overlap of returned release IDs and average rank-delta for shared IDs. Low jaccard confirms H2 — Discogs returns different IDs across calls, so warming the prior set doesn't help the next one.
+
+**Usage:**
+```bash
+DISCOGS_TOKEN=... python scripts/discogs_ranking_jitter.py \
+  --track "Moments of Soft Persuasion" --artist Yoshimura
+DISCOGS_TOKEN=... python scripts/discogs_ranking_jitter.py \
+  --track Coastin --artist "Quiet Force" --repeat 3 --delay-seconds 45 --json
+```
+
+Bypasses `DiscogsService` (no L1 LRU, no semaphore) to surface Discogs-side ranking behavior directly. Default delay is 30s (within Discogs's 60req/60s window); the `X-Discogs-Ratelimit-Remaining` header is logged after each call.
+
 ## Artist Name Variation Audit (`scripts/variation_audit/`)
 
 Cross-references WXYC library catalog artist name variations against local Discogs and MusicBrainz datasets. Classifies each relationship (ALIAS, MEMBER_OF_GROUP, SEPARATE_ARTIST, COLLABORATION, SPELLING_VARIANT, SPLIT_RELEASE) and identifies artists that should have their own library code. Output includes flowsheet play counts and own-release counts for prioritization.

--- a/scripts/cache_miss_provenance.py
+++ b/scripts/cache_miss_provenance.py
@@ -1,0 +1,291 @@
+"""LML#537 probe #1 — Cache miss provenance sample.
+
+For a sample of recent cache-miss → API-call events, classify each by:
+
+  (a) did the ``release`` row already exist at miss time?
+  (b) if (a), did it carry any ``release_track`` rows?
+  (c) which lookup method missed (where extractable from the log line)?
+  (d) was the release ID seen earlier in the window (any line referencing it)?
+
+Output: CSV at ``--out`` (default ``/tmp/lml-537-cache-miss-provenance.csv``)
+with one row per release_id extracted from the input. The (a)/(b) split
+separates first-time misses (H1: ETL coverage gap) from
+release-row-exists-with-tracks misses (H3': ``validate_track_on_release``
+returning ``False`` as a cache hit). The (d) flag flags artist-warm hits
+where the validate path's miss was the only gap.
+
+Input shapes accepted (pick one):
+
+* ``--log PATH`` — a text log file (``railway logs`` export, ``-`` for stdin).
+  The script tries a default set of regexes against each line; lines that
+  match contribute one row to the sample. The regex set captures the
+  INFO-level lines that already exist in production:
+
+    * ``Validated: 'TRACK' by 'ARTIST' found on release RELEASE_ID``
+    * ``Validated (fuzzy): 'TRACK' by 'ARTIST' on release RELEASE_ID``
+    * ``Track 'TRACK' by 'ARTIST' NOT found on release RELEASE_ID``
+    * ``Failed to fetch release RELEASE_ID``
+
+  Each of these fires on the API leg of ``validate_track_on_release`` —
+  i.e., the cache missed on that release_id. ``method`` is set to
+  ``validate_track_on_release`` for all four.
+
+* ``--ids PATH`` — a CSV with columns ``release_id`` and ``method`` (and
+  optional ``timestamp``). Use this when feeding the sample from a
+  Sentry trace export rather than a stdout log.
+
+The script does not write to PG. Read-only.
+
+Usage::
+
+    DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_miss_provenance.py --log railway.log
+    DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_miss_provenance.py --log - < railway.log
+    DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_miss_provenance.py --ids sentry-export.csv --limit 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import random
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import psycopg
+
+
+@dataclass(frozen=True)
+class MissEvent:
+    """A single cache-miss event extracted from the input."""
+
+    release_id: int
+    method: str
+    timestamp: str  # original log timestamp prefix or ""
+
+
+# The regex set targeting the INFO-level log lines that already exist in prod.
+# Each carries a ``release_id`` extractable group. ``method`` is fixed per
+# pattern — all four fire on the validate path which is the dominant warm-up
+# channel per the issue's H1.
+_LOG_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"Validated: '.+' by '.+' found on release (\d+)"), "validate_track_on_release"),
+    (
+        re.compile(r"Validated \(fuzzy\): '.+' by '.+' on release (\d+)"),
+        "validate_track_on_release",
+    ),
+    (re.compile(r"Track '.+' by '.+' NOT found on release (\d+)"), "validate_track_on_release"),
+    (re.compile(r"Failed to fetch release (\d+)"), "get_release"),
+)
+
+# Best-effort timestamp prefix (ISO-8601-ish or RFC 3339); empty if absent.
+_TIMESTAMP_PREFIX = re.compile(r"^(\d{4}-\d{2}-\d{2}[T ][\d:.+Z\-]+)\s")
+
+
+def extract_from_log(stream: Iterable[str]) -> list[MissEvent]:
+    """Parse a log stream and return one ``MissEvent`` per matching line."""
+    events: list[MissEvent] = []
+    for line in stream:
+        timestamp = ""
+        m = _TIMESTAMP_PREFIX.match(line)
+        if m:
+            timestamp = m.group(1)
+        for pattern, method in _LOG_PATTERNS:
+            hit = pattern.search(line)
+            if hit:
+                release_id = int(hit.group(1))
+                events.append(MissEvent(release_id, method, timestamp))
+                break
+    return events
+
+
+def extract_from_ids_csv(path: Path) -> list[MissEvent]:
+    """Read a CSV with ``release_id`` and ``method`` columns."""
+    events: list[MissEvent] = []
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                release_id = int(row["release_id"])
+            except (KeyError, ValueError):
+                continue
+            method = row.get("method", "")
+            timestamp = row.get("timestamp", "")
+            events.append(MissEvent(release_id, method, timestamp))
+    return events
+
+
+def classify(conn: psycopg.Connection, events: list[MissEvent]) -> list[dict[str, object]]:
+    """For each unique release_id, query PG for existence + release_track count.
+
+    The query is one round-trip with an ``= ANY`` filter — cheap even for
+    a few hundred IDs.
+
+    Returns one classified row per input event (in input order).
+    """
+    if not events:
+        return []
+
+    unique_ids = sorted({e.release_id for e in events})
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT r.id, count(rt.release_id) AS release_track_count
+            FROM release r
+            LEFT JOIN release_track rt ON rt.release_id = r.id
+            WHERE r.id = ANY(%s)
+            GROUP BY r.id
+            """,
+            (unique_ids,),
+        )
+        # Maps release_id -> release_track_count. Absent key = row didn't exist.
+        present: dict[int, int] = {row[0]: row[1] for row in cur.fetchall()}
+
+    # First-occurrence index per release_id, for the "prior_seen_in_window" flag.
+    first_seen: dict[int, int] = {}
+    for idx, event in enumerate(events):
+        first_seen.setdefault(event.release_id, idx)
+
+    classified: list[dict[str, object]] = []
+    for idx, event in enumerate(events):
+        existed = event.release_id in present
+        track_count = present.get(event.release_id, 0)
+        prior = first_seen[event.release_id] < idx
+        classified.append(
+            {
+                "timestamp": event.timestamp,
+                "method": event.method,
+                "release_id": event.release_id,
+                "release_existed": existed,
+                "release_track_count": track_count,
+                "prior_seen_in_window": prior,
+            }
+        )
+    return classified
+
+
+def emit_csv(rows: list[dict[str, object]], out) -> None:
+    fields = [
+        "timestamp",
+        "method",
+        "release_id",
+        "release_existed",
+        "release_track_count",
+        "prior_seen_in_window",
+    ]
+    w = csv.DictWriter(out, fieldnames=fields)
+    w.writeheader()
+    w.writerows(rows)
+
+
+def print_summary(rows: list[dict[str, object]]) -> None:
+    total = len(rows)
+    if not total:
+        print("(no events extracted — try expanding --log patterns or use --ids)")
+        return
+    existed = sum(1 for r in rows if r["release_existed"])
+    with_tracks = sum(1 for r in rows if r["release_existed"] and r["release_track_count"])
+    prior_seen = sum(1 for r in rows if r["prior_seen_in_window"])
+
+    def pct(n: int) -> str:
+        return f"({n / total:.1%})"
+
+    print(f"events:                                        {total:>5}")
+    print(f"  release row existed at miss time:            {existed:>5} {pct(existed)}")
+    print(f"    ... with release_track count > 0:          {with_tracks:>5} {pct(with_tracks)}")
+    print(f"  release_id repeated within window:           {prior_seen:>5} {pct(prior_seen)}")
+    print()
+    print("Interpretation per LML#537:")
+    print("  existed=False                  → first-time miss (H1 — ETL coverage gap)")
+    print("  existed=True, track_count=0    → first-time miss after artist-only seed (still H1)")
+    print(
+        "  existed=True, track_count>0    → release was already known with tracks "
+        "(H3' — validate returned False as a hit)"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--log",
+        type=str,
+        help="Path to a log file (use '-' for stdin). Mutually exclusive with --ids.",
+    )
+    parser.add_argument(
+        "--ids",
+        type=Path,
+        help="CSV with release_id,method[,timestamp] columns. Mutually exclusive with --log.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Random sample size from the extracted events (default: 50). 0 = keep all.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="RNG seed for the --limit sample (default: nondeterministic).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("/tmp/lml-537-cache-miss-provenance.csv"),
+        help="Output CSV path (default: /tmp/lml-537-cache-miss-provenance.csv).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.log and not args.ids:
+        print("error: pass either --log or --ids", file=sys.stderr)
+        return 2
+    if args.log and args.ids:
+        print("error: --log and --ids are mutually exclusive", file=sys.stderr)
+        return 2
+
+    dsn = os.environ.get("DATABASE_URL_DISCOGS")
+    if not dsn:
+        print("error: DATABASE_URL_DISCOGS env var required", file=sys.stderr)
+        return 2
+
+    if args.log:
+        if args.log == "-":
+            events = extract_from_log(sys.stdin)
+        else:
+            with Path(args.log).open() as f:
+                events = extract_from_log(f)
+    else:
+        events = extract_from_ids_csv(args.ids)
+
+    if not events:
+        print("error: no events extracted from input", file=sys.stderr)
+        print("  log patterns tried:", file=sys.stderr)
+        for pattern, method in _LOG_PATTERNS:
+            print(f"    {method}: {pattern.pattern}", file=sys.stderr)
+        return 1
+
+    if args.limit and len(events) > args.limit:
+        rng = random.Random(args.seed)
+        events = rng.sample(events, args.limit)
+
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        classified = classify(conn, events)
+
+    with args.out.open("w", newline="") as f:
+        emit_csv(classified, f)
+
+    print_summary(classified)
+    print()
+    print(f"CSV: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cache_miss_provenance.py
+++ b/scripts/cache_miss_provenance.py
@@ -19,16 +19,18 @@ Input shapes accepted (pick one):
 * ``--log PATH`` — a text log file (``railway logs`` export, ``-`` for stdin).
   The script tries a default set of regexes against each line; lines that
   match contribute one row to the sample. The regex set captures the
-  INFO-level lines that already exist in production:
+  INFO-level lines that fire when ``validate_track_on_release`` reached
+  the API leg (i.e., the cache missed for that release_id):
 
     * ``Validated: 'TRACK' by 'ARTIST' found on release RELEASE_ID``
     * ``Validated (fuzzy): 'TRACK' by 'ARTIST' on release RELEASE_ID``
     * ``Track 'TRACK' by 'ARTIST' NOT found on release RELEASE_ID``
-    * ``Failed to fetch release RELEASE_ID``
 
-  Each of these fires on the API leg of ``validate_track_on_release`` —
-  i.e., the cache missed on that release_id. ``method`` is set to
-  ``validate_track_on_release`` for all four.
+  ``method`` is set to ``validate_track_on_release`` for all three. The
+  ``Failed to fetch release RELEASE_ID`` warning is *not* captured here —
+  it fires on an API failure (timeout, 5xx) rather than a clean cache
+  miss, and including it would conflate H1/H3' provenance with availability
+  faults.
 
 * ``--ids PATH`` — a CSV with columns ``release_id`` and ``method`` (and
   optional ``timestamp``). Use this when feeding the sample from a
@@ -69,10 +71,12 @@ class MissEvent:
     timestamp: str  # original log timestamp prefix or ""
 
 
-# The regex set targeting the INFO-level log lines that already exist in prod.
-# Each carries a ``release_id`` extractable group. ``method`` is fixed per
-# pattern — all four fire on the validate path which is the dominant warm-up
-# channel per the issue's H1.
+# INFO-level log lines that fire on the validate path's API leg — i.e., the
+# cache missed for that release_id and we then asked Discogs. These are the
+# dominant warm-up channel per the issue's H1. The ``Failed to fetch release``
+# warning is deliberately NOT in this set: it fires on API failures (timeout,
+# 5xx) rather than clean cache misses, and including it would conflate
+# H1/H3' provenance with availability faults.
 _LOG_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"Validated: '.+' by '.+' found on release (\d+)"), "validate_track_on_release"),
     (
@@ -80,7 +84,6 @@ _LOG_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
         "validate_track_on_release",
     ),
     (re.compile(r"Track '.+' by '.+' NOT found on release (\d+)"), "validate_track_on_release"),
-    (re.compile(r"Failed to fetch release (\d+)"), "get_release"),
 )
 
 # Best-effort timestamp prefix (ISO-8601-ish or RFC 3339); empty if absent.

--- a/scripts/cache_miss_provenance.py
+++ b/scripts/cache_miss_provenance.py
@@ -123,18 +123,40 @@ def extract_from_ids_csv(path: Path) -> list[MissEvent]:
     return events
 
 
-def classify(conn: psycopg.Connection, events: list[MissEvent]) -> list[dict[str, object]]:
-    """For each unique release_id, query PG for existence + release_track count.
+def compute_first_seen(events: list[MissEvent]) -> dict[int, int]:
+    """Index of the first occurrence per ``release_id`` over the input events.
 
-    The query is one round-trip with an ``= ANY`` filter — cheap even for
-    a few hundred IDs.
-
-    Returns one classified row per input event (in input order).
+    Computed over the FULL events list *before* any sampling so that
+    ``prior_seen_in_window`` stays anchored to the user's log window, not
+    to whichever subset ``rng.sample`` happened to pick.
     """
-    if not events:
+    first_seen: dict[int, int] = {}
+    for idx, event in enumerate(events):
+        first_seen.setdefault(event.release_id, idx)
+    return first_seen
+
+
+def classify(
+    conn: psycopg.Connection,
+    indexed_events: list[tuple[int, MissEvent]],
+    first_seen: dict[int, int],
+) -> list[dict[str, object]]:
+    """For each ``(original_index, event)`` pair, classify by PG state.
+
+    ``first_seen`` is precomputed over the *full* log so that
+    ``prior_seen_in_window`` reflects whether the release_id appeared
+    earlier in the user's input window — not just earlier in the sample.
+    ``rng.sample`` returns elements in random selection order and would
+    otherwise silently invert the semantic.
+
+    Returns one classified row per input event, in the input order of
+    ``indexed_events`` (caller is expected to pass them sorted by
+    ``original_index`` for a chronological CSV).
+    """
+    if not indexed_events:
         return []
 
-    unique_ids = sorted({e.release_id for e in events})
+    unique_ids = sorted({e.release_id for _, e in indexed_events})
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -149,16 +171,11 @@ def classify(conn: psycopg.Connection, events: list[MissEvent]) -> list[dict[str
         # Maps release_id -> release_track_count. Absent key = row didn't exist.
         present: dict[int, int] = {row[0]: row[1] for row in cur.fetchall()}
 
-    # First-occurrence index per release_id, for the "prior_seen_in_window" flag.
-    first_seen: dict[int, int] = {}
-    for idx, event in enumerate(events):
-        first_seen.setdefault(event.release_id, idx)
-
     classified: list[dict[str, object]] = []
-    for idx, event in enumerate(events):
+    for original_idx, event in indexed_events:
         existed = event.release_id in present
         track_count = present.get(event.release_id, 0)
-        prior = first_seen[event.release_id] < idx
+        prior = first_seen[event.release_id] < original_idx
         classified.append(
             {
                 "timestamp": event.timestamp,
@@ -272,14 +289,19 @@ def main(argv: list[str] | None = None) -> int:
             print(f"    {method}: {pattern.pattern}", file=sys.stderr)
         return 1
 
-    if args.limit and len(events) > args.limit:
+    # Compute first_seen over the FULL log BEFORE sampling so the
+    # prior_seen_in_window flag stays anchored to the user's log window
+    # rather than to whichever subset rng.sample happened to pick.
+    first_seen = compute_first_seen(events)
+    indexed_events = list(enumerate(events))
+    if args.limit and len(indexed_events) > args.limit:
         rng = random.Random(args.seed)
-        events = rng.sample(events, args.limit)
+        indexed_events = sorted(rng.sample(indexed_events, args.limit), key=lambda p: p[0])
 
     import psycopg
 
     with psycopg.connect(dsn) as conn:
-        classified = classify(conn, events)
+        classified = classify(conn, indexed_events, first_seen)
 
     with args.out.open("w", newline="") as f:
         emit_csv(classified, f)

--- a/scripts/cache_warm_histogram.py
+++ b/scripts/cache_warm_histogram.py
@@ -1,0 +1,157 @@
+"""LML#537 probe #2 — Dynamic-write contribution histogram.
+
+Counts ``release`` rows by the day they were stamped with
+``artwork_checked_at``. Separates the ETL load (large early-day buckets,
+populated when ``discogs-etl`` first ran) from API-driven warm-up
+(post-Alembic-0009 daily delta — i.e., the dynamic cache fill that has
+been working since 2026-06-07 when LML#534's PK fix landed).
+
+If the post-2026-06-07 daily mean is small relative to the ETL load, the
+warm-up channel is structurally limited — confirming H1 from #537.
+
+Usage::
+
+    DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_warm_histogram.py
+    DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_warm_histogram.py --csv
+    DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_warm_histogram.py --since 2026-06-07
+
+Read-only; one query. No state is touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import os
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import psycopg
+
+# The deploy that fixed dynamic write-back. See LML#537 issue body and
+# discogs-etl alembic 0009 (cache_metadata_unique). Used as the default
+# split point for "before" (ETL fill) vs "after" (dynamic warm-up) buckets.
+_DEFAULT_CUTOFF = dt.date(2026, 6, 7)
+
+
+def fetch_histogram(conn: psycopg.Connection) -> list[tuple[dt.date, int]]:
+    """All non-null ``artwork_checked_at`` rows, bucketed by day."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                date_trunc('day', artwork_checked_at)::date AS day,
+                count(*) AS rows
+            FROM release
+            WHERE artwork_checked_at IS NOT NULL
+            GROUP BY 1
+            ORDER BY 1
+            """
+        )
+        return [(row[0], row[1]) for row in cur.fetchall()]
+
+
+def summarise(rows: list[tuple[dt.date, int]], cutoff: dt.date) -> dict[str, float | int]:
+    """Compute totals + before/after means around ``cutoff``."""
+    if not rows:
+        return {
+            "total_rows": 0,
+            "days_before": 0,
+            "days_after": 0,
+            "rows_before": 0,
+            "rows_after": 0,
+            "mean_before": 0.0,
+            "mean_after": 0.0,
+        }
+
+    rows_before = sum(c for d, c in rows if d < cutoff)
+    rows_after = sum(c for d, c in rows if d >= cutoff)
+    days_before = sum(1 for d, _ in rows if d < cutoff)
+    days_after = sum(1 for d, _ in rows if d >= cutoff)
+
+    return {
+        "total_rows": rows_before + rows_after,
+        "days_before": days_before,
+        "days_after": days_after,
+        "rows_before": rows_before,
+        "rows_after": rows_after,
+        "mean_before": rows_before / days_before if days_before else 0.0,
+        "mean_after": rows_after / days_after if days_after else 0.0,
+    }
+
+
+def print_table(rows: list[tuple[dt.date, int]], cutoff: dt.date) -> None:
+    if not rows:
+        print("(no rows with artwork_checked_at IS NOT NULL)")
+        return
+    max_count = max(c for _, c in rows)
+    width = len(f"{max_count:,}")
+    print(f"{'day':<12} {'rows':>{width}}  marker")
+    for d, c in rows:
+        marker = "POST" if d >= cutoff else ""
+        print(f"{d.isoformat():<12} {c:>{width},}  {marker}")
+
+
+def print_summary(summary: dict[str, float | int], cutoff: dt.date) -> None:
+    print()
+    print(f"total rows (artwork_checked_at not null): {summary['total_rows']:>10,}")
+    print(f"cutoff:                                   {cutoff.isoformat()}")
+    print(
+        f"  before ({summary['days_before']} days):"
+        f"                          {summary['rows_before']:>10,}"
+        f"  (mean {summary['mean_before']:.1f}/day)"
+    )
+    print(
+        f"  on/after ({summary['days_after']} days):"
+        f"                        {summary['rows_after']:>10,}"
+        f"  (mean {summary['mean_after']:.1f}/day)"
+    )
+    if summary["mean_after"] and summary["mean_before"]:
+        ratio = summary["mean_after"] / summary["mean_before"]
+        print(f"  post-cutoff / pre-cutoff daily-mean ratio: {ratio:.3f}")
+
+
+def emit_csv(rows: list[tuple[dt.date, int]], out) -> None:
+    w = csv.writer(out)
+    w.writerow(["day", "rows"])
+    for d, c in rows:
+        w.writerow([d.isoformat(), c])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since",
+        type=dt.date.fromisoformat,
+        default=_DEFAULT_CUTOFF,
+        help=(
+            "Cutoff date (YYYY-MM-DD) that splits pre/post-deploy buckets. "
+            f"Default: {_DEFAULT_CUTOFF.isoformat()} (Alembic 0009 deploy)."
+        ),
+    )
+    parser.add_argument("--csv", action="store_true", help="Emit CSV to stdout instead of a table")
+    args = parser.parse_args(argv)
+
+    dsn = os.environ.get("DATABASE_URL_DISCOGS")
+    if not dsn:
+        print("error: DATABASE_URL_DISCOGS env var required", file=sys.stderr)
+        return 2
+
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        rows = fetch_histogram(conn)
+
+    if args.csv:
+        emit_csv(rows, sys.stdout)
+        return 0
+
+    print_table(rows, args.since)
+    print_summary(summarise(rows, args.since), args.since)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/discogs_ranking_jitter.py
+++ b/scripts/discogs_ranking_jitter.py
@@ -1,0 +1,250 @@
+"""LML#537 probe #3 — Discogs ranking-jitter test.
+
+For a ``(track, artist)`` query shape, issue two identical
+``/database/search`` calls separated by a short delay and measure how
+stable Discogs's ranking is. The shape of the result determines whether
+the seam's per-call warm-up of ``release_track`` can structurally
+benefit the *next* identical query:
+
+* High overlap (jaccard ~ 1.0) → warming this call's release IDs warms
+  the next one too. Cache warm-up is mechanically effective.
+* Low overlap (jaccard < 0.5) → Discogs returns different IDs across
+  calls. Warming the prior set doesn't help the next one. H2 confirmed.
+
+The script issues queries against ``api.discogs.com`` directly rather
+than through ``DiscogsService``; it deliberately bypasses the L1 LRU
+and the rate-limiter semaphore so the result reflects Discogs-side
+behavior, not LML-side caching. The default delay (30s) is well within
+Discogs's 60req/60s window — concurrent runs against the same token
+will eat into prod's budget; rerun a few times rather than in a tight
+loop.
+
+Usage::
+
+    DISCOGS_TOKEN=... python scripts/discogs_ranking_jitter.py \\
+        --track "Moments of Soft Persuasion" --artist "Yoshimura"
+    DISCOGS_TOKEN=... python scripts/discogs_ranking_jitter.py \\
+        --track Coastin --artist "Quiet Force" --repeat 3 --delay-seconds 45
+    DISCOGS_TOKEN=... python scripts/discogs_ranking_jitter.py --track ... --artist ... --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DISCOGS_API_BASE = "https://api.discogs.com"
+_DEFAULT_LIMIT = 20
+
+
+@dataclass
+class JitterPair:
+    """A single pair of identical-query results captured back-to-back."""
+
+    call_a_ids: list[int]
+    call_b_ids: list[int]
+    delay_seconds: float
+
+    @property
+    def set_a(self) -> set[int]:
+        return set(self.call_a_ids)
+
+    @property
+    def set_b(self) -> set[int]:
+        return set(self.call_b_ids)
+
+    @property
+    def overlap(self) -> int:
+        return len(self.set_a & self.set_b)
+
+    @property
+    def union(self) -> int:
+        return len(self.set_a | self.set_b)
+
+    @property
+    def jaccard(self) -> float:
+        if not self.union:
+            return 0.0
+        return self.overlap / self.union
+
+    def position_stability(self) -> float | None:
+        """Average |rank_a - rank_b| for IDs present in both result lists.
+
+        Lower is more stable. ``None`` when the lists share no IDs.
+        """
+        rank_a = {rid: idx for idx, rid in enumerate(self.call_a_ids)}
+        rank_b = {rid: idx for idx, rid in enumerate(self.call_b_ids)}
+        shared = set(rank_a) & set(rank_b)
+        if not shared:
+            return None
+        return sum(abs(rank_a[r] - rank_b[r]) for r in shared) / len(shared)
+
+
+def _build_params(track: str, artist: str, limit: int) -> dict[str, str | int]:
+    return {
+        "type": "release",
+        "track": track,
+        "artist": artist,
+        "per_page": limit,
+    }
+
+
+def _extract_release_ids(payload: dict) -> list[int]:
+    """Return the ``id`` from each ``results[*]`` in Discogs's response."""
+    return [int(r["id"]) for r in payload.get("results", []) if "id" in r]
+
+
+async def _search_once(
+    client: httpx.AsyncClient, params: dict, token: str
+) -> tuple[list[int], int | None]:
+    """One ``/database/search`` request; returns (release_ids, ratelimit_remaining)."""
+    headers = {"Authorization": f"Discogs token={token}", "User-Agent": "LML/537-jitter"}
+    resp = await client.get(f"{_DISCOGS_API_BASE}/database/search", params=params, headers=headers)
+    resp.raise_for_status()
+    remaining = resp.headers.get("X-Discogs-Ratelimit-Remaining")
+    return _extract_release_ids(resp.json()), int(remaining) if remaining else None
+
+
+async def run_pair(
+    client: httpx.AsyncClient,
+    track: str,
+    artist: str,
+    delay_seconds: float,
+    token: str,
+    limit: int,
+) -> JitterPair:
+    """Issue two identical queries separated by ``delay_seconds``."""
+    params = _build_params(track, artist, limit)
+    ids_a, rem_a = await _search_once(client, params, token)
+    await asyncio.sleep(delay_seconds)
+    ids_b, rem_b = await _search_once(client, params, token)
+    logger.info(
+        "ratelimit_remaining: call_a=%s call_b=%s",
+        rem_a if rem_a is not None else "?",
+        rem_b if rem_b is not None else "?",
+    )
+    return JitterPair(call_a_ids=ids_a, call_b_ids=ids_b, delay_seconds=delay_seconds)
+
+
+def aggregate(pairs: list[JitterPair]) -> dict[str, float | int]:
+    """Aggregate stats across N pairs."""
+    if not pairs:
+        return {"pairs": 0}
+    jaccards = [p.jaccard for p in pairs]
+    stabilities = [s for p in pairs if (s := p.position_stability()) is not None]
+    return {
+        "pairs": len(pairs),
+        "jaccard_mean": sum(jaccards) / len(jaccards),
+        "jaccard_min": min(jaccards),
+        "jaccard_max": max(jaccards),
+        "position_stability_mean": (
+            sum(stabilities) / len(stabilities) if stabilities else float("nan")
+        ),
+    }
+
+
+def print_pair(pair: JitterPair, index: int) -> None:
+    print(
+        f"  pair {index}: "
+        f"|A|={len(pair.call_a_ids)} |B|={len(pair.call_b_ids)} "
+        f"overlap={pair.overlap} union={pair.union} "
+        f"jaccard={pair.jaccard:.3f} "
+        f"stability={pair.position_stability()}"
+    )
+
+
+def print_summary(agg: dict[str, float | int]) -> None:
+    if not agg.get("pairs"):
+        return
+    print()
+    print(f"pairs:                {agg['pairs']}")
+    print(
+        f"jaccard mean / min / max:   "
+        f"{agg['jaccard_mean']:.3f} / {agg['jaccard_min']:.3f} / {agg['jaccard_max']:.3f}"
+    )
+    stability = agg["position_stability_mean"]
+    if stability == stability:  # noqa: PLR0124 — NaN check
+        print(f"position_stability_mean:  {stability:.2f}")
+    else:
+        print("position_stability_mean:  (no shared IDs across any pair)")
+    print()
+    print("Interpretation per LML#537 (H2):")
+    print("  jaccard ~ 1.0 → warming this call's IDs warms the next; cache warm-up effective.")
+    print(
+        "  jaccard < 0.5 → Discogs returns different IDs across calls; "
+        "warm-up is structurally ineffective for repeat lookups."
+    )
+
+
+async def _main_async(args: argparse.Namespace, token: str) -> int:
+    pairs: list[JitterPair] = []
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        for i in range(args.repeat):
+            pair = await run_pair(
+                client,
+                track=args.track,
+                artist=args.artist,
+                delay_seconds=args.delay_seconds,
+                token=token,
+                limit=args.limit,
+            )
+            pairs.append(pair)
+            if not args.json:
+                print(f"track='{args.track}' artist='{args.artist}'")
+                print_pair(pair, i + 1)
+
+    agg = aggregate(pairs)
+    if args.json:
+        print(json.dumps({"pairs": [p.__dict__ for p in pairs], "aggregate": agg}, default=list))
+    else:
+        print_summary(agg)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--track", required=True, help="Track title (queried as ?track=)")
+    parser.add_argument("--artist", required=True, help="Artist name (queried as ?artist=)")
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=30.0,
+        help="Seconds between the two calls of each pair (default: 30)",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help="Number of pairs to issue (default: 1)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=_DEFAULT_LIMIT,
+        help=f"per_page on the Discogs query (default: {_DEFAULT_LIMIT})",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable output instead of a summary"
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("DISCOGS_TOKEN")
+    if not token:
+        print("error: DISCOGS_TOKEN env var required", file=sys.stderr)
+        return 2
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    return asyncio.run(_main_async(args, token))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/discogs_ranking_jitter.py
+++ b/scripts/discogs_ranking_jitter.py
@@ -40,9 +40,10 @@ from dataclasses import dataclass
 
 import httpx
 
+from discogs.service import DISCOGS_API_BASE
+
 logger = logging.getLogger(__name__)
 
-_DISCOGS_API_BASE = "https://api.discogs.com"
 _DEFAULT_LIMIT = 20
 
 
@@ -54,27 +55,14 @@ class JitterPair:
     call_b_ids: list[int]
     delay_seconds: float
 
-    @property
-    def set_a(self) -> set[int]:
-        return set(self.call_a_ids)
-
-    @property
-    def set_b(self) -> set[int]:
-        return set(self.call_b_ids)
-
-    @property
-    def overlap(self) -> int:
-        return len(self.set_a & self.set_b)
-
-    @property
-    def union(self) -> int:
-        return len(self.set_a | self.set_b)
-
-    @property
-    def jaccard(self) -> float:
-        if not self.union:
-            return 0.0
-        return self.overlap / self.union
+    def stats(self) -> tuple[int, int, float]:
+        """Return ``(overlap, union, jaccard)`` computed in a single pass."""
+        set_a = set(self.call_a_ids)
+        set_b = set(self.call_b_ids)
+        overlap = len(set_a & set_b)
+        union = len(set_a | set_b)
+        jaccard = overlap / union if union else 0.0
+        return overlap, union, jaccard
 
     def position_stability(self) -> float | None:
         """Average |rank_a - rank_b| for IDs present in both result lists.
@@ -87,6 +75,19 @@ class JitterPair:
         if not shared:
             return None
         return sum(abs(rank_a[r] - rank_b[r]) for r in shared) / len(shared)
+
+    def to_record(self) -> dict[str, object]:
+        """Serializable shape that includes derived metrics — used by --json."""
+        overlap, union, jaccard = self.stats()
+        return {
+            "call_a_ids": self.call_a_ids,
+            "call_b_ids": self.call_b_ids,
+            "delay_seconds": self.delay_seconds,
+            "overlap": overlap,
+            "union": union,
+            "jaccard": jaccard,
+            "position_stability": self.position_stability(),
+        }
 
 
 def _build_params(track: str, artist: str, limit: int) -> dict[str, str | int]:
@@ -108,7 +109,7 @@ async def _search_once(
 ) -> tuple[list[int], int | None]:
     """One ``/database/search`` request; returns (release_ids, ratelimit_remaining)."""
     headers = {"Authorization": f"Discogs token={token}", "User-Agent": "LML/537-jitter"}
-    resp = await client.get(f"{_DISCOGS_API_BASE}/database/search", params=params, headers=headers)
+    resp = await client.get(f"{DISCOGS_API_BASE}/database/search", params=params, headers=headers)
     resp.raise_for_status()
     remaining = resp.headers.get("X-Discogs-Ratelimit-Remaining")
     return _extract_release_ids(resp.json()), int(remaining) if remaining else None
@@ -139,7 +140,7 @@ def aggregate(pairs: list[JitterPair]) -> dict[str, float | int]:
     """Aggregate stats across N pairs."""
     if not pairs:
         return {"pairs": 0}
-    jaccards = [p.jaccard for p in pairs]
+    jaccards = [p.stats()[2] for p in pairs]
     stabilities = [s for p in pairs if (s := p.position_stability()) is not None]
     return {
         "pairs": len(pairs),
@@ -153,11 +154,12 @@ def aggregate(pairs: list[JitterPair]) -> dict[str, float | int]:
 
 
 def print_pair(pair: JitterPair, index: int) -> None:
+    overlap, union, jaccard = pair.stats()
     print(
         f"  pair {index}: "
         f"|A|={len(pair.call_a_ids)} |B|={len(pair.call_b_ids)} "
-        f"overlap={pair.overlap} union={pair.union} "
-        f"jaccard={pair.jaccard:.3f} "
+        f"overlap={overlap} union={union} "
+        f"jaccard={jaccard:.3f} "
         f"stability={pair.position_stability()}"
     )
 
@@ -204,7 +206,7 @@ async def _main_async(args: argparse.Namespace, token: str) -> int:
 
     agg = aggregate(pairs)
     if args.json:
-        print(json.dumps({"pairs": [p.__dict__ for p in pairs], "aggregate": agg}, default=list))
+        print(json.dumps({"pairs": [p.to_record() for p in pairs], "aggregate": agg}))
     else:
         print_summary(agg)
     return 0

--- a/scripts/discogs_ranking_jitter.py
+++ b/scripts/discogs_ranking_jitter.py
@@ -77,7 +77,13 @@ class JitterPair:
         return sum(abs(rank_a[r] - rank_b[r]) for r in shared) / len(shared)
 
     def to_record(self) -> dict[str, object]:
-        """Serializable shape that includes derived metrics — used by --json."""
+        """Serializable shape for ``--json`` output. Keys:
+
+        ``call_a_ids`` (list[int]), ``call_b_ids`` (list[int]),
+        ``delay_seconds`` (float), ``overlap`` (int), ``union`` (int),
+        ``jaccard`` (float), ``position_stability`` (float | None — ``None``
+        when the two result lists share no IDs).
+        """
         overlap, union, jaccard = self.stats()
         return {
             "call_a_ids": self.call_a_ids,
@@ -136,8 +142,13 @@ async def run_pair(
     return JitterPair(call_a_ids=ids_a, call_b_ids=ids_b, delay_seconds=delay_seconds)
 
 
-def aggregate(pairs: list[JitterPair]) -> dict[str, float | int]:
-    """Aggregate stats across N pairs."""
+def aggregate(pairs: list[JitterPair]) -> dict[str, float | int | None]:
+    """Aggregate stats across N pairs.
+
+    ``position_stability_mean`` is ``None`` when no pair has shared IDs —
+    JSON-serializes as ``null`` (strict-parser-safe), unlike ``float('nan')``
+    which Python's ``json.dumps`` emits as literal ``NaN``.
+    """
     if not pairs:
         return {"pairs": 0}
     jaccards = [p.stats()[2] for p in pairs]
@@ -147,9 +158,7 @@ def aggregate(pairs: list[JitterPair]) -> dict[str, float | int]:
         "jaccard_mean": sum(jaccards) / len(jaccards),
         "jaccard_min": min(jaccards),
         "jaccard_max": max(jaccards),
-        "position_stability_mean": (
-            sum(stabilities) / len(stabilities) if stabilities else float("nan")
-        ),
+        "position_stability_mean": (sum(stabilities) / len(stabilities) if stabilities else None),
     }
 
 
@@ -164,7 +173,7 @@ def print_pair(pair: JitterPair, index: int) -> None:
     )
 
 
-def print_summary(agg: dict[str, float | int]) -> None:
+def print_summary(agg: dict[str, float | int | None]) -> None:
     if not agg.get("pairs"):
         return
     print()
@@ -174,10 +183,10 @@ def print_summary(agg: dict[str, float | int]) -> None:
         f"{agg['jaccard_mean']:.3f} / {agg['jaccard_min']:.3f} / {agg['jaccard_max']:.3f}"
     )
     stability = agg["position_stability_mean"]
-    if stability == stability:  # noqa: PLR0124 — NaN check
-        print(f"position_stability_mean:  {stability:.2f}")
-    else:
+    if stability is None:
         print("position_stability_mean:  (no shared IDs across any pair)")
+    else:
+        print(f"position_stability_mean:  {stability:.2f}")
     print()
     print("Interpretation per LML#537 (H2):")
     print("  jaccard ~ 1.0 → warming this call's IDs warms the next; cache warm-up effective.")

--- a/tests/unit/test_cache_miss_provenance.py
+++ b/tests/unit/test_cache_miss_provenance.py
@@ -29,17 +29,22 @@ def test_extract_pulls_release_ids_from_validate_log_lines():
         "2026-06-11T07:42:01.123Z INFO Validated: 'Aluminum Tunes' by 'Stereolab' found on release 9876",
         "2026-06-11T07:42:02.456Z INFO Track 'Yoshimura' by 'X' NOT found on release 11111",
         "2026-06-11T07:42:03.789Z INFO Validated (fuzzy): 'Foo' by 'Bar' on release 22222",
-        "2026-06-11T07:42:04.999Z WARNING Failed to fetch release 33333 (rate limited or error)",
         "2026-06-11T07:42:05.000Z INFO unrelated noise",
     ]
     events = extract_from_log(lines)
 
-    assert [e.release_id for e in events] == [9876, 11111, 22222, 33333]
-    assert events[0].method == "validate_track_on_release"
-    assert events[1].method == "validate_track_on_release"
-    assert events[2].method == "validate_track_on_release"
-    assert events[3].method == "get_release"
+    assert [e.release_id for e in events] == [9876, 11111, 22222]
+    assert all(e.method == "validate_track_on_release" for e in events)
     assert events[0].timestamp == "2026-06-11T07:42:01.123Z"
+
+
+def test_extract_skips_api_failure_lines():
+    """Failed-to-fetch warnings fire on API faults, not cache misses, so the
+    extractor must NOT pull them into the H1/H3' provenance sample (LML#537)."""
+    lines = [
+        "2026-06-11T07:42:04.999Z WARNING Failed to fetch release 33333 (rate limited or error)",
+    ]
+    assert extract_from_log(lines) == []
 
 
 def test_classify_release_existed_with_tracks_is_h3prime_candidate():

--- a/tests/unit/test_cache_miss_provenance.py
+++ b/tests/unit/test_cache_miss_provenance.py
@@ -1,0 +1,116 @@
+"""Tests for ``scripts/cache_miss_provenance.py`` (LML#537 probe #1)."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+
+from scripts.cache_miss_provenance import (
+    MissEvent,
+    classify,
+    emit_csv,
+    extract_from_log,
+)
+
+
+def _fake_conn(rows: list[tuple[int, int]]):
+    """Build a psycopg-shaped mock that yields ``rows`` from ``fetchall()``."""
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=None)
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    return conn
+
+
+def test_extract_pulls_release_ids_from_validate_log_lines():
+    lines = [
+        "2026-06-11T07:42:01.123Z INFO Validated: 'Aluminum Tunes' by 'Stereolab' found on release 9876",
+        "2026-06-11T07:42:02.456Z INFO Track 'Yoshimura' by 'X' NOT found on release 11111",
+        "2026-06-11T07:42:03.789Z INFO Validated (fuzzy): 'Foo' by 'Bar' on release 22222",
+        "2026-06-11T07:42:04.999Z WARNING Failed to fetch release 33333 (rate limited or error)",
+        "2026-06-11T07:42:05.000Z INFO unrelated noise",
+    ]
+    events = extract_from_log(lines)
+
+    assert [e.release_id for e in events] == [9876, 11111, 22222, 33333]
+    assert events[0].method == "validate_track_on_release"
+    assert events[1].method == "validate_track_on_release"
+    assert events[2].method == "validate_track_on_release"
+    assert events[3].method == "get_release"
+    assert events[0].timestamp == "2026-06-11T07:42:01.123Z"
+
+
+def test_classify_release_existed_with_tracks_is_h3prime_candidate():
+    """When the release row was already present *with* track rows but the
+    seam still missed, we suspect H3' (validate False-as-hit). The
+    classifier must surface this distinction."""
+    events = [MissEvent(release_id=9876, method="validate_track_on_release", timestamp="t")]
+    conn = _fake_conn([(9876, 7)])  # release exists with 7 tracks
+
+    rows = classify(conn, events)
+
+    assert rows == [
+        {
+            "timestamp": "t",
+            "method": "validate_track_on_release",
+            "release_id": 9876,
+            "release_existed": True,
+            "release_track_count": 7,
+            "prior_seen_in_window": False,
+        }
+    ]
+
+
+def test_classify_release_absent_is_h1_first_time_miss():
+    """The H1 case: release row didn't exist at miss time → ETL gap."""
+    events = [MissEvent(release_id=12345, method="validate_track_on_release", timestamp="t")]
+    conn = _fake_conn([])  # no matching row
+
+    rows = classify(conn, events)
+
+    assert rows[0]["release_existed"] is False
+    assert rows[0]["release_track_count"] == 0
+
+
+def test_classify_marks_prior_seen_within_window():
+    """A release_id that appeared earlier in the same input window flags
+    the second occurrence — relevant when the warm-up of the same release
+    by an earlier validate didn't help the subsequent one."""
+    events = [
+        MissEvent(release_id=42, method="validate_track_on_release", timestamp="t1"),
+        MissEvent(release_id=42, method="validate_track_on_release", timestamp="t2"),
+    ]
+    conn = _fake_conn([(42, 3)])
+
+    rows = classify(conn, events)
+
+    assert rows[0]["prior_seen_in_window"] is False
+    assert rows[1]["prior_seen_in_window"] is True
+
+
+def test_emit_csv_round_trips():
+    rows = [
+        {
+            "timestamp": "t",
+            "method": "validate_track_on_release",
+            "release_id": 1,
+            "release_existed": True,
+            "release_track_count": 5,
+            "prior_seen_in_window": False,
+        }
+    ]
+    out = io.StringIO()
+    emit_csv(rows, out)
+    text = out.getvalue().strip().splitlines()
+    assert (
+        text[0]
+        == "timestamp,method,release_id,release_existed,release_track_count,prior_seen_in_window"
+    )
+    assert text[1] == "t,validate_track_on_release,1,True,5,False"
+
+
+def test_classify_handles_empty_input():
+    conn = _fake_conn([])
+    assert classify(conn, []) == []

--- a/tests/unit/test_cache_miss_provenance.py
+++ b/tests/unit/test_cache_miss_provenance.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 from scripts.cache_miss_provenance import (
     MissEvent,
     classify,
+    compute_first_seen,
     emit_csv,
     extract_from_log,
 )
@@ -52,9 +53,11 @@ def test_classify_release_existed_with_tracks_is_h3prime_candidate():
     seam still missed, we suspect H3' (validate False-as-hit). The
     classifier must surface this distinction."""
     events = [MissEvent(release_id=9876, method="validate_track_on_release", timestamp="t")]
+    indexed = list(enumerate(events))
+    first_seen = compute_first_seen(events)
     conn = _fake_conn([(9876, 7)])  # release exists with 7 tracks
 
-    rows = classify(conn, events)
+    rows = classify(conn, indexed, first_seen)
 
     assert rows == [
         {
@@ -71,9 +74,11 @@ def test_classify_release_existed_with_tracks_is_h3prime_candidate():
 def test_classify_release_absent_is_h1_first_time_miss():
     """The H1 case: release row didn't exist at miss time → ETL gap."""
     events = [MissEvent(release_id=12345, method="validate_track_on_release", timestamp="t")]
+    indexed = list(enumerate(events))
+    first_seen = compute_first_seen(events)
     conn = _fake_conn([])  # no matching row
 
-    rows = classify(conn, events)
+    rows = classify(conn, indexed, first_seen)
 
     assert rows[0]["release_existed"] is False
     assert rows[0]["release_track_count"] == 0
@@ -87,12 +92,38 @@ def test_classify_marks_prior_seen_within_window():
         MissEvent(release_id=42, method="validate_track_on_release", timestamp="t1"),
         MissEvent(release_id=42, method="validate_track_on_release", timestamp="t2"),
     ]
+    indexed = list(enumerate(events))
+    first_seen = compute_first_seen(events)
     conn = _fake_conn([(42, 3)])
 
-    rows = classify(conn, events)
+    rows = classify(conn, indexed, first_seen)
 
     assert rows[0]["prior_seen_in_window"] is False
     assert rows[1]["prior_seen_in_window"] is True
+
+
+def test_classify_preserves_prior_seen_across_random_sampling():
+    """LML#537 review iter-3 regression: rng.sample() returns elements in
+    random order, so the prior_seen_in_window flag must be anchored to
+    the original log position (first_seen computed BEFORE sampling) and
+    each sampled event must carry its original index forward."""
+    # Full log: id=99 appears first, id=42 appears later.
+    events = [
+        MissEvent(release_id=99, method="validate_track_on_release", timestamp="t1"),
+        MissEvent(release_id=42, method="validate_track_on_release", timestamp="t2"),
+        MissEvent(release_id=99, method="validate_track_on_release", timestamp="t3"),
+    ]
+    first_seen = compute_first_seen(events)
+    # Sampled in reversed order — simulating what rng.sample might produce.
+    indexed_reordered = [(2, events[2]), (0, events[0])]
+    conn = _fake_conn([(99, 5)])
+
+    rows = classify(conn, indexed_reordered, first_seen)
+
+    # Row 0 in the sample carries original_idx=2; first_seen[99]=0 < 2 → True.
+    assert rows[0]["prior_seen_in_window"] is True
+    # Row 1 in the sample carries original_idx=0; first_seen[99]=0 < 0 → False.
+    assert rows[1]["prior_seen_in_window"] is False
 
 
 def test_emit_csv_round_trips():
@@ -118,4 +149,4 @@ def test_emit_csv_round_trips():
 
 def test_classify_handles_empty_input():
     conn = _fake_conn([])
-    assert classify(conn, []) == []
+    assert classify(conn, [], {}) == []

--- a/tests/unit/test_cache_warm_histogram.py
+++ b/tests/unit/test_cache_warm_histogram.py
@@ -1,0 +1,56 @@
+"""Tests for ``scripts/cache_warm_histogram.py`` (LML#537 probe #2)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+
+from scripts.cache_warm_histogram import emit_csv, summarise
+
+
+def test_summarise_splits_on_cutoff():
+    rows = [
+        (dt.date(2026, 6, 1), 100),
+        (dt.date(2026, 6, 2), 200),
+        (dt.date(2026, 6, 6), 50),
+        (dt.date(2026, 6, 7), 30),  # cutoff day — counts as "after"
+        (dt.date(2026, 6, 8), 40),
+        (dt.date(2026, 6, 9), 35),
+    ]
+    summary = summarise(rows, dt.date(2026, 6, 7))
+
+    assert summary["rows_before"] == 350
+    assert summary["rows_after"] == 105
+    assert summary["days_before"] == 3
+    assert summary["days_after"] == 3
+    assert summary["total_rows"] == 455
+    assert summary["mean_before"] == 350 / 3
+    assert summary["mean_after"] == 35.0
+
+
+def test_summarise_handles_no_post_cutoff_days():
+    """The post-deploy regime might be empty if the cutoff is in the future."""
+    rows = [(dt.date(2026, 6, 1), 100)]
+    summary = summarise(rows, dt.date(2026, 6, 10))
+
+    assert summary["rows_after"] == 0
+    assert summary["mean_after"] == 0.0
+    assert summary["mean_before"] == 100.0
+
+
+def test_summarise_handles_empty_input():
+    summary = summarise([], dt.date(2026, 6, 7))
+    assert summary["total_rows"] == 0
+    assert summary["mean_before"] == 0.0
+    assert summary["mean_after"] == 0.0
+
+
+def test_emit_csv_round_trips():
+    rows = [(dt.date(2026, 6, 7), 30), (dt.date(2026, 6, 8), 40)]
+    out = io.StringIO()
+    emit_csv(rows, out)
+    assert out.getvalue().strip().splitlines() == [
+        "day,rows",
+        "2026-06-07,30",
+        "2026-06-08,40",
+    ]

--- a/tests/unit/test_discogs_ranking_jitter.py
+++ b/tests/unit/test_discogs_ranking_jitter.py
@@ -1,9 +1,9 @@
 """Tests for ``scripts/discogs_ranking_jitter.py`` (LML#537 probe #3).
 
-The script issues live Discogs calls; tests cover the pure math (jaccard,
-position stability, aggregate) and the response-extraction helper. The
-HTTP wire is mocked via ``httpx.MockTransport`` so the real Discogs
-endpoint is never touched.
+The script issues live Discogs calls; tests cover the pure math (stats,
+position stability, aggregate, serialization) and the response-extraction
+helper. The HTTP wire is mocked via ``httpx.MockTransport`` so the real
+Discogs endpoint is never touched.
 """
 
 from __future__ import annotations
@@ -21,33 +21,51 @@ from scripts.discogs_ranking_jitter import (
 )
 
 
-def test_jaccard_one_when_identical():
+def test_stats_jaccard_one_when_identical():
     pair = JitterPair(call_a_ids=[1, 2, 3], call_b_ids=[1, 2, 3], delay_seconds=30)
-    assert pair.jaccard == 1.0
+    overlap, union, jaccard = pair.stats()
+    assert (overlap, union, jaccard) == (3, 3, 1.0)
     assert pair.position_stability() == 0.0
 
 
-def test_jaccard_zero_when_disjoint():
+def test_stats_jaccard_zero_when_disjoint():
     pair = JitterPair(call_a_ids=[1, 2], call_b_ids=[3, 4], delay_seconds=30)
-    assert pair.jaccard == 0.0
+    overlap, union, jaccard = pair.stats()
+    assert (overlap, union, jaccard) == (0, 4, 0.0)
     assert pair.position_stability() is None
 
 
-def test_jaccard_partial_overlap_and_rank_shift():
+def test_stats_partial_overlap_and_rank_shift():
     """Overlap of {1, 2} out of union {1, 2, 3, 4, 5}; ranks shifted."""
     pair = JitterPair(call_a_ids=[1, 2, 3], call_b_ids=[2, 1, 4, 5], delay_seconds=30)
-    assert pair.overlap == 2
-    assert pair.union == 5
-    assert pair.jaccard == pytest.approx(0.4)
+    overlap, union, jaccard = pair.stats()
+    assert overlap == 2
+    assert union == 5
+    assert jaccard == pytest.approx(0.4)
     # Rank-delta: 1 is at index 0 in A and 1 in B (delta 1). 2 is at 1 in A
     # and 0 in B (delta 1). Mean = 1.0
     assert pair.position_stability() == 1.0
 
 
-def test_jaccard_empty_lists():
+def test_stats_empty_lists():
     pair = JitterPair(call_a_ids=[], call_b_ids=[], delay_seconds=30)
-    assert pair.jaccard == 0.0
+    assert pair.stats() == (0, 0, 0.0)
     assert pair.position_stability() is None
+
+
+def test_to_record_includes_derived_metrics():
+    """`--json` output must surface jaccard/overlap/union/stability per pair —
+    using `dataclass.__dict__` would have dropped them (LML#537 review)."""
+    pair = JitterPair(call_a_ids=[1, 2], call_b_ids=[2, 3], delay_seconds=30)
+    record = pair.to_record()
+
+    assert record["call_a_ids"] == [1, 2]
+    assert record["call_b_ids"] == [2, 3]
+    assert record["delay_seconds"] == 30
+    assert record["overlap"] == 1
+    assert record["union"] == 3
+    assert record["jaccard"] == pytest.approx(1 / 3)
+    assert record["position_stability"] == pytest.approx(1.0)
 
 
 def test_extract_release_ids_skips_rows_without_id():
@@ -110,4 +128,4 @@ async def test_run_pair_issues_two_calls_and_extracts_ids(monkeypatch):
 
     assert pair.call_a_ids == [1, 2, 3]
     assert pair.call_b_ids == [2, 4]
-    assert pair.overlap == 1
+    assert pair.stats()[0] == 1  # overlap

--- a/tests/unit/test_discogs_ranking_jitter.py
+++ b/tests/unit/test_discogs_ranking_jitter.py
@@ -8,8 +8,6 @@ Discogs endpoint is never touched.
 
 from __future__ import annotations
 
-import math
-
 import httpx
 import pytest
 
@@ -86,10 +84,13 @@ def test_aggregate_means_and_min_max():
     assert agg["position_stability_mean"] == 0.0
 
 
-def test_aggregate_no_shared_ids_yields_nan_stability():
+def test_aggregate_no_shared_ids_yields_none_stability():
+    """Use ``None`` (JSON-serializes as ``null``) rather than ``float('nan')``
+    which Python's ``json.dumps`` emits as literal ``NaN`` — invalid per
+    RFC 8259 and rejected by ``jq`` / strict parsers."""
     pairs = [JitterPair(call_a_ids=[1], call_b_ids=[2], delay_seconds=30)]
     agg = aggregate(pairs)
-    assert math.isnan(agg["position_stability_mean"])
+    assert agg["position_stability_mean"] is None
 
 
 def test_aggregate_empty():

--- a/tests/unit/test_discogs_ranking_jitter.py
+++ b/tests/unit/test_discogs_ranking_jitter.py
@@ -1,0 +1,113 @@
+"""Tests for ``scripts/discogs_ranking_jitter.py`` (LML#537 probe #3).
+
+The script issues live Discogs calls; tests cover the pure math (jaccard,
+position stability, aggregate) and the response-extraction helper. The
+HTTP wire is mocked via ``httpx.MockTransport`` so the real Discogs
+endpoint is never touched.
+"""
+
+from __future__ import annotations
+
+import math
+
+import httpx
+import pytest
+
+from scripts.discogs_ranking_jitter import (
+    JitterPair,
+    _extract_release_ids,
+    aggregate,
+    run_pair,
+)
+
+
+def test_jaccard_one_when_identical():
+    pair = JitterPair(call_a_ids=[1, 2, 3], call_b_ids=[1, 2, 3], delay_seconds=30)
+    assert pair.jaccard == 1.0
+    assert pair.position_stability() == 0.0
+
+
+def test_jaccard_zero_when_disjoint():
+    pair = JitterPair(call_a_ids=[1, 2], call_b_ids=[3, 4], delay_seconds=30)
+    assert pair.jaccard == 0.0
+    assert pair.position_stability() is None
+
+
+def test_jaccard_partial_overlap_and_rank_shift():
+    """Overlap of {1, 2} out of union {1, 2, 3, 4, 5}; ranks shifted."""
+    pair = JitterPair(call_a_ids=[1, 2, 3], call_b_ids=[2, 1, 4, 5], delay_seconds=30)
+    assert pair.overlap == 2
+    assert pair.union == 5
+    assert pair.jaccard == pytest.approx(0.4)
+    # Rank-delta: 1 is at index 0 in A and 1 in B (delta 1). 2 is at 1 in A
+    # and 0 in B (delta 1). Mean = 1.0
+    assert pair.position_stability() == 1.0
+
+
+def test_jaccard_empty_lists():
+    pair = JitterPair(call_a_ids=[], call_b_ids=[], delay_seconds=30)
+    assert pair.jaccard == 0.0
+    assert pair.position_stability() is None
+
+
+def test_extract_release_ids_skips_rows_without_id():
+    payload = {"results": [{"id": 1}, {"id": 2, "title": "x"}, {"title": "no id"}]}
+    assert _extract_release_ids(payload) == [1, 2]
+
+
+def test_aggregate_means_and_min_max():
+    pairs = [
+        JitterPair(call_a_ids=[1, 2], call_b_ids=[1, 2], delay_seconds=30),  # jaccard 1.0, stab 0
+        JitterPair(call_a_ids=[1, 2], call_b_ids=[3, 4], delay_seconds=30),  # jaccard 0.0, no stab
+    ]
+    agg = aggregate(pairs)
+    assert agg["pairs"] == 2
+    assert agg["jaccard_mean"] == 0.5
+    assert agg["jaccard_min"] == 0.0
+    assert agg["jaccard_max"] == 1.0
+    assert agg["position_stability_mean"] == 0.0
+
+
+def test_aggregate_no_shared_ids_yields_nan_stability():
+    pairs = [JitterPair(call_a_ids=[1], call_b_ids=[2], delay_seconds=30)]
+    agg = aggregate(pairs)
+    assert math.isnan(agg["position_stability_mean"])
+
+
+def test_aggregate_empty():
+    assert aggregate([]) == {"pairs": 0}
+
+
+@pytest.mark.asyncio
+async def test_run_pair_issues_two_calls_and_extracts_ids(monkeypatch):
+    """End-to-end of run_pair against a mocked Discogs transport. The two
+    responses differ — the script must read each independently."""
+    payloads = iter(
+        [
+            {"results": [{"id": 1}, {"id": 2}, {"id": 3}]},
+            {"results": [{"id": 2}, {"id": 4}]},
+        ]
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=next(payloads))
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        # No actual sleep — fast-forward the delay.
+        async def _no_sleep(seconds):
+            return None
+
+        monkeypatch.setattr("scripts.discogs_ranking_jitter.asyncio.sleep", _no_sleep)
+        pair = await run_pair(
+            client,
+            track="Track",
+            artist="Artist",
+            delay_seconds=0,
+            token="fake-token",
+            limit=10,
+        )
+
+    assert pair.call_a_ids == [1, 2, 3]
+    assert pair.call_b_ids == [2, 4]
+    assert pair.overlap == 1

--- a/tests/unit/test_discogs_request_telemetry.py
+++ b/tests/unit/test_discogs_request_telemetry.py
@@ -1,0 +1,285 @@
+"""Tests for the LML#537 rate-limiter telemetry tags.
+
+When the `fallthrough` seam falls through to the API leg, it sets a
+`_request_context_var` carrying the seam's `label` and the resolved
+`cache_state`. `_request_with_retry` reads that contextvar inside its
+`lml.discogs.semaphore` and `lml.discogs.rate_limiter` spans, tagging
+each with `lml.discogs.method` and `lml.discogs.cache_state`. This lets
+the Sentry wait-time histogram be split by which method's cache-miss
+triggered the wait and by how the cache leg resolved (`miss`, `skip`,
+`no_pg`, `cooldown`).
+
+Covered:
+
+1. **Tag presence on miss** — both spans carry method + cache_state.
+2. **All four cache_state values** — parametrized over `miss`, `skip`,
+   `no_pg`, `cooldown`.
+3. **CancelledError reset** — the contextvar's `Token` reset survives
+   `asyncio.CancelledError` so a cancelled call doesn't leak state into
+   the next one.
+4. **No contextvar set** — direct `_request_with_retry` callers (the
+   health probe, tests) don't have a contextvar set; spans should not
+   blow up and should not carry the tags.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from discogs import fallthrough as fallthrough_mod
+from discogs.fallthrough import (
+    _request_context_var,
+    _reset_cool_down_for_tests,
+    fallthrough,
+)
+from discogs.memory_cache import set_skip_cache
+
+
+class _SpanRecorder:
+    """Replacement for ``sentry_sdk.start_span`` that records every span's
+    data dict so tests can assert tag values after the fact."""
+
+    def __init__(self) -> None:
+        self.spans: list[dict[str, object]] = []
+
+    def __call__(self, *, op: str, name: str) -> _SpanRecorder._Ctx:
+        record: dict[str, object] = {"op": op, "name": name, "data": {}}
+        self.spans.append(record)
+        return self._Ctx(record)
+
+    class _Ctx:
+        def __init__(self, record: dict[str, object]) -> None:
+            self._record = record
+
+        def __enter__(self) -> _SpanRecorder._Span:
+            return _SpanRecorder._Span(self._record)
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    class _Span:
+        def __init__(self, record: dict[str, object]) -> None:
+            self._record = record
+
+        def set_data(self, key: str, value: object) -> None:
+            data = self._record["data"]
+            assert isinstance(data, dict)
+            data[key] = value
+
+
+@pytest.fixture(autouse=True)
+def _reset_cool_down():
+    """Cool-down is process-wide; reset between tests so cases don't bleed."""
+    _reset_cool_down_for_tests()
+    yield
+    _reset_cool_down_for_tests()
+
+
+@pytest.fixture
+def _ensure_skip_cache_clear():
+    """Reset the per-request skip flag between cases."""
+    set_skip_cache(False)
+    yield
+    set_skip_cache(False)
+
+
+@pytest.fixture
+def span_recorder():
+    """Patch ``sentry_sdk.start_span`` (the symbol both modules use)."""
+    recorder = _SpanRecorder()
+    with (
+        patch("discogs.service.sentry_sdk.start_span", recorder),
+        patch("discogs.fallthrough.sentry_sdk.start_span", recorder),
+    ):
+        yield recorder
+
+
+def _request_with_retry_spans(recorder: _SpanRecorder) -> list[dict[str, object]]:
+    """Filter the recorder's spans down to the two emitted by
+    ``DiscogsService._request_with_retry`` (the `lock.acquire` ones)."""
+    return [s for s in recorder.spans if s["op"] == "lock.acquire"]
+
+
+async def _drive_request_with_retry() -> None:
+    """Call `_request_with_retry` against a mocked-out semaphore +
+    rate-limiter so the test doesn't actually issue an HTTP request.
+
+    The httpx response is mocked too — we only care that the two spans
+    fire under whichever contextvar state the test set up."""
+    from discogs.service import DiscogsService
+
+    fake_semaphore = MagicMock()
+    fake_semaphore.acquire = AsyncMock()
+    fake_semaphore.release = MagicMock()
+    fake_semaphore._waiters = []
+
+    fake_limiter = MagicMock()
+    fake_limiter.acquire = AsyncMock()
+
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.headers = {}
+
+    fake_client = MagicMock()
+    fake_client.request = AsyncMock(return_value=fake_response)
+
+    service = DiscogsService.__new__(DiscogsService)
+    service._get_client = AsyncMock(return_value=fake_client)  # type: ignore[method-assign]
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=fake_semaphore),
+        patch("discogs.service.get_rate_limiter", return_value=fake_limiter),
+    ):
+        await service._request_with_retry("GET", "/releases/12345")
+
+
+# ---------------------------------------------------------------------------
+# 1. Tag presence on the miss path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semaphore_and_rate_limiter_spans_tagged_on_miss(
+    span_recorder, _ensure_skip_cache_clear
+):
+    """The common cache-miss flow: PG returned None, seam fell through to
+    the API leg, both wait spans carry the method + state tags."""
+    pg_read = AsyncMock(return_value=None)
+
+    async def api_fetch():
+        await _drive_request_with_retry()
+        return "fresh-value"
+
+    result = await fallthrough(
+        label="get_release",
+        pg_read=pg_read,
+        api_fetch=api_fetch,
+    )
+
+    assert result == "fresh-value"
+    spans = _request_with_retry_spans(span_recorder)
+    assert len(spans) == 2
+    for span in spans:
+        data = span["data"]
+        assert isinstance(data, dict)
+        assert data.get("lml.discogs.method") == "get_release"
+        assert data.get("lml.discogs.cache_state") == "miss"
+
+
+# ---------------------------------------------------------------------------
+# 2. All four cache_state values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scenario,expected_state",
+    [
+        ("miss", "miss"),
+        ("skip", "skip"),
+        ("no_pg", "no_pg"),
+        ("cooldown", "cooldown"),
+    ],
+)
+async def test_cache_state_resolves_correctly(
+    span_recorder, _ensure_skip_cache_clear, scenario, expected_state
+):
+    """The seam must compute cache_state from its own gating logic, not
+    from the caller's inputs verbatim."""
+    pg_read: AsyncMock | None = AsyncMock(return_value=None)
+
+    if scenario == "skip":
+        set_skip_cache(True)
+    elif scenario == "no_pg":
+        pg_read = None
+    elif scenario == "cooldown":
+        # Arm the cool-down by hand — mirrors the existing test pattern in
+        # test_fallthrough.py (which already pokes _cool_down_until).
+        import time
+
+        fallthrough_mod._cool_down_until = time.monotonic() + 5
+
+    async def api_fetch():
+        await _drive_request_with_retry()
+        return "fresh-value"
+
+    await fallthrough(
+        label="get_release",
+        pg_read=pg_read,
+        api_fetch=api_fetch,
+    )
+
+    spans = _request_with_retry_spans(span_recorder)
+    assert len(spans) == 2
+    for span in spans:
+        data = span["data"]
+        assert isinstance(data, dict)
+        assert data.get("lml.discogs.method") == "get_release"
+        assert data.get("lml.discogs.cache_state") == expected_state
+
+
+# ---------------------------------------------------------------------------
+# 3. CancelledError reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_resets_on_cancelled_error(span_recorder, _ensure_skip_cache_clear):
+    """If the API leg is cancelled mid-flight, the seam's `finally` must
+    still reset the contextvar (Token-paired set/reset)."""
+    pg_read = AsyncMock(return_value=None)
+
+    async def cancelling_api_fetch():
+        raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await fallthrough(
+            label="get_release",
+            pg_read=pg_read,
+            api_fetch=cancelling_api_fetch,
+        )
+
+    assert _request_context_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_context_resets_on_normal_return(span_recorder, _ensure_skip_cache_clear):
+    """Sibling of the cancellation case — normal return also resets so the
+    next call in the same task doesn't see stale state."""
+    pg_read = AsyncMock(return_value=None)
+
+    async def api_fetch():
+        return "fresh-value"
+
+    await fallthrough(
+        label="get_release",
+        pg_read=pg_read,
+        api_fetch=api_fetch,
+    )
+
+    assert _request_context_var.get() is None
+
+
+# ---------------------------------------------------------------------------
+# 4. No contextvar set — direct callers untouched
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_tag_when_called_outside_seam(span_recorder):
+    """The health probe and a handful of legacy tests call
+    `_request_with_retry` directly. Without a contextvar set, the spans
+    must not blow up and must not carry the LML#537 tags."""
+    assert _request_context_var.get() is None
+    await _drive_request_with_retry()
+
+    spans = _request_with_retry_spans(span_recorder)
+    assert len(spans) == 2
+    for span in spans:
+        data = span["data"]
+        assert isinstance(data, dict)
+        assert "lml.discogs.method" not in data
+        assert "lml.discogs.cache_state" not in data

--- a/tests/unit/test_discogs_request_telemetry.py
+++ b/tests/unit/test_discogs_request_telemetry.py
@@ -316,8 +316,6 @@ async def test_cacheless_get_release_tags_with_no_pg(
     # _request_with_retry needs the same mocked semaphore/limiter as the
     # other tests; mirror _drive_request_with_retry's setup here so we can
     # drive a real method call through the cacheless branch.
-    from unittest.mock import AsyncMock, MagicMock, patch
-
     fake_response = MagicMock()
     fake_response.status_code = 200
     fake_response.headers = {}

--- a/tests/unit/test_discogs_request_telemetry.py
+++ b/tests/unit/test_discogs_request_telemetry.py
@@ -1,25 +1,28 @@
 """Tests for the LML#537 rate-limiter telemetry tags.
 
-When the `fallthrough` seam falls through to the API leg, it sets a
-`_request_context_var` carrying the seam's `label` and the resolved
-`cache_state`. `_request_with_retry` reads that contextvar inside its
-`lml.discogs.semaphore` and `lml.discogs.rate_limiter` spans, tagging
-each with `lml.discogs.method` and `lml.discogs.cache_state`. This lets
-the Sentry wait-time histogram be split by which method's cache-miss
-triggered the wait and by how the cache leg resolved (`miss`, `skip`,
-`no_pg`, `cooldown`).
+When the ``fallthrough`` seam (or the ``request_context`` helper used by
+the three API-only methods that bypass it) falls through to the API leg,
+it sets ``_request_context_var`` carrying the seam's ``label`` and the
+resolved ``cache_state``. ``_request_with_retry`` reads that contextvar
+inside its ``lml.discogs.semaphore`` and ``lml.discogs.rate_limiter``
+spans, tagging each with ``lml.discogs.method`` and
+``lml.discogs.cache_state``. This lets the Sentry wait-time histogram be
+split by which method's cache-miss triggered the wait and by how the
+cache leg resolved (``miss``, ``skip``, ``no_pg``, ``cooldown``).
 
 Covered:
 
 1. **Tag presence on miss** — both spans carry method + cache_state.
-2. **All four cache_state values** — parametrized over `miss`, `skip`,
-   `no_pg`, `cooldown`.
-3. **CancelledError reset** — the contextvar's `Token` reset survives
-   `asyncio.CancelledError` so a cancelled call doesn't leak state into
-   the next one.
-4. **No contextvar set** — direct `_request_with_retry` callers (the
-   health probe, tests) don't have a contextvar set; spans should not
-   blow up and should not carry the tags.
+2. **All four cache_state values** — parametrized over ``miss``, ``skip``,
+   ``no_pg``, ``cooldown``.
+3. **CancelledError reset** — the contextvar's ``Token`` reset survives
+   ``asyncio.CancelledError``.
+4. **No contextvar set** — direct ``_request_with_retry`` callers (a
+   handful of legacy tests) don't have a contextvar set; spans should
+   not blow up and should not carry the tags.
+5. **request_context helper** — used by ``search_releases_by_album_title``,
+   ``get_label_image``, ``get_master`` (the three API-only methods that
+   bypass ``fallthrough``); spans get tagged the same as the seam path.
 """
 
 from __future__ import annotations
@@ -34,40 +37,10 @@ from discogs.fallthrough import (
     _request_context_var,
     _reset_cool_down_for_tests,
     fallthrough,
+    request_context,
 )
 from discogs.memory_cache import set_skip_cache
-
-
-class _SpanRecorder:
-    """Replacement for ``sentry_sdk.start_span`` that records every span's
-    data dict so tests can assert tag values after the fact."""
-
-    def __init__(self) -> None:
-        self.spans: list[dict[str, object]] = []
-
-    def __call__(self, *, op: str, name: str) -> _SpanRecorder._Ctx:
-        record: dict[str, object] = {"op": op, "name": name, "data": {}}
-        self.spans.append(record)
-        return self._Ctx(record)
-
-    class _Ctx:
-        def __init__(self, record: dict[str, object]) -> None:
-            self._record = record
-
-        def __enter__(self) -> _SpanRecorder._Span:
-            return _SpanRecorder._Span(self._record)
-
-        def __exit__(self, exc_type, exc, tb) -> None:
-            return None
-
-    class _Span:
-        def __init__(self, record: dict[str, object]) -> None:
-            self._record = record
-
-        def set_data(self, key: str, value: object) -> None:
-            data = self._record["data"]
-            assert isinstance(data, dict)
-            data[key] = value
+from discogs.service import DiscogsService
 
 
 @pytest.fixture(autouse=True)
@@ -87,30 +60,40 @@ def _ensure_skip_cache_clear():
 
 
 @pytest.fixture
-def span_recorder():
-    """Patch ``sentry_sdk.start_span`` (the symbol both modules use)."""
-    recorder = _SpanRecorder()
+def service():
+    """A real DiscogsService — its ``_get_client`` honors a pre-set
+    ``self._client`` (see service.py:286), letting tests inject a mock
+    client without bypassing ``__init__``."""
+    return DiscogsService(token="test-token")
+
+
+@pytest.fixture
+def captured_spans():
+    """Patch ``sentry_sdk.start_span`` (the symbol both modules reference;
+    they resolve to the same module object) with a recorder that captures
+    each span as a MagicMock keyed by ``name``. Mirrors the canonical
+    pattern used by ``test_discogs_service.py``."""
+    spans: dict[str, MagicMock] = {}
+
+    def _start_span(*, op: str, name: str, **kwargs):
+        ctx = MagicMock()
+        span = MagicMock()
+        span.op = op
+        ctx.__enter__.return_value = span
+        ctx.__exit__.return_value = False
+        spans[name] = span
+        return ctx
+
     with (
-        patch("discogs.service.sentry_sdk.start_span", recorder),
-        patch("discogs.fallthrough.sentry_sdk.start_span", recorder),
+        patch("discogs.service.sentry_sdk.start_span", side_effect=_start_span),
+        patch("discogs.fallthrough.sentry_sdk.start_span", side_effect=_start_span),
     ):
-        yield recorder
+        yield spans
 
 
-def _request_with_retry_spans(recorder: _SpanRecorder) -> list[dict[str, object]]:
-    """Filter the recorder's spans down to the two emitted by
-    ``DiscogsService._request_with_retry`` (the `lock.acquire` ones)."""
-    return [s for s in recorder.spans if s["op"] == "lock.acquire"]
-
-
-async def _drive_request_with_retry() -> None:
-    """Call `_request_with_retry` against a mocked-out semaphore +
-    rate-limiter so the test doesn't actually issue an HTTP request.
-
-    The httpx response is mocked too — we only care that the two spans
-    fire under whichever contextvar state the test set up."""
-    from discogs.service import DiscogsService
-
+async def _drive_request_with_retry(service: DiscogsService) -> None:
+    """Drive ``_request_with_retry`` against an in-memory mock client +
+    mocked semaphore/limiter. Does not issue an HTTP request."""
     fake_semaphore = MagicMock()
     fake_semaphore.acquire = AsyncMock()
     fake_semaphore.release = MagicMock()
@@ -123,17 +106,26 @@ async def _drive_request_with_retry() -> None:
     fake_response.status_code = 200
     fake_response.headers = {}
 
-    fake_client = MagicMock()
-    fake_client.request = AsyncMock(return_value=fake_response)
-
-    service = DiscogsService.__new__(DiscogsService)
-    service._get_client = AsyncMock(return_value=fake_client)  # type: ignore[method-assign]
+    mock_client = MagicMock()
+    mock_client.request = AsyncMock(return_value=fake_response)
+    service._client = mock_client
 
     with (
         patch("discogs.service.get_semaphore", return_value=fake_semaphore),
         patch("discogs.service.get_rate_limiter", return_value=fake_limiter),
     ):
         await service._request_with_retry("GET", "/releases/12345")
+
+
+def _assert_tagged(span: MagicMock, method: str, state: str) -> None:
+    """Both wait spans must carry ``lml.discogs.method`` and ``lml.discogs.cache_state``."""
+    data = {call.args[0]: call.args[1] for call in span.set_data.call_args_list}
+    assert data.get("lml.discogs.method") == method, (
+        f"span {span} missing/wrong method tag; calls: {data}"
+    )
+    assert data.get("lml.discogs.cache_state") == state, (
+        f"span {span} missing/wrong cache_state tag; calls: {data}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -143,14 +135,14 @@ async def _drive_request_with_retry() -> None:
 
 @pytest.mark.asyncio
 async def test_semaphore_and_rate_limiter_spans_tagged_on_miss(
-    span_recorder, _ensure_skip_cache_clear
+    service, captured_spans, _ensure_skip_cache_clear
 ):
     """The common cache-miss flow: PG returned None, seam fell through to
     the API leg, both wait spans carry the method + state tags."""
     pg_read = AsyncMock(return_value=None)
 
     async def api_fetch():
-        await _drive_request_with_retry()
+        await _drive_request_with_retry(service)
         return "fresh-value"
 
     result = await fallthrough(
@@ -160,13 +152,13 @@ async def test_semaphore_and_rate_limiter_spans_tagged_on_miss(
     )
 
     assert result == "fresh-value"
-    spans = _request_with_retry_spans(span_recorder)
-    assert len(spans) == 2
-    for span in spans:
-        data = span["data"]
-        assert isinstance(data, dict)
-        assert data.get("lml.discogs.method") == "get_release"
-        assert data.get("lml.discogs.cache_state") == "miss"
+    sem_span = captured_spans.get("lml.discogs.semaphore")
+    rate_span = captured_spans.get("lml.discogs.rate_limiter")
+    assert sem_span is not None and rate_span is not None, (
+        f"expected both wait spans, got: {list(captured_spans)}"
+    )
+    _assert_tagged(sem_span, "get_release", "miss")
+    _assert_tagged(rate_span, "get_release", "miss")
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +177,7 @@ async def test_semaphore_and_rate_limiter_spans_tagged_on_miss(
     ],
 )
 async def test_cache_state_resolves_correctly(
-    span_recorder, _ensure_skip_cache_clear, scenario, expected_state
+    service, captured_spans, _ensure_skip_cache_clear, scenario, expected_state
 ):
     """The seam must compute cache_state from its own gating logic, not
     from the caller's inputs verbatim."""
@@ -203,7 +195,7 @@ async def test_cache_state_resolves_correctly(
         fallthrough_mod._cool_down_until = time.monotonic() + 5
 
     async def api_fetch():
-        await _drive_request_with_retry()
+        await _drive_request_with_retry(service)
         return "fresh-value"
 
     await fallthrough(
@@ -212,13 +204,10 @@ async def test_cache_state_resolves_correctly(
         api_fetch=api_fetch,
     )
 
-    spans = _request_with_retry_spans(span_recorder)
-    assert len(spans) == 2
-    for span in spans:
-        data = span["data"]
-        assert isinstance(data, dict)
-        assert data.get("lml.discogs.method") == "get_release"
-        assert data.get("lml.discogs.cache_state") == expected_state
+    for name in ("lml.discogs.semaphore", "lml.discogs.rate_limiter"):
+        span = captured_spans.get(name)
+        assert span is not None, f"expected {name} span; got: {list(captured_spans)}"
+        _assert_tagged(span, "get_release", expected_state)
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +216,7 @@ async def test_cache_state_resolves_correctly(
 
 
 @pytest.mark.asyncio
-async def test_context_resets_on_cancelled_error(span_recorder, _ensure_skip_cache_clear):
+async def test_context_resets_on_cancelled_error(captured_spans, _ensure_skip_cache_clear):
     """If the API leg is cancelled mid-flight, the seam's `finally` must
     still reset the contextvar (Token-paired set/reset)."""
     pg_read = AsyncMock(return_value=None)
@@ -246,7 +235,7 @@ async def test_context_resets_on_cancelled_error(span_recorder, _ensure_skip_cac
 
 
 @pytest.mark.asyncio
-async def test_context_resets_on_normal_return(span_recorder, _ensure_skip_cache_clear):
+async def test_context_resets_on_normal_return(captured_spans, _ensure_skip_cache_clear):
     """Sibling of the cancellation case — normal return also resets so the
     next call in the same task doesn't see stale state."""
     pg_read = AsyncMock(return_value=None)
@@ -269,17 +258,41 @@ async def test_context_resets_on_normal_return(span_recorder, _ensure_skip_cache
 
 
 @pytest.mark.asyncio
-async def test_no_tag_when_called_outside_seam(span_recorder):
-    """The health probe and a handful of legacy tests call
-    `_request_with_retry` directly. Without a contextvar set, the spans
-    must not blow up and must not carry the LML#537 tags."""
+async def test_no_tag_when_called_outside_seam(service, captured_spans):
+    """A handful of legacy tests call ``_request_with_retry`` directly.
+    Without a contextvar set, the spans must not blow up and must not
+    carry the LML#537 tags."""
     assert _request_context_var.get() is None
-    await _drive_request_with_retry()
+    await _drive_request_with_retry(service)
 
-    spans = _request_with_retry_spans(span_recorder)
-    assert len(spans) == 2
-    for span in spans:
-        data = span["data"]
-        assert isinstance(data, dict)
-        assert "lml.discogs.method" not in data
-        assert "lml.discogs.cache_state" not in data
+    for name in ("lml.discogs.semaphore", "lml.discogs.rate_limiter"):
+        span = captured_spans.get(name)
+        assert span is not None
+        data_keys = {call.args[0] for call in span.set_data.call_args_list}
+        assert "lml.discogs.method" not in data_keys
+        assert "lml.discogs.cache_state" not in data_keys
+
+
+# ---------------------------------------------------------------------------
+# 5. request_context helper — tags spans for API-only methods that bypass fallthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_context_tags_direct_caller_spans(
+    service, captured_spans, _ensure_skip_cache_clear
+):
+    """``search_releases_by_album_title``, ``get_label_image``, ``get_master``
+    each call ``_request_with_retry`` directly (no fallthrough). The
+    ``request_context`` helper they wrap their call in must propagate the
+    method tag + cache_state=no_pg the same way the seam does."""
+    with request_context("get_label_image", "no_pg"):
+        await _drive_request_with_retry(service)
+
+    for name in ("lml.discogs.semaphore", "lml.discogs.rate_limiter"):
+        span = captured_spans.get(name)
+        assert span is not None
+        _assert_tagged(span, "get_label_image", "no_pg")
+
+    # And the contextvar resets cleanly outside the with-block.
+    assert _request_context_var.get() is None

--- a/tests/unit/test_discogs_request_telemetry.py
+++ b/tests/unit/test_discogs_request_telemetry.py
@@ -34,9 +34,9 @@ import pytest
 
 from discogs import fallthrough as fallthrough_mod
 from discogs.fallthrough import (
-    _request_context_var,
     _reset_cool_down_for_tests,
     fallthrough,
+    get_request_context,
     request_context,
 )
 from discogs.memory_cache import set_skip_cache
@@ -231,7 +231,7 @@ async def test_context_resets_on_cancelled_error(captured_spans, _ensure_skip_ca
             api_fetch=cancelling_api_fetch,
         )
 
-    assert _request_context_var.get() is None
+    assert get_request_context() is None
 
 
 @pytest.mark.asyncio
@@ -249,7 +249,7 @@ async def test_context_resets_on_normal_return(captured_spans, _ensure_skip_cach
         api_fetch=api_fetch,
     )
 
-    assert _request_context_var.get() is None
+    assert get_request_context() is None
 
 
 # ---------------------------------------------------------------------------
@@ -262,7 +262,7 @@ async def test_no_tag_when_called_outside_seam(service, captured_spans):
     """A handful of legacy tests call ``_request_with_retry`` directly.
     Without a contextvar set, the spans must not blow up and must not
     carry the LML#537 tags."""
-    assert _request_context_var.get() is None
+    assert get_request_context() is None
     await _drive_request_with_retry(service)
 
     for name in ("lml.discogs.semaphore", "lml.discogs.rate_limiter"):
@@ -286,7 +286,7 @@ async def test_request_context_tags_direct_caller_spans(
     each call ``_request_with_retry`` directly (no fallthrough). The
     ``request_context`` helper they wrap their call in must propagate the
     method tag + cache_state=no_pg the same way the seam does."""
-    with request_context("get_label_image", "no_pg"):
+    with request_context("get_label_image"):
         await _drive_request_with_retry(service)
 
     for name in ("lml.discogs.semaphore", "lml.discogs.rate_limiter"):
@@ -295,4 +295,62 @@ async def test_request_context_tags_direct_caller_spans(
         _assert_tagged(span, "get_label_image", "no_pg")
 
     # And the contextvar resets cleanly outside the with-block.
-    assert _request_context_var.get() is None
+    assert get_request_context() is None
+
+
+# ---------------------------------------------------------------------------
+# 6. ``cache is None`` fallback — the four seam methods' bypass branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cacheless_get_release_tags_with_no_pg(
+    service, captured_spans, _ensure_skip_cache_clear
+):
+    """When DiscogsService runs without a cache_service (production fallback
+    used by ``discogs/lookup.py:27`` and explicit ``service=None`` paths),
+    ``get_release`` short-circuits the seam and calls ``_api_fetch`` directly.
+    That branch is wrapped in ``request_context('get_release')`` so the
+    wait-time spans participate in the LML#537 histogram split."""
+    assert service.cache_service is None
+    # _request_with_retry needs the same mocked semaphore/limiter as the
+    # other tests; mirror _drive_request_with_retry's setup here so we can
+    # drive a real method call through the cacheless branch.
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.headers = {}
+    fake_response.json.return_value = {
+        "id": 12345,
+        "title": "Stereolab - Aluminum Tunes",
+        "artists": [{"name": "Stereolab", "id": 1}],
+        "labels": [],
+        "genres": [],
+        "styles": [],
+        "year": 1998,
+        "tracklist": [],
+    }
+
+    mock_client = MagicMock()
+    mock_client.request = AsyncMock(return_value=fake_response)
+    service._client = mock_client
+
+    fake_semaphore = MagicMock()
+    fake_semaphore.acquire = AsyncMock()
+    fake_semaphore.release = MagicMock()
+    fake_semaphore._waiters = []
+
+    fake_limiter = MagicMock()
+    fake_limiter.acquire = AsyncMock()
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=fake_semaphore),
+        patch("discogs.service.get_rate_limiter", return_value=fake_limiter),
+    ):
+        await service.get_release(12345)
+
+    for name in ("lml.discogs.semaphore", "lml.discogs.rate_limiter"):
+        span = captured_spans.get(name)
+        assert span is not None
+        _assert_tagged(span, "get_release", "no_pg")


### PR DESCRIPTION
Implements four of the six concrete next steps from #537 — three diagnostic scripts and one Sentry-side telemetry improvement. The remaining two (#4 steady-state estimate, #5 PG row-count audit) are non-code follow-ups that will live as comments on the issue once a few days of data accumulate.

## Probes

### #6 — Rate-limiter telemetry tag (`discogs/service.py`, `discogs/fallthrough.py`)

Tags `lml.discogs.semaphore` and `lml.discogs.rate_limiter` Sentry spans with `lml.discogs.method` and `lml.discogs.cache_state` so the wait-time histogram can be split by which cache method's API miss triggered the wait. `cache_state` is one of `miss` (PG checked and missed), `skip` (per-request bypass via `should_skip_cache()`), `no_pg` (read-only method), or `cooldown` (#324 short-circuit active). Threaded via a `ContextVar` set in the `fallthrough` seam and read in `_request_with_retry` — same pattern as the existing `_skip_cache_var` in `discogs/memory_cache.py`, so no kwargs threading through 9 call sites. `Token`-paired set/reset survives `CancelledError`.

### #1 — Cache miss provenance sample (`scripts/cache_miss_provenance.py`)

For a sample of cache-miss → API-call events, classifies each by whether the `release` row already existed at miss time and whether it carried `release_track` rows. Separates first-time misses (H1 — ETL coverage gap) from release-row-exists-with-tracks misses (H3' — `validate_track_on_release` returning `False` as a cache hit). Accepts either a Railway log file (parsed by built-in regex patterns against the existing INFO-level `Validated:` / `Failed to fetch release` lines) or a CSV of `release_id,method` rows from a Sentry trace export.

Example run:
```bash
DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_miss_provenance.py --log railway-export.log --limit 50
```

Outputs `/tmp/lml-537-cache-miss-provenance.csv` + a summary table.

### #2 — Dynamic-write contribution histogram (`scripts/cache_warm_histogram.py`)

Buckets `release.artwork_checked_at` by day and contrasts the pre-Alembic-0009 ETL fill with the post-deploy dynamic warm-up daily mean. A small post-deploy mean confirms H1.

```bash
DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_warm_histogram.py
DATABASE_URL_DISCOGS=postgresql://... python scripts/cache_warm_histogram.py --csv > histogram.csv
```

### #3 — Discogs ranking jitter (`scripts/discogs_ranking_jitter.py`)

Issues two identical `/database/search?track=...&artist=...` calls separated by a delay and measures jaccard overlap of returned release IDs + average rank-delta for shared IDs. Low jaccard confirms H2 — Discogs returns different IDs across calls, so warming the prior set doesn't help the next one. Bypasses `DiscogsService` (no L1 LRU, no semaphore) to surface Discogs-side ranking behavior directly.

```bash
DISCOGS_TOKEN=... python scripts/discogs_ranking_jitter.py \
  --track "Moments of Soft Persuasion" --artist Yoshimura --repeat 3
```

## Out of scope

- **#4 steady-state estimate** — back-of-envelope math; will be a comment on #537 after data lands.
- **#5 PG row-count audit** — daily snapshot to capture over a week; the histogram in #2 already gives the cumulative shape.

## Test plan

- [x] Unit tests for #6 cover all four `cache_state` values (parametrized), the CancelledError reset, the normal-return reset, and the no-contextvar-set path that keeps direct callers (health probe) working
- [x] Unit tests for the three scripts cover the pure math (jaccard, position stability, summarise) and the input parsers (log regex, CSV)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy --ignore-missing-imports` clean on changed files
- [x] Full `pytest tests/unit/` pass (2446 tests; the 1 pre-existing asyncpg event-loop teardown race in `test_dependencies.py` is unrelated — passes in isolation)
- [ ] Run #2 against staging cache PG, confirm output shape; eyeball the post-cutoff daily mean
- [ ] Run #1 against a 1-hour Railway log window
- [ ] Run #3 with the three slow-lookup queries from the issue body
- [ ] Confirm the new tags appear in Sentry on staging after deploy

Refs #537.