### PR TITLE
feat(#626): scope artist correction to a library-only channel

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -2155,6 +2155,8 @@ async def find_library_albums_with_cached_track(
     artist: str | None,
     discogs_service: DiscogsService | None,
     limit: int = MAX_SEARCH_RESULTS,
+    *,
+    match_artist: str | None = None,
 ) -> list[LibraryItem]:
     """Find WXYC library albums whose Discogs cache entry lists ``song`` by ``artist``.
 
@@ -2164,11 +2166,19 @@ async def find_library_albums_with_cached_track(
     answer "which releases by this artist contain this track?" in milliseconds —
     even when the upstream ``resolve_albums_for_track`` / API path missed it.
 
+    Two-channel artist (LML#626): the Discogs-cache probe keys on the typed
+    ``artist`` (the cache holds Discogs-credited names), while the library
+    match-back keys on ``match_artist`` when supplied — the library-corrected
+    name — so a misspelled library artist still promotes its catalog row.
+    ``match_artist`` defaults to ``artist`` to preserve single-channel behavior
+    for callers that don't distinguish the two.
+
     Cache-only by design: skips any API fallback path. Returns ``[]`` cleanly
     when the cache is unavailable, fails, or has nothing for the query.
     """
     if not discogs_service or not song or not artist:
         return []
+    match_against = match_artist or artist
     cache_service = getattr(discogs_service, "cache_service", None)
     if cache_service is None:
         return []
@@ -2192,7 +2202,7 @@ async def find_library_albums_with_cached_track(
         for item in candidate_items:
             if item.id in seen_ids:
                 continue
-            if not artist_matches_item(item, artist):
+            if not artist_matches_item(item, match_against):
                 continue
             matches.append(item)
             seen_ids.add(item.id)
@@ -3376,7 +3386,11 @@ async def perform_lookup(
                     # library album. Catches the case where the upstream
                     # track→releases lookup missed a release the cache holds.
                     promoted = await find_library_albums_with_cached_track(
-                        db, parsed.song, parsed.artist, discogs_service
+                        db,
+                        parsed.song,
+                        parsed.artist,
+                        discogs_service,
+                        match_artist=library_artist_for(parsed),
                     )
                     if promoted:
                         library_results = promoted

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -771,6 +771,18 @@ def artist_matches_item(item: LibraryItem, artist: str) -> bool:
     return False
 
 
+def library_artist_for(parsed: ParsedRequest) -> str | None:
+    """The artist name the *library-side* legs should search/match against.
+
+    Library channel of the two-channel seam (WXYC/library-metadata-lookup#626):
+    the fuzzy correction on ``parsed.library_artist`` when present, else the
+    typed ``parsed.artist``. Read by ``db.search`` query construction and the
+    ``artist_matches_item`` match-backs — never by the Discogs-facing probes or
+    ``validate_release_for_track``, which always use the typed ``parsed.artist``.
+    """
+    return parsed.library_artist or parsed.artist
+
+
 async def resolve_albums_for_track(
     parsed: ParsedRequest,
     discogs_service: DiscogsService | None = None,
@@ -1334,13 +1346,20 @@ async def search_library_with_fallback(
 ) -> tuple[list[LibraryItem], bool]:
     """Search library with artist+album(s), falling back to artist+song or artist-only.
 
+    Library channel of the two-channel seam (WXYC/library-metadata-lookup#626):
+    every artist-keyed library operation here uses ``library_artist_for(parsed)``
+    — the fuzzy correction when present, else the typed name — so a misspelled
+    *library* artist still finds its row. The typed ``parsed.artist`` is reserved
+    for the Discogs-facing paths elsewhere.
+
     Returns:
         Tuple of (library_results, song_not_found_flag)
     """
     all_results: list[LibraryItem] = []
     seen_ids: set[int] = set()
+    lib_artist = library_artist_for(parsed)
 
-    if not parsed.artist and albums:
+    if not lib_artist and albums:
         # No artist parsed — search by album title alone
         for album in albums:
             results = await db.search(query=album, limit=_FETCH_LIMIT)
@@ -1348,20 +1367,20 @@ async def search_library_with_fallback(
                 return results[:MAX_SEARCH_RESULTS], False
         return [], bool(parsed.song)
 
-    if parsed.artist and albums:
+    if lib_artist and albums:
 
         async def search_one_album(album: str) -> list[LibraryItem]:
-            query = f"{parsed.artist} {album}"
+            query = f"{lib_artist} {album}"
             results = await db.search(query=query, limit=_FETCH_LIMIT)
-            results = filter_results_by_artist(results, parsed.artist)
+            results = filter_results_by_artist(results, lib_artist)
 
             album_lower = album.lower()
             album_normalized = re.sub(r"[^\w\s]", " ", album_lower)
             album_normalized = " ".join(album_normalized.split())
             album_words = {w for w in album_normalized.split() if len(w) > 2 and w not in STOPWORDS}
-            album_is_artist = parsed.artist and normalize_for_comparison(
+            album_is_artist = lib_artist and normalize_for_comparison(
                 album
-            ) == normalize_for_comparison(parsed.artist)
+            ) == normalize_for_comparison(lib_artist)
 
             filtered_results = []
             for item in results:
@@ -1423,10 +1442,10 @@ async def search_library_with_fallback(
             "falling through to artist search"
         )
 
-    if parsed.artist and parsed.song:
-        query = f"{parsed.artist} {parsed.song}"
+    if lib_artist and parsed.song:
+        query = f"{lib_artist} {parsed.song}"
         results = await db.search(query=query, limit=_FETCH_LIMIT)
-        results = filter_results_by_artist(results, parsed.artist)
+        results = filter_results_by_artist(results, lib_artist)
         results = _filter_results_by_album_match(results, parsed.album)
 
         if results:
@@ -1437,10 +1456,10 @@ async def search_library_with_fallback(
             )
             return results, True
 
-    if not all_results and parsed.artist:
-        logger.info(f"No results for albums {albums}, trying artist only: '{parsed.artist}'")
-        results = await db.search(query=parsed.artist, limit=_FETCH_LIMIT)
-        results = filter_results_by_artist(results, parsed.artist)
+    if not all_results and lib_artist:
+        logger.info(f"No results for albums {albums}, trying artist only: '{lib_artist}'")
+        results = await db.search(query=lib_artist, limit=_FETCH_LIMIT)
+        results = filter_results_by_artist(results, lib_artist)
         results = _filter_results_by_album_match(results, parsed.album)
         if results:
             return results, True
@@ -1458,6 +1477,12 @@ async def search_compilations_for_track(
     The second tuple element maps each surfaced library id to the
     :class:`~lookup.release_resolution.ResolvedRelease` it matched — the widened
     ``discogs_titles`` seam consumed by the artwork-binding step.
+
+    Two-channel seam (WXYC/library-metadata-lookup#626): the Discogs probes and
+    ``validate_release_for_track`` use the typed ``parsed.artist`` (via
+    ``artist_for_probes``); the library-side keyword search and the two
+    ``artist_matches_item`` match-backs use ``lib_artist`` (the correction when
+    present, else the typed name).
     """
     if not parsed.song or not parsed.artist:
         return [], {}
@@ -1467,6 +1492,7 @@ async def search_compilations_for_track(
     results = []
     seen_ids = set()
     discogs_titles: dict[int, ResolvedRelease] = {}
+    lib_artist = library_artist_for(parsed)
 
     # Carried-release ranking (LML#604 deferred finding #2). When the flag is on,
     # a library row matched by multiple releases binds the title-best one — the
@@ -1484,9 +1510,7 @@ async def search_compilations_for_track(
 
     keyword_matches = []
     try:
-        artist_words = (
-            re.sub(r"[^\w\s]", " ", parsed.artist.lower()).split() if parsed.artist else []
-        )
+        artist_words = re.sub(r"[^\w\s]", " ", lib_artist.lower()).split() if lib_artist else []
         song_words = re.sub(r"[^\w\s]", " ", parsed.song.lower()).split() if parsed.song else []
 
         sig_artist = [w for w in artist_words if len(w) > 3 and w not in STOPWORDS]
@@ -1502,7 +1526,7 @@ async def search_compilations_for_track(
             if keyword_results:
                 filtered_results = []
                 for item in keyword_results:
-                    if artist_matches_item(item, parsed.artist):
+                    if lib_artist and artist_matches_item(item, lib_artist):
                         filtered_results.append(item)
                     elif is_compilation_artist(item.artist or ""):
                         filtered_results.append(item)
@@ -1673,7 +1697,7 @@ async def search_compilations_for_track(
             if not matches and release_info.is_compilation:
                 matches = await search_album_fuzzy(db, f"Various {release_album}")
 
-            if matches and parsed.artist and not skip_artist_match_filter:
+            if matches and lib_artist and not skip_artist_match_filter:
                 from rapidfuzz import fuzz as _fuzz
 
                 filtered_matches = []
@@ -1681,7 +1705,7 @@ async def search_compilations_for_track(
                 release_album_lower = release_album.lower()
 
                 for match in matches:
-                    if artist_matches_item(match, parsed.artist):
+                    if artist_matches_item(match, lib_artist):
                         filtered_matches.append(match)
                     elif discogs_is_compilation and is_compilation_artist(match.artist or ""):
                         title_score = _fuzz.ratio(release_album_lower, (match.title or "").lower())
@@ -3245,7 +3269,16 @@ async def perform_lookup(
             )
         if corrected:
             corrected_artist = corrected
-            parsed.artist = corrected
+            # Two-channel seam (WXYC/library-metadata-lookup#626): do NOT
+            # overwrite ``parsed.artist``. The typed value must keep flowing to
+            # every Discogs-facing path (the three Discogs-aware strategies'
+            # probes, ``validate_release_for_track``, and the library-miss
+            # Discogs probe), or a *distinct* non-library artist one edit from a
+            # library name gets snapped into the library's vocabulary on Discogs.
+            # Thread the correction on ``library_artist``, read only by the
+            # library-side legs (``db.search`` queries + ``artist_matches_item``
+            # match-backs).
+            parsed.library_artist = corrected
     else:
         with telemetry.track_step("album_lookup"):
             albums_for_search, song_not_found = await resolve_albums_for_track(

--- a/services/parser.py
+++ b/services/parser.py
@@ -20,6 +20,20 @@ class ParsedRequest(BaseModel):
     song: str | None = None
     album: str | None = None
     artist: str | None = None
+    library_artist: str | None = None
+    """The library-fuzzy spelling correction for ``artist`` (the second channel
+    of the two-channel seam, WXYC/library-metadata-lookup#626).
+
+    ``artist`` always holds the *typed* value and flows to every Discogs-facing
+    path (the Discogs probes, ``validate_release_for_track``, the library-miss
+    Discogs probe). ``library_artist`` carries the corrected name and is read
+    ONLY by the library-side legs — the ``db.search`` queries and the
+    ``artist_matches_item`` match-backs. ``None`` when no correction was applied;
+    the library legs fall back to ``artist`` in that case. Keeping the two apart
+    stops a *distinct* non-library artist whose name is one edit from a library
+    artist ("Plug" vs library "Plugz") from being snapped into the library's
+    vocabulary for Discogs resolution."""
+
     is_request: bool = True
     message_type: MessageType = MessageType.REQUEST
     raw_message: str = ""

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -338,6 +338,105 @@ class TestPerformLookupArtistCorrection:
         assert response.corrected_artist == "Stereolab"
         assert telemetry.steps.get("album_lookup") is not None
 
+    @pytest.mark.asyncio
+    async def test_typed_artist_reaches_discogs_probe_corrected_reaches_library(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """Two-channel seam (WXYC/library-metadata-lookup#626) end-to-end.
+
+        Typed "Plug" is a *distinct* non-library artist one edit from library
+        "Plugz". The correction must NOT snap "Plug" into Discogs resolution:
+        ``search_releases_by_track`` (the Discogs probe) sees the typed "Plug",
+        while the primary library leg's ``db.search`` queries carry the corrected
+        "Plugz".
+
+        ``raw_message`` is deliberately non-ambiguous (no "X - Y" two-part shape)
+        so SWAPPED_INTERPRETATION — which re-parses the raw message into typed
+        tokens and is out of this seam's scope — never fires and the only library
+        queries come from ``search_library_with_fallback``.
+        """
+        from discogs.models import TrackReleasesResponse
+
+        mock_library_db.find_similar_artist.return_value = "Plugz"
+        mock_library_db.search.return_value = []
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+        mock_discogs_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(track="Drift", artist="Plug", releases=[], total=0)
+        )
+
+        request = LookupRequest(
+            artist="Plug",
+            song="Drift",
+            raw_message="dj played Drift by Plug",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        # The correction is reported, but parsed.artist was NOT overwritten:
+        # every Discogs probe saw the typed "Plug".
+        assert response.corrected_artist == "Plugz"
+        assert mock_discogs_service.search_releases_by_track.await_count >= 1
+        for call in mock_discogs_service.search_releases_by_track.await_args_list:
+            artist_arg = call.kwargs.get("artist")
+            if artist_arg is None and len(call.args) >= 2:
+                artist_arg = call.args[1]
+            assert artist_arg == "Plug"
+
+        # The library leg used the corrected "Plugz" — every artist-keyed
+        # library query carries it, and none falls back to the typed "Plug".
+        library_queries = [
+            (c.kwargs.get("query") or (c.args[0] if c.args else ""))
+            for c in mock_library_db.search.await_args_list
+        ]
+        assert any("Plugz" in q for q in library_queries)
+        assert not any("Plug" in q and "Plugz" not in q for q in library_queries)
+
+    @pytest.mark.asyncio
+    async def test_misspelled_library_artist_still_binds_to_library_row(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """The accepted-trade-off direction: a misspelled *library* artist still
+        corrects and binds to its library row via the corrected library leg.
+
+        Typed "Stereolb" corrects to library "Stereolab"; the artist+album
+        library search surfaces the Stereolab row, which is returned.
+        """
+        stereolab_row = make_library_item(id=10, artist="Stereolab", title="Aluminum Tunes")
+        mock_library_db.find_similar_artist.return_value = "Stereolab"
+        mock_library_db.search.return_value = [stereolab_row]
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        request = LookupRequest(
+            artist="Stereolb",
+            album="Aluminum Tunes",
+            raw_message="Stereolb - Aluminum Tunes",
+        )
+
+        with patch(
+            "lookup.orchestrator.fetch_artwork_for_items",
+            new_callable=AsyncMock,
+            return_value=[(stereolab_row, None)],
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        assert response.corrected_artist == "Stereolab"
+        assert any(item.library_item.id == 10 for item in response.results)
+        # The library search ran under the corrected name.
+        library_queries = [
+            (c.kwargs.get("query") or (c.args[0] if c.args else ""))
+            for c in mock_library_db.search.await_args_list
+        ]
+        assert any("Stereolab" in q for q in library_queries)
+
 
 # ---------------------------------------------------------------------------
 # Tests: perform_lookup - album resolution from Discogs

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1162,6 +1162,56 @@ class TestFindLibraryAlbumsWithCachedTrack:
         assert result[0].id == 12682
 
     @pytest.mark.asyncio
+    async def test_match_back_uses_corrected_artist_when_supplied(
+        self, mock_library_db, mock_discogs_service
+    ):
+        """LML#626 two-channel: the library match-back keys on ``match_artist``
+        (the library-corrected name), so a misspelled typed artist still promotes
+        its catalog row — while the Discogs-cache probe stays on the typed name."""
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+            return_value=self._cache_releases(("Aluminum Tunes", "Stereolab"))
+        )
+        row = make_library_item(id=42, artist="Stereolab", title="Aluminum Tunes")
+        mock_library_db.search.return_value = [row]
+
+        result = await find_library_albums_with_cached_track(
+            mock_library_db,
+            "Cybele's Reverie",
+            "Stereolb",  # typed (misspelled)
+            mock_discogs_service,
+            match_artist="Stereolab",  # library-corrected
+        )
+
+        assert [item.id for item in result] == [42]
+        # The cache probe used the typed name, not the correction.
+        probe = mock_discogs_service.cache_service.search_releases_by_track
+        assert probe.await_args.kwargs["artist"] == "Stereolb"
+
+    @pytest.mark.asyncio
+    async def test_match_back_defaults_to_typed_artist_without_correction(
+        self, mock_library_db, mock_discogs_service
+    ):
+        """Without ``match_artist`` the match-back falls back to the typed
+        ``artist`` (single-channel default) — a misspelled typed name drops the
+        row, which is why ``perform_lookup`` threads the corrected name in."""
+        mock_discogs_service.cache_service = AsyncMock()
+        mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+            return_value=self._cache_releases(("Aluminum Tunes", "Stereolab"))
+        )
+        row = make_library_item(id=42, artist="Stereolab", title="Aluminum Tunes")
+        mock_library_db.search.return_value = [row]
+
+        result = await find_library_albums_with_cached_track(
+            mock_library_db,
+            "Cybele's Reverie",
+            "Stereolb",  # typed (misspelled), no correction supplied
+            mock_discogs_service,
+        )
+
+        assert result == []
+
+    @pytest.mark.asyncio
     async def test_returns_empty_without_discogs_service(self, mock_library_db):
         result = await find_library_albums_with_cached_track(
             mock_library_db, "Song", "Artist", None

--- a/tests/unit/test_resolver_pre_pass.py
+++ b/tests/unit/test_resolver_pre_pass.py
@@ -30,7 +30,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from discogs.models import TrackReleasesResponse
+from discogs.models import ReleaseInfo, TrackReleasesResponse
 from lookup.orchestrator import (
     CANONICAL_ARTIST_SIMILARITY_FLOOR,
     ResolverOutcome,
@@ -38,6 +38,7 @@ from lookup.orchestrator import (
     search_compilations_for_track,
 )
 from services.parser import ParsedRequest
+from tests.factories import make_library_item
 
 
 @pytest.fixture
@@ -311,3 +312,153 @@ class TestResolverPrePassCallSite:
             if artist_arg is None and len(call.args) >= 2:
                 artist_arg = call.args[1]
             assert artist_arg == "Alexander Robotnik"
+
+
+class TestLibraryCorrectionTwoChannelSeam:
+    """The B1 two-channel seam (WXYC/library-metadata-lookup#626).
+
+    ``perform_lookup`` no longer overwrites ``parsed.artist`` with the
+    library-fuzzy correction. Instead it threads the corrected name on
+    ``parsed.library_artist`` — used ONLY by the library-side legs — while the
+    typed ``parsed.artist`` flows unchanged to every Discogs-facing path. These
+    tests pin the seam at ``search_compilations_for_track``, where one function
+    drives both a Discogs probe (typed) and a library match-back (corrected).
+
+    The trap this prevents: a *distinct* non-library artist whose name is one
+    edit from a library artist ("Plug" vs library "Plugz") must hit Discogs
+    under the typed name, not the snapped library vocabulary.
+    """
+
+    @pytest.mark.asyncio
+    async def test_probe_sees_typed_artist_library_match_back_sees_corrected(self):
+        """Typed "Plug", corrected library_artist "Plugz".
+
+        The two Discogs probes and ``validate_release_for_track`` must receive
+        the TYPED "Plug"; the library match-back must accept the row whose
+        artist is the corrected "Plugz".
+        """
+        db = AsyncMock()
+        db.exact_title = AsyncMock(
+            return_value=[make_library_item(id=7, artist="Plugz", title="Electric Dreams")]
+        )
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = None
+        service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Electric Dreams",
+                artist="Plug",
+                releases=[
+                    ReleaseInfo(
+                        album="Electric Dreams",
+                        artist="Plug",
+                        release_id=555,
+                        release_url="https://discogs.com/release/555",
+                        is_compilation=False,
+                    )
+                ],
+                total=1,
+            )
+        )
+
+        parsed = ParsedRequest(
+            artist="Plug",
+            library_artist="Plugz",
+            song="Electric Dreams",
+            raw_message="Plug - Electric Dreams",
+        )
+
+        with patch(
+            "lookup.orchestrator.validate_release_for_track",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_validate:
+            results, _titles = await search_compilations_for_track(
+                db, parsed, discogs_service=service
+            )
+
+        # Discogs probes: the TYPED artist, never the corrected library name.
+        assert service.search_releases_by_track.await_count == 2
+        for call in service.search_releases_by_track.await_args_list:
+            artist_arg = call.kwargs.get("artist")
+            if artist_arg is None and len(call.args) >= 2:
+                artist_arg = call.args[1]
+            assert artist_arg == "Plug"
+
+        # validate_release_for_track: the TYPED artist.
+        mock_validate.assert_awaited()
+        for call in mock_validate.await_args_list:
+            validate_artist = call.args[3] if len(call.args) >= 4 else call.kwargs.get("artist")
+            assert validate_artist == "Plug"
+
+        # The corrected library row still binds — the library match-back used
+        # "Plugz" (typed "Plug" would also prefix-match here, so the binding
+        # alone isn't decisive; the probe/validate assertions above are).
+        assert [item.id for item in results] == [7]
+
+    @pytest.mark.asyncio
+    async def test_distinct_artist_match_back_uses_corrected_not_typed(self):
+        """Typed "Sun" (distinct), corrected library_artist "Sun Araw".
+
+        A library row by an unrelated "Sunburned Hand of the Man" must NOT bind
+        off the typed "Sun" — the match-back keys on the corrected "Sun Araw",
+        which that row's artist does not start with. Without the seam, the
+        match-back would run against whichever single value won, conflating the
+        two channels.
+        """
+        db = AsyncMock()
+        # Library album-fuzzy returns an unrelated "Sun"-prefixed row.
+        db.exact_title = AsyncMock(
+            return_value=[
+                make_library_item(id=9, artist="Sunburned Hand of the Man", title="Headdress")
+            ]
+        )
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = None
+        service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Headdress",
+                artist="Sun",
+                releases=[
+                    ReleaseInfo(
+                        album="Headdress",
+                        artist="Sun",
+                        release_id=556,
+                        release_url="https://discogs.com/release/556",
+                        is_compilation=False,
+                    )
+                ],
+                total=1,
+            )
+        )
+
+        parsed = ParsedRequest(
+            artist="Sun",
+            library_artist="Sun Araw",
+            song="Headdress",
+            raw_message="Sun - Headdress",
+        )
+
+        with patch(
+            "lookup.orchestrator.validate_release_for_track",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            results, _titles = await search_compilations_for_track(
+                db, parsed, discogs_service=service
+            )
+
+        # Probes still see the typed "Sun".
+        for call in service.search_releases_by_track.await_args_list:
+            artist_arg = call.kwargs.get("artist")
+            if artist_arg is None and len(call.args) >= 2:
+                artist_arg = call.args[1]
+            assert artist_arg == "Sun"
+
+        # The unrelated "Sunburned..." row is rejected by the corrected
+        # "Sun Araw" match-back — proving the match-back used library_artist,
+        # not the typed "Sun" (which the row *would* prefix-match).
+        assert results == []


### PR DESCRIPTION
## B1 — two-channel artist-correction seam

Stops `perform_lookup` from overwriting `parsed.artist` with the library-fuzzy correction. The typed value now flows unchanged to every Discogs-facing path (the strategy probes, `validate_release_for_track`, `_library_miss_discogs_search`); the correction is threaded on a new `parsed.library_artist` field consumed only by the library-side legs (`search_library_with_fallback` and the `artist_matches_item` match-backs in `search_compilations_for_track`).

This fixes the silent snapping of a non-library artist whose name is fuzzy-close to a library artist onto the wrong catalog artist for Discogs resolution, while preserving the misspelled-library-artist binding (the corrected name still reaches the library search).

**Note:** `search_with_alternative_interpretation` (SWAPPED) was intentionally left on typed tokens — since #622 it carries a Discogs track-narrowing leg, so routing the corrected name into it would introduce exactly the corrected-name-hits-Discogs path this change forbids.

Part of the #625 epic. The merged state across this and the sibling PRs (#627/#632/#633) passes lint/format and 3093 unit tests.

Closes #626
