### PR TITLE
feat(entity): add get_release_identity_provenance_bulk to EntityStore (LML#525 prep B/3)

### DIFF
--- a/core/bulk_concurrency.py
+++ b/core/bulk_concurrency.py
@@ -1,0 +1,108 @@
+"""Shared concurrency primitives for bulk FastAPI handlers.
+
+Hoisted out of ``lookup/router.py`` so both ``/api/v1/lookup/bulk`` and the
+``/api/v1/cache/refresh-for-identities`` dispatcher (LML#525) can share the
+same shape — bounded outer semaphore, client-disconnect sentinel race, and
+``CancelledError``-safe future drain.
+
+The three pieces:
+
+- ``max_concurrency_from_env(default)`` — resolves ``LML_BULK_MAX_CONCURRENT``,
+  floored at 1 so a misconfigured ``0`` can't hang the gather.
+- ``watch_disconnect(request)`` — sentinel coroutine that returns when uvicorn
+  delivers an ``http.disconnect`` ASGI message. Used in an ``asyncio.wait``
+  race against the actual work so a client abort releases any per-replica
+  rate-limit / semaphore permits the gather is still holding.
+- ``cancel_and_drain(future)`` — cancel a future and swallow the resulting
+  ``CancelledError``. Required because cancellation is asynchronous; merely
+  calling ``.cancel()`` doesn't free the permits until the task observes the
+  cancel and unwinds.
+
+The env knob (default 10) is shared between both endpoints intentionally —
+they have the same outer/inner gate shape and similar per-item work profile.
+If observed behavior diverges, splitting into per-endpoint knobs (with the
+shared one as fallback) is mechanical.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from typing import Any
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+_BULK_MAX_CONCURRENT_ENV = "LML_BULK_MAX_CONCURRENT"
+
+
+def max_concurrency_from_env(default: int) -> int:
+    """Resolve ``LML_BULK_MAX_CONCURRENT``, floored at 1.
+
+    Read at request time (not via ``Settings``) to mirror
+    ``LML_SEARCH_BUDGET_MS`` in ``core/search.py:resolve_search_budget_ms`` —
+    both are runtime knobs.
+
+    Args:
+        default: Fallback used when the env var is unset or unparseable.
+
+    Returns:
+        The resolved concurrency cap, clamped to ``>= 1``.
+    """
+    raw = os.getenv(_BULK_MAX_CONCURRENT_ENV)
+    if not raw:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r, falling back to %d",
+            _BULK_MAX_CONCURRENT_ENV,
+            raw,
+            default,
+        )
+        return default
+
+
+async def watch_disconnect(request: Request) -> None:
+    """Sentinel task: returns when the client closes its socket.
+
+    uvicorn does not propagate client-side socket close into the handler — the
+    handler keeps running and the in-flight ``gather`` keeps draining queued
+    Discogs work, holding semaphore permits past the point any caller cares
+    about the result. We race this sentinel against the gather and cancel the
+    gather when the sentinel wins.
+
+    Awaits ``request.receive()`` directly rather than polling
+    ``request.is_disconnected()`` — the polling helper hangs under httpx's
+    ASGITransport in tests (anyio CancelScope/asyncio interaction), and the
+    direct ``receive()`` loop is the canonical Starlette pattern anyway.
+    """
+    while True:
+        message = await request.receive()
+        if message.get("type") == "http.disconnect":
+            return
+
+
+async def cancel_and_drain(future: asyncio.Future[Any]) -> None:
+    """Cancel a future and swallow the resulting ``CancelledError``.
+
+    Used by every bulk handler that races a gather against a disconnect
+    sentinel — twice on each path (gather cleanup on abort + sentinel cleanup
+    on happy path) so the two branches stay symmetric and permits actually
+    free on cancellation (the bare ``.cancel()`` call is asynchronous — the
+    underlying tasks have to observe it and unwind before the permits return).
+    """
+    future.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await future
+
+
+__all__ = [
+    "cancel_and_drain",
+    "max_concurrency_from_env",
+    "watch_disconnect",
+]

--- a/entity/store.py
+++ b/entity/store.py
@@ -136,6 +136,42 @@ INSERT INTO entity.release_reconciliation_log
 VALUES ($1, $2, $3, $4, $5)\
 """
 
+# LML#525: bulk read of per-source external IDs for a batch of release
+# identity_ids. Reads the `entity.release_identity` row directly rather than
+# the reconciliation log — the per-source UNIQUE columns already carry the
+# canonical (source, external_id) projection, and a single round-trip vs.
+# N is what makes the cache-refresh dispatcher's fan-out economical. The
+# reconciliation_log is reserved for cases where multi-version provenance
+# per source matters; not needed for cache warming.
+#
+# Idiom matches `_BULK_GET_IDENTITY_EXACT_SQL` above: bind the input list as
+# a single int array and let PG fan it out against the PK index in one query.
+_BULK_GET_RELEASE_IDENTITY_PROVENANCE_SQL = """\
+SELECT id,
+       discogs_release_id, discogs_master_id, musicbrainz_release_id,
+       spotify_album_id, apple_music_album_id, bandcamp_album_url
+FROM entity.release_identity
+WHERE id = ANY($1::int[])\
+"""
+
+# Maps `entity.release_identity` columns to the source-key vocabulary the
+# cache-refresh dispatcher and the rest of the LML codebase use. Keep in
+# lockstep with `identity.release_validation.RELEASE_SOURCE_COLUMN`: this
+# is the inverse direction (column → source). Defining it here rather than
+# importing-and-inverting keeps the store's read path independent of the
+# validation module's load order, and lets the column-set evolve with the
+# release-identity schema without retrofitting `release_validation` for
+# read-only sources (e.g. `musicbrainz_release_id` is readable today even
+# though no write helper / sentinel rule exists for it yet).
+_RELEASE_IDENTITY_COLUMN_TO_SOURCE: tuple[tuple[str, str], ...] = (
+    ("discogs_release_id", "discogs_release"),
+    ("discogs_master_id", "discogs_master"),
+    ("musicbrainz_release_id", "musicbrainz_release"),
+    ("spotify_album_id", "spotify_album"),
+    ("apple_music_album_id", "apple_music_album"),
+    ("bandcamp_album_url", "bandcamp"),
+)
+
 # Shared merge / delete primitives. Used both by `EntityDeduplicator.merge_group`
 # (for QID-collapse merges) and by the LML#377 orphan-pass helpers
 # `merge_identity_by_library_name` / `delete_identity_by_library_name`. Hoisted
@@ -854,3 +890,47 @@ class EntityStore:
             method,
             confidence,
         )
