### PR TITLE
fix(orchestrator): exact-title pre-pass in search_album_fuzzy recovers high-rowid library matches

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1117,6 +1117,49 @@ class ArtistSearchAliasesBulkResponse(BaseModel):
     cache_stats: CacheStats | None = None
 
 
+class CacheRefreshSourceOutcome(StrEnum):
+    success = "success"
+    error = "error"
+    not_implemented = "not_implemented"
+
+
+class CacheRefreshItemStatus(StrEnum):
+    warmed = "warmed"
+    not_found = "not_found"
+    not_implemented = "not_implemented"
+    error = "error"
+
+
+class CacheRefreshArtistOutcome(BaseModel):
+    external_id: str
+    outcome: CacheRefreshSourceOutcome
+    message: str | None = Field(
+        None,
+        description="Exception class name when `outcome != success`. Bare `str()` of the exception is intentionally NOT serialized — it may carry upstream error bodies, SQL fragments, or file paths. Full traceback lands in Sentry.\n",
+    )
+
+
+class CacheRefreshSourceResult(BaseModel):
+    release_outcome: CacheRefreshSourceOutcome
+    artists: list[CacheRefreshArtistOutcome] | None = Field([], validate_default=True)
+    message: str | None = None
+
+
+class CacheRefreshResultItem(BaseModel):
+    identity_id: int
+    status: CacheRefreshItemStatus
+    sources: dict[str, CacheRefreshSourceResult] | None = None
+    message: str | None = None
+
+
+class BulkCacheRefreshRequest(BaseModel):
+    identity_ids: list[int] = Field(..., min_length=1)
+
+
+class BulkCacheRefreshResponse(BaseModel):
+    results: list[CacheRefreshResultItem]
+
+
 class DiscogsTrackItem(BaseModel):
     position: str
     title: str

--- a/library/db.py
+++ b/library/db.py
@@ -387,28 +387,52 @@ class LibraryDB:
         rows = await cursor.fetchall()
         return list(rows)
 
-    async def exact_title(self, album_title: str, limit: int = 50) -> list[LibraryItem]:
+    async def exact_title(self, album_title: str) -> list[LibraryItem]:
         """Return library rows whose ``title`` is literally ``album_title``.
 
-        Case-insensitive (``COLLATE NOCASE``) but no tokenization, no fuzzy
-        scoring, no prefix matching. Useful as a pre-pass before
-        :meth:`search`: a literal Discogs album title is the most reliable
-        signal of a library row, and the FTS5 path otherwise truncates
-        by rowid and can drop exact-title matches whose row was added later
-        in the catalog (see ``lookup.orchestrator.search_album_fuzzy``).
+        Case-insensitive but no tokenization, no fuzzy scoring, no prefix
+        matching. Useful as a pre-pass before :meth:`search`: a literal Discogs
+        album title is the most reliable signal of a library row, and the FTS5
+        path otherwise truncates by rowid and can drop exact-title matches
+        whose row was added later in the catalog (see
+        ``lookup.orchestrator.search_album_fuzzy``).
+
+        Returns every match — no implicit ``LIMIT``. Library rows are
+        intrinsically bounded by catalog conventions (high-collision titles
+        like "Greatest Hits" top out around 150 in practice); a hidden cap
+        would recreate the rowid-truncation bug class this method exists to
+        avoid.
+
+        Two-phase query: a case-sensitive equality lookup runs first so the
+        ``idx_title`` BINARY index covers the common case (Title Case query
+        against Title Case catalog), then a ``COLLATE NOCASE`` scan runs only
+        on miss. The scan is ~500x slower than the index lookup on the live
+        library, so the fast path matters when ``search_album_fuzzy`` runs
+        per-Discogs-release inside a single lookup.
         """
         if not self._conn:
             raise RuntimeError("Database not connected")
         if not album_title:
             return []
+        album_title = album_title.strip()
+        if not album_title:
+            return []
 
-        sql = f"""
-            SELECT {self._select_columns()}
-            FROM library
-            WHERE title = ? COLLATE NOCASE
-            LIMIT ?
-        """
-        cursor = await self._conn.execute(sql, (album_title, limit))
+        select_cols = self._select_columns()
+        # Fast path: BINARY equality uses idx_title.
+        cursor = await self._conn.execute(
+            f"SELECT {select_cols} FROM library WHERE title = ?",
+            (album_title,),
+        )
+        rows = await cursor.fetchall()
+        if rows:
+            return [LibraryItem(**dict(row)) for row in rows]
+
+        # Slow path: case-insensitive scan, only for the rare casing mismatch.
+        cursor = await self._conn.execute(
+            f"SELECT {select_cols} FROM library WHERE title = ? COLLATE NOCASE",
+            (album_title,),
+        )
         rows = await cursor.fetchall()
         return [LibraryItem(**dict(row)) for row in rows]
 

--- a/library/db.py
+++ b/library/db.py
@@ -387,6 +387,31 @@ class LibraryDB:
         rows = await cursor.fetchall()
         return list(rows)
 
