### PR TITLE
fix(ci): pin fastapi<0.137 — 0.137.0 broke route-introspection tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ authors = [
 ]
 
 dependencies = [
-    "fastapi>=0.104.0",
+    # Upper bound: FastAPI 0.137.0 (2026-06-14) reshaped `app.routes` to wrap
+    # `include_router(...)` calls in `_IncludedRouter`, breaking the
+    # route-introspection tests in `tests/unit/test_{auth,main}.py`. Drop the
+    # `<0.137` cap once those tests are migrated to walk the new shape. See
+    # WXYC/library-metadata-lookup#562 (immediate pin) and #563 (test migration).
+    "fastapi>=0.104.0,<0.137",
     "uvicorn>=0.24.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",


### PR DESCRIPTION
## Summary

FastAPI 0.137.0 (released 2026-06-14 12:51 UTC) reshaped `app.routes`: each `app.include_router(...)` call is now wrapped in an `_IncludedRouter` placeholder instead of being flattened. That broke the introspection helpers in `tests/unit/test_main.py` and `tests/unit/test_auth.py` (14 failing assertions, blocking `main` + `prod` CI since 20:04 UTC).

This is the immediate **Step 1** from #562 — a 5-line upper-bound pin to unblock deploys today. The forward-compat **Step 2** test migration is already up at #564 (closes #563). Once that lands and we have green CI against 0.137.x, this cap can be dropped.

Production code is unaffected — FastAPI's own request-handling path descends through `_IncludedRouter` correctly. The pre-fix prod deployment at `97c204d` is healthy; only further deploys were blocked.

## Test plan

- [x] Local install with the new pin resolves to `fastapi-0.136.3` (verified)
- [x] 15 previously-failing tests in `tests/unit/test_auth.py::TestProtectedRouteRegistration` + `tests/unit/test_main.py::TestAppRouterRegistration` pass (verified)
- [x] `ruff check .` + `ruff format --check .` clean
- [x] Full `tests/unit/` suite: 2518 passed
- [ ] CI green on this PR

## Follow-ups out of scope here

- `request-o-matic` has the same unbounded `fastapi>=0.104.0` pin **and** the same `app.routes` walking pattern in `tests/unit/test_main.py:29,48,91,106`. Latent break on next push there — should get a paired pin PR.
- `wxyc-fastapi` and `semantic-index` also have unbounded `fastapi>=0.110` pins. No `app.routes` introspection in either, but exposed to other 0.137 fallout if any.

Closes #562