### PR TITLE
Drop grandfathered apple-table backfill — LML#573 PR-2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The shared Discogs-cache PostgreSQL database has two schemas LML touches, with a
 - **`entity.*` is discogs-cache-owned** — the cross-service identity contract (`entity.identity`, `entity.release_identity`, and their reconciliation logs). It is created and migrated **only** via discogs-cache alembic migrations. LML reads/writes rows but must **not** `CREATE TABLE` in `entity.*`. Adding a new release-identity column still pays the three-repo dance (wxyc-shared enum → discogs-cache alembic → LML); see [WXYC/wiki#83](https://github.com/WXYC/wiki/issues/83).
 - **`lml_cache.*` is LML-owned** — application caches with no external readers and no wire contract (e.g. `lml_cache.album_streaming_url_cache`). LML bootstraps these from the FastAPI lifespan in `main.py` (`CREATE SCHEMA IF NOT EXISTS lml_cache` + `CREATE TABLE IF NOT EXISTS`), with no discogs-cache coordination. discogs-cache tooling never touches `lml_cache.*` (its truncate guard at `scripts/import_csv.py` rejects schema-qualified names outright).
 
-Rule of thumb: if another repo reads it, it belongs in `entity.*` and goes through alembic; if it's a private LML cache, it belongs in `lml_cache.*` and is lifespan-bootstrapped. (Migration in progress via LML#573: the new streaming-URL cache lands in `lml_cache.*`; the grandfathered `entity.album_apple_music_lookup_cache` is dropped in #573's PR-2.)
+Rule of thumb: if another repo reads it, it belongs in `entity.*` and goes through alembic; if it's a private LML cache, it belongs in `lml_cache.*` and is lifespan-bootstrapped. (Completed via LML#573: the streaming-URL cache lives in `lml_cache.album_streaming_url_cache`; the grandfathered `entity.album_apple_music_lookup_cache` was dropped in #573's PR-2.)
 
 ## Example Music Data for Tests
 

--- a/entity/streaming_url_cache.py
+++ b/entity/streaming_url_cache.py
@@ -98,29 +98,6 @@ CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
 )\
 """
 
-# Idempotent cross-schema backfill from the grandfathered apple-only table
-# (LML#571). Runs only when ``entity.album_apple_music_lookup_cache`` still
-# exists (the caller guards with ``to_regclass``); PR-2 drops the old table
-# and removes this. ``last_checked_at`` is projected EXPLICITLY (not left to
-# the column default) so each backfilled known-miss row keeps its original
-# TTL — relying on ``now()`` would extend every known miss by up to 7 days.
-_BACKFILL_SQL = """\
-INSERT INTO lml_cache.album_streaming_url_cache
-    (service, artist_normalized, album_normalized, url, last_checked_at)
-SELECT 'apple_music_album', artist_normalized, album_normalized,
-       apple_music_url, last_checked_at
-FROM entity.album_apple_music_lookup_cache
-ON CONFLICT (service, artist_normalized, album_normalized) DO NOTHING\
-"""
-
-# Probe for the grandfathered table before running the backfill. ``to_regclass``
-# returns NULL (not an error) when the table is absent, so a fresh PG that
-# never had the apple-only table makes the backfill a clean no-op. Aliased so
-# the ``PgSource.fetchone`` dict carries a stable ``source_exists`` key.
-_BACKFILL_SOURCE_EXISTS_SQL = (
-    "SELECT to_regclass('entity.album_apple_music_lookup_cache') IS NOT NULL AS source_exists"
-)
-
 # Staleness lives in the WHERE clause (LML#576). ``$1`` is the service key,
 # ``$4`` the lower bound on ``last_checked_at`` for a "fresh" known miss
 # (typically ``now - miss_ttl``). A hit (url not null) is always returned; a
@@ -147,7 +124,7 @@ SET url = EXCLUDED.url,
 
 
 async def set_up_streaming_url_cache_schema(pg: PgSource) -> None:
-    """Apply the idempotent DDL and run the one-time apple-table backfill.
+    """Apply the idempotent cache-schema DDL.
 
     Called once from ``main.py`` lifespan. The schema and table creation are
     both ``IF NOT EXISTS`` so re-running on every boot is safe. The
@@ -156,18 +133,9 @@ async def set_up_streaming_url_cache_schema(pg: PgSource) -> None:
     boot LML cleanly. If the discogs-cache PG is unreachable at startup, the
     caller logs and continues; the cache layer degrades to a no-op until the
     next deploy.
-
-    The backfill is guarded by ``to_regclass`` so it is a no-op on a fresh PG
-    that never had ``entity.album_apple_music_lookup_cache``. PR-2 removes the
-    backfill after the old table is dropped.
     """
     await pg.execute(_DDL_SCHEMA)
     await pg.execute(_DDL_TABLE)
