### PR TITLE
docs: document lml_cache.* vs entity.* schema ownership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,15 @@ Bug fixes: write a test that reproduces the bug first, confirm it fails, then fi
 - **[wxyc-etl](https://github.com/WXYC/wxyc-etl)** -- Shared Rust library with Python bindings (PyO3/maturin). Provides `wxyc_etl.text` (artist name normalization, diacritics stripping, compilation detection) and `wxyc_etl.schema` (library.db column definitions). These were previously duplicated locally in `core/matching.py`.
 - **[discogs-cache](https://github.com/WXYC/discogs-etl)** -- ETL pipeline that populates the PostgreSQL Discogs cache consumed by `discogs/cache_service.py`. The pipeline is filtered by `library.db`, which discogs-cache generates from the WXYC MySQL catalog via `scripts/export_to_sqlite.py`. The `library.db` file serves dual purpose: runtime search for this service and primary input to the discogs-cache pipeline. The library ETL scripts (`export_to_sqlite.py`, `sync-library.sh`) live in discogs-cache.
 
+## PostgreSQL schema ownership
+
+The shared Discogs-cache PostgreSQL database has two schemas LML touches, with a hard ownership boundary ([discogs-etl#288](https://github.com/WXYC/discogs-etl/issues/288), Option 3):
+
+- **`entity.*` is discogs-cache-owned** — the cross-service identity contract (`entity.identity`, `entity.release_identity`, and their reconciliation logs). It is created and migrated **only** via discogs-cache alembic migrations. LML reads/writes rows but must **not** `CREATE TABLE` in `entity.*`. Adding a new release-identity column still pays the three-repo dance (wxyc-shared enum → discogs-cache alembic → LML); see [WXYC/wiki#83](https://github.com/WXYC/wiki/issues/83).
+- **`lml_cache.*` is LML-owned** — application caches with no external readers and no wire contract (e.g. `lml_cache.album_streaming_url_cache`). LML bootstraps these from the FastAPI lifespan in `main.py` (`CREATE SCHEMA IF NOT EXISTS lml_cache` + `CREATE TABLE IF NOT EXISTS`), with no discogs-cache coordination. discogs-cache tooling never touches `lml_cache.*` (its truncate guard at `scripts/import_csv.py` rejects schema-qualified names outright).
+
+Rule of thumb: if another repo reads it, it belongs in `entity.*` and goes through alembic; if it's a private LML cache, it belongs in `lml_cache.*` and is lifespan-bootstrapped. (Migration in progress via LML#573: the new streaming-URL cache lands in `lml_cache.*`; the grandfathered `entity.album_apple_music_lookup_cache` is dropped in #573's PR-2.)
+
 ## Example Music Data for Tests
 
 WXYC is a freeform station. When creating test fixtures or mock data, use representative artists instead of mainstream acts like Queen, Radiohead, or The Beatles. The canonical data source is `wxyc-shared/src/test-utils/wxyc-example-data.json`.


### PR DESCRIPTION
Documents the `entity.*` vs `lml_cache.*` schema-ownership boundary decided in WXYC/discogs-etl#288 (Option 3).

`entity.*` is the discogs-cache-owned cross-service identity contract (alembic-only; LML reads and writes rows but never `CREATE TABLE`s there). LML's private application caches live in a new LML-owned `lml_cache.*` schema bootstrapped from the FastAPI lifespan. The migration to `lml_cache.*` is in progress via #573 (the streaming-URL cache lands there; the grandfathered `entity.album_apple_music_lookup_cache` is dropped in #573's PR-2), so the note is phrased as in-progress.

Doc-only change.

Related: #573, WXYC/discogs-etl#288