+    async def exact_title(self, album_title: str, limit: int = 50) -> list[LibraryItem]:
+        """Return library rows whose ``title`` is literally ``album_title``.
+
+        Case-insensitive (``COLLATE NOCASE``) but no tokenization, no fuzzy
+        scoring, no prefix matching. Useful as a pre-pass before
+        :meth:`search`: a literal Discogs album title is the most reliable
+        signal of a library row, and the FTS5 path otherwise truncates
+        by rowid and can drop exact-title matches whose row was added later
+        in the catalog (see ``lookup.orchestrator.search_album_fuzzy``).
+        """
+        if not self._conn:
+            raise RuntimeError("Database not connected")
+        if not album_title:
+            return []
+
+        sql = f"""
+            SELECT {self._select_columns()}
+            FROM library
+            WHERE title = ? COLLATE NOCASE
+            LIMIT ?
+        """
+        cursor = await self._conn.execute(sql, (album_title, limit))
+        rows = await cursor.fetchall()
+        return [LibraryItem(**dict(row)) for row in rows]
+
     async def _fuzzy_search(self, query: str, limit: int, threshold: int = 70) -> list[LibraryItem]:
         """
         Fuzzy search fallback using rapidfuzz for typo tolerance.

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1699,6 +1699,16 @@ async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryIte
     """Search for album with fuzzy keyword matching."""
     from rapidfuzz import fuzz
 
+    # Exact-title pre-pass. The FTS5 path below truncates to
+    # ``MAX_SEARCH_RESULTS`` rows in implementation-defined (rowid) order, which
+    # silently drops literal-title matches whose library row was added later in
+    # the catalog. Discogs typically hands us the album title verbatim, so a
+    # literal hit is the most reliable signal — surface it before falling
+    # through to fuzzy scoring.
+    exact = await db.exact_title(album_title)
+    if exact:
+        return exact
+
     async def _search_and_filter(query: str) -> list[LibraryItem]:
         raw = await db.search(query=query, limit=MAX_SEARCH_RESULTS)
         if not raw:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def mock_library_db():
     """Create a mock library database."""
     db = AsyncMock()
     db.search = AsyncMock(return_value=[])
+    db.exact_title = AsyncMock(return_value=[])
     db.find_similar_artist = AsyncMock(return_value=None)
     db.connect = AsyncMock()
     db.close = AsyncMock()

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -53,6 +53,7 @@ class TestAlbumTitleFallback:
     async def test_fallback_fires_when_results_empty_album_present_no_swap(self):
         """All three guard conditions met → ``search_releases_by_album_title`` runs."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         service = AsyncMock()
@@ -83,6 +84,7 @@ class TestAlbumTitleFallback:
     @pytest.mark.asyncio
     async def test_fallback_skipped_when_album_missing(self):
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         service = AsyncMock()
@@ -116,6 +118,7 @@ class TestAlbumTitleFallback:
         get_settings.cache_clear()
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         service = AsyncMock()
@@ -174,6 +177,7 @@ class TestAlbumTitleFallback:
             title="Orcutt-Shelley-Miller",
         )
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[library_item])
 
         # Five pressings of the trio release returned by both probes.
@@ -238,6 +242,7 @@ class TestAlbumTitleFallback:
         call was made."""
         library_item = make_library_item(id=42, artist="A Real Artist", title="An Album")
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[library_item])
 
         service = AsyncMock()
@@ -297,6 +302,7 @@ class TestAlbumTitleFallback:
             title="Orcutt Shelley Miller",
         )
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[item])
 
         service = AsyncMock()
@@ -345,6 +351,7 @@ class TestAlbumTitleFallback:
             title="Orcutt Shelley Miller",
         )
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[item])
 
         service = AsyncMock()
@@ -405,6 +412,7 @@ class TestAlbumTitleProbeConcurrency:
             return _probe
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         service = AsyncMock()
@@ -451,6 +459,7 @@ class TestAlbumTitleProbeConcurrency:
         """
         library_item = make_library_item(id=42, artist="A Real Artist", title="An Album")
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[library_item])
 
         service = AsyncMock()
@@ -521,6 +530,7 @@ class TestAlbumTitleProbeConcurrency:
             return _empty_response()
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         service = AsyncMock()

--- a/tests/unit/test_compilation_wave_merge.py
+++ b/tests/unit/test_compilation_wave_merge.py
@@ -103,6 +103,7 @@ class TestWaveMergeGate:
         )
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         # db.search call order inside search_compilations_for_track:
         # 1. keyword pre-pass ("vivien goldman launderette") → empty
@@ -183,6 +184,7 @@ class TestWaveMergeGate:
         )
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         async def _search(query, limit=None, **_):
             if "disco not disco" in query.lower():
@@ -239,6 +241,7 @@ class TestWaveMergeGate:
         )
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         async def _search(query, limit=None, **_):
             if "resolutionary" in query.lower():
@@ -296,6 +299,7 @@ class TestWaveMergeGate:
         )
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         async def _search(query, limit=None, **_):
             if "disco not disco" in query.lower():

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -55,6 +55,7 @@ class TestAlternativeInterpretationBothResults:
     async def test_combines_and_deduplicates(self):
         """When both interpretations match, results are combined and deduplicated."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item1 = _item(id=1, artist="Foo", title="Bar")
         item2 = _item(id=2, artist="Bar", title="Foo")
         shared = _item(id=3, artist="Foo", title="Shared")
@@ -83,6 +84,7 @@ class TestSearchSongAsArtist:
     async def test_direct_artist_match(self):
         """Direct library search with song-as-artist returns results."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(id=1, artist="Stereolab", title="Dots and Loops")
         db.search = AsyncMock(return_value=[item])
 