-    # Guard in Python (not a SQL DO block) so the backfill is a clean no-op
-    # on a PG that never had the old apple-only table.
-    row = await pg.fetchone(_BACKFILL_SOURCE_EXISTS_SQL)
-    if row is not None and row["source_exists"]:
-        await pg.execute(_BACKFILL_SQL)
 
 
 @dataclass(frozen=True)

--- a/main.py
+++ b/main.py
@@ -67,12 +67,10 @@ async def lifespan(app: FastAPI):
     # ``set_up_streaming_url_cache_schema`` runs ``CREATE SCHEMA IF NOT EXISTS
     # lml_cache`` first (the LML-owned application-cache schema, per
     # discogs-etl#288 Option 3), so a fresh PG without any LML schema applied
-    # still bootstraps cleanly, then runs a ``to_regclass``-guarded backfill
-    # from the grandfathered ``entity.album_apple_music_lookup_cache`` (dropped
-    # by PR-2). If the pool itself is unavailable, log and continue — the cache
-    # layer's get/set wrap their queries in try/except and return "miss" on any
-    # PG error, so /lookup degrades to one extra probe per request rather than
-    # failing startup.
+    # still bootstraps cleanly. If the pool itself is unavailable, log and
+    # continue — the cache layer's get/set wrap their queries in try/except and
+    # return "miss" on any PG error, so /lookup degrades to one extra probe per
+    # request rather than failing startup.
     if settings.database_url_discogs:
         try:
             from core.dependencies import get_discogs_pool

--- a/tests/integration/test_streaming_url_persistent_lookup.py
+++ b/tests/integration/test_streaming_url_persistent_lookup.py
@@ -5,8 +5,8 @@ LML#573 generalized the Apple-only ``entity.album_apple_music_lookup_cache``
 the cache module ``entity/streaming_url_cache.py``, and the read-through
 resolver ``resolve_streaming_url_with_cache``. All unit coverage mocks
 ``PgSource``; this file is the matching ``@pytest.mark.pg`` layer that drives
-the real schema, the real UPSERT, the real TTL math, and the cross-schema
-backfill against an actual PostgreSQL connection.
+the real schema, the real UPSERT, and the real TTL math against an actual
+PostgreSQL connection.
 
 Concrete production risks the unit tests cannot catch:
 
@@ -15,8 +15,6 @@ Concrete production risks the unit tests cannot catch:
   would break the SQL ``last_checked_at > $4`` comparison.
 * UPSERT semantics — the composite-PK ``ON CONFLICT`` updates in place.
 * ``to_match_form`` normalization parity between SELECT and UPSERT.
-* The backfill preserves each row's ``last_checked_at`` (the TTL-preservation
-  AC) instead of resetting it to ``now()``.
 
 Run with: pytest -m pg -v tests/integration/test_streaming_url_persistent_lookup.py
 """
@@ -46,18 +44,6 @@ DATABASE_URL = os.getenv(
     "postgresql://discogs:discogs@localhost:5433/discogs",
 )
 
-# Old apple-only table DDL (LML#571) — recreated by the backfill test so it
-# can drive the cross-schema copy. Mirrors entity/apple_music_album_cache.py.
-_OLD_APPLE_TABLE_DDL = """\
-CREATE TABLE IF NOT EXISTS entity.album_apple_music_lookup_cache (
-    artist_normalized TEXT NOT NULL,
-    album_normalized TEXT NOT NULL,
-    apple_music_url TEXT,
-    last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    PRIMARY KEY (artist_normalized, album_normalized)
-)
-"""
-
 _SERVICE_CASES = [
     ("apple_music_album", "https://music.apple.com/us/album/aluminum-tunes/1234567890"),
     ("spotify_album", "https://open.spotify.com/album/1A2GTWGt0LBTGQAyA3OKAf"),
@@ -86,22 +72,15 @@ async def set_up_cache_schema(pg_pool, pg_source):
     """Reset to a clean ``lml_cache`` schema and apply the cache DDL.
 
     Surgical (not ``DROP SCHEMA entity CASCADE``): only the LML-owned
