### PR TITLE
refactor(#604): extract release_resolution module + widen discogs_titles seam (PR1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,30 @@ _Avoid_: "App ID" (different identifier type, for iOS apps), "service ID" (yet a
 
 **Match floor**: Per-call verification threshold (`fuzz.token_set_ratio >= 80`) applied to Apple Music search results' artist/track/album fields before accepting a URL. Stops the wrong link from freezing onto a flowsheet row when Apple's search ranking is unstable for obscure artists (LML#389, #396).
 
+### Release resolution (compilation cross-reference)
+
+**Release resolution**: Finding *which specific Discogs release* a track sits on and confirming the track is actually on it, by cross-referencing the track against Discogs release search and checking the tracklist. Independent of the release-level artist credit — it answers "which release", not "does the typed artist own this release". Lives in one module, `lookup/release_resolution.py`: `resolve_release_for_track(song, artist, album?)` returns a ranked `list[ResolvedRelease]` (title-match to the requested album first, stable `release_id` tie-break), or empty. The module also owns the shared probe/validate primitives (`merge_wave_b_compilations`, `validate_release_for_track`) that the miss-path search strategies (`TRACK_ON_COMPILATION`, `SONG_AS_TRACK`) delegate to — they keep their own interleaved library-match-then-validate flow (so validation only pays for library-matching releases, LML#536), while the binding step calls `resolve_release_for_track` directly as its lazy fallback.
+_Avoid_: "album lookup", "Discogs search" (those name the raw probe; release resolution is probe + tracklist validation + ranking).
+
+**ResolvedRelease**: The value release resolution yields — `release_id`, `release_url`, `is_compilation`, `album_title`. Carried internally (never on the wire) from whichever producer resolved it to the binding step, keyed by library-row id. The seam that carries it was historically lossy: it carried only the album-title string (`discogs_titles: dict[int, str]`), dropping the proven `release_id`.
+
+**Track-credit validation**: `validate_track_on_release` matching the *per-track* artist credit (`tracklist[].artists`), not the release-level artist. This is why a Various-Artists compilation validates: "Message to Black Youth" credits "A Guy Called Gerald" on its own tracklist row even though the release credits "Various". Release resolution leans on this so the typed track-artist never has to match the release credit.
+
+**Artist floor**: The 80/80 acceptance threshold the artwork/Discogs-binding search applies to (release artist, title) via `find_best_typed_match` — the same family as the Apple Music **match floor** above. It correctly rejects a wrong-artist release, but it *also* rejects the right Various-Artists release for a track-artist query, because "A Guy Called Gerald" can never clear 80 against a release credited "Various". Release resolution deliberately **bypasses** the artist floor: the artist was already settled by track-credit validation, so binding a resolved release does not re-gate on the release credit.
+
+**Binding step**: `fetch_artwork_for_items` — where a resolved release becomes the album's outbound `discogs_url` / artwork / `release_year` (the `DiscogsMatchResult` Backend persists to `album_metadata`). When it carries a `ResolvedRelease` it trust-and-binds by id (no re-search, no floor); when it doesn't and its floor search comes up empty, it *lazily* runs release resolution as a fallback (flagged; negative-cached; live-worker path only, not the bulk backfill).
+
+**Compilation / Various-Artists (V/A)**: A release crediting "Various" at the release level while each track credits its own artist. Filed in the WXYC library under its own V/A conventions (see the librarian V/A invariant). The reason a flowsheet track and its Discogs release disagree on "the artist".
+
 ## Example dialogue
+
+> **Dev**: A compilation track shows streaming buttons and cover art but no Discogs link. Why just that one?
+>
+> **Domain expert**: Three different paths feed those surfaces. Streaming links resolve track-level by (artist, album), and the cover comes from the app's own free-text Discogs search — neither touches the **artist floor**. The Discogs link only appears when **release resolution** bound a `discogs_url`, and for a Various-Artists release the binding step re-searched by the track artist and the artist floor rejected "Various".
+>
+> **Dev**: But we *know* which release it's on — the track validated against the tracklist.
+>
+> **Domain expert**: Right, that's **track-credit validation** — it matches the per-track credit, so the comp validates fine. The problem was the proven `release_id` got dropped at a lossy seam and the binding step re-derived a release through the floor. Resolve it once, carry the **ResolvedRelease**, and let binding trust it instead of re-floor-gating.
 
 > **Dev**: A DJ reported that the Apple Music button for one of her flowsheet entries opens the wrong song. The wrong artist's track. Same title.
 >

--- a/core/search.py
+++ b/core/search.py
@@ -21,6 +21,7 @@ import sentry_sdk
 
 from generated.api_models import TrackMatchHint
 from library.models import LibraryItem
+from lookup.release_resolution import ResolvedRelease
 from services.parser import ParsedRequest
 
 logger = logging.getLogger(__name__)
@@ -330,8 +331,14 @@ class SearchState:
     strategies_tried: list[SearchStrategyType] = field(default_factory=list)
     """List of strategies that have been executed."""
 
-    discogs_titles: dict[int, str] = field(default_factory=dict)
-    """Map of library item ID to Discogs album title (for artwork lookup)."""
+    discogs_titles: dict[int, ResolvedRelease] = field(default_factory=dict)
+    """Map of library item ID to the resolved Discogs release (for artwork lookup).
+
+    Widened from ``dict[int, str]`` (bare album title) to carry the full
+    :class:`~lookup.release_resolution.ResolvedRelease` — release id/url,
+    compilation flag, and the album title the seam used to carry. Internal to
+    LML; never on the wire.
+    """
 
     albums_for_search: list[str] = field(default_factory=list)
     """Album names resolved from Discogs track lookup (may contain multiple)."""
@@ -427,8 +434,8 @@ class Outcome:
     after the compilation hit replaces them.
     """
 
-    discogs_titles: dict[int, str] | None = None
-    """Per-id Discogs album titles (for artwork lookup). ``None`` = no-op."""
+    discogs_titles: dict[int, ResolvedRelease] | None = None
+    """Per-id resolved Discogs releases (for artwork lookup). ``None`` = no-op."""
 
     matched_via_by_id: dict[int, list[TrackMatchHint]] | None = None
     """Per-id track-match hints (catalog-track-search §5.1). ``None`` = no-op."""
@@ -488,7 +495,9 @@ class Outcome:
         return cls(items=items, song_not_found_after=True)
 
     @classmethod
-    def compilation(cls, items: list[LibraryItem], *, discogs_titles: dict[int, str]) -> "Outcome":
+    def compilation(
+        cls, items: list[LibraryItem], *, discogs_titles: dict[int, ResolvedRelease]
+    ) -> "Outcome":
         """TRACK_ON_COMPILATION's full signal.
 
         Five writes packaged together:

--- a/core/search.py
+++ b/core/search.py
@@ -15,14 +15,20 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import ClassVar, Protocol
+from typing import TYPE_CHECKING, ClassVar, Protocol
 
 import sentry_sdk
 
 from generated.api_models import TrackMatchHint
 from library.models import LibraryItem
-from lookup.release_resolution import ResolvedRelease
 from services.parser import ParsedRequest
+
+if TYPE_CHECKING:
+    # Type-only import: ``core`` referencing ``lookup`` at runtime would invert the
+    # layering and risk an import cycle. ``release_resolution`` is a leaf today, but
+    # keeping this reference annotation-only (quoted below) makes the boundary
+    # structural, not just a convention defended by a comment.
+    from lookup.release_resolution import ResolvedRelease
 
 logger = logging.getLogger(__name__)
 
@@ -331,7 +337,7 @@ class SearchState:
     strategies_tried: list[SearchStrategyType] = field(default_factory=list)
     """List of strategies that have been executed."""
 
-    discogs_titles: dict[int, ResolvedRelease] = field(default_factory=dict)
+    discogs_titles: "dict[int, ResolvedRelease]" = field(default_factory=dict)
     """Map of library item ID to the resolved Discogs release (for artwork lookup).
 
     Widened from ``dict[int, str]`` (bare album title) to carry the full
@@ -434,7 +440,7 @@ class Outcome:
     after the compilation hit replaces them.
     """
 
-    discogs_titles: dict[int, ResolvedRelease] | None = None
+    discogs_titles: "dict[int, ResolvedRelease] | None" = None
     """Per-id resolved Discogs releases (for artwork lookup). ``None`` = no-op."""
 
     matched_via_by_id: dict[int, list[TrackMatchHint]] | None = None
@@ -496,7 +502,7 @@ class Outcome:
 
     @classmethod
     def compilation(
-        cls, items: list[LibraryItem], *, discogs_titles: dict[int, ResolvedRelease]
+        cls, items: list[LibraryItem], *, discogs_titles: "dict[int, ResolvedRelease]"
     ) -> "Outcome":
         """TRACK_ON_COMPILATION's full signal.
 

--- a/docs/plans/compilation-release-resolution.md
+++ b/docs/plans/compilation-release-resolution.md
@@ -1,0 +1,157 @@
+# Compilation release resolution — bind `discogs_url` for Various-Artists tracks
+
+## Problem
+
+A flowsheet track that lives on a Various-Artists (V/A) compilation never gets a Discogs link in the app, even when LML can prove exactly which Discogs release the track sits on. Concrete case: **A Guy Called Gerald — "Message to Black Youth"**, on the compilation **"When There Is No Sun"** ([discogs.com/release/36907527](https://www.discogs.com/release/36907527), credited to "Various"). The iOS "More Info" section renders its Discogs button only when `album.discogsURL` is non-nil; that value traces to `album_metadata.discogs_url` in Backend, which LML never bound.
+
+Streaming buttons and cover art *do* appear because they resolve through compilation-agnostic paths (track-level streaming lookup keyed by `(artist, album)`; the iOS app's own free-text Discogs artwork search). Only the structured Discogs link is missing — and it is missing for **every** compilation track, systematically.
+
+## Root cause (traced)
+
+Two independent facts combine:
+
+1. **No producer fires for a found album row.** Every LML path that resolves a *specific* V/A `release_id` by track — `TRACK_ON_COMPILATION`, `SONG_AS_TRACK`, and the library-miss probe (`lookup/orchestrator.py:3108`) — is gated on `song_not_found` / library-miss. The enrichment worker supplies the album, so:
+   - `resolve_albums_for_track` short-circuits at `lookup/orchestrator.py:826` (album present, ≠ artist) → returns `song_not_found=False` (it never runs the Discogs track lookup).
+   - That `False` seeds the pipeline (`:3084`); `ARTIST_PLUS_ALBUM` finds the row and returns `Outcome.album_match`, which **leaves `song_not_found` untouched** (`core/search.py:476`).
+   - `TrackOnCompilation.should_attempt = song_not_found_with_artist_and_song` (`core/search.py:633`, gate at `lookup/strategies/track_on_compilation.py:50`) → `False`. The compilation strategy never runs.
+
+2. **The binding step re-derives the release through an artist floor that rejects "Various".** `fetch_artwork_for_items.fetch_one` (`lookup/orchestrator.py:2145+`) re-searches Discogs by `item.alternate_artist_name or item.artist` (`:2155`) — the track artist — and only swaps in the "Various" search form `if is_compilation_artist(artist)` (`:2156`), i.e. only when the *library row itself* is filed under "Various". For a track-artist row it scores candidates with `find_best_typed_match` at the 80/80 **artist floor** (`:2188`); "A Guy Called Gerald" can never clear 80 against a release credited "Various", so the result is `None` → no `DiscogsMatchResult` → no `discogs_url`.
+
+**Why the fix is possible:** `validate_track_on_release` matches the *per-track* artist credit (`discogs/service.py:1432-1436`, `_scan_tracklist_for_match`), not the release-level credit. "Message to Black Youth" credits "A Guy Called Gerald" on its own tracklist row, so the comp validates `True` for the track artist. The artist floor lives only in the artwork re-search; routing the binding step through validation instead of the floor is the bypass.
+
+## Approach
+
+Extract one deep release-resolution module and make the binding step its newest caller. This is the "consolidation" framing (vs. a one-off patch in `fetch_one`): today `process_release` (`:1610`), `SONG_AS_TRACK._validate_one` (`:1024`), and the library-miss probe each re-implement "find the Discogs release this track sits on, and validate it." Collapse that into one module; the binding step calls it lazily when its floor search fails.
+
+### The module
+
+```python
+# lookup/release_resolution.py  (new)
+"""Release resolution — find and validate the Discogs release a track sits on.
+
+Owns the probe set (Discogs release search by track + per-candidate track-credit
+validation) and ranking (title match to album, stable release_id tie-break).
+Does NOT own row matching (library search, artist/compilation filtering) — the
+search strategies own that. Called by TRACK_ON_COMPILATION, SONG_AS_TRACK, and
+the binding step's lazy fallback (floor rejection + song present).
+"""
+
+@dataclass(frozen=True)
+class ResolvedRelease:
+    release_id: int
+    release_url: str
+    is_compilation: bool
+    album_title: str            # preserves today's discogs_titles value
+
+async def resolve_release_for_track(
+    song: str,
+    artist: str,
+    album: str | None,
+    discogs_service: DiscogsService,
+) -> list[ResolvedRelease]:
+    """Find and validate the Discogs release(s) a track sits on.
+
+    Owns the probe set (the Wave A/B `search_releases_by_track` calls + the
+    conditional V/A-merge, lifted wholesale from search_compilations_for_track
+    :1481-1519) and per-candidate `validate_track_on_release` (which matches the
+    per-track credit, not the release credit). Does NOT do library-row matching.
+
+    Returns releases ranked by title match to `album` (via `score_match` on
+    TITLE ONLY — deliberately not find_best_typed_match, whose artist floor is
+    what we are bypassing; artist is settled by track-credit validation), with a
+    stable `release_id` tie-break. Empty when nothing validates.
+    """
+```
+
+- **Boundary: release-only.** Library-row matching (`search_album_fuzzy` + the artist/compilation filter) stays in the strategies; the binding step already has its row.
+- **Return: ranked list.** Ranking is owned by the module (title-match primary, stable `release_id` tie-break). The binding step takes `[0]`; strategies that want per-release provenance iterate. This is what kills the divergent-pressing bug — instead of taking Discogs's top-1 from a re-search (which can be a deluxe reissue), the module deterministically prefers the release whose title matches the requested album.
+
+### The seam
+
+`SearchState.discogs_titles: dict[int, str]` (`core/search.py:333`) becomes `dict[int, ResolvedRelease]`, threaded through `Outcome.compilation` (`core/search.py:491`), `_apply` (`:570`), and into `fetch_artwork_for_items`. Internal to LML — never on the wire.
+
+### The binding step
+
+`fetch_one` gains two paths:
+- **Carried release present** (strategy already resolved it): trust-and-bind — synthesize `DiscogsSearchResult` from `release_id`/`release_url`, fetch art via `_resolve_fallback_artwork(release_id)` (`:2096`), skip `search()` + floor. Downstream `enrich_artwork_results` fills year/label/genres via `get_release` as today.
+- **No carried release AND floor search returned `None` AND `song` present**: lazily call `resolve_release_for_track`, take `[0]`, trust-and-bind. This is the path that fixes a directly-found album row.
+
+Trust is sound: a carried release was validated this same request; a lazily-resolved release was just validated by the module. The floor was never a validation backstop — it is a search disambiguator, and validation already settled the artist.
+
+## Decisions (locked)
+
+| # | Decision | Resolution |
+|---|---|---|
+| 1 | Channel | Internal `ResolvedRelease` on the upgraded `discogs_titles` dict. Not on `LibraryItem`, not on the wire. |
+| 2 | Binding behavior | Trust-and-bind (skip search + floor; `get_release(id)` for art/year). |
+| 3 | Shape | Extract one `resolve_release_for_track` module; strategies delegate; binding calls lazily on floor-reject. |
+| 4 | Module boundary | Release-only (probe + track-credit validation). Row-matching stays in strategies. |
+| 5 | Return | Ranked `list[ResolvedRelease]`; title-match primary, stable `release_id` tie-break; binding takes `[0]`. |
+| 6 | Cost posture | Flagged (default off), **negative-cached**, **bulk path excluded**. Live worker is first consumer. |
+| 7 | Sequencing | PR1 behavior-neutral extraction **+ seam-widen** → PR2 flagged lazy bind. |
+| 8 | Wire scope | Invisible; internal telemetry only. No `api.yaml` change. |
+
+## PR1 — Extract the module + widen the seam (behavior-neutral)
+
+**Goal:** pay down the duplication and do all the structural plumbing at once, with zero *observable* behavior change. The existing pinned suites (LML#536 / #301 / #400 / #478) are the proof — if a behavior test (which rows surface, which `discogs_url` binds) moves, the extraction is wrong.
+
+- New `lookup/release_resolution.py`: module docstring (above) + `ResolvedRelease` + `resolve_release_for_track`. Lift the probe set + V/A-merge from `search_compilations_for_track` (`:1481-1519`) and the `validate_track_on_release` loop.
+- `search_compilations_for_track.process_release` (`:1537-1633`) delegates its probe+validate to the module; keeps its own `search_album_fuzzy` + row filter.
+- `SONG_AS_TRACK._validate_one` (`:1006-1043`) delegates likewise.
+- **Widen the seam here** (not PR2 — doing it later would re-touch these exact call sites): `SearchState.discogs_titles: dict[int, str]` → `dict[int, ResolvedRelease]`, through `Outcome.compilation` (`core/search.py:491`), `_apply` (`:570`), and the `fetch_artwork_for_items` signature (`:2137`). **The binding step stays behavior-identical** — it extracts `release.album_title` from the carried `ResolvedRelease` and re-searches exactly as today. The richer type is produced but not yet *consumed* differently. That consumption is PR2's flagged change.
+- Tests: characterization on observable behavior (rows, URLs). Internal-shape assertions that referenced `discogs_titles[id] == "<title>"` update mechanically to `discogs_titles[id].album_title == "<title>"` — part of the refactor, not a behavior change. Run the full marker matrix (`pg`, `external_api`) green.
+
+**Risk:** hottest matching code. Mitigation: behavior-identical extraction + widen; green pinned behavior-tests as the contract; ranking helper reuses existing `score_match`, and because the binding step still re-searches in PR1, scoring/selection is unchanged until PR2.
+
+## PR2 — Lazy bind (flagged behavior)
+
+**Goal:** the symptom fix. All structural plumbing (module, widened seam) already landed in PR1; PR2 changes only how the binding step *consumes* the seam, behind a flag.
+
+- `fetch_one` (`lookup/orchestrator.py:2145+`): add two paths — (a) **carried-release trust-and-bind** (a `ResolvedRelease` is present in the seam → synthesize `DiscogsSearchResult` from `release_id`/`release_url`, art via `_resolve_fallback_artwork(release_id)`, skip `search()`+floor); (b) **lazy fallback** — when no carried release AND the floor search returned `None` AND `song` is present AND the flag is on AND `allow_release_resolution_fallback`, call `resolve_release_for_track`, take `[0]`, trust-and-bind.
+- **Flag** — add to `config/settings.py` (mirror `lml_resolve_artist_canonical`):
+  ```python
+  lml_resolve_compilation_release: bool = Field(
+      default=False,
+      description=(
+          "When True, the artwork binding step lazily runs "
+          "resolve_release_for_track() as a fallback when its floor search "
+          "returns None and a song is present — binding the validated release "
+          "(typically a Various-Artists compilation) without the artist floor. "
+          "When False, a floor-rejected release stays unbound (existing "
+          "behavior). Default False; roll staging -> prod, watch Discogs call "
+          "rate. Never enabled on the /lookup/bulk path. See LML#<issue>."
+      ),
+  )
+  ```
+- **Negative cache:** wrap `resolve_release_for_track` with the L1 `@async_cached` null-pinning pattern, keyed `(song, artist, album)`, so an unresolvable row does not re-probe every poll. Mandatory — without it this is the 2026-05-21 backfill-monopolization / LML#370-#372 cascade shape.
+- **Bulk exclusion:** add `allow_release_resolution_fallback: bool = True` to `perform_lookup`'s signature. `handle_lookup` (`lookup/router.py:172`) uses the default (`True`); `handle_bulk_lookup`'s `_run_one` (`lookup/router.py:333`) passes `False`. So the 35k-album bulk drain can never trigger the fan-out. Historical compilation backfill, if wanted, is a separate paced job.
+- **Telemetry:** a `_log_track_validation`-style counter for "lazy fallback fired / bound" so we can prove adoption and watch cost. No wire field.
+
+### Test matrix (PR2)
+
+| Test | Asserts |
+|---|---|
+| **Red→green spine** | Stub Discogs so `search_releases_by_track("Message to Black Youth","A Guy Called Gerald")` returns `ReleaseInfo(album="When There Is No Sun", artist="Various", release_id=36907527, release_url="https://www.discogs.com/release/36907527", is_compilation=True)`, and `get_release(36907527)` returns a tracklist whose "Message to Black Youth" row credits "A Guy Called Gerald" (so `validate_track_on_release` passes on the per-track credit). Request `(artist="A Guy Called Gerald", album="When There Is No Sun", song="Message to Black Youth")` with the flag on; assert `discogs_url == "https://www.discogs.com/release/36907527"`. Fails today (floor rejects "Various"). |
+| Negative cache | A second identical request issues no new Discogs probe when the first resolved to empty. |
+| Bulk exclusion | `/lookup/bulk` does not invoke the lazy fallback. |
+| Ranking | Two validated pressings (original + reissue) → the title-matched original is bound, deterministically across runs. |
+| Carried-release trust | A `TRACK_ON_COMPILATION` hit binds by id without a re-search (assert no `search()` call). |
+| Flag off | Flag disabled → behavior identical to pre-PR2 (no fallback, floor `None` stays `None`). |
+
+## Out of scope
+
+- Wire provenance (`TrackMatchHint.release_id` / `matched_via` for the bound comp) — the optional follow-on if a real consumer (e.g. dj-site "appears on compilation X") appears.
+- The consolidation of the 80-floor constants and the V/A gates into one verdict module (review Candidate #2) — separate, calibration-sensitive work.
+- Persisting `discogs_release_id` as a first-class column / `entity.release_identity` join (review Candidate #3) — crosses the discogs-cache schema-ownership seam.
+- Backend `album_metadata` projection consolidation (review Candidate #4) — BS-side, project #32 / Epic D.
+
+## Rollout
+
+1. Merge PR1 (no behavior change; auto-deploys to staging on `main`).
+2. Merge PR2 with `lml_resolve_compilation_release` **off**.
+3. Enable on staging; verify the spine case binds and watch the Discogs call-rate metric.
+4. Enable on prod (`prod` branch). Spot-check the screenshot case in the app; confirm no cascade signature on the Discogs semaphore.
+
+## CONTEXT.md
+
+This branch adds the "Release resolution (compilation cross-reference)" language section to `CONTEXT.md` (Release resolution, ResolvedRelease, track-credit validation, artist floor, binding step, compilation/V-A) and an example dialogue. It travels with PR1.

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -80,6 +80,12 @@ from lookup.external_search import (
     search_external_tracks,
 )
 from lookup.models import LookupRequest, LookupResponse, LookupResultItem
+from lookup.release_resolution import (
+    ResolvedRelease,
+    _log_track_validation,
+    merge_wave_b_compilations,
+    validate_release_for_track,
+)
 from lookup.strategies import build_strategies
 from lookup.streaming_url_postprocess import apply_streaming_url_postprocess
 from lookup.timeouts import apple_music_lookup_timeout_s
@@ -535,64 +541,6 @@ def _project_mb_rescue_attrs(
         logger.warning("Failed to project mb_rescue attrs onto Sentry transaction: %s", e)
 
 
-def _log_track_validation(
-    *,
-    source: str,
-    release_id: int,
-    song: str,
-    artist: str | None,
-    verdict: bool,
-    latency_ms: float,
-    sample_rate: float = 0.01,
-) -> None:
-    """Audit instrumentation for ``DiscogsService.validate_track_on_release`` (A7 / LML#344).
-
-    The cascade has two validation call sites: the inline check inside
-    ``TRACK_ON_COMPILATION``'s ``process_release`` and the post-cascade
-    sweep in ``filter_results_by_track_validation``. The audit ticket wants
-    to know how often the second call runs after the first already vetted
-    the same release, and how often the two verdicts disagree.
-
-    This helper records each call with a ``source`` label so downstream
-    Sentry analysis can split (release_id, verdict) pairs by source.
-    Two surfaces:
-
-    - **Sentry breadcrumb on every call** — trace explorer queries against
-      ``category:track_validation`` to count divergences without log-pipeline
-      tooling. Always-on; cost is microseconds per call.
-    - **Structured INFO log on a 1% sample** — cheap Railway-log grep target
-      for spot-checking. The full population is too large to log at INFO,
-      so the sample is randomized per call.
-
-    Both surfaces are non-essential; any SDK exception is swallowed and the
-    request proceeds. Same swallow pattern as :func:`_log_album_title_fallback`
-    / :func:`_log_resolver_pre_pass`.
-
-    The acceptance criterion from #344 is "7 days of data" — this helper
-    ships the instrumentation; the decision about whether to delete one of
-    the call sites is a follow-up after the data is in.
-    """
-    payload: dict[str, Any] = {
-        "source": source,
-        "release_id": release_id,
-        "song": song,
-        "artist": artist,
-        "verdict": verdict,
-        "latency_ms": round(latency_ms, 2),
-    }
-    try:
-        sentry_sdk.add_breadcrumb(
-            category="track_validation",
-            level="info",
-            data=payload,
-        )
-    except Exception as e:
-        logger.warning("Failed to add track_validation breadcrumb: %s", e)
-
-    if random.random() < sample_rate:
-        logger.info("track_validation %s", payload)
-
-
 def _log_resolver_pre_pass(outcome: ResolverOutcome, *, actual_swap: bool) -> None:
     """Emit shadow-mode telemetry for the resolver pre-pass.
 
@@ -1022,17 +970,12 @@ async def search_song_as_track(
         # after library matching so we only pay the API cost for releases we'd
         # actually return, mirroring search_compilations_for_track.
         if release.release_id:
-            _validation_start = time.monotonic()
-            is_valid = await discogs_service.validate_track_on_release(
-                release.release_id, song, release.artist
-            )
-            _log_track_validation(
+            is_valid = await validate_release_for_track(
+                discogs_service,
+                release.release_id,
+                song,
+                release.artist,
                 source="song_as_track",
-                release_id=release.release_id,
-                song=song,
-                artist=release.artist,
-                verdict=is_valid,
-                latency_ms=(time.monotonic() - _validation_start) * 1000,
             )
             if not is_valid:
                 logger.debug(
@@ -1370,8 +1313,13 @@ async def search_compilations_for_track(
     db: LibraryDB,
     parsed: ParsedRequest,
     discogs_service: DiscogsService | None = None,
-) -> tuple[list[LibraryItem], dict[int, str]]:
-    """Search for track on compilation albums using Discogs and library keyword search."""
+) -> tuple[list[LibraryItem], dict[int, ResolvedRelease]]:
+    """Search for track on compilation albums using Discogs and library keyword search.
+
+    The second tuple element maps each surfaced library id to the
+    :class:`~lookup.release_resolution.ResolvedRelease` it matched — the widened
+    ``discogs_titles`` seam consumed by the artwork-binding step.
+    """
     if not parsed.song or not parsed.artist:
         return [], {}
 
@@ -1379,7 +1327,7 @@ async def search_compilations_for_track(
 
     results = []
     seen_ids = set()
-    discogs_titles: dict[int, str] = {}
+    discogs_titles: dict[int, ResolvedRelease] = {}
 
     keyword_matches = []
     try:
@@ -1501,22 +1449,14 @@ async def search_compilations_for_track(
                 probe_tuple = gathered[2]
                 assert isinstance(probe_tuple, tuple)
                 album_fallback_response, album_fallback_error = probe_tuple
-            raw_releases = list(response.releases or [])
 
-            # Only merge VA results if Wave A already surfaced a *true V/A* hit.
-            # Gating on ``r.is_compilation`` alone (Discogs's ``format=Compilation``
-            # flag) over-suppresses: single-artist retrospectives are flagged
-            # ``Compilation`` too, but they are not V/A and Wave B is the only
-            # probe that surfaces real V/A releases. See WXYC#527.
-            has_va_compilation = any(
-                r.is_compilation and is_compilation_artist(r.artist or "") for r in raw_releases
+            # Merge Wave B's V/A compilations into Wave A unless Wave A already
+            # surfaced a true-V/A hit (WXYC#527). The merge logic is owned by
+            # ``lookup.release_resolution.merge_wave_b_compilations`` so the
+            # release-resolution module and this strategy can't drift apart.
+            raw_releases = merge_wave_b_compilations(
+                list(response.releases or []), list(va_response.releases or [])
             )
-            if not has_va_compilation:
-                seen_album_keys = {r.album.lower() for r in raw_releases}
-                for r in va_response.releases or []:
-                    if r.is_compilation and r.album.lower() not in seen_album_keys:
-                        raw_releases.append(r)
-                        seen_album_keys.add(r.album.lower())
         else:
             # No injected service — fall back to lookup helper (validates all)
             tuples = await lookup_releases_by_track(song_search, parsed.artist, service=None)
@@ -1539,7 +1479,7 @@ async def search_compilations_for_track(
             *,
             skip_self_named_album: bool = True,
             skip_artist_match_filter: bool = False,
-        ) -> list[tuple[LibraryItem, str]]:
+        ) -> list[tuple[LibraryItem, ResolvedRelease]]:
             """Process one Discogs release: library search, filter, validate.
 
             ``skip_self_named_album`` defaults True to preserve existing behavior
@@ -1606,19 +1546,14 @@ async def search_compilations_for_track(
 
             # Validate that the track actually exists on this release.
             # Deferred until after library matching so we only validate
-            # releases we might actually return — saving API calls.
+            # releases we might actually return — saving API calls (LML#536).
             if discogs_service and release_info.release_id and parsed.artist:
-                _validation_start = time.monotonic()
-                is_valid = await discogs_service.validate_track_on_release(
-                    release_info.release_id, song_search, parsed.artist
-                )
-                _log_track_validation(
+                is_valid = await validate_release_for_track(
+                    discogs_service,
+                    release_info.release_id,
+                    song_search,
+                    parsed.artist,
                     source="compilation_inline",
-                    release_id=release_info.release_id,
-                    song=song_search,
-                    artist=parsed.artist,
-                    verdict=is_valid,
-                    latency_ms=(time.monotonic() - _validation_start) * 1000,
                 )
                 if not is_valid:
                     logger.info(
@@ -1630,7 +1565,13 @@ async def search_compilations_for_track(
                 f"Found '{parsed.song}' in library on '{matches[0].title}' "
                 f"(matched from Discogs: '{release_album}')"
             )
-            return [(match, release_album) for match in matches]
+            resolved = ResolvedRelease(
+                release_id=release_info.release_id,
+                release_url=release_info.release_url,
+                is_compilation=bool(release_info.is_compilation),
+                album_title=release_album,
+            )
+            return [(match, resolved) for match in matches]
 
         # Chunked dispatch so the per-request validate budget stays bounded
         # once the response cap is hit. Without chunking, asyncio.gather
@@ -1641,11 +1582,11 @@ async def search_compilations_for_track(
         async for _, release_matches in _chunked_gather(
             raw_releases, process_release, MAX_SEARCH_RESULTS
         ):
-            for match, discogs_album in release_matches:
+            for match, resolved in release_matches:
                 if match.id not in seen_ids:
                     results.append(match)
                     seen_ids.add(match.id)
-                    discogs_titles[match.id] = discogs_album
+                    discogs_titles[match.id] = resolved
             if len(results) >= MAX_SEARCH_RESULTS:
                 break
 
@@ -1699,11 +1640,11 @@ async def search_compilations_for_track(
             async for _, release_matches in _chunked_gather(
                 fallback_releases, fallback_worker, MAX_SEARCH_RESULTS
             ):
-                for match, discogs_album in release_matches:
+                for match, resolved in release_matches:
                     if match.id not in seen_ids:
                         results.append(match)
                         seen_ids.add(match.id)
-                        discogs_titles[match.id] = discogs_album
+                        discogs_titles[match.id] = resolved
                 if len(results) >= MAX_SEARCH_RESULTS:
                     break
             if fallback_releases:
@@ -2134,7 +2075,7 @@ async def _resolve_fallback_artwork(discogs_service: DiscogsService, release_id:
 async def fetch_artwork_for_items(
     items: list[LibraryItem],
     discogs_service: DiscogsService | None,
-    discogs_titles: dict[int, str] | None = None,
+    discogs_titles: dict[int, ResolvedRelease] | None = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Fetch artwork for multiple library items in parallel."""
     if not discogs_service:
@@ -2144,7 +2085,11 @@ async def fetch_artwork_for_items(
 
     async def fetch_one(item: LibraryItem) -> DiscogsSearchResult | None:
         try:
-            album = discogs_titles.get(item.id, item.title)
+            # The widened seam carries a ResolvedRelease; its album_title is the
+            # value the seam used to carry as a bare string. Falls back to the
+            # library row's own title when no release was resolved for this id.
+            resolved = discogs_titles.get(item.id)
+            album = resolved.album_title if resolved is not None else item.title
 
             # Self-titled albums stored as "S/t" should use the artist name
             # for Discogs search instead of the abbreviation
@@ -3033,7 +2978,7 @@ async def perform_lookup(
     items_with_artwork: list[tuple[LibraryItem, DiscogsSearchResult | None]] = []
     song_not_found = False
     found_on_compilation = False
-    discogs_titles: dict[int, str] = {}
+    discogs_titles: dict[int, ResolvedRelease] = {}
     corrected_artist: str | None = None
 
     # Steps 1+2: Correct artist spelling and resolve albums (parallel)

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -10,7 +10,6 @@ import logging
 import os
 import random
 import re
-import time
 from collections.abc import AsyncIterator, Callable, Coroutine
 from dataclasses import dataclass
 from functools import partial
@@ -82,7 +81,6 @@ from lookup.external_search import (
 from lookup.models import LookupRequest, LookupResponse, LookupResultItem
 from lookup.release_resolution import (
     ResolvedRelease,
-    _log_track_validation,
     merge_wave_b_compilations,
     validate_release_for_track,
 )
@@ -1945,17 +1943,8 @@ async def filter_results_by_track_validation(
                     )
                     return None
 
-                _validation_start = time.monotonic()
-                is_valid = await discogs_service.validate_track_on_release(
-                    best_result.release_id, song, artist
-                )
-                _log_track_validation(
-                    source="step_3b",
-                    release_id=best_result.release_id,
-                    song=song,
-                    artist=artist,
-                    verdict=is_valid,
-                    latency_ms=(time.monotonic() - _validation_start) * 1000,
+                is_valid = await validate_release_for_track(
+                    discogs_service, best_result.release_id, song, artist, source="step_3b"
                 )
                 if is_valid:
                     logger.info(

--- a/lookup/release_resolution.py
+++ b/lookup/release_resolution.py
@@ -1,0 +1,221 @@
+"""Release resolution — find and validate the Discogs release a track sits on.
+
+Owns the probe set (Discogs release search by track + per-candidate track-credit
+validation) and ranking (title match to album, stable release_id tie-break).
+Does NOT own row matching (library search, artist/compilation filtering) — the
+search strategies own that. Called by TRACK_ON_COMPILATION, SONG_AS_TRACK, and
+(in a later change) the binding step's lazy fallback.
+
+Deliberately a leaf module: it imports only from ``discogs`` / ``clients`` /
+``wxyc_etl``, never from ``core`` or ``lookup``. Keeping it import-acyclic is
+what lets ``core.search`` reference ``ResolvedRelease`` on the widened
+``discogs_titles`` seam without a circular import.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import sentry_sdk
+from wxyc_etl.text import is_compilation_artist
+
+from clients.streaming.matching import score_match
+from discogs.models import ReleaseInfo
+from discogs.service import DiscogsService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedRelease:
+    """A Discogs release validated to contain a specific track.
+
+    Carried on the internal ``discogs_titles`` seam (``dict[int,
+    ResolvedRelease]``) from the search strategies to the artwork-binding step.
+    ``album_title`` preserves the value the seam carried as a bare string before
+    the type was widened.
+    """
+
+    release_id: int
+    release_url: str
+    is_compilation: bool
+    album_title: str
+
+
+def merge_wave_b_compilations(
+    wave_a: list[ReleaseInfo], wave_b: list[ReleaseInfo]
+) -> list[ReleaseInfo]:
+    """Merge Wave B's V/A compilations into Wave A, unless Wave A already has one.
+
+    Lifted from ``search_compilations_for_track`` (WXYC#527). Wave A is the
+    artist-field probe; Wave B is the keyword probe filtered to
+    ``format=Compilation``. Gating on ``r.is_compilation`` alone over-suppresses
+    — single-artist retrospectives are flagged ``Compilation`` too — so the
+    merge only fires when Wave A surfaced no *true V/A* hit (compilation AND a
+    compilation-artist credit), and only adds Wave B rows that are themselves
+    V/A compilations and not already present by album title.
+    """
+    merged = list(wave_a)
+    has_va_compilation = any(
+        r.is_compilation and is_compilation_artist(r.artist or "") for r in merged
+    )
+    if not has_va_compilation:
+        seen_album_keys = {r.album.lower() for r in merged}
+        for r in wave_b:
+            if r.is_compilation and r.album.lower() not in seen_album_keys:
+                merged.append(r)
+                seen_album_keys.add(r.album.lower())
+    return merged
+
+
+def _log_track_validation(
+    *,
+    source: str,
+    release_id: int,
+    song: str,
+    artist: str | None,
+    verdict: bool,
+    latency_ms: float,
+    sample_rate: float = 0.01,
+) -> None:
+    """Audit instrumentation for ``DiscogsService.validate_track_on_release`` (A7 / LML#344).
+
+    The cascade has two validation call sites: the inline check inside
+    ``TRACK_ON_COMPILATION``'s ``process_release`` and the post-cascade
+    sweep in ``filter_results_by_track_validation``. The audit ticket wants
+    to know how often the second call runs after the first already vetted
+    the same release, and how often the two verdicts disagree.
+
+    This helper records each call with a ``source`` label so downstream
+    Sentry analysis can split (release_id, verdict) pairs by source.
+    Two surfaces:
+
+    - **Sentry breadcrumb on every call** — trace explorer queries against
+      ``category:track_validation`` to count divergences without log-pipeline
+      tooling. Always-on; cost is microseconds per call.
+    - **Structured INFO log on a 1% sample** — cheap Railway-log grep target
+      for spot-checking. The full population is too large to log at INFO,
+      so the sample is randomized per call.
+
+    Both surfaces are non-essential; any SDK exception is swallowed and the
+    request proceeds. Same swallow pattern as ``_log_album_title_fallback``
+    / ``_log_resolver_pre_pass``.
+
+    The acceptance criterion from #344 is "7 days of data" — this helper
+    ships the instrumentation; the decision about whether to delete one of
+    the call sites is a follow-up after the data is in.
+    """
+    payload: dict[str, Any] = {
+        "source": source,
+        "release_id": release_id,
+        "song": song,
+        "artist": artist,
+        "verdict": verdict,
+        "latency_ms": round(latency_ms, 2),
+    }
+    try:
+        sentry_sdk.add_breadcrumb(
+            category="track_validation",
+            level="info",
+            data=payload,
+        )
+    except Exception as e:
+        logger.warning("Failed to add track_validation breadcrumb: %s", e)
+
+    if random.random() < sample_rate:
+        logger.info("track_validation %s", payload)
+
+
+async def validate_release_for_track(
+    discogs_service: DiscogsService,
+    release_id: int,
+    song: str,
+    artist: str,
+    *,
+    source: str,
+) -> bool:
+    """Validate a track's per-track credit on a release, with audit telemetry.
+
+    The shared primitive both ``TRACK_ON_COMPILATION`` (``process_release``)
+    and ``SONG_AS_TRACK`` (``_validate_one``) delegate to — wrapping
+    ``validate_track_on_release`` with the LML#344 timing + ``source``-labelled
+    ``_log_track_validation`` breadcrumb that was previously duplicated at each
+    site. Callers keep their own guards (release_id truthiness, artist presence)
+    and skip-logging; this owns the validate-and-record step.
+    """
+    start = time.monotonic()
+    verdict = await discogs_service.validate_track_on_release(release_id, song, artist)
+    _log_track_validation(
+        source=source,
+        release_id=release_id,
+        song=song,
+        artist=artist,
+        verdict=verdict,
+        latency_ms=(time.monotonic() - start) * 1000,
+    )
+    return verdict
+
+
+def _rank(releases: list[ResolvedRelease], album: str | None) -> list[ResolvedRelease]:
+    """Rank validated releases by title match to ``album`` (stable id tie-break).
+
+    Deliberately scores TITLE ONLY (not ``find_best_typed_match``, whose artist
+    floor is what this module bypasses — artist is settled by track-credit
+    validation). When ``album`` is empty there is nothing to rank against, so
+    the stable ``release_id`` ordering stands alone.
+    """
+    album_query = (album or "").strip()
+    if not album_query:
+        return sorted(releases, key=lambda r: r.release_id)
+    return sorted(
+        releases,
+        key=lambda r: (-score_match(album_query, r.album_title), r.release_id),
+    )
+
+
+async def resolve_release_for_track(
+    song: str,
+    artist: str,
+    album: str | None,
+    discogs_service: DiscogsService | None,
+) -> list[ResolvedRelease]:
+    """Find and validate the Discogs release(s) a track sits on.
+
+    Probes Discogs by track (Wave A artist-field + Wave B keyword/compilation),
+    merges Wave B's V/A compilations, validates each candidate's per-track credit
+    via ``validate_track_on_release`` (which matches the per-track credit, not the
+    release credit), and returns the validated releases ranked by title match to
+    ``album``. Empty when nothing validates.
+    """
+    if discogs_service is None or not song or not artist:
+        return []
+
+    wave_a, wave_b = await asyncio.gather(
+        discogs_service.search_releases_by_track(song, artist),
+        discogs_service.search_releases_by_track(song, artist, artist_as_keyword=True),
+    )
+    candidates = merge_wave_b_compilations(list(wave_a.releases or []), list(wave_b.releases or []))
+
+    validated: list[ResolvedRelease] = []
+    for release in candidates:
+        if not release.release_id:
+            continue
+        if not await validate_release_for_track(
+            discogs_service, release.release_id, song, artist, source="release_resolution"
+        ):
+            continue
+        validated.append(
+            ResolvedRelease(
+                release_id=release.release_id,
+                release_url=release.release_url,
+                is_compilation=bool(release.is_compilation),
+                album_title=release.album,
+            )
+        )
+
+    return _rank(validated, album)

--- a/lookup/release_resolution.py
+++ b/lookup/release_resolution.py
@@ -191,23 +191,41 @@ async def resolve_release_for_track(
     via ``validate_track_on_release`` (which matches the per-track credit, not the
     release credit), and returns the validated releases ranked by title match to
     ``album``. Empty when nothing validates.
+
+    Degrades gracefully on Discogs failures, matching the resilience of the
+    ``search_compilations_for_track`` path this was lifted from: a probe failure
+    yields an empty list (no candidates to resolve), and a single candidate's
+    validation failure drops only that candidate — releases already validated in
+    the same call survive. The live-worker caller (PR2's lazy bind) must never
+    have a transient Discogs error abort the whole request.
     """
     if discogs_service is None or not song or not artist:
         return []
 
-    wave_a, wave_b = await asyncio.gather(
-        discogs_service.search_releases_by_track(song, artist),
-        discogs_service.search_releases_by_track(song, artist, artist_as_keyword=True),
-    )
+    try:
+        wave_a, wave_b = await asyncio.gather(
+            discogs_service.search_releases_by_track(song, artist),
+            discogs_service.search_releases_by_track(song, artist, artist_as_keyword=True),
+        )
+    except Exception as exc:
+        logger.warning("Release-resolution probe failed for %r by %r: %s", song, artist, exc)
+        return []
     candidates = merge_wave_b_compilations(list(wave_a.releases or []), list(wave_b.releases or []))
 
     validated: list[ResolvedRelease] = []
     for release in candidates:
         if not release.release_id:
             continue
-        if not await validate_release_for_track(
-            discogs_service, release.release_id, song, artist, source="release_resolution"
-        ):
+        try:
+            is_valid = await validate_release_for_track(
+                discogs_service, release.release_id, song, artist, source="release_resolution"
+            )
+        except Exception as exc:
+            logger.warning(
+                "Release-resolution validation failed for release %s: %s", release.release_id, exc
+            )
+            continue
+        if not is_valid:
             continue
         validated.append(
             ResolvedRelease(

--- a/lookup/strategies/track_on_compilation.py
+++ b/lookup/strategies/track_on_compilation.py
@@ -28,11 +28,12 @@ from core.search import (
 )
 from library.db import LibraryDB
 from library.models import LibraryItem
+from lookup.release_resolution import ResolvedRelease
 from services.parser import ParsedRequest
 
 TrackOnCompilationExecute = Callable[
     [LibraryDB, ParsedRequest],
-    Awaitable[tuple[list[LibraryItem], dict[int, str]]],
+    Awaitable[tuple[list[LibraryItem], dict[int, ResolvedRelease]]],
 ]
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,6 +3,7 @@
 from discogs.models import DiscogsSearchResult
 from generated.api_models import DiscogsMatchResult, LibraryCatalogItem
 from library.models import LibraryItem
+from lookup.release_resolution import ResolvedRelease
 
 
 def make_library_item(id=1, artist="Stereolab", title="Aluminum Tunes", **kwargs):
@@ -59,6 +60,20 @@ def make_match_result(release_id=123, **kwargs):
     }
     defaults.update(kwargs)
     return DiscogsMatchResult(release_id=release_id, **defaults)
+
+
+def make_resolved_release(release_id=123, album_title="Aluminum Tunes", **kwargs):
+    """Build a ResolvedRelease (the widened ``discogs_titles`` seam value).
+
+    Defaults to a compilation since that is the seam's primary case; override
+    ``is_compilation`` / ``release_url`` via kwargs as needed.
+    """
+    defaults = {
+        "release_url": f"https://www.discogs.com/release/{release_id}",
+        "is_compilation": True,
+    }
+    defaults.update(kwargs)
+    return ResolvedRelease(release_id=release_id, album_title=album_title, **defaults)
 
 
 LOOKUP_BODY = {

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -27,7 +27,6 @@ from generated.api_models import (
     TrackMatchSource,
 )
 from lookup.orchestrator import (
-    _log_track_validation,
     _resolve_fallback_artwork,
     artist_matches_item,
     build_context_message,
@@ -41,6 +40,7 @@ from lookup.orchestrator import (
     search_song_as_track,
     search_with_alternative_interpretation,
 )
+from lookup.release_resolution import ResolvedRelease
 from services.parser import MessageType, ParsedRequest
 from tests.factories import make_discogs_result, make_library_item
 
@@ -1192,7 +1192,14 @@ class TestFetchArtworkForItems:
         )
         mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[artwork])
 
-        discogs_titles = {20: "Disco Not Disco (Post Punk, Electro & Leftfield Disco Classics)"}
+        discogs_titles = {
+            20: ResolvedRelease(
+                release_id=99999,
+                release_url="https://www.discogs.com/release/99999",
+                is_compilation=True,
+                album_title="Disco Not Disco (Post Punk, Electro & Leftfield Disco Classics)",
+            )
+        }
         results = await fetch_artwork_for_items(
             items=[item], discogs_service=mock_discogs_service, discogs_titles=discogs_titles
         )
@@ -2704,130 +2711,3 @@ class TestApiCallCap:
             "Item B never fired the cap but inherited A's signal — concurrent "
             "bulk regression (iter-3 review)."
         )
-
-
-# ---------------------------------------------------------------------------
-# Tests: _log_track_validation (A7 / LML#344 audit instrumentation)
-# ---------------------------------------------------------------------------
-
-
-class TestLogTrackValidation:
-    """Audit instrumentation for the two validate_track_on_release call sites.
-
-    LML#344 wants to know how often the step-3b validation runs after
-    TRACK_ON_COMPILATION's inline validation already vetted the same release,
-    and how often the two verdicts diverge. The helper records each
-    validation call with a source label so downstream Sentry analysis can
-    split (release_id, verdict) pairs by source.
-
-    Two surfaces:
-      - Sentry breadcrumb every call (always-on; trace explorer queries against it).
-      - Structured INFO log on a 1% sample (cheap Railway-log grep target).
-
-    Sample rate is parameterizable so tests can force the deterministic branch.
-    """
-
-    def test_records_breadcrumb_on_every_call(self):
-        """Every call must produce a Sentry breadcrumb (always-on for trace explorer)."""
-        with patch("lookup.orchestrator.sentry_sdk.add_breadcrumb") as mock_breadcrumb:
-            _log_track_validation(
-                source="compilation_inline",
-                release_id=12345,
-                song="VI Scose Poise",
-                artist="Autechre",
-                verdict=True,
-                latency_ms=42.5,
-                sample_rate=0.0,  # disable log sampling; only breadcrumb path
-            )
-        mock_breadcrumb.assert_called_once()
-        call = mock_breadcrumb.call_args
-        assert call.kwargs["category"] == "track_validation"
-        data = call.kwargs["data"]
-        assert data["source"] == "compilation_inline"
-        assert data["release_id"] == 12345
-        assert data["song"] == "VI Scose Poise"
-        assert data["artist"] == "Autechre"
-        assert data["verdict"] is True
-        assert data["latency_ms"] == 42.5
-
-    def test_samples_info_log_at_configured_rate(self):
-        """When the random sample fires, an INFO log is emitted alongside the breadcrumb."""
-        with (
-            patch("lookup.orchestrator.random.random", return_value=0.005),  # 0.5% < 1% → fires
-            patch("lookup.orchestrator.logger") as mock_logger,
-            patch("lookup.orchestrator.sentry_sdk.add_breadcrumb"),
-        ):
-            _log_track_validation(
-                source="step_3b",
-                release_id=1,
-                song="x",
-                artist="y",
-                verdict=False,
-                latency_ms=1.0,
-                sample_rate=0.01,
-            )
-        # logger.info called with the structured payload
-        info_calls = [c for c in mock_logger.info.call_args_list if "track_validation" in str(c)]
-        assert len(info_calls) == 1
-
-    def test_does_not_sample_info_log_when_rate_misses(self):
-        """When the random draw exceeds the sample rate, no INFO log fires.
-
-        Even at 1% sampling we still need the *deterministic* off-path so
-        Railway logs aren't flooded by every /lookup. The breadcrumb path
-        runs unconditionally; only the structured log is gated.
-        """
-        with (
-            patch("lookup.orchestrator.random.random", return_value=0.99),  # 99% > 1% → no fire
-            patch("lookup.orchestrator.logger") as mock_logger,
-            patch("lookup.orchestrator.sentry_sdk.add_breadcrumb"),
-        ):
-            _log_track_validation(
-                source="step_3b",
-                release_id=1,
-                song="x",
-                artist="y",
-                verdict=False,
-                latency_ms=1.0,
-                sample_rate=0.01,
-            )
-        info_calls = [c for c in mock_logger.info.call_args_list if "track_validation" in str(c)]
-        assert len(info_calls) == 0
-
-    def test_handles_sentry_sdk_failure(self):
-        """A Sentry SDK exception must not break /lookup.
-
-        Mirrors the swallow-and-log pattern in _log_album_title_fallback /
-        _log_resolver_pre_pass / _log_search_budget_exceeded. The audit
-        layer is non-essential — it cannot be allowed to take down the
-        request path.
-        """
-        with patch(
-            "lookup.orchestrator.sentry_sdk.add_breadcrumb",
-            side_effect=RuntimeError("sentry exploded"),
-        ):
-            # Must not raise.
-            _log_track_validation(
-                source="compilation_inline",
-                release_id=1,
-                song="x",
-                artist="y",
-                verdict=True,
-                latency_ms=1.0,
-                sample_rate=0.0,
-            )
-
-    def test_handles_null_artist(self):
-        """Some call paths pass artist=None; the helper must accept it."""
-        with patch("lookup.orchestrator.sentry_sdk.add_breadcrumb") as mock_breadcrumb:
-            _log_track_validation(
-                source="step_3b",
-                release_id=1,
-                song="x",
-                artist=None,
-                verdict=False,
-                latency_ms=1.0,
-                sample_rate=0.0,
-            )
-        data = mock_breadcrumb.call_args.kwargs["data"]
-        assert data["artist"] is None

--- a/tests/unit/test_outcome.py
+++ b/tests/unit/test_outcome.py
@@ -22,24 +22,8 @@ import pytest
 
 from core.search import Outcome, SearchState, _apply
 from generated.api_models import TrackMatchHint, TrackMatchSource
-from lookup.release_resolution import ResolvedRelease
 from tests.factories import make_library_item as _item
-
-
-def _rr(release_id: int, album_title: str) -> ResolvedRelease:
-    """Build a ResolvedRelease for the widened ``discogs_titles`` seam.
-
-    The seam carries ResolvedRelease values; these plumbing tests only thread
-    the dict through Outcome / _apply, so the release_url / compilation flag are
-    incidental — ``album_title`` is the field artwork binding reads.
-    """
-    return ResolvedRelease(
-        release_id=release_id,
-        release_url=f"https://www.discogs.com/release/{release_id}",
-        is_compilation=True,
-        album_title=album_title,
-    )
-
+from tests.factories import make_resolved_release as _rr
 
 # ---------------------------------------------------------------------------
 # Outcome constructors

--- a/tests/unit/test_outcome.py
+++ b/tests/unit/test_outcome.py
@@ -22,7 +22,24 @@ import pytest
 
 from core.search import Outcome, SearchState, _apply
 from generated.api_models import TrackMatchHint, TrackMatchSource
+from lookup.release_resolution import ResolvedRelease
 from tests.factories import make_library_item as _item
+
+
+def _rr(release_id: int, album_title: str) -> ResolvedRelease:
+    """Build a ResolvedRelease for the widened ``discogs_titles`` seam.
+
+    The seam carries ResolvedRelease values; these plumbing tests only thread
+    the dict through Outcome / _apply, so the release_url / compilation flag are
+    incidental — ``album_title`` is the field artwork binding reads.
+    """
+    return ResolvedRelease(
+        release_id=release_id,
+        release_url=f"https://www.discogs.com/release/{release_id}",
+        is_compilation=True,
+        album_title=album_title,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Outcome constructors
@@ -103,7 +120,7 @@ class TestOutcomeConstructors:
           - `song_not_found_after=False` (we DID match the song, just on a compilation)
         """
         item = _item(id=46602, artist="Various", title="Trax Records 20th Anniversary")
-        titles = {46602: "Trax Records 20th Anniversary"}
+        titles = {46602: _rr(46602, "Trax Records 20th Anniversary")}
         o = Outcome.compilation([item], discogs_titles=titles)
         assert o.items == [item]
         assert o.song_not_found_after is False
@@ -240,7 +257,7 @@ class TestApplyCompilation:
 
     def test_writes_results_titles_flag(self):
         item = _item(id=46602, artist="Various", title="Trax Comp")
-        titles = {46602: "Trax Records 20th"}
+        titles = {46602: _rr(46602, "Trax Records 20th")}
         state = SearchState(results=[], song_not_found=True)
         _apply(state, Outcome.compilation([item], discogs_titles=titles))
         assert state.results == [item]
@@ -261,7 +278,7 @@ class TestApplyCompilation:
         state = SearchState(results=[artist_fallback], song_not_found=True)
         _apply(
             state,
-            Outcome.compilation([compilation], discogs_titles={46602: "Trax Comp"}),
+            Outcome.compilation([compilation], discogs_titles={46602: _rr(46602, "Trax Comp")}),
         )
         assert state.results == [compilation]
         assert state.artist_fallback_results == [artist_fallback]
@@ -275,7 +292,7 @@ class TestApplyCompilation:
         state = SearchState(results=[], song_not_found=True)
         _apply(
             state,
-            Outcome.compilation([compilation], discogs_titles={46602: "Trax Comp"}),
+            Outcome.compilation([compilation], discogs_titles={46602: _rr(46602, "Trax Comp")}),
         )
         assert state.artist_fallback_results == []
         assert state.results == [compilation]
@@ -287,7 +304,7 @@ class TestApplyCompilation:
         state = SearchState(results=[prior], song_not_found=False)
         _apply(
             state,
-            Outcome.compilation([compilation], discogs_titles={46602: "Trax Comp"}),
+            Outcome.compilation([compilation], discogs_titles={46602: _rr(46602, "Trax Comp")}),
         )
         # Direct hit prior + compilation hit now: nothing to stash as "fallback".
         assert state.artist_fallback_results == []

--- a/tests/unit/test_release_resolution.py
+++ b/tests/unit/test_release_resolution.py
@@ -88,6 +88,64 @@ class TestResolveReleaseForTrack:
 
         assert [r.release_id for r in resolved] == [36907527]
 
+    @pytest.mark.asyncio
+    async def test_skips_candidate_with_falsy_release_id(self):
+        """A probed release with release_id=0 (malformed Discogs row) is skipped
+        before validation — never validated, never resolved."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        zero = ReleaseInfo(
+            album="When There Is No Sun",
+            artist="Various",
+            release_id=0,
+            release_url="",
+            is_compilation=True,
+        )
+        good = _va_comp(release_id=36907527, album="When There Is No Sun")
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(zero, good))
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert [r.release_id for r in resolved] == [36907527]
+        # The zero-id row was skipped before the validate probe ran.
+        assert svc.validate_track_on_release.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_wave_b_keyword_probe_surfaces_va_comp_when_wave_a_has_none(self):
+        """End-to-end wave routing: Wave A (artist-field probe) returns a non-V/A
+        release; only Wave B (artist_as_keyword=True) surfaces the V/A comp, which
+        the merge pulls in and validates. Catches a wave-swap or dropped-keyword-probe
+        wiring bug that the isolated merge unit test cannot see."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        def _route(track, artist, artist_as_keyword=False):
+            if artist_as_keyword:
+                return _track_response(_va_comp(release_id=36907527, album="When There Is No Sun"))
+            return _track_response(_single_artist(1, "An Unrelated Solo Album"))
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(side_effect=_route)
+        # Only the V/A comp validates the per-track credit.
+        svc.validate_track_on_release = AsyncMock(
+            side_effect=lambda rid, song, artist: rid == 36907527
+        )
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert [r.release_id for r in resolved] == [36907527]
+
 
 def _single_artist(release_id: int, album: str, *, is_compilation: bool = False) -> ReleaseInfo:
     return ReleaseInfo(
@@ -137,6 +195,16 @@ class TestMergeWaveBCompilations:
         merged = merge_wave_b_compilations(wave_a, wave_b)
 
         assert [r.release_id for r in merged] == [1, 3]
+
+    def test_dedups_wave_b_against_wave_a_by_album_title(self):
+        from lookup.release_resolution import merge_wave_b_compilations
+
+        wave_a = [_single_artist(1, "Shared Title")]
+        wave_b = [_va_comp(release_id=2, album="Shared Title")]
+
+        merged = merge_wave_b_compilations(wave_a, wave_b)
+
+        assert [r.release_id for r in merged] == [1]
 
 
 class TestRanking:
@@ -273,15 +341,67 @@ class TestEmptyCases:
 
         assert resolved == []
 
-    def test_dedups_wave_b_against_wave_a_by_album_title(self):
-        from lookup.release_resolution import merge_wave_b_compilations
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_blank_song_or_artist_without_probing(self):
+        """The song/artist guard short-circuits before any Discogs probe."""
+        from lookup.release_resolution import resolve_release_for_track
 
-        wave_a = [_single_artist(1, "Shared Title")]
-        wave_b = [_va_comp(release_id=2, album="Shared Title")]
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock()
 
-        merged = merge_wave_b_compilations(wave_a, wave_b)
+        assert await resolve_release_for_track("", "A Guy Called Gerald", "X", svc) == []
+        assert await resolve_release_for_track("Message to Black Youth", "", "X", svc) == []
 
-        assert [r.release_id for r in merged] == [1]
+        svc.search_releases_by_track.assert_not_awaited()
+
+
+class TestErrorHandling:
+    """Release resolution degrades gracefully on Discogs failures (matches the
+    resilience of the search_compilations_for_track path it was lifted from)."""
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_returns_empty(self):
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(side_effect=RuntimeError("discogs 503"))
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert resolved == []
+
+    @pytest.mark.asyncio
+    async def test_single_validation_failure_preserves_other_releases(self):
+        """One candidate's validation raising must not discard already-validated
+        releases — the divergence the lift could otherwise introduce."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        good = _va_comp(release_id=36907527, album="When There Is No Sun")
+        boom = _va_comp(release_id=111, album="When There Is No Sun")
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(good, boom))
+
+        async def _validate(rid, song, artist):
+            if rid == 111:
+                raise RuntimeError("discogs timeout")
+            return True
+
+        svc.validate_track_on_release = AsyncMock(side_effect=_validate)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert [r.release_id for r in resolved] == [36907527]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_release_resolution.py
+++ b/tests/unit/test_release_resolution.py
@@ -1,0 +1,413 @@
+"""Unit tests for ``lookup.release_resolution`` (compilation cross-reference).
+
+The module owns "find and validate the Discogs release a track sits on" — the
+probe set (Wave A/B ``search_releases_by_track`` + the conditional V/A-merge)
+and per-candidate ``validate_track_on_release`` — and ranks validated releases
+by title match to the requested album. It does NOT do library-row matching.
+
+The spine case throughout: A Guy Called Gerald — "Message to Black Youth" on the
+Various-Artists compilation "When There Is No Sun" (discogs release 36907527).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from discogs.models import ReleaseInfo, TrackReleasesResponse
+from lookup.release_resolution import _log_track_validation
+
+
+def _track_response(*releases: ReleaseInfo) -> TrackReleasesResponse:
+    return TrackReleasesResponse(
+        track="Message to Black Youth",
+        artist="A Guy Called Gerald",
+        releases=list(releases),
+        total=len(releases),
+    )
+
+
+def _va_comp(
+    release_id: int = 36907527,
+    album: str = "When There Is No Sun",
+) -> ReleaseInfo:
+    return ReleaseInfo(
+        album=album,
+        artist="Various",
+        release_id=release_id,
+        release_url=f"https://www.discogs.com/release/{release_id}",
+        is_compilation=True,
+    )
+
+
+class TestResolveReleaseForTrack:
+    @pytest.mark.asyncio
+    async def test_returns_validated_release_as_resolved_release(self):
+        """A track that probes to a V/A comp and validates → one ResolvedRelease."""
+        from lookup.release_resolution import ResolvedRelease, resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(_va_comp()))
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert resolved == [
+            ResolvedRelease(
+                release_id=36907527,
+                release_url="https://www.discogs.com/release/36907527",
+                is_compilation=True,
+                album_title="When There Is No Sun",
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_drops_releases_that_fail_track_credit_validation(self):
+        """A probed release whose track-credit doesn't validate is excluded."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        wrong = _va_comp(release_id=111, album="Some Other Comp")
+        right = _va_comp(release_id=36907527, album="When There Is No Sun")
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(wrong, right))
+        # Only the right release validates the per-track credit.
+        svc.validate_track_on_release = AsyncMock(
+            side_effect=lambda rid, song, artist: rid == 36907527
+        )
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert [r.release_id for r in resolved] == [36907527]
+
+
+def _single_artist(release_id: int, album: str, *, is_compilation: bool = False) -> ReleaseInfo:
+    return ReleaseInfo(
+        album=album,
+        artist="A Guy Called Gerald",
+        release_id=release_id,
+        release_url=f"https://www.discogs.com/release/{release_id}",
+        is_compilation=is_compilation,
+    )
+
+
+class TestMergeWaveBCompilations:
+    """The WXYC#527 V/A-merge, extracted so the comp strategy can delegate to it."""
+
+    def test_merges_wave_b_va_comp_when_wave_a_has_no_va_hit(self):
+        from lookup.release_resolution import merge_wave_b_compilations
+
+        wave_a = [_single_artist(1, "A Guy Called Gerald Album")]
+        wave_b = [_va_comp(release_id=2, album="When There Is No Sun")]
+
+        merged = merge_wave_b_compilations(wave_a, wave_b)
+
+        assert [r.release_id for r in merged] == [1, 2]
+
+    def test_does_not_merge_wave_b_when_wave_a_already_has_va_comp(self):
+        from lookup.release_resolution import merge_wave_b_compilations
+
+        wave_a = [_va_comp(release_id=1, album="Wave A Comp")]
+        wave_b = [_va_comp(release_id=2, album="Wave B Comp")]
+
+        merged = merge_wave_b_compilations(wave_a, wave_b)
+
+        assert [r.release_id for r in merged] == [1]
+
+    def test_skips_wave_b_non_compilation_rows(self):
+        from lookup.release_resolution import merge_wave_b_compilations
+
+        wave_a = [_single_artist(1, "Solo Album")]
+        # Per-row Wave B inclusion gates on ``is_compilation`` only (faithful to
+        # the original): a non-compilation row is skipped, a Compilation-flagged
+        # row is merged even when its artist is single-artist.
+        wave_b = [
+            _single_artist(2, "Plain Single"),
+            _single_artist(3, "Retrospective", is_compilation=True),
+        ]
+
+        merged = merge_wave_b_compilations(wave_a, wave_b)
+
+        assert [r.release_id for r in merged] == [1, 3]
+
+
+class TestRanking:
+    @pytest.mark.asyncio
+    async def test_prefers_title_matched_release_over_lower_id_mismatch(self):
+        """The divergent-pressing fix: rank by title match, not Discogs's top-1.
+
+        A different-titled release with a *lower* release_id (the kind of thing
+        Discogs's keyword re-search surfaces at the top) must not outrank the
+        release whose title matches the requested album — release_id is only the
+        stable tie-break.
+        """
+        from lookup.release_resolution import resolve_release_for_track
+
+        mismatch = _va_comp(release_id=10, album="Acid House Classics")
+        original = _va_comp(release_id=99, album="When There Is No Sun")
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(mismatch, original))
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert [r.release_id for r in resolved] == [99, 10]
+
+    @pytest.mark.asyncio
+    async def test_equal_title_match_resolves_by_stable_release_id(self):
+        """Two pressings whose titles normalize equally (original + deluxe
+        reissue) resolve by stable release_id — deterministic across runs."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        reissue = _va_comp(release_id=10, album="When There Is No Sun (Deluxe Reissue Edition)")
+        original = _va_comp(release_id=99, album="When There Is No Sun")
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(reissue, original))
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert [r.release_id for r in resolved] == [10, 99]
+
+    @pytest.mark.asyncio
+    async def test_stable_release_id_tie_break_when_no_album(self):
+        """With no album to rank against, ordering is stable by release_id."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(
+            return_value=_track_response(
+                _va_comp(release_id=50, album="Comp B"),
+                _va_comp(release_id=20, album="Comp A"),
+            )
+        )
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album=None,
+            discogs_service=svc,
+        )
+
+        assert [r.release_id for r in resolved] == [20, 50]
+
+
+class TestValidateReleaseForTrack:
+    """The shared validate+telemetry primitive both strategies delegate to."""
+
+    @pytest.mark.asyncio
+    async def test_returns_verdict_and_records_telemetry(self, monkeypatch):
+        from lookup import release_resolution as rr
+
+        logged: list[dict] = []
+        monkeypatch.setattr(rr, "_log_track_validation", lambda **kw: logged.append(kw))
+
+        svc = AsyncMock()
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        verdict = await rr.validate_release_for_track(
+            svc,
+            36907527,
+            "Message to Black Youth",
+            "A Guy Called Gerald",
+            source="unit",
+        )
+
+        assert verdict is True
+        svc.validate_track_on_release.assert_awaited_once_with(
+            36907527, "Message to Black Youth", "A Guy Called Gerald"
+        )
+        assert logged and logged[0]["source"] == "unit"
+        assert logged[0]["release_id"] == 36907527
+        assert logged[0]["verdict"] is True
+        assert "latency_ms" in logged[0]
+
+
+class TestEmptyCases:
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_discogs_service(self):
+        from lookup.release_resolution import resolve_release_for_track
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=None,
+        )
+
+        assert resolved == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_nothing_validates(self):
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(_va_comp()))
+        svc.validate_track_on_release = AsyncMock(return_value=False)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert resolved == []
+
+    def test_dedups_wave_b_against_wave_a_by_album_title(self):
+        from lookup.release_resolution import merge_wave_b_compilations
+
+        wave_a = [_single_artist(1, "Shared Title")]
+        wave_b = [_va_comp(release_id=2, album="Shared Title")]
+
+        merged = merge_wave_b_compilations(wave_a, wave_b)
+
+        assert [r.release_id for r in merged] == [1]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _log_track_validation (A7 / LML#344 audit instrumentation)
+# Relocated from test_orchestrator_helpers.py when the helper moved into this
+# leaf module; patch targets point at lookup.release_resolution accordingly.
+# ---------------------------------------------------------------------------
+
+
+class TestLogTrackValidation:
+    """Audit instrumentation for the two validate_track_on_release call sites.
+
+    LML#344 wants to know how often the step-3b validation runs after
+    TRACK_ON_COMPILATION's inline validation already vetted the same release,
+    and how often the two verdicts diverge. The helper records each
+    validation call with a source label so downstream Sentry analysis can
+    split (release_id, verdict) pairs by source.
+
+    Two surfaces:
+      - Sentry breadcrumb every call (always-on; trace explorer queries against it).
+      - Structured INFO log on a 1% sample (cheap Railway-log grep target).
+
+    Sample rate is parameterizable so tests can force the deterministic branch.
+    """
+
+    def test_records_breadcrumb_on_every_call(self):
+        """Every call must produce a Sentry breadcrumb (always-on for trace explorer)."""
+        with patch("lookup.release_resolution.sentry_sdk.add_breadcrumb") as mock_breadcrumb:
+            _log_track_validation(
+                source="compilation_inline",
+                release_id=12345,
+                song="VI Scose Poise",
+                artist="Autechre",
+                verdict=True,
+                latency_ms=42.5,
+                sample_rate=0.0,  # disable log sampling; only breadcrumb path
+            )
+        mock_breadcrumb.assert_called_once()
+        call = mock_breadcrumb.call_args
+        assert call.kwargs["category"] == "track_validation"
+        data = call.kwargs["data"]
+        assert data["source"] == "compilation_inline"
+        assert data["release_id"] == 12345
+        assert data["song"] == "VI Scose Poise"
+        assert data["artist"] == "Autechre"
+        assert data["verdict"] is True
+        assert data["latency_ms"] == 42.5
+
+    def test_samples_info_log_at_configured_rate(self):
+        """When the random sample fires, an INFO log is emitted alongside the breadcrumb."""
+        with (
+            patch("lookup.release_resolution.random.random", return_value=0.005),  # 0.5% < 1%
+            patch("lookup.release_resolution.logger") as mock_logger,
+            patch("lookup.release_resolution.sentry_sdk.add_breadcrumb"),
+        ):
+            _log_track_validation(
+                source="step_3b",
+                release_id=1,
+                song="x",
+                artist="y",
+                verdict=False,
+                latency_ms=1.0,
+                sample_rate=0.01,
+            )
+        # logger.info called with the structured payload
+        info_calls = [c for c in mock_logger.info.call_args_list if "track_validation" in str(c)]
+        assert len(info_calls) == 1
+
+    def test_does_not_sample_info_log_when_rate_misses(self):
+        """When the random draw exceeds the sample rate, no INFO log fires.
+
+        Even at 1% sampling we still need the *deterministic* off-path so
+        Railway logs aren't flooded by every /lookup. The breadcrumb path
+        runs unconditionally; only the structured log is gated.
+        """
+        with (
+            patch("lookup.release_resolution.random.random", return_value=0.99),  # 99% > 1%
+            patch("lookup.release_resolution.logger") as mock_logger,
+            patch("lookup.release_resolution.sentry_sdk.add_breadcrumb"),
+        ):
+            _log_track_validation(
+                source="step_3b",
+                release_id=1,
+                song="x",
+                artist="y",
+                verdict=False,
+                latency_ms=1.0,
+                sample_rate=0.01,
+            )
+        info_calls = [c for c in mock_logger.info.call_args_list if "track_validation" in str(c)]
+        assert len(info_calls) == 0
+
+    def test_handles_sentry_sdk_failure(self):
+        """A Sentry SDK exception must not break /lookup.
+
+        Mirrors the swallow-and-log pattern in _log_album_title_fallback /
+        _log_resolver_pre_pass / _log_search_budget_exceeded. The audit
+        layer is non-essential — it cannot be allowed to take down the
+        request path.
+        """
+        with patch(
+            "lookup.release_resolution.sentry_sdk.add_breadcrumb",
+            side_effect=RuntimeError("sentry exploded"),
+        ):
+            # Must not raise.
+            _log_track_validation(
+                source="compilation_inline",
+                release_id=1,
+                song="x",
+                artist="y",
+                verdict=True,
+                latency_ms=1.0,
+                sample_rate=0.0,
+            )
+
+    def test_handles_null_artist(self):
+        """Some call paths pass artist=None; the helper must accept it."""
+        with patch("lookup.release_resolution.sentry_sdk.add_breadcrumb") as mock_breadcrumb:
+            _log_track_validation(
+                source="step_3b",
+                release_id=1,
+                song="x",
+                artist=None,
+                verdict=False,
+                latency_ms=1.0,
+                sample_rate=0.0,
+            )
+        data = mock_breadcrumb.call_args.kwargs["data"]
+        assert data["artist"] is None

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -39,25 +39,10 @@ from core.search import (
     song_not_found_with_artist_and_song,
 )
 from generated.api_models import TrackMatchHint, TrackMatchSource
-from lookup.release_resolution import ResolvedRelease
 from lookup.strategies import build_strategies
 from services.parser import ParsedRequest
 from tests.factories import make_library_item as _item
-
-
-def _rr(release_id: int, album_title: str) -> ResolvedRelease:
-    """Build a ResolvedRelease for the widened ``discogs_titles`` seam.
-
-    TRACK_ON_COMPILATION's execute func returns ``dict[int, ResolvedRelease]``;
-    these runner tests assert that map threads through the pipeline unchanged.
-    """
-    return ResolvedRelease(
-        release_id=release_id,
-        release_url=f"https://www.discogs.com/release/{release_id}",
-        is_compilation=True,
-        album_title=album_title,
-    )
-
+from tests.factories import make_resolved_release as _rr
 
 # ---------------------------------------------------------------------------
 # Test helpers: tiny strategy stand-ins for runner-level tests

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -39,9 +39,25 @@ from core.search import (
     song_not_found_with_artist_and_song,
 )
 from generated.api_models import TrackMatchHint, TrackMatchSource
+from lookup.release_resolution import ResolvedRelease
 from lookup.strategies import build_strategies
 from services.parser import ParsedRequest
 from tests.factories import make_library_item as _item
+
+
+def _rr(release_id: int, album_title: str) -> ResolvedRelease:
+    """Build a ResolvedRelease for the widened ``discogs_titles`` seam.
+
+    TRACK_ON_COMPILATION's execute func returns ``dict[int, ResolvedRelease]``;
+    these runner tests assert that map threads through the pipeline unchanged.
+    """
+    return ResolvedRelease(
+        release_id=release_id,
+        release_url=f"https://www.discogs.com/release/{release_id}",
+        is_compilation=True,
+        album_title=album_title,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Test helpers: tiny strategy stand-ins for runner-level tests
@@ -385,7 +401,7 @@ class TestExecuteSearchPipeline:
 
         search_lib = AsyncMock(return_value=([], True))  # song_not_found
         search_alt = AsyncMock(return_value=([], None))
-        search_comp = AsyncMock(return_value=([item], {1: "Rock Comp"}))
+        search_comp = AsyncMock(return_value=([item], {1: _rr(1, "Rock Comp")}))
 
         strategies = _build_test_strategies(search_lib, search_alt, search_comp)
 
@@ -402,7 +418,7 @@ class TestExecuteSearchPipeline:
         )
 
         assert state.found_on_compilation is True
-        assert state.discogs_titles == {1: "Rock Comp"}
+        assert state.discogs_titles == {1: _rr(1, "Rock Comp")}
 
     @pytest.mark.asyncio
     async def test_compilation_search_when_song_not_found_from_album_resolution(self):
@@ -423,7 +439,10 @@ class TestExecuteSearchPipeline:
         search_lib = AsyncMock(return_value=([], False))
         search_alt = AsyncMock(return_value=([], None))
         search_comp = AsyncMock(
-            return_value=([compilation], {46602: "Trax Records 20th Anniversary Collection"})
+            return_value=(
+                [compilation],
+                {46602: _rr(46602, "Trax Records 20th Anniversary Collection")},
+            )
         )
 
         strategies = _build_test_strategies(search_lib, search_alt, search_comp)
@@ -443,7 +462,9 @@ class TestExecuteSearchPipeline:
 
         assert state.found_on_compilation is True
         assert state.results == [compilation]
-        assert state.discogs_titles == {46602: "Trax Records 20th Anniversary Collection"}
+        assert state.discogs_titles == {
+            46602: _rr(46602, "Trax Records 20th Anniversary Collection")
+        }
 
     @pytest.mark.asyncio
     async def test_comma_format_triggers_swapped_interpretation(self):


### PR DESCRIPTION
## Summary

PR1 of the compilation-release-resolution plan (#604). Behavior-neutral structural groundwork for binding `discogs_url` on Various-Artists compilation tracks. **No observable behavior change** — this PR extracts a module and widens an internal seam so PR2's symptom fix is a small, flag-gated change.

Background: a flowsheet track on a V/A compilation never gets a Discogs link, because the binding step re-derives the release through an 80/80 artist floor that "A Guy Called Gerald" can never clear against a release credited "Various". The fix routes binding through per-track-credit validation instead of the floor. Full design and decisions: [`docs/plans/compilation-release-resolution.md`](docs/plans/compilation-release-resolution.md).

## What's in this PR

- **New leaf module `lookup/release_resolution.py`** — owns "find and validate the Discogs release a track sits on":
  - `ResolvedRelease` (release_id, release_url, is_compilation, album_title).
  - `resolve_release_for_track(song, artist, album, discogs_service)` — probe Wave A/B + V/A-merge + per-candidate `validate_track_on_release` + rank (title-match to album, stable `release_id` tie-break). This is PR2's consumer; dormant in PR1.
  - Shared primitives `merge_wave_b_compilations` (the WXYC#527 V/A-merge) and `validate_release_for_track` (validate + LML#344 telemetry).
  - `_log_track_validation` relocated here (re-exported from `orchestrator`) so the module stays import-acyclic and `core.search` can reference `ResolvedRelease` without a cycle.
- **Strategies delegate to the shared primitives** but keep their interleaved probe → library-match → validate-only-matches flow, so the LML#536 invariant holds (validate only the releases that matched the library, not every probed candidate).
- **Seam widened** `discogs_titles: dict[int, str]` → `dict[int, ResolvedRelease]` across `SearchState`, `Outcome.compilation`/`_apply`, the `TrackOnCompilation` execute alias, `search_compilations_for_track`, `fetch_artwork_for_items`, and `perform_lookup`. `fetch_one` reads `ResolvedRelease.album_title` — the value the seam used to carry as a string — so it still re-searches exactly as before. Internal only; no `api.yaml` change.
- **CONTEXT.md** gains the "Release resolution (compilation cross-reference)" language section.

## Why behavior-neutral

The pinned suites are the contract. `test_orchestrator_gaps::test_validates_only_library_matching_releases` (the LML#536 `validate_track_on_release.call_count == 1` pin) stays green, proving the deferred-validation cost profile is unchanged. Internal-shape test assertions that referenced the seam update mechanically to the `ResolvedRelease` type.

## Testing

- Full default suite (`-m 'not pg and not external_api'`): **2995 passed**, 1 skipped, 2 xfailed.
- New `tests/unit/test_release_resolution.py`: 17 tests (probe/merge/validate/rank/telemetry).
- `ruff check .` + `ruff format --check .`: clean. `mypy` clean on changed modules.
- `pg` / `external_api` markers need infra unavailable locally (CI-gated); both collect with zero import errors, and no integration/e2e test references the internal seam.

## Follow-up

PR2 (flagged lazy bind) delivers the actual symptom fix — `fetch_one` trust-and-bind + lazy `resolve_release_for_track` fallback behind `lml_resolve_compilation_release` (default off, negative-cached, bulk-excluded).

Part of #604.
