### PR TITLE
refactor(#612): hoist pg_pool and mb/wikidata mock fixtures into conftest

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,9 +4,11 @@ Provides a real LibraryDB backed by in-memory SQLite with FTS5,
 seeded with representative catalog items.
 """
 
+import os
 from unittest.mock import AsyncMock
 
 import aiosqlite
+import asyncpg
 import pytest
 import pytest_asyncio
 
@@ -14,6 +16,61 @@ from config.settings import Settings
 from discogs.models import DiscogsSearchResponse
 from library.db import LibraryDB
 from tests.factories import make_discogs_result
+
+# ---------------------------------------------------------------------------
+# PostgreSQL test pool (shared by the ``@pytest.mark.pg`` integration suite)
+# ---------------------------------------------------------------------------
+
+# Centralized DSN for the real PostgreSQL container the ``pg`` suite runs
+# against. Modules that also need the DSN directly -- for ``source._dsn``
+# wiring or ``monkeypatch.setenv("DATABASE_URL_DISCOGS", ...)`` -- import it
+# from here instead of re-deriving the ``os.getenv`` default.
+DATABASE_URL = os.getenv(
+    "DATABASE_URL_TEST",
+    "postgresql://discogs:discogs@localhost:5433/discogs",
+)
+
+
+async def _make_pg_pool(max_size: int):
+    """Yield a real asyncpg pool, or ``pytest.skip`` when PostgreSQL is absent.
+
+    Async-generator helper backing :func:`pg_pool` and :func:`pg_pool_large`.
+    The skip-on-connect-failure contract keeps the ``pg`` suite green
+    (all-skipped) on a host with no test PostgreSQL -- exactly what the
+    previously-per-file copies did.
+    """
+    try:
+        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=max_size)
+    except Exception as e:
+        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
+        return
+    yield pool
+    await pool.close()
+
+
+@pytest_asyncio.fixture
+async def pg_pool():
+    """Real asyncpg pool (``max_size=3``); skips on connect failure.
+
+    The common case across the ``pg`` integration suite. Modules needing the
+    larger cap depend on :func:`pg_pool_large` instead.
+    """
+    async for pool in _make_pg_pool(max_size=3):
+        yield pool
+
+
+@pytest_asyncio.fixture
+async def pg_pool_large():
+    """Real asyncpg pool (``max_size=4``); skips on connect failure.
+
+    Identical to :func:`pg_pool` apart from the connection cap. Modules whose
+    fixtures historically created a ``max_size=4`` pool alias their local
+    ``pg_pool`` to this one, so downstream consumers keep the larger cap
+    without re-typing every request.
+    """
+    async for pool in _make_pg_pool(max_size=4):
+        yield pool
+
 
 # ---------------------------------------------------------------------------
 # Seed data -- representative catalog items

--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -10,27 +10,12 @@ Run with: pytest -m pg -v
 
 from __future__ import annotations
 
-import os
-
-import asyncpg
 import pytest
 import pytest_asyncio
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
-
-
-@pytest_asyncio.fixture
-async def pg_pool():
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+# ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
+# there for the ``monkeypatch.setenv("DATABASE_URL_DISCOGS", ...)`` wiring below.
+from tests.integration.conftest import DATABASE_URL
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_cache_refresh_for_identities.py
+++ b/tests/integration/test_cache_refresh_for_identities.py
@@ -17,10 +17,8 @@ test so we own a clean substrate without depending on the live discogs-cache.
 from __future__ import annotations
 
 import asyncio
-import os
 from unittest.mock import AsyncMock, patch
 
-import asyncpg
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -29,21 +27,20 @@ from discogs.models import ArtistCredit, ArtistDetails, ReleaseMetadataResponse
 from entity.sources import PgSource
 from entity.store import EntityStore
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
+# ``DATABASE_URL`` (and the conftest ``pg_pool_large``) come from conftest;
+# imported here for the ``source._dsn`` wiring and ``monkeypatch.setenv`` below.
+from tests.integration.conftest import DATABASE_URL
 
 
 @pytest_asyncio.fixture
-async def pg_pool():
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=4)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+async def pg_pool(pg_pool_large):
+    """Alias to the conftest ``max_size=4`` pool.
+
+    This module's downstream fixtures and tests request ``pg_pool`` by name and
+    historically got a ``max_size=4`` pool; aliasing keeps that cap without
+    re-typing every request.
+    """
+    yield pg_pool_large
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_cache_service_artist_writer.py
+++ b/tests/integration/test_cache_service_artist_writer.py
@@ -22,31 +22,15 @@ Run with: ``pytest -m pg -v tests/integration/test_cache_service_artist_writer.p
 
 from __future__ import annotations
 
-import os
 from datetime import UTC, datetime
 
-import asyncpg
 import pytest
 import pytest_asyncio
 
 from discogs.cache_service import DiscogsCacheService
 from discogs.models import ArtistDetails
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
-
-
-@pytest_asyncio.fixture
-async def pg_pool():
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+# ``pg_pool`` (max_size=3) is provided by tests/integration/conftest.py.
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_cache_service_tombstones.py
+++ b/tests/integration/test_cache_service_tombstones.py
@@ -27,9 +27,6 @@ Run with: `pytest -m pg -v tests/integration/test_cache_service_tombstones.py`
 
 from __future__ import annotations
 
-import os
-
-import asyncpg
 import pytest
 import pytest_asyncio
 
@@ -44,21 +41,7 @@ from discogs.models import (
     TrackItem,
 )
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
-
-
-@pytest_asyncio.fixture
-async def pg_pool():
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+# ``pg_pool`` (max_size=3) is provided by tests/integration/conftest.py.
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_charset_torture_entity_identity.py
+++ b/tests/integration/test_charset_torture_entity_identity.py
@@ -15,9 +15,6 @@ or a normalization step is silently inserted.
 
 from __future__ import annotations
 
-import os
-
-import asyncpg
 import pytest
 import pytest_asyncio
 
@@ -25,10 +22,9 @@ from entity.sources import PgSource
 from entity.store import EntityStore
 from tests.charset_torture import CharsetTortureEntry, entry_id, iter_entries
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
+# ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
+# there for the ``source._dsn`` wiring below.
+from tests.integration.conftest import DATABASE_URL
 
 CORPUS_ENTRIES = list(iter_entries())
 
@@ -43,18 +39,6 @@ CORPUS_ENTRIES = list(iter_entries())
 PG_TEXT_STRIP_OVERRIDES: dict[tuple[str, str], str] = {
     ("quoting", "null\x00byte"): "nullbyte",
 }
-
-
-@pytest_asyncio.fixture
-async def pg_pool():
-    """Create a connection pool to the test database, or skip on connect failure."""
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -9,10 +9,8 @@ Requires: DATABASE_URL_TEST env var or Docker postgres on port 5433.
 
 from __future__ import annotations
 
-import os
 from typing import ClassVar
 
-import asyncpg
 import pytest
 import pytest_asyncio
 
@@ -26,22 +24,9 @@ from scripts.entity_resolution.__main__ import (
 from scripts.entity_resolution.dedup import EntityDeduplicator
 from scripts.entity_resolution.discogs import DiscogsReconciler
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
-
-
-@pytest_asyncio.fixture
-async def pg_pool():
-    """Create a connection pool to the test database."""
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+# ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
+# there for the ``source._dsn`` wiring and ``monkeypatch.setenv`` calls below.
+from tests.integration.conftest import DATABASE_URL
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_lookup_negative_cache.py
+++ b/tests/integration/test_lookup_negative_cache.py
@@ -17,29 +17,12 @@ Run with: pytest -m pg -v
 
 from __future__ import annotations
 
-import os
-
-import asyncpg
 import pytest
 import pytest_asyncio
 
 from discogs.cache_service import DiscogsCacheService
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
-
-
-@pytest_asyncio.fixture
-async def pg_pool():
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+# ``pg_pool`` (max_size=3) is provided by tests/integration/conftest.py.
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_release_identity.py
+++ b/tests/integration/test_release_identity.py
@@ -22,30 +22,27 @@ Run with: pytest -m pg -v tests/integration/test_release_identity.py
 from __future__ import annotations
 
 import asyncio
-import os
 
-import asyncpg
 import pytest
 import pytest_asyncio
 
 from entity.sources import PgSource
 from entity.store import EntityStore
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
+# ``DATABASE_URL`` (and the conftest ``pg_pool_large``) come from conftest;
+# imported here for the ``source._dsn`` wiring and ``monkeypatch.setenv`` below.
+from tests.integration.conftest import DATABASE_URL
 
 
 @pytest_asyncio.fixture
-async def pg_pool():
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=4)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+async def pg_pool(pg_pool_large):
+    """Alias to the conftest ``max_size=4`` pool.
+
+    This module's downstream fixtures and tests request ``pg_pool`` by name and
+    historically got a ``max_size=4`` pool; aliasing keeps that cap without
+    re-typing every request.
+    """
+    yield pg_pool_large
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -14,27 +14,12 @@ Run with: ``pytest -m pg -v``
 
 from __future__ import annotations
 
-import os
-
-import asyncpg
 import pytest
 import pytest_asyncio
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
-
-
-@pytest_asyncio.fixture
-async def pg_pool():
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=3)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+# ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
+# there for the ``monkeypatch.setenv("DATABASE_URL_DISCOGS", ...)`` wiring below.
+from tests.integration.conftest import DATABASE_URL
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_streaming_url_persistent_lookup.py
+++ b/tests/integration/test_streaming_url_persistent_lookup.py
@@ -21,7 +21,6 @@ Run with: pytest -m pg -v tests/integration/test_streaming_url_persistent_lookup
 
 from __future__ import annotations
 
-import os
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
@@ -39,11 +38,6 @@ from entity.streaming_url_cache import (
 )
 from streaming.models import SourceMatch
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL_TEST",
-    "postgresql://discogs:discogs@localhost:5433/discogs",
-)
-
 _SERVICE_CASES = [
     ("apple_music_album", "https://music.apple.com/us/album/aluminum-tunes/1234567890"),
     ("spotify_album", "https://open.spotify.com/album/1A2GTWGt0LBTGQAyA3OKAf"),
@@ -51,14 +45,14 @@ _SERVICE_CASES = [
 
 
 @pytest_asyncio.fixture
-async def pg_pool():
-    try:
-        pool = await asyncpg.create_pool(DATABASE_URL, min_size=1, max_size=4)
-    except Exception as e:
-        pytest.skip(f"Cannot connect to test PostgreSQL: {e}")
-        return
-    yield pool
-    await pool.close()
+async def pg_pool(pg_pool_large):
+    """Alias to the conftest ``max_size=4`` pool.
+
+    This module's downstream fixtures and tests request ``pg_pool`` by name and
+    historically got a ``max_size=4`` pool; aliasing keeps that cap without
+    re-typing every request.
+    """
+    yield pg_pool_large
 
 
 @pytest_asyncio.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -150,6 +150,34 @@ def es256_keypair() -> tuple[str, str]:
 
 
 @pytest.fixture
+def mock_mb_pg():
+    """Mock ``PgSource`` for the musicbrainz-cache PostgreSQL DB.
+
+    Superset of the two historical shapes: exposes both ``fetchall`` (artist /
+    release / track fallback queries) and ``fetchone`` (reconciliation single
+    -row lookups). Callers that only read ``fetchall`` never touch ``fetchone``,
+    so the extra attribute is inert for them.
+    """
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetchone = AsyncMock(return_value=None)
+    return pg
+
+
+@pytest.fixture
+def mock_wikidata_pg():
+    """Mock ``PgSource`` for the wikidata-cache PostgreSQL DB (P434 bridge).
+
+    Same superset shape as :func:`mock_mb_pg`: both ``fetchall`` and
+    ``fetchone`` are present so the 2-attr and 3-attr call sites share one def.
+    """
+    pg = AsyncMock()
+    pg.fetchall = AsyncMock(return_value=[])
+    pg.fetchone = AsyncMock(return_value=None)
+    return pg
+
+
+@pytest.fixture
 def mock_posthog_client():
     """Mock PostHog client."""
     client = Mock()

--- a/tests/unit/test_external_artist_search.py
+++ b/tests/unit/test_external_artist_search.py
@@ -24,11 +24,7 @@ def mock_discogs_cache():
     return cache
 
 
-@pytest.fixture
-def mock_mb_pg():
-    pg = AsyncMock()
-    pg.fetchall = AsyncMock(return_value=[])
-    return pg
+# ``mock_mb_pg`` is provided by tests/unit/conftest.py.
 
 
 class TestSearchExternalArtists:

--- a/tests/unit/test_external_release_search.py
+++ b/tests/unit/test_external_release_search.py
@@ -27,11 +27,7 @@ def mock_discogs_cache():
     return cache
 
 
-@pytest.fixture
-def mock_mb_pg():
-    pg = AsyncMock()
-    pg.fetchall = AsyncMock(return_value=[])
-    return pg
+# ``mock_mb_pg`` is provided by tests/unit/conftest.py.
 
 
 class TestSearchExternalAlbums:

--- a/tests/unit/test_musicbrainz_reconciliation.py
+++ b/tests/unit/test_musicbrainz_reconciliation.py
@@ -6,22 +6,7 @@ import pytest
 
 from scripts.entity_resolution.musicbrainz import MusicBrainzReconciler
 
-
-@pytest.fixture
-def mock_mb_pg():
-    """Mock PgSource for musicbrainz-cache."""
-    pg = AsyncMock()
-    pg.fetchall = AsyncMock(return_value=[])
-    pg.fetchone = AsyncMock(return_value=None)
-    return pg
-
-
-@pytest.fixture
-def mock_wikidata_pg():
-    """Mock PgSource for wikidata-cache (P434 bridge)."""
-    pg = AsyncMock()
-    pg.fetchall = AsyncMock(return_value=[])
-    return pg
+# ``mock_mb_pg`` and ``mock_wikidata_pg`` are provided by tests/unit/conftest.py.
 
 
 @pytest.fixture

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -28,13 +28,7 @@ def mock_sparql():
     return sparql
 
 
-@pytest.fixture
-def mock_wikidata_pg():
-    """Mock PgSource for wikidata-cache."""
-    pg = AsyncMock()
-    pg.fetchall = AsyncMock(return_value=[])
-    pg.fetchone = AsyncMock(return_value=None)
-    return pg
+# ``mock_wikidata_pg`` is provided by tests/unit/conftest.py.
 
 
 @pytest.fixture


### PR DESCRIPTION
Addresses structural-audit finding #9 (parts 1 + 3), a behavior-preserving test-only refactor. Ten integration files each redefined a `pg_pool` fixture (repeating a `DATABASE_URL` constant and a skip-on-connection-failure body, 7 at `max_size=3` and 3 at `max_size=4`); these are hoisted to `tests/integration/conftest.py` as a `_make_pg_pool(max_size)` factory backing named `pg_pool` (3) and `pg_pool_large` (4) fixtures, preserving both sizes. Five `mock_mb_pg`/`mock_wikidata_pg` fixtures across four unit files (2-attr and 3-attr forms) are hoisted to `tests/unit/conftest.py` as the 3-attr superset. The `app_client` fixtures are deliberately left untouched so the queued #613 work rebases cleanly. Baseline and post-change test runs match exactly (3000 passed; the 179 pg-marked tests skip cleanly without Postgres).

Note: `max_size=4` was preserved rather than assumed-incidental. If the team confirms it was accidental drift, `pg_pool_large` and the three local alias fixtures collapse into the single size-3 `pg_pool`.

Closes #612