### PR TITLE
fix(cache): filter release_track_artist to extra=0 in get_release (LML#588)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -549,11 +549,16 @@ class DiscogsCacheService:
                     """,
                     release_id,
                 ),
+                # extra=0 → main-performer credits only; producers/remixers/
+                # writers excluded so TrackItem.artists is safe for
+                # _scan_tracklist_for_match's (artist, track) validation.
+                # See L217-228 for the full rationale (#333, #585, #588).
                 self.pool.fetch(
                     """
                     SELECT track_sequence, artist_name
                     FROM release_track_artist
                     WHERE release_id = $1
+                      AND extra = 0
                     ORDER BY track_sequence
                     """,
                     release_id,

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -549,11 +549,15 @@ class DiscogsCacheService:
                     """,
                     release_id,
                 ),
-                # extra=0 → main-performer credits only; producers/remixers/
-                # writers excluded so TrackItem.artists is safe for
-                # _scan_tracklist_for_match's (artist, track) validation.
-                # See L217-228 for the full rationale (#333, #585, #588).
                 self.pool.fetch(
+                    # `extra = 0` keeps TrackItem.artists tight on main-performer
+                    # credits; extras (writer/producer/remixer) live with
+                    # `extra = 1` and would otherwise cross-pollinate the
+                    # `(artist, track)` validation `_scan_tracklist_for_match`
+                    # runs over this list in `discogs/service.py`. Mirrors the
+                    # filter `validate_track_on_release` already applies; see
+                    # #333 for the precision/recall trade-off and #588 for this
+                    # call site.
                     """
                     SELECT track_sequence, artist_name
                     FROM release_track_artist

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -291,18 +291,20 @@ class TestGetRelease:
         assert result.tracklist[0].artists == ["Some Artist"]
 
     @pytest.mark.asyncio
-    async def test_excludes_extra_artists_from_track_artists(
+    async def test_query_filters_release_track_artist_to_extra_zero(
         self, cache_service, mock_asyncpg_pool
     ):
-        """LML#588: TrackItem.artists must include only performers (extra=0),
-        not producers/writers/remixers (extra=1). _scan_tracklist_for_match
-        iterates this list for (artist, track) validation; a non-performer
-        name credited as e.g. producer would otherwise validate a track they
-        never performed on.
+        """get_release's per-track credit query must restrict to main credits.
+
+        LML#588: without ``AND extra = 0``, producer/writer/remixer credits
+        (``extra = 1``) cross-pollinate ``TrackItem.artists`` and contaminate
+        ``_scan_tracklist_for_match``'s (artist, track) validation. Mirrors
+        the SQL-presence pattern at ``TestValidateTrackOnRelease``'s
+        ``test_query_filters_release_track_artist_to_extra_zero`` (#333).
         """
         mock_asyncpg_pool.fetchrow = AsyncMock(
             return_value={
-                "id": 42,
+                "id": 1,
                 "title": "On Your Own Love Again",
                 "release_year": 2015,
                 "artwork_url": None,
@@ -311,38 +313,33 @@ class TestGetRelease:
                 "not_found": False,
             }
         )
+        captured_queries: list[str] = []
 
-        track_artist_rows = [
-            {"track_sequence": 1, "artist_name": "Jessica Pratt", "extra": 0},
-            {"track_sequence": 1, "artist_name": "Al Carlson", "extra": 1},
-        ]
-
-        async def route(query, *args):
-            if "release_track_artist" in query:
-                # Mimic PG: when the query asks for `extra = 0`, return only
-                # the performer rows. Without the filter, both rows leak through.
-                if "extra = 0" in query:
-                    return [r for r in track_artist_rows if r["extra"] == 0]
-                return track_artist_rows
-            if "release_track" in query:
-                return [{"position": "1", "title": "Back, Baby", "duration": None, "sequence": 1}]
-            if "release_artist" in query:
-                return [
-                    {
-                        "artist_id": None,
-                        "artist_name": "Jessica Pratt",
-                        "extra": 0,
-                        "role": None,
-                    }
-                ]
+        async def capture_fetch(query, *args):
+            captured_queries.append(query)
             return []
 
-        mock_asyncpg_pool.fetch = AsyncMock(side_effect=route)
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=capture_fetch)
 
