### PR TITLE
feat(cache): extend refresh_identity/dispatch_source signatures for new cache legs

### DIFF
--- a/cache/dispatch.py
+++ b/cache/dispatch.py
@@ -43,7 +43,11 @@ from cache.models import (
 from discogs.models import ReleaseMetadataResponse
 
 if TYPE_CHECKING:
+    from clients.bandcamp import BandcampClient
+    from clients.streaming.apple_music import AppleMusicClient
+    from clients.streaming.spotify import SpotifyClient
     from discogs.service import DiscogsService
+    from entity.sources import PgSourceProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +191,11 @@ async def _dispatch_source(
     identity_id: int,
     source: str,
     external_id: str,
+    *,
+    mb_pg: PgSourceProtocol | None = None,
+    spotify_client: SpotifyClient | None = None,
+    apple_music_client: AppleMusicClient | None = None,
+    bandcamp_client: BandcampClient | None = None,
 ) -> SourceRefreshOutcome:
     """Run the release leg for one source and walk its artists if any."""
     with sentry_sdk.start_span(op="cache.refresh.release", name=f"{source}:{external_id}") as span:
@@ -238,6 +247,10 @@ async def refresh_identity(
     identity_id: int,
     source_pairs: list[tuple[str, str]],
     discogs_service: DiscogsService,
+    mb_pg: PgSourceProtocol | None = None,
+    spotify_client: SpotifyClient | None = None,
+    apple_music_client: AppleMusicClient | None = None,
+    bandcamp_client: BandcampClient | None = None,
 ) -> CacheRefreshResultItem:
     """Run all source legs for one identity_id and roll up the per-id status.
 
@@ -250,6 +263,24 @@ async def refresh_identity(
             not gate concurrency itself; the per-replica Discogs semaphore /
             rate limiter in ``discogs/ratelimit.py`` apply through
             ``get_release`` / ``get_artist_details``.
+        mb_pg: Optional ``musicbrainz-cache`` ``PgSource`` for the
+            ``musicbrainz_release`` leg (LML#547). ``None`` (the default and
+            DI short-circuit when ``DATABASE_URL_MUSICBRAINZ`` is unset)
+            preserves the existing ``not_implemented`` outcome.
+        spotify_client: Optional ``SpotifyClient`` for the ``spotify_album``
+            leg (LML#549). ``None`` (the default and DI short-circuit when
+            Spotify credentials are unset) preserves the existing
+            ``not_implemented`` outcome.
+        apple_music_client: Optional ``AppleMusicClient`` for the
+            ``apple_music_album`` leg (LML#550). ``None`` (the default and DI
+            short-circuit when Apple Music credentials are unset) preserves
+            the existing ``not_implemented`` outcome.
+        bandcamp_client: Optional ``BandcampClient`` for the ``bandcamp``
+            leg (LML#548). ``None`` (the default) preserves the existing
+            ``not_implemented`` outcome. Bandcamp has no auth requirement
+            so the DI singleton always builds a client at runtime; the
+            ``| None`` shape exists for unit-test substitutability and to
+            mirror the other three optional clients.
 
     Returns:
         A ``CacheRefreshResultItem`` with per-source outcomes and the
@@ -264,7 +295,14 @@ async def refresh_identity(
         sources: dict[str, SourceRefreshOutcome] = {}
         for source, external_id in source_pairs:
             sources[source] = await _dispatch_source(
-                discogs_service, identity_id, source, external_id
+                discogs_service,
+                identity_id,
+                source,
+                external_id,
+                mb_pg=mb_pg,
+                spotify_client=spotify_client,
+                apple_music_client=apple_music_client,
+                bandcamp_client=bandcamp_client,
             )
 
         status = compute_per_id_status(sources)

--- a/cache/router.py
+++ b/cache/router.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import Counter
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
 from asyncpg.exceptions import PostgresError
@@ -51,10 +51,21 @@ from core.bulk_concurrency import (
     max_concurrency_from_env,
     watch_disconnect,
 )
-from core.dependencies import get_discogs_service
+from core.dependencies import get_discogs_service, get_musicbrainz_pg
 from discogs.service import DiscogsService
 from entity.store import EntityStore
 from identity.dependencies import get_entity_store
+from streaming.dependencies import (
+    get_apple_music_client,
+    get_bandcamp_client,
+    get_spotify_client,
+)
+
+if TYPE_CHECKING:
+    from clients.bandcamp import BandcampClient
+    from clients.streaming.apple_music import AppleMusicClient
+    from clients.streaming.spotify import SpotifyClient
+    from entity.sources import PgSourceProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +144,10 @@ async def handle_refresh_for_identities(
     http_request: Request,
     entity_store: EntityStore | None = Depends(get_entity_store),
     discogs_service: DiscogsService | None = Depends(get_discogs_service),
+    mb_pg: PgSourceProtocol | None = Depends(get_musicbrainz_pg),
+    spotify_client: SpotifyClient | None = Depends(get_spotify_client),
+    apple_music_client: AppleMusicClient | None = Depends(get_apple_music_client),
+    bandcamp_client: BandcampClient | None = Depends(get_bandcamp_client),
 ) -> BulkCacheRefreshResponse:
     """Bulk cache refresh. See route docstring for protocol."""
     # Manual 400-on-overflow before Pydantic so oversize doesn't get 422'd.
@@ -194,6 +209,10 @@ async def handle_refresh_for_identities(
                     identity_id=identity_id,
                     source_pairs=provenance[identity_id],
                     discogs_service=discogs,
+                    mb_pg=mb_pg,
+                    spotify_client=spotify_client,
+                    apple_music_client=apple_music_client,
+                    bandcamp_client=bandcamp_client,
                 )
             except asyncio.CancelledError:
                 # Cancellation always propagates. Without this re-raise, a

--- a/tests/unit/test_cache_dispatch.py
+++ b/tests/unit/test_cache_dispatch.py
@@ -372,3 +372,59 @@ class TestRefreshIdentity:
         )
         assert result.status == "not_implemented"
         assert result.sources[source].release_outcome == "not_implemented"
+
+    # ----------------------------------------------------------------------
+    # LML#589 — signature-prep commit
+    #
+    # The four cache legs (musicbrainz_release / spotify_album /
+    # apple_music_album / bandcamp) each get their own implementation issue
+    # (LML#547, #548, #549, #550) blocked on #589. This prep commit extends
+    # the dispatcher signature now so all four leg PRs can be developed in
+    # parallel without colliding on signature edits, while preserving the
+    # existing "not_implemented" behavior when the corresponding client is
+    # None (the dependency-injection short-circuit for missing creds).
+    # ----------------------------------------------------------------------
+
+    async def test_musicbrainz_release_still_not_implemented_when_mb_pg_is_none(self):
+        discogs = AsyncMock()
+        result = await refresh_identity(
+            identity_id=1,
+            source_pairs=[("musicbrainz_release", "ext-id")],
+            discogs_service=discogs,
+            mb_pg=None,
+        )
+        assert result.status == "not_implemented"
+        assert result.sources["musicbrainz_release"].release_outcome == "not_implemented"
+
+    async def test_spotify_album_still_not_implemented_when_spotify_client_is_none(self):
+        discogs = AsyncMock()
+        result = await refresh_identity(
+            identity_id=1,
+            source_pairs=[("spotify_album", "ext-id")],
+            discogs_service=discogs,
+            spotify_client=None,
+        )
+        assert result.status == "not_implemented"
+        assert result.sources["spotify_album"].release_outcome == "not_implemented"
+
+    async def test_apple_music_album_still_not_implemented_when_apple_music_client_is_none(self):
+        discogs = AsyncMock()
+        result = await refresh_identity(
+            identity_id=1,
+            source_pairs=[("apple_music_album", "ext-id")],
+            discogs_service=discogs,
+            apple_music_client=None,
+        )
+        assert result.status == "not_implemented"
+        assert result.sources["apple_music_album"].release_outcome == "not_implemented"
+
+    async def test_bandcamp_still_not_implemented_when_bandcamp_client_is_none(self):
+        discogs = AsyncMock()
+        result = await refresh_identity(
+            identity_id=1,
+            source_pairs=[("bandcamp", "ext-id")],
+            discogs_service=discogs,
+            bandcamp_client=None,
+        )
+        assert result.status == "not_implemented"
+        assert result.sources["bandcamp"].release_outcome == "not_implemented"


### PR DESCRIPTION
Closes #589.

Zero-behavior-change prep commit. Extends `refresh_identity` and `_dispatch_source` in `cache/dispatch.py`, and the `handle_refresh_for_identities` route handler in `cache/router.py`, to accept four new optional service clients so the four follow-up cache-leg PRs can be developed in parallel without colliding on signature edits.

## What changes

- **`cache/dispatch.py`** — `_dispatch_source` and `refresh_identity` each gain four keyword-only optional params, all defaulting to `None`:
  - `mb_pg: PgSourceProtocol | None` — for the MusicBrainz leg (#547)
  - `spotify_client: SpotifyClient | None` — for the Spotify leg (#549)
  - `apple_music_client: AppleMusicClient | None` — for the Apple Music leg (#550)
  - `bandcamp_client: BandcampClient | None` — for the Bandcamp leg (#548)
- **`cache/router.py`** — `handle_refresh_for_identities` wires the same four params via existing DI providers (`get_musicbrainz_pg` in `core/dependencies.py`; `get_spotify_client` / `get_apple_music_client` / `get_bandcamp_client` in `streaming/dependencies.py`) and threads them through to `refresh_identity`.
- All four client types are guarded under `TYPE_CHECKING` to avoid circular imports — same pattern as the existing `DiscogsService` import in `cache/dispatch.py`.

## What does not change

The `_NOT_IMPLEMENTED_SOURCES` short-circuit is unchanged. With `None` defaults across the board, every existing call site (including the integration test suite) continues to produce the existing `release_outcome = "not_implemented"` for `musicbrainz_release`, `spotify_album`, `apple_music_album`, and `bandcamp` — exactly as before. No leg is wired in this PR.

The `bandcamp_client` param is typed `BandcampClient | None` even though `get_bandcamp_client` always returns a non-None client (Bandcamp has no auth requirement). The wider parameter type mirrors the other three optional clients and lets unit tests substitute `None` cleanly.

## Unblocks

- WXYC/library-metadata-lookup#547 — MusicBrainz leg
- WXYC/library-metadata-lookup#548 — Bandcamp leg
- WXYC/library-metadata-lookup#549 — Spotify leg
- WXYC/library-metadata-lookup#550 — Apple Music leg

## Tests

Four new tests in `TestRefreshIdentity` (`tests/unit/test_cache_dispatch.py`) assert that explicitly passing `None` for each new param preserves the existing `not_implemented` behavior. All 25 prior unit tests and all 13 integration tests pass without modification.

```
uv run pytest tests/unit/test_cache_dispatch.py tests/integration/test_cache_refresh_for_identities.py -v -m "pg or not pg"
# 29 unit + 13 integration → 42 passed
uv run ruff check .       # All checks passed!
uv run ruff format --check .  # 325 files already formatted
```