### PR TITLE
fix(orchestrator): match V/A series with vol. N (#531)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1570,6 +1570,73 @@ async def search_compilations_for_track(
     return limit_results(results), discogs_titles
 
 
+# V/A series suffixes catalogued in WXYC library as "<base>, vol. N" or close
+# variants. See WXYC/library-metadata-lookup#531 — Discogs returns the canonical
+# release with a long parenthetical subtitle ("Disco Not Disco (Post Punk,
+# Electro & Leftfield Disco Classics 1974-1986)") while the library keeps the
+# terse series identifier ("Disco Not Disco, vol. 1"), so the standard
+# length-sensitive fuzz.ratio path in ``album_title_acceptable`` rejects them.
+_VA_VOLUME_SUFFIX_RE = re.compile(r"[,\s]+vol(?:\.|ume)?\s+\w+\s*$", re.IGNORECASE)
+
+
+def _va_series_base(library_title_lower: str) -> str | None:
+    """If ``library_title_lower`` is a ``<base>, vol. N`` series identifier,
+    return the lowercased ``<base>``. Otherwise return ``None``.
+
+    Strips trailing ``, vol. N`` / ``, volume N`` / `` vol. N`` / `` volume N``
+    (and ``vol N`` without the dot). The numeric tail is ``\\w+`` so roman
+    numerals ("vol. III") and mixed identifiers ("vol. 2a") also match.
+    """
+    match = _VA_VOLUME_SUFFIX_RE.search(library_title_lower)
+    if not match:
+        return None
+    base = library_title_lower[: match.start()].rstrip(" ,")
+    return base or None
+
+
+def _va_series_title_match(query_lower: str, item: LibraryItem) -> bool:
+    """Special-case for V/A series releases catalogued as ``<base>, vol. N``.
+
+    The library files V/A compilations under a terse ``<base>, vol. N`` series
+    identifier (filing convention preserved in ``library.artist_name`` — see
+    the V/A invariant in CONTEXT.md), while Discogs returns the canonical
+    release with a long descriptive subtitle. Neither the prefix branch nor the
+    length-sensitive ``fuzz.ratio`` branch of ``album_title_acceptable`` can
+    bridge that asymmetry, so V/A series rows stay hidden.
+
+    This accepts when:
+
+    1. The library item is a V/A row (``is_compilation_artist`` on the artist
+       string — gate keeps the looser path from grandfathering non-V/A albums
+       with the same shape, e.g. an artist's own ``Live Sessions, vol. 2``).
+    2. The library title parses as ``<base>, vol. N`` (or close-cousin
+       ``vol. N`` / ``volume N`` variants).
+    3. The Discogs query title starts with ``<base>`` followed by a
+       non-alphanumeric boundary — protects against base-prefix collisions like
+       ``Disco`` matching every Discogs release that happens to start with
+       that word.
+
+    Returns True when all three hold; the caller then bypasses
+    ``album_title_acceptable`` for this row.
+
+    See WXYC/library-metadata-lookup#531.
+    """
+    if not is_compilation_artist(item.artist or ""):
+        return False
+    library_title_lower = (item.title or "").lower()
+    base = _va_series_base(library_title_lower)
+    if not base:
+        return False
+    if not query_lower.startswith(base):
+        return False
+    # Require a word boundary after the base so "Disco" doesn't grandfather
+    # every Discogs release whose title starts with that token.
+    tail = query_lower[len(base) :]
+    if tail and tail[0].isalnum():
+        return False
+    return True
+
+
 def album_title_acceptable(query_lower: str, result_lower: str) -> bool:
     """Check if a library album title is an acceptable match for a Discogs album title.
 
@@ -1624,7 +1691,10 @@ async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryIte
     if results:
         album_lower = album_title.lower()
         results = [
-            r for r in results if album_title_acceptable(album_lower, (r.title or "").lower())
+            r
+            for r in results
+            if _va_series_title_match(album_lower, r)
+            or album_title_acceptable(album_lower, (r.title or "").lower())
         ]
 
     if not results:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1598,9 +1598,8 @@ def _va_series_title_match(query_lower: str, item: LibraryItem) -> bool:
     """Special-case for V/A series releases catalogued as ``<base>, vol. N``.
 
     The library files V/A compilations under a terse ``<base>, vol. N`` series
-    identifier (filing convention preserved in ``library.artist_name`` — see
-    the V/A invariant in CONTEXT.md), while Discogs returns the canonical
-    release with a long descriptive subtitle. Neither the prefix branch nor the
+    identifier (filing convention preserved in ``library.artist_name``), while
+    Discogs returns the canonical release with a long descriptive subtitle. Neither the prefix branch nor the
     length-sensitive ``fuzz.ratio`` branch of ``album_title_acceptable`` can
     bridge that asymmetry, so V/A series rows stay hidden.
 

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -792,6 +792,68 @@ class TestSearchAlbumFuzzy:
         assert len(results) == 1
         assert results[0].id == 57500
 
+    @pytest.mark.asyncio
+    async def test_matches_va_series_with_volume_against_long_subtitle(self):
+        """V/A library row catalogued as ``<base>, vol. N`` surfaces against a
+        Discogs release with a long parenthetical subtitle (WXYC#531).
+
+        Library row 58610 catalogues ``Disco Not Disco, vol. 1`` under artist
+        ``Various Artists - Rock - D``. Discogs returns the canonical release as
+        ``Disco Not Disco (Post Punk, Electro & Leftfield Disco Classics
+        1974-1986)``. The base ``Disco Not Disco`` matches as a prefix on the
+        Discogs side, and the library suffix is the recognised ``, vol. N``
+        series identifier, gated on ``is_compilation_artist`` so non-V/A albums
+        are not grandfathered through this looser path.
+        """
+        db = AsyncMock()
+        item = _item(
+            id=58610,
+            artist="Various Artists - Rock - D",
+            title="Disco Not Disco, vol. 1",
+            call_letters="V",
+        )
+
+        # FTS5 returns the V/A row on shared tokens ("disco", "not"). The new
+        # vol.-N gate must accept it instead of falling through to the
+        # length-sensitive fuzz.ratio reject in album_title_acceptable.
+        db.search = AsyncMock(return_value=[item])
+
+        results = await search_album_fuzzy(
+            db,
+            "Disco Not Disco (Post Punk, Electro & Leftfield Disco Classics 1974-1986)",
+        )
+        assert len(results) == 1
+        assert results[0].id == 58610
+
+    @pytest.mark.asyncio
+    async def test_va_series_gate_does_not_grandfather_non_compilation(self):
+        """The ``, vol. N`` special-case is gated on ``is_compilation_artist``.
+
+        A non-V/A library row with the same shape (``<base>, vol. N``) must NOT
+        be accepted against an unrelated Discogs release whose title merely
+        starts with the same ``<base>``. This is the regression guard for
+        directions (2) and (3) in WXYC#531 — option (1) is deliberately
+        narrow.
+        """
+        db = AsyncMock()
+        item = _item(
+            id=99999,
+            artist="Some Band",
+            title="Live Sessions, vol. 2",
+        )
+
+        db.search = AsyncMock(return_value=[item])
+
+        # Long descriptive Discogs title that shares the "Live Sessions" prefix
+        # but is otherwise unrelated. Without the V/A gate this would slip
+        # through the new special-case; with the gate it must be rejected by
+        # the existing length-sensitive fuzz.ratio path.
+        results = await search_album_fuzzy(
+            db,
+            "Live Sessions (Acoustic Recordings From The Greek Theatre 1998-2002)",
+        )
+        assert results == []
+
 
 # ---------------------------------------------------------------------------
 # filter_results_by_track_validation -- exception (lines 482-483)


### PR DESCRIPTION
Closes #531

## Summary

- V/A library rows catalogued as `<base>, vol. N` (e.g. library row 58610 — `Disco Not Disco, vol. 1` under artist `Various Artists - Rock - D`) were hidden by `search_album_fuzzy` whenever Discogs returned the canonical release with a long parenthetical subtitle (`Disco Not Disco (Post Punk, Electro & Leftfield Disco Classics 1974-1986)`). Neither the prefix branch nor the length-sensitive `fuzz.ratio` branch of `album_title_acceptable` could bridge the asymmetry, and the significant-words fallback couldn't either because the terse library title contributes only one keyword.
- Applies option (1) from the issue: special-case the `<base>, vol. N` / `, volume N` / ` vol. N` / ` volume N` shape inside `search_album_fuzzy`, gated on `is_compilation_artist(item.artist)` so non-V/A albums with the same shape are NOT grandfathered through. The match also requires a word boundary after `<base>` in the Discogs query, so a `Disco`-prefix collision can't slip a V/A row past the gate.
- Preserves the V/A filing-convention invariant (CONTEXT.md) — the new gate reads `library.artist_name` to detect compilation rows; it does not rewrite, normalize, or strip the call-letter scheme.

## Test plan

- [x] `tests/unit/test_orchestrator_gaps.py::TestSearchAlbumFuzzy::test_matches_va_series_with_volume_against_long_subtitle` — failing without the fix, passes with it. Exercises the exact data shape called out in the issue body (library 58610 vs the long Discogs subtitle).
- [x] `tests/unit/test_orchestrator_gaps.py::TestSearchAlbumFuzzy::test_va_series_gate_does_not_grandfather_non_compilation` — non-V/A `Live Sessions, vol. 2` row is still rejected against an unrelated `Live Sessions (...)` Discogs title, confirming the `is_compilation_artist` gate.
- [x] `tests/unit/test_orchestrator_gaps.py::TestCompilationSeriesRejection::test_rejects_similar_but_different_compilation` — pre-existing guard: `Explorations on the Dancefloor vol. 3` is still rejected against `Get On The Dance Floor Volume 5` (different base), confirming the new gate doesn't relax that rejection.
- [x] Full unit suite green locally (2469 tests).
- [x] `ruff check`, `ruff format --check`, `mypy` all green on touched files.