### PR TITLE
feat(#632): positive lml_cache.release_resolution_cache

### DIFF
--- a/entity/release_resolution_cache.py
+++ b/entity/release_resolution_cache.py
@@ -1,0 +1,246 @@
+"""Persistent positive ``(artist, title, kind) -> release_id`` cache.
+
+LML#628's A1 carry-through re-runs a Discogs search plus per-release
+track-validation for non-library releases on **every** flowsheet add, because
+no tier persists a positive resolution: ``search`` /
+``validate_track_on_release`` are read-only, the negative cache stores only
+misses, and the in-memory L1 tiers evaporate on restart. This module is the
+durable positive cache that lets the 2nd-and-later add of the same non-library
+release short-circuit the probe+validate entirely.
+
+It stores **only** the resolved Discogs ``release_id`` — the existing by-ID
+``get_release`` cache fills in the rest, so there is no metadata duplication
+here. A ``NULL`` ``release_id`` records a known miss.
+
+This module is purely additive infra (LML#632): the table + read/write helpers.
+**#628** wires the read (short-circuit) and the write (after a cold resolve)
+into the lookup path; nothing in this repo calls these helpers yet.
+
+Models ``entity/streaming_url_cache.py`` (LML#573). Same LML-owned ``lml_cache``
+schema (per WXYC/discogs-etl#288 Option 3, *not* the discogs-cache-owned
+``entity.*``), same lifespan bootstrap, same best-effort posture (PG errors
+swallowed + logged so the caller degrades to a live probe).
+
+Keys: ``(artist_normalized, title_normalized, is_track)``, where normalization
+applies ``wxyc_etl.text.to_match_form`` (NFC + diacritic stripping +
+lowercasing + whitespace collapse) — the same normalization the streaming and
+negative caches use. The key is the **typed** artist (consistent with the #626
+two-channel decision). ``is_track`` discriminates the two channels: ``True`` for
+a ``(artist, track)`` resolution, ``False`` for ``(artist, album)``.
+
+Staleness is a SQL-side filter (mirroring ``discogs/cache_service.py`` and the
+streaming cache), but with a **dual TTL** that diverges from the streaming
+template's eternal-hit policy:
+
+* ``release_id IS NOT NULL`` AND ``resolved_at > now() - positive_ttl`` —
+  fresh positive hit. Returned as the ``release_id``.
+* ``release_id IS NOT NULL`` AND ``resolved_at <= now() - positive_ttl`` —
+  stale hit. A resolution is a *derived inference* (Discogs releases merge and
+  delete), so positive entries self-heal quarterly instead of living forever.
+  Filtered by the WHERE clause; the caller sees the same "no row" shape as an
+  absent entry and re-resolves.
+* ``release_id IS NULL`` AND ``resolved_at > now() - miss_ttl`` — fresh known
+  miss. The SELECT returns the row; ``get_cached_release_id`` reports
+  ``was_present=True, release_id=None``, distinct from the absent case, so the
+  caller can skip the live probe.
+* ``release_id IS NULL`` AND ``resolved_at <= now() - miss_ttl`` — stale miss.
+  Filtered out; the caller falls through to a live probe. The stale row stays
+  and the next probe's UPSERT refreshes it in place.
+
+``get_cached_release_id`` therefore returns a three-valued ``ReleaseResolution``:
+``was_present=True, release_id=<int>`` (fresh hit), ``was_present=True,
+release_id=None`` (fresh known miss — skip the probe), or ``was_present=False,
+release_id=None`` (absent or stale — run the probe). The streaming cache
+collapses miss and absent both to ``None`` in its public ``get``; this cache
+keeps them distinct because a positive cache's whole value is short-circuiting
+the known miss. (LML#632 only ships the table + helpers; #628 consumes this
+result to gate its read-through.)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from wxyc_etl.text import to_match_form
+
+from entity.sources import PgSource
+
+logger = logging.getLogger(__name__)
+
+# How long a fresh positive resolution stays authoritative before it is
+# re-derived. Diverges from the streaming cache's eternal-hit policy: a
+# resolved ``release_id`` is a derived inference, and Discogs releases merge or
+# get deleted, so let positive entries self-heal on a quarterly cadence.
+DEFAULT_POSITIVE_TTL = timedelta(days=90)
+
+# How long a known-miss row stays authoritative before we re-probe Discogs.
+# Matches the negative cache / streaming cache (7 days): long enough that a
+# request spike doesn't repeatedly hammer the API for the same misses, short
+# enough that a newly-cataloged release becomes resolvable within a week.
+DEFAULT_MISS_TTL = timedelta(days=7)
+
+_DDL_SCHEMA = "CREATE SCHEMA IF NOT EXISTS lml_cache"
+
+# Named CHECK constraint (``release_id_validity``) avoids reliance on PG
+# auto-naming, matching the streaming cache's convention. Kept free of inline
+# SQL comments so the parity test can compare it verbatim against the
+# comment-stripped ``CREATE TABLE`` body in release_resolution_cache.sql.
+_DDL_TABLE = """\
+CREATE TABLE IF NOT EXISTS lml_cache.release_resolution_cache (
+    artist_normalized TEXT NOT NULL,
+    title_normalized TEXT NOT NULL,
+    is_track BOOLEAN NOT NULL,
+    release_id INTEGER,
+    resolved_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (artist_normalized, title_normalized, is_track),
+    CONSTRAINT release_id_validity CHECK (release_id IS NULL OR release_id > 0)
+)\
+"""
+
+# Staleness lives in the WHERE clause. ``$1``/``$2`` are the normalized keys,
+# ``$3`` the ``is_track`` discriminator, ``$4`` the positive-hit cutoff
+# (``now - positive_ttl``) and ``$5`` the miss cutoff (``now - miss_ttl``). A
+# fresh positive hit passes the first OR branch; a fresh known miss passes the
+# second. A stale hit, a stale miss, and an absent row all return no row.
+_SELECT_SQL = """\
+SELECT release_id
+FROM lml_cache.release_resolution_cache
+WHERE artist_normalized = $1 AND title_normalized = $2 AND is_track = $3
+  AND (
+    (release_id IS NOT NULL AND resolved_at > $4)
+    OR (release_id IS NULL AND resolved_at > $5)
+  )\
+"""
+
+# UPSERT: keep the latest resolution and refresh ``resolved_at`` on conflict.
+# The ``release_id=None`` write path records "resolved to a miss at time T" so
+# subsequent adds inside the miss TTL short-circuit the probe.
+_UPSERT_SQL = """\
+INSERT INTO lml_cache.release_resolution_cache
+    (artist_normalized, title_normalized, is_track, release_id, resolved_at)
+VALUES ($1, $2, $3, $4, now())
+ON CONFLICT (artist_normalized, title_normalized, is_track) DO UPDATE
+SET release_id = EXCLUDED.release_id,
+    resolved_at = EXCLUDED.resolved_at\
+"""
+
+
+@dataclass(frozen=True)
+class ReleaseResolution:
+    """Outcome of a release-resolution cache read.
+
+    Three-valued, because a positive cache must let the caller tell a fresh
+    known miss (skip the live probe) from an absent/stale entry (run it):
+
+    * ``was_present=True`` and ``release_id`` is an ``int`` — a fresh resolution
+      inside ``positive_ttl``. Short-circuit with this ``release_id``.
+    * ``was_present=True`` and ``release_id is None`` — a fresh **known miss**
+      inside ``miss_ttl``. Short-circuit: the live probe already came up empty
+      recently, so skip it.
+    * ``was_present=False`` (``release_id`` always ``None``) — no fresh row: the
+      entry is absent, the positive hit aged past ``positive_ttl``, or the miss
+      aged past ``miss_ttl``. Run the live probe. The SQL WHERE collapses all
+      three into this shape, so the caller can't (and needn't) tell them apart.
+    """
+
+    release_id: int | None
+    was_present: bool
+
+
+async def set_up_release_resolution_cache_schema(pg: PgSource) -> None:
+    """Apply the idempotent cache-schema DDL.
+
+    Called once from ``main.py`` lifespan, right after
+    ``set_up_streaming_url_cache_schema``. The schema and table creation are
+    both ``IF NOT EXISTS`` so re-running on every boot is safe. The
+    schema-creation step lets a fresh discogs-cache PG (local dev, test
+    fixtures, future docker-compose stacks) boot LML cleanly. If the
+    discogs-cache PG is unreachable at startup, the caller logs and continues;
+    the cache layer degrades to a no-op until the next deploy.
+    """
+    await pg.execute(_DDL_SCHEMA)
+    await pg.execute(_DDL_TABLE)
+
+
+async def get_cached_release_id(
+    pg: PgSource,
+    *,
+    artist: str,
+    title: str,
+    is_track: bool,
+    positive_ttl: timedelta = DEFAULT_POSITIVE_TTL,
+    miss_ttl: timedelta = DEFAULT_MISS_TTL,
+    now: datetime | None = None,
+) -> ReleaseResolution:
+    """Look up a cached resolution for ``(artist, title, is_track)``.
+
+    Returns a :class:`ReleaseResolution` (see its docstring for the three-valued
+    contract): a fresh hit carries the ``release_id``; a fresh known miss carries
+    ``release_id=None`` with ``was_present=True``; an absent or stale entry
+    carries ``was_present=False``.
+
+    PG failures return ``ReleaseResolution(None, was_present=False)`` (best-effort,
+    same posture as the streaming and negative caches), so the caller falls
+    through to a live probe as if the cache were empty. ``now`` is exposed for
+    testability; production callers leave it at the default.
+    """
+    artist_key = to_match_form(artist)
+    title_key = to_match_form(title)
+    reference_now = now or datetime.now(UTC)
+    positive_cutoff = reference_now - positive_ttl
+    miss_cutoff = reference_now - miss_ttl
+    try:
+        row = await pg.fetchone(
+            _SELECT_SQL, artist_key, title_key, is_track, positive_cutoff, miss_cutoff
+        )
+    except Exception:
+        logger.exception(
+            "release_resolution_cache get failed for %s / %s / is_track=%s",
+            artist_key,
+            title_key,
+            is_track,
+        )
+        return ReleaseResolution(release_id=None, was_present=False)
+
+    if row is None:
+        # No row, a stale positive hit, or a stale miss — all filtered by the
+        # SQL WHERE into the same "absent" shape. Caller re-resolves.
+        return ReleaseResolution(release_id=None, was_present=False)
+
+    # Present + fresh: a non-null release_id is a hit; a null is a known miss
+    # the caller should honor (skip the probe). ``was_present`` distinguishes
+    # this from the absent case above.
+    return ReleaseResolution(release_id=row["release_id"], was_present=True)
+
+
+async def set_cached_release_id(
+    pg: PgSource,
+    *,
+    artist: str,
+    title: str,
+    is_track: bool,
+    release_id: int | None,
+) -> None:
+    """UPSERT a cache row for ``(artist, title, is_track)``.
+
+    Pass a positive ``release_id`` for a resolved hit, ``None`` to record a
+    known miss. ``resolved_at`` is set to ``now()`` server-side on both insert
+    and conflict-update.
+
+    Write failures are logged and swallowed: cache writes are best-effort. A
+    request that produced a real resolution still uses it even if the write
+    fails.
+    """
+    artist_key = to_match_form(artist)
+    title_key = to_match_form(title)
+    try:
+        await pg.execute(_UPSERT_SQL, artist_key, title_key, is_track, release_id)
+    except Exception:
+        logger.exception(
+            "release_resolution_cache set failed for %s / %s / is_track=%s",
+            artist_key,
+            title_key,
+            is_track,
+        )

--- a/entity/release_resolution_cache.sql
+++ b/entity/release_resolution_cache.sql
@@ -1,0 +1,34 @@
+-- Positive release-resolution cache schema for LML#632.
+--
+-- This file is the canonical DDL reference for the
+-- `lml_cache.release_resolution_cache` table. Like
+-- `lml_cache.album_streaming_url_cache` (LML#573) and unlike
+-- `entity.release_identity` (the discogs-cache-owned identity contract,
+-- migrated via alembic), this table lives in the LML-owned `lml_cache.*`
+-- schema (per WXYC/discogs-etl#288, Option 3) and is bootstrapped from LML's
+-- own FastAPI lifespan -- no discogs-cache coordination. discogs-cache tooling
+-- never touches `lml_cache.*`.
+--
+-- This file exists so:
+--
+--   1. The LML PR's reviewer has the DDL inline for comparison.
+--   2. An operator can apply the schema directly to a non-discogs-cache PG
+--      (e.g. local dev) without booting the full LML app.
+--
+-- The runtime source of truth is `entity/release_resolution_cache.py`
+-- (`set_up_release_resolution_cache_schema`), which issues these statements via
+-- the `IF NOT EXISTS` forms on every boot. If the canonical shape changes,
+-- update both places (and the parity assertions in
+-- tests/unit/test_release_resolution_cache_schema.py).
+
+CREATE SCHEMA IF NOT EXISTS lml_cache;
+
+CREATE TABLE IF NOT EXISTS lml_cache.release_resolution_cache (
+    artist_normalized TEXT NOT NULL,
+    title_normalized TEXT NOT NULL,
+    is_track BOOLEAN NOT NULL,
+    release_id INTEGER,
+    resolved_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (artist_normalized, title_normalized, is_track),
+    CONSTRAINT release_id_validity CHECK (release_id IS NULL OR release_id > 0)
+);

--- a/main.py
+++ b/main.py
@@ -74,13 +74,22 @@ async def lifespan(app: FastAPI):
     if settings.database_url_discogs:
         try:
             from core.dependencies import get_discogs_pool
+            from entity.release_resolution_cache import (
+                set_up_release_resolution_cache_schema,
+            )
             from entity.sources import PgSource
             from entity.streaming_url_cache import set_up_streaming_url_cache_schema
 
             pool = await get_discogs_pool()
             if pool is not None:
-                await set_up_streaming_url_cache_schema(PgSource(pool=pool))
+                source = PgSource(pool=pool)
+                await set_up_streaming_url_cache_schema(source)
                 logger.info("Streaming-URL cache schema ready")
+                # Positive release-resolution cache (LML#632), another LML-owned
+                # ``lml_cache.*`` application cache. Same pool, same best-effort
+                # posture; #628 wires its read/write into the lookup path.
+                await set_up_release_resolution_cache_schema(source)
+                logger.info("Release-resolution cache schema ready")
             else:
                 logger.info(
                     "Discogs cache pool unavailable at startup — streaming-URL cache "

--- a/tests/integration/test_release_resolution_cache.py
+++ b/tests/integration/test_release_resolution_cache.py
@@ -1,0 +1,235 @@
+"""Integration tests for the positive release-resolution cache (LML#632).
+
+Mirrors ``tests/integration/test_streaming_url_persistent_lookup.py``. LML#632
+adds the LML-owned ``lml_cache.release_resolution_cache`` table plus the cache
+module ``entity/release_resolution_cache.py`` (read/write helpers). All unit
+coverage mocks ``PgSource``; this file is the matching ``@pytest.mark.pg`` layer
+driving the real schema, the real UPSERT, and the real dual-TTL math against an
+actual PostgreSQL connection.
+
+Concrete production risks the unit tests cannot catch:
+
+* The named CHECK constraint rejects a non-positive ``release_id``.
+* TIMESTAMPTZ codec drift — asyncpg returns aware ``datetime``; a naive value
+  would break the ``resolved_at`` cutoff comparison.
+* UPSERT semantics — the composite-PK ``ON CONFLICT`` updates in place.
+* ``to_match_form`` normalization parity between SELECT and UPSERT.
+* The dual TTL: a positive hit reads stale after 90 days; a miss reads fresh
+  inside 7 days and stale after.
+
+Run with: pytest -m pg -v tests/integration/test_release_resolution_cache.py
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from entity.release_resolution_cache import (
+    get_cached_release_id,
+    set_cached_release_id,
+    set_up_release_resolution_cache_schema,
+)
+from entity.sources import PgSource
+
+
+@pytest_asyncio.fixture
+async def pg_source(pg_pool):
+    """A ``PgSource`` borrowing the test pool (no-op close)."""
+    return PgSource(pool=pg_pool)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_cache_schema(pg_pool, pg_source):
+    """Reset to a clean ``lml_cache`` schema and apply the cache DDL.
+
+    Surgical (not ``DROP SCHEMA entity CASCADE``): only the LML-owned
+    ``lml_cache`` schema is touched, so the discogs-cache-owned ``entity.*``
+    identity tables in the shared test PG stay intact. ``DROP SCHEMA ...
+    CASCADE`` also drops the sibling ``album_streaming_url_cache`` if present;
+    both are LML-owned application caches and are re-bootstrapped on demand by
+    their own suites, so this is safe.
+    """
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS lml_cache CASCADE")
+    await set_up_release_resolution_cache_schema(pg_source)
+    yield
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS lml_cache CASCADE")
+
+
+@pytest.mark.pg
+class TestSchemaBootstrap:
+    @pytest.mark.asyncio
+    async def test_second_boot_is_a_no_op(self, pg_source, pg_pool):
+        await set_up_release_resolution_cache_schema(pg_source)
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT count(*)::int AS n FROM information_schema.tables "
+                "WHERE table_schema = 'lml_cache' "
+                "AND table_name = 'release_resolution_cache'"
+            )
+        assert row["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_named_check_constraint_rejects_non_positive_release_id(self, pg_pool):
+        # release_id must be NULL (a miss) or strictly positive.
+        with pytest.raises(asyncpg.PostgresError):
+            async with pg_pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO lml_cache.release_resolution_cache "
+                    "(artist_normalized, title_normalized, is_track, release_id) "
+                    "VALUES ('x', 'y', false, 0)"
+                )
+
+
+@pytest.mark.pg
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_set_then_get_returns_release_id(self, pg_source):
+        await set_cached_release_id(
+            pg_source, artist="Juana Molina", title="DOGA", is_track=False, release_id=12345
+        )
+        result = await get_cached_release_id(
+            pg_source, artist="Juana Molina", title="DOGA", is_track=False
+        )
+        assert result.was_present is True
+        assert result.release_id == 12345
+
+    @pytest.mark.asyncio
+    async def test_track_and_album_channels_coexist_under_same_key(self, pg_source):
+        # ``is_track`` is part of the PK — the same (artist, title) can carry
+        # independent rows for the track and album channels without colliding.
+        await set_cached_release_id(
+            pg_source, artist="Jessica Pratt", title="Back, Baby", is_track=True, release_id=111
+        )
+        await set_cached_release_id(
+            pg_source, artist="Jessica Pratt", title="Back, Baby", is_track=False, release_id=222
+        )
+        track = await get_cached_release_id(
+            pg_source, artist="Jessica Pratt", title="Back, Baby", is_track=True
+        )
+        album = await get_cached_release_id(
+            pg_source, artist="Jessica Pratt", title="Back, Baby", is_track=False
+        )
+        assert track.release_id == 111
+        assert album.release_id == 222
+
+    @pytest.mark.asyncio
+    async def test_upsert_updates_in_place(self, pg_source, pg_pool):
+        await set_cached_release_id(
+            pg_source, artist="Cat Power", title="Moon Pix", is_track=False, release_id=1
+        )
+        await set_cached_release_id(
+            pg_source, artist="Cat Power", title="Moon Pix", is_track=False, release_id=999
+        )
+        async with pg_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT release_id FROM lml_cache.release_resolution_cache "
+                "WHERE artist_normalized = 'cat power' AND title_normalized = 'moon pix' "
+                "AND is_track = false"
+            )
+        assert len(rows) == 1, "ON CONFLICT must update in place, not insert"
+        assert rows[0]["release_id"] == 999
+
+    @pytest.mark.asyncio
+    async def test_normalization_symmetry(self, pg_source):
+        await set_cached_release_id(
+            pg_source, artist="Nilüfer Yanya", title="PAINLESS", is_track=False, release_id=42
+        )
+        result = await get_cached_release_id(
+            pg_source, artist="Nilufer Yanya", title="painless", is_track=False
+        )
+        assert result.release_id == 42
+
+
+@pytest.mark.pg
+class TestDualTTL:
+    @pytest.mark.asyncio
+    async def test_absent_entry_reads_not_present(self, pg_source):
+        # Nothing written: an absent entry is the "run the live probe" shape.
+        result = await get_cached_release_id(
+            pg_source, artist="Sessa", title="Estrela Acesa", is_track=False
+        )
+        assert result.was_present is False
+        assert result.release_id is None
+
+    @pytest.mark.asyncio
+    async def test_known_miss_within_7_days_is_returned(self, pg_source):
+        await set_cached_release_id(
+            pg_source, artist="Sessa", title="Estrela Acesa", is_track=False, release_id=None
+        )
+        # A fresh miss is a present row whose release_id is None: the caller
+        # honors it (skip the probe), distinct from an absent entry.
+        result = await get_cached_release_id(
+            pg_source, artist="Sessa", title="Estrela Acesa", is_track=False
+        )
+        assert result.was_present is True
+        assert result.release_id is None
+
+    @pytest.mark.asyncio
+    async def test_known_miss_past_7_days_reads_stale(self, pg_source, pg_pool):
+        await set_cached_release_id(
+            pg_source, artist="Sessa", title="Estrela Acesa", is_track=False, release_id=None
+        )
+        now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+        past = now - timedelta(days=8)
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE lml_cache.release_resolution_cache SET resolved_at = $1 "
+                "WHERE artist_normalized = 'sessa' AND title_normalized = 'estrela acesa' "
+                "AND is_track = false",
+                past,
+            )
+        # Stale miss is filtered by the SQL: reads as absent (re-probe).
+        result = await get_cached_release_id(
+            pg_source, artist="Sessa", title="Estrela Acesa", is_track=False, now=now
+        )
+        assert result.was_present is False
+        assert result.release_id is None
+
+    @pytest.mark.asyncio
+    async def test_positive_hit_within_90_days_is_returned(self, pg_source, pg_pool):
+        await set_cached_release_id(
+            pg_source, artist="Stereolab", title="Aluminum Tunes", is_track=False, release_id=7
+        )
+        now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+        recent = now - timedelta(days=80)
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE lml_cache.release_resolution_cache SET resolved_at = $1 "
+                "WHERE artist_normalized = 'stereolab' AND title_normalized = 'aluminum tunes' "
+                "AND is_track = false",
+                recent,
+            )
+        result = await get_cached_release_id(
+            pg_source, artist="Stereolab", title="Aluminum Tunes", is_track=False, now=now
+        )
+        assert result.was_present is True
+        assert result.release_id == 7
+
+    @pytest.mark.asyncio
+    async def test_positive_hit_past_90_days_reads_stale(self, pg_source, pg_pool):
+        await set_cached_release_id(
+            pg_source, artist="Stereolab", title="Aluminum Tunes", is_track=False, release_id=7
+        )
+        now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+        ancient = now - timedelta(days=91)
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE lml_cache.release_resolution_cache SET resolved_at = $1 "
+                "WHERE artist_normalized = 'stereolab' AND title_normalized = 'aluminum tunes' "
+                "AND is_track = false",
+                ancient,
+            )
+        # A positive hit older than 90 days is a derived inference that may have
+        # gone stale (Discogs releases merge/delete) — filtered by the SQL, so
+        # the caller sees the same "absent" shape and re-resolves.
+        result = await get_cached_release_id(
+            pg_source, artist="Stereolab", title="Aluminum Tunes", is_track=False, now=now
+        )
+        assert result.was_present is False
+        assert result.release_id is None

