### PR TITLE
chore(#606): regenerate api_models.py for wxyc-shared FlowsheetV2 sync

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -318,6 +318,10 @@ class EntryType7(StrEnum):
 
 class FlowsheetV2BreakpointEntry(FlowsheetV2Base):
     entry_type: Literal["breakpoint"]
+    radio_hour: AwareDatetime | None = Field(
+        None,
+        description="Exact top-of-hour this breakpoint marks (ISO 8601), sourced from tubafrenzy's RADIO_HOUR. Distinct from `add_time`, which is the row's logging instant (~1 min before the hour). Optional and nullable: absent on servers predating the producer rollout, null for breakpoint rows not yet backfilled. Clients use `radio_hour` for the hour-marker label when present and fall back to `add_time` otherwise.",
+    )
     message: str | None = None
 
 
@@ -1529,6 +1533,12 @@ class FlowsheetV2TrackEntry(FlowsheetV2Base):
         description="Whether this album is available on streaming platforms. False means WXYC library exclusive. Null if unknown.",
     )
     metadata_status: MetadataStatus | None = None
+    genres: list[str] | None = Field(
+        None, description="Discogs genre tags surfaced on the Playcut Detail card."
+    )
+    styles: list[str] | None = Field(
+        None, description="Discogs style tags (finer-grained than genres)."
+    )
 
 
 class Entries(


### PR DESCRIPTION
Closes #606.

The `Codegen Freshness` CI job runs only on `pull_request` events (skipped on `main` pushes), so the committed `generated/api_models.py` drifted from the current `wxyc-shared` `api.yaml` contract without anyone noticing. It surfaced as a CI failure on PR #605, but is unrelated to that PR's feature work — it's pre-existing stale codegen.

Regenerating from `wxyc-shared@main` adds three optional, nullable FlowsheetV2 fields:

- `FlowsheetV2BreakpointEntry.radio_hour` (`AwareDatetime | None`) — exact top-of-hour the breakpoint marks, from tubafrenzy's `RADIO_HOUR`.
- `FlowsheetV2TrackEntry.genres` (`list[str] | None`) — Discogs genre tags for the Playcut Detail card.
- `FlowsheetV2TrackEntry.styles` (`list[str] | None`) — Discogs style tags (finer-grained than genres).

This is generated-models-only with no behavior change. After this merges, PR #605 can rebase onto `main` and its `Codegen Freshness` check will pass; the same gate is unblocked for any other open PR.

## Verification

Regenerated against `wxyc-shared@main` (sibling synced to `origin/main`). `bash scripts/generate_api_models.sh` is idempotent — staging the regen and re-running leaves `git diff --exit-code generated/` clean. Local gates all pass: `ruff check .`, `ruff format --check .`, `mypy . --ignore-missing-imports` (no new errors; the 2 pre-existing `audit_va_writeback_pollution.py` errors are unrelated and present on `main`), and the full default `pytest` suite (2983 passed, 1 skipped, 2 xfailed).