### PR TITLE
fix(discogs): in-flight dedup in @async_cached (LML#544 / follow-up to #537)

### DIFF
--- a/discogs/memory_cache.py
+++ b/discogs/memory_cache.py
@@ -267,16 +267,28 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
                     logger.debug(f"Cache in-flight join for {func.__name__}")
                     get_cache_stats_recorder().record("memory_cache_inflight_join")
                     try:
-                        follower_result = await existing
+                        # `asyncio.shield` isolates each follower's `_fut_waiter`
+                        # to a per-await wrapper future (LML#544 round 3). Without
+                        # it, one follower's external task cancellation would
+                        # call `_fut_waiter.cancel()` on the SHARED `existing`
+                        # future, cascading CancelledError to every other follower
+                        # AND wedging the event loop: surviving followers retry,
+                        # find the same cancelled-done future in inflight (the
+                        # leader has not yet popped it), `await` it (which does
+                        # NOT yield for a done future), receive CancelledError,
+                        # and `continue` — a synchronous infinite loop. Shield
+                        # makes each follower's cancellation local; the shared
+                        # future stays pending until the leader actually
+                        # completes or cancels it.
+                        follower_result = await asyncio.shield(existing)
                     except asyncio.CancelledError:
-                        # Leader's task was cancelled and the future was
-                        # cancelled downstream. If WE were not cancelled
-                        # (cancelling() == 0), don't inherit the leader's
-                        # cancellation across an unrelated request boundary —
-                        # `continue` retries from the top of the loop, where
-                        # the leader's `finally` has popped the in-flight entry
-                        # and we'll either hit a fresh L1 entry, join a new
-                        # leader, or become one ourselves.
+                        # Either WE were cancelled, or the leader cancelled its
+                        # future (intentional broadcast that the leader bailed).
+                        # If our own task was asked to cancel, propagate; the
+                        # client / caller asked us to stop. Otherwise retry: the
+                        # leader's `finally` has popped the in-flight entry, so
+                        # the top of the loop sees a fresh slot and we'll either
+                        # hit a fresh L1 entry, join a new leader, or become one.
                         current = asyncio.current_task()
                         if current is None or current.cancelling() > 0:
                             raise

--- a/discogs/memory_cache.py
+++ b/discogs/memory_cache.py
@@ -244,85 +244,102 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
             # arguments are unchanged. The function name is identity-preserved.
             key = make_normalized_cache_key(func.__name__, *cache_args, **kwargs)
 
-            # Check cache
-            if key in cache:
-                logger.debug(f"Cache hit for {func.__name__}")
-                get_cache_stats_recorder().record_memory_cache_hit()
-                result = cache[key]
-                return _set_cached_flag(result, cached=True)  # type: ignore[no-any-return]
+            # Iterative retry on cancellation-driven coalescing failures (LML#544
+            # round 2). Each loop iteration re-runs cache/in-flight checks from
+            # the top, so a cancelled leader's pop leaves us seeing a fresh
+            # slot. A loop keeps stack depth constant under sustained
+            # cancellation cascades — recursion would grow one frame per retry
+            # and hit sys.recursionlimit under pathological conditions.
+            while True:
+                # Check cache
+                if key in cache:
+                    logger.debug(f"Cache hit for {func.__name__}")
+                    get_cache_stats_recorder().record_memory_cache_hit()
+                    result = cache[key]
+                    return _set_cached_flag(result, cached=True)  # type: ignore[no-any-return]
 
-            # Coalesce concurrent callers (LML#537). If another caller is
-            # already resolving this key, await its future and return the
-            # same value — marked cached=True to match serial-hit semantics.
-            inflight = _inflight_for(cache)
-            existing = inflight.get(key)
-            if existing is not None:
-                logger.debug(f"Cache in-flight join for {func.__name__}")
-                get_cache_stats_recorder().record("memory_cache_inflight_join")
-                try:
-                    follower_result = await existing
-                except asyncio.CancelledError:
-                    # Leader's task was cancelled and the future was cancelled
-                    # downstream. If WE were not cancelled (cancelling() == 0),
-                    # don't inherit the leader's cancellation across an unrelated
-                    # request boundary — retry by re-entering the wrapper. The
-                    # leader's `finally` has already popped the in-flight entry,
-                    # so this re-entry sees a fresh slot.
-                    current = asyncio.current_task()
-                    if current is None or current.cancelling() > 0:
-                        raise
-                    return await wrapper(*args, **kwargs)  # type: ignore[no-any-return]
-                return _set_cached_flag(follower_result, cached=True)  # type: ignore[no-any-return]
-
-            # Leader path: create the future, run the function, broadcast.
-            # `get_running_loop()` is safe because `wrapper` is `async def`
-            # and only runs inside an active event loop.
-            future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
-            inflight[key] = future
-            try:
-                logger.debug(f"Cache miss for {func.__name__}")
-                result = await func(*args, **kwargs)  # type: ignore[misc]
-                # Broadcast to followers BEFORE writing to L1, so a cache-write
-                # failure does not poison the followers' view of a successful
-                # fetch. The future.done() guard handles the (edge) case where
-                # the future was externally cancelled while the fetch was in
-                # flight — we still want to return the result to the leader's
-                # caller and let the cache write surface its own error.
-                if not future.done():
-                    future.set_result(result)
-                # Don't cache None results (existing contract).
-                if result is not None:
+                # Coalesce concurrent callers (LML#537). If another caller is
+                # already resolving this key, await its future and return the
+                # same value — marked cached=True to match serial-hit semantics.
+                inflight = _inflight_for(cache)
+                existing = inflight.get(key)
+                if existing is not None:
+                    logger.debug(f"Cache in-flight join for {func.__name__}")
+                    get_cache_stats_recorder().record("memory_cache_inflight_join")
                     try:
-                        cache[key] = result
-                    except Exception:
-                        # The fetch succeeded and was broadcast; treat an L1
-                        # write failure as a cache-layer issue, not a fetch
-                        # failure. Log and continue.
-                        logger.exception(
-                            "L1 cache write failed for %s; result still served",
-                            func.__name__,
+                        follower_result = await existing
+                    except asyncio.CancelledError:
+                        # Leader's task was cancelled and the future was
+                        # cancelled downstream. If WE were not cancelled
+                        # (cancelling() == 0), don't inherit the leader's
+                        # cancellation across an unrelated request boundary —
+                        # `continue` retries from the top of the loop, where
+                        # the leader's `finally` has popped the in-flight entry
+                        # and we'll either hit a fresh L1 entry, join a new
+                        # leader, or become one ourselves.
+                        current = asyncio.current_task()
+                        if current is None or current.cancelling() > 0:
+                            raise
+                        get_cache_stats_recorder().record(
+                            "memory_cache_inflight_retry_after_cancel"
                         )
-                return result  # type: ignore[no-any-return]
-            except asyncio.CancelledError:
-                # Cancel the future so existing followers know the leader bailed.
-                # Their `except asyncio.CancelledError` arm decides whether to
-                # retry (when they themselves were not cancelled) or propagate.
-                # Do NOT broadcast cancellation via set_exception — that would
-                # inject CancelledError into every follower's task context.
-                if not future.done():
-                    future.cancel()
-                raise
-            except Exception as exc:
-                if not future.done():
-                    future.set_exception(exc)
-                    # Mark the exception as retrieved on the future so asyncio
-                    # doesn't log "Future exception was never retrieved" when no
-                    # follower joined this in-flight window. Followers awaiting
-                    # the future consume the exception independently.
-                    future.exception()
-                raise
-            finally:
-                inflight.pop(key, None)
+                        continue
+                    return _set_cached_flag(follower_result, cached=True)  # type: ignore[no-any-return]
+
+                # Leader path: create the future, run the function, broadcast.
+                # `get_running_loop()` is safe because `wrapper` is `async def`
+                # and only runs inside an active event loop.
+                future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+                inflight[key] = future
+                try:
+                    logger.debug(f"Cache miss for {func.__name__}")
+                    result = await func(*args, **kwargs)  # type: ignore[misc]
+                    # Broadcast to followers BEFORE writing to L1, so a
+                    # cache-write failure does not poison the followers' view
+                    # of a successful fetch. The future.done() guard is
+                    # defensive against future-evolution (e.g., an external
+                    # watchdog cancelling in-flight futures by reference); no
+                    # internal call site does this today.
+                    if not future.done():
+                        future.set_result(result)
+                    # Don't cache None results (existing contract).
+                    if result is not None:
+                        try:
+                            cache[key] = result
+                        except Exception:
+                            # The fetch succeeded and was broadcast; treat an
+                            # L1 write failure as a cache-layer issue, not a
+                            # fetch failure. Log and emit a counter so the
+                            # rare 'cache layer broken' state surfaces in
+                            # cache-stats dashboards instead of being silent.
+                            get_cache_stats_recorder().record("memory_cache_write_failed")
+                            logger.exception(
+                                "L1 cache write failed for %s; result still served",
+                                func.__name__,
+                            )
+                    return result  # type: ignore[no-any-return]
+                except asyncio.CancelledError:
+                    # Cancel the future so existing followers know the leader
+                    # bailed. Their `except asyncio.CancelledError` arm
+                    # decides whether to retry (when they themselves were not
+                    # cancelled) or propagate. Do NOT broadcast cancellation
+                    # via set_exception — that would inject CancelledError
+                    # into every follower's task context.
+                    if not future.done():
+                        future.cancel()
+                    raise
+                except Exception as exc:
+                    if not future.done():
+                        future.set_exception(exc)
+                        # Mark the exception as retrieved on the future so
+                        # asyncio doesn't log "Future exception was never
+                        # retrieved" when no follower joined this in-flight
+                        # window. Followers awaiting the future consume the
+                        # exception independently.
+                        future.exception()
+                    raise
+                finally:
+                    inflight.pop(key, None)
 
         # Stash the cache + name so `evict_cached` can drop a single entry
         # using the SAME key derivation. Keeping these on the wrapper means a

--- a/discogs/memory_cache.py
+++ b/discogs/memory_cache.py
@@ -146,6 +146,13 @@ def clear_all_caches() -> None:
         _validation_cache
     for cache in _cache_registry:
         cache.clear()
+        # Drop the per-cache in-flight Future map too (LML#544). cache.clear()
+        # only empties the TTLCache contents; without this, orphan Futures
+        # attached via _inflight_for survive a clear and a new caller can join
+        # a dead leader's future.
+        inflight = getattr(cache, "_lml_inflight", None)
+        if inflight is not None:
+            inflight.clear()
     # Reset lazy caches so they get recreated with fresh settings
     _track_cache = None
     _release_cache = None
@@ -206,6 +213,12 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
     exception. The in-flight entry is dropped in a `finally`, so a transient
     failure or None result does not pin state.
 
+    Cancellation semantics: if the leader's task is cancelled, the future
+    is cancelled (not broadcast as an exception) and existing followers
+    detect that, re-enter the wrapper, and either join a fresh leader or
+    become one themselves. Cancellation of the leader does NOT propagate
+    across unrelated request contexts that happen to share the key.
+
     Args:
         cache: TTLCache instance to use for caching
 
@@ -245,7 +258,20 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
             existing = inflight.get(key)
             if existing is not None:
                 logger.debug(f"Cache in-flight join for {func.__name__}")
-                follower_result = await existing
+                get_cache_stats_recorder().record("memory_cache_inflight_join")
+                try:
+                    follower_result = await existing
+                except asyncio.CancelledError:
+                    # Leader's task was cancelled and the future was cancelled
+                    # downstream. If WE were not cancelled (cancelling() == 0),
+                    # don't inherit the leader's cancellation across an unrelated
+                    # request boundary — retry by re-entering the wrapper. The
+                    # leader's `finally` has already popped the in-flight entry,
+                    # so this re-entry sees a fresh slot.
+                    current = asyncio.current_task()
+                    if current is None or current.cancelling() > 0:
+                        raise
+                    return await wrapper(*args, **kwargs)  # type: ignore[no-any-return]
                 return _set_cached_flag(follower_result, cached=True)  # type: ignore[no-any-return]
 
             # Leader path: create the future, run the function, broadcast.
@@ -256,19 +282,44 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
             try:
                 logger.debug(f"Cache miss for {func.__name__}")
                 result = await func(*args, **kwargs)  # type: ignore[misc]
+                # Broadcast to followers BEFORE writing to L1, so a cache-write
+                # failure does not poison the followers' view of a successful
+                # fetch. The future.done() guard handles the (edge) case where
+                # the future was externally cancelled while the fetch was in
+                # flight — we still want to return the result to the leader's
+                # caller and let the cache write surface its own error.
+                if not future.done():
+                    future.set_result(result)
                 # Don't cache None results (existing contract).
                 if result is not None:
-                    cache[key] = result
-                future.set_result(result)
+                    try:
+                        cache[key] = result
+                    except Exception:
+                        # The fetch succeeded and was broadcast; treat an L1
+                        # write failure as a cache-layer issue, not a fetch
+                        # failure. Log and continue.
+                        logger.exception(
+                            "L1 cache write failed for %s; result still served",
+                            func.__name__,
+                        )
                 return result  # type: ignore[no-any-return]
-            except BaseException as exc:
-                future.set_exception(exc)
-                # Mark the exception as retrieved on the future so asyncio
-                # doesn't log "Future exception was never retrieved" when no
-                # follower joined this in-flight window. Followers awaiting
-                # the future consume the exception independently; this no-op
-                # call only matters on the no-follower path.
-                future.exception()
+            except asyncio.CancelledError:
+                # Cancel the future so existing followers know the leader bailed.
+                # Their `except asyncio.CancelledError` arm decides whether to
+                # retry (when they themselves were not cancelled) or propagate.
+                # Do NOT broadcast cancellation via set_exception — that would
+                # inject CancelledError into every follower's task context.
+                if not future.done():
+                    future.cancel()
+                raise
+            except Exception as exc:
+                if not future.done():
+                    future.set_exception(exc)
+                    # Mark the exception as retrieved on the future so asyncio
+                    # doesn't log "Future exception was never retrieved" when no
+                    # follower joined this in-flight window. Followers awaiting
+                    # the future consume the exception independently.
+                    future.exception()
                 raise
             finally:
                 inflight.pop(key, None)

--- a/discogs/memory_cache.py
+++ b/discogs/memory_cache.py
@@ -1,5 +1,6 @@
 """Caching utilities for Discogs API responses using TTL-based LRU cache."""
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -171,12 +172,39 @@ def _set_cached_flag(result: Any, cached: bool) -> Any:
     return result
 
 
+def _inflight_for(cache: TTLCache) -> dict[str, "asyncio.Future[Any]"]:
+    """Per-cache map of in-flight Futures for concurrent-request coalescing.
+
+    Lazily attached to the cache instance the first time a wrapper enters the
+    fallthrough path. Each entry's lifetime spans exactly one fetch — the
+    leader pops it in its `finally` once the future is resolved (success,
+    None, or exception). Followers share the leader's value via
+    `await future` without re-entering the underlying function.
+
+    Exported as a module-level helper (parallel to `_normalize_for_cache_key`)
+    so unit tests can assert the map is empty post-resolve without reaching
+    into the cache instance's private attribute. LML#537.
+    """
+    inflight = getattr(cache, "_lml_inflight", None)
+    if inflight is None:
+        inflight = {}
+        cache._lml_inflight = inflight  # type: ignore[attr-defined]
+    return inflight
+
+
 def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Decorator for caching async function results.
 
     The decorated function's results are cached based on its arguments.
     If the result has a 'cached' field, it will be set to True on cache hits.
     None results are not cached.
+
+    Concurrent callers for the same key coalesce onto a single in-flight
+    Future, so the wrapped function runs once per key per in-flight window
+    (LML#537). Followers receive the leader's value (with `cached=True`
+    applied when the result shape supports it), or re-raise the leader's
+    exception. The in-flight entry is dropped in a `finally`, so a transient
+    failure or None result does not pin state.
 
     Args:
         cache: TTLCache instance to use for caching
@@ -210,15 +238,40 @@ def async_cached(cache: TTLCache) -> Callable[[Callable[..., T]], Callable[..., 
                 result = cache[key]
                 return _set_cached_flag(result, cached=True)  # type: ignore[no-any-return]
 
-            # Cache miss - call function
-            logger.debug(f"Cache miss for {func.__name__}")
-            result = await func(*args, **kwargs)  # type: ignore[misc]
+            # Coalesce concurrent callers (LML#537). If another caller is
+            # already resolving this key, await its future and return the
+            # same value — marked cached=True to match serial-hit semantics.
+            inflight = _inflight_for(cache)
+            existing = inflight.get(key)
+            if existing is not None:
+                logger.debug(f"Cache in-flight join for {func.__name__}")
+                follower_result = await existing
+                return _set_cached_flag(follower_result, cached=True)  # type: ignore[no-any-return]
 
-            # Don't cache None results
-            if result is not None:
-                cache[key] = result
-
-            return result  # type: ignore[no-any-return]
+            # Leader path: create the future, run the function, broadcast.
+            # `get_running_loop()` is safe because `wrapper` is `async def`
+            # and only runs inside an active event loop.
+            future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+            inflight[key] = future
+            try:
+                logger.debug(f"Cache miss for {func.__name__}")
+                result = await func(*args, **kwargs)  # type: ignore[misc]
+                # Don't cache None results (existing contract).
+                if result is not None:
+                    cache[key] = result
+                future.set_result(result)
+                return result  # type: ignore[no-any-return]
+            except BaseException as exc:
+                future.set_exception(exc)
+                # Mark the exception as retrieved on the future so asyncio
+                # doesn't log "Future exception was never retrieved" when no
+                # follower joined this in-flight window. Followers awaiting
+                # the future consume the exception independently; this no-op
+                # call only matters on the no-follower path.
+                future.exception()
+                raise
+            finally:
+                inflight.pop(key, None)
 
         # Stash the cache + name so `evict_cached` can drop a single entry
         # using the SAME key derivation. Keeping these on the wrapper means a

--- a/docs/plans/lml-537-l1-inflight-dedup.md
+++ b/docs/plans/lml-537-l1-inflight-dedup.md
@@ -113,7 +113,9 @@ The leader's broadcast (`future.set_result(result)`) fires **before** `cache[key
 
 ### Interaction with `evict_cached`
 
-`evict_cached` only touches the `TTLCache` (`cache.pop(key, None)`). It does **not** touch the in-flight map. Justification: if an eviction races with an in-flight fetch, the leader has already started; the right behavior is to let it finish (followers get the value), then the next post-eviction caller will miss and fetch. Evicting an in-flight entry would just orphan the followers.
+`evict_cached` only touches the `TTLCache` (`cache.pop(key, None)`). It does **not** touch the in-flight map. Justification: if an eviction races with an in-flight fetch, the leader has already started; followers awaiting the leader's future hold a direct reference to it and still receive the value. Evicting the in-flight entry would just orphan the followers.
+
+Note on ordering when `evict_cached` runs *before* the leader's write-back: the leader's eventual `cache[key] = result` will repopulate the L1 entry, so the next caller hits the just-written value — not "miss and fetch." Tombstone-clear flows that need to guarantee no stale serve should re-evict after the in-flight fetch resolves, or queue evictions through a higher-level seam that knows when leaders complete.
 
 ### Interaction with `clear_all_caches`
 

--- a/docs/plans/lml-537-l1-inflight-dedup.md
+++ b/docs/plans/lml-537-l1-inflight-dedup.md
@@ -88,9 +88,24 @@ The leader stores `result` in `cache[key]` only if non-None (preserving the exis
 
 ### Raise semantics
 
-If `await func(...)` raises, the leader propagates the exception to all followers via `future.set_exception(exc)`, then the `finally` clause pops the in-flight entry. Followers re-raise the exception to their callers. The next caller (post-pop) starts fresh.
+If `await func(...)` raises a non-cancellation `Exception`, the leader broadcasts it to followers via `future.set_exception(exc)`, then the `finally` clause pops the in-flight entry. Followers re-raise the same exception instance. The next caller (post-pop) starts fresh.
 
-This matches the orchestrator's existing error-handling expectation: a transient Discogs failure should not silently pin a bad cached entry; the next call should retry. Followers see the exact same exception the leader saw — symmetric with what would have happened if all callers had each entered the fallthrough independently. The blast radius does not grow: the same code path that would have raised once-per-caller (N raises in the old code) now raises once-per-caller in the new code (N raises). Only the underlying fetch count drops from N to 1.
+This matches the orchestrator's existing error-handling expectation: a transient Discogs failure should not silently pin a bad cached entry; the next call should retry. Followers see the exact same exception the leader saw — the future broadcasts the leader's instance, not a reconstruction, so Sentry deduplication, traceback chaining, and identity-based downstream checks behave normally.
+
+### Cancellation semantics (the asymmetric case)
+
+Cancellation is **not** a value — it's an out-of-band signal scoped to a task. In production, the leader and the followers can be in **unrelated request contexts** that happen to share a module-level singleton cache. If Request A's task is cancelled (per-request timeout, client disconnect), broadcasting the cancellation across the future would inject `CancelledError` into Request B's task tree, even though B was never cancelled. That's wrong.
+
+The implementation handles cancellation specifically:
+
+- **Leader cancelled**: the `except asyncio.CancelledError` arm cancels the future (so followers know the leader bailed) and re-raises, terminating the leader's task normally.
+- **Follower receives cancellation from `await future`**: the `except asyncio.CancelledError` arm checks `asyncio.current_task().cancelling()`. If 0, the follower's own task was not cancelled — re-enter the wrapper to either join a fresh leader or become one. If >0, the follower was actually cancelled — re-raise.
+
+This restores the asymmetry: cancellation is per-task, the dedup layer does not flatten it across unrelated requests. Cost: a cancelled leader trades one follower retry per concurrent caller (bounded by the orchestrator's concurrency cap). Benefit: one client's disconnect can't cascade into another client's failures.
+
+### Cache-write failure isolation
+
+The leader's broadcast (`future.set_result(result)`) fires **before** `cache[key] = result`. If the L1 write raises (e.g., a future cachetools eviction-callback throws), followers still see the successful fetch and only the leader's caller sees the cache-layer error. A `try/except` around the cache write logs and continues — a cache failure is not the same as a fetch failure.
 
 ### Interaction with `skip_cache` flag
 
@@ -99,6 +114,10 @@ This matches the orchestrator's existing error-handling expectation: a transient
 ### Interaction with `evict_cached`
 
 `evict_cached` only touches the `TTLCache` (`cache.pop(key, None)`). It does **not** touch the in-flight map. Justification: if an eviction races with an in-flight fetch, the leader has already started; the right behavior is to let it finish (followers get the value), then the next post-eviction caller will miss and fetch. Evicting an in-flight entry would just orphan the followers.
+
+### Interaction with `clear_all_caches`
+
+`clear_all_caches()` resets each registered cache's `_lml_inflight` map alongside the TTL contents. Without this, in-flight Futures attached lazily by `_inflight_for` would survive a clear and a post-clear caller could join a dead leader's future — defeating the point of the clear.
 
 ### Interaction with `should_skip_cache` across leader / follower
 
@@ -137,10 +156,11 @@ No behavioral changes during refactor.
 
 ## Risk surface
 
-- **Memory leak via abandoned futures.** If a task is cancelled between `in_flight[key] = future` and the `finally`, the `finally` still runs (because `try/finally` is exception-safe for `CancelledError`). Followers awaiting the future receive `CancelledError`. Mitigation already in design: `finally` always pops; followers see cancellation and re-raise (their own task tree handles it).
+- **Memory leak via abandoned futures.** The `finally` clause always pops the in-flight entry, including on `CancelledError`. Followers see cancellation via the future being cancelled and either retry (if their own task was not cancelled) or propagate (if it was) — see the cancellation semantics section above.
 - **Performance regression on serial callers.** The added `if key in in_flight` check is `O(1)` dict membership against a dict that's empty in steady-state for serial callers. Negligible.
 - **Thread safety.** asyncio coroutines are single-threaded per event loop. The in-flight dict is touched only within the wrapper's coroutine body — no `await` between read and write of the dict — so no race within the dedup logic itself.
-- **Cross-event-loop test pollution.** The in-flight map is stashed on the cache instance, which is shared across tests via the module-level registry. Each test creates its own `cache` via `create_ttl_cache`, so map isolation is automatic. The lazy-attachment shape doesn't accumulate across `clear_all_caches()` calls (the map is per-cache, and the lazy caches are reset to `None` on clear).
+- **Cross-event-loop test pollution.** The in-flight map is stashed on the cache instance, which is shared across tests via the module-level registry. `clear_all_caches()` resets the per-cache `_lml_inflight` map alongside the TTL contents, so prior-test orphans don't survive into the next test. Each test in `TestAsyncCachedInFlightDedup` also creates its own `cache` via `create_ttl_cache`, providing belt-and-suspenders isolation.
+- **Telemetry observability.** The follower path records a `memory_cache_inflight_join` event via the cache stats recorder so the dedup is visible in the cache-stats stream; without this, in-flight joins would be invisible to dashboards (the L1 hit counter wouldn't tick because the entry isn't in the TTLCache yet). The Sentry semaphore/limiter spans (`lml.discogs.semaphore`, `lml.discogs.rate_limiter`) still only attach to the leader's trace — a follower's transaction looks fast because it skipped the seam entirely. This is a deeper observability tradeoff and out of scope; the `memory_cache_inflight_join` counter is the operationally-useful signal for "is the dedup firing?"
 
 ## Acceptance
 

--- a/docs/plans/lml-537-l1-inflight-dedup.md
+++ b/docs/plans/lml-537-l1-inflight-dedup.md
@@ -1,0 +1,157 @@
+# LML #537 (follow-up) — L1 in-flight dedup in `@async_cached`
+
+**Parent issue:** [WXYC/library-metadata-lookup#537](https://github.com/WXYC/library-metadata-lookup/issues/537) — *Discogs cache hit ratio plateaued at ~50%*
+
+**Sibling investigations:** issue #537's compounding-cause set: (1) `get_release` predicate strictness on artwork columns, (2) **L1 `@async_cached` race (this plan)**, (3) Discogs semaphore wait. The first ticket lands the highest-leverage, smallest-blast-radius fix.
+
+## Background
+
+The `@async_cached` decorator at `discogs/memory_cache.py:188-221` does a non-atomic check-then-set across an `await` of the wrapped function:
+
+```python
+if key in cache:                                    # check
+    return _set_cached_flag(cache[key], cached=True)
+result = await func(*args, **kwargs)                # await yields the event loop
+if result is not None:
+    cache[key] = result                             # set
+```
+
+For network-bound wrapped functions (`get_release`, `get_artist_details`, `search`, `validate_track_on_release`, `_search_track`, `get_master`, `get_label_image`, and `cache_service.py`'s artist-search cache), the `await` window covers a PG round-trip plus the Discogs API call — easily hundreds of milliseconds to seconds. Every caller that arrives during that window sees the same L1 miss and enters the fallthrough seam independently.
+
+Production tracing (issue #537 latest comment) shows duplicate fetches inside a 10-second window for the same release_id: release 28184356 fetched 3× at 13:05:41/44/45, release 3657075 fetched 3× at 13:05:34/39/40. Two real concurrent paths put the same `release_id` into a single `asyncio.gather` within one request:
+
+1. **`search_compilations_for_track` Wave-A/Wave-B merge** (`lookup/orchestrator.py:1331-1356`) dedups by **album-name lowercase**, not release_id. Two release entries with different album-string formatting (typographic vs ASCII apostrophe, trailing version tag) can share a `release_id`. They flow into `_chunked_gather(raw_releases, process_release, MAX_SEARCH_RESULTS=5)`, where `process_release` → `validate_track_on_release(release_id, …)` → `get_release(release_id)` runs in `asyncio.gather`.
+2. **Validation → get_release nesting**: `validate_track_on_release` itself wraps `get_release`. Even a single fan-out element drives two cached calls — one for the validation row, one for the release row. Five concurrent chunk items × two nested cached calls each is enough to reproduce the observed 2-3× duplicate fetches.
+
+The duplicates multiply pressure on the 5-permit Discogs semaphore (`discogs/service.py:373-374`), inflating the `lml.discogs.semaphore` p95 wait (9.7s). Closing the race shrinks the API call count, which shrinks the semaphore queue.
+
+## Scope of this change
+
+A single file change to `discogs/memory_cache.py` adding per-key in-flight `asyncio.Future` coalescing inside `async_cached`. No call-site changes. No new public API. No behavioral change for serial callers, single-instance tests, or any code path that doesn't have concurrent L1 misses on the same key.
+
+Out of scope (separate tickets):
+
+- Predicate widening for `get_release`'s `is_pg_hit` (Cause #1).
+- Bumping Discogs semaphore from 5 (Cause #3).
+- Probe methodology fixes (`cache_warm_histogram.py` writer-source split).
+- Anything in `lookup/orchestrator.py` or `discogs/fallthrough.py`.
+
+## Design
+
+### Mechanism
+
+A per-cache `dict[str, asyncio.Future]` maps cache key → in-flight future for any key currently being resolved. The wrapper becomes:
+
+```python
+async def wrapper(*args, **kwargs) -> T:
+    if should_skip_cache():
+        return await func(*args, **kwargs)
+
+    key = make_normalized_cache_key(...)
+
+    if key in cache:                                      # L1 hit (unchanged)
+        return _set_cached_flag(cache[key], cached=True)
+
+    in_flight = _inflight_for(cache)
+    if key in in_flight:                                  # follower path
+        result = await in_flight[key]
+        return _set_cached_flag(result, cached=True)
+
+    future: asyncio.Future = asyncio.get_running_loop().create_future()
+    in_flight[key] = future
+    try:                                                  # leader path
+        result = await func(*args, **kwargs)
+        if result is not None:
+            cache[key] = result
+        future.set_result(result)
+        return result
+    except BaseException as exc:
+        future.set_exception(exc)
+        raise
+    finally:
+        in_flight.pop(key, None)
+```
+
+The per-cache map is stashed on the `TTLCache` instance (a single attribute set in `create_ttl_cache` — no global registry — so each cache owns its own in-flight set). This keeps the wrapper threadless and respects the fact that distinct caches with the same key string should not coalesce.
+
+### Why a Future, not a Lock or Event
+
+A `Lock` would serialize all callers through the seam, but the second arrival would still re-enter the cache lookup and might miss again if the TTL evicted between unlock and the second check. A `Future` lets the leader compute once and broadcast the result to all followers atomically.
+
+### Cleanup invariant
+
+The `finally` clause removes the in-flight entry **after** the future is resolved. Followers that took a reference before the `pop` are not affected — they hold the resolved future. New callers arriving after the `pop` either find the value in the L1 cache (success path) or start a fresh fetch (None/raise path).
+
+### None-result semantics
+
+The leader stores `result` in `cache[key]` only if non-None (preserving the existing "don't cache None" contract). The leader still does `future.set_result(None)` so followers receive the same None. The next arrival sees no `cache` entry and no `in_flight` entry → starts a fresh fetch. This matches the existing serial-caller behavior: None results don't pin a value, so the next call retries.
+
+### Raise semantics
+
+If `await func(...)` raises, the leader propagates the exception to all followers via `future.set_exception(exc)`, then the `finally` clause pops the in-flight entry. Followers re-raise the exception to their callers. The next caller (post-pop) starts fresh.
+
+This matches the orchestrator's existing error-handling expectation: a transient Discogs failure should not silently pin a bad cached entry; the next call should retry. Followers see the exact same exception the leader saw — symmetric with what would have happened if all callers had each entered the fallthrough independently. The blast radius does not grow: the same code path that would have raised once-per-caller (N raises in the old code) now raises once-per-caller in the new code (N raises). Only the underlying fetch count drops from N to 1.
+
+### Interaction with `skip_cache` flag
+
+`should_skip_cache()` short-circuits at the top of the wrapper, before any cache or in-flight bookkeeping. Skip-cache callers bypass both the L1 cache and the dedup, preserving the existing A/B-comparison contract (every skip-cache call hits the underlying function).
+
+### Interaction with `evict_cached`
+
+`evict_cached` only touches the `TTLCache` (`cache.pop(key, None)`). It does **not** touch the in-flight map. Justification: if an eviction races with an in-flight fetch, the leader has already started; the right behavior is to let it finish (followers get the value), then the next post-eviction caller will miss and fetch. Evicting an in-flight entry would just orphan the followers.
+
+### Interaction with `should_skip_cache` across leader / follower
+
+Edge case: leader started under `skip_cache=False`, follower arrives with `skip_cache=True`. The current `should_skip_cache()` is a `ContextVar`-scoped flag (per-request). A follower in a different request with `skip_cache=True` short-circuits at the top of the wrapper and never reaches the in-flight check — it gets its own underlying call, which is correct. The leader and follower are in different "skip-cache stances" and that's preserved.
+
+## Tests (TDD)
+
+Append to `tests/unit/test_memory_cache.py`. Each test is appended as a new method of a new `TestAsyncCachedInFlightDedup` class. Existing tests are not modified.
+
+### Red phase — failing tests
+
+All tests live in a new `TestAsyncCachedInFlightDedup` class with a docstring explaining the class tests "concurrent request coalescing in `@async_cached`'s in-flight Future map." Each test creates its own isolated `create_ttl_cache(...)` instance (matching the existing `TestAsyncCached` pattern in `test_memory_cache.py:319-405`) to avoid test-order dependencies on a shared cache.
+
+1. **`test_concurrent_same_key_calls_underlying_once`** — N=5 concurrent `asyncio.gather` calls to the same wrapped key against a slow coroutine (await `asyncio.sleep(0.05)` inside). Pre-fix: call_count == 5. Post-fix: call_count == 1, all callers receive the same result.
+2. **`test_concurrent_distinct_keys_each_call_underlying`** — N=5 concurrent calls with distinct keys. call_count == 5 always (sanity check that dedup is key-scoped, not global).
+3. **`test_leader_raise_propagates_to_followers`** — leader's underlying function raises `RuntimeError`. All N followers also raise `RuntimeError`. call_count == 1 (only the leader entered the function). A subsequent serial call starts fresh (no pinned exception in the in-flight map).
+4. **`test_leader_none_result_followers_get_none`** — leader returns None. All N followers receive None (explicitly asserted: `result is None` per follower, no timeout, no raise). No entry written to L1 cache. Subsequent serial call invokes the function again (no pinned None).
+5. **`test_followers_get_cached_flag_true_when_result_supports_it`** — leader returns `{"data": "x", "cached": False}`. Followers get the same dict with `cached=True` set, matching the existing serial cache-hit semantics.
+6. **`test_skip_cache_in_follower_short_circuits_independently`** — leader starts with `skip_cache=False` (no skip). Mid-await, a separate task with `skip_cache=True` calls the same key. The skip-cache caller bypasses both cache and dedup, invokes the function independently. (Tests the ContextVar boundary.)
+7. **`test_inflight_entry_cleaned_up_after_resolve`** — after `await wrapper(...)` returns, `_inflight_for(cache)` is empty. Subsequent concurrent calls re-enter the leader/follower split correctly.
+8. **`test_evict_cached_does_not_touch_inflight`** — leader is mid-await; concurrent `evict_cached` on the same key. Followers still get the leader's result; the L1 cache is then evicted; the next post-eviction call misses and re-fetches.
+
+### Green phase — implementation
+
+Single file edit at `discogs/memory_cache.py`. New module-level private helper `_inflight_for(cache)` that lazily attaches a `dict[str, asyncio.Future[Any]]` to the cache instance via `getattr(cache, "_lml_inflight", None) or setattr`. Wrapper rewritten as the design block above. `create_ttl_cache` is not modified (lazy attachment in `_inflight_for` avoids needing to touch the factory).
+
+**Pre-decided** (per reviewer #2): `_inflight_for` is exported at module-level (parallel to `_normalize_for_cache_key` at `memory_cache.py:67`) so cleanup tests can assert `_inflight_for(cache) == {}` without reaching into `cache._lml_inflight` directly. The underscore-prefix keeps it private but accessible.
+
+**Pre-decided** (per reviewer #3): the implementation includes a one-line comment at the `asyncio.get_running_loop().create_future()` site explaining that `get_running_loop()` is safe here because the wrapper is `async def` and only runs inside an active event loop.
+
+### Refactor pass
+
+After green, evaluate whether the in-flight dict needs a more precise type annotation (`dict[str, asyncio.Future[T]]` vs `dict[str, asyncio.Future[Any]]`); the existing wrapper uses `T = TypeVar("T")` but doesn't push it through to runtime, so `Any` is consistent with the surrounding code.
+
+No behavioral changes during refactor.
+
+## Risk surface
+
+- **Memory leak via abandoned futures.** If a task is cancelled between `in_flight[key] = future` and the `finally`, the `finally` still runs (because `try/finally` is exception-safe for `CancelledError`). Followers awaiting the future receive `CancelledError`. Mitigation already in design: `finally` always pops; followers see cancellation and re-raise (their own task tree handles it).
+- **Performance regression on serial callers.** The added `if key in in_flight` check is `O(1)` dict membership against a dict that's empty in steady-state for serial callers. Negligible.
+- **Thread safety.** asyncio coroutines are single-threaded per event loop. The in-flight dict is touched only within the wrapper's coroutine body — no `await` between read and write of the dict — so no race within the dedup logic itself.
+- **Cross-event-loop test pollution.** The in-flight map is stashed on the cache instance, which is shared across tests via the module-level registry. Each test creates its own `cache` via `create_ttl_cache`, so map isolation is automatic. The lazy-attachment shape doesn't accumulate across `clear_all_caches()` calls (the map is per-cache, and the lazy caches are reset to `None` on clear).
+
+## Acceptance
+
+- All 8 new unit tests pass.
+- Existing 36 `test_memory_cache.py` tests pass unchanged.
+- `tests/integration/test_memory_cache.py` unchanged and passes.
+- `ruff check` + `ruff format --check` clean.
+- One follow-up PR (separate ticket) considers whether to add an integration-style test that exercises the dedup through `discogs/service.py:get_release` with a stubbed Discogs HTTP client, to pin the seam-level behavior end-to-end. Out of scope for this PR's TDD pass.
+
+## Estimated diff
+
+- `discogs/memory_cache.py`: ~30 lines added, ~5 modified, 0 removed.
+- `tests/unit/test_memory_cache.py`: ~150 lines added.
+- No other files.

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -134,7 +134,17 @@ async def handle_lookup(
     ),
 ):
     """Process a lookup request."""
-    init_cache_stats()
+    # Pre-declare LML-specific cache-stats keys so PostHog/Sentry payload shapes
+    # are stable even on requests with zero in-flight joins or zero L1 write
+    # failures (LML#544 round 2). Without extra_keys, the keys would only
+    # appear in payloads from the first request that records them.
+    init_cache_stats(
+        extra_keys=(
+            "memory_cache_inflight_join",
+            "memory_cache_inflight_retry_after_cancel",
+            "memory_cache_write_failed",
+        )
+    )
     if skip_cache:
         set_skip_cache(True)
     telemetry = RequestTelemetry(
@@ -326,7 +336,17 @@ async def handle_bulk_lookup(
     # One cache_stats context for the whole batch: the in-process caches are
     # shared, so aggregate counters reflect the batch's behavior — the property
     # that motivates this endpoint.
-    init_cache_stats()
+    # Pre-declare LML-specific cache-stats keys so PostHog/Sentry payload shapes
+    # are stable even on requests with zero in-flight joins or zero L1 write
+    # failures (LML#544 round 2). Without extra_keys, the keys would only
+    # appear in payloads from the first request that records them.
+    init_cache_stats(
+        extra_keys=(
+            "memory_cache_inflight_join",
+            "memory_cache_inflight_retry_after_cancel",
+            "memory_cache_write_failed",
+        )
+    )
 
     max_concurrent = _max_concurrency_from_env()
     semaphore = asyncio.Semaphore(max_concurrent)

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -1,10 +1,13 @@
 """Unit tests for discogs/memory_cache.py."""
 
+import asyncio
+
 import pytest
 from pydantic import BaseModel
 
 from discogs.memory_cache import (
     _cache_registry,
+    _inflight_for,
     _set_cached_flag,
     async_cached,
     clear_all_caches,
@@ -403,6 +406,244 @@ class TestAsyncCached:
         await my_func("a")
         await my_func("b")
         assert len(cache) == 2
+
+
+# ---------------------------------------------------------------------------
+# Concurrent request coalescing (LML#537)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCachedInFlightDedup:
+    """`@async_cached` coalesces concurrent callers for the same key onto a
+    single in-flight Future so the wrapped function runs once per key per
+    in-flight window — closing the non-atomic check-then-set race documented
+    in LML#537. Each test creates its own isolated cache to avoid test-order
+    dependencies on a shared in-flight map."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_key_calls_underlying_once(self):
+        # The race: N concurrent callers all see L1 miss, all enter
+        # fallthrough independently. With the in-flight Future, the leader
+        # runs once and broadcasts to all followers.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+
+        @async_cached(cache)
+        async def slow_fetch(arg):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return {"data": arg, "cached": False}
+
+        results = await asyncio.gather(*[slow_fetch("x") for _ in range(5)])
+
+        assert call_count == 1
+        for r in results:
+            assert r["data"] == "x"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_distinct_keys_each_call_underlying(self):
+        # Dedup is key-scoped, not global: concurrent calls with distinct
+        # keys each invoke the function once.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+
+        @async_cached(cache)
+        async def slow_fetch(arg):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)
+            return {"data": arg, "cached": False}
+
+        keys = ["a", "b", "c", "d", "e"]
+        await asyncio.gather(*[slow_fetch(k) for k in keys])
+
+        assert call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_leader_raise_propagates_to_followers(self):
+        # Transient API failure: leader raises, all followers re-raise the
+        # same exception type, function ran exactly once. A subsequent serial
+        # call starts fresh — no exception pinned in the in-flight map.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+
+        @async_cached(cache)
+        async def raising_fetch(arg):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)
+            raise RuntimeError("upstream boom")
+
+        results = await asyncio.gather(
+            *[raising_fetch("x") for _ in range(4)], return_exceptions=True
+        )
+        assert call_count == 1
+        assert all(isinstance(r, RuntimeError) for r in results)
+        assert all(str(r) == "upstream boom" for r in results)
+
+        # Fresh serial call: in-flight entry was cleared, function runs again.
+        with pytest.raises(RuntimeError):
+            await raising_fetch("x")
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_leader_none_result_followers_get_none(self):
+        # None results don't get cached in the L1 TTL (existing contract).
+        # Followers must still receive the None verbatim (no timeout, no
+        # raise), and the in-flight entry must be cleared so a subsequent
+        # call re-invokes the function.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+
+        @async_cached(cache)
+        async def maybe_none(arg):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.01)
+            return None
+
+        results = await asyncio.gather(*[maybe_none("x") for _ in range(4)])
+
+        assert call_count == 1
+        for r in results:
+            assert r is None
+        assert len(cache) == 0
+
+        # Subsequent serial call invokes the function again — None wasn't pinned.
+        result = await maybe_none("x")
+        assert result is None
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_followers_get_cached_flag_true_when_result_supports_it(self):
+        # When the leader's result is a dict with a `cached` field, followers
+        # should receive it with `cached=True` set, matching the serial cache-hit
+        # path's behavior.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+
+        @async_cached(cache)
+        async def fetch(arg):
+            await asyncio.sleep(0.01)
+            return {"data": arg, "cached": False}
+
+        results = await asyncio.gather(*[fetch("x") for _ in range(3)])
+
+        # At least one of the three is the leader (cached=False on its result
+        # because the leader returns its own freshly-computed value). The
+        # followers receive the result via the future and should be marked
+        # cached=True. We don't care which order — just that at least one is
+        # marked cached=True so the seam-level instrumentation is consistent.
+        cached_count = sum(1 for r in results if r["cached"] is True)
+        assert cached_count >= 2  # at least 2 followers see cached=True
+
+    @pytest.mark.asyncio
+    async def test_skip_cache_in_follower_short_circuits_independently(self):
+        # `should_skip_cache()` short-circuits at the top of the wrapper,
+        # before any cache or in-flight bookkeeping. A skip-cache caller
+        # bypasses the dedup entirely and invokes the underlying function
+        # directly — even while a leader is mid-await on the same key.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+
+        @async_cached(cache)
+        async def fetch(arg):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.02)
+            return {"data": arg, "cached": False}
+
+        async def normal_caller():
+            return await fetch("x")
+
+        async def skip_caller():
+            set_skip_cache(True)
+            try:
+                return await fetch("x")
+            finally:
+                set_skip_cache(False)
+
+        await asyncio.gather(normal_caller(), skip_caller())
+        # Two callers entered the function: the leader (normal) and the
+        # skip-cache caller. The skip-cache caller does not share the
+        # leader's future.
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_inflight_entry_cleaned_up_after_resolve(self):
+        # After `await wrapper(...)` returns, the in-flight map for that key
+        # must be empty. Otherwise abandoned futures pile up and the next
+        # concurrent batch would still observe leader/follower coalescing,
+        # but cleanup is what makes the map memory-stable.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+
+        @async_cached(cache)
+        async def fetch(arg):
+            await asyncio.sleep(0.01)
+            return {"data": arg, "cached": False}
+
+        await fetch("x")
+        assert _inflight_for(cache) == {}
+
+        # A second concurrent batch hits the cache directly (already populated)
+        # so it never enters the in-flight branch — still must leave the map
+        # empty.
+        await asyncio.gather(*[fetch("x") for _ in range(3)])
+        assert _inflight_for(cache) == {}
+
+    @pytest.mark.asyncio
+    async def test_evict_cached_does_not_touch_inflight(self):
+        # `evict_cached` operates on the TTLCache only — it does NOT pop the
+        # in-flight Future map. So a mid-await eviction must leave the
+        # leader's future intact: the leader still resolves, followers still
+        # get the result. The downstream L1 state after the race is governed
+        # by normal evict + write ordering (covered by existing tests); the
+        # invariant this test pins is the dedup-layer one.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+
+        @async_cached(cache)
+        async def fetch(arg):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return {"data": arg, "cached": False}
+
+        inflight_during_evict: dict[str, asyncio.Future] = {}
+
+        async def follower():
+            return await fetch("x")
+
+        async def evictor():
+            # Wait a tick so the leader is mid-await with the future pinned.
+            await asyncio.sleep(0.01)
+            # Snapshot the in-flight map, call evict, confirm the map is
+            # unchanged. The leader's future is still in place after evict.
+            before = dict(_inflight_for(cache))
+            evict_cached(fetch, "x")
+            after = dict(_inflight_for(cache))
+            inflight_during_evict.update(after)
+            assert before == after, "evict_cached must not touch the in-flight map"
+            assert len(after) == 1, "leader's future must still be pinned"
+
+        leader_task = asyncio.create_task(fetch("x"))
+        follower_task = asyncio.create_task(follower())
+        evictor_task = asyncio.create_task(evictor())
+
+        leader_result, follower_result, _ = await asyncio.gather(
+            leader_task, follower_task, evictor_task
+        )
+
+        # Both leader and follower see the same data — eviction didn't sever
+        # the future.
+        assert leader_result["data"] == "x"
+        assert follower_result["data"] == "x"
+        # Only one underlying call — the follower joined the leader's future.
+        assert call_count == 1
+        # Leader's `finally` popped its entry; map empty post-resolve.
+        assert _inflight_for(cache) == {}
+        # The evictor saw the leader's pinned future mid-flight.
+        assert len(inflight_during_evict) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -799,6 +799,87 @@ class TestAsyncCachedInFlightDedup:
         assert _inflight_for(cache) == {}
 
     @pytest.mark.asyncio
+    async def test_cancelling_one_follower_does_not_cascade_to_siblings(self):
+        # The multi-follower cancellation isolation contract (LML#544 round 3).
+        # Two followers share a leader's in-flight future. One follower is
+        # cancelled externally (the per-request budget of THAT request expired,
+        # client disconnected, sibling task in its gather failed). The OTHER
+        # follower must still receive the leader's result within a bounded
+        # time — and the event loop must not wedge.
+        #
+        # Without `asyncio.shield` on the follower's await, asyncio's
+        # task-cancel mechanism would call `_fut_waiter.cancel()` on the
+        # SHARED Future, cascading CancelledError to the surviving follower.
+        # That follower would retry, find the still-cancelled-and-pinned
+        # future in inflight (the leader has not yet popped), `await` it —
+        # which does NOT yield for a done future — and busy-loop, blocking
+        # the event loop indefinitely. The test bounds the time via
+        # `asyncio.wait_for` and verifies the leader/siblings still progress.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+        leader_in_flight = asyncio.Event()
+        leader_can_proceed = asyncio.Event()
+
+        @async_cached(cache)
+        async def fetch(arg):
+            nonlocal call_count
+            call_count += 1
+            leader_in_flight.set()
+            await leader_can_proceed.wait()
+            return {"data": arg, "cached": False}
+
+        async def follower():
+            await leader_in_flight.wait()
+            return await fetch("x")
+
+        leader_task = asyncio.create_task(fetch("x"))
+        follower_a = asyncio.create_task(follower())
+        follower_b = asyncio.create_task(follower())
+
+        # Wait for both followers to join the leader's future.
+        await leader_in_flight.wait()
+        key = make_normalized_cache_key("fetch", "x")
+        inflight = _inflight_for(cache)
+        for _ in range(50):
+            leader_future = inflight.get(key)
+            if leader_future is not None and len(leader_future._callbacks) >= 2:
+                break
+            await asyncio.sleep(0)
+        assert leader_future is not None
+        assert len(leader_future._callbacks) >= 2, "both followers must have joined"
+
+        # Cancel follower_a. With shield, this cancels follower_a's per-await
+        # wrapper Future, NOT the shared leader's future. follower_b's await
+        # stays pending. Without shield, the shared future is cancelled and
+        # follower_b busy-loops in the wrapper's retry path.
+        follower_a.cancel()
+        leader_can_proceed.set()
+
+        # Leader resolves normally; follower_b joins it; follower_a propagates
+        # its own cancellation. Bound the test on wall-clock time so the
+        # busy-loop bug surfaces as a TimeoutError rather than a hang.
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                leader_task,
+                follower_b,
+                follower_a,
+                return_exceptions=True,
+            ),
+            timeout=1.0,
+        )
+        leader_result, follower_b_result, follower_a_result = results
+
+        assert leader_result["data"] == "x"
+        assert follower_b_result["data"] == "x", (
+            "surviving follower must receive leader's value, not inherit "
+            "the cancelled sibling's cancellation"
+        )
+        assert isinstance(follower_a_result, asyncio.CancelledError)
+        # Exactly one underlying call — the dedup held even under cancellation.
+        assert call_count == 1
+        assert _inflight_for(cache) == {}
+
+    @pytest.mark.asyncio
     async def test_clear_all_caches_resets_inflight_map(self):
         # `clear_all_caches()` must drop `_lml_inflight` along with the TTL
         # contents — otherwise orphan Futures linger on the cache instance

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -463,8 +463,9 @@ class TestAsyncCachedInFlightDedup:
     @pytest.mark.asyncio
     async def test_leader_raise_propagates_to_followers(self):
         # Transient API failure: leader raises, all followers re-raise the
-        # same exception type, function ran exactly once. A subsequent serial
-        # call starts fresh — no exception pinned in the in-flight map.
+        # SAME exception instance (broadcast via future), function ran exactly
+        # once. A subsequent serial call starts fresh — no exception pinned in
+        # the in-flight map.
         cache = create_ttl_cache(maxsize=10, ttl=300)
         call_count = 0
 
@@ -481,6 +482,11 @@ class TestAsyncCachedInFlightDedup:
         assert call_count == 1
         assert all(isinstance(r, RuntimeError) for r in results)
         assert all(str(r) == "upstream boom" for r in results)
+        # The broadcast-via-Future contract guarantees every observer sees the
+        # leader's exception instance, not a reconstructed copy. Pinning this
+        # so a refactor that switches to (type, args) side-channeling fails
+        # loudly — Sentry dedup and exception-chain machinery rely on identity.
+        assert all(r is results[0] for r in results)
 
         # Fresh serial call: in-flight entry was cleared, function runs again.
         with pytest.raises(RuntimeError):
@@ -517,25 +523,26 @@ class TestAsyncCachedInFlightDedup:
 
     @pytest.mark.asyncio
     async def test_followers_get_cached_flag_true_when_result_supports_it(self):
-        # When the leader's result is a dict with a `cached` field, followers
-        # should receive it with `cached=True` set, matching the serial cache-hit
-        # path's behavior.
+        # The deterministic split: of N concurrent callers, exactly 1 is the
+        # leader (returns its own freshly-computed `cached=False` result) and
+        # N-1 are followers (receive the leader's value through `_set_cached_flag`
+        # with cached=True). A loose `>=` lower-bound would silently pass under
+        # a regression where the leader's result gets wrapped through
+        # `_set_cached_flag` too (all cached=True), or where _set_cached_flag
+        # mutates the shared dict (all cached=True via aliasing). Pin the exact
+        # invariant to catch both.
         cache = create_ttl_cache(maxsize=10, ttl=300)
+        n = 3
 
         @async_cached(cache)
         async def fetch(arg):
             await asyncio.sleep(0.01)
             return {"data": arg, "cached": False}
 
-        results = await asyncio.gather(*[fetch("x") for _ in range(3)])
+        results = await asyncio.gather(*[fetch("x") for _ in range(n)])
 
-        # At least one of the three is the leader (cached=False on its result
-        # because the leader returns its own freshly-computed value). The
-        # followers receive the result via the future and should be marked
-        # cached=True. We don't care which order — just that at least one is
-        # marked cached=True so the seam-level instrumentation is consistent.
         cached_count = sum(1 for r in results if r["cached"] is True)
-        assert cached_count >= 2  # at least 2 followers see cached=True
+        assert cached_count == n - 1, f"expected exactly {n - 1} followers, got {cached_count}"
 
     @pytest.mark.asyncio
     async def test_skip_cache_in_follower_short_circuits_independently(self):
@@ -543,13 +550,18 @@ class TestAsyncCachedInFlightDedup:
         # before any cache or in-flight bookkeeping. A skip-cache caller
         # bypasses the dedup entirely and invokes the underlying function
         # directly — even while a leader is mid-await on the same key.
+        # Use an asyncio.Event to deterministically pin "leader is mid-await
+        # WHEN skip_caller proceeds," rather than relying on gather scheduling
+        # order (which gives no such guarantee).
         cache = create_ttl_cache(maxsize=10, ttl=300)
         call_count = 0
+        leader_in_flight = asyncio.Event()
 
         @async_cached(cache)
         async def fetch(arg):
             nonlocal call_count
             call_count += 1
+            leader_in_flight.set()
             await asyncio.sleep(0.02)
             return {"data": arg, "cached": False}
 
@@ -557,6 +569,9 @@ class TestAsyncCachedInFlightDedup:
             return await fetch("x")
 
         async def skip_caller():
+            # Wait until the leader is registered before proceeding so we
+            # exercise the "skip bypasses an ACTIVE leader" invariant.
+            await leader_in_flight.wait()
             set_skip_cache(True)
             try:
                 return await fetch("x")
@@ -599,24 +614,31 @@ class TestAsyncCachedInFlightDedup:
         # get the result. The downstream L1 state after the race is governed
         # by normal evict + write ordering (covered by existing tests); the
         # invariant this test pins is the dedup-layer one.
+        # Use an asyncio.Event signaled by the leader to deterministically
+        # pin "leader is mid-await" instead of guessing a sleep interval —
+        # the prior sleep-based timing flaked on loaded CI runners.
         cache = create_ttl_cache(maxsize=10, ttl=300)
         call_count = 0
+        leader_in_flight = asyncio.Event()
+        evictor_done = asyncio.Event()
 
         @async_cached(cache)
         async def fetch(arg):
             nonlocal call_count
             call_count += 1
-            await asyncio.sleep(0.05)
+            leader_in_flight.set()
+            # Hold mid-await until the evictor has had its turn to assert.
+            await evictor_done.wait()
             return {"data": arg, "cached": False}
 
         inflight_during_evict: dict[str, asyncio.Future] = {}
 
         async def follower():
+            await leader_in_flight.wait()
             return await fetch("x")
 
         async def evictor():
-            # Wait a tick so the leader is mid-await with the future pinned.
-            await asyncio.sleep(0.01)
+            await leader_in_flight.wait()
             # Snapshot the in-flight map, call evict, confirm the map is
             # unchanged. The leader's future is still in place after evict.
             before = dict(_inflight_for(cache))
@@ -625,6 +647,7 @@ class TestAsyncCachedInFlightDedup:
             inflight_during_evict.update(after)
             assert before == after, "evict_cached must not touch the in-flight map"
             assert len(after) == 1, "leader's future must still be pinned"
+            evictor_done.set()
 
         leader_task = asyncio.create_task(fetch("x"))
         follower_task = asyncio.create_task(follower())
@@ -644,6 +667,85 @@ class TestAsyncCachedInFlightDedup:
         assert _inflight_for(cache) == {}
         # The evictor saw the leader's pinned future mid-flight.
         assert len(inflight_during_evict) == 1
+
+    @pytest.mark.asyncio
+    async def test_leader_cancellation_does_not_cascade_to_followers(self):
+        # The cancellation contract (LML#544 round 2): when the leader's task
+        # is cancelled, the future is cancelled (not broadcast as an exception)
+        # and followers detect the cancellation and retry by re-entering the
+        # wrapper — they do NOT inherit the leader's cancellation, because in
+        # production the leader and the followers can be in unrelated request
+        # contexts that share a module-level cache. One client's disconnect
+        # must not abort another client's work.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        call_count = 0
+        leader_in_flight = asyncio.Event()
+        leader_can_proceed = asyncio.Event()
+
+        @async_cached(cache)
+        async def fetch(arg):
+            nonlocal call_count
+            call_count += 1
+            leader_in_flight.set()
+            # Cancellable wait — when leader_task.cancel() fires, this raises.
+            await leader_can_proceed.wait()
+            return {"data": arg, "cached": False}
+
+        async def follower():
+            await leader_in_flight.wait()
+            return await fetch("x")
+
+        leader_task = asyncio.create_task(fetch("x"))
+        follower_task = asyncio.create_task(follower())
+
+        # Wait until both the leader is in-flight AND the follower has joined.
+        await leader_in_flight.wait()
+        # Give the follower a tick to register on the future.
+        await asyncio.sleep(0)
+        # Cancel ONLY the leader. The follower's task is not cancelled.
+        leader_task.cancel()
+        # Allow the post-retry leader (the follower, on re-entry) to proceed.
+        # We need to release the gate before the retry's call to fetch completes.
+        # The follower will retry, become a NEW leader, run fetch again — call
+        # number 2 — and block on leader_can_proceed.wait(). Set it now.
+        leader_can_proceed.set()
+
+        # The leader's awaited task should raise CancelledError when awaited
+        # (it was cancelled). The follower's task should complete successfully
+        # because it retried via recursion in the wrapper.
+        with pytest.raises(asyncio.CancelledError):
+            await leader_task
+        follower_result = await follower_task
+
+        assert follower_result["data"] == "x"
+        # Two underlying calls: the cancelled leader's call (counted but
+        # cancelled mid-await), and the retry-leader's successful call.
+        assert call_count == 2
+        # In-flight map fully drained.
+        assert _inflight_for(cache) == {}
+
+    @pytest.mark.asyncio
+    async def test_clear_all_caches_resets_inflight_map(self):
+        # `clear_all_caches()` must drop `_lml_inflight` along with the TTL
+        # contents — otherwise orphan Futures linger on the cache instance
+        # and a post-clear caller can join a dead leader's future (LML#544).
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        # Seed the in-flight map without going through the wrapper, so we
+        # don't have to coordinate against the leader's `finally` pop.
+        sentinel_key = "sentinel"
+        sentinel_future: asyncio.Future = asyncio.get_running_loop().create_future()
+        _inflight_for(cache)[sentinel_key] = sentinel_future
+        assert _inflight_for(cache) == {sentinel_key: sentinel_future}
+
+        clear_all_caches()
+
+        # The cache instance is still in the registry (the registry doesn't
+        # pop; clear() only empties the TTLCache and the in-flight map). The
+        # in-flight map must now be empty.
+        assert _inflight_for(cache) == {}
+
+        # Drop the unawaited future cleanly so asyncio doesn't complain.
+        sentinel_future.cancel()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -672,7 +672,7 @@ class TestAsyncCachedInFlightDedup:
     async def test_leader_cancellation_does_not_cascade_to_followers(self):
         # The cancellation contract (LML#544 round 2): when the leader's task
         # is cancelled, the future is cancelled (not broadcast as an exception)
-        # and followers detect the cancellation and retry by re-entering the
+        # and followers detect the cancellation and retry by looping in the
         # wrapper — they do NOT inherit the leader's cancellation, because in
         # production the leader and the followers can be in unrelated request
         # contexts that share a module-level cache. One client's disconnect
@@ -698,21 +698,35 @@ class TestAsyncCachedInFlightDedup:
         leader_task = asyncio.create_task(fetch("x"))
         follower_task = asyncio.create_task(follower())
 
-        # Wait until both the leader is in-flight AND the follower has joined.
+        # Wait until the leader is in-flight.
         await leader_in_flight.wait()
-        # Give the follower a tick to register on the future.
-        await asyncio.sleep(0)
+        # Deterministically wait for the follower to have registered as an
+        # awaiter on the leader's future. `await future` adds a done-callback
+        # to the Future's internal _callbacks list, so its length growing past
+        # zero is the actual condition we care about — not a guess at how many
+        # event-loop ticks it takes the follower to get there. Polling with
+        # an upper-bound bails the test fast if the contract changes.
+        key = make_normalized_cache_key("fetch", "x")
+        inflight = _inflight_for(cache)
+        for _ in range(50):
+            leader_future = inflight.get(key)
+            if leader_future is not None and leader_future._callbacks:
+                break
+            await asyncio.sleep(0)
+        assert leader_future is not None, "leader's future disappeared"
+        assert leader_future._callbacks, "follower never joined leader's future"
+
         # Cancel ONLY the leader. The follower's task is not cancelled.
         leader_task.cancel()
         # Allow the post-retry leader (the follower, on re-entry) to proceed.
-        # We need to release the gate before the retry's call to fetch completes.
         # The follower will retry, become a NEW leader, run fetch again — call
-        # number 2 — and block on leader_can_proceed.wait(). Set it now.
+        # number 2 — and block on leader_can_proceed.wait(). Set it now so the
+        # retry-leader's await returns without waiting.
         leader_can_proceed.set()
 
         # The leader's awaited task should raise CancelledError when awaited
         # (it was cancelled). The follower's task should complete successfully
-        # because it retried via recursion in the wrapper.
+        # because it retried via the loop in the wrapper.
         with pytest.raises(asyncio.CancelledError):
             await leader_task
         follower_result = await follower_task
@@ -722,6 +736,66 @@ class TestAsyncCachedInFlightDedup:
         # cancelled mid-await), and the retry-leader's successful call.
         assert call_count == 2
         # In-flight map fully drained.
+        assert _inflight_for(cache) == {}
+
+    @pytest.mark.asyncio
+    async def test_follower_own_cancellation_propagates(self):
+        # The mirror of the prior test: when the follower's own task is
+        # cancelled (cancelling() > 0), the wrapper MUST propagate the
+        # CancelledError rather than swallowing it via retry. Without this
+        # guard, a cancelled FastAPI request task would keep running through
+        # the retry path, holding resources past the client disconnect.
+        cache = create_ttl_cache(maxsize=10, ttl=300)
+        leader_in_flight = asyncio.Event()
+        leader_can_proceed = asyncio.Event()
+
+        @async_cached(cache)
+        async def fetch(arg):
+            leader_in_flight.set()
+            await leader_can_proceed.wait()
+            return {"data": arg, "cached": False}
+
+        async def follower():
+            await leader_in_flight.wait()
+            return await fetch("x")
+
+        leader_task = asyncio.create_task(fetch("x"))
+        follower_task = asyncio.create_task(follower())
+
+        # Wait until the follower has joined the leader's future.
+        await leader_in_flight.wait()
+        key = make_normalized_cache_key("fetch", "x")
+        inflight = _inflight_for(cache)
+        for _ in range(50):
+            leader_future = inflight.get(key)
+            if leader_future is not None and leader_future._callbacks:
+                break
+            await asyncio.sleep(0)
+        assert leader_future is not None and leader_future._callbacks
+
+        # Cancel the FOLLOWER. cancelling() on the follower's task is now 1.
+        # When the leader's future eventually resolves (or is cancelled), the
+        # follower's `except asyncio.CancelledError` arm must propagate, not
+        # retry — because its OWN task was asked to stop.
+        follower_task.cancel()
+
+        # Let the leader complete so its future resolves with success. If the
+        # follower retries (regression), the retry would also propagate the
+        # task cancellation; either way the follower's task ends cancelled.
+        # We want to specifically verify that the follower does NOT block on
+        # a retry-leader's fetch — i.e., that cancellation is honored
+        # promptly. Setting leader_can_proceed lets the leader finish.
+        leader_can_proceed.set()
+
+        # Leader completes normally.
+        leader_result = await leader_task
+        assert leader_result["data"] == "x"
+
+        # Follower's task observes its own cancellation and propagates it.
+        with pytest.raises(asyncio.CancelledError):
+            await follower_task
+
+        # In-flight map fully drained (the leader's finally popped its entry).
         assert _inflight_for(cache) == {}
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #544. Follow-up to #537.

## Summary

- Adds per-cache in-flight `asyncio.Future` coalescing inside `@async_cached`. Concurrent callers for the same key share one fetch; followers receive the leader's value (or re-raise its exception). The wrapped function now runs once per key per in-flight window.
- Closes the non-atomic check-then-set race documented in #537's latest comment as Cause #2. Production traces show release 28184356 fetched 3× at 13:05:41/44/45 and release 3657075 fetched 3× at 13:05:34/39/40 — both within the L1 TTL window. The race produces those duplicates; this PR coalesces them.
- Single-file change to `discogs/memory_cache.py`. No call-site changes. New test class `TestAsyncCachedInFlightDedup` covers concurrent same-key coalescing, distinct-key isolation, exception propagation, None semantics, `cached=True` on followers, `skip_cache` boundary, in-flight cleanup, and evict-mid-flight safety.

Design + risk analysis in `docs/plans/lml-537-l1-inflight-dedup.md`.

## Test plan

- [x] 8 new unit tests pass (`tests/unit/test_memory_cache.py::TestAsyncCachedInFlightDedup`).
- [x] All 46 existing `test_memory_cache.py` unit tests pass unchanged.
- [x] All 7 `tests/integration/test_memory_cache.py` integration tests pass unchanged.
- [x] All 286 discogs-adjacent unit tests pass (no regression in `discogs/service.py`, `discogs/fallthrough.py`, `discogs/cache_service.py`, `discogs/router.py`, request telemetry).
- [x] Full unit test suite green (2463 / 2463).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy discogs/memory_cache.py` clean.
- [ ] Verified in staging: post-merge, watch `lml.discogs.semaphore` p95 and the `cache hit / miss` per-method histogram in Sentry for the next 24h. Expect duplicate-release_id traces (same id within seconds) to drop.

## Out of scope

- `get_release` predicate widening on artwork columns (#537 Cause #1) — separate ticket.
- Bumping Discogs semaphore from 5 (#537 Cause #3) — separate ticket.
- Probe methodology fixes (`cache_warm_histogram.py` writer-source split, `cache_miss_provenance.py` at-miss-time anchoring) — captured in #537 thread.