+
+    async def get_release_identity_provenance_bulk(
+        self, identity_ids: list[int]
+    ) -> dict[int, list[tuple[str, str]]]:
+        """Return per-source ``(source, external_id)`` pairs for each identity_id.
+
+        Single round-trip against ``entity.release_identity``: PG fans the
+        input list out against the PK index, the row is decomposed in Python
+        by reading every per-source column that is non-NULL.
+
+        Missing identity_ids are **absent** from the returned dict (not
+        None-valued) — the cache-refresh dispatcher renders that absence as
+        per-id ``status = "not_found"`` (LML#525 contract).
+
+        Every external_id is stringified so callers don't have to branch on
+        ``int``-vs-``str`` types when serializing per-source outcomes. Discogs
+        IDs land as decimal strings; TEXT-shaped sources round-trip verbatim.
+
+        Args:
+            identity_ids: List of release-identity row IDs to look up. Empty
+                input returns ``{}`` without a PG round-trip.
+
+        Returns:
+            ``{identity_id: [(source, external_id), ...]}``. The list per
+            identity holds one entry per non-NULL source column on the row.
+            A row whose per-source columns are all NULL (legally possible
+            but never produced by the v1 mint protocol) yields an empty
+            list, distinguishing "row exists, nothing wired" from "row
+            absent" (which is omitted from the dict entirely).
+        """
+        if not identity_ids:
+            return {}
+        rows = await self._pg.fetchall(_BULK_GET_RELEASE_IDENTITY_PROVENANCE_SQL, identity_ids)
+        if not rows:
+            return {}
+        result: dict[int, list[tuple[str, str]]] = {}
+        for row in rows:
+            pairs: list[tuple[str, str]] = []
+            for column, source in _RELEASE_IDENTITY_COLUMN_TO_SOURCE:
+                value = row[column]
+                if value is not None:
+                    pairs.append((source, str(value)))
+            result[row["id"]] = pairs
+        return result

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-import os
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 
@@ -15,6 +13,11 @@ from pydantic import ValidationError
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
 
 from clients.streaming.apple_music import AppleMusicClient
