### PR TITLE
fix(ci): pin fastapi<0.137 — promote to prod

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ authors = [
 ]
 
 dependencies = [
-    "fastapi>=0.104.0",
+    # Upper bound: FastAPI 0.137.0 (2026-06-14) reshaped `app.routes` to wrap
+    # `include_router(...)` calls in `_IncludedRouter`, breaking the
+    # route-introspection tests in `tests/unit/test_{auth,main}.py`. Drop the
+    # `<0.137` cap once those tests are migrated to walk the new shape. See
+    # WXYC/library-metadata-lookup#562 (immediate pin) and #563 (test migration).
+    "fastapi>=0.104.0,<0.137",
     "uvicorn>=0.24.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",


### PR DESCRIPTION
## Summary

Promote #565 (merged to `main` as 0a55e7f) to `prod`. Identical diff: `fastapi>=0.104.0,<0.137` upper-bound pin so CI installs resolve to fastapi 0.136.x, unblocking the route-introspection tests that FastAPI 0.137.0 broke.

`main` CI went green on the merge of #565; this PR brings prod to parity so the production deploy pipeline unblocks too.

## Test plan

- [x] Already verified on #565 against `main`: pip resolves to fastapi 0.136.3, 15 previously-failing tests + full 2518 unit suite green, ruff clean
- [ ] CI green on this PR

Refs #562