-    ``lml_cache`` schema and the grandfathered apple-only table are touched, so
-    the discogs-cache-owned ``entity.*`` identity tables in the shared test PG
-    stay intact. With the old apple table dropped, the bootstrap's
-    ``to_regclass`` guard sees it absent and the backfill is a no-op for the
-    round-trip tests (the backfill test recreates + seeds it, then re-runs the
-    idempotent bootstrap).
+    ``lml_cache`` schema is touched, so the discogs-cache-owned ``entity.*``
+    identity tables in the shared test PG stay intact.
     """
     async with pg_pool.acquire() as conn:
         await conn.execute("DROP SCHEMA IF EXISTS lml_cache CASCADE")
-        await conn.execute("DROP TABLE IF EXISTS entity.album_apple_music_lookup_cache")
-        await conn.execute("CREATE SCHEMA IF NOT EXISTS entity")
     await set_up_streaming_url_cache_schema(pg_source)
     yield
     async with pg_pool.acquire() as conn:
         await conn.execute("DROP SCHEMA IF EXISTS lml_cache CASCADE")
-        await conn.execute("DROP TABLE IF EXISTS entity.album_apple_music_lookup_cache")
 
 
 @pytest.mark.pg
@@ -243,82 +222,3 @@ class TestRoundTrip:
             pg_source, service=service, artist="Nilufer Yanya", album="painless"
         )
         assert result == sample_url
-
-
-@pytest.mark.pg
-class TestAppleBackfill:
-    """The lifespan backfill copies the grandfathered apple-only rows into the
-    new table, keyed under ``service = 'apple_music_album'``, preserving each
-    row's ``last_checked_at`` (the TTL-preservation AC)."""
-
-    @pytest.mark.asyncio
-    async def test_backfill_preserves_last_checked_at(self, pg_source, pg_pool):
-        # Recreate + seed the OLD apple table: one hit, one known-miss with an
-        # 8-day-old timestamp. The known-miss timestamp is the load-bearing
-        # assertion — a naive backfill resetting it to now() would resurrect a
-        # stale miss for another 7 days.
-        old_miss_ts = datetime(2026, 6, 9, 9, 0, 0, tzinfo=UTC)
-        async with pg_pool.acquire() as conn:
-            await conn.execute(_OLD_APPLE_TABLE_DDL)
-            await conn.execute(
-                "INSERT INTO entity.album_apple_music_lookup_cache "
-                "(artist_normalized, album_normalized, apple_music_url, last_checked_at) "
-                "VALUES ('stereolab', 'aluminum tunes', "
-                "'https://music.apple.com/us/album/aluminum-tunes/1', now())"
-            )
-            await conn.execute(
-                "INSERT INTO entity.album_apple_music_lookup_cache "
-                "(artist_normalized, album_normalized, apple_music_url, last_checked_at) "
-                "VALUES ('sessa', 'estrela acesa', NULL, $1)",
-                old_miss_ts,
-            )
-
-        # Re-run the idempotent bootstrap — now the to_regclass guard fires and
-        # the backfill copies both rows.
-        await set_up_streaming_url_cache_schema(pg_source)
-
-        async with pg_pool.acquire() as conn:
-            hit = await conn.fetchrow(
-                "SELECT url FROM lml_cache.album_streaming_url_cache "
-                "WHERE service = 'apple_music_album' AND artist_normalized = 'stereolab' "
-                "AND album_normalized = 'aluminum tunes'"
-            )
-            miss = await conn.fetchrow(
-                "SELECT url, last_checked_at FROM lml_cache.album_streaming_url_cache "
-                "WHERE service = 'apple_music_album' AND artist_normalized = 'sessa' "
-                "AND album_normalized = 'estrela acesa'"
-            )
-        assert hit is not None
-        assert hit["url"] == "https://music.apple.com/us/album/aluminum-tunes/1"
-        assert miss is not None
-        assert miss["url"] is None
-        # The original timestamp survived — NOT reset to now().
-        assert miss["last_checked_at"] == old_miss_ts
-
-    @pytest.mark.asyncio
-    async def test_backfill_does_not_clobber_existing_rows(self, pg_source, pg_pool):
-        # ON CONFLICT DO NOTHING: a row already present in the new table wins
-        # over the backfill source (idempotent re-runs never overwrite).
-        await set_cached_streaming_url(
-            pg_source,
-            service="apple_music_album",
-            artist="Stereolab",
-            album="Aluminum Tunes",
-            url="https://music.apple.com/us/album/new/2",
-        )
-        async with pg_pool.acquire() as conn:
-            await conn.execute(_OLD_APPLE_TABLE_DDL)
-            await conn.execute(
-                "INSERT INTO entity.album_apple_music_lookup_cache "
-                "(artist_normalized, album_normalized, apple_music_url) "
-                "VALUES ('stereolab', 'aluminum tunes', "
-                "'https://music.apple.com/us/album/old/1')"
-            )
-        await set_up_streaming_url_cache_schema(pg_source)
-        async with pg_pool.acquire() as conn:
-            row = await conn.fetchrow(
-                "SELECT url FROM lml_cache.album_streaming_url_cache "
-                "WHERE service = 'apple_music_album' AND artist_normalized = 'stereolab' "
-                "AND album_normalized = 'aluminum tunes'"
-            )
-        assert row["url"] == "https://music.apple.com/us/album/new/2"