--- a/tests/unit/test_release_resolution_cache_schema.py
+++ b/tests/unit/test_release_resolution_cache_schema.py
@@ -1,0 +1,121 @@
+"""Unit tests for the release-resolution cache schema bootstrap (LML#632).
+
+Mirrors ``tests/unit/test_streaming_url_cache_schema.py``. Two surfaces:
+
+* ``entity/release_resolution_cache.sql`` — the canonical-DDL reference file
+  (mirrors ``entity/streaming_url_cache.sql``). It must describe the
+  ``lml_cache.release_resolution_cache`` table with the named CHECK constraint
+  and composite PK, so a reviewer / operator has the DDL inline.
+* ``set_up_release_resolution_cache_schema`` — the lifespan bootstrap helper.
+  It must issue ``CREATE SCHEMA`` then ``CREATE TABLE`` (named CHECK) and
+  nothing else.
+
+The parity assertion pins the module's runtime ``CREATE TABLE`` text to the
+``.sql`` reference so the two cannot silently drift. PG is mocked; the
+integration layer (``tests/integration/test_release_resolution_cache.py``)
+drives the real DDL and TTL math against PostgreSQL.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from entity.release_resolution_cache import (
+    _DDL_TABLE,
+    set_up_release_resolution_cache_schema,
+)
+from entity.sources import PgSource
+
+_SQL_REFERENCE = (
+    Path(__file__).resolve().parent.parent.parent / "entity" / "release_resolution_cache.sql"
+)
+
+
+class TestCanonicalDDLReference:
+    """``entity/release_resolution_cache.sql`` is the inline DDL reference."""
+
+    def test_reference_file_exists(self):
+        assert _SQL_REFERENCE.is_file()
+
+    def test_targets_lml_cache_schema_and_table(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in ddl
+        assert "lml_cache.release_resolution_cache" in ddl
+
+    def test_has_named_check_constraint(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "CONSTRAINT release_id_validity CHECK" in ddl
+        assert "release_id IS NULL OR release_id > 0" in ddl
+
+    def test_has_composite_primary_key(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "PRIMARY KEY (artist_normalized, title_normalized, is_track)" in ddl
+
+    def test_module_create_table_matches_sql_reference(self):
+        # The .sql file is the hand-maintained mirror of the runtime DDL. Pin
+        # the module's ``CREATE TABLE ...`` statement (modulo SQL comments and
+        # the trailing semicolon) to the reference so the mirror can't drift —
+        # the same contract ``test_streaming_url_cache_schema`` enforces, but
+        # via a full text comparison since this DDL carries no generated list.
+        ddl = _SQL_REFERENCE.read_text()
+        sql_create = _extract_create_table(ddl)
+        module_create = _strip_sql_comments(_DDL_TABLE).strip().rstrip(";")
+        assert sql_create == module_create, (
+            "entity/release_resolution_cache.sql CREATE TABLE drifted from the "
+            "_DDL_TABLE in entity/release_resolution_cache.py — update both."
+        )
+
+
+def _strip_sql_comments(sql: str) -> str:
+    """Drop ``--`` line comments and collapse incidental whitespace.
+
+    Lets the parity check compare the *shape* of the two DDL statements without
+    tripping on the explanatory comments the ``.sql`` reference carries inline.
+    """
+    lines = []
+    for raw in sql.splitlines():
+        line = raw.split("--", 1)[0].rstrip()
+        if line.strip():
+            lines.append(line.strip())
+    return " ".join(lines)
+
+
+def _extract_create_table(ddl: str) -> str:
+    """Pull the single ``CREATE TABLE ...);`` statement out of the .sql file."""
+    start = ddl.index("CREATE TABLE")
+    end = ddl.index(";", start)
+    return _strip_sql_comments(ddl[start:end]).strip().rstrip(";")
+
+
+@pytest.mark.asyncio
+class TestSetUpReleaseResolutionCacheSchema:
+    """``set_up_release_resolution_cache_schema`` runs exactly the idempotent DDL."""
+
+    async def test_creates_schema_then_table(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="CREATE")
+
+        await set_up_release_resolution_cache_schema(pg)
+
+        # Exactly two executes — schema, then table. No backfill.
+        assert pg.execute.await_count == 2
+        schema_sql = pg.execute.await_args_list[0].args[0]
+        table_sql = pg.execute.await_args_list[1].args[0]
+        assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in schema_sql
+        assert "CREATE TABLE IF NOT EXISTS lml_cache.release_resolution_cache" in table_sql
+        assert "CONSTRAINT release_id_validity CHECK" in table_sql
+        assert "PRIMARY KEY (artist_normalized, title_normalized, is_track)" in table_sql
+
+    async def test_does_not_read_or_backfill(self):
+        # The bootstrap is pure DDL: no probe, no INSERT.
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="CREATE")
+
+        await set_up_release_resolution_cache_schema(pg)
+
+        pg.fetchone.assert_not_awaited()
+        executed = [call.args[0] for call in pg.execute.await_args_list]
+        assert not any("INSERT" in sql for sql in executed)


### PR DESCRIPTION
## Positive resolution cache: `lml_cache.release_resolution_cache`

Adds a durable LML-owned positive cache mapping a normalized `(artist, title, is_track)` to a resolved Discogs `release_id`, modeled on `lml_cache.album_streaming_url_cache`. Lifespan-bootstrapped (not alembic), keyed via `to_match_form`, with a 90-day positive TTL and 7-day miss TTL enforced in the read SQL.

The read returns a three-valued `ReleaseResolution(release_id, was_present)` so the consumer (#628) can distinguish a fresh hit, a fresh known-miss (skip the probe), and absent/stale (run the probe).

Purely additive — not wired into the lookup path (that is #628). The `pg`-marked integration test runs in CI's Postgres job.

Part of the #625 epic.

Closes #632
