### PR TITLE
fix(#640): guard streaming matcher against sparse result rows

### DIFF
--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -409,6 +409,20 @@ def record_match_telemetry(
         logger.warning("Failed to emit matcher telemetry: %s", e)
 
 
+# Adapter extractors subscript raw API dicts directly (e.g. Spotify's
+# ``x["artists"][0]["name"]``, Deezer's ``x["artist"]["name"]``). A sparse or
+# malformed upstream row — a missing key, an empty ``artists`` list, a null
+# where a dict is expected — makes one of them raise mid-loop. Without a
+# per-item guard that exception propagates out of the matcher and aborts the
+# whole match, erasing every well-formed row in the same response (LML#640).
+# The guard catches exactly these extraction-shaped errors and skips the one
+# bad row; a genuine programming error in an extractor (e.g. calling a
+# non-callable) is not in this set and still surfaces loudly rather than being
+# silently swallowed for every row. Kept narrow on purpose — it wraps only the
+# extractor calls, never the scoring.
+_EXTRACTION_ERRORS = (KeyError, IndexError, TypeError)
+
+
 def find_best_match(
     results: list[dict],
     query_artist: str,
@@ -441,8 +455,19 @@ def find_best_match(
     best: dict | None = None
     best_score = 0.0
     for item in results:
-        result_artist = artist_fn(item)
-        result_title = title_fn(item)
+        # Extract every field up front, inside the guard, so a sparse row is
+        # skipped whichever extractor trips — including ``url_fn``/``id_fn``,
+        # which only feed a floor-clearing winner. Evaluating them per-row (vs.
+        # lazily on the winner) costs a dict subscript and changes no output for
+        # well-formed rows. See ``_EXTRACTION_ERRORS`` (LML#640).
+        try:
+            result_artist = artist_fn(item)
+            result_title = title_fn(item)
+            result_url = url_fn(item)
+            result_id = id_fn(item) if id_fn is not None else None
+        except _EXTRACTION_ERRORS as exc:
+            logger.warning("Skipping malformed result row in find_best_match: %s", exc)
+            continue
         artist_score = score_match(query_artist, result_artist)
         title_score = score_match(query_title, result_title)
         if not is_acceptable_match(artist_score, title_score):
@@ -451,7 +476,7 @@ def find_best_match(
         if combined > best_score:
             best_score = combined
             match: dict = {
-                "url": url_fn(item),
+                "url": result_url,
                 "confidence": combined,
                 "matched_artist": result_artist,
                 "matched_title": result_title,
@@ -461,7 +486,7 @@ def find_best_match(
                 "title_score": title_score,
             }
             if id_fn is not None:
-                match["id"] = id_fn(item)
+                match["id"] = result_id
             best = match
     return best
 
@@ -512,8 +537,15 @@ def find_best_typed_match[T](
     best: T | None = None
     best_score = 0.0
     for item in results:
-        r_artist = artist_fn(item) or ""
-        r_title = title_fn(item) or ""
+        # Same per-item guard as ``find_best_match`` — the orchestrator lookup
+        # path runs through here, so a malformed candidate must be skipped, not
+        # fatal (LML#640).
+        try:
+            r_artist = artist_fn(item) or ""
+            r_title = title_fn(item) or ""
+        except _EXTRACTION_ERRORS as exc:
+            logger.warning("Skipping malformed result row in find_best_typed_match: %s", exc)
+            continue
         artist_score = max(score_match(q, r_artist) for q in artist_variants)
         title_score = max(score_match(q, r_title) for q in title_variants)
         if not is_acceptable_match(artist_score, title_score):

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -524,6 +524,190 @@ class TestFindBestMatch:
         assert best["confidence"] > 0
 
 
+# The exact extractor shapes the adapters pass — replicated here so the guard is
+# tested against the real subscript chains, not a paraphrase.
+#   Spotify: clients/streaming/spotify.py:66-68
+#   Deezer:  clients/streaming/deezer.py:39-41
+_SPOTIFY_EXTRACTORS = {
+    "artist_fn": lambda x: x["artists"][0]["name"],
+    "title_fn": lambda x: x["name"],
+    "url_fn": lambda x: x["external_urls"]["spotify"],
+}
+_DEEZER_EXTRACTORS = {
+    "artist_fn": lambda x: x["artist"]["name"],
+    "title_fn": lambda x: x["title"],
+    "url_fn": lambda x: x["link"],
+}
+
+_SPOTIFY_GOOD = {
+    "name": "DOGA",
+    "artists": [{"name": "Juana Molina"}],
+    "external_urls": {"spotify": "https://open.spotify.com/album/good"},
+}
+_DEEZER_GOOD = {
+    "artist": {"name": "Juana Molina"},
+    "title": "DOGA",
+    "link": "https://www.deezer.com/album/good",
+}
+
+
+class TestFindBestMatchSparseRowGuard:
+    """LML#640: a single sparse/malformed row must not erase every match.
+
+    The Spotify/Deezer extractors subscript raw API dicts directly, so a row
+    missing ``artists`` / ``external_urls`` / ``link`` (or carrying an empty
+    ``artists`` list) raises ``KeyError``/``IndexError``/``TypeError`` mid-loop.
+    Before the per-item guard, that exception propagated out of
+    ``find_best_match`` and aborted the whole match — the well-formed rows in
+    the same response were lost with it. The guard skips (and logs) just the
+    bad row.
+    """
+
+    @pytest.mark.parametrize(
+        "sparse_row",
+        [
+            pytest.param({"name": "X", "external_urls": {"spotify": "http://x"}}, id="no-artists"),
+            pytest.param(
+                {"name": "X", "artists": [], "external_urls": {"spotify": "http://x"}},
+                id="empty-artists-list",
+            ),
+            pytest.param(
+                {"name": "X", "artists": [{}], "external_urls": {"spotify": "http://x"}},
+                id="artist-without-name",
+            ),
+            pytest.param(
+                {"artists": [{"name": "X"}], "external_urls": {"spotify": "http://x"}},
+                id="no-title",
+            ),
+        ],
+    )
+    def test_spotify_sparse_row_skipped_good_row_survives(self, sparse_row):
+        from clients.streaming.matching import find_best_match
+
+        best = find_best_match(
+            [sparse_row, _SPOTIFY_GOOD],
+            "Juana Molina",
+            "DOGA",
+            **_SPOTIFY_EXTRACTORS,
+        )
+        assert best is not None
+        assert best["url"] == "https://open.spotify.com/album/good"
+        assert best["matched_title"] == "DOGA"
+
+    @pytest.mark.parametrize(
+        "sparse_row",
+        [
+            pytest.param({"title": "X", "link": "http://x"}, id="no-artist"),
+            pytest.param({"artist": None, "title": "X", "link": "http://x"}, id="null-artist"),
+            pytest.param(
+                {"artist": {}, "title": "X", "link": "http://x"}, id="artist-without-name"
+            ),
+            pytest.param({"artist": {"name": "X"}, "link": "http://x"}, id="no-title"),
+        ],
+    )
+    def test_deezer_sparse_row_skipped_good_row_survives(self, sparse_row):
+        from clients.streaming.matching import find_best_match
+
+        best = find_best_match(
+            [sparse_row, _DEEZER_GOOD],
+            "Juana Molina",
+            "DOGA",
+            **_DEEZER_EXTRACTORS,
+        )
+        assert best is not None
+        assert best["url"] == "https://www.deezer.com/album/good"
+        assert best["matched_title"] == "DOGA"
+
+    def test_sparse_row_after_good_row_does_not_erase_winner(self):
+        """Order independence: the bad row trailing a good row must not undo it."""
+        from clients.streaming.matching import find_best_match
+
+        best = find_best_match(
+            [_DEEZER_GOOD, {"title": "X", "link": "http://x"}],
+            "Juana Molina",
+            "DOGA",
+            **_DEEZER_EXTRACTORS,
+        )
+        assert best is not None
+        assert best["url"] == "https://www.deezer.com/album/good"
+
+    def test_floor_clearing_row_with_unextractable_url_is_skipped(self):
+        """A row that clears the artist/title floor but whose ``url_fn`` raises
+        is skipped, not fatal — and a lower-priority well-formed row still wins.
+
+        ``url_fn`` is the one extractor evaluated only for a candidate that
+        clears the floor, so this pins that the guard covers it too (not just
+        the always-run artist/title extractors)."""
+        from clients.streaming.matching import find_best_match
+
+        # First row matches on artist/title but has no ``external_urls`` → url_fn
+        # raises KeyError. Second row is fully well-formed.
+        no_url = {"name": "DOGA", "artists": [{"name": "Juana Molina"}]}
+        best = find_best_match(
+            [no_url, _SPOTIFY_GOOD],
+            "Juana Molina",
+            "DOGA",
+            **_SPOTIFY_EXTRACTORS,
+        )
+        assert best is not None
+        assert best["url"] == "https://open.spotify.com/album/good"
+
+    def test_only_sparse_rows_returns_none_without_raising(self):
+        from clients.streaming.matching import find_best_match
+
+        best = find_best_match(
+            [
+                {"title": "X", "link": "http://x"},
+                {"artist": None, "title": "Y", "link": "http://y"},
+            ],
+            "Juana Molina",
+            "DOGA",
+            **_DEEZER_EXTRACTORS,
+        )
+        assert best is None
+
+    def test_skipped_row_is_logged(self):
+        from clients.streaming.matching import find_best_match
+
+        with patch("clients.streaming.matching.logger") as mock_logger:
+            find_best_match(
+                [{"title": "X", "link": "http://x"}, _DEEZER_GOOD],
+                "Juana Molina",
+                "DOGA",
+                **_DEEZER_EXTRACTORS,
+            )
+        mock_logger.warning.assert_called_once()
+
+    def test_well_formed_response_does_not_log(self):
+        """No spurious warnings when every row is well-formed (no behavior change)."""
+        from clients.streaming.matching import find_best_match
+
+        with patch("clients.streaming.matching.logger") as mock_logger:
+            find_best_match(
+                [_SPOTIFY_GOOD],
+                "Juana Molina",
+                "DOGA",
+                **_SPOTIFY_EXTRACTORS,
+            )
+        mock_logger.warning.assert_not_called()
+
+    def test_typed_match_sparse_row_skipped(self):
+        """The sibling matcher on the orchestrator lookup path has the same
+        unguarded shape — a malformed candidate must be skipped, not fatal."""
+        from clients.streaming.matching import find_best_typed_match
+
+        good = {"artist": {"name": "Juana Molina"}, "title": "DOGA"}
+        bad = {"title": "DOGA"}  # no ``artist`` key → KeyError in artist_fn
+        best = find_best_typed_match(
+            [bad, good],
+            query_artist="Juana Molina",
+            query_title="DOGA",
+            artist_fn=lambda x: x["artist"]["name"],
+            title_fn=lambda x: x["title"],
+        )
+        assert best is good
+
+
 class TestRecordMatchTelemetry:
     """LML#592: emit the winning match's per-axis scores to Sentry.
 


### PR DESCRIPTION
## Summary

A single sparse or malformed streaming result row used to erase **every** match in the same response. The Spotify and Deezer adapters pass extractors that subscript raw API dicts directly — `x["artists"][0]["name"]`, `x["artist"]["name"]`, `x["external_urls"]["spotify"]`, `x["link"]` — and `find_best_match` iterated them with no per-item guard. A row missing `artists` / `external_urls` / `link`, or carrying an empty `artists` list or a null artist, raised `KeyError`/`IndexError`/`TypeError` mid-loop; the exception propagated out and aborted the whole match, taking the well-formed rows with it. (Apple Music was already safe via `.get()` chains.)

## Change

The **deeper fix** the issue called for: a narrow per-item guard in the matcher itself, so all adapters are protected uniformly rather than special-casing each extractor.

- `find_best_match` (`clients/streaming/matching.py`): extract all four values (`artist_fn`/`title_fn`/`url_fn`/`id_fn`) up front inside a `try/except`; skip and log the row on an extraction error. `url_fn`/`id_fn` are now evaluated per-row (vs. lazily on the winner) so a row that clears the floor but has an unextractable URL is skipped instead of fatal — **no output change for well-formed rows**.
- `find_best_typed_match`: the same guard. It's the sibling on the **orchestrator lookup path** and had the identical unguarded shape — covered here so a known-identical landmine isn't left behind. (This is the one scope addition beyond the issue's literal `find_best_match` mention; flagged in the issue triage.)
- New module constant `_EXTRACTION_ERRORS = (KeyError, IndexError, TypeError)` documents the rationale once and keeps the skip narrow: a genuine programming error in an extractor still surfaces loudly; only extraction-shaped errors are swallowed, and scoring is never inside the guard.

This protects every adapter routed through `find_best_source_match` — Spotify, Deezer, **and Bandcamp** (also direct-subscript) — plus the scripts that call `find_best_match` directly.

## Tests

New `TestFindBestMatchSparseRowGuard` (TDD, red→green):
- Spotify and Deezer extractor shapes, parametrized over sparse-row variants (missing key, empty `artists` list, artist-without-name, null artist, missing title) → the good row in the same response still matches, no exception.
- Floor-clearing row with an unextractable URL is skipped; a well-formed row still wins.
- Order independence (bad row trailing a good row doesn't undo the winner).
- Skipped rows are logged; all-well-formed responses do **not** log.
- `find_best_typed_match` sparse-row coverage.

Existing matcher tests (acceptance floor, telemetry, typed-match) stay green — no semantics change for well-formed rows.

Local checks: `ruff check` + `ruff format` clean, `mypy . --ignore-missing-imports` clean, full suite `3090 passed, 1 skipped, 2 xfailed`.

Closes #640