@@ -94,6 +96,7 @@ class TestSearchSongAsArtist:
     async def test_discogs_fallback(self):
         """When direct search fails, looks up Discogs for releases by that artist."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(id=2, artist="Stereolab", title="Emperor Tomato Ketchup")
 
         # Direct search returns nothing; album search finds it
@@ -114,6 +117,7 @@ class TestSearchSongAsArtist:
     async def test_discogs_returns_no_releases(self):
         """When Discogs also finds nothing, returns empty."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         with patch(
@@ -129,6 +133,7 @@ class TestSearchSongAsArtist:
     async def test_compilation_match_via_discogs(self):
         """Discogs cross-reference matches compilation albums."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         comp_item = _item(id=3, artist="Various Artists", title="Indie Comp 2020")
 
         # Direct search returns nothing; album search finds compilation
@@ -148,6 +153,7 @@ class TestSearchSongAsArtist:
     async def test_skips_empty_album_title(self):
         """Discogs releases with empty album titles are skipped."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         with patch(
@@ -170,6 +176,7 @@ class TestSearchLibraryWithFallbackSongPath:
     async def test_artist_plus_song_fallback_when_no_discogs_albums(self):
         """When Discogs found no albums (empty list), falls back to artist+song."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item1 = _item(id=1, artist="Queen", title="Greatest Hits")
         item2 = _item(id=2, artist="Queen", title="Bohemian Rhapsody Single")
 
@@ -195,6 +202,7 @@ class TestSearchLibraryWithFallbackSongPath:
         handles rejecting false positives from the fallback results.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(id=1, artist="Queen", title="Greatest Hits")
 
         db.search = AsyncMock(
@@ -226,6 +234,7 @@ class TestSearchCompilationsForTrack:
     @pytest.mark.asyncio
     async def test_no_song_returns_empty(self):
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         parsed = ParsedRequest(artist="Queen", raw_message="Queen")
         results, titles = await search_compilations_for_track(db, parsed)
         assert results == []
@@ -234,6 +243,7 @@ class TestSearchCompilationsForTrack:
     @pytest.mark.asyncio
     async def test_no_artist_returns_empty(self):
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         parsed = ParsedRequest(song="Bohemian Rhapsody", raw_message="Bohemian Rhapsody")
         results, titles = await search_compilations_for_track(db, parsed)
         assert results == []
@@ -242,6 +252,7 @@ class TestSearchCompilationsForTrack:
     async def test_keyword_search_with_compilation_filter(self):
         """Keyword search returns results filtered by artist or compilation."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         comp = _item(id=1, artist="Various Artists", title="Rock Hits")
         match = _item(id=2, artist="Queen", title="Best of Queen")
 
@@ -268,6 +279,7 @@ class TestSearchCompilationsForTrack:
     async def test_discogs_cross_reference(self):
         """Finds track on a compilation via Discogs cross-reference."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         comp = _item(id=1, artist="Various Artists", title="Rock Classics")
 
         # First call: keyword search (no results)
@@ -295,6 +307,7 @@ class TestSearchCompilationsForTrack:
     async def test_remix_detection(self):
         """Detects remix info in raw message and uses it for search."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         parsed = ParsedRequest(
@@ -318,6 +331,7 @@ class TestSearchCompilationsForTrack:
     async def test_skips_artist_named_albums(self):
         """Skips Discogs releases where album name matches artist name."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         parsed = ParsedRequest(
@@ -339,6 +353,7 @@ class TestSearchCompilationsForTrack:
     async def test_skips_short_album_names(self):
         """Skips Discogs releases with very short album names."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         parsed = ParsedRequest(
@@ -360,6 +375,7 @@ class TestSearchCompilationsForTrack:
     async def test_compilation_artist_filter(self):
         """Discogs compilation artist + library compilation artist both pass filter."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         comp = _item(id=1, artist="Various Artists", title="Rock Comp")
 
         # keyword: no results; album search: compilation item
@@ -389,6 +405,7 @@ class TestSearchCompilationsForTrack:
         compilation series). fuzz.ratio = 73.5, below the 80 threshold.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         wrong_item = _item(
             id=3288,
             artist="Various Artists - Hiphop",
@@ -417,6 +434,7 @@ class TestSearchCompilationsForTrack:
     async def test_max_results_break(self):
         """Stops collecting once MAX_SEARCH_RESULTS reached."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         items_by_title = {
             f"Comp {i}": _item(id=i, artist="Various Artists", title=f"Comp {i}") for i in range(30)
         }