--- a/tests/unit/test_streaming_url_cache_schema.py
+++ b/tests/unit/test_streaming_url_cache_schema.py
@@ -7,13 +7,12 @@ Two surfaces:
   ``lml_cache.album_streaming_url_cache`` table with the named CHECK
   constraint and composite PK, so a reviewer / operator has the DDL inline.
 * ``set_up_streaming_url_cache_schema`` — the lifespan bootstrap helper. It
-  must issue ``CREATE SCHEMA``, ``CREATE TABLE`` (named CHECK), and the
-  ``to_regclass``-guarded cross-schema backfill that preserves each
-  backfilled row's ``last_checked_at`` (the TTL-preservation AC).
+  must issue ``CREATE SCHEMA`` then ``CREATE TABLE`` (named CHECK) and nothing
+  else (the LML#571→#573 apple-table backfill was removed in #573's PR-2).
 
 PG is mocked; the integration layer
 (``tests/integration/test_streaming_url_persistent_lookup.py``) drives the
-real DDL + backfill against PostgreSQL.
+real DDL against PostgreSQL.
 """
 
 from __future__ import annotations
@@ -74,17 +73,16 @@ class TestCanonicalDDLReference:
 
 @pytest.mark.asyncio
 class TestSetUpStreamingUrlCacheSchema:
-    """``set_up_streaming_url_cache_schema`` runs idempotent DDL + guarded backfill."""
+    """``set_up_streaming_url_cache_schema`` runs exactly the idempotent DDL."""
 
     async def test_creates_schema_then_table(self):
         pg = AsyncMock(spec=PgSource)
         pg.execute = AsyncMock(return_value="CREATE")
-        # No grandfathered table → backfill is a no-op.
-        pg.fetchone = AsyncMock(return_value={"source_exists": False})
 
         await set_up_streaming_url_cache_schema(pg)
 
-        # First two executes: schema, then table.
+        # Exactly two executes — schema, then table. No backfill.
+        assert pg.execute.await_count == 2
         schema_sql = pg.execute.await_args_list[0].args[0]
         table_sql = pg.execute.await_args_list[1].args[0]
         assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in schema_sql
@@ -92,39 +90,16 @@ class TestSetUpStreamingUrlCacheSchema:
         assert "CONSTRAINT album_streaming_url_cache_service_valid CHECK" in table_sql
         assert "PRIMARY KEY (service, artist_normalized, album_normalized)" in table_sql
 
-    async def test_skips_backfill_when_old_table_absent(self):
+    async def test_does_not_probe_or_backfill_the_old_apple_table(self):
+        # Regression guard for #573 PR-2: the grandfathered
+        # ``entity.album_apple_music_lookup_cache`` backfill is gone — the
+        # bootstrap must not probe ``to_regclass`` or run any INSERT.
         pg = AsyncMock(spec=PgSource)
         pg.execute = AsyncMock(return_value="CREATE")
-        pg.fetchone = AsyncMock(return_value={"source_exists": False})
 
         await set_up_streaming_url_cache_schema(pg)
 
-        # Exactly two executes (schema + table); no backfill INSERT.
-        assert pg.execute.await_count == 2
-        # The guard probed to_regclass first.
-        probe_sql = pg.fetchone.await_args.args[0]
-        assert "to_regclass('entity.album_apple_music_lookup_cache')" in probe_sql
-
-    async def test_runs_backfill_when_old_table_present(self):
-        pg = AsyncMock(spec=PgSource)
-        pg.execute = AsyncMock(return_value="CREATE")
-        pg.fetchone = AsyncMock(return_value={"source_exists": True})
-
-        await set_up_streaming_url_cache_schema(pg)
-
-        # Schema, table, then the backfill INSERT.
-        assert pg.execute.await_count == 3
-        backfill_sql = pg.execute.await_args_list[2].args[0]
-        assert "INSERT INTO lml_cache.album_streaming_url_cache" in backfill_sql
-        assert "FROM entity.album_apple_music_lookup_cache" in backfill_sql
-        assert "'apple_music_album'" in backfill_sql
-        assert (
-            "ON CONFLICT (service, artist_normalized, album_normalized) DO NOTHING" in backfill_sql
-        )
-        # TTL-preservation AC: last_checked_at is projected EXPLICITLY in the
-        # SELECT, not left to the column default (which would extend every
-        # backfilled known-miss row's TTL by up to 7 days).
-        assert "last_checked_at" in backfill_sql
-        assert "now()" not in backfill_sql, (
-            "backfill must project the source row's last_checked_at, not now()"
-        )
+        pg.fetchone.assert_not_awaited()
+        executed = [call.args[0] for call in pg.execute.await_args_list]
+        assert not any("INSERT" in sql for sql in executed)
+        assert not any("album_apple_music_lookup_cache" in sql for sql in executed)


### PR DESCRIPTION
PR-2 of [#573](https://github.com/WXYC/library-metadata-lookup/issues/573). PR-1 ([#597](https://github.com/WXYC/library-metadata-lookup/pull/597)) generalized the Apple-only persistent URL cache into the polymorphic `lml_cache.album_streaming_url_cache` table and, to preserve production rows during the cutover, left the old `entity.album_apple_music_lookup_cache` table in place behind a `to_regclass`-guarded, idempotent lifespan backfill (copies apple rows into the new table under `service = 'apple_music_album'`, preserving each row's `last_checked_at`). This is the cleanup tail: now that PR-1 has baked, remove the dead backfill machinery. After this, `entity.*` holds only discogs-cache-owned identity tables, restoring the ownership invariant ([discogs-etl#288](https://github.com/WXYC/discogs-etl/issues/288) Option 3).

This is **LML-only**: discogs-etl has no alembic migration for the old table (LML created it in lifespan, so LML may drop it), and discogs-etl's `CLAUDE.md` already documents the retired pattern.

## Changes
- `entity/streaming_url_cache.py` — remove `_BACKFILL_SQL` + `_BACKFILL_SOURCE_EXISTS_SQL` and the guarded backfill in `set_up_streaming_url_cache_schema` (reduces to `CREATE SCHEMA` + `CREATE TABLE`).
- `main.py` — trim the lifespan comment's backfill clause.
- `tests/unit/test_streaming_url_cache_schema.py` — drop the two backfill tests; add a regression guard asserting the bootstrap never probes `to_regclass` or runs an `INSERT`.
- `tests/integration/test_streaming_url_persistent_lookup.py` — remove the `TestAppleBackfill` class + `_OLD_APPLE_TABLE_DDL`; simplify the autouse fixture to reset only `lml_cache`.
- `CLAUDE.md` — mark the `entity.*` → `lml_cache.*` migration complete.

## Operational step (gated, not in this PR)
After the 72h prod bake (≈2026-06-20 19:29 UTC) with all three epic-#573 trigger criteria met, run a `SELECT … orphaned = 0` parity check against the prod discogs-cache PG, then `DROP TABLE entity.album_apple_music_lookup_cache`. The still-deployed pre-PR-2 backfill guard no-ops cleanly once the table is absent, so the DROP is safe to run before or after this merges.

## Verification
- `ruff check` + `ruff format --check`: clean.
- `mypy . --ignore-missing-imports`: no issues (330 files).
- `pytest tests/unit`: 2728 passed (incl. the new regression guard).
- `pytest -m pg tests/integration/test_streaming_url_persistent_lookup.py`: 14 passed against `postgres:16-alpine`.

## Scope
Does **not** close [#573](https://github.com/WXYC/library-metadata-lookup/issues/573) — PR-3 (Bandcamp + Deezer + cache warmer) remains.