### PR TITLE
test(unit): walk _IncludedRouter wrappers from FastAPI 0.137

### DIFF
--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -384,8 +384,23 @@ class TestProtectedRouteRegistration:
         )
 
 
-def _find_route(app, method, path):
+def _iter_effective_routes(app):
+    """Yield route-like objects for every concrete endpoint reachable from ``app.routes``.
+
+    FastAPI >= 0.137 wraps each ``include_router(...)`` call in an ``_IncludedRouter``
+    so the underlying ``APIRoute`` objects no longer live directly in ``app.routes``;
+    they are exposed via ``effective_route_contexts()`` with prefix + include-dependencies
+    merged in. Older FastAPI flattens them and is handled by the else branch.
+    """
     for r in app.routes:
+        if hasattr(r, "effective_route_contexts"):
+            yield from r.effective_route_contexts()
+        else:
+            yield r
+
+
+def _find_route(app, method, path):
+    for r in _iter_effective_routes(app):
         if getattr(r, "path", None) == path and method in getattr(r, "methods", set()):
             return r
     return None

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -58,7 +58,15 @@ class TestAppRouterRegistration:
     def test_routes_registered(self):
         from main import app
 
-        routes = [r.path for r in app.routes]
+        # FastAPI >= 0.137 wraps include_router(...) calls in _IncludedRouter,
+        # so the underlying APIRoute objects must be reached through
+        # effective_route_contexts() rather than read off app.routes directly.
+        routes = []
+        for r in app.routes:
+            if hasattr(r, "effective_route_contexts"):
+                routes.extend(ctx.path for ctx in r.effective_route_contexts())
+            elif hasattr(r, "path"):
+                routes.append(r.path)
         assert "/health" in routes
         assert "/api/v1/lookup" in routes
         assert "/api/v1/library/search" in routes


### PR DESCRIPTION
## Summary

- FastAPI 0.137.0 (released 2026-06-14) wraps each `app.include_router(...)` call in an `_IncludedRouter` object inside `app.routes`. The underlying `APIRoute` objects are now exposed lazily through `_IncludedRouter.effective_route_contexts()` with prefix + include-router dependencies merged in.
- This broke two introspection-based test helpers (`tests/unit/test_auth.py::_find_route` and `tests/unit/test_main.py::test_routes_registered`), causing **14 unit tests** to fail on prod CI run [27510485534](https://github.com/WXYC/library-metadata-lookup/actions/runs/27510485534/job/81309519604).
- Both helpers now descend through `effective_route_contexts()` when the wrapper is present, falling back to direct attribute access for unwrapped routes (`/openapi.json`, `/docs`, `/redoc`) and for older FastAPI versions. Production code is unaffected — FastAPI's own request-handling path traverses `_IncludedRouter` correctly.

Closes #563

## Test plan

- [x] Reproduce locally with `fastapi==0.137.0` — 14 tests in `tests/unit/test_auth.py::TestProtectedRouteRegistration` + `tests/unit/test_main.py::TestAppRouterRegistration::test_routes_registered` go red.
- [x] After fix: all 15 previously-failing tests green.
- [x] Full `tests/unit/` run: 2518 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Default Tests CI job passes on this PR.