### PR TITLE
refactor(#610): guard Identity/IdentityResponse parity + document provenance pipeline

### DIFF
--- a/identity/bulk_resolve.py
+++ b/identity/bulk_resolve.py
@@ -97,7 +97,32 @@ def _identity_to_external_ids(identity: Identity) -> dict[IdentitySource, str]:
 
 @dataclass(frozen=True)
 class _ComposedRow:
-    """Per-source row, post Rule 6 floor and method/confidence resolution."""
+    """The *normalize* stage of the per-source provenance pipeline.
+
+    Three superficially-similar row types make up a deliberate
+    parse -> normalize -> validate pipeline. They are NOT duplication — each
+    layer changes the types, so do NOT try to "deduplicate" them into one:
+
+    1. ``ProvenanceRow`` (``entity/store.py``) — *parse*. The raw DB read-model
+       straight off ``entity.reconciliation_log``: ``source``/``method`` are
+       loose ``str`` (whatever the matcher logged, incl. the internal-only
+       ``inherited`` method), ``confidence`` is ``float | None``.
+    2. ``_ComposedRow`` (this class) — *normalize*. ``source``/``method`` are
+       now api.yaml enums, ``confidence`` is a required ``float`` (the ``None``
+       case is defaulted upstream), the Rule 6 floor has been applied, and the
+       added ``is_inherited`` bool carries the one piece of state that has no
+       wire representation: ``method == "inherited"`` has no ``IdentityMethod``
+       enum value, so it rides as a bool here and gates Rule 3 (it never
+       reaches the wire — see ``_row_to_provenance``).
+    3. ``BulkResolveProvenanceEntry`` (``generated/api_models.py``) — *validate*.
+       The wire contract, generated from ``wxyc-shared/api.yaml``:
+       ``confidence`` is a ``confloat(ge=0, le=1)`` and ``is_inherited`` is
+       gone (it was never part of the contract).
+
+    Collapsing any pair would either leak the loose DB strings onto the wire,
+    drop the internal ``is_inherited`` gate, or couple the generated wire model
+    to LML-internal composition state.
+    """
 
     source: IdentitySource
     method: IdentityMethod

--- a/identity/models.py
+++ b/identity/models.py
@@ -1,10 +1,24 @@
 """Pydantic response models for identity resolution endpoints."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from entity.store import Identity
 
 
 class IdentityResponse(BaseModel):
-    """A single resolved artist identity with external identifiers."""
+    """A single resolved artist identity with external identifiers.
+
+    Wire-model counterpart to the ``entity.store.Identity`` DB read-model: it
+    carries the same eight artist-identity fields but drops the internal DB
+    primary key ``id``. ``from_identity`` is the field-agnostic projection from
+    one to the other; the parity test in ``tests/unit/test_identity_models.py``
+    fails CI if the two field sets ever diverge (modulo ``id``).
+    """
 
     library_name: str
     discogs_artist_id: int | None = None
@@ -14,6 +28,18 @@ class IdentityResponse(BaseModel):
     apple_music_artist_id: str | None = None
     bandcamp_id: str | None = None
     reconciliation_status: str = "unreconciled"
+
+    @classmethod
+    def from_identity(cls, identity: Identity) -> IdentityResponse:
+        """Project an entity-store ``Identity`` onto the wire model, dropping ``id``.
+
+        Field-agnostic by design: ``model_validate(..., from_attributes=True)``
+        reads every matching attribute off the dataclass, so adding a shared
+        identity field needs no edit here — only on the two models, which the
+        parity test keeps aligned. The extra ``id`` attribute on the dataclass
+        is ignored because it has no corresponding field on this model.
+        """
+        return cls.model_validate(identity, from_attributes=True)
 
 
 class BulkIdentityRequest(BaseModel):

--- a/identity/router.py
+++ b/identity/router.py
@@ -64,20 +64,6 @@ _ENTITY_STORE_UNAVAILABLE_DETAIL = (
 )
 
 
-def _identity_to_response(identity: Identity) -> IdentityResponse:
-    """Convert an EntityStore Identity dataclass to a Pydantic response model."""
-    return IdentityResponse(
-        library_name=identity.library_name,
-        discogs_artist_id=identity.discogs_artist_id,
-        wikidata_qid=identity.wikidata_qid,
-        musicbrainz_artist_id=identity.musicbrainz_artist_id,
-        spotify_artist_id=identity.spotify_artist_id,
-        apple_music_artist_id=identity.apple_music_artist_id,
-        bandcamp_id=identity.bandcamp_id,
-        reconciliation_status=identity.reconciliation_status,
-    )
-
-
 def _require_entity_store(store: EntityStore | None) -> EntityStore:
     """Raise 503 if the entity store is not available."""
     if store is None:
@@ -108,7 +94,7 @@ async def resolve_identity(
         raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
     if identity is None:
         raise HTTPException(status_code=404, detail=f"No identity found for '{name}'")
-    return _identity_to_response(identity)
+    return IdentityResponse.from_identity(identity)
 
 
 @router.post(
@@ -143,7 +129,7 @@ async def bulk_resolve_identities(
             logger.exception("Entity store query failed mid-bulk for name=%r", name)
             raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
         if identity is not None:
-            identities.append(_identity_to_response(identity))
+            identities.append(IdentityResponse.from_identity(identity))
         else:
             unresolved.append(name)
 

--- a/tests/unit/test_identity_models.py
+++ b/tests/unit/test_identity_models.py
@@ -1,0 +1,78 @@
+"""Unit tests for identity/models.py wire models and Identity↔IdentityResponse parity.
+
+`Identity` (``entity/store.py``, a dataclass DB read-model) and
+`IdentityResponse` (``identity/models.py``, the public wire model) carry the same
+eight artist-identity fields; `Identity` adds only the internal DB primary key
+`id`. They are projected onto each other by ``IdentityResponse.from_identity``,
+which is field-agnostic (``model_validate(..., from_attributes=True)``).
+
+The parity test below fails if the two field sets ever diverge (modulo `id`), so
+adding a source identifier to one without the other breaks CI rather than
+silently dropping the field from API responses (audit finding #2).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from entity.store import Identity
+from identity.models import IdentityResponse
+
+
+def test_identity_response_fields_match_identity_minus_id():
+    """The wire model's fields must equal the dataclass's fields minus `id`.
+
+    This is the structural drift guard: if a future change adds a shared
+    identity field to `Identity` but forgets `IdentityResponse` (or vice
+    versa), this assertion fails at CI time instead of the field silently
+    never reaching the API response.
+    """
+    identity_fields = {f.name for f in dataclasses.fields(Identity)} - {"id"}
+    response_fields = set(IdentityResponse.model_fields)
+    assert identity_fields == response_fields
+
+
+class TestFromIdentity:
+    """`IdentityResponse.from_identity` projects an Identity onto the wire model."""
+
+    def test_fully_populated_identity_round_trips(self):
+        """Every shared field carries across; the internal `id` is dropped."""
+        identity = Identity(
+            id=99,
+            library_name="Stereolab",
+            discogs_artist_id=2154,
+            wikidata_qid="Q484464",
+            musicbrainz_artist_id="d4133898-91ea-48ea-8820-1b85825901fe",
+            spotify_artist_id="1p6GVMFhLhSrRE7qgy8aAS",
+            apple_music_artist_id="5765873",
+            bandcamp_id="stereolab",
+            reconciliation_status="reconciled",
+        )
+
+        response = IdentityResponse.from_identity(identity)
+
+        assert response.library_name == "Stereolab"
+        assert response.discogs_artist_id == 2154
+        assert response.wikidata_qid == "Q484464"
+        assert response.musicbrainz_artist_id == "d4133898-91ea-48ea-8820-1b85825901fe"
+        assert response.spotify_artist_id == "1p6GVMFhLhSrRE7qgy8aAS"
+        assert response.apple_music_artist_id == "5765873"
+        assert response.bandcamp_id == "stereolab"
+        assert response.reconciliation_status == "reconciled"
+        # The internal DB primary key is not part of the wire contract.
+        assert not hasattr(response, "id")
+
+    def test_defaults_are_preserved(self):
+        """An Identity built with only a name keeps the dataclass defaults."""
+        identity = Identity(id=1, library_name="Sessa")
+
+        response = IdentityResponse.from_identity(identity)
+
+        assert response.library_name == "Sessa"
+        assert response.reconciliation_status == "unreconciled"
+        assert response.discogs_artist_id is None
+        assert response.wikidata_qid is None
+        assert response.musicbrainz_artist_id is None
+        assert response.spotify_artist_id is None
+        assert response.apple_music_artist_id is None
+        assert response.bandcamp_id is None


### PR DESCRIPTION
Addresses structural-audit findings #2 and #3.

Finding #2: `Identity` (dataclass) and `IdentityResponse` (pydantic model) shared 8 fields kept in sync by a hand-maintained `_identity_to_response` mapper with no test guarding alignment. This replaces the mapper with an `IdentityResponse.from_identity` classmethod backed by `model_validate(..., from_attributes=True)` (no config tweak needed), repoints both call sites, and adds a parity test asserting `dataclasses.fields(Identity)` minus `id` matches `IdentityResponse.model_fields` so future drift fails CI.

Finding #3 (docs-only): the `ProvenanceRow` -> `_ComposedRow` -> `BulkResolveProvenanceEntry` types are a deliberate parse/normalize/validate pipeline, not duplication. Expanded the `_ComposedRow` docstring to document the diverging types at each layer and why they must not be merged. No behavior or type changes; `generated/api_models.py` untouched.

Closes #610