### PR TITLE
Instrument 80/80 matcher floor with marginal-artist-clear telemetry (#592)

### DIFF
--- a/clients/bandcamp.py
+++ b/clients/bandcamp.py
@@ -124,6 +124,7 @@ class BandcampClient(BaseStreamingClient):
             artist_fn=lambda _: matched_artist_name,
             title_fn=lambda x: x["title"],
             url_fn=lambda x: x["url"],
+            service="bandcamp",
         )
 
     async def search_artist(self, artist_name: str) -> list[dict]:

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -359,6 +359,7 @@ class AppleMusicClient(BaseStreamingClient):
             artist_fn=_extract_artist_name,
             title_fn=_extract_name,
             url_fn=_extract_url,
+            service="apple_music",
         )
 
     async def find_track_metadata(

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -45,7 +45,11 @@ from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from clients.streaming.base import BaseStreamingClient
-from clients.streaming.matching import find_best_source_match
+from clients.streaming.matching import (
+    SCORE_MATCH_ACCEPTANCE_FLOOR,
+    find_best_source_match,
+    record_match_telemetry,
+)
 from streaming.models import SourceMatch
 
 
@@ -71,12 +75,13 @@ class AppleMusicTrackMatch:
 logger = logging.getLogger(__name__)
 
 # Minimum fuzzy score (0-100) for accepting an Apple Music search result as a
-# genuine match. Mirrors the 80/80 floor every other provider uses inside
-# `clients/streaming/matching.is_acceptable_match`. Stops the wrong link from
-# freezing onto a flowsheet row when Apple's search ranking is unstable for
+# genuine match. Bound to the shared `SCORE_MATCH_ACCEPTANCE_FLOOR` every other
+# provider uses inside `clients/streaming/matching.is_acceptable_match` — not a
+# re-declared literal, so the two can't drift (LML#592). Stops the wrong link
+# from freezing onto a flowsheet row when Apple's search ranking is unstable for
 # obscure artists (LML#389) or returns a same-titled track from the wrong
 # album (LML#396).
-_APPLE_MUSIC_MATCH_FLOOR = 80.0
+_APPLE_MUSIC_MATCH_FLOOR = SCORE_MATCH_ACCEPTANCE_FLOOR
 
 # Apple Music developer-token lifetime. Apple permits `exp` up to ~6 months;
 # we sign per-request with a short window so a leaked token's blast radius
@@ -388,8 +393,10 @@ class AppleMusicClient(BaseStreamingClient):
 
         best_overall: dict | None = None
         best_overall_score = 0.0
+        best_overall_axes: tuple[float, float] = (0.0, 0.0)
         best_with_artwork: dict | None = None
         best_with_artwork_score = 0.0
+        best_with_artwork_axes: tuple[float, float] = (0.0, 0.0)
 
         for item in results:
             attrs = item.get("attributes") or {}
@@ -416,13 +423,29 @@ class AppleMusicClient(BaseStreamingClient):
             if combined > best_overall_score:
                 best_overall_score = combined
                 best_overall = item
+                best_overall_axes = (artist_score, track_score)
             if (attrs.get("artwork") or {}).get("url") and combined > best_with_artwork_score:
                 best_with_artwork_score = combined
                 best_with_artwork = item
+                best_with_artwork_axes = (artist_score, track_score)
 
         best = best_with_artwork or best_overall
         if best is None:
             return None
+
+        # LML#592: emit the CHOSEN winner's axis scores (track surface). Scores
+        # are stashed in lockstep with each candidate so they describe whichever
+        # record `best_with_artwork or best_overall` actually selected — not the
+        # higher-fuzz record that artwork preference may have passed over.
+        artist_axis, track_axis = (
+            best_with_artwork_axes if best is best_with_artwork else best_overall_axes
+        )
+        record_match_telemetry(
+            artist_score=artist_axis,
+            title_score=track_axis,
+            service="apple_music",
+            surface="track",
+        )
 
         # When ``album`` was not supplied the 80/80(/80) floor collapses to
         # 80/80 — any artist+song match clears regardless of album, and

--- a/clients/streaming/deezer.py
+++ b/clients/streaming/deezer.py
@@ -39,6 +39,7 @@ class DeezerClient(BaseStreamingClient):
             artist_fn=lambda x: x["artist"]["name"],
             title_fn=lambda x: x["title"],
             url_fn=lambda x: x["link"],
+            service="deezer",
         )
 
     async def search_album(self, artist: str, title: str) -> list[dict]:

--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -488,7 +488,7 @@ def find_best_source_match(
     artist_fn: Callable[[dict], str],
     title_fn: Callable[[dict], str],
     url_fn: Callable[[dict], str],
-    service: str = "unknown",
+    service: str,
 ) -> SourceMatch | None:
     """Run ``find_best_match`` and wrap the verdict as a ``SourceMatch``.
 
@@ -501,8 +501,13 @@ def find_best_source_match(
     id, so the extra extractor was dead weight in adapter bodies.
 
     ``service`` labels the LML#592 match telemetry emitted for the winning
-    candidate (album surface). It defaults to ``"unknown"`` so a caller that
-    forgets it still records — telemetry is never load-bearing.
+    candidate (album surface) with the originating streaming service
+    ("apple_music", "spotify", ...). It is **required** rather than defaulted:
+    a silent ``"unknown"`` default once let an adapter (Apple) drop its album
+    matches into an unattributable telemetry bucket instead of failing loudly,
+    and because telemetry is best-effort the mistake would have been swallowed
+    at runtime. Requiring the label turns a forgotten ``service=`` into a
+    call-time ``TypeError`` caught by the first test, not silent data rot.
     """
     best = find_best_match(
         results,

--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable, Iterable
 
+import sentry_sdk
 from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison  # noqa: F401
 
 from discogs.matching import strip_discogs_suffix  # noqa: F401
 from streaming.models import SourceMatch
+
+logger = logging.getLogger(__name__)
 
 # Trailing format indicators: 12", 7", 10", LP, EP, CD, and multi-disc (x 2, x 3, ...)
 _FORMAT_SUFFIX_RE = re.compile(
@@ -305,6 +309,54 @@ def is_acceptable_match(artist_score: float, title_score: float) -> bool:
     )
 
 
+# LML#592 telemetry bands. The 80/80 floor admits organic short-name artist
+# collisions on a shared album title ("Wand" vs "Wanda" scores 88.89 against
+# an identical title at 100). These bands classify the *signature* of such a
+# clear — a marginal artist score against a high title — so we can measure how
+# often it happens in production BEFORE deciding whether to tighten the floor.
+# Raw scores are emitted alongside the boolean, so the bands can be re-tuned in
+# Sentry queries without a code change. NOT acceptance thresholds: nothing here
+# rejects a match. The artist axis is the discriminator; titles collide cheaply.
+MARGINAL_ARTIST_CEILING: float = 90.0  # artist in [floor, ceiling) is "marginal"
+HIGH_TITLE_FLOOR: float = 95.0  # title >= this is "high" — the collision tell
+
+
+def record_match_telemetry(
+    *, artist_score: float, title_score: float, service: str, surface: str
+) -> None:
+    """Emit a winning match's per-axis fuzzy scores to Sentry (LML#592).
+
+    Opens a lightweight ``matcher.match`` span carrying the raw artist/title
+    scores plus a derived ``marginal_artist_clear`` flag (artist in
+    ``[SCORE_MATCH_ACCEPTANCE_FLOOR, MARGINAL_ARTIST_CEILING)`` while title is
+    ``>= HIGH_TITLE_FLOOR``). Called once per resolved match, so the count of
+    these spans is the denominator and the flagged subset is the numerator of
+    the marginal-clear rate.
+
+    Telemetry must never break a lookup: any failure is swallowed with a warning
+    (mirrors ``_project_cache_stats_to_transaction`` in ``lookup/router.py``).
+
+    Args:
+        artist_score: Fuzzy score of the request artist vs the matched artist.
+        title_score: Fuzzy score of the request title vs the matched title.
+        service: Streaming service that produced the match ("apple_music", ...).
+        surface: Match surface — "album" or "track".
+    """
+    try:
+        with sentry_sdk.start_span(op="matcher.match", name=f"{service}:{surface}") as span:
+            span.set_data("matcher.service", service)
+            span.set_data("matcher.surface", surface)
+            span.set_data("matcher.artist_score", artist_score)
+            span.set_data("matcher.title_score", title_score)
+            span.set_data(
+                "matcher.marginal_artist_clear",
+                SCORE_MATCH_ACCEPTANCE_FLOOR <= artist_score < MARGINAL_ARTIST_CEILING
+                and title_score >= HIGH_TITLE_FLOOR,
+            )
+    except Exception as e:  # defensive; telemetry is best-effort, never fatal
+        logger.warning("Failed to emit matcher telemetry: %s", e)
+
+
 def find_best_match(
     results: list[dict],
     query_artist: str,
@@ -351,6 +403,10 @@ def find_best_match(
                 "confidence": combined,
                 "matched_artist": result_artist,
                 "matched_title": result_title,
+                # Per-axis scores so callers can emit match telemetry (LML#592):
+                # the artist axis is the discriminator on shared-title collisions.
+                "artist_score": artist_score,
+                "title_score": title_score,
             }
             if id_fn is not None:
                 match["id"] = id_fn(item)
@@ -432,6 +488,7 @@ def find_best_source_match(
     artist_fn: Callable[[dict], str],
     title_fn: Callable[[dict], str],
     url_fn: Callable[[dict], str],
+    service: str = "unknown",
 ) -> SourceMatch | None:
     """Run ``find_best_match`` and wrap the verdict as a ``SourceMatch``.
 
@@ -442,6 +499,10 @@ def find_best_source_match(
     the ``best is None / SourceMatch(url=..., confidence=...)`` boilerplate
     here. ``id_fn`` deliberately omitted — ``SourceMatch`` doesn't carry an
     id, so the extra extractor was dead weight in adapter bodies.
+
+    ``service`` labels the LML#592 match telemetry emitted for the winning
+    candidate (album surface). It defaults to ``"unknown"`` so a caller that
+    forgets it still records — telemetry is never load-bearing.
     """
     best = find_best_match(
         results,
@@ -453,4 +514,10 @@ def find_best_source_match(
     )
     if best is None:
         return None
+    record_match_telemetry(
+        artist_score=best["artist_score"],
+        title_score=best["title_score"],
+        service=service,
+        surface="album",
+    )
     return SourceMatch(url=best["url"], confidence=best["confidence"])

--- a/clients/streaming/spotify.py
+++ b/clients/streaming/spotify.py
@@ -66,6 +66,7 @@ class SpotifyClient(BaseStreamingClient):
             artist_fn=lambda x: x["artists"][0]["name"],
             title_fn=lambda x: x["name"],
             url_fn=lambda x: x["external_urls"]["spotify"],
+            service="spotify",
         )
 
     async def search_album(self, artist: str, title: str, market: str = "US") -> list[dict]:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,3 +103,14 @@ Wiring:
 - `DATABASE_URL_DISCOGS` (already required for the standard cache) covers the discogs leg.
 - `DATABASE_URL_MUSICBRAINZ` is new — when unset the MB leg is skipped silently.
 - Existing callers (no flag) see no behavior change and no extra queries.
+
+## Streaming-match telemetry (LML#592)
+
+Every winning streaming match emits a lightweight `matcher.match` Sentry span (via `record_match_telemetry` in `clients/streaming/matching.py`) carrying the per-axis fuzzy scores. It is emitted once per resolved match on both surfaces: the album path (`find_best_source_match`, all adapters) and the Apple track path (`find_track_metadata`, which inlines its own `token_set_ratio` floor). Span data keys:
+
+- `matcher.service` — `"apple_music" | "spotify" | "deezer" | "bandcamp"`
+- `matcher.surface` — `"album" | "track"`
+- `matcher.artist_score` / `matcher.title_score` — raw fuzzy scores (0-100) of the winner
+- `matcher.marginal_artist_clear` — `true` when the artist score is marginal (`[SCORE_MATCH_ACCEPTANCE_FLOOR, MARGINAL_ARTIST_CEILING)`) against a high title (`>= HIGH_TITLE_FLOOR`) — the short-name-collision signature (e.g. "Wand" matching "Wanda" on a shared album title)
+
+The count of `matcher.match` spans is the denominator and the `marginal_artist_clear` subset is the numerator of the marginal-clear rate. This is **instrumentation only** — it measures the 80/80 floor's behavior so the artist-axis floor can be tightened later on evidence, not assumption. Telemetry failures are swallowed (best-effort), so they never break a lookup.

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -818,6 +818,74 @@ class TestFindTrackMetadata:
         assert match.url == url
 
 
+class TestFindTrackMetadataEmits:
+    """LML#592: the Apple track probe (``token_set_ratio``) emits match
+    telemetry for the winner under ``surface="track"``.
+
+    This path inlines its own floor and never calls the shared predicate, so
+    it must be instrumented separately. ``record_match_telemetry`` itself is
+    unit-tested in test_streaming_matching.py; here we pin the WIRING — that
+    the track path calls it once, with surface/service set and the *chosen*
+    winner's per-axis scores.
+    """
+
+    @pytest.mark.asyncio
+    async def test_emits_marginal_clear_for_track_winner(self, es256_keypair):
+        client = _client(es256_keypair)
+        # Request "Wand" / "DOGA"; Apple returns "Wanda" on a same-titled
+        # track + album. token_set_ratio("wand","wanda") == 88.89 (marginal).
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response(
+                [_make_song_data(name="DOGA", artist_name="Wanda", album_name="DOGA")]
+            )
+        )
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.record_match_telemetry") as rec:
+            match = await client.find_track_metadata("Wand", "DOGA", album="DOGA")
+
+        assert match is not None  # still clears — this PR instruments, it does not reject
+        rec.assert_called_once()
+        kwargs = rec.call_args.kwargs
+        assert kwargs["surface"] == "track"
+        assert kwargs["service"] == "apple_music"
+        assert 80.0 <= kwargs["artist_score"] < 90.0  # marginal artist axis
+        assert kwargs["title_score"] >= 95.0  # high title axis
+
+    @pytest.mark.asyncio
+    async def test_emits_scores_of_chosen_winner_not_top_fuzz(self, es256_keypair):
+        """``best = best_with_artwork or best_overall`` — the emitted scores
+        must describe the CHOSEN winner (artwork-preferred), not the
+        higher-fuzz artworkless record. Guards the lockstep-stash fix."""
+        client = _client(es256_keypair)
+        # A: exact artist, NO artwork -> higher combined -> best_overall.
+        a = _make_song_data(
+            name="DOGA",
+            artist_name="Wand",
+            album_name="DOGA",
+            url="https://music.apple.com/us/song/a/1",
+        )
+        # B: marginal artist, WITH artwork -> best_with_artwork -> chosen as best.
+        b = _make_song_data_full(
+            name="DOGA",
+            artist_name="Wanda",
+            album_name="DOGA",
+            url="https://music.apple.com/us/song/b/2",
+        )
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([a, b]))
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.record_match_telemetry") as rec:
+            match = await client.find_track_metadata("Wand", "DOGA", album="DOGA")
+
+        assert match is not None
+        assert match.url.endswith("/b/2")  # artwork-preferred winner chosen
+        # Emitted artist score is B's marginal 88.89, NOT A's exact 100.0.
+        assert 80.0 <= rec.call_args.kwargs["artist_score"] < 90.0
+
+
 class TestRetryBehavior:
     """429 and transient 5xx are retried; terminal 4xx are not. Mirrors
     SpotifyClient's _search_with_retry shape."""

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -493,6 +493,28 @@ class TestFindAlbumMatch:
         assert match is not None
         assert match.url.endswith("/456")
 
