### PR TITLE
refactor(#611): extract shared scripts/_lib signals + runtime helpers

### DIFF
--- a/scripts/_lib/__init__.py
+++ b/scripts/_lib/__init__.py
@@ -1,0 +1,6 @@
+"""Shared helpers for the one-shot scripts under ``scripts/``.
+
+Extracted to remove cross-script duplication of the SIGINT/SIGTERM
+graceful-shutdown handler (audit finding #7) and the ``main()`` runtime
+preamble (audit finding #8). See ``signals.py`` and ``runtime.py``.
+"""

--- a/scripts/_lib/runtime.py
+++ b/scripts/_lib/runtime.py
@@ -1,0 +1,61 @@
+"""Shared ``main()`` preamble for the one-shot scripts.
+
+:func:`set_up_script_runtime` folds the boilerplate that the streaming-pipeline
+scripts run before handing off to ``asyncio.run(run(...))``: load ``.env``,
+configure root logging, optionally quiet the noisy ``httpx`` logger, and install
+the graceful-shutdown signal handler. Argument parsing and ``asyncio.run`` stay
+with the caller.
+
+The flags exist to reproduce — not normalize — the small per-script differences:
+
+* ``include_logger_name`` toggles ``%(name)s`` in the log format. The two
+  variant-A scripts include it; the two variant-B scripts omit it.
+* ``quiet_httpx`` raises the ``httpx`` logger to ``WARNING``. Variant A and
+  ``search_unmatched_compilations`` do this; ``discogs_rematch`` does not.
+* ``shutdown_unit`` / ``log_force_quit`` are threaded through to
+  :func:`scripts._lib.signals.install_shutdown_handler` (variant A uses
+  ``"batch"``/``True``; variant B uses ``"item"``/``False``).
+"""
+
+from __future__ import annotations
+
+import logging
+from logging import Logger
+
+from dotenv import load_dotenv
+
+from scripts._lib.signals import ShutdownFlag, install_shutdown_handler
+
+
+def set_up_script_runtime(
+    *,
+    logger: Logger,
+    verbose: bool = False,
+    shutdown_unit: str = "batch",
+    log_force_quit: bool = True,
+    quiet_httpx: bool = True,
+    include_logger_name: bool = True,
+) -> ShutdownFlag:
+    """Run the shared script preamble and return the installed shutdown flag.
+
+    Performs ``load_dotenv`` → ``logging.basicConfig`` → optional ``httpx``
+    quieting → ``install_shutdown_handler``. The caller still owns argparse and
+    ``asyncio.run(run(args, shutdown))``.
+    """
+    load_dotenv()
+
+    level = logging.DEBUG if verbose else logging.INFO
+    if include_logger_name:
+        fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    else:
+        fmt = "%(asctime)s %(levelname)s %(message)s"
+    logging.basicConfig(level=level, format=fmt, datefmt="%H:%M:%S")
+
+    if quiet_httpx:
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    return install_shutdown_handler(
+        logger=logger,
+        unit=shutdown_unit,
+        log_force_quit=log_force_quit,
+    )

--- a/scripts/_lib/signals.py
+++ b/scripts/_lib/signals.py
@@ -1,0 +1,79 @@
+"""Graceful-shutdown signal handling shared by the one-shot scripts.
+
+The four streaming-pipeline scripts previously each carried a byte-identical
+``_handle_signal`` callback plus a module-level ``_shutdown_requested`` flag, in
+two behaviorally-distinct variants:
+
+* **Variant A** (``unit="batch"``, ``log_force_quit=True``) — logs a warning on
+  the force-quit (second) signal before exiting.
+* **Variant B** (``unit="item"``, ``log_force_quit=False``) — exits silently on
+  the force-quit signal.
+
+``ShutdownFlag`` holds the latch as *instance state* behind a ``.requested``
+property. Scripts read the flag many times via a module-level handle
+(``_shutdown.requested``); because the latch lives on the instance rather than a
+re-bound module global, every read observes the mutation. (A
+``from ... import _shutdown_requested`` would have bound the boolean by value and
+never seen it flip — the bug this design avoids.)
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+from logging import Logger
+from types import FrameType
+
+_DEFAULT_SIGNALS: tuple[signal.Signals, ...] = (signal.SIGINT, signal.SIGTERM)
+
+
+class ShutdownFlag:
+    """A latch toggled by SIGINT/SIGTERM for cooperative graceful shutdown.
+
+    The first signal sets :attr:`requested` (the running loop is expected to
+    finish its current ``unit`` of work and stop). A second signal forces an
+    immediate ``sys.exit(1)``, optionally logging a warning first.
+    """
+
+    def __init__(
+        self,
+        *,
+        logger: Logger,
+        unit: str = "batch",
+        log_force_quit: bool = True,
+    ) -> None:
+        self._logger = logger
+        self._unit = unit
+        self._log_force_quit = log_force_quit
+        self._requested = False
+
+    @property
+    def requested(self) -> bool:
+        """Whether a graceful shutdown has been requested."""
+        return self._requested
+
+    def handle(self, signum: int, frame: FrameType | None) -> None:
+        """Signal callback: latch on the first signal, force-quit on the second."""
+        if self._requested:
+            if self._log_force_quit:
+                self._logger.warning("Force quit requested, exiting immediately")
+            sys.exit(1)
+        self._logger.info("Shutdown requested, finishing current %s...", self._unit)
+        self._requested = True
+
+
+def install_shutdown_handler(
+    *,
+    logger: Logger,
+    unit: str = "batch",
+    log_force_quit: bool = True,
+    signals: tuple[signal.Signals, ...] = _DEFAULT_SIGNALS,
+) -> ShutdownFlag:
+    """Create a :class:`ShutdownFlag` and register it for ``signals``.
+
+    Returns the flag so the caller can read ``flag.requested`` from its loop.
+    """
+    flag = ShutdownFlag(logger=logger, unit=unit, log_force_quit=log_force_quit)
+    for sig in signals:
+        signal.signal(sig, flag.handle)
+    return flag

--- a/scripts/discogs_rematch.py
+++ b/scripts/discogs_rematch.py
@@ -13,30 +13,22 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import signal
 import sys
 from argparse import ArgumentParser
 
 import aiosqlite
-from dotenv import load_dotenv
 
 from clients.streaming.matching import (
     normalize_artist_credit,
     score_match,
     strip_format_suffix,
 )
+from scripts._lib.runtime import set_up_script_runtime
+from scripts._lib.signals import ShutdownFlag
 
 logger = logging.getLogger("discogs_rematch")
 
-_shutdown_requested = False
-
-
-def _handle_signal(signum, frame):
-    global _shutdown_requested
-    if _shutdown_requested:
-        sys.exit(1)
-    logger.info("Shutdown requested, finishing current item...")
-    _shutdown_requested = True
+_shutdown = ShutdownFlag(logger=logger, unit="item", log_force_quit=False)
 
 
 ARTIST_THRESHOLD_RELAXED = 70.0
@@ -171,7 +163,7 @@ async def _run_pass(
     """Run a pass function over a list of rows. Returns match count."""
     found = 0
     for i, row in enumerate(rows, 1):
-        if _shutdown_requested:
+        if _shutdown.requested:
             break
         result = await pass_fn(pool, row)
         if result:
@@ -243,7 +235,7 @@ async def run(args) -> None:
             logger.info("Pass 1 complete: %d Discogs matches", found)
 
         # Pass 2: not-enriched (no discogs_artist)
-        if args.run_pass in ("2", "all") and not _shutdown_requested:
+        if args.run_pass in ("2", "all") and not _shutdown.requested:
             cursor = await db.execute(
                 f"""SELECT id, display_artist, display_title
                     FROM albums
@@ -274,8 +266,8 @@ async def run(args) -> None:
         await db.close()
 
 
-def main():
-    load_dotenv()
+def main() -> None:
+    global _shutdown
     parser = ArgumentParser(description="Re-match albums missing Discogs links")
     parser.add_argument("--db-path", default="streaming_availability.db")
     parser.add_argument(
@@ -290,15 +282,14 @@ def main():
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
 
-    level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s %(levelname)s %(message)s",
-        datefmt="%H:%M:%S",
+    _shutdown = set_up_script_runtime(
+        logger=logger,
+        verbose=args.verbose,
+        shutdown_unit="item",
+        log_force_quit=False,
+        quiet_httpx=False,
+        include_logger_name=False,
     )
-
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
 
     asyncio.run(run(args))
 

--- a/scripts/search_unmatched_compilations.py
+++ b/scripts/search_unmatched_compilations.py
@@ -12,12 +12,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import signal
-import sys
 from argparse import ArgumentParser
 
 import aiosqlite
-from dotenv import load_dotenv
 
 from clients.streaming.matching import (
     find_best_match,
@@ -25,19 +22,13 @@ from clients.streaming.matching import (
     score_match,
     strip_format_suffix,
 )
+from scripts._lib.runtime import set_up_script_runtime
+from scripts._lib.signals import ShutdownFlag
 from scripts.track_streaming.compilation_search import build_compilation_query
 
 logger = logging.getLogger("search_compilations")
 
-_shutdown_requested = False
-
-
-def _handle_signal(signum, frame):
-    global _shutdown_requested
-    if _shutdown_requested:
-        sys.exit(1)
-    logger.info("Shutdown requested, finishing current item...")
-    _shutdown_requested = True
+_shutdown = ShutdownFlag(logger=logger, unit="item", log_force_quit=False)
 
 
 # Deezer/Spotify accessors for album search
@@ -132,7 +123,7 @@ async def run(args) -> None:
 
         try:
             for i, row in enumerate(rows, 1):
-                if _shutdown_requested:
+                if _shutdown.requested:
                     break
 
                 _, search_title = build_compilation_query(
@@ -189,7 +180,7 @@ async def run(args) -> None:
         logger.warning("DATABASE_URL_DISCOGS not set, skipping Discogs search")
         discogs_misses = rows
 
-    if _shutdown_requested or args.discogs_only:
+    if _shutdown.requested or args.discogs_only:
         await db.close()
         return
 
@@ -213,7 +204,7 @@ async def run(args) -> None:
 
     try:
         for i, row in enumerate(discogs_misses, 1):
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
 
             search_artist, search_title = build_compilation_query(
@@ -339,8 +330,8 @@ async def run(args) -> None:
     await db.close()
 
 
-def main():
-    load_dotenv()
+def main() -> None:
+    global _shutdown
     parser = ArgumentParser(description="Search unmatched compilations by title")
     parser.add_argument("--db-path", default="streaming_availability.db")
     parser.add_argument("--limit", type=int, default=100000)
@@ -349,16 +340,14 @@ def main():
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
 
-    level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s %(levelname)s %(message)s",
-        datefmt="%H:%M:%S",
+    _shutdown = set_up_script_runtime(
+        logger=logger,
+        verbose=args.verbose,
+        shutdown_unit="item",
+        log_force_quit=False,
+        quiet_httpx=True,
+        include_logger_name=False,
     )
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
 
     asyncio.run(run(args))
 

--- a/scripts/streaming_availability/__main__.py
+++ b/scripts/streaming_availability/__main__.py
@@ -17,11 +17,8 @@ if TYPE_CHECKING:
 import asyncio
 import logging
 import os
-import signal
 import sys
 from pathlib import Path
-
-from dotenv import load_dotenv
 
 from clients.streaming.apple_music import AppleMusicClient
 from clients.streaming.deezer import DeezerClient
@@ -31,6 +28,8 @@ from clients.streaming.matching import (
     strip_format_suffix,
 )
 from clients.streaming.spotify import SpotifyClient
+from scripts._lib.runtime import set_up_script_runtime
+from scripts._lib.signals import ShutdownFlag
 from scripts.streaming_availability.dedup import deduplicate_library
 from scripts.streaming_availability.discogs_enricher import (
     check_wxyc_schema,
@@ -42,16 +41,7 @@ from scripts.streaming_availability.results_db import ResultsDB
 
 logger = logging.getLogger("streaming_availability")
 
-_shutdown_requested = False
-
-
-def _handle_signal(signum, frame):
-    global _shutdown_requested
-    if _shutdown_requested:
-        logger.warning("Force quit requested, exiting immediately")
-        sys.exit(1)
-    logger.info("Shutdown requested, finishing current batch...")
-    _shutdown_requested = True
+_shutdown = ShutdownFlag(logger=logger, unit="batch", log_force_quit=True)
 
 
 # ---------------------------------------------------------------------------
@@ -81,13 +71,13 @@ async def _process_spotify(
     not_found = 0
     errors = 0
 
-    while not _shutdown_requested:
+    while not _shutdown.requested:
         rows = await results_db.get_pending("spotify", limit=batch_size)
         if not rows:
             break
 
         for row in rows:
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
 
             album_id = row["id"]
@@ -183,13 +173,13 @@ async def _process_apple_music(
     not_found = 0
     errors = 0
 
-    while not _shutdown_requested:
+    while not _shutdown.requested:
         rows = await _get_rows(limit=batch_size)
         if not rows:
             break
 
         for row in rows:
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
 
             album_id = row["id"]
@@ -264,13 +254,13 @@ async def _process_deezer(
     not_found = 0
     errors = 0
 
-    while not _shutdown_requested:
+    while not _shutdown.requested:
         rows = await results_db.get_pending("deezer", limit=batch_size)
         if not rows:
             break
 
         for row in rows:
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
 
             album_id = row["id"]
@@ -361,13 +351,13 @@ async def _process_discogs_enrichment(
     not_found = 0
     errors = 0
 
-    while not _shutdown_requested:
+    while not _shutdown.requested:
         rows = await results_db.get_pending_discogs(limit=batch_size)
         if not rows:
             break
 
         for row in rows:
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
 
             album_id = row["id"]
@@ -848,7 +838,7 @@ async def run(args: argparse.Namespace) -> None:
             )
 
         # Apple Music (still sequential, runs after pipeline)
-        if not args.spotify_only and not _shutdown_requested:
+        if not args.spotify_only and not _shutdown.requested:
             am_team = os.environ.get("APPLE_MUSIC_TEAM_ID")
             am_key = os.environ.get("APPLE_MUSIC_KEY_ID")
             am_priv = os.environ.get("APPLE_MUSIC_PRIVATE_KEY")
@@ -898,21 +888,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main():
-    load_dotenv()
+def main() -> None:
+    global _shutdown
     args = parse_args()
-
-    level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-        datefmt="%H:%M:%S",
-    )
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
-
+    _shutdown = set_up_script_runtime(logger=logger, verbose=args.verbose)
     asyncio.run(run(args))
 
 

--- a/scripts/track_streaming/__main__.py
+++ b/scripts/track_streaming/__main__.py
@@ -14,13 +14,11 @@ import asyncio
 import json
 import logging
 import os
-import signal
-import sys
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
-from dotenv import load_dotenv
-
+from scripts._lib.runtime import set_up_script_runtime
+from scripts._lib.signals import ShutdownFlag
 from scripts.streaming_availability.results_db import ResultsDB
 from scripts.track_streaming.api_search import search_track_on_services
 from scripts.track_streaming.local_index import LocalStreamingIndex, TrackEntry
@@ -31,16 +29,7 @@ from scripts.track_streaming.track_extractor import (
 
 logger = logging.getLogger("track_streaming")
 
-_shutdown_requested = False
-
-
-def _handle_signal(signum, frame):
-    global _shutdown_requested
-    if _shutdown_requested:
-        logger.warning("Force quit requested, exiting immediately")
-        sys.exit(1)
-    logger.info("Shutdown requested, finishing current batch...")
-    _shutdown_requested = True
+_shutdown = ShutdownFlag(logger=logger, unit="batch", log_force_quit=True)
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +71,7 @@ async def phase_extract(results_db: ResultsDB, args) -> int:
 
     try:
         for i, row in enumerate(singles, 1):
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
             tracks = await extract_single_tracks(row, discogs_cache=discogs_cache)
             if tracks:
@@ -96,7 +85,7 @@ async def phase_extract(results_db: ResultsDB, args) -> int:
 
     logger.info("Singles extraction complete: %d tracks from %d singles", inserted, len(singles))
 
-    if _shutdown_requested:
+    if _shutdown.requested:
         return inserted
 
     # Compilations
@@ -124,7 +113,7 @@ async def phase_extract(results_db: ResultsDB, args) -> int:
 
     comp_inserted = 0
     for i, row in enumerate(comps, 1):
-        if _shutdown_requested:
+        if _shutdown.requested:
             break
         comp_data = comp_data_by_id.get(row["id"])
         tracks = extract_compilation_tracks(row, comp_data)
@@ -185,7 +174,7 @@ async def phase_build_index(results_db: ResultsDB) -> LocalStreamingIndex:
         batch_size = 1000
 
         for batch_start in range(0, len(release_ids), batch_size):
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
             batch = release_ids[batch_start : batch_start + batch_size]
             rows = await pool.fetch(
@@ -242,13 +231,13 @@ async def phase_local_resolve(results_db: ResultsDB, index: LocalStreamingIndex)
     resolved = 0
     checked = 0
 
-    while not _shutdown_requested:
+    while not _shutdown.requested:
         pending = await results_db.get_pending_tracks(limit=500)
         if not pending:
             break
 
         for row in pending:
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
             checked += 1
             match = index.lookup(row["artist"], row["title"])
@@ -301,13 +290,13 @@ async def phase_api_search(results_db: ResultsDB, args) -> tuple[int, int]:
     checked = 0
 
     try:
-        while not _shutdown_requested:
+        while not _shutdown.requested:
             tracks = await results_db.get_local_miss_tracks(limit=args.batch_size)
             if not tracks:
                 break
 
             for row in tracks:
-                if _shutdown_requested:
+                if _shutdown.requested:
                     break
                 checked += 1
                 try:
@@ -378,7 +367,7 @@ async def phase_validate(results_db: ResultsDB, args) -> tuple[int, int]:
 
     async with httpx.AsyncClient() as http:
         for i, row in enumerate(rows, 1):
-            if _shutdown_requested:
+            if _shutdown.requested:
                 break
 
             is_valid = True
@@ -437,7 +426,7 @@ async def phase_album_rollup(results_db: ResultsDB) -> tuple[int, int]:
     off_streaming = 0
 
     for album_id in album_ids:
-        if _shutdown_requested:
+        if _shutdown.requested:
             break
         summary = await results_db.get_album_track_summary(album_id)
         if summary["pending"] > 0:
@@ -496,7 +485,7 @@ async def run(args) -> None:
                 return
 
         # Phase 2: Build index
-        if args.phase in ("resolve", "all") and not _shutdown_requested:
+        if args.phase in ("resolve", "all") and not _shutdown.requested:
             index = await phase_build_index(results_db)
 
             # Phase 3: Local resolution
@@ -504,18 +493,18 @@ async def run(args) -> None:
             logger.info("Phase 3 complete: %d / %d resolved locally", resolved, checked)
 
         # Phase 4: API search
-        if args.phase in ("search", "all") and not _shutdown_requested:
+        if args.phase in ("search", "all") and not _shutdown.requested:
             if not args.skip_api:
                 found, checked = await phase_api_search(results_db, args)
                 logger.info("Phase 4 complete: %d / %d found via API", found, checked)
 
         # Phase 4.5: Validate API matches
-        if args.phase in ("validate", "all") and not _shutdown_requested:
+        if args.phase in ("validate", "all") and not _shutdown.requested:
             valid, invalid = await phase_validate(results_db, args)
             logger.info("Phase 4.5 complete: %d valid, %d false positives", valid, invalid)
 
         # Phase 5: Album rollup
-        if args.phase in ("rollup", "all") and not _shutdown_requested:
+        if args.phase in ("rollup", "all") and not _shutdown.requested:
             on, off = await phase_album_rollup(results_db)
             logger.info("Phase 5 complete: %d on streaming, %d off streaming", on, off)
 
@@ -555,21 +544,10 @@ def parse_args(argv: list[str] | None = None) -> Namespace:
     return parser.parse_args(argv)
 
 
-def main():
-    load_dotenv()
+def main() -> None:
+    global _shutdown
     args = parse_args()
-
-    level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-        datefmt="%H:%M:%S",
-    )
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
-
+    _shutdown = set_up_script_runtime(logger=logger, verbose=args.verbose)
     asyncio.run(run(args))
 
 

--- a/tests/unit/test_lib_runtime.py
+++ b/tests/unit/test_lib_runtime.py
@@ -1,0 +1,108 @@
+"""Unit tests for scripts/_lib/runtime.py."""
+
+from __future__ import annotations
+
+import logging
+import signal
+
+import pytest
+
+from scripts._lib.runtime import set_up_script_runtime
+from scripts._lib.signals import ShutdownFlag
+
+
+@pytest.fixture(autouse=True)
+def restore_signals():
+    """Snapshot SIGINT/SIGTERM handlers and restore them after the test."""
+    saved = {sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)}
+    yield
+    for sig, handler in saved.items():
+        signal.signal(sig, handler)
+
+
+@pytest.fixture(autouse=True)
+def no_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace load_dotenv with a no-op so the test does not read the real .env."""
+    monkeypatch.setattr("scripts._lib.runtime.load_dotenv", lambda: None)
+
+
+def _reset_root_logging() -> None:
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+
+def test_returns_shutdown_flag() -> None:
+    _reset_root_logging()
+    flag = set_up_script_runtime(logger=logging.getLogger("rt_return"))
+    assert isinstance(flag, ShutdownFlag)
+
+
+def test_calls_load_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_root_logging()
+    called: list[bool] = []
+    monkeypatch.setattr("scripts._lib.runtime.load_dotenv", lambda: called.append(True))
+    set_up_script_runtime(logger=logging.getLogger("rt_dotenv"))
+    assert called == [True]
+
+
+@pytest.mark.parametrize(
+    "verbose, expected",
+    [(False, logging.INFO), (True, logging.DEBUG)],
+)
+def test_verbose_sets_root_level(verbose: bool, expected: int) -> None:
+    _reset_root_logging()
+    set_up_script_runtime(logger=logging.getLogger("rt_level"), verbose=verbose)
+    assert logging.getLogger().level == expected
+
+
+def test_quiet_httpx_true_silences_httpx_logger() -> None:
+    _reset_root_logging()
+    logging.getLogger("httpx").setLevel(logging.NOTSET)
+    set_up_script_runtime(logger=logging.getLogger("rt_httpx_on"), quiet_httpx=True)
+    assert logging.getLogger("httpx").level == logging.WARNING
+
+
+def test_quiet_httpx_false_leaves_httpx_logger_untouched() -> None:
+    _reset_root_logging()
+    logging.getLogger("httpx").setLevel(logging.NOTSET)
+    set_up_script_runtime(logger=logging.getLogger("rt_httpx_off"), quiet_httpx=False)
+    assert logging.getLogger("httpx").level == logging.NOTSET
+
+
+@pytest.mark.parametrize(
+    "include_logger_name, name_in_format",
+    [(True, True), (False, False)],
+)
+def test_include_logger_name_toggles_formatter(
+    include_logger_name: bool, name_in_format: bool
+) -> None:
+    _reset_root_logging()
+    set_up_script_runtime(
+        logger=logging.getLogger("rt_fmt"),
+        include_logger_name=include_logger_name,
+    )
+    handler = logging.getLogger().handlers[0]
+    assert handler.formatter is not None
+    fmt = handler.formatter._fmt or ""
+    assert ("%(name)s" in fmt) is name_in_format
+
+
+@pytest.mark.parametrize(
+    "shutdown_unit, log_force_quit",
+    [
+        pytest.param("batch", True, id="variant-a"),
+        pytest.param("item", False, id="variant-b"),
+    ],
+)
+def test_threads_shutdown_variant(shutdown_unit: str, log_force_quit: bool) -> None:
+    _reset_root_logging()
+    flag = set_up_script_runtime(
+        logger=logging.getLogger("rt_variant"),
+        shutdown_unit=shutdown_unit,
+        log_force_quit=log_force_quit,
+    )
+    assert flag._unit == shutdown_unit
+    assert flag._log_force_quit is log_force_quit
+    assert signal.getsignal(signal.SIGINT) == flag.handle
+    assert signal.getsignal(signal.SIGTERM) == flag.handle

--- a/tests/unit/test_lib_signals.py
+++ b/tests/unit/test_lib_signals.py
@@ -1,0 +1,94 @@
+"""Unit tests for scripts/_lib/signals.py."""
+
+from __future__ import annotations
+
+import logging
+import signal
+
+import pytest
+
+from scripts._lib.signals import ShutdownFlag, install_shutdown_handler
+
+
+@pytest.fixture
+def restore_signals():
+    """Snapshot SIGINT/SIGTERM handlers and restore them after the test."""
+    saved = {sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)}
+    yield
+    for sig, handler in saved.items():
+        signal.signal(sig, handler)
+
+
+def test_requested_false_on_construction() -> None:
+    flag = ShutdownFlag(logger=logging.getLogger("t"))
+    assert flag.requested is False
+
+
+@pytest.mark.parametrize("unit", ["batch", "item"])
+def test_first_signal_sets_flag_and_logs_unit(unit: str, caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger(f"test_first_{unit}")
+    flag = ShutdownFlag(logger=logger, unit=unit)
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        flag.handle(signal.SIGINT, None)
+
+    assert flag.requested is True
+    assert f"finishing current {unit}" in caplog.text
+    assert any(r.levelno == logging.INFO for r in caplog.records)
+
+
+def test_second_signal_force_quits_with_warning_when_enabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = logging.getLogger("test_force_warn")
+    flag = ShutdownFlag(logger=logger, unit="batch", log_force_quit=True)
+    flag.handle(signal.SIGINT, None)  # first: latch
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with pytest.raises(SystemExit) as exc:
+            flag.handle(signal.SIGINT, None)
+
+    assert exc.value.code == 1
+    assert "Force quit requested" in caplog.text
+
+
+def test_second_signal_force_quits_silently_when_disabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = logging.getLogger("test_force_silent")
+    flag = ShutdownFlag(logger=logger, unit="item", log_force_quit=False)
+    flag.handle(signal.SIGINT, None)  # first: latch
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        caplog.clear()
+        with pytest.raises(SystemExit) as exc:
+            flag.handle(signal.SIGINT, None)
+
+    assert exc.value.code == 1
+    assert "Force quit requested" not in caplog.text
+
+
+def test_install_registers_sigint_and_sigterm(restore_signals: None) -> None:
+    logger = logging.getLogger("test_install")
+    flag = install_shutdown_handler(logger=logger)
+
+    assert isinstance(flag, ShutdownFlag)
+    assert signal.getsignal(signal.SIGINT) == flag.handle
+    assert signal.getsignal(signal.SIGTERM) == flag.handle
+
+
+@pytest.mark.parametrize(
+    "unit, log_force_quit",
+    [
+        pytest.param("batch", True, id="variant-a"),
+        pytest.param("item", False, id="variant-b"),
+    ],
+)
+def test_install_threads_variant_params(
+    unit: str, log_force_quit: bool, restore_signals: None
+) -> None:
+    logger = logging.getLogger("test_variant")
+    flag = install_shutdown_handler(logger=logger, unit=unit, log_force_quit=log_force_quit)
+
+    assert flag._unit == unit
+    assert flag._log_force_quit is log_force_quit

--- a/tests/unit/test_scripts_import_smoke.py
+++ b/tests/unit/test_scripts_import_smoke.py
@@ -1,0 +1,33 @@
+"""Import-smoke the scripts that adopted scripts/_lib helpers.
+
+Guards against the new ``from scripts._lib...`` import lines silently breaking
+the four scripts, and confirms each script's module-level ``_shutdown`` handle is
+wired to the correct variant (audit findings #7 + #8).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from scripts._lib.signals import ShutdownFlag
+
+_VARIANTS = [
+    pytest.param("scripts.streaming_availability.__main__", "batch", True, id="streaming-avail"),
+    pytest.param("scripts.track_streaming.__main__", "batch", True, id="track-streaming"),
+    pytest.param("scripts.discogs_rematch", "item", False, id="discogs-rematch"),
+    pytest.param("scripts.search_unmatched_compilations", "item", False, id="search-comps"),
+]
+
+
+@pytest.mark.parametrize("module_name, unit, log_force_quit", _VARIANTS)
+def test_script_imports_with_expected_shutdown_variant(
+    module_name: str, unit: str, log_force_quit: bool
+) -> None:
+    module = importlib.import_module(module_name)
+    shutdown = module._shutdown
+    assert isinstance(shutdown, ShutdownFlag)
+    assert shutdown.requested is False
+    assert shutdown._unit == unit
+    assert shutdown._log_force_quit is log_force_quit


### PR DESCRIPTION
Addresses structural-audit findings #7 and #8. Four scripts duplicated a `_handle_signal` + module-level `_shutdown_requested` flag in two variants, and two scripts shared a `main()` preamble. This adds a `scripts/_lib/` package: `signals.py` (a `ShutdownFlag` exposing a `.requested` property over instance state, fixing the bind-by-value hazard, plus `install_shutdown_handler` parameterized over the two variants via `unit` and `log_force_quit`) and `runtime.py` (`set_up_script_runtime` with `include_logger_name`/`quiet_httpx` flags so the Variant-B preamble differences are preserved). All four scripts are rewritten to use the helpers with no observable behavior change; the variant differences are asserted by new unit tests.

Closes #611