### PR TITLE
fix(discogs): close remaining id<=0 caller-validation gaps + observability backstop (#546)

### DIFF
--- a/discogs/markup_parser.py
+++ b/discogs/markup_parser.py
@@ -176,19 +176,33 @@ def _classify_tag(tag: str, text: str, pos_after_tag: int) -> tuple[_DiscogsToke
         return (_ArtistName(name=match.group(1)), pos_after_tag)
 
     # Artist ID: [a12345]
+    # LML#546: ``\d+`` matches ``0``, so ``[a0]`` would tokenize to
+    # ``_ArtistId(0)`` and forward into DiscogsService.get_artist_details(0),
+    # whose 404 is tombstoned (LML#510) and permanently poisons the row. Drop
+    # the token at the tokenize boundary — Discogs ids start at 1. Mirrored
+    # below for release / master ids.
     match = ARTIST_ID_PATTERN.match(tag)
     if match:
-        return (_ArtistId(id=int(match.group(1))), pos_after_tag)
+        artist_id = int(match.group(1))
+        if artist_id <= 0:
+            return None
+        return (_ArtistId(id=artist_id), pos_after_tag)
 
     # Release ID: [r12345] or [r=12345]
     match = RELEASE_ID_PATTERN.match(tag)
     if match:
-        return (_ReleaseId(id=int(match.group(1))), pos_after_tag)
+        release_id = int(match.group(1))
+        if release_id <= 0:
+            return None
+        return (_ReleaseId(id=release_id), pos_after_tag)
 
     # Master ID: [m123] or [m=123]
     match = MASTER_ID_PATTERN.match(tag)
     if match:
-        return (_MasterId(id=int(match.group(1))), pos_after_tag)
+        master_id = int(match.group(1))
+        if master_id <= 0:
+            return None
+        return (_MasterId(id=master_id), pos_after_tag)
 
     # Label name: [l=Name]
     match = LABEL_NAME_PATTERN.match(tag)

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -749,6 +749,24 @@ class DiscogsService:
         Returns:
             ReleaseMetadataResponse with full metadata, or None on error
         """
+        # LML#546 observability backstop. The LML#518 decision record puts
+        # ``id <= 0`` validation at the caller, not at this boundary, to avoid
+        # masking LML-internal bugs in other call paths. We honor that — this
+        # log does NOT raise and does NOT change behavior. It exists so that
+        # if a future caller forgets the guard (e.g. LML#525's multiplexer),
+        # the regression is visible in Sentry breadcrumbs instead of
+        # silently tombstoning the row (LML#510). ``stack_info=True`` captures
+        # the caller chain so triage can identify the unguarded site without
+        # re-running the request.
+        if release_id <= 0:
+            logger.warning(
+                "DiscogsService.get_release received non-positive id=%d — "
+                "caller must validate (see LML#518). Proceeding per the "
+                "'callers validate' policy; the 404 from Discogs will "
+                "tombstone this id permanently. See LML#546.",
+                release_id,
+                stack_info=True,
+            )
 
         async def _api_fetch() -> ReleaseMetadataResponse | None:
             try:
@@ -942,6 +960,17 @@ class DiscogsService:
         Returns:
             ArtistDetails with full metadata, or None on error
         """
+        # LML#546 observability backstop. See get_release above for the full
+        # rationale. Log-only, does NOT raise, does NOT change behavior.
+        if artist_id <= 0:
+            logger.warning(
+                "DiscogsService.get_artist_details received non-positive id=%d — "
+                "caller must validate (see LML#518). Proceeding per the "
+                "'callers validate' policy; the 404 from Discogs will "
+                "tombstone this id permanently. See LML#546.",
+                artist_id,
+                stack_info=True,
+            )
 
         async def _api_fetch() -> ArtistDetails | None:
             try:

--- a/release/discogs_resolver.py
+++ b/release/discogs_resolver.py
@@ -54,6 +54,18 @@ async def resolve_discogs_release(service: DiscogsService, release_id: str) -> D
             warnings=[f"Discogs release ID '{release_id}' is not a number"],
         )
 
+    # LML#546: Discogs release ids start at 1. A non-positive id forwarded to
+    # ``service.get_release`` triggers a 404 from Discogs, which the
+    # fallthrough seam tombstones (LML#510) — permanently poisoning the row
+    # for every subsequent caller. The LML#518 decision record puts this
+    # validation at the caller, not the service boundary. Reject here.
+    if rid <= 0:
+        return DiscogsResolveResult(
+            canonical=None,
+            identifiers=ReleaseIdentifiers(),
+            warnings=[f"Discogs release ID '{rid}' is not positive"],
+        )
+
     try:
         release = await service.get_release(rid)
     except Exception:

--- a/tests/unit/release/test_discogs_resolver.py
+++ b/tests/unit/release/test_discogs_resolver.py
@@ -112,6 +112,22 @@ class TestResolveDiscogsRelease:
         assert len(result.warnings) == 1
         mock_service.get_release.assert_not_called()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_id", ["0", "-1", "-12345"])
+    async def test_rejects_non_positive_id_without_calling_service(self, mock_service, bad_id):
+        """LML#546: Discogs release ids start at 1. A `release_id <= 0` value
+        coming from user input or upstream synthesis must short-circuit before
+        ``service.get_release`` is touched, because the 404 the service would
+        get from Discogs writes a permanent tombstone (LML#510) that poisons
+        the row for everyone. The resolver is the boundary; reject here.
+        """
+        result = await resolve_discogs_release(mock_service, bad_id)
+
+        assert result.canonical is None
+        assert len(result.warnings) == 1
+        assert "positive" in result.warnings[0].lower()
+        mock_service.get_release.assert_not_called()
+
 
 class TestResolveDiscogsMaster:
     @pytest.mark.asyncio

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -1229,6 +1229,59 @@ class TestGetRelease:
         assert result is not None
         assert result.videos == []
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_id", [0, -1, -12345])
+    async def test_non_positive_id_logs_warning_with_stack_and_still_proceeds(
+        self, service, caplog, bad_id
+    ):
+        """LML#546 observability backstop: ``id <= 0`` reaching ``get_release``
+        means a caller skipped the LML#518 "callers validate" guard. Per the
+        decision record we do NOT raise here (boundary creep), but we emit a
+        WARN with ``stack_info=True`` so future regressions surface in Sentry
+        instead of silently tombstoning the row (LML#510). The call MUST still
+        proceed to ``_request_with_retry`` so behavior is unchanged.
+        """
+        import logging
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "x",
+            "artists": [],
+            "tracklist": [],
+            "images": [],
+            "labels": [],
+            "genres": [],
+            "styles": [],
+        }
+
+        with (
+            patch.object(
+                service,
+                "_request_with_retry",
+                new_callable=AsyncMock,
+                return_value=mock_resp,
+            ) as mock_request,
+            caplog.at_level(logging.WARNING, logger="discogs.service"),
+        ):
+            await service.get_release(bad_id)
+
+        mock_request.assert_called_once()
+        records = [
+            r
+            for r in caplog.records
+            if "get_release" in r.getMessage() and str(bad_id) in r.getMessage()
+        ]
+        assert records, (
+            f"expected WARN log for non-positive id={bad_id}, "
+            f"got: {[r.getMessage() for r in caplog.records]}"
+        )
+        # `stack_info=True` populates the record's `stack_info` attribute.
+        assert any(getattr(r, "stack_info", None) for r in records), (
+            "expected stack_info on the WARN record (set via stack_info=True)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # search_releases_by_album_title
@@ -2320,6 +2373,52 @@ class TestGetArtistDetails:
             await service_with_cache.get_artist_details(77)
 
         service_with_cache.cache_service.write_artist_details.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_id", [0, -1, -12345])
+    async def test_non_positive_id_logs_warning_with_stack_and_still_proceeds(
+        self, service, caplog, bad_id
+    ):
+        """LML#546 observability backstop: see the get_release equivalent. The
+        artist surface gets the same belt-and-suspenders WARN-with-stack so a
+        future unguarded caller (e.g. LML#525's multiplexer) is visible in
+        Sentry instead of permanently tombstoning the artist row.
+        """
+        import logging
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "id": 1,
+            "name": "x",
+            "images": [],
+        }
+
+        with (
+            patch.object(
+                service,
+                "_request_with_retry",
+                new_callable=AsyncMock,
+                return_value=mock_resp,
+            ) as mock_request,
+            caplog.at_level(logging.WARNING, logger="discogs.service"),
+        ):
+            await service.get_artist_details(bad_id)
+
+        mock_request.assert_called_once()
+        records = [
+            r
+            for r in caplog.records
+            if "get_artist_details" in r.getMessage() and str(bad_id) in r.getMessage()
+        ]
+        assert records, (
+            f"expected WARN log for non-positive id={bad_id}, "
+            f"got: {[r.getMessage() for r in caplog.records]}"
+        )
+        assert any(getattr(r, "stack_info", None) for r in records), (
+            "expected stack_info on the WARN record (set via stack_info=True)"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_markup_parser.py
+++ b/tests/unit/test_markup_parser.py
@@ -503,6 +503,21 @@ class TestTokenize:
         assert tokens[2] == _PlainText(text=" and ")
         assert tokens[3] == _ArtistName(name="Sean Booth")
 
+    @pytest.mark.parametrize(
+        "markup",
+        ["[a0]", "[r0]", "[r=0]", "[m0]", "[m=0]"],
+    )
+    def test_rejects_zero_id_tokens_as_malformed(self, markup):
+        """LML#546: the ``[a\\d+]`` / ``[r=?\\d+]`` / ``[m=?\\d+]`` patterns accept
+        ``0`` because ``\\d+`` matches it. Discogs ids start at 1, so ``[a0]`` /
+        ``[r0]`` / ``[m0]`` are malformed tokens. Rejecting them at tokenize time
+        stops a poisoned id from reaching the service layer (where it would
+        tombstone the row per LML#510). Negative ids (``[a-1]``) already fail
+        the regex, so they don't need a separate guard.
+        """
+        tokens = tokenize(markup)
+        assert tokens == [], f"expected {markup!r} to be dropped as malformed, got {tokens!r}"
+
 
 # MARK: - Resolve Unit Tests
 


### PR DESCRIPTION
## Summary

- `release/discogs_resolver.py` and `discogs/markup_parser.py` tokenize step both gain a per-caller `id <= 0` guard, closing the two sites the LML#518 audit missed. Both short-circuit before `DiscogsService.get_release` / `get_artist_details` is touched, so a non-positive id can no longer leak into the API and tombstone the row (LML#510).
- `DiscogsService.get_release` and `get_artist_details` gain a `stack_info=True` WARN log when `id <= 0` reaches the service body. Log-only, does NOT raise, does NOT change behavior — the explicit hedge against the per-caller discipline failing again (e.g., LML#525's multiplexer dispatcher shipping without its own guard). The log surfaces as a Sentry breadcrumb so the unguarded caller chain is visible at triage time.
- Honors LML#518's "boundary stays open, callers validate" decision: the public service surface is unchanged, only the observability backstop is added.

Closes #546

## Test plan

- [x] Failing test first for `release/discogs_resolver.py` rejecting `release_id=0`, `-1`, `-12345` without calling the service.
- [x] Failing test first for `discogs/markup_parser.py` tokenize dropping `[a0]`, `[r0]`, `[r=0]`, `[m0]`, `[m=0]`.
- [x] Failing test first for the service-layer WARN-with-stack on `get_release` and `get_artist_details`, asserting the call still proceeds to `_request_with_retry` (observability-only).
- [x] `uv run pytest tests/unit/` — all 2481 unit tests green locally.
- [x] `uv run ruff check` + `uv run ruff format --check` + `uv run mypy` on the touched files — clean.