### PR TITLE
feat(#633): bounded sequential-early-exit on resolve_release_for_track

### DIFF
--- a/lookup/release_resolution.py
+++ b/lookup/release_resolution.py
@@ -162,6 +162,33 @@ async def validate_release_for_track(
     return verdict
 
 
+def prerank_candidates_for_validation(
+    candidates: list[ReleaseInfo], album: str | None
+) -> list[ReleaseInfo]:
+    """Order probe candidates so the likeliest match is validated first (LML#633).
+
+    The bounded sequential-early-exit path validates candidates in this order and
+    returns the first that passes, so the ordering decides how few
+    ``validate_track_on_release`` calls the happy path costs.
+
+    With an ``album`` to match, this applies the same TITLE-only signal
+    ``rank_resolved_releases`` applies *after* validation — moved *before* it so
+    the top title match is tried first (stable ``release_id`` tie-break). With no
+    ``album`` there is nothing to title-rank, so it falls back to the #629
+    no-album rule: prefer an own-release (``is_compilation=False``) over a
+    compilation, then stable ``release_id``. The non-bounded path does not call
+    this — it validates every candidate and ranks ``rank_resolved_releases``
+    after, so its ordering is unchanged.
+    """
+    album_query = (album or "").strip()
+    if not album_query:
+        return sorted(candidates, key=lambda r: (r.is_compilation, r.release_id))
+    return sorted(
+        candidates,
+        key=lambda r: (-score_match(album_query, r.album), r.release_id),
+    )
+
+
 def rank_resolved_releases(
     releases: list[ResolvedRelease], album: str | None
 ) -> list[ResolvedRelease]:
@@ -192,6 +219,7 @@ async def resolve_release_for_track(
     discogs_service: DiscogsService | None,
     *,
     also_probe_album_title: bool = False,
+    max_validations: int | None = None,
 ) -> list[ResolvedRelease]:
     """Find and validate the Discogs release(s) a track sits on.
 
@@ -200,6 +228,23 @@ async def resolve_release_for_track(
     via ``validate_track_on_release`` (which matches the per-track credit, not the
     release credit), and returns the validated releases ranked by title match to
     ``album``. Empty when nothing validates.
+
+    ``max_validations`` selects between two validation modes (LML#633):
+
+    - **Default (``None``) — validate-all, rank-after.** Every candidate is
+      validated; the survivors are ranked by ``rank_resolved_releases``. This is
+      the original behavior the #604 lazy-bind callers depend on, kept
+      byte-for-byte; they pass no bound.
+    - **Bounded (an int) — sequential-early-exit.** Candidates are pre-ranked by
+      ``prerank_candidates_for_validation`` (the title signal moved *before*
+      validation), validated in that order, and the **first** that validates is
+      returned — stopping after at most ``max_validations`` attempts. This is the
+      cold-cache cost cap #628 points at every non-library add: a popular track
+      with 20-40 candidates costs 1 validate call on the happy path (top title
+      match validates) instead of 20-40, and the N=5 backstop bounds the worst
+      case. Sequential (not concurrent) to minimize Discogs quota — the binding
+      constraint — and degrade gently under the fallthrough seam's rate-limit
+      cool-down. (See the #625 decision record.)
 
     When ``also_probe_album_title`` is set and ``album`` is non-empty, a third
     album-title probe (``search_releases_by_album_title``) joins the Wave A/B
@@ -266,10 +311,10 @@ async def resolve_release_for_track(
                 candidates.append(r)
                 seen_ids.add(r.release_id)
 
-    validated: list[ResolvedRelease] = []
-    for release in candidates:
-        if not release.release_id:
-            continue
+    async def _validate_one(release: ReleaseInfo) -> ResolvedRelease | None:
+        """Validate one candidate's per-track credit; return the ``ResolvedRelease``
+        on a pass, ``None`` on a fail or a swallowed validation error (a single
+        candidate's failure must never abort the whole call)."""
         try:
             is_valid = await validate_release_for_track(
                 discogs_service, release.release_id, song, artist, source="release_resolution"
@@ -278,17 +323,36 @@ async def resolve_release_for_track(
             logger.warning(
                 "Release-resolution validation failed for release %s: %s", release.release_id, exc
             )
-            continue
+            return None
         if not is_valid:
-            continue
-        validated.append(
-            ResolvedRelease(
-                release_id=release.release_id,
-                release_url=release.release_url,
-                is_compilation=bool(release.is_compilation),
-                album_title=release.album,
-            )
+            return None
+        return ResolvedRelease(
+            release_id=release.release_id,
+            release_url=release.release_url,
+            is_compilation=bool(release.is_compilation),
+            album_title=release.album,
         )
+
+    if max_validations is not None:
+        # Bounded sequential-early-exit (LML#633): pre-rank, validate in order,
+        # return the first that passes, stop after ``max_validations`` attempts.
+        # Falsy-id rows can never be validated, so drop them before counting the
+        # budget — they must not consume an attempt slot.
+        ranked = prerank_candidates_for_validation([r for r in candidates if r.release_id], album)
+        for release in ranked[:max_validations]:
+            resolved = await _validate_one(release)
+            if resolved is not None:
+                return [resolved]
+        return []
+
+    # Default: validate-all, rank-after (the #604 lazy-bind contract).
+    validated: list[ResolvedRelease] = []
+    for release in candidates:
+        if not release.release_id:
+            continue
+        resolved = await _validate_one(release)
+        if resolved is not None:
+            validated.append(resolved)
 
     return rank_resolved_releases(validated, album)
 

--- a/tests/unit/test_release_resolution.py
+++ b/tests/unit/test_release_resolution.py
@@ -327,6 +327,159 @@ class TestRanking:
         assert [r.release_id for r in resolved] == [20, 50]
 
 
+def _eight_candidates() -> list[ReleaseInfo]:
+    """Eight V/A comps whose titles deliberately do NOT pre-rank in input order.
+
+    Input order is by ``release_id`` (10..80); the exact title match
+    "When There Is No Sun" sits at id 80 (last in input) so a test that asserts
+    "the title-top validates first" genuinely proves the pre-rank moved it to the
+    front, not that input order happened to coincide.
+    """
+    return [
+        _va_comp(release_id=10, album="Acid House Classics"),
+        _va_comp(release_id=20, album="Some Other Comp"),
+        _va_comp(release_id=30, album="Totally Different"),
+        _va_comp(release_id=40, album="Comp A"),
+        _va_comp(release_id=50, album="Comp B"),
+        _va_comp(release_id=60, album="An Unrelated Solo Album"),
+        _va_comp(release_id=70, album="Yet Another Comp"),
+        _va_comp(release_id=80, album="When There Is No Sun"),  # exact title match
+    ]
+
+
+class TestBoundedEarlyExit:
+    """Opt-in bounded sequential-early-exit (LML#633).
+
+    ``max_validations`` defaults to ``None`` (today's validate-all, rank-after —
+    pins the #604 lazy-bind callers byte-for-byte). When set to an int the
+    resolver pre-ranks candidates by title score, validates in rank order,
+    returns the first that validates, and stops after that many attempts (the
+    consumer #628 passes 5).
+    """
+
+    @pytest.mark.asyncio
+    async def test_title_top_validates_first_single_call(self):
+        """8 candidates, the title-top-ranked one validates → exactly 1 validate
+        call, and that release is returned."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(*_eight_candidates()))
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+            max_validations=5,
+        )
+
+        assert [r.release_id for r in resolved] == [80]
+        assert svc.validate_track_on_release.await_count == 1
+        # The single validate probe was the title-top (id 80), not input-order #1.
+        assert svc.validate_track_on_release.await_args.args[0] == 80
+
+    @pytest.mark.asyncio
+    async def test_title_top_fails_second_validates_two_calls(self):
+        """Title-top fails validation, the #2-ranked validates → exactly 2 calls,
+        returns the #2-ranked release."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        # Pre-rank: id 80 (exact, 100) > id 20 ("Some Other Comp", 45.7) > rest.
+        # 80 fails the per-track credit; 20 passes.
+        candidates = _eight_candidates()
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(*candidates))
+        svc.validate_track_on_release = AsyncMock(side_effect=lambda rid, song, artist: rid == 20)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+            max_validations=5,
+        )
+
+        assert [r.release_id for r in resolved] == [20]
+        assert svc.validate_track_on_release.await_count == 2
+        # Probed in rank order: title-top (80) first, then the runner-up (20).
+        assert [c.args[0] for c in svc.validate_track_on_release.await_args_list] == [80, 20]
+
+    @pytest.mark.asyncio
+    async def test_none_validate_stops_at_backstop_cap(self):
+        """No candidate validates → stops after exactly 5 attempts (the N=5
+        backstop), returns empty — even though 8 candidates were available."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(*_eight_candidates()))
+        svc.validate_track_on_release = AsyncMock(return_value=False)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+            max_validations=5,
+        )
+
+        assert resolved == []
+        assert svc.validate_track_on_release.await_count == 5
+
+    @pytest.mark.asyncio
+    async def test_default_mode_validates_all_candidates(self):
+        """Default mode (no ``max_validations`` arg) validates ALL 8 candidates —
+        pins the #604 lazy-bind callers unchanged (validate-all, rank-after)."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(*_eight_candidates()))
+        svc.validate_track_on_release = AsyncMock(return_value=False)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+        )
+
+        assert resolved == []
+        assert svc.validate_track_on_release.await_count == 8
+
+    @pytest.mark.asyncio
+    async def test_no_album_orders_by_own_release_then_id_early_exits(self):
+        """No-album case: nothing to title-rank, so order by prefer
+        ``is_compilation=False`` (own release) then stable ``release_id``,
+        early-exit on first validation, capped at 5. The own-release with the
+        lowest id is probed first and, validating, ends the sweep at 1 call."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(
+            return_value=_track_response(
+                _va_comp(release_id=20, album="A V/A Comp"),  # is_compilation=True
+                _single_artist(50, "Own Album B"),  # is_compilation=False
+                _single_artist(40, "Own Album A"),  # is_compilation=False, lower id
+            )
+        )
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album=None,
+            discogs_service=svc,
+            max_validations=5,
+        )
+
+        # Own releases first (40 before 50 by id), comp last → 40 probed first,
+        # validates, early-exit.
+        assert [r.release_id for r in resolved] == [40]
+        assert svc.validate_track_on_release.await_count == 1
+        assert svc.validate_track_on_release.await_args.args[0] == 40
+
+
 class TestValidateReleaseForTrack:
     """The shared validate+telemetry primitive both strategies delegate to."""
 


### PR DESCRIPTION
## Bounded sequential-early-exit on `resolve_release_for_track`

Adds an opt-in `max_validations: int | None = None`. Default (`None`) preserves today's validate-all / rank-after behavior, so the existing #604 lazy-bind callers are byte-for-byte unchanged. When set, candidates are pre-ranked by title score (no-album falls back to prefer-own-release then stable id, per #629), validated in rank order, and the first that validates is returned — stopping after N attempts.

#628 will wire this as `max_validations=5`. Call-count tests pin the 1 / 2 / 5 / 8 behaviors; the full unit suite (incl. the 125-test #604 lazy-bind suite) stays green on the default path.

Part of the #625 epic.

Closes #633