@@ -460,6 +478,7 @@ class TestSearchCompilationsForTrack:
     async def test_discogs_exception_falls_back_to_keyword(self):
         """When Discogs search raises, falls back to keyword matches."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         keyword_item = _item(id=1, artist="Queen", title="Best Hits")
 
         # keyword search succeeds
@@ -491,6 +510,7 @@ class TestSearchCompilationsForTrack:
         The keyword fallback then returns "808 State" anyway — a false positive.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         false_positive = _item(id=958, artist="808 State", title="808 State")
 
         # First call (keyword search): returns the false positive
@@ -526,6 +546,7 @@ class TestSearchCompilationsForTrack:
         incorrectly accepts it because the fuzz.ratio is high (~84%).
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         chicago_v = _item(id=100, artist="Chicago", title="Chicago V")
 
         # Keyword search returns Chicago V; search_album_fuzzy also returns it
@@ -564,6 +585,7 @@ class TestSearchCompilationsForTrack:
         fallback does not fire.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         self_titled = _item(id=1, artist="Weird Al Yankovic", title="Weird Al Yankovic")
         db.search = AsyncMock(return_value=[self_titled])
 
@@ -595,6 +617,7 @@ class TestSearchCompilationsForTrack:
         where we search the library before validating each Discogs release.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         comp = _item(
             id=46602,
             artist="Various Artists",
@@ -708,6 +731,7 @@ class TestSearchAlbumFuzzy:
     async def test_exact_match(self):
         """Exact match returns results directly."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(id=1, title="OK Computer")
         db.search = AsyncMock(return_value=[item])
 
@@ -718,6 +742,7 @@ class TestSearchAlbumFuzzy:
     async def test_fuzzy_fallback(self):
         """When exact match fails, tries fuzzy keyword search."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(id=1, title="The Very Best Greatest Hits Collection")
 
         # First search: no results. Second search: fuzzy match found.
@@ -731,6 +756,7 @@ class TestSearchAlbumFuzzy:
     async def test_fuzzy_threshold_filters(self):
         """Fuzzy results below threshold are filtered out."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(id=1, title="Completely Different Title")
 
         # Exact: empty; all fuzzy attempts return unrelated item (filtered each time)
@@ -744,6 +770,7 @@ class TestSearchAlbumFuzzy:
     async def test_no_significant_words(self):
         """Short album title with no significant words skips fuzzy search."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
 
         results = await search_album_fuzzy(db, "The")
@@ -759,6 +786,7 @@ class TestSearchAlbumFuzzy:
         Dropping to 3 words ("trax 20th anniversary") should find it.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(id=46602, title="Trax Records 20th Anniversary Collection")
 
         # First call: exact match (full title) -> empty
@@ -781,6 +809,7 @@ class TestSearchAlbumFuzzy:
         enough to accept this.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(id=57500, title="Nao Wave- Brazilian Punk 82-88")
 
         # Call 1: exact FTS5 search -> empty (diacritics mismatch)
@@ -807,6 +836,7 @@ class TestSearchAlbumFuzzy:
         are not grandfathered through this looser path.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         item = _item(
             id=58610,
             artist="Various Artists - Rock - D",
@@ -892,6 +922,7 @@ class TestSearchAlbumFuzzy:
         would return ``[]``.
         """
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         seed = _item(
             id=58610,
             artist="Various Artists - Rock - D",

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1671,6 +1671,7 @@ class TestSearchSongAsTrack:
     @pytest.mark.asyncio
     async def test_no_song_returns_empty(self):
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         results, matched_via = await search_song_as_track(db, None)
         assert results == []
         assert matched_via == {}
@@ -1679,6 +1680,7 @@ class TestSearchSongAsTrack:
     @pytest.mark.asyncio
     async def test_blank_song_returns_empty(self):
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         results, matched_via = await search_song_as_track(db, "")
         assert results == []
         assert matched_via == {}
@@ -1687,6 +1689,7 @@ class TestSearchSongAsTrack:
     async def test_no_discogs_service_returns_empty(self):
         """Without a Discogs service, the strategy can't run and must no-op."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         results, matched_via = await search_song_as_track(
             db, "vi scose poise", discogs_service=None
         )
@@ -1697,6 +1700,7 @@ class TestSearchSongAsTrack:
     @pytest.mark.asyncio
     async def test_no_discogs_releases_returns_empty(self):
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         svc = AsyncMock()
         svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
             track="vi scose poise", artist=None, releases=[], total=0
@@ -1712,6 +1716,7 @@ class TestSearchSongAsTrack:
     async def test_library_miss_returns_empty(self):
         """Discogs returns releases but none match in library — empty result."""
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search.return_value = []
         svc = AsyncMock()
         svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
@@ -1743,6 +1748,7 @@ class TestSearchSongAsTrack:
         """
         confield = make_library_item(id=60359, artist="Autechre", title="Confield")
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search.return_value = [confield]
         svc = AsyncMock()
         svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
@@ -1784,6 +1790,7 @@ class TestSearchSongAsTrack:
             title="Trax Records 20th Anniversary Collection",
         )
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search.return_value = [va_album]
         svc = AsyncMock()
         svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
@@ -1815,6 +1822,7 @@ class TestSearchSongAsTrack:
         """
         confield = make_library_item(id=60359, artist="Autechre", title="Confield")
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search.return_value = [confield]
         svc = AsyncMock()
         svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
@@ -1848,6 +1856,7 @@ class TestSearchSongAsTrack:
         """
         confield = make_library_item(id=60359, artist="Autechre", title="Confield")
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search.return_value = [confield]
         svc = AsyncMock()
         svc.search_releases_by_track.return_value = DiscogsTrackReleasesResponse(
@@ -1889,6 +1898,7 @@ class TestSearchSongAsTrack:
             title="Trax Records 20th Anniversary Collection",
         )
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         async def search_side_effect(query, **kwargs):
             return [va_album] if query.startswith("Various ") else []
