### PR TITLE
fix(cache): widen get_release is_pg_hit predicate (#542)

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -898,25 +898,39 @@ class DiscogsService:
                 # bidirectionally constrained `T`. The runtime contract is
                 # unchanged.
                 pg_write=cache.write_release,  # type: ignore[arg-type]
-                # `artwork_url IS NULL AND artwork_checked_at IS NULL` is the
-                # "never asked" state — the bulk loader populated the row but
-                # LML has not yet asked Discogs (~48% of release rows are like
-                # this; see WXYC/library-metadata-lookup#414 and
-                # WXYC/discogs-etl#239). Falling through to the API is the
-                # back-fill path. Once `artwork_checked_at` is set, both
-                # "asked, got a cover" and "asked, no cover" are full hits —
-                # we don't re-ask Discogs about the no-cover tail.
+                # LML#542 widened predicate. The cache row is a HIT when any
+                # one of three signals says "we already have something useful
+                # for this id":
                 #
-                # LML#510 tombstones (not_found=True) carry
-                # artwork_checked_at=now() so they satisfy this predicate too;
-                # the boundary translation below converts them to None for
-                # the public caller. Keeping the predicate type-opaque (no
-                # `not_found` check here) means the fallthrough seam stays
-                # generic — only the public `DiscogsService` methods
-                # understand the tombstone shape.
+                #   1. `not_found` — LML#510 tombstone; the boundary
+                #      translation below converts it to None for the caller.
+                #      Checked explicitly so a tombstone with NULL
+                #      `artwork_checked_at` (not produced by today's write
+                #      path, but cheap defense) still short-circuits.
+                #   2. `tracklist` non-empty — the bulk loader and the live
+                #      write_release path both stamp `release_track` rows
+                #      whenever the release tree is populated. If we have
+                #      tracks, the release exists and is hydrated; artwork
+                #      can be back-filled out of band without paying a
+                #      Discogs round-trip on the hot path.
+                #   3. `artwork_checked_at IS NOT NULL` — LML has hit the
+                #      live API for this release at least once, regardless
+                #      of whether Discogs returned a cover. Keeps the
+                #      "asked, no cover" tail from re-burning the
+                #      rate-limit budget (the #423 invariant).
+                #
+                # The artwork-columns-only predicate from #423 was diagnosed
+                # in #537's `cache_miss_provenance` probe as causing ~20%
+                # of `get_release` calls to fall through to the API even
+                # though the full release tree (release + release_artist +
+                # release_track + release_track_artist) was already in PG —
+                # only the artwork columns were still NULL. Widening here
+                # decouples artwork availability from cache-hit eligibility;
+                # `extended=true` consumers still surface artwork when the
+                # row has it, but we no longer FETCH purely to populate it.
                 is_pg_hit=lambda v: (
                     v is not None
-                    and (v.artwork_url is not None or v.artwork_checked_at is not None)
+                    and (bool(v.not_found) or bool(v.tracklist) or v.artwork_checked_at is not None)
                 ),
                 breadcrumb_data={"release_id": release_id},
             )

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -916,6 +916,13 @@ class TestGetRelease:
             artist="Artist",
             release_url="https://discogs.com/release/123",
             artwork_url="https://img.com/cached.jpg",
+            # `artwork_checked_at` co-occurs with `artwork_url` in production
+            # — `cache_service.write_release` stamps both in the same write,
+            # and the bulk loader does too. Without this, the LML#542
+            # widened predicate (`not_found OR tracklist OR
+            # artwork_checked_at`) would mark this row as a miss because
+            # `artwork_url` alone is not in the predicate.
+            artwork_checked_at=datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC),
             cached=True,
         )
         service_with_cache.cache_service.get_release = AsyncMock(return_value=cached)