+    @pytest.mark.asyncio
+    async def test_emits_apple_music_service_for_album_winner(self, es256_keypair):
+        """LML#592: the album surface must label its telemetry with
+        service="apple_music", like the track surface does. ``find_album_match``
+        routes through the shared ``find_best_source_match`` chokepoint, whose
+        ``service`` kwarg defaults to "unknown" — Apple must pass its own label
+        so its album matches aren't misattributed to the "unknown" bucket in the
+        per-service marginal-clear breakdown. Patches the matching-module seam
+        because the album emit fires from inside ``find_best_source_match``, not
+        from the apple_music-level import the track path uses.
+        """
+        client = _client(es256_keypair)
+        client.search_album = AsyncMock(return_value=[_make_album_data()])
+
+        with patch("clients.streaming.matching.record_match_telemetry") as rec:
+            match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+
+        assert match is not None
+        rec.assert_called_once()
+        assert rec.call_args.kwargs["service"] == "apple_music"
+        assert rec.call_args.kwargs["surface"] == "album"
+
 
 def _make_song_data_full(
     name: str = "Hebebeb (Zrag)",
@@ -832,18 +854,24 @@ class TestFindTrackMetadataEmits:
     @pytest.mark.asyncio
     async def test_emits_marginal_clear_for_track_winner(self, es256_keypair):
         client = _client(es256_keypair)
-        # Request "Wand" / "DOGA"; Apple returns "Wanda" on a same-titled
-        # track + album. token_set_ratio("wand","wanda") == 88.89 (marginal).
+        # Request artist "Wand" / song "la paradoja" / album "DOGA"; Apple
+        # returns "Wanda" — token_set_ratio("wand","wanda") == 88.89 (marginal).
+        # The song title matches exactly (track axis 100) while album_name
+        # "DOGAS" is a deliberate near-miss to "DOGA" (88.89 — clears the 80
+        # floor but stays below the 95 high-title band). Keeping the track and
+        # album scores distinct pins that the emitted title_score is the *track*
+        # axis: a regression that emitted album_score instead would drop to
+        # 88.89 and fail the >= 95 assertion below.
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
             return_value=_songs_response(
-                [_make_song_data(name="DOGA", artist_name="Wanda", album_name="DOGA")]
+                [_make_song_data(name="la paradoja", artist_name="Wanda", album_name="DOGAS")]
             )
         )
         client._http = mock_http
 
         with patch("clients.streaming.apple_music.record_match_telemetry") as rec:
-            match = await client.find_track_metadata("Wand", "DOGA", album="DOGA")
+            match = await client.find_track_metadata("Wand", "la paradoja", album="DOGA")
 
         assert match is not None  # still clears — this PR instruments, it does not reject
         rec.assert_called_once()
@@ -851,7 +879,7 @@ class TestFindTrackMetadataEmits:
         assert kwargs["surface"] == "track"
         assert kwargs["service"] == "apple_music"
         assert 80.0 <= kwargs["artist_score"] < 90.0  # marginal artist axis
-        assert kwargs["title_score"] >= 95.0  # high title axis
+        assert kwargs["title_score"] >= 95.0  # high title axis (the track, not the album)
 
     @pytest.mark.asyncio
     async def test_emits_scores_of_chosen_winner_not_top_fuzz(self, es256_keypair):
@@ -861,16 +889,19 @@ class TestFindTrackMetadataEmits:
         client = _client(es256_keypair)
         # A: exact artist, NO artwork -> higher combined -> best_overall.
         a = _make_song_data(
-            name="DOGA",
+            name="la paradoja",
             artist_name="Wand",
             album_name="DOGA",
             url="https://music.apple.com/us/song/a/1",
         )
         # B: marginal artist, WITH artwork -> best_with_artwork -> chosen as best.
