### PR TITLE
fix(lookup): album-titled request no longer hits 'song not on any album' fallback (LML#586)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1198,6 +1198,52 @@ async def _library_miss_discogs_search(
     return library_item, best
 
 
+# Minimum fuzzy score for promoting an artist-fallback row whose *title*
+# matches the requested "song" — i.e. recognising the parsed song as the
+# album the user actually wanted. Set higher than `_ALBUM_MATCH_FLOOR`
+# because the consequence here is asserting the user's intent (album,
+# not track); a borderline match should *not* override the song-not-found
+# message.
+_SONG_AS_ALBUM_TITLE_FLOOR = 90.0
+
+
+def _filter_results_by_song_as_album_title(
+    results: list[LibraryItem],
+    song: str | None,
+) -> list[LibraryItem]:
+    """Pick artist-fallback rows whose title matches the requested song.
+
+    Handles the request shape "on patrol, sun araw" — request-o-matic routes
+    it as ``song="On Patrol"`` / ``artist="Sun Araw"``, but the user typed
+    an album name. The artist+song FTS branch of
+    :func:`search_library_with_fallback` surfaces the matching album because
+    the album title contains the song words; per-result track validation
+    then reasonably comes back empty (no track titled "On Patrol" exists on
+    that album — it IS the album) and ``song_not_found`` stays set,
+    producing the misleading 'not on any album' context message about a
+    result sitting in its own list.
+
+    Floor is ``_SONG_AS_ALBUM_TITLE_FLOOR`` (>= 90 via
+    ``rapidfuzz.fuzz.token_set_ratio``) — high enough that a coincidental
+    word overlap won't override the song-not-found path.
+
+    Returns the subset of ``results`` whose normalised title clears the
+    floor against the normalised song. Empty input or whitespace-only song
+    returns ``[]`` cleanly.
+    """
+    if not song or not song.strip() or not results:
+        return []
+    from rapidfuzz import fuzz
+
+    norm_song = normalize_for_comparison(song)
+    matches: list[LibraryItem] = []
+    for item in results:
+        title_norm = normalize_for_comparison(item.title or "")
+        if fuzz.token_set_ratio(norm_song, title_norm) >= _SONG_AS_ALBUM_TITLE_FLOOR:
+            matches.append(item)
+    return matches
+
+
 async def search_library_with_fallback(
     db: LibraryDB,
     parsed: ParsedRequest,
@@ -3097,6 +3143,25 @@ async def perform_lookup(
                     if promoted:
                         library_results = promoted
                         song_not_found = False
+                    else:
+                        # Last resort before declaring song-not-found: the
+                        # request shape "<album-title>, <artist>" can route to
+                        # us as ``song=<album-title>``. If a surviving result's
+                        # title clears the floor against ``parsed.song``, the
+                        # user wanted that album. Surfacing it as found-the-
+                        # album avoids the misleading 'not on any album'
+                        # message about a row sitting in the result list.
+                        title_matches = _filter_results_by_song_as_album_title(
+                            library_results, parsed.song
+                        )
+                        if title_matches:
+                            logger.info(
+                                f"Promoted {len(title_matches)} of {len(library_results)} "
+                                f"artist-fallback row(s) whose title matches song "
+                                f"'{parsed.song}' — treating as album request"
+                            )
+                            library_results = title_matches
+                            song_not_found = False
         elif search_state.artist_fallback_results:
             # Compilation found, but the artist's own album may also contain the track.
             # Validate the artist fallback results (saved before compilation search

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -653,6 +653,80 @@ class TestPerformLookupFallback:
             "Promoting a confirmed track-bearing album should clear song_not_found"
         )
 
+    @pytest.mark.asyncio
+    async def test_song_matching_album_title_clears_song_not_found(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """When the requested "song" is the title of an album by the artist,
+        treat it as a direct album match — not a song-not-found fallback.
+
+        Reproduces "on patrol, sun araw": request-o-matic routed it as
+        ``song="On Patrol"`` / ``artist="Sun Araw"``. The Sun Araw album
+        "On Patrol" is in the library and surfaced by the artist+song FTS
+        branch, but Discogs has no track called "On Patrol" on any Sun Araw
+        release, so per-result validation + cached-track promotion both
+        fail and ``song_not_found`` stays True. The bot then says
+        '"On Patrol" is not on any album in the library' — about the album
+        sitting in its own result list.
+        """
+        on_patrol = LibraryItem(
+            id=42,
+            artist="Sun Araw",
+            title="On Patrol",
+            call_letters="SU",
+            artist_call_number=138,
+            release_call_number=1,
+            genre="Rock",
+            format="cd",
+        )
+
+        mock_library_db.find_similar_artist.return_value = None
+
+        # search_library_with_fallback call order for (artist + song, no album):
+        #   1. artist + song FTS -> finds "On Patrol" (title matches the song term)
+        async def fake_search(query=None, **kwargs):
+            q = (query or "").lower()
+            if "sun araw" in q:
+                return [on_patrol]
+            return []
+
+        mock_library_db.search.side_effect = fake_search
+
+        # Per-result validation fails: no track named "On Patrol" on this release.
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+        mock_discogs_service.validate_track_on_release.return_value = False
+
+        # Cache-known-track promotion also turns up empty (no Sun Araw release
+        # in the cache contains a track titled "On Patrol").
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(return_value=[])
+
+        request = LookupRequest(
+            artist="Sun Araw",
+            song="On Patrol",
+            raw_message="on patrol, sun araw",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        assert len(response.results) == 1
+        assert response.results[0].library_item.title == "On Patrol"
+        assert response.song_not_found is False, (
+            "The album titled 'On Patrol' is in results — the user wanted "
+            "that album, not a track. song_not_found should be cleared."
+        )
+        assert response.context_message is None, (
+            "Should not emit the misleading 'not on any album' message when "
+            "results contain an album titled the same as the requested song."
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: perform_lookup - compilation search


### PR DESCRIPTION
Closes #586.

## Summary

Slack request `on patrol, sun araw` returned the Sun Araw album "On Patrol" in the result list **and** the message *"On Patrol" is not on any album in the library, but here are some albums by Sun Araw* — about the album sitting in its own result list. Adds a last-resort step-3b branch in `perform_lookup`: when validation + cached-track promotion both fail and a surviving artist-fallback row's title clears 90 against `parsed.song` (rapidfuzz `token_set_ratio`), promote those rows and clear `song_not_found`. `build_context_message` then returns `None` so the bot shows the album with no misleading prefix.

## Why a high floor

The new fallback overrides the song-not-found message based on title-equals-song. A coincidental word overlap (song "Patrol" vs album "On Patrol Reissue") should NOT override a legitimate "couldn't find that track" signal, so `_SONG_AS_ALBUM_TITLE_FLOOR = 90.0`, above the 80 used by `_ALBUM_MATCH_FLOOR`. Same `normalize_for_comparison` + `rapidfuzz.fuzz.token_set_ratio` pair as the existing helper.

## Why step 3b (not pre-pipeline)

The check needs the surviving artist-fallback rows, which only exist after FTS + per-result track validation + cached-track promotion run. A pre-pipeline check would either re-derive that work or fire on rows we'd otherwise reject. The check lives right after the cached-track promotion: it's the same shape ("validation said no, here's a recovery probe") and it shares the `elif song_not_found:` gate so it never overrides a confirmed track-on-album result.

## Test plan

- [x] New regression test in `TestPerformLookupFallback`: `song="On Patrol"`, `artist="Sun Araw"`, library has a Sun Araw album titled "On Patrol", Discogs has no track titled "On Patrol" on any release, cache lookup empty — asserts `song_not_found=False`, `context_message=None`, result list contains the album.
- [x] `tests/unit/test_orchestrator.py` (190 tests) + `tests/unit/test_orchestrator_helpers.py` + `tests/unit/test_orchestrator_gaps.py` all pass.
- [x] Full unit suite: 2618 pass; one pre-existing event-loop teardown flake in `test_dependencies.py` unrelated to this change (passes in isolation).
- [x] `ruff check` + `ruff format --check` clean.

## Files

- `lookup/orchestrator.py` — `_SONG_AS_ALBUM_TITLE_FLOOR` constant + `_filter_results_by_song_as_album_title` helper alongside `_filter_results_by_album_match`; new `else` branch in `perform_lookup` step 3b.
- `tests/unit/test_orchestrator.py` — `test_song_matching_album_title_clears_song_not_found`.