@@ -1058,6 +1065,90 @@ class TestGetRelease:
         mock_request.assert_not_called()
         service_with_cache.cache_service.write_release.assert_not_called()
         assert result is cached
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_with_tracklist_and_null_artwork_columns_does_not_call_api(
+        self, service_with_cache
+    ):
+        """LML#542: a cache row with the full release tree populated
+        (`release_track` rows exist, surfaced as a non-empty ``tracklist``) is
+        a HIT regardless of whether ``artwork_url`` / ``artwork_checked_at``
+        are NULL. The artwork-columns gate from #423 was costing ~20% of
+        ``get_release`` calls a full Discogs round-trip even though every
+        column except artwork was already in PG — diagnosed in #537's
+        `cache_miss_provenance` probe. Widening the predicate to accept
+        ``release_track``-populated rows recovers that miss rate; artwork
+        backfill is decoupled.
+        """
+        cached = ReleaseMetadataResponse(
+            release_id=33696617,
+            title="Aluminum Tunes",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/33696617",
+            artwork_url=None,
+            artwork_checked_at=None,
+            tracklist=[
+                TrackItem(position="A1", title="Pop Quiz", duration="3:33", artists=[]),
+                TrackItem(position="A2", title="The Extension Trip", duration="4:12", artists=[]),
+            ],
+            cached=True,
+        )
+        service_with_cache.cache_service.get_release = AsyncMock(return_value=cached)
+        service_with_cache.cache_service.write_release = AsyncMock()
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_request:
+            result = await service_with_cache.get_release(33696617)
+
+        mock_request.assert_not_called()
+        service_with_cache.cache_service.write_release.assert_not_called()
+        assert result is cached
+        # Artwork stays NULL on the cached response — the point of the
+        # widening is to stop paying a Discogs round-trip purely to populate
+        # artwork; the field remains nullable for consumers.
+        assert result.artwork_url is None
+        assert result.artwork_checked_at is None
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_tombstone_only_signal_does_not_call_api(self, service_with_cache):
+        """LML#542 tombstone wrinkle: ``not_found = True`` rows are HITs even
+        if ``artwork_checked_at`` happens to be unset and the child cascade
+        is empty. The tombstone write path in ``cache_service.write_release``
+        stamps ``artwork_checked_at = now()`` today, so in practice the
+        ``artwork_checked_at`` arm of the predicate already catches them —
+        but the predicate must not silently regress to "tombstone with NULL
+        ``artwork_checked_at`` falls through to the API" if a future code
+        path ever produces one. The boundary translates the tombstone back
+        to ``None`` for the caller (LML#510).
+        """
+        tombstone = ReleaseMetadataResponse(
+            release_id=33696618,
+            title="",
+            artist="",
+            release_url="https://www.discogs.com/release/33696618",
+            artwork_url=None,
+            artwork_checked_at=None,
+            tracklist=[],
+            not_found=True,
+            cached=True,
+        )
+        service_with_cache.cache_service.get_release = AsyncMock(return_value=tombstone)
+        service_with_cache.cache_service.write_release = AsyncMock()
+
+        with patch.object(
+            service_with_cache,
+            "_request_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_request:
+            result = await service_with_cache.get_release(33696618)
+
+        mock_request.assert_not_called()
+        service_with_cache.cache_service.write_release.assert_not_called()
+        # LML#510 boundary: tombstone → None.
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_404_returns_none(self, service):


### PR DESCRIPTION
Closes #542.

## Summary

- Widens the `get_release` PG-hit predicate from `artwork_url IS NOT NULL OR artwork_checked_at IS NOT NULL` (set by #423) to `not_found OR tracklist OR artwork_checked_at IS NOT NULL`. Decouples artwork availability from cache-hit eligibility — any row where the release tree is populated, a tombstone exists, or LML has already hit the live API counts as a hit.
- Recovers the ~20% miss rate diagnosed in #537's `cache_miss_provenance` probe: 100% of the 68 unique missed release_ids existed in PG with the full release tree populated and only the artwork columns NULL. Each fall-through paid 7-13s of Discogs semaphore contention purely to back-fill artwork.
- Explicit `not_found` arm defends against a future code path that produces a tombstone without `artwork_checked_at` (today's `cache_service.write_release` tombstone branch stamps `now()`, so the third arm already catches them, but a regression would silently re-burn rate-limit budget on every 404 read).
- Single source change to `discogs/service.py` get_release's `is_pg_hit` lambda + comment rewrite. No call-site changes; no schema changes; no admin-endpoint surface added (Option A from the issue).

## Test plan

- [x] Two new `TestGetRelease` cases: (1) `release_track` populated + NULL artwork columns is a HIT (no API call), (2) tombstone-only signal is a HIT translated to None at the boundary.
- [x] Existing `test_cache_hit_with_null_artwork_and_null_checked_at_falls_through_to_api` still passes — empty tracklist + NULL artwork columns continues to fall through (preserves the bulk-loader back-fill path for rows that ARE genuinely incomplete).
- [x] Existing `test_cache_hit_with_checked_at_set_and_null_artwork_does_not_call_api` still passes — the "asked, no cover" tail (predicate's third arm) still short-circuits.
- [x] Updated `test_cached_release` to set `artwork_checked_at` alongside `artwork_url` (production invariant from `write_release` — both columns are stamped in the same write).
- [x] Full unit suite green (2469 / 2469).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy discogs/service.py` clean.
- [ ] Post-deploy: re-run #540's `cache_miss_provenance` probe; expect `GET /releases/N` rate to fall toward the rate of genuinely-new-to-LML releases.
- [ ] Post-deploy: confirm `extended=true` lookups against known-warmed releases still surface `artwork_url` (the column stays populated; we just stop fetching purely to populate it).

## Out of scope

- Option B from the issue (admin warm-artwork endpoint + background warm-up task on `/api/v1/lookup`) — landable as a follow-up if `extended=true` traffic needs artwork pace-keeping. Option A is sufficient to recover the miss rate.
- Bumping the Discogs semaphore (#537 Cause #3) — separate ticket.