+from core.bulk_concurrency import (
+    cancel_and_drain,
+    max_concurrency_from_env,
+    watch_disconnect,
+)
 from core.dependencies import (
     get_discogs_cache_service,
     get_discogs_service,
@@ -205,57 +208,6 @@ async def handle_lookup(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
-async def _watch_disconnect(request: Request) -> None:
-    """Sentinel task: returns when the client closes its socket.
-
-    uvicorn does not propagate client-side socket close into the handler — the
-    handler keeps running and the in-flight `gather` keeps draining queued
-    Discogs work, holding 5-permit semaphore permits past the point any caller
-    cares about the result. We race this sentinel against the gather and cancel
-    the gather when the sentinel wins.
-
-    Awaits ``request.receive()`` directly rather than polling
-    ``request.is_disconnected()`` — the polling helper hangs under httpx's
-    ASGITransport in tests (anyio CancelScope/asyncio interaction), and the
-    direct ``receive()`` loop is the canonical Starlette pattern anyway.
-    """
-    while True:
-        message = await request.receive()
-        if message.get("type") == "http.disconnect":
-            return
-
-
-async def _cancel_and_drain(future: asyncio.Future[Any]) -> None:
-    """Cancel a future and swallow the resulting ``CancelledError``.
-
-    Used twice in the bulk handler (gather cleanup on abort + sentinel cleanup
-    on happy path) — extracted so the two branches stay symmetric.
-    """
-    future.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await future
-
-
-def _max_concurrency_from_env() -> int:
-    """Resolve LML_BULK_MAX_CONCURRENT, floored at 1 to keep a misconfigured 0 from hanging.
-
-    Read at request time (not via `Settings`) to mirror `LML_SEARCH_BUDGET_MS`
-    in `core/search.py:resolve_search_budget_ms` — both are runtime knobs.
-    """
-    raw = os.getenv("LML_BULK_MAX_CONCURRENT")
-    if not raw:
-        return _BULK_LOOKUP_DEFAULT_CONCURRENCY
-    try:
-        return max(1, int(raw))
-    except ValueError:
-        logger.warning(
-            "Invalid LML_BULK_MAX_CONCURRENT=%r, falling back to %d",
-            raw,
-            _BULK_LOOKUP_DEFAULT_CONCURRENCY,
-        )
-        return _BULK_LOOKUP_DEFAULT_CONCURRENCY
-
-
 @router.post(
     "/lookup/bulk",
     response_model=BulkLookupResponse,
@@ -348,7 +300,7 @@ async def handle_bulk_lookup(
         )
     )
 
-    max_concurrent = _max_concurrency_from_env()
+    max_concurrent = max_concurrency_from_env(_BULK_LOOKUP_DEFAULT_CONCURRENCY)
     semaphore = asyncio.Semaphore(max_concurrent)
     batch_telemetry = RequestTelemetry(
         api_call_keys=["discogs"],
@@ -422,14 +374,14 @@ async def handle_bulk_lookup(
             #
             # Spawning the sentinel must happen *after* `await
             # http_request.json()` above has fully consumed the request body —
-            # _watch_disconnect awaits `request.receive()`, which would
+            # watch_disconnect awaits `request.receive()`, which would
             # otherwise swallow `http.request` body messages the body parser
             # needs.
             gather_future = asyncio.gather(
                 *(_run_one(i, item) for i, item in enumerate(request.items))
             )
             sentinel_task = asyncio.create_task(
-                _watch_disconnect(http_request),
+                watch_disconnect(http_request),
                 name="lml.bulk.disconnect_sentinel",
             )
             waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
@@ -441,8 +393,8 @@ async def handle_bulk_lookup(
                 # the children must be drained, not just signalled — otherwise
                 # the semaphore permits this PR exists to release are still
                 # held while the cancellation propagates asynchronously.
-                await _cancel_and_drain(gather_future)
-                await _cancel_and_drain(sentinel_task)
+                await cancel_and_drain(gather_future)
+                await cancel_and_drain(sentinel_task)
                 raise
 
             client_aborted = sentinel_task in done and not gather_future.done()
@@ -453,7 +405,7 @@ async def handle_bulk_lookup(
                 # carries the bulk-specific context. Key-name asymmetry
                 # intentional.
                 sentry_sdk.set_tag("lml.client_aborted", "true")
-                await _cancel_and_drain(gather_future)
+                await cancel_and_drain(gather_future)
                 # Exit log fires for the abort branch too — operators see the
                 # batch size + abort reason without digging into Sentry.
                 logger.warning(
@@ -466,7 +418,7 @@ async def handle_bulk_lookup(
                 # counts would skew batch-completion analytics.
                 raise HTTPException(status_code=499, detail="client disconnected")
 
-            await _cancel_and_drain(sentinel_task)
+            await cancel_and_drain(sentinel_task)
             results = gather_future.result()
 
         _project_cache_stats_to_transaction(get_cache_stats())

--- a/tests/integration/test_release_identity.py
+++ b/tests/integration/test_release_identity.py
@@ -272,6 +272,108 @@ class TestReleaseIdentityStore:
         assert len(log_rows) == 1
 
 
+@pytest.mark.pg
+class TestGetReleaseIdentityProvenanceBulk:
+    """LML#525: bulk read that powers the cache-refresh dispatcher.
+
+    The dispatcher takes a batch of ``identity_id``s and needs to know which
+    ``(source, external_id)`` pairs each one carries, so it can fan out to the
+    per-source release-cache refresh paths. The store method reads each row's
+    per-source columns and returns them as a dict keyed by ``identity_id``.
+
+    Missing identity_ids are **absent** from the dict (not None-valued) — the
+    router renders absence as ``status = "not_found"``. External IDs are
+    stringified at the boundary so the router doesn't have to branch on
+    int-vs-str when serializing per-source outcomes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_dict(self, pg_source):
+        store = EntityStore(pg_source)
+        assert await store.get_release_identity_provenance_bulk([]) == {}
+
+    @pytest.mark.asyncio
+    async def test_single_discogs_release_returns_one_pair(self, pg_source):
+        store = EntityStore(pg_source)
+        identity_id, _ = await store.mint_or_get_release_identity(
+            source="discogs_release", external_id="12345"
+        )
+        result = await store.get_release_identity_provenance_bulk([identity_id])
+        assert result == {identity_id: [("discogs_release", "12345")]}
+
+    @pytest.mark.asyncio
+    async def test_row_with_both_discogs_release_and_master_returns_both_pairs(self, pg_source):
+        """A single row can carry multiple per-source IDs (cross-source join, LML#207)."""
+        store = EntityStore(pg_source)
+        # Mint via discogs_release first, then directly UPDATE the master column
+        # — emulates the LML#207 joiner setting both columns on one row.
+        identity_id, _ = await store.mint_or_get_release_identity(
+            source="discogs_release", external_id="12345"
+        )
+        await pg_source.execute(
+            "UPDATE entity.release_identity SET discogs_master_id = $1 WHERE id = $2",
+            789,
+            identity_id,
+        )
+        result = await store.get_release_identity_provenance_bulk([identity_id])
+        assert set(result[identity_id]) == {
+            ("discogs_release", "12345"),
+            ("discogs_master", "789"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_row_with_text_sources_returns_string_external_ids(self, pg_source):
+        """TEXT-typed columns (Bandcamp URL, MBID, Spotify) round-trip as strings."""
+        store = EntityStore(pg_source)
+        url = "https://autechre.bandcamp.com/album/confield"
+        identity_id, _ = await store.mint_or_get_release_identity(
+            source="bandcamp", external_id=url
+        )
+        # Hand-populate the TEXT-shaped sources that have no mint helper today
+        # (musicbrainz_release / spotify_album / apple_music_album are
+        # LML#217-era follow-ups, but the store method should already be able
+        # to read them since the columns exist on the table).
+        await pg_source.execute(
+            "UPDATE entity.release_identity "
+            "SET musicbrainz_release_id = $1, spotify_album_id = $2, apple_music_album_id = $3 "
+            "WHERE id = $4",
+            "mbid-abc",
+            "spotify-xyz",
+            "apple-456",
+            identity_id,
+        )
+        result = await store.get_release_identity_provenance_bulk([identity_id])
+        assert set(result[identity_id]) == {
+            ("bandcamp", url),
+            ("musicbrainz_release", "mbid-abc"),
+            ("spotify_album", "spotify-xyz"),
+            ("apple_music_album", "apple-456"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_ids_are_absent_not_none(self, pg_source):
+        store = EntityStore(pg_source)
+        identity_id, _ = await store.mint_or_get_release_identity(
+            source="discogs_release", external_id="111"
+        )
+        result = await store.get_release_identity_provenance_bulk([identity_id, 99_999])
+        assert identity_id in result
+        assert 99_999 not in result
+
+    @pytest.mark.asyncio
+    async def test_multi_id_input_returns_one_entry_per_existing_row(self, pg_source):
+        store = EntityStore(pg_source)
+        id_a, _ = await store.mint_or_get_release_identity("discogs_release", "111")
+        id_b, _ = await store.mint_or_get_release_identity("discogs_release", "222")
+        id_c, _ = await store.mint_or_get_release_identity(
+            "bandcamp", "https://x.bandcamp.com/album/y"
+        )
+        result = await store.get_release_identity_provenance_bulk([id_a, id_b, id_c])
+        assert result[id_a] == [("discogs_release", "111")]
+        assert result[id_b] == [("discogs_release", "222")]
+        assert result[id_c] == [("bandcamp", "https://x.bandcamp.com/album/y")]
+
+
 @pytest_asyncio.fixture
 async def app_client(monkeypatch):
     """ASGI client with the LML app pointed at the test PG.

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -399,7 +399,7 @@ class TestBulkLookupEndpoint:
     ):
         """Garbage in `LML_BULK_MAX_CONCURRENT` must fall back to the default + warn.
 
-        Pins the contract documented at `_max_concurrency_from_env`: a misconfigured
+        Pins the contract documented at `max_concurrency_from_env`: a misconfigured
         env var doesn't blow up the route, it warns and uses the default.
         """
         import logging
@@ -648,7 +648,7 @@ class TestBulkLookupClientAbort:
     on disconnect, the handler cancels in-flight items, releases permits, and
     short-circuits with HTTP 499.
 
-    Tests patch ``_watch_disconnect`` directly; the receive-channel mechanism
+    Tests patch ``watch_disconnect`` directly; the receive-channel mechanism
     is exercised in production by uvicorn.
     """
 
@@ -699,7 +699,7 @@ class TestBulkLookupClientAbort:
                     new_callable=AsyncMock,
                     side_effect=slow_lookup,
                 ) as mock_lookup,
-                patch("lookup.router._watch_disconnect", self._disconnect_after()),
+                patch("lookup.router.watch_disconnect", self._disconnect_after()),
             ):
                 async with AsyncClient(
                     transport=ASGITransport(app=app), base_url="http://test"
@@ -754,7 +754,7 @@ class TestBulkLookupClientAbort:
                 new_callable=AsyncMock,
                 side_effect=slow_lookup,
             ),
-            patch("lookup.router._watch_disconnect", self._disconnect_after()),
+            patch("lookup.router.watch_disconnect", self._disconnect_after()),
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app_client), base_url="http://test"
@@ -798,7 +798,7 @@ class TestBulkLookupClientAbort:
                 new_callable=AsyncMock,
                 side_effect=slow_lookup,
             ),
-            patch("lookup.router._watch_disconnect", self._disconnect_after()),
+            patch("lookup.router.watch_disconnect", self._disconnect_after()),
             patch("lookup.router.sentry_sdk.set_tag", side_effect=capture_tag),
         ):
             async with AsyncClient(


### PR DESCRIPTION
## Summary

Adds `EntityStore.get_release_identity_provenance_bulk(identity_ids: list[int]) -> dict[int, list[tuple[str, str]]]` — one PG round-trip that resolves a batch of `entity.release_identity.id` values to their per-source `(source, external_id)` pairs.

Reads the `entity.release_identity` row directly (the per-source UNIQUE columns already carry the canonical projection) rather than the reconciliation log. The reconciliation log is reserved for cases where multi-version provenance per source matters; cache warming doesn't need it.

Missing identity_ids are **absent** from the returned dict (not None-valued) so the LML#525 dispatcher can render absence as `status = \"not_found\"`. External IDs are stringified at the boundary so callers don't have to branch on int-vs-str when serializing per-source outcomes.

SQL idiom mirrors the existing `_BULK_GET_IDENTITY_EXACT_SQL`: `WHERE id = ANY(\$1::int[])` against the PK index. The column→source mapping is hoisted to a module-level tuple so adding a future source means one new entry rather than retrofitting an if-chain.

## Stacked context

This is **PR B of 3** for LML#525:

- **A** ([#557](https://github.com/WXYC/library-metadata-lookup/pull/557)) → main: concurrency hoist
- **B (this PR)** → A: this store method
- **C** → B: the endpoint itself

This PR's diff against base only shows the store change; the lookup-router hoist is in PR A.

## Test plan

- [x] 6 new PG integration tests in `tests/integration/test_release_identity.py` cover: empty input, single-source row, multi-source row (`discogs_release` + `discogs_master` on the same row, simulating the LML#207 cross-source joiner's output), TEXT-shaped sources (mbid / spotify / apple_music round-tripped as strings), missing-ids absent contract, and multi-id input.
- [x] `pytest -m pg tests/integration/test_release_identity.py::TestGetReleaseIdentityProvenanceBulk` — 6 passed against local PG.
- [x] `ruff check .` + `ruff format --check .` clean.
- [ ] CI: PG + Lint + Type Check.

Part of #525.