-        result = await cache_service.get_release(42)
-        assert result is not None
-        assert result.tracklist[0].artists == ["Jessica Pratt"]
-        assert "Al Carlson" not in result.tracklist[0].artists
+        await cache_service.get_release(1)
+
+        rta_queries = [q for q in captured_queries if "release_track_artist" in q]
+        assert rta_queries, (
+            f"Expected a query against release_track_artist; got: {captured_queries!r}"
+        )
+        # Normalize whitespace before the adjacency check — get_release uses
+        # a multi-line triple-quoted SQL string, so ``release_track_artist``
+        # and ``WHERE`` are separated by newlines + indentation in the raw
+        # text. Pin the *complete* WHERE clause adjacency (not just the
+        # substring ``extra = 0``, which could co-occur in an unrelated CTE
+        # branch, whitespace-different variant, or a ``-- extra = 0``
+        # comment) so a future refactor that drops the filter can't slip
+        # through.
+        normalized = " ".join(rta_queries[0].split())
+        assert "release_track_artist WHERE release_id = $1 AND extra = 0" in normalized, (
+            "Expected `release_track_artist WHERE release_id = $1 AND extra = 0` "
+            f"in the release_track_artist query (see #588); got: {rta_queries[0]!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_reads_videos(self, cache_service, mock_asyncpg_pool):

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -291,6 +291,60 @@ class TestGetRelease:
         assert result.tracklist[0].artists == ["Some Artist"]
 
     @pytest.mark.asyncio
+    async def test_excludes_extra_artists_from_track_artists(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """LML#588: TrackItem.artists must include only performers (extra=0),
+        not producers/writers/remixers (extra=1). _scan_tracklist_for_match
+        iterates this list for (artist, track) validation; a non-performer
+        name credited as e.g. producer would otherwise validate a track they
+        never performed on.
+        """
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 42,
+                "title": "On Your Own Love Again",
+                "release_year": 2015,
+                "artwork_url": None,
+                "released": None,
+                "artwork_checked_at": None,
+                "not_found": False,
+            }
+        )
+
+        track_artist_rows = [
+            {"track_sequence": 1, "artist_name": "Jessica Pratt", "extra": 0},
+            {"track_sequence": 1, "artist_name": "Al Carlson", "extra": 1},
+        ]
+
+        async def route(query, *args):
+            if "release_track_artist" in query:
+                # Mimic PG: when the query asks for `extra = 0`, return only
+                # the performer rows. Without the filter, both rows leak through.
+                if "extra = 0" in query:
+                    return [r for r in track_artist_rows if r["extra"] == 0]
+                return track_artist_rows
+            if "release_track" in query:
+                return [{"position": "1", "title": "Back, Baby", "duration": None, "sequence": 1}]
+            if "release_artist" in query:
+                return [
+                    {
+                        "artist_id": None,
+                        "artist_name": "Jessica Pratt",
+                        "extra": 0,
+                        "role": None,
+                    }
+                ]
+            return []
+
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=route)
+
+        result = await cache_service.get_release(42)
+        assert result is not None
+        assert result.tracklist[0].artists == ["Jessica Pratt"]
+        assert "Al Carlson" not in result.tracklist[0].artists
+
+    @pytest.mark.asyncio
     async def test_reads_videos(self, cache_service, mock_asyncpg_pool):
         """get_release returns videos fetched from release_video table."""
         mock_asyncpg_pool.fetchrow = AsyncMock(


### PR DESCRIPTION
Closes #588.

## What

`DiscogsCacheService.get_release()` reads `release_track_artist` to build `TrackItem.artists`. The query had no `extra = 0` filter, so producer / writer / remixer credits (`extra = 1`) leaked into the list. `_scan_tracklist_for_match` in `discogs/service.py` iterates `item.artists` for `(artist, track)` validation, so a non-performer's name (e.g. someone credited as producer) could validate a track they never performed on.

## Fix

Added `AND extra = 0` to the `release_track_artist` query inside `get_release()` (`discogs/cache_service.py`), plus a short comment pointing back to the full rationale block at `cache_service.py:217-228`.

## Tests (red → green)

Added `TestGetRelease::test_excludes_extra_artists_from_track_artists`, which mocks two `release_track_artist` rows on the same track sequence — one `extra=0` (Jessica Pratt, performer) and one `extra=1` (Al Carlson, producer) — and asserts the producer name does NOT appear in `TrackItem.artists`.

Confirmed red before the fix:

\`\`\`
>       assert result.tracklist[0].artists == [\"Jessica Pratt\"]
E       AssertionError: assert ['Jessica Pratt', 'Al Carlson'] == ['Jessica Pratt']
E         Left contains one more item: 'Al Carlson'
\`\`\`

Confirmed green after the fix; full unit suite (2626 tests, `not pg and not external_api`) is green.

## Related

- Mirrors the pattern PR #585 applied to the five script-layer read sites (`scripts/va_disambiguate/discogs_lookup.py`, `scripts/match_compilations.py`, `scripts/track_streaming/__main__.py`). The `get_release()` call site was missed in that PR.
- Sibling issue #472 (`get_release_metadata`) has the same gap; it will follow the same recipe in its own PR. The companion comment at `cache_service.py:217-228` lists #472-#475 as the parallel filter family.