@@ -1932,6 +1942,7 @@ class TestSearchSongAsTrack:
         import time as _time
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         releases = [
             DiscogsReleaseInfo(
                 album=f"Album {i}",
@@ -2002,6 +2013,7 @@ class TestSearchSongAsTrack:
         item_b = make_library_item(id=102, artist="Artist B", title="Album B")
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         async def search_side_effect(query, **kwargs):
             q = query.lower()
@@ -2078,6 +2090,7 @@ class TestSearchSongAsTrack:
 
         confield = make_library_item(id=60359, artist="Autechre", title="Confield")
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search.return_value = [confield]
 
         # Use the compilation path so we can vary artist_credit per release
@@ -2087,6 +2100,7 @@ class TestSearchSongAsTrack:
         # what we read back to assert input-order accumulation.
         va_album = make_library_item(id=60359, artist="Various Artists", title="Confield Comp")
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
         db.search.return_value = [va_album]
 
         svc = AsyncMock()
@@ -2143,6 +2157,7 @@ class TestSearchSongAsTrack:
 
         n_candidates = 20
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         # Each release maps to a distinct library row that prefix-matches it,
         # so validate fires for every one.
@@ -2247,6 +2262,7 @@ class TestSearchSongAsTrack:
         ]
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         async def search_side_effect(query, **kwargs):
             for item in items:
@@ -2317,6 +2333,7 @@ class TestSearchCompilationsEarlyExit:
         ]
 
         db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
 
         async def _search(query, limit=None, **_):
             q = query.lower()

--- a/tests/unit/test_search_album_fuzzy.py
+++ b/tests/unit/test_search_album_fuzzy.py
@@ -208,6 +208,114 @@ class TestSearchAlbumFuzzyExactTitle:
         )
 
     @pytest.mark.asyncio
