### PR TITLE
refactor(#609): consolidate Bandcamp/Discogs ResolveResult into one type

### DIFF
--- a/release/bandcamp_resolver.py
+++ b/release/bandcamp_resolver.py
@@ -17,14 +17,13 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass
 from datetime import datetime
 from urllib.parse import urlparse
 
 import httpx
 
 from clients.bandcamp import BandcampClient
-from release.models import CanonicalRelease, ReleaseIdentifiers
+from release.models import CanonicalRelease, ReleaseIdentifiers, ResolveResult
 
 logger = logging.getLogger(__name__)
 
@@ -33,15 +32,6 @@ _LD_JSON_BLOCK_RE = re.compile(
     r'<script[^>]+type="application/ld\+json"[^>]*>(.*?)</script>',
     re.DOTALL,
 )
-
-
-@dataclass
-class BandcampResolveResult:
-    """Result of resolving a single Bandcamp album URL."""
-
-    canonical: CanonicalRelease | None
-    identifiers: ReleaseIdentifiers
-    warnings: list[str]
 
 
 def _host(url: str | None) -> str | None:
@@ -69,7 +59,7 @@ def _parse_year(date_published: str | None) -> int | None:
         return int(match.group()) if match else None
 
 
-def parse_bandcamp_album_html(html: str, album_url: str) -> BandcampResolveResult:
+def parse_bandcamp_album_html(html: str, album_url: str) -> ResolveResult:
     """Pull the JSON-LD blob out of an album page and project to canonical form.
 
     Pure function — separated from the HTTP fetch so tests run against committed
@@ -79,7 +69,7 @@ def parse_bandcamp_album_html(html: str, album_url: str) -> BandcampResolveResul
 
     blocks = _LD_JSON_BLOCK_RE.findall(html)
     if not blocks:
-        return BandcampResolveResult(
+        return ResolveResult(
             canonical=None,
             identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
             warnings=["Bandcamp page did not contain a JSON-LD MusicAlbum block"],
@@ -103,7 +93,7 @@ def parse_bandcamp_album_html(html: str, album_url: str) -> BandcampResolveResul
             break
 
     if album_data is None:
-        return BandcampResolveResult(
+        return ResolveResult(
             canonical=None,
             identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
             warnings=["Bandcamp page JSON-LD did not contain a MusicAlbum entry"],
@@ -113,7 +103,7 @@ def parse_bandcamp_album_html(html: str, album_url: str) -> BandcampResolveResul
     by_artist = album_data.get("byArtist") or {}
     artist_name = by_artist.get("name") if isinstance(by_artist, dict) else None
     if not name or not artist_name:
-        return BandcampResolveResult(
+        return ResolveResult(
             canonical=None,
             identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
             warnings=["Bandcamp JSON-LD missing required name or byArtist.name"],
@@ -141,7 +131,7 @@ def parse_bandcamp_album_html(html: str, album_url: str) -> BandcampResolveResul
 
     identifiers = ReleaseIdentifiers(bandcamp_album_url=album_url)
 
-    return BandcampResolveResult(canonical=canonical, identifiers=identifiers, warnings=warnings)
+    return ResolveResult(canonical=canonical, identifiers=identifiers, warnings=warnings)
 
 
 async def fetch_bandcamp_album_html(client: BandcampClient, album_url: str) -> str | None:
@@ -170,11 +160,11 @@ async def fetch_bandcamp_album_html(client: BandcampClient, album_url: str) -> s
     return response.text
 
 
-async def resolve_bandcamp_album(client: BandcampClient, album_url: str) -> BandcampResolveResult:
+async def resolve_bandcamp_album(client: BandcampClient, album_url: str) -> ResolveResult:
     """Fetch + parse an album page in one call. Wraps the two helpers above."""
     html = await fetch_bandcamp_album_html(client, album_url)
     if html is None:
-        return BandcampResolveResult(
+        return ResolveResult(
             canonical=None,
             identifiers=ReleaseIdentifiers(bandcamp_album_url=album_url),
             warnings=[f"Bandcamp page could not be fetched: {album_url}"],

--- a/release/discogs_resolver.py
+++ b/release/discogs_resolver.py
@@ -18,24 +18,14 @@ rate-limit budget for v1 of this endpoint.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 
 from discogs.service import DiscogsService
-from release.models import CanonicalRelease, ReleaseIdentifiers
+from release.models import CanonicalRelease, ReleaseIdentifiers, ResolveResult
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class DiscogsResolveResult:
-    """Result of resolving a single Discogs release ID."""
-
-    canonical: CanonicalRelease | None
-    identifiers: ReleaseIdentifiers
-    warnings: list[str]
-
-
-async def resolve_discogs_release(service: DiscogsService, release_id: str) -> DiscogsResolveResult:
+async def resolve_discogs_release(service: DiscogsService, release_id: str) -> ResolveResult:
     """Look up a Discogs release and project to canonical form.
 
     Returns a result whose ``canonical`` is None when the release could not
@@ -48,7 +38,7 @@ async def resolve_discogs_release(service: DiscogsService, release_id: str) -> D
     try:
         rid = int(release_id)
     except ValueError:
-        return DiscogsResolveResult(
+        return ResolveResult(
             canonical=None,
             identifiers=ReleaseIdentifiers(),
             warnings=[f"Discogs release ID '{release_id}' is not a number"],
@@ -60,7 +50,7 @@ async def resolve_discogs_release(service: DiscogsService, release_id: str) -> D
     # for every subsequent caller. The LML#518 decision record puts this
     # validation at the caller, not the service boundary. Reject here.
     if rid <= 0:
-        return DiscogsResolveResult(
+        return ResolveResult(
             canonical=None,
             identifiers=ReleaseIdentifiers(),
             warnings=[f"Discogs release ID '{rid}' is not positive"],
@@ -70,7 +60,7 @@ async def resolve_discogs_release(service: DiscogsService, release_id: str) -> D
         release = await service.get_release(rid)
     except Exception:
         logger.exception("Discogs release fetch failed for %s", rid)
-        return DiscogsResolveResult(
+        return ResolveResult(
             canonical=None,
             identifiers=ReleaseIdentifiers(discogs_release_id=rid),
             warnings=[f"Discogs lookup failed for release {rid}"],
@@ -81,7 +71,7 @@ async def resolve_discogs_release(service: DiscogsService, release_id: str) -> D
             f"Discogs release {rid} could not be fetched "
             "(rate-limited, not found, or temporarily unavailable)"
         )
-        return DiscogsResolveResult(
+        return ResolveResult(
             canonical=None,
             identifiers=ReleaseIdentifiers(discogs_release_id=rid),
             warnings=warnings,
@@ -108,17 +98,17 @@ async def resolve_discogs_release(service: DiscogsService, release_id: str) -> D
         discogs_artist_id=release.artist_id,
     )
 
-    return DiscogsResolveResult(canonical=canonical, identifiers=identifiers, warnings=warnings)
+    return ResolveResult(canonical=canonical, identifiers=identifiers, warnings=warnings)
 
 
-async def resolve_discogs_master(_service: DiscogsService, master_id: str) -> DiscogsResolveResult:
+async def resolve_discogs_master(_service: DiscogsService, master_id: str) -> ResolveResult:
     """Master URLs are not yet supported.
 
     The Discogs API would let us pivot ``master_id`` → ``main_release_id`` →
     full release, but that adds a second API call per paste. Defer until
     we see real demand for master-URL pastes.
     """
-    return DiscogsResolveResult(
+    return ResolveResult(
         canonical=None,
         identifiers=ReleaseIdentifiers(discogs_master_id=_safe_int(master_id)),
         warnings=[

--- a/release/models.py
+++ b/release/models.py
@@ -8,6 +8,7 @@ its rotation-release create form in one round trip.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -110,3 +111,20 @@ class ReleaseResolveResponse(BaseModel):
             "to the user but still allow them to save."
         ),
     )
+
+
+@dataclass
+class ResolveResult:
+    """Result of resolving a single source (Discogs release/master or Bandcamp album).
+
+    Shared by every per-source resolver in ``release/`` so there is one shape to
+    maintain. The orchestrator field-unpacks ``canonical``/``identifiers``/``warnings``
+    and discriminates the source via ``parsed.source``, so this type carries no
+    source tag of its own. ``canonical`` is None when the source could not be
+    fetched (rate-limited, not found, network error); ``warnings`` then explains
+    why so the form can fall back to manual entry without hiding the failure.
+    """
+
+    canonical: CanonicalRelease | None
+    identifiers: ReleaseIdentifiers
+    warnings: list[str]

--- a/tests/unit/release/test_discogs_resolver.py
+++ b/tests/unit/release/test_discogs_resolver.py
@@ -12,10 +12,10 @@ from generated.api_models import (
     DiscogsReleaseMetadata,
 )
 from release.discogs_resolver import (
-    DiscogsResolveResult,
     resolve_discogs_master,
     resolve_discogs_release,
 )
+from release.models import ResolveResult
 
 
 def _make_release(**overrides) -> DiscogsReleaseMetadata:
@@ -47,7 +47,7 @@ class TestResolveDiscogsRelease:
         result = await resolve_discogs_release(mock_service, "12345")
 
         mock_service.get_release.assert_awaited_once_with(12345)
-        assert isinstance(result, DiscogsResolveResult)
+        assert isinstance(result, ResolveResult)
         assert result.canonical is not None
         assert result.canonical.artist == "Juana Molina"
         assert result.canonical.title == "DOGA"

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -203,11 +203,10 @@ class TestBandcampBranch:
                 new=AsyncMock(return_value=_stream(on_streaming=False)),
             ),
         ):
-            from release.bandcamp_resolver import BandcampResolveResult
-            from release.models import CanonicalRelease, ReleaseIdentifiers
+            from release.models import CanonicalRelease, ReleaseIdentifiers, ResolveResult
 
             url = "https://juana-molina.bandcamp.com/album/doga"
-            mock_resolve.return_value = BandcampResolveResult(
+            mock_resolve.return_value = ResolveResult(
                 canonical=CanonicalRelease(artist="Juana Molina", title="DOGA", label=None),
                 identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
                 warnings=[],
@@ -237,11 +236,10 @@ class TestBandcampBranch:
             patch("release.orchestrator.resolve_bandcamp_album", new=AsyncMock()) as mock_resolve,
             patch("release.orchestrator.check_streaming_availability", new=check_mock),
         ):
-            from release.bandcamp_resolver import BandcampResolveResult
-            from release.models import CanonicalRelease, ReleaseIdentifiers
+            from release.models import CanonicalRelease, ReleaseIdentifiers, ResolveResult
 
             url = "https://juana-molina.bandcamp.com/album/doga"
-            mock_resolve.return_value = BandcampResolveResult(
+            mock_resolve.return_value = ResolveResult(
                 canonical=CanonicalRelease(artist="Juana Molina", title="DOGA"),
                 identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
                 warnings=[],
@@ -279,10 +277,9 @@ class TestBandcampBranch:
             ) as mock_resolve,
             patch("release.orchestrator.check_streaming_availability") as cs,
         ):
-            from release.bandcamp_resolver import BandcampResolveResult
-            from release.models import ReleaseIdentifiers
+            from release.models import ReleaseIdentifiers, ResolveResult
 
-            mock_resolve.return_value = BandcampResolveResult(
+            mock_resolve.return_value = ResolveResult(
                 canonical=None,
                 identifiers=ReleaseIdentifiers(bandcamp_album_url="https://x.bandcamp.com/album/y"),
                 warnings=["could not be fetched"],
@@ -312,11 +309,10 @@ class TestBandcampBranch:
                 new=AsyncMock(return_value=_stream()),
             ),
         ):
-            from release.bandcamp_resolver import BandcampResolveResult
-            from release.models import CanonicalRelease, ReleaseIdentifiers
+            from release.models import CanonicalRelease, ReleaseIdentifiers, ResolveResult
 
             url = "https://juana-molina.bandcamp.com/album/doga"
-            mock_resolve.return_value = BandcampResolveResult(
+            mock_resolve.return_value = ResolveResult(
                 canonical=CanonicalRelease(artist="Juana Molina", title="DOGA"),
                 identifiers=ReleaseIdentifiers(bandcamp_album_url=url),
                 warnings=[],

--- a/tests/unit/release/test_resolve_result.py
+++ b/tests/unit/release/test_resolve_result.py
@@ -1,0 +1,36 @@
+"""Pins the consolidated ``ResolveResult`` shape (LML#609).
+
+``BandcampResolveResult`` and ``DiscogsResolveResult`` were byte-for-byte
+identical 3-field dataclasses. They are consolidated into a single
+``release.models.ResolveResult``; the two old names must be gone (clean
+rename, no back-compat aliases).
+"""
+
+from __future__ import annotations
+
+import release.bandcamp_resolver as bandcamp_resolver
+import release.discogs_resolver as discogs_resolver
+from release.models import CanonicalRelease, ReleaseIdentifiers, ResolveResult
+
+
+def test_resolve_result_lives_in_release_models():
+    result = ResolveResult(
+        canonical=CanonicalRelease(artist="Juana Molina", title="DOGA"),
+        identifiers=ReleaseIdentifiers(),
+        warnings=[],
+    )
+    assert result.canonical is not None
+    assert result.canonical.artist == "Juana Molina"
+    assert result.identifiers == ReleaseIdentifiers()
+    assert result.warnings == []
+
+
+def test_resolve_result_accepts_none_canonical():
+    result = ResolveResult(canonical=None, identifiers=ReleaseIdentifiers(), warnings=["nope"])
+    assert result.canonical is None
+    assert result.warnings == ["nope"]
+
+
+def test_old_result_type_names_are_gone():
+    assert not hasattr(bandcamp_resolver, "BandcampResolveResult")
+    assert not hasattr(discogs_resolver, "DiscogsResolveResult")


### PR DESCRIPTION
Addresses structural-audit finding #1. `BandcampResolveResult` and `DiscogsResolveResult` were byte-for-byte identical (`canonical`/`identifiers`/`warnings`). This consolidates them into a single `ResolveResult` dataclass in `release/models.py`, alongside `CanonicalRelease`/`ReleaseIdentifiers` which both resolvers already import, so no new import edge or cycle is introduced. Both resolvers' construction sites and signatures are retargeted, and the tests are updated; the orchestrator field-unpacks and never isinstance-checks, so it required no changes (verified). Behavior-preserving, no back-compat alias.

Closes #609