### PR TITLE
fix(orchestrator): strip Discogs paren-subtitle before search (#531)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1678,23 +1678,48 @@ def album_title_acceptable(query_lower: str, result_lower: str) -> bool:
     return fuzz.ratio(query_lower, result_lower) >= 50
 
 
+_TRAILING_PARENTHETICAL_RE = re.compile(r"\s*\([^)]*\)\s*$")
+"""Strip a trailing parenthetical suffix from a Discogs album query before search.
+
+Discogs ``release.title`` often carries a long descriptive subtitle in
+parentheses (e.g. ``Disco Not Disco (Post Punk, Electro & Leftfield Disco
+Classics 1974-1986)``). The library catalogues only the base (``Disco Not
+Disco, vol. 1``), and the FTS5 implicit-AND query against the full Discogs
+title returns empty — the subtitle terms aren't in the library row. Stripping
+the parenthetical produces a query that FTS5 surfaces to the right rows, and
+the existing prefix branch in ``album_title_acceptable`` accepts the
+library row via ``result.startswith(query)``.
+"""
+
+
 async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryItem]:
     """Search for album with fuzzy keyword matching."""
     from rapidfuzz import fuzz
 
-    results = await db.search(query=album_title, limit=MAX_SEARCH_RESULTS)
-
-    # Filter exact FTS5 results by title similarity to reject subset matches
-    # (e.g., FTS5 matches "808 State" for query "The Best Of 808 State: Blueprint"
-    # because it tokenizes and matches on shared terms "808" and "State")
-    if results:
-        album_lower = album_title.lower()
-        results = [
+    async def _search_and_filter(query: str) -> list[LibraryItem]:
+        raw = await db.search(query=query, limit=MAX_SEARCH_RESULTS)
+        if not raw:
+            return []
+        q_lower = query.lower()
+        return [
             r
-            for r in results
-            if _va_series_title_match(album_lower, r)
-            or album_title_acceptable(album_lower, (r.title or "").lower())
+            for r in raw
+            if _va_series_title_match(q_lower, r)
+            or album_title_acceptable(q_lower, (r.title or "").lower())
         ]
+
+    # First try the un-stripped query. If FTS5 finds candidates but the
+    # post-filter rejects them all, retry with the parenthetical stripped —
+    # this rescues the over-specific Discogs subtitle case (WXYC#531) where
+    # the LIKE/fuzzy fallback inside db.search returns a tangentially related
+    # row that the post-filter then drops, leaving the actual library row
+    # unseen because FTS5's implicit-AND on the full title returns empty.
+    results = await _search_and_filter(album_title)
+
+    if not results:
+        stripped = _TRAILING_PARENTHETICAL_RE.sub("", album_title).strip()
+        if stripped and stripped != album_title:
+            results = await _search_and_filter(stripped)
 
     if not results:
         words = re.sub(r"[^\w\s]", " ", album_title.lower()).split()

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1678,18 +1678,21 @@ def album_title_acceptable(query_lower: str, result_lower: str) -> bool:
     return fuzz.ratio(query_lower, result_lower) >= 50
 
 
-_TRAILING_PARENTHETICAL_RE = re.compile(r"\s*\([^)]*\)\s*$")
-"""Strip a trailing parenthetical suffix from a Discogs album query before search.
-
-Discogs ``release.title`` often carries a long descriptive subtitle in
-parentheses (e.g. ``Disco Not Disco (Post Punk, Electro & Leftfield Disco
-Classics 1974-1986)``). The library catalogues only the base (``Disco Not
-Disco, vol. 1``), and the FTS5 implicit-AND query against the full Discogs
-title returns empty — the subtitle terms aren't in the library row. Stripping
-the parenthetical produces a query that FTS5 surfaces to the right rows, and
-the existing prefix branch in ``album_title_acceptable`` accepts the
-library row via ``result.startswith(query)``.
-"""
+# Strip *all* trailing parenthetical suffixes from a Discogs album query before
+# search. See WXYC/library-metadata-lookup#531 — Discogs ``release.title`` often
+# carries a long descriptive subtitle in parentheses (e.g. ``Disco Not Disco
+# (Post Punk, Electro & Leftfield Disco Classics 1974-1986)``) and routinely
+# stacks multiple groups (``Album (Deluxe Edition) (Remastered)``, ``Album
+# (Live) (Bonus Track)``). The library catalogues only the base (``Disco Not
+# Disco, vol. 1``); the full Discogs title fails the FTS5 query in different
+# ways depending on its shape (see the block comment on the retry below).
+# Stripping the parenthetical(s) produces a query that FTS5 surfaces to the
+# right rows, and the existing prefix branch in ``album_title_acceptable``
+# accepts the library row via ``result.startswith(query)``. The ``+`` makes
+# this idempotent over stacked groups so a single ``sub`` call peels all
+# trailing parens — ``Album (Live) (Remastered)`` strips to ``Album``, not
+# ``Album (Live)`` which would still be an FTS5 syntax error.
+_TRAILING_PARENTHETICAL_RE = re.compile(r"(?:\s*\([^)]*\)\s*)+$")
 
 
 async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryItem]:
@@ -1708,12 +1711,23 @@ async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryIte
             or album_title_acceptable(q_lower, (r.title or "").lower())
         ]
 
-    # First try the un-stripped query. If FTS5 finds candidates but the
-    # post-filter rejects them all, retry with the parenthetical stripped —
-    # this rescues the over-specific Discogs subtitle case (WXYC#531) where
-    # the LIKE/fuzzy fallback inside db.search returns a tangentially related
-    # row that the post-filter then drops, leaving the actual library row
-    # unseen because FTS5's implicit-AND on the full title returns empty.
+    # First try the un-stripped query. If it produces no surviving candidates,
+    # retry with all trailing parenthetical groups stripped — this rescues
+    # the over-specific Discogs subtitle case (WXYC#531). The full Discogs
+    # title fails the FTS5 search layer in three distinct ways depending on
+    # its shape, all of which strip-retry repairs:
+    #   1. FTS5 throws on special characters in the subtitle (``&`` is the
+    #      common offender), ``db.search`` swallows the error and falls
+    #      through to the LIKE / fuzzy fallback layers.
+    #   2. ``_fallback_like_search`` uses implicit-AND across title+artist,
+    #      requiring every significant word to appear — terse library rows
+    #      (``Disco Not Disco, vol. 1``) lack the subtitle's words and
+    #      return empty.
+    #   3. ``_fuzzy_search`` candidate-trawls on the longest word's 3-char
+    #      prefix and returns tangentially related rows that the post-filter
+    #      then drops.
+    # In all three shapes the actual library row goes unseen until the
+    # paren-strip retry produces a query FTS5 can answer cleanly.
     results = await _search_and_filter(album_title)
 
     if not results:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -118,6 +118,13 @@ SEED_ITEMS = [
     (12680, "Arkology", "Lee 'Scratch' Perry", "Pe", 1, 17, "Reggae", "CD"),
     (12684, "Dub Fire", "Lee 'Scratch' Perry", "Pe", 1, 21, "Reggae", "CD"),
     (12682, "Live at Maritime Hall", "Lee 'Scratch' Perry", "Pe", 1, 20, "Reggae", "CD"),
+    # V/A series catalogued under the librarian's <base>, vol. N convention,
+    # against which Discogs returns the canonical release with a long
+    # parenthetical subtitle. The repro shape for WXYC#531.
+    (58610, "Disco Not Disco, vol. 1", "Various Artists - Rock - D", "V", 3, 1, "Rock", "CD"),
+    (58611, "Disco Not Disco, vol. 2", "Various Artists - Rock - D", "V", 3, 2, "Rock", "CD"),
+    # Non-V/A with the same shape — regression guard so the gate stays narrow.
+    (60001, "Live Sessions, vol. 2", "Some Band", "S", 4, 2, "Rock", "CD"),
 ]
 
 

--- a/tests/integration/test_search_album_fuzzy.py
+++ b/tests/integration/test_search_album_fuzzy.py
@@ -26,10 +26,12 @@ async def test_va_series_with_volume_surfaces_against_long_paren_subtitle(librar
     surface against the Discogs canonical release whose title carries a long
     parenthetical subtitle.
 
-    The pre-fix behavior is empty results because FTS5 implicit-AND on the full
-    title cannot match the terse library row, the LIKE fallback requires every
-    significant word in title/artist, and the fuzzy fallback candidate-trawls
-    on the longest word's 3-char prefix.
+    Pre-fix behavior is empty results: FTS5 throws on ``&`` in the subtitle,
+    ``db.search`` swallows the syntax error and falls through to the LIKE /
+    fuzzy ladder, the LIKE fallback requires every significant word to appear
+    in title or artist (the subtitle's words don't), and the fuzzy fallback
+    candidate-trawls on the longest word's 3-char prefix and surfaces
+    tangentially related rows that the post-filter then drops.
     """
     results = await search_album_fuzzy(
         library_db,

--- a/tests/integration/test_search_album_fuzzy.py
+++ b/tests/integration/test_search_album_fuzzy.py
@@ -11,9 +11,13 @@ that class of regression can't recur silently.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
-from lookup.orchestrator import search_album_fuzzy
+from discogs.models import ReleaseInfo, TrackReleasesResponse
+from lookup.orchestrator import search_album_fuzzy, search_compilations_for_track
+from services.parser import ParsedRequest
 
 
 @pytest.mark.asyncio
@@ -70,16 +74,99 @@ async def test_plain_base_query_unchanged(library_db):
 
 @pytest.mark.asyncio
 async def test_paren_on_discogs_side_with_matching_library_base(library_db):
-    """Regression guard for the existing prefix branch: a Discogs query with a
-    paren-suffix already matched a library row whose title is the base. E.g.,
-    ``OK Computer (OKNOTOK Anniversary Edition)`` should surface a library row
-    titled ``OK Computer`` via the pre-existing ``query.startswith(result)``
-    branch.
+    """Exercises the new paren-strip retry against a non-V/A library row.
 
-    Uses ``Aluminum Tunes`` from the seed because no parenthetical-suffixed
-    seed row exists; the assertion is that the un-suffixed library row
-    surfaces.
+    For ``Aluminum Tunes (Remastered)``, the un-stripped query trips FTS5's
+    special-char handling on ``(`` — ``db.search`` swallows the syntax error
+    and falls through the LIKE / fuzzy ladder. The LIKE fallback eliminates
+    the Stereolab row because ``"Remastered"`` is absent from title and
+    artist; the fuzzy fallback's longest-word 3-char prefix (``rem``) only
+    coincidentally surfaces the row via ``Stereolab``. The paren-strip
+    retry rebuilds the query as plain ``Aluminum Tunes``, which FTS5
+    answers cleanly and the existing prefix branch in
+    ``album_title_acceptable`` accepts via ``query.startswith(result)``.
     """
     results = await search_album_fuzzy(library_db, "Aluminum Tunes (Remastered)")
     titles = {r.title for r in results}
     assert "Aluminum Tunes" in titles
+
+
+@pytest.mark.asyncio
+async def test_non_va_paren_match_filtered_by_downstream_artist_gate(library_db):
+    """The widened matching layer surfaces non-V/A rows for any Discogs query
+    that shares a prefix with a library title; the downstream artist gate
+    inside ``process_release`` must drop them when artists don't match.
+
+    Seed row 60001 catalogues ``Live Sessions, vol. 2`` under ``Some Band``.
+    A Discogs release titled ``Live Sessions (Acoustic Recordings From The
+    Greek Theatre 1998-2002)`` credited to ``Some Other Band`` will be
+    surfaced by ``search_album_fuzzy`` (the paren-strip retry produces
+    ``Live Sessions``, which prefix-matches row 60001's title). Without the
+    artist gate the row would slip through to the user, despite the artist
+    mismatch.
+
+    Pins three things in one test:
+
+    1. ``search_album_fuzzy`` does widen for non-V/A rows (the strip-retry
+       is unconditional on V/A-ness — by design, since V/A-ness is a
+       library-row property unknown at query construction time).
+    2. ``process_release``'s ``artist_matches_item`` filter drops the
+       non-V/A row when ``parsed.artist`` doesn't prefix-match the
+       library-row artist, so the false positive never surfaces.
+    3. The ``Live Sessions, vol. 2`` seed row earns its keep as a
+       regression fixture — adding it to the SQLite seed without a test
+       asserting on it was the gap this test closes.
+    """
+    parsed = ParsedRequest(
+        artist="Some Other Band",
+        song="Recording 3",
+        raw_message="Recording 3 by Some Other Band",
+    )
+
+    service = AsyncMock()
+    service.cache_service = None
+
+    async def _track_releases(track, artist=None, artist_as_keyword=False, **_):
+        # Wave A returns the non-V/A release shape that the seed row's title
+        # prefix-matches after the paren-strip. Wave B returns empty (no
+        # genuine V/A surfaces; the row is a false-positive candidate).
+        releases = (
+            []
+            if artist_as_keyword
+            else [
+                ReleaseInfo(
+                    album="Live Sessions (Acoustic Recordings From The Greek Theatre 1998-2002)",
+                    artist="Some Other Band",
+                    release_id=70001,
+                    release_url="https://www.discogs.com/release/70001",
+                    is_compilation=False,
+                ),
+            ]
+        )
+        return TrackReleasesResponse(
+            track=track,
+            artist=artist,
+            releases=list(releases),
+            total=len(releases),
+        )
+
+    service.search_releases_by_track = AsyncMock(side_effect=_track_releases)
+    # Track validation would say True (track is on the release) — the artist
+    # gate must filter before we ever get here. If it didn't, the row would
+    # surface in results and this test would fail.
+    service.validate_track_on_release = AsyncMock(return_value=True)
+
+    with patch(
+        "lookup.orchestrator.lookup_releases_by_track",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        items, _titles = await search_compilations_for_track(
+            library_db, parsed, discogs_service=service
+        )
+
+    titles = {item.title for item in items}
+    assert "Live Sessions, vol. 2" not in titles, (
+        f"Non-V/A row paired with a non-matching Discogs artist must be filtered "
+        f"by process_release's artist gate, got: {titles}"
+    )

--- a/tests/integration/test_search_album_fuzzy.py
+++ b/tests/integration/test_search_album_fuzzy.py
@@ -1,0 +1,85 @@
+"""Integration tests for ``search_album_fuzzy`` against a real SQLite+FTS5.
+
+The unit tests in ``tests/unit/test_orchestrator_gaps.py::TestSearchAlbumFuzzy``
+stub ``db.search``, which hides FTS5 / LIKE-fallback / fuzzy-fallback semantics.
+WXYC#531 shipped a fix (PR #552) whose unit tests passed but whose end-to-end
+behavior against a real library was a no-op — the helper sat in a post-filter
+block that never received candidates because the un-stripped Discogs subtitle
+query produced empty results. These tests exercise the real search path so
+that class of regression can't recur silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lookup.orchestrator import search_album_fuzzy
+
+
+@pytest.mark.asyncio
+async def test_va_series_with_volume_surfaces_against_long_paren_subtitle(library_db):
+    """Repro for WXYC#531: V/A library row ``Disco Not Disco, vol. 1`` must
+    surface against the Discogs canonical release whose title carries a long
+    parenthetical subtitle.
+
+    The pre-fix behavior is empty results because FTS5 implicit-AND on the full
+    title cannot match the terse library row, the LIKE fallback requires every
+    significant word in title/artist, and the fuzzy fallback candidate-trawls
+    on the longest word's 3-char prefix.
+    """
+    results = await search_album_fuzzy(
+        library_db,
+        "Disco Not Disco (Post Punk, Electro & Leftfield Disco Classics 1974-1986)",
+    )
+    titles = {r.title for r in results}
+    assert "Disco Not Disco, vol. 1" in titles, (
+        f"V/A vol.1 must surface against the long-subtitle Discogs query, got: {titles}"
+    )
+    assert "Disco Not Disco, vol. 2" in titles, (
+        f"V/A vol.2 must also surface — both volumes share the base, got: {titles}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_va_series_surfaces_against_various_prefix_retry(library_db):
+    """The compilation retry path in ``process_release`` prepends ``Various ``
+    to the album title when the base search returns no matches. That retry must
+    also surface the V/A row when the Discogs title carries a paren subtitle.
+    """
+    results = await search_album_fuzzy(
+        library_db,
+        "Various Disco Not Disco (Post Punk, Electro & Leftfield Disco Classics 1974-1986)",
+    )
+    titles = {r.title for r in results}
+    assert "Disco Not Disco, vol. 1" in titles, (
+        f"Various-prefix retry must surface V/A vol.1, got: {titles}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_plain_base_query_unchanged(library_db):
+    """Regression guard: a query that already matches by FTS5 (no paren,
+    exact prefix of the library row) must continue to surface. This locks in
+    the existing prefix-acceptance branch in ``album_title_acceptable``.
+    """
+    results = await search_album_fuzzy(library_db, "Disco Not Disco")
+    titles = {r.title for r in results}
+    assert "Disco Not Disco, vol. 1" in titles
+    assert "Disco Not Disco, vol. 2" in titles
+
+
+@pytest.mark.asyncio
+async def test_paren_on_discogs_side_with_matching_library_base(library_db):
+    """Regression guard for the existing prefix branch: a Discogs query with a
+    paren-suffix already matched a library row whose title is the base. E.g.,
+    ``OK Computer (OKNOTOK Anniversary Edition)`` should surface a library row
+    titled ``OK Computer`` via the pre-existing ``query.startswith(result)``
+    branch.
+
+    Uses ``Aluminum Tunes`` from the seed because no parenthetical-suffixed
+    seed row exists; the assertion is that the un-suffixed library row
+    surfaces.
+    """
+    results = await search_album_fuzzy(library_db, "Aluminum Tunes (Remastered)")
+    titles = {r.title for r in results}
+    assert "Aluminum Tunes" in titles

--- a/tests/integration/test_search_album_fuzzy.py
+++ b/tests/integration/test_search_album_fuzzy.py
@@ -158,6 +158,20 @@ async def test_non_va_paren_match_filtered_by_downstream_artist_gate(library_db)
     # surface in results and this test would fail.
     service.validate_track_on_release = AsyncMock(return_value=True)
 
+    # First pin the matching layer: search_album_fuzzy must surface the row
+    # via the paren-strip retry. Without this assertion the end-to-end check
+    # below could silently pass a regression in the strip-retry (nothing to
+    # filter = nothing in titles, indistinguishable from "filtered correctly").
+    matching_layer = await search_album_fuzzy(
+        library_db,
+        "Live Sessions (Acoustic Recordings From The Greek Theatre 1998-2002)",
+    )
+    matching_layer_titles = {item.title for item in matching_layer}
+    assert "Live Sessions, vol. 2" in matching_layer_titles, (
+        f"Matching layer must widen via the paren-strip retry — without this "
+        f"the artist-gate assertion below is vacuous, got: {matching_layer_titles}"
+    )
+
     with patch(
         "lookup.orchestrator.lookup_releases_by_track",
         new_callable=AsyncMock,

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -898,7 +898,7 @@ class TestSearchAlbumFuzzy:
             title="Disco Not Disco, vol. 1",
         )
 
-        async def search(query: str, limit: int = 5) -> list:
+        async def search(query, limit=None, **_):
             # Only surface the V/A seed when the query has been fully stripped
             # to the base. Any partially-stripped retry returns empty, so an
             # incorrect regex (peeling only the trailing group) yields [] from

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -876,6 +876,43 @@ class TestSearchAlbumFuzzy:
         )
         assert _va_series_title_match("disco not disco", item) is True
 
+    @pytest.mark.asyncio
+    async def test_paren_strip_handles_multiple_trailing_groups(self):
+        """Discogs titles routinely stack trailing paren groups, e.g.
+        ``Album (Deluxe Edition) (Remastered)`` or ``Album (Live) (Bonus
+        Track)``. The paren-strip retry must peel *all* trailing groups in a
+        single pass — peeling only the last one leaves ``Album (Live)``,
+        whose ``(`` still trips FTS5's syntax check and the retry's purpose
+        (a query FTS5 can answer cleanly) is defeated.
+
+        Verified by giving ``db.search`` a strict side-effect that returns the
+        V/A seed only when called with the fully-stripped base, and asserting
+        the row surfaces. If the regex peeled only the trailing group, the
+        retry query would be ``Disco Not Disco (Live)`` and ``db.search``
+        would return ``[]``.
+        """
+        db = AsyncMock()
+        seed = _item(
+            id=58610,
+            artist="Various Artists - Rock - D",
+            title="Disco Not Disco, vol. 1",
+        )
+
+        async def search(query: str, limit: int = 5) -> list:
+            # Only surface the V/A seed when the query has been fully stripped
+            # to the base. Any partially-stripped retry returns empty, so an
+            # incorrect regex (peeling only the trailing group) yields [] from
+            # the assertion below.
+            if query == "Disco Not Disco":
+                return [seed]
+            return []
+
+        db.search = AsyncMock(side_effect=search)
+
+        results = await search_album_fuzzy(db, "Disco Not Disco (Live) (Remastered)")
+        assert len(results) == 1
+        assert results[0].id == 58610
+
 
 # ---------------------------------------------------------------------------
 # filter_results_by_track_validation -- exception (lines 482-483)

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from lookup.orchestrator import (
+    _va_series_title_match,
     album_title_acceptable,
     fetch_artwork_for_items,
     filter_results_by_track_validation,
@@ -825,34 +826,55 @@ class TestSearchAlbumFuzzy:
         assert len(results) == 1
         assert results[0].id == 58610
 
-    @pytest.mark.asyncio
-    async def test_va_series_gate_does_not_grandfather_non_compilation(self):
+    def test_va_series_gate_does_not_grandfather_non_compilation(self):
         """The ``, vol. N`` special-case is gated on ``is_compilation_artist``.
 
         A non-V/A library row with the same shape (``<base>, vol. N``) must NOT
-        be accepted against an unrelated Discogs release whose title merely
-        starts with the same ``<base>``. This is the regression guard for
-        directions (2) and (3) in WXYC#531 — option (1) is deliberately
-        narrow.
+        be accepted through the ``_va_series_title_match`` looser path. Asserts
+        the gate directly rather than through ``search_album_fuzzy`` end-to-end
+        — the latter can reach the row via the existing prefix branch in
+        ``album_title_acceptable`` once the search query is paren-stripped
+        (the broader matching layer is gated downstream by
+        ``_release_matches_library_row``'s artist check in ``process_release``,
+        so a non-V/A row paired with a different Discogs artist is filtered
+        out before it surfaces to the user).
         """
-        db = AsyncMock()
         item = _item(
             id=99999,
             artist="Some Band",
             title="Live Sessions, vol. 2",
         )
 
-        db.search = AsyncMock(return_value=[item])
-
-        # Long descriptive Discogs title that shares the "Live Sessions" prefix
-        # but is otherwise unrelated. Without the V/A gate this would slip
-        # through the new special-case; with the gate it must be rejected by
-        # the existing length-sensitive fuzz.ratio path.
-        results = await search_album_fuzzy(
-            db,
-            "Live Sessions (Acoustic Recordings From The Greek Theatre 1998-2002)",
+        # The V/A helper must reject regardless of whether the query has a
+        # paren subtitle or has been stripped to the base — the artist gate
+        # is what keeps non-V/A rows out of the looser path.
+        assert (
+            _va_series_title_match(
+                "live sessions (acoustic recordings from the greek theatre 1998-2002)",
+                item,
+            )
+            is False
         )
-        assert results == []
+        assert _va_series_title_match("live sessions", item) is False
+
+    def test_va_series_gate_accepts_va_artist_with_matching_base(self):
+        """Companion to the gate-narrowness test: confirm the helper *does*
+        accept V/A rows with a matching base. Pins the positive contract that
+        the gate exists to widen.
+        """
+        item = _item(
+            id=58610,
+            artist="Various Artists - Rock - D",
+            title="Disco Not Disco, vol. 1",
+        )
+        assert (
+            _va_series_title_match(
+                "disco not disco (post punk, electro & leftfield disco classics 1974-1986)",
+                item,
+            )
+            is True
+        )
+        assert _va_series_title_match("disco not disco", item) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- PR #552 closed #531 but its fix was a no-op against the real `library.db` — `search_album_fuzzy` for the issue's repro query still returned `[]`. Unit tests passed by stubbing `db.search` to feed the V/A item directly to the post-filter; no integration coverage exercised the real SQLite+FTS5 path.
- Add a paren-strip fallback in `search_album_fuzzy`: when the un-stripped query produces no surviving candidates, retry with a trailing-parenthetical regex strip. The `_va_series_title_match` helper from #552 is retained for the narrow case it actually covers.
- Add `tests/integration/test_search_album_fuzzy.py` exercising the real FTS5 pipeline so this class of regression can't recur silently.

## Why the merged fix didn't work

Verified at `d0a0401` against the real `library.db`:

1. FTS5 `MATCH ?` on the full Discogs subtitle throws (`fts5: syntax error near "&"`).
2. `_fallback_like_search` requires every significant word in title/artist (implicit AND). The library row contains "disco"+"not" but not "post"/"punk"/"electro"/"leftfield"/"classics"/"1974"/"1986" → empty.
3. `_fuzzy_search` candidate-trawls on the `[:3]`-prefix of the longest word ("lef") → unrelated rows → empty.

`db.search` returns `[]` before the post-filter runs, so `_va_series_title_match` has no candidates to accept.

## The fix

Run the un-stripped search first. If nothing survives, strip a trailing parenthetical (`\s*\([^)]*\)\s*$`) and retry. The stripped query "Disco Not Disco" surfaces rows 58610/58611 via FTS5 directly, and the existing `result.startswith(query)` branch in `album_title_acceptable` accepts each.

Side effect: the matching layer is now wider for non-V/A queries with trailing parentheticals too. False positives are caught downstream by `_release_matches_library_row`'s artist gate in `process_release`.

## Test changes

- `test_va_series_gate_does_not_grandfather_non_compilation` (PR #552) asserted matching-layer narrowness via `search_album_fuzzy` end-to-end. With paren-strip, the assertion is reached via the existing prefix branch, not the V/A gate. Updated to assert `_va_series_title_match` directly (the unit it actually claims to test) + companion positive-contract test.
- New `tests/integration/test_search_album_fuzzy.py`:
  - `test_va_series_with_volume_surfaces_against_long_paren_subtitle` — the #531 repro
  - `test_va_series_surfaces_against_various_prefix_retry` — covers `process_release`'s `Various ` retry path
  - `test_plain_base_query_unchanged` — regression guard
  - `test_paren_on_discogs_side_with_matching_library_base` — regression guard for existing prefix-acceptance

## Test plan

- [x] `tests/integration/test_search_album_fuzzy.py` fails before the fix, passes after (TDD verified)
- [x] Full unit suite: 2,470 passed
- [x] Non-`pg` / non-`external_api` integration suite: 242 passed
- [x] `ruff check` clean
- [x] `ruff format --check` clean

Closes #531