+        # B's album_name "DOGAS" is a deliberate near-miss (album axis 88.89)
+        # while its track title matches exactly (track axis 100), so the title
+        # assertion below pins the *track* axis of the chosen winner.
         b = _make_song_data_full(
-            name="DOGA",
+            name="la paradoja",
             artist_name="Wanda",
-            album_name="DOGA",
+            album_name="DOGAS",
             url="https://music.apple.com/us/song/b/2",
         )
         mock_http = AsyncMock(spec=httpx.AsyncClient)
@@ -878,12 +909,15 @@ class TestFindTrackMetadataEmits:
         client._http = mock_http
 
         with patch("clients.streaming.apple_music.record_match_telemetry") as rec:
-            match = await client.find_track_metadata("Wand", "DOGA", album="DOGA")
+            match = await client.find_track_metadata("Wand", "la paradoja", album="DOGA")
 
         assert match is not None
         assert match.url.endswith("/b/2")  # artwork-preferred winner chosen
         # Emitted artist score is B's marginal 88.89, NOT A's exact 100.0.
         assert 80.0 <= rec.call_args.kwargs["artist_score"] < 90.0
+        # Emitted title score is B's track axis (la paradoja == 100), NOT B's
+        # album axis (DOGA vs DOGAS == 88.89) — pins (artist, track) lockstep.
+        assert rec.call_args.kwargs["title_score"] >= 95.0
 
 
 class TestRetryBehavior:

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -643,6 +643,27 @@ class TestFindBestSourceMatchEmits:
         assert match is None
         mock_sentry.start_span.assert_not_called()
 
+    def test_service_is_required(self):
+        """``service`` must be a required keyword arg, never silently defaulted.
+
+        A defaulted ``service="unknown"`` once let an adapter's album matches
+        (Apple's) drop into an unattributable telemetry bucket instead of
+        failing loudly — telemetry is best-effort and would have swallowed the
+        mistake at runtime (LML#592). Pin the required contract so re-adding a
+        default is caught here, not in production data.
+        """
+        from clients.streaming.matching import find_best_source_match
+
+        with pytest.raises(TypeError):
+            find_best_source_match(
+                self._WAND,
+                "Wand",
+                "DOGA",
+                artist_fn=lambda r: r["artist"],
+                title_fn=lambda r: r["album"],
+                url_fn=lambda r: r["url"],
+            )  # no service= → TypeError
+
 
 class TestAcceptanceFloorUnchanged:
     """LML#592 is instrument-only: the 80/80 floor is NOT tightened in this PR.

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -1,5 +1,7 @@
 """Unit tests for clients/streaming/matching.py."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from clients.streaming.matching import (
@@ -407,6 +409,30 @@ class TestFindBestMatch:
         assert best["url"] == "http://b"
         assert best["matched_title"] == "Aluminum Tunes"
 
+    def test_returns_per_axis_scores(self):
+        """find_best_match surfaces the winning candidate's artist/title scores.
+
+        LML#592: callers emit these to Sentry to measure how often a match
+        clears the floor with a marginal artist score against a high title.
+        Uses the Wand/Wanda short-name collision (artist 88.89, title 100).
+        """
+        from clients.streaming.matching import find_best_match, score_match
+
+        results = [
+            {"artist": "Wanda", "album": "DOGA", "url": "http://w"},
+        ]
+        best = find_best_match(
+            results,
+            "Wand",
+            "DOGA",
+            artist_fn=lambda r: r["artist"],
+            title_fn=lambda r: r["album"],
+            url_fn=lambda r: r["url"],
+        )
+        assert best is not None
+        assert best["artist_score"] == score_match("Wand", "Wanda")
+        assert best["title_score"] == score_match("DOGA", "DOGA")
+
     def test_returns_none_when_no_acceptable_match(self):
         from clients.streaming.matching import find_best_match
 
@@ -496,6 +522,162 @@ class TestFindBestMatch:
         assert best["url"] == "https://open.spotify.com/album/xyz"
         assert best["id"] == "xyz"
         assert best["confidence"] > 0
+
+
+class TestRecordMatchTelemetry:
+    """LML#592: emit the winning match's per-axis scores to Sentry.
+
+    Instrumentation only — measures how often a match clears the 80/80 floor
+    with a marginal artist score (80-90) against a high title (~100), the
+    short-name-collision signature (Wand/Wanda). No threshold change.
+    """
+
+    def test_noop_without_active_transaction(self):
+        """Outside a Sentry transaction the helper must not raise."""
+        from clients.streaming.matching import record_match_telemetry
+
+        # The real sentry_sdk.start_span returns a no-op span when uninitialized;
+        # the helper must tolerate that (and any error) silently.
+        record_match_telemetry(
+            artist_score=88.89, title_score=100.0, service="apple_music", surface="album"
+        )
+
+    def test_emits_expected_span_data(self):
+        from clients.streaming.matching import record_match_telemetry
+
+        with patch("clients.streaming.matching.sentry_sdk") as mock_sentry:
+            mock_span = MagicMock()
+            mock_sentry.start_span.return_value.__enter__.return_value = mock_span
+            record_match_telemetry(
+                artist_score=88.89, title_score=100.0, service="apple_music", surface="album"
+            )
+
+        assert mock_sentry.start_span.call_args.kwargs["op"] == "matcher.match"
+        data = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
+        assert data["matcher.service"] == "apple_music"
+        assert data["matcher.surface"] == "album"
+        assert data["matcher.artist_score"] == 88.89
+        assert data["matcher.title_score"] == 100.0
+        assert data["matcher.marginal_artist_clear"] is True
+
+    def test_telemetry_failure_is_swallowed(self):
+        """A telemetry error must never propagate into the lookup path."""
+        from clients.streaming.matching import record_match_telemetry
+
+        with patch("clients.streaming.matching.sentry_sdk") as mock_sentry:
+            mock_sentry.start_span.side_effect = RuntimeError("sentry down")
+            # Must not raise.
+            record_match_telemetry(
+                artist_score=88.89, title_score=100.0, service="spotify", surface="album"
+            )
+
+    @pytest.mark.parametrize(
+        "artist_score, title_score, expected",
+        [
+            pytest.param(88.89, 100.0, True, id="wand-wanda-marginal"),
+            pytest.param(85.71, 100.0, True, id="hyd-hyde-marginal"),
+            pytest.param(95.0, 100.0, False, id="artist-clearly-above-band"),
+            pytest.param(85.0, 80.0, False, id="title-not-high"),
+            pytest.param(80.0, 80.0, False, id="both-at-floor"),
+            pytest.param(88.0, 96.0, True, id="inside-both-bands"),
+            pytest.param(90.0, 100.0, False, id="artist-at-ceiling-excluded"),
+        ],
+    )
+    def test_marginal_artist_clear_classification(self, artist_score, title_score, expected):
+        from clients.streaming.matching import record_match_telemetry
+
+        with patch("clients.streaming.matching.sentry_sdk") as mock_sentry:
+            mock_span = MagicMock()
+            mock_sentry.start_span.return_value.__enter__.return_value = mock_span
+            record_match_telemetry(
+                artist_score=artist_score,
+                title_score=title_score,
+                service="apple_music",
+                surface="track",
+            )
+
+        data = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
+        assert data["matcher.marginal_artist_clear"] is expected
+
+
+class TestFindBestSourceMatchEmits:
+    """LML#592: the album chokepoint emits match telemetry for the winner."""
+
+    _WAND = [{"artist": "Wanda", "album": "DOGA", "url": "http://w"}]
+
+    def test_emits_marginal_clear_for_album_winner(self):
+        from clients.streaming.matching import find_best_source_match
+
+        with patch("clients.streaming.matching.sentry_sdk") as mock_sentry:
+            mock_span = MagicMock()
+            mock_sentry.start_span.return_value.__enter__.return_value = mock_span
+            match = find_best_source_match(
+                self._WAND,
+                "Wand",
+                "DOGA",
+                artist_fn=lambda r: r["artist"],
+                title_fn=lambda r: r["album"],
+                url_fn=lambda r: r["url"],
+                service="deezer",
+            )
+
+        assert match is not None  # still clears — this PR instruments, it does not reject
+        data = {c.args[0]: c.args[1] for c in mock_span.set_data.call_args_list}
+        assert data["matcher.surface"] == "album"
+        assert data["matcher.service"] == "deezer"
+        assert data["matcher.marginal_artist_clear"] is True
+
+    def test_no_emit_when_nothing_clears(self):
+        from clients.streaming.matching import find_best_source_match
+
+        with patch("clients.streaming.matching.sentry_sdk") as mock_sentry:
+            match = find_best_source_match(
+                [{"artist": "Cat Power", "album": "Moon Pix", "url": "http://x"}],
+                "Autechre",
+                "Confield",
+                artist_fn=lambda r: r["artist"],
+                title_fn=lambda r: r["album"],
+                url_fn=lambda r: r["url"],
+                service="deezer",
+            )
+        assert match is None
+        mock_sentry.start_span.assert_not_called()
+
+
+class TestAcceptanceFloorUnchanged:
+    """LML#592 is instrument-only: the 80/80 floor is NOT tightened in this PR.
+
+    These pins fail loudly if a future edit changes acceptance while only
+    telemetry was intended. The Wand/Wanda short-name collision must still
+    CLEAR — we measure it now; rejecting it is a gated follow-up.
+    """
+
+    def test_floor_constant_unchanged(self):
+        from clients.streaming.matching import SCORE_MATCH_ACCEPTANCE_FLOOR
+
+        assert SCORE_MATCH_ACCEPTANCE_FLOOR == 80.0
+
+    def test_wand_wanda_still_clears_predicate(self):
+        from clients.streaming.matching import is_acceptable_match, score_match
+
+        artist = score_match("Wand", "Wanda")
+        assert artist == pytest.approx(88.89, abs=0.01)
+        assert is_acceptable_match(artist, score_match("DOGA", "DOGA")) is True
+
+    def test_wand_wanda_still_selected_as_album_match(self):
+        from clients.streaming.matching import find_best_source_match
+
+        match = find_best_source_match(
+            [{"artist": "Wanda", "album": "DOGA", "url": "http://w"}],
+            "Wand",
+            "DOGA",
+            artist_fn=lambda r: r["artist"],
+            title_fn=lambda r: r["album"],
+            url_fn=lambda r: r["url"],
+            service="deezer",
+        )
+        assert match is not None
+        assert match.url == "http://w"
 
 
 class TestFindBestTypedMatch:


### PR DESCRIPTION
Part 1 of #592 — **instrumentation only, no acceptance behavior changed.**

## Problem

The shared 80/80 fuzzy-match floor (`is_acceptable_match`) admits organic short-name artist collisions on a shared album title. `score_match("Wand","Wanda") = 88.89` clears the 80 artist floor while an identical album title scores 100, so a request for **Wand**'s album can lock onto a same-titled **Wanda** release. The wrong URL is then cached as a *hit* and persists indefinitely (the resolver short-circuits on any present URL regardless of age).

Per the issue's staging, this PR **instruments first** so the marginal-clear rate is measurable in production *before* deciding whether to tighten the artist-axis floor. Tightening Apple's mature path speculatively risks regressing legitimate short-name matches — so it is deliberately left as a gated follow-up.

## What this does

Every winning streaming match emits a lightweight `matcher.match` Sentry span carrying the per-axis fuzzy scores, on **both** surfaces:

- **Album path** — `find_best_source_match` (all adapters: Apple, Spotify, Deezer, Bandcamp)
- **Apple track path** — `find_track_metadata`, which inlines its own `token_set_ratio` floor and never touches the shared predicate, so it is instrumented separately

Span data keys:

- `matcher.service` — `apple_music | spotify | deezer | bandcamp`
- `matcher.surface` — `album | track`
- `matcher.artist_score` / `matcher.title_score` — raw fuzzy scores (0–100) of the winner
- `matcher.marginal_artist_clear` — `true` when the artist score is marginal (`[80, 90)`) against a high title (`>= 95`) — the short-name-collision signature

The count of `matcher.match` spans is the denominator and the `marginal_artist_clear` subset is the numerator of the marginal-clear rate. Raw scores are emitted alongside the boolean so the bands can be re-tuned in Sentry queries without a code change. Telemetry failures are swallowed (best-effort) — never fatal to a lookup.

Also binds Apple's `_APPLE_MUSIC_MATCH_FLOOR` to the shared `SCORE_MATCH_ACCEPTANCE_FLOOR` so the two 80.0 literals can no longer drift.

## Tests (TDD, red→green)

- `find_best_match` now returns `artist_score`/`title_score`
- `TestRecordMatchTelemetry` — no-op safety, swallowed failure, parametrized marginal classification (incl. ceiling boundary)
- `TestFindBestSourceMatchEmits` — album emits / no-emit when nothing clears
- `TestFindTrackMetadataEmits` — track emits + an artwork-vs-top-fuzz divergence case (pins that emitted scores describe the *chosen* winner)
- `TestAcceptanceFloorUnchanged` — Wand/Wanda still **clears**; this PR measures, it does not reject

Full unit suite green (2763 passed); ruff + mypy clean.

## Not in this PR

- **Gated tightening** (the conditional half of #592): raise the artist-axis floor — flat or length-conditioned — once the counter shows a non-trivial marginal-clear rate. Must hold for the `token_set_ratio` track path, not just `token_sort_ratio` album. A combined-score requirement is a no-op here (Wand/Wanda's combined is 94.4).
- The Spotify/Deezer sparse-row `KeyError` (separate ticket, already noted out of scope in #592).

Refs #592 (intentionally not auto-closing — #592 tracks the follow-up tightening).