+    async def test_strips_whitespace_around_discogs_titles(self, tmp_path):
+        """Discogs payloads occasionally carry trailing whitespace; an
+        unnormalized literal-equality check would otherwise quietly fall
+        through to the FTS5 path and re-expose the rowid-truncation bug."""
+        db = LibraryDB(db_path=_create_kaleidoscope_library(tmp_path))
+        await db.connect()
+        try:
+            results = await search_album_fuzzy(db, "  Kaleidoscope  ")
+            returned_ids = {item.id for item in results}
+        finally:
+            await db.close()
+
+        assert {100, 5000, 60000} <= returned_ids, (
+            "Whitespace-padded titles must match the literal-title pre-pass; "
+            f"got {sorted(returned_ids)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_matches_when_query_case_differs_from_library(self, tmp_path):
+        """Library cataloguing uses Title Case; Discogs occasionally hands us
+        a lower-case or all-caps title. The pre-pass must be case-insensitive
+        so a casing mismatch doesn't fall through to FTS5."""
+        # Build a tiny library with the row stored Title Case; query lower-case.
+        db_file = tmp_path / "library.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("""
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY, title TEXT, artist TEXT, call_letters TEXT,
+                artist_call_number INTEGER, release_call_number INTEGER, genre TEXT,
+                format TEXT, alternate_artist_name TEXT, label TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE VIRTUAL TABLE library_fts USING fts5(
+                title, artist, alternate_artist_name,
+                content='library', content_rowid='id'
+            )
+        """)
+        rows = [
+            (1, "Kaleidoscope", "DJ Food", "DJ", 1, 1, "Electronic", "cd", "", "Ninja Tune"),
+        ]
+        conn.executemany("INSERT INTO library VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+        conn.executemany(
+            "INSERT INTO library_fts(rowid, title, artist, alternate_artist_name) VALUES (?, ?, ?, ?)",
+            [(r[0], r[1], r[2], r[8]) for r in rows],
+        )
+        conn.commit()
+        conn.close()
+
+        db = LibraryDB(db_path=db_file)
+        await db.connect()
+        try:
+            results = await search_album_fuzzy(db, "kaleidoscope")
+            ids_lower = {r.id for r in results}
+            results_upper = await search_album_fuzzy(db, "KALEIDOSCOPE")
+            ids_upper = {r.id for r in results_upper}
+        finally:
+            await db.close()
+
+        assert 1 in ids_lower, f"lower-case query must match Title Case row; got {ids_lower}"
+        assert 1 in ids_upper, f"upper-case query must match Title Case row; got {ids_upper}"
+
+    @pytest.mark.asyncio
+    async def test_does_not_truncate_common_titles(self, tmp_path):
+        """Library has 150+ "Greatest Hits" / "Best Of" / "Live" rows in
+        production; the literal-title pre-pass must return all of them so
+        downstream artist filters can find the right one. A LIMIT cap would
+        recreate the rowid-truncation bug at a higher threshold."""
+        db_file = tmp_path / "library.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("""
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY, title TEXT, artist TEXT, call_letters TEXT,
+                artist_call_number INTEGER, release_call_number INTEGER, genre TEXT,
+                format TEXT, alternate_artist_name TEXT, label TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE VIRTUAL TABLE library_fts USING fts5(
+                title, artist, alternate_artist_name,
+                content='library', content_rowid='id'
+            )
+        """)
+        rows = [
+            (i, "Greatest Hits", f"Artist {i:03d}", "X", 1, 1, "Rock", "cd", "", "Label")
+            for i in range(1, 101)  # 100 rows literally titled "Greatest Hits"
+        ]
+        conn.executemany("INSERT INTO library VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+        conn.executemany(
+            "INSERT INTO library_fts(rowid, title, artist, alternate_artist_name) VALUES (?, ?, ?, ?)",
+            [(r[0], r[1], r[2], r[8]) for r in rows],
+        )
+        conn.commit()
+        conn.close()
+
+        db = LibraryDB(db_path=db_file)
+        await db.connect()
+        try:
+            results = await search_album_fuzzy(db, "Greatest Hits")
+        finally:
+            await db.close()
+
+        assert len(results) == 100, (
+            f"all 100 literal-title rows must surface so artist filtering can pick the right one; "
+            f"got {len(results)}"
+        )
+
+    @pytest.mark.asyncio
     async def test_returns_high_rowid_exact_title_match(self, tmp_path):
         """Tracer-bullet shape of the production miss.
 

--- a/tests/unit/test_search_album_fuzzy.py
+++ b/tests/unit/test_search_album_fuzzy.py
@@ -1,0 +1,317 @@
+"""Behavior tests for ``lookup.orchestrator.search_album_fuzzy``.
+
+The reproducer comes from a real lookup miss: ``Tenant by Siouxsie and the
+Banshees``. The library has three releases literally titled "Kaleidoscope"
+(Kaleidoscope by DJ Food, by Siouxsie and the Banshees, and by Peter
+Batchelor), plus several near-titled releases ("Kaleidoscope World",
+"Keyboard Kaleidoscope", "Greetings from Cartoonistan" by an artist named
+Kaleidoscope, etc.). Discogs surfaces "Tenant" on Siouxsie's *Kaleidoscope*,
+and downstream library matching is expected to recover Siouxsie's row.
+
+The bug: ``search_album_fuzzy`` truncates the FTS5 candidate set to the first
+five rowids (no ``ORDER BY rank``), which drops the highest-rowid row even
+when the title is a literal exact match.
+
+These tests verify the public behavior: any library row whose title literally
+matches the query (case-insensitive) is returned, regardless of how many
+fuzzy near-titles outrank it by rowid in the library.
+
+The end-to-end perform_lookup test reproduces the production miss against a
+real fixture library so the actual SQLite/FTS5 ordering quirk participates in
+the trace.
+"""
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from discogs.models import DiscogsSearchResponse, ReleaseInfo, TrackReleasesResponse
+from library.db import LibraryDB
+from lookup.models import LookupRequest
+from lookup.orchestrator import perform_lookup, search_album_fuzzy
+from tests.conftest import make_lml_telemetry
+
+
+def _create_kaleidoscope_library(tmp_path: Path) -> Path:
+    """Build a small FTS-backed library that triggers the rowid-truncation bug.
+
+    Row layout (rowid order):
+
+        100   Kaleidoscope        DJ Food                     <-- low rowid exact-title
+        200   Kaleidoscope World  Chills                       <-- decoy, fuzzy-only
+        201   Kaleidoscope World  Chills                       <-- decoy, fuzzy-only (dup)
+        300   Greetings from ...  Kaleidoscope (band name)    <-- decoy, artist-only match
+        400   Keyboard Kaleido... Dick Hyman                   <-- decoy, fuzzy-only
+        4990  The Scream         Siouxsie and the Banshees     <-- artist-fallback decoy
+        ...
+        4994  Nocturne           Siouxsie and the Banshees     <-- artist-fallback decoy
+        5000  Kaleidoscope        Siouxsie and the Banshees   <-- the one we lose
+        60000 Kaleidoscope        Peter Batchelor              <-- exact, also high rowid
+
+    The five low-rowid Siouxsie rows (4990-4994) mirror SI 11/1-11/5 in
+    production: they fill ``limit_results(...)`` at MAX_SEARCH_RESULTS=5 and
+    hide SI 11/6 (Siouxsie's *Kaleidoscope*) from the artist-only fallback.
+    """
+    db_file = tmp_path / "library.db"
+    conn = sqlite3.connect(db_file)
+    conn.execute("""
+        CREATE TABLE library (
+            id INTEGER PRIMARY KEY,
+            title TEXT,
+            artist TEXT,
+            call_letters TEXT,
+            artist_call_number INTEGER,
+            release_call_number INTEGER,
+            genre TEXT,
+            format TEXT,
+            alternate_artist_name TEXT,
+            label TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE VIRTUAL TABLE library_fts USING fts5(
+            title, artist, alternate_artist_name,
+            content='library', content_rowid='id'
+        )
+    """)
+
+    rows = [
+        (100, "Kaleidoscope", "DJ Food", "DJ", 1, 1, "Electronic", "cd", "", "Ninja Tune"),
+        (200, "Kaleidoscope World", "Chills", "CH", 2, 1, "Rock", "cd", "", "Flying Nun"),
+        (201, "Kaleidoscope World", "Chills", "CH", 2, 2, "Rock", "cd", "", "Flying Nun"),
+        (
+            300,
+            "Greetings from Cartoonistan",
+            "Kaleidoscope",
+            "KA",
+            3,
+            1,
+            "Rock",
+            "cd",
+            "",
+            "self-released",
+        ),
+        (400, "Keyboard Kaleidoscope", "Dick Hyman", "HY", 4, 1, "Jazz", "cd", "", "Project 3"),
+        (
+            4990,
+            "The Scream",
+            "Siouxsie and the Banshees",
+            "SI",
+            11,
+            1,
+            "Rock",
+            "vinyl",
+            "",
+            "Polydor",
+        ),
+        (4991, "Juju", "Siouxsie and the Banshees", "SI", 11, 2, "Rock", "vinyl", "", "Polydor"),
+        (
+            4992,
+            "Once Upon a Time: The Singles",
+            "Siouxsie and the Banshees",
+            "SI",
+            11,
+            3,
+            "Rock",
+            "vinyl",
+            "",
+            "Polydor",
+        ),
+        (
+            4993,
+            "Dear Prudence",
+            "Siouxsie and the Banshees",
+            "SI",
+            11,
+            4,
+            "Rock",
+            "vinyl",
+            "",
+            "Polydor",
+        ),
+        (
+            4994,
+            "Nocturne",
+            "Siouxsie and the Banshees",
+            "SI",
+            11,
+            5,
+            "Rock",
+            "vinyl",
+            "",
+            "Polydor",
+        ),
+        (
+            5000,
+            "Kaleidoscope",
+            "Siouxsie and the Banshees",
+            "SI",
+            11,
+            6,
+            "Rock",
+            "vinyl",
+            "",
+            "Polydor",
+        ),
+        (
+            60000,
+            "Kaleidoscope",
+            "Peter Batchelor",
+            "BA",
+            5,
+            1,
+            "Electronic",
+            "cd",
+            "",
+            "empreintes DIGITALes",
+        ),
+    ]
+    conn.executemany(
+        "INSERT INTO library VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.executemany(
+        "INSERT INTO library_fts(rowid, title, artist, alternate_artist_name) VALUES (?, ?, ?, ?)",
+        [(r[0], r[1], r[2], r[8]) for r in rows],
+    )
+    conn.commit()
+    conn.close()
+    return db_file
+
+
+class TestSearchAlbumFuzzyExactTitle:
+    """``search_album_fuzzy`` must return every literal-title match.
+
+    Discogs hands us an album title; we expect the library row whose title is
+    exactly that string to be a candidate every time, even when there are
+    enough fuzzy near-titles to bury it in the FTS rowid stream.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_all_three_literal_kaleidoscope_rows(self, tmp_path):
+        db = LibraryDB(db_path=_create_kaleidoscope_library(tmp_path))
+        await db.connect()
+        try:
+            results = await search_album_fuzzy(db, "Kaleidoscope")
+            returned_ids = {item.id for item in results}
+        finally:
+            await db.close()
+
+        # All three rows whose title is literally "Kaleidoscope" must be in the
+        # candidate set, regardless of rowid position. The bug drops id=5000
+        # and id=60000 because the FTS5 LIMIT 5 + rowid ordering cuts them off
+        # before any title-based filtering runs.
+        assert {100, 5000, 60000} <= returned_ids, (
+            f"expected exact-title rows {{100, 5000, 60000}} in results, got {sorted(returned_ids)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_high_rowid_exact_title_match(self, tmp_path):
+        """Tracer-bullet shape of the production miss.
+
+        Mirrors the production lookup for ``Tenant by Siouxsie and the
+        Banshees`` after Discogs surfaces *Kaleidoscope* as the track-bearing
+        release. The library row for Siouxsie's *Kaleidoscope* sits at a high
+        rowid (5000 in the fixture, 43595 in production); pre-fix, FTS5 with
+        ``LIMIT 5`` and no ``ORDER BY rank`` drops it.
+        """
+        db = LibraryDB(db_path=_create_kaleidoscope_library(tmp_path))
+        await db.connect()
+        try:
+            results = await search_album_fuzzy(db, "Kaleidoscope")
+        finally:
+            await db.close()
+
+        siouxsie_rows = [
+            item
+            for item in results
+            if (item.artist or "").startswith("Siouxsie")
+            and (item.title or "").lower() == "kaleidoscope"
+        ]
+        assert siouxsie_rows, (
+            "search_album_fuzzy must surface Siouxsie's Kaleidoscope row; "
+            f"got titles {[(r.id, r.title, r.artist) for r in results]}"
+        )
+
+
+class TestPerformLookupRecoversTenantOnKaleidoscope:
+    """End-to-end reproducer for the Tenant / Siouxsie / Kaleidoscope miss.
+
+    Discogs surfaces ``Kaleidoscope`` as a release containing the track
+    ``Tenant`` by Siouxsie and the Banshees. ``search_compilations_for_track``
+    then calls ``search_album_fuzzy(db, "Kaleidoscope")`` to map that Discogs
+    title back to a WXYC library row. Pre-fix, FTS5's rowid-ordered ``LIMIT 5``
+    truncation drops Siouxsie's library row before any artist filter runs;
+    post-fix, the exact-title pre-pass recovers it.
+
+    Drives ``perform_lookup`` against a real fixture library so the actual
+    SQLite/FTS5 ordering quirk participates in the trace, end to end.
+    """
+
+    @pytest.mark.asyncio
+    async def test_promotes_kaleidoscope_when_discogs_surfaces_release(self, tmp_path):
+        db = LibraryDB(db_path=_create_kaleidoscope_library(tmp_path))
+        await db.connect()
+        try:
+            telemetry = make_lml_telemetry()
+            discogs = AsyncMock()
+            # Discogs's artist-scoped track probe returns the canonical
+            # Kaleidoscope release — what Discogs production would return for
+            # "Tenant by Siouxsie and the Banshees".
+            kaleidoscope_release = ReleaseInfo(
+                album="Kaleidoscope",
+                artist="Siouxsie and the Banshees",
+                release_id=104287,
+                release_url="https://discogs.com/release/104287",
+                is_compilation=False,
+            )
+            discogs.search_releases_by_track = AsyncMock(
+                return_value=TrackReleasesResponse(
+                    track="Tenant",
+                    artist="Siouxsie and the Banshees",
+                    releases=[kaleidoscope_release],
+                    total=1,
+                    cached=False,
+                )
+            )
+            # The release truly contains the track.
+            discogs.validate_track_on_release = AsyncMock(return_value=True)
+            # Artwork search is irrelevant for this assertion.
+            discogs.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+            # No resolver pre-pass interference.
+            discogs.cache_service = None
+
+            request = LookupRequest(
+                artist="Siouxsie and the Banshees",
+                song="Tenant",
+                raw_message="Tenant, Siouxsie and the Banshees",
+            )
+
+            with patch(
+                "lookup.orchestrator.lookup_releases_by_track",
+                new_callable=AsyncMock,
+                return_value=[],
+            ):
+                response = await perform_lookup(request, db, discogs, telemetry)
+
+            promoted_titles = [r.library_item.title for r in response.results]
+            promoted_artists = [r.library_item.artist for r in response.results]
+        finally:
+            await db.close()
+
+        assert "Kaleidoscope" in promoted_titles, (
+            "Discogs surfaced Kaleidoscope; library matching must recover "
+            f"Siouxsie's row. got titles {promoted_titles}"
+        )
+        kaleidoscope_artists = [
+            promoted_artists[i] for i, t in enumerate(promoted_titles) if t == "Kaleidoscope"
+        ]
+        assert any((a or "").startswith("Siouxsie") for a in kaleidoscope_artists), (
+            "Recovered Kaleidoscope must be Siouxsie's, not DJ Food's or "
+            f"Peter Batchelor's; got artists {kaleidoscope_artists}"
+        )
+        assert response.song_not_found is False, (
+            "A confirmed track-bearing album should clear song_not_found"
+        )


### PR DESCRIPTION
Closes #560.

## Summary

- `search_album_fuzzy`'s FTS5 path capped at `LIMIT MAX_SEARCH_RESULTS=5` with no `ORDER BY rank`, so SQLite returned matches in rowid order and silently dropped literal-title matches whose library row was added later in the catalog. Production miss: *Tenant* on *Kaleidoscope* by Siouxsie and the Banshees (library id 43595) — four lower-rowid "Kaleidoscope*" titles filled the slice first.
- Same truncation killed both recovery paths — `search_compilations_for_track` → `process_release(album="Kaleidoscope")` and the cache-only `find_library_albums_with_cached_track` safety net.
- New `LibraryDB.exact_title()` uses `WHERE title = ? COLLATE NOCASE`; `search_album_fuzzy` calls it first and falls through to the existing FTS5 path when empty. Edition-suffix / punctuation-variant handling is unchanged.
- Mocked `LibraryDB` call sites that exercise `search_album_fuzzy` now seed `db.exact_title = AsyncMock(return_value=[])` so the pre-pass returns empty and existing FTS-path assertions still hold.
- Why `ORDER BY rank` alone isn't enough: BM25 ranks Siouxsie's row *worst* of the three exact-title matches because the long artist string lengthens the FTS document. Full reasoning in #560.

## Test plan

- [x] New `tests/unit/test_search_album_fuzzy.py` — RED before the fix, GREEN after (verified by stashing the fix and re-running).
  - Unit: `search_album_fuzzy("Kaleidoscope")` returns all three literal-title library rows (low/mid/high rowid).
  - Unit: surfaces Siouxsie's high-rowid Kaleidoscope.
  - Integration: end-to-end `perform_lookup` against a real fixture library + mocked Discogs returning Kaleidoscope — `response.results` includes Siouxsie's Kaleidoscope row; `response.song_not_found` is `False`. Pre-fix this returned `['Juju', 'The Scream', 'Once Upon a Time: The Singles', 'Dear Prudence', 'Nocturne']` — same shape as the production miss.
- [x] Full unit suite: 2515 passed.
- [x] `ruff check .` clean.
- [x] `ruff format --check .` clean.
- [x] `mypy library/db.py lookup/orchestrator.py tests/unit/test_search_album_fuzzy.py tests/conftest.py --ignore-missing-imports` clean.