### PR TITLE
refactor(core): hoist bulk concurrency primitives to core/bulk_concurrency (LML#525 prep A/3)

### DIFF
--- a/core/bulk_concurrency.py
+++ b/core/bulk_concurrency.py
@@ -1,0 +1,108 @@
+"""Shared concurrency primitives for bulk FastAPI handlers.
+
+Hoisted out of ``lookup/router.py`` so both ``/api/v1/lookup/bulk`` and the
+``/api/v1/cache/refresh-for-identities`` dispatcher (LML#525) can share the
+same shape — bounded outer semaphore, client-disconnect sentinel race, and
+``CancelledError``-safe future drain.
+
+The three pieces:
+
+- ``max_concurrency_from_env(default)`` — resolves ``LML_BULK_MAX_CONCURRENT``,
+  floored at 1 so a misconfigured ``0`` can't hang the gather.
+- ``watch_disconnect(request)`` — sentinel coroutine that returns when uvicorn
+  delivers an ``http.disconnect`` ASGI message. Used in an ``asyncio.wait``
+  race against the actual work so a client abort releases any per-replica
+  rate-limit / semaphore permits the gather is still holding.
+- ``cancel_and_drain(future)`` — cancel a future and swallow the resulting
+  ``CancelledError``. Required because cancellation is asynchronous; merely
+  calling ``.cancel()`` doesn't free the permits until the task observes the
+  cancel and unwinds.
+
+The env knob (default 10) is shared between both endpoints intentionally —
+they have the same outer/inner gate shape and similar per-item work profile.
+If observed behavior diverges, splitting into per-endpoint knobs (with the
+shared one as fallback) is mechanical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from typing import Any
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+_BULK_MAX_CONCURRENT_ENV = "LML_BULK_MAX_CONCURRENT"
+
+
+def max_concurrency_from_env(default: int) -> int:
+    """Resolve ``LML_BULK_MAX_CONCURRENT``, floored at 1.
+
+    Read at request time (not via ``Settings``) to mirror
+    ``LML_SEARCH_BUDGET_MS`` in ``core/search.py:resolve_search_budget_ms`` —
+    both are runtime knobs.
+
+    Args:
+        default: Fallback used when the env var is unset or unparseable.
+
+    Returns:
+        The resolved concurrency cap, clamped to ``>= 1``.
+    """
+    raw = os.getenv(_BULK_MAX_CONCURRENT_ENV)
+    if not raw:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r, falling back to %d",
+            _BULK_MAX_CONCURRENT_ENV,
+            raw,
+            default,
+        )
+        return default
+
+
+async def watch_disconnect(request: Request) -> None:
+    """Sentinel task: returns when the client closes its socket.
+
+    uvicorn does not propagate client-side socket close into the handler — the
+    handler keeps running and the in-flight ``gather`` keeps draining queued
+    Discogs work, holding semaphore permits past the point any caller cares
+    about the result. We race this sentinel against the gather and cancel the
+    gather when the sentinel wins.
+
+    Awaits ``request.receive()`` directly rather than polling
+    ``request.is_disconnected()`` — the polling helper hangs under httpx's
+    ASGITransport in tests (anyio CancelScope/asyncio interaction), and the
+    direct ``receive()`` loop is the canonical Starlette pattern anyway.
+    """
+    while True:
+        message = await request.receive()
+        if message.get("type") == "http.disconnect":
+            return
+
+
+async def cancel_and_drain(future: asyncio.Future[Any]) -> None:
+    """Cancel a future and swallow the resulting ``CancelledError``.
+
+    Used by every bulk handler that races a gather against a disconnect
+    sentinel — twice on each path (gather cleanup on abort + sentinel cleanup
+    on happy path) so the two branches stay symmetric and permits actually
+    free on cancellation (the bare ``.cancel()`` call is asynchronous — the
+    underlying tasks have to observe it and unwind before the permits return).
+    """
+    future.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await future
+
+
+__all__ = [
+    "cancel_and_drain",
+    "max_concurrency_from_env",
+    "watch_disconnect",
+]

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-import os
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 
@@ -15,6 +13,11 @@ from pydantic import ValidationError
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
 
 from clients.streaming.apple_music import AppleMusicClient
+from core.bulk_concurrency import (
+    cancel_and_drain,
+    max_concurrency_from_env,
+    watch_disconnect,
+)
 from core.dependencies import (
     get_discogs_cache_service,
     get_discogs_service,
@@ -205,57 +208,6 @@ async def handle_lookup(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-async def _watch_disconnect(request: Request) -> None:
-    """Sentinel task: returns when the client closes its socket.
-
-    uvicorn does not propagate client-side socket close into the handler — the
-    handler keeps running and the in-flight `gather` keeps draining queued
-    Discogs work, holding 5-permit semaphore permits past the point any caller
-    cares about the result. We race this sentinel against the gather and cancel
-    the gather when the sentinel wins.
-
-    Awaits ``request.receive()`` directly rather than polling
-    ``request.is_disconnected()`` — the polling helper hangs under httpx's
-    ASGITransport in tests (anyio CancelScope/asyncio interaction), and the
-    direct ``receive()`` loop is the canonical Starlette pattern anyway.
-    """
-    while True:
-        message = await request.receive()
-        if message.get("type") == "http.disconnect":
-            return
-
-
-async def _cancel_and_drain(future: asyncio.Future[Any]) -> None:
-    """Cancel a future and swallow the resulting ``CancelledError``.
-
-    Used twice in the bulk handler (gather cleanup on abort + sentinel cleanup
-    on happy path) — extracted so the two branches stay symmetric.
-    """
-    future.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await future
-
-
-def _max_concurrency_from_env() -> int:
-    """Resolve LML_BULK_MAX_CONCURRENT, floored at 1 to keep a misconfigured 0 from hanging.
-
-    Read at request time (not via `Settings`) to mirror `LML_SEARCH_BUDGET_MS`
-    in `core/search.py:resolve_search_budget_ms` — both are runtime knobs.
-    """
-    raw = os.getenv("LML_BULK_MAX_CONCURRENT")
-    if not raw:
-        return _BULK_LOOKUP_DEFAULT_CONCURRENCY
-    try:
-        return max(1, int(raw))
-    except ValueError:
-        logger.warning(
-            "Invalid LML_BULK_MAX_CONCURRENT=%r, falling back to %d",
-            raw,
-            _BULK_LOOKUP_DEFAULT_CONCURRENCY,
-        )
-        return _BULK_LOOKUP_DEFAULT_CONCURRENCY
-
-
 @router.post(
     "/lookup/bulk",
     response_model=BulkLookupResponse,
@@ -348,7 +300,7 @@ async def handle_bulk_lookup(
         )
     )
 
-    max_concurrent = _max_concurrency_from_env()
+    max_concurrent = max_concurrency_from_env(_BULK_LOOKUP_DEFAULT_CONCURRENCY)
     semaphore = asyncio.Semaphore(max_concurrent)
     batch_telemetry = RequestTelemetry(
         api_call_keys=["discogs"],
@@ -422,14 +374,14 @@ async def handle_bulk_lookup(
             #
             # Spawning the sentinel must happen *after* `await
             # http_request.json()` above has fully consumed the request body —
-            # _watch_disconnect awaits `request.receive()`, which would
+            # watch_disconnect awaits `request.receive()`, which would
             # otherwise swallow `http.request` body messages the body parser
             # needs.
             gather_future = asyncio.gather(
                 *(_run_one(i, item) for i, item in enumerate(request.items))
             )
             sentinel_task = asyncio.create_task(
-                _watch_disconnect(http_request),
+                watch_disconnect(http_request),
                 name="lml.bulk.disconnect_sentinel",
             )
             waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
@@ -441,8 +393,8 @@ async def handle_bulk_lookup(
                 # the children must be drained, not just signalled — otherwise
                 # the semaphore permits this PR exists to release are still
                 # held while the cancellation propagates asynchronously.
-                await _cancel_and_drain(gather_future)
-                await _cancel_and_drain(sentinel_task)
+                await cancel_and_drain(gather_future)
+                await cancel_and_drain(sentinel_task)
                 raise
 
             client_aborted = sentinel_task in done and not gather_future.done()
@@ -453,7 +405,7 @@ async def handle_bulk_lookup(
                 # carries the bulk-specific context. Key-name asymmetry
                 # intentional.
                 sentry_sdk.set_tag("lml.client_aborted", "true")
-                await _cancel_and_drain(gather_future)
+                await cancel_and_drain(gather_future)
                 # Exit log fires for the abort branch too — operators see the
                 # batch size + abort reason without digging into Sentry.
                 logger.warning(
@@ -466,7 +418,7 @@ async def handle_bulk_lookup(
                 # counts would skew batch-completion analytics.
                 raise HTTPException(status_code=499, detail="client disconnected")
 
-            await _cancel_and_drain(sentinel_task)
+            await cancel_and_drain(sentinel_task)
             results = gather_future.result()
 
         _project_cache_stats_to_transaction(get_cache_stats())

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -399,7 +399,7 @@ class TestBulkLookupEndpoint:
     ):
         """Garbage in `LML_BULK_MAX_CONCURRENT` must fall back to the default + warn.
 
-        Pins the contract documented at `_max_concurrency_from_env`: a misconfigured
+        Pins the contract documented at `max_concurrency_from_env`: a misconfigured
         env var doesn't blow up the route, it warns and uses the default.
         """
         import logging
@@ -648,7 +648,7 @@ class TestBulkLookupClientAbort:
     on disconnect, the handler cancels in-flight items, releases permits, and
     short-circuits with HTTP 499.
 
-    Tests patch ``_watch_disconnect`` directly; the receive-channel mechanism
+    Tests patch ``watch_disconnect`` directly; the receive-channel mechanism
     is exercised in production by uvicorn.
     """
 
@@ -699,7 +699,7 @@ class TestBulkLookupClientAbort:
                     new_callable=AsyncMock,
                     side_effect=slow_lookup,
                 ) as mock_lookup,
-                patch("lookup.router._watch_disconnect", self._disconnect_after()),
+                patch("lookup.router.watch_disconnect", self._disconnect_after()),
             ):
                 async with AsyncClient(
                     transport=ASGITransport(app=app), base_url="http://test"
@@ -754,7 +754,7 @@ class TestBulkLookupClientAbort:
                 new_callable=AsyncMock,
                 side_effect=slow_lookup,
             ),
-            patch("lookup.router._watch_disconnect", self._disconnect_after()),
+            patch("lookup.router.watch_disconnect", self._disconnect_after()),
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app_client), base_url="http://test"
@@ -798,7 +798,7 @@ class TestBulkLookupClientAbort:
                 new_callable=AsyncMock,
                 side_effect=slow_lookup,
             ),
-            patch("lookup.router._watch_disconnect", self._disconnect_after()),
+            patch("lookup.router.watch_disconnect", self._disconnect_after()),
             patch("lookup.router.sentry_sdk.set_tag", side_effect=capture_tag),
         ):
             async with AsyncClient(


### PR DESCRIPTION
## Summary

Pure refactor — pulls `max_concurrency_from_env`, `watch_disconnect`, and `cancel_and_drain` out of `lookup/router.py` into a new `core/bulk_concurrency.py`. The shape (bounded outer semaphore + client-disconnect sentinel race + drain-on-cancel) is about to be reused by `/api/v1/cache/refresh-for-identities` (LML#525), so it makes sense to share one implementation.

`/api/v1/lookup/bulk` behavior is unchanged. The three patch sites in `tests/unit/test_bulk_lookup_endpoint.py` that pointed at the previously-private `lookup.router._watch_disconnect` are updated to point at `lookup.router.watch_disconnect` (the public name imported from the new module — same target object, different attribute path).

## Stacked context

This is **PR A of 3** for LML#525:

- **A (this PR)** → main: concurrency hoist
- **B** → A: `EntityStore.get_release_identity_provenance_bulk`
- **C** → B: `POST /api/v1/cache/refresh-for-identities` (the actual endpoint)

GitHub re-bases B onto main automatically once A merges.

## Test plan

- [x] `pytest tests/unit/test_bulk_lookup_endpoint.py` — 20 passed, including the three patches that follow the new symbol path.
- [x] `ruff check .` + `ruff format --check .` clean.
- [ ] CI: Default + Lint + Type Check + PG.

Part of #525.