### PR TITLE
Wire Bandcamp into the polymorphic streaming-URL cache — LML#573 PR-3

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -217,6 +217,15 @@ class Settings(BaseSettings):
             "supplies True. New in PR-1. See WXYC/library-metadata-lookup#573."
         ),
     )
+    lml_persist_streaming_url_bandcamp: bool = Field(
+        default=False,
+        description=(
+            "Per-service flag for Bandcamp in the streaming-URL cache "
+            "post-process. A service persists only when this AND "
+            "LML_PERSIST_STREAMING_URLS are both True. Default False; Railway "
+            "supplies True. New in PR-3. See WXYC/library-metadata-lookup#573."
+        ),
+    )
     # Streaming Webhook Configuration
     streaming_webhook_urls: str | None = Field(
         None,

--- a/entity/streaming_url_cache.py
+++ b/entity/streaming_url_cache.py
@@ -72,17 +72,22 @@ logger = logging.getLogger(__name__)
 # visible within a week.
 DEFAULT_MISS_TTL = timedelta(days=7)
 
-# The two services PR-1 ships. The named CHECK constraint pins this set at
-# the DB level; PR-3 ALTERs it to add 'bandcamp' and 'deezer_album'. Kept as
-# a module constant so the bootstrap DDL and a parity test can both reference
-# it without re-typing the literal.
-_PR1_SERVICES = ("apple_music_album", "spotify_album")
+# The services the cache ships. The named CHECK constraint pins this set at
+# the DB level; a future PR adding a service (Deezer's 'deezer_album') extends
+# this tuple and the ALTER below picks it up. Kept as a module constant so the
+# bootstrap DDL and a parity test can both reference it without re-typing the
+# literal. PR-3 added 'bandcamp'.
+_SERVICES = ("apple_music_album", "spotify_album", "bandcamp")
+
+# Shared IN-list literal so the CREATE-time CHECK and the idempotent ALTER are
+# generated from the same source — they can never drift.
+_SERVICE_IN_LIST = ", ".join(f"'{s}'" for s in _SERVICES)
 
 _DDL_SCHEMA = "CREATE SCHEMA IF NOT EXISTS lml_cache"
 
 # Named CHECK constraint (``album_streaming_url_cache_service_valid``) avoids
-# reliance on PG auto-naming so PR-3's ALTER can DROP/ADD it by name. The
-# service-value list is generated from ``_PR1_SERVICES`` so the two stay in
+# reliance on PG auto-naming so the ALTER below can DROP/ADD it by name. The
+# service-value list is generated from ``_SERVICES`` so the two stay in
 # lockstep.
 _DDL_TABLE = f"""\
 CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
@@ -93,9 +98,24 @@ CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
     last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (service, artist_normalized, album_normalized),
     CONSTRAINT album_streaming_url_cache_service_valid CHECK (
-        service IN ({", ".join(f"'{s}'" for s in _PR1_SERVICES)})
+        service IN ({_SERVICE_IN_LIST})
     )
 )\
+"""
+
+# Idempotent widen of the named CHECK. ``CREATE TABLE IF NOT EXISTS`` is a
+# no-op on an already-created prod table, so a new service value added to
+# ``_SERVICES`` would never reach an existing table without this ALTER. The
+# DROP-IF-EXISTS + ADD pair is byte-stable across boots (a no-op once the
+# constraint already matches) and runs atomically within the single statement.
+# The ADD re-validates existing rows; the set only ever grows, so apple/spotify
+# rows always pass. Driven from the same ``_SERVICE_IN_LIST`` as the CREATE.
+_DDL_ALTER_CHECK = f"""\
+ALTER TABLE lml_cache.album_streaming_url_cache
+    DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid,
+    ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK (
+        service IN ({_SERVICE_IN_LIST})
+    )\
 """
 
 # Staleness lives in the WHERE clause (LML#576). ``$1`` is the service key,
@@ -133,9 +153,15 @@ async def set_up_streaming_url_cache_schema(pg: PgSource) -> None:
     boot LML cleanly. If the discogs-cache PG is unreachable at startup, the
     caller logs and continues; the cache layer degrades to a no-op until the
     next deploy.
+
+    The final ALTER widens the named CHECK constraint to the current
+    ``_SERVICES`` set. ``CREATE TABLE IF NOT EXISTS`` cannot add a value to an
+    already-created table's constraint, so without the ALTER a prod table frozen
+    at an older service set would reject UPSERTs for a newly-added service.
     """
     await pg.execute(_DDL_SCHEMA)
     await pg.execute(_DDL_TABLE)
+    await pg.execute(_DDL_ALTER_CHECK)
 
 
 @dataclass(frozen=True)

--- a/entity/streaming_url_cache.py
+++ b/entity/streaming_url_cache.py
@@ -106,10 +106,14 @@ CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
 # Idempotent widen of the named CHECK. ``CREATE TABLE IF NOT EXISTS`` is a
 # no-op on an already-created prod table, so a new service value added to
 # ``_SERVICES`` would never reach an existing table without this ALTER. The
-# DROP-IF-EXISTS + ADD pair is byte-stable across boots (a no-op once the
-# constraint already matches) and runs atomically within the single statement.
-# The ADD re-validates existing rows; the set only ever grows, so apple/spotify
-# rows always pass. Driven from the same ``_SERVICE_IN_LIST`` as the CREATE.
+# DROP-IF-EXISTS + ADD pair is byte-stable across boots and runs atomically
+# within the single statement. Note ``ADD CONSTRAINT … CHECK`` is NOT a metadata
+# no-op even when the constraint text is unchanged: PostgreSQL re-validates every
+# existing row (a brief seq scan under an ACCESS EXCLUSIVE lock) on each boot.
+# That cost is acceptable here — this cache table is modest and the bootstrap
+# runs once per process start, not per request — and the set only ever grows, so
+# existing apple/spotify/bandcamp rows always pass. Driven from the same
+# ``_SERVICE_IN_LIST`` as the CREATE so the two can't drift.
 _DDL_ALTER_CHECK = f"""\
 ALTER TABLE lml_cache.album_streaming_url_cache
     DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid,

--- a/entity/streaming_url_cache.sql
+++ b/entity/streaming_url_cache.sql
@@ -24,9 +24,9 @@ CREATE SCHEMA IF NOT EXISTS lml_cache;
 CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
     -- Service discriminator. The named CHECK constraint pins the allowed set
     -- so a typo'd service key fails loudly at write time rather than minting a
-    -- silently-unreadable row. PR-3 extends it via a transactional
-    -- `ALTER TABLE ... DROP CONSTRAINT album_streaming_url_cache_service_valid;
-    --  ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK (...)`.
+    -- silently-unreadable row. PR-3 added 'bandcamp'; a new service is added by
+    -- extending this list AND the idempotent ALTER below (the runtime drives
+    -- both from `_SERVICES`).
     service TEXT NOT NULL,
     artist_normalized TEXT NOT NULL,
     album_normalized TEXT NOT NULL,
@@ -37,6 +37,17 @@ CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
     last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (service, artist_normalized, album_normalized),
     CONSTRAINT album_streaming_url_cache_service_valid CHECK (
-        service IN ('apple_music_album', 'spotify_album')
+        service IN ('apple_music_album', 'spotify_album', 'bandcamp')
     )
 );
+
+-- Idempotent widen of the named CHECK so an already-created table (where
+-- `CREATE TABLE IF NOT EXISTS` is a no-op) picks up service values added after
+-- its creation. Byte-stable across boots; runs atomically within the one
+-- statement. The runtime (`set_up_streaming_url_cache_schema`) issues this on
+-- every boot, generated from `_SERVICES`.
+ALTER TABLE lml_cache.album_streaming_url_cache
+    DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid,
+    ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK (
+        service IN ('apple_music_album', 'spotify_album', 'bandcamp')
+    );

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -25,6 +25,7 @@ from wxyc_fastapi.observability import (
     get_cache_stats_recorder,
 )
 
+from clients.bandcamp import BandcampClient
 from clients.streaming.apple_music import AppleMusicClient, AppleMusicTrackMatch
 from clients.streaming.matching import (
     SCORE_MATCH_ACCEPTANCE_FLOOR,
@@ -2463,6 +2464,7 @@ async def enrich_artwork_results(
     mb_pg: PgSourceProtocol | None = None,
     apple_music: AppleMusicClient | None = None,
     spotify: SpotifyClient | None = None,
+    bandcamp: BandcampClient | None = None,
     entity_store: EntityStore | None = None,
     discogs_cache_pg: PgSource | None = None,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
@@ -2904,17 +2906,17 @@ async def enrich_artwork_results(
         # Fall back to search URLs for any service without a direct link.
         # Spotify's templated fallback was deleted in LML#573 — the persistent
         # streaming-URL cache post-process below now backstops spotify_url with
-        # a real album page (and mints the identity) instead of a generic
-        # search URL. YouTube Music / Bandcamp / SoundCloud keep their templated
-        # fallbacks (no album-cache tier for them in PR-1; Bandcamp joins in PR-3).
+        # a real album page (and mints the identity) instead of a generic search
+        # URL. Bandcamp's fallback is DEFERRED past the post-process (LML#573
+        # PR-3): the post-process only fires when its URL field is ``None``, so a
+        # pre-filled search URL would silently disable the Bandcamp leg — the
+        # search URL is applied below, only if the cache/probe leaves it None.
+        # YouTube Music / SoundCloud have no album-cache tier, so they keep
+        # their pre-post-process templated fallbacks.
         if row_artist and search_term:
             if not youtube_music_url:
                 youtube_music_url = _build_streaming_search_url(
                     "https://music.youtube.com/search?q=", row_artist, search_term
-                )
-            if not bandcamp_url:
-                bandcamp_url = _build_streaming_search_url(
-                    "https://bandcamp.com/search?q=", row_artist, search_term
                 )
             if not soundcloud_url:
                 soundcloud_url = _build_streaming_search_url(
@@ -2935,24 +2937,35 @@ async def enrich_artwork_results(
         # LML "streaming URLs for non-library albums" (LML#573) — when the
         # existing per-item probe + override couldn't surface a service URL,
         # the polymorphic post-process runs a cache-backed probe per configured
-        # service (Apple + Spotify) with the REQUEST's (artist, album) — not the
-        # library row's. Fixes the wrong-fallback-row attack (non-library album
-        # like Hyd / "Hold Onto Me Infinity" falls back to a same-titled library
-        # row by a different artist, in-line probe runs with the wrong artist
-        # name → null). Results persist to ``lml_cache.album_streaming_url_cache``
-        # so future lookups short-circuit the upstream API, and live resolutions
-        # mint the parsed ID into ``entity.release_identity``. The ``clients``
-        # dict may carry ``None`` values (e.g. Spotify creds unconfigured) — the
-        # post-process filters them. Gated by the master + per-service flags.
+        # service (Apple + Spotify + Bandcamp) with the REQUEST's (artist, album)
+        # — not the library row's. Fixes the wrong-fallback-row attack
+        # (non-library album like Hyd / "Hold Onto Me Infinity" falls back to a
+        # same-titled library row by a different artist, in-line probe runs with
+        # the wrong artist name → null). Results persist to
+        # ``lml_cache.album_streaming_url_cache`` so future lookups short-circuit
+        # the upstream API, and live resolutions mint the parsed ID into
+        # ``entity.release_identity``. The ``clients`` dict may carry ``None``
+        # values (e.g. Spotify creds unconfigured) — the post-process filters
+        # them. Gated by the master + per-service flags.
         await apply_streaming_url_postprocess(
             update,
-            clients={"apple_music": apple_music, "spotify": spotify},
+            clients={"apple_music": apple_music, "spotify": spotify, "bandcamp": bandcamp},
             pg=discogs_cache_pg,
             entity_store=entity_store,
             request_artist=artist,
             request_album=album,
             settings=get_settings(),
         )
+
+        # Bandcamp's templated search-URL fallback, deferred past the
+        # post-process (LML#573 PR-3): apply it only if the cache/probe (and any
+        # librarian-curated streaming_links override) left bandcamp_url empty, so
+        # a resolved album page / direct link always wins over the generic search
+        # link. Priority: direct link > cache/probe > search URL.
+        if row_artist and search_term and not update["bandcamp_url"]:
+            update["bandcamp_url"] = _build_streaming_search_url(
+                "https://bandcamp.com/search?q=", row_artist, search_term
+            )
 
         # Extended fields land on the top-1 result only and require artwork
         # (same positional + artwork gating as the album-derived scalars).
@@ -3235,6 +3248,7 @@ async def perform_lookup(
     mb_pg: PgSourceProtocol | None = None,
     apple_music: AppleMusicClient | None = None,
     spotify: SpotifyClient | None = None,
+    bandcamp: BandcampClient | None = None,
     discogs_cache_pg: PgSource | None = None,
     caller_budget_ms: int | None = None,
     allow_release_resolution_fallback: bool = True,
@@ -3472,6 +3486,7 @@ async def perform_lookup(
                 mb_pg=mb_pg,
                 apple_music=apple_music,
                 spotify=spotify,
+                bandcamp=bandcamp,
                 entity_store=entity_store,
                 discogs_cache_pg=discogs_cache_pg,
             )

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -2927,14 +2927,18 @@ async def enrich_artwork_results(
             "release_year": year_result,
             "artist_bio": artist_bio,
             "wikipedia_url": wikipedia_url,
-            "spotify_url": spotify_url,
+            # spotify_url / bandcamp_url are normalized to None (like
+            # apple_music_url) so an empty-string streaming_links override
+            # (library.db returns the column verbatim, no '' -> None coercion) is
+            # treated as "absent" by the post-process active-filter (`is None`).
+            # Without this, "" skips the cache/probe leg AND either surfaces
+            # straight to the client (spotify has no fallback) or gets a search
+            # URL while the leg was skipped (bandcamp's deferred `not …`
+            # fallback). youtube / soundcloud aren't post-process services and
+            # overwrite "" with a search URL above, so they need no normalization.
+            "spotify_url": spotify_url or None,
             "apple_music_url": apple_music_override or apple_music_url or None,
             "youtube_music_url": youtube_music_url,
-            # Normalize to None (like apple_music_url) so an empty-string
-            # streaming_links override (library.db returns the column verbatim)
-            # is treated as "absent" by BOTH the post-process active-filter
-            # (`is None`) and the deferred search-URL fallback (`not …`). Without
-            # this, "" would skip the cache/probe leg yet still get a search URL.
             "bandcamp_url": bandcamp_url or None,
             "soundcloud_url": soundcloud_url,
         }

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -2930,7 +2930,12 @@ async def enrich_artwork_results(
             "spotify_url": spotify_url,
             "apple_music_url": apple_music_override or apple_music_url or None,
             "youtube_music_url": youtube_music_url,
-            "bandcamp_url": bandcamp_url,
+            # Normalize to None (like apple_music_url) so an empty-string
+            # streaming_links override (library.db returns the column verbatim)
+            # is treated as "absent" by BOTH the post-process active-filter
+            # (`is None`) and the deferred search-URL fallback (`not …`). Without
+            # this, "" would skip the cache/probe leg yet still get a search URL.
+            "bandcamp_url": bandcamp_url or None,
             "soundcloud_url": soundcloud_url,
         }
 

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import ValidationError
 from wxyc_fastapi.observability import RequestTelemetry, get_cache_stats, init_cache_stats
 
+from clients.bandcamp import BandcampClient
 from clients.streaming.apple_music import AppleMusicClient
 from clients.streaming.spotify import SpotifyClient
 from core.bulk_concurrency import (
@@ -44,7 +45,11 @@ from lookup.models import (
     LookupResponse,
 )
 from lookup.orchestrator import perform_lookup
-from streaming.dependencies import get_apple_music_client, get_spotify_client
+from streaming.dependencies import (
+    get_apple_music_client,
+    get_bandcamp_client,
+    get_spotify_client,
+)
 
 if TYPE_CHECKING:
     from posthog import Posthog
@@ -142,6 +147,7 @@ async def handle_lookup(
     posthog_client: Posthog | None = Depends(get_posthog_client),
     apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     spotify: SpotifyClient | None = Depends(get_spotify_client),
+    bandcamp: BandcampClient | None = Depends(get_bandcamp_client),
     skip_cache: bool = False,
     x_caller_budget_ms: int | None = Header(
         default=None,
@@ -179,6 +185,7 @@ async def handle_lookup(
             mb_pg=mb_pg,
             apple_music=apple_music,
             spotify=spotify,
+            bandcamp=bandcamp,
             discogs_cache_pg=discogs_cache_pg,
             caller_budget_ms=x_caller_budget_ms,
         )
@@ -253,6 +260,7 @@ async def handle_bulk_lookup(
     posthog_client: Posthog | None = Depends(get_posthog_client),
     apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     spotify: SpotifyClient | None = Depends(get_spotify_client),
+    bandcamp: BandcampClient | None = Depends(get_bandcamp_client),
     skip_cache: bool = False,
     x_caller_budget_ms: int | None = Header(
         default=None,
@@ -340,6 +348,7 @@ async def handle_bulk_lookup(
                         mb_pg=mb_pg,
                         apple_music=apple_music,
                         spotify=spotify,
+                        bandcamp=bandcamp,
                         discogs_cache_pg=discogs_cache_pg,
                         caller_budget_ms=x_caller_budget_ms,
                         # The 35k-album bulk drain must never trigger the LML#604

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -260,7 +260,9 @@ async def handle_bulk_lookup(
     posthog_client: Posthog | None = Depends(get_posthog_client),
     apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     spotify: SpotifyClient | None = Depends(get_spotify_client),
-    bandcamp: BandcampClient | None = Depends(get_bandcamp_client),
+    # No Bandcamp dependency on the bulk path — the Bandcamp leg is disabled
+    # here (bandcamp=None at the perform_lookup call below), so resolving its
+    # client would be dead work. See the call site for the rate-limit rationale.
     skip_cache: bool = False,
     x_caller_budget_ms: int | None = Header(
         default=None,
@@ -348,7 +350,16 @@ async def handle_bulk_lookup(
                         mb_pg=mb_pg,
                         apple_music=apple_music,
                         spotify=spotify,
-                        bandcamp=bandcamp,
+                        # Bandcamp is intentionally NOT forwarded on the bulk
+                        # path (LML#573 PR-3): its client is rate-limited to
+                        # 1 req/s, so a per-item live album probe would serialize
+                        # the 35k-album drain into hours of requests against
+                        # Bandcamp (and starve the shared singleton for the live
+                        # /lookup path). Passing None makes the post-process skip
+                        # the Bandcamp leg here; the search-URL fallback still
+                        # applies, and the offline warmer (#548) is the right tier
+                        # for bulk Bandcamp cache population.
+                        bandcamp=None,
                         discogs_cache_pg=discogs_cache_pg,
                         caller_budget_ms=x_caller_budget_ms,
                         # The 35k-album bulk drain must never trigger the LML#604

--- a/lookup/streaming_url_postprocess.py
+++ b/lookup/streaming_url_postprocess.py
@@ -71,6 +71,7 @@ from entity.streaming_url_cache import (
 from identity.release_validation import validate_and_canonicalize_external_id
 from lookup.timeouts import APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR, probe_timeout_s_from_env
 from release.apple_music_url_parser import apple_album_id_from_url
+from release.bandcamp_url_parser import bandcamp_album_id_from_url
 from release.spotify_url_parser import spotify_album_id_from_url
 
 if TYPE_CHECKING:
@@ -84,6 +85,14 @@ logger = logging.getLogger(__name__)
 # Bandcamp may run looser). A service whose entry also sets ``timeout_env_var``
 # can be retuned at request time via that env var (see _effective_probe_timeout_s).
 _DEFAULT_PROBE_TIMEOUT_S = 4.0
+
+# Bandcamp runs looser than the 4s default: its 1 req/s rate limit (and 2-way
+# concurrency cap) makes burst queue waits — not the HTTP round-trip — the
+# dominant cost, so a tight ceiling would time out healthy probes under load.
+# Ships at 9.0 without the offline pre-warmer; drops to ``_DEFAULT_PROBE_TIMEOUT_S``
+# once #548's warmer populates the cache ahead of the hot path
+# (WXYC/library-metadata-lookup#573).
+_BANDCAMP_PROBE_TIMEOUT_S = 9.0
 
 
 @dataclass(frozen=True)
@@ -120,11 +129,11 @@ class StreamingUrlCacheConfig:
 # Cache + post-process registry. Deliberately a SUBSET of
 # ``identity.release_validation.RELEASE_SOURCE_CONFIG`` (5 entries): Discogs
 # release/master are identity-only (never resolved from a live streaming
-# probe), and Bandcamp is identity-mintable but only joins the cache config in
-# PR-3. Only Apple + Spotify are both minted-from-live-probe AND URL-cached in
-# PR-1. The parity test asserts these keys ⊆ RELEASE_SOURCE_CONFIG keys; the
-# completeness guard in the test suite pins the exact key set. PR-3 ALTERs the
-# table's named CHECK constraint and adds 'bandcamp' + 'deezer_album' here.
+# probe). Apple + Spotify (PR-1) and Bandcamp (PR-3) are all
+# minted-from-live-probe AND URL-cached. The parity test asserts these keys ⊆
+# RELEASE_SOURCE_CONFIG keys; the completeness guard in the test suite pins the
+# exact key set. A future PR adds Deezer ('deezer_album') here and ALTERs the
+# table's named CHECK constraint to match.
 STREAMING_URL_CACHE_CONFIG: dict[str, StreamingUrlCacheConfig] = {
     "apple_music_album": StreamingUrlCacheConfig(
         miss_ttl=DEFAULT_MISS_TTL,
@@ -144,6 +153,17 @@ STREAMING_URL_CACHE_CONFIG: dict[str, StreamingUrlCacheConfig] = {
         url_field="spotify_url",
         client_attr="spotify",
         flag_setting="lml_persist_streaming_url_spotify",
+    ),
+    "bandcamp": StreamingUrlCacheConfig(
+        miss_ttl=DEFAULT_MISS_TTL,
+        # Looser ceiling than Apple/Spotify — see _BANDCAMP_PROBE_TIMEOUT_S.
+        probe_timeout_s=_BANDCAMP_PROBE_TIMEOUT_S,
+        # Bandcamp's external_id IS the canonical album URL (no opaque ID); the
+        # extractor returns the parser-canonical URL the validator expects.
+        url_to_external_id=bandcamp_album_id_from_url,
+        url_field="bandcamp_url",
+        client_attr="bandcamp",
+        flag_setting="lml_persist_streaming_url_bandcamp",
     ),
 }
 

--- a/release/bandcamp_url_parser.py
+++ b/release/bandcamp_url_parser.py
@@ -1,0 +1,39 @@
+"""Bandcamp album-URL canonicalization.
+
+Companion to ``release.apple_music_url_parser`` and
+``release.spotify_url_parser``: the streaming-URL cache post-process
+(``lookup/streaming_url_postprocess.py``) mints
+``entity.release_identity.bandcamp_album_url`` from a freshly-resolved Bandcamp
+album URL, and the ``bandcamp`` registry entry's ``url_to_external_id``
+extractor is this function.
+
+Unlike Apple / Spotify — whose external_id is a numeric / base62 ID extracted
+*from* the URL — Bandcamp has no opaque ID: the canonical album URL itself is
+the identity (the ``bandcamp_album_url TEXT UNIQUE`` column). So this returns
+the *canonical URL* (lowercased host, trailing slash stripped, query / fragment
+dropped) rather than a sub-string ID, and surfaces a non-Bandcamp / malformed
+URL as ``None`` so the post-process skips the mint.
+
+Parsing is delegated to ``release.url_parser.parse_url`` — the same parser the
+identity validator (``identity.release_validation._validate_bandcamp_album_url``)
+canonicalizes against — so the form this emits round-trips through the validator
+without drift.
+"""
+
+from __future__ import annotations
+
+from release.url_parser import parse_url
+
+
+def bandcamp_album_id_from_url(url: str) -> str | None:
+    """``<artist>.bandcamp.com/album/<slug>`` → canonical album URL, else ``None``.
+
+    Returns the canonical Bandcamp album URL (the entity's external_id) on a
+    valid album URL, or ``None`` for a non-Bandcamp host, a non-album path, or
+    malformed input — the caller treats ``None`` as "URL did not carry an
+    extractable Bandcamp identity" and skips the mint rather than raising.
+    """
+    parsed = parse_url(url)
+    if parsed is None or parsed.source != "bandcamp":
+        return None
+    return parsed.identifier

--- a/tests/integration/test_streaming_url_persistent_lookup.py
+++ b/tests/integration/test_streaming_url_persistent_lookup.py
@@ -41,6 +41,7 @@ from streaming.models import SourceMatch
 _SERVICE_CASES = [
     ("apple_music_album", "https://music.apple.com/us/album/aluminum-tunes/1234567890"),
     ("spotify_album", "https://open.spotify.com/album/1A2GTWGt0LBTGQAyA3OKAf"),
+    ("bandcamp", "https://juanamolina.bandcamp.com/album/doga"),
 ]
 
 
@@ -92,7 +93,7 @@ class TestSchemaBootstrap:
 
     @pytest.mark.asyncio
     async def test_named_check_constraint_rejects_unknown_service(self, pg_pool):
-        # The CHECK must actually fire for a service outside the PR-1 set.
+        # The CHECK must actually fire for a service outside the shipped set.
         with pytest.raises(asyncpg.PostgresError):
             async with pg_pool.acquire() as conn:
                 await conn.execute(
@@ -100,6 +101,51 @@ class TestSchemaBootstrap:
                     "(service, artist_normalized, album_normalized, url) "
                     "VALUES ('deezer_album', 'x', 'y', 'https://example.test')"
                 )
+
+    @pytest.mark.asyncio
+    async def test_alter_widens_check_on_preexisting_table(self, pg_pool, pg_source):
+        # The production migration path: a prod table frozen at the pre-bandcamp
+        # service set must pick up 'bandcamp' on the next boot. CREATE TABLE IF
+        # NOT EXISTS is a no-op on the existing table; the idempotent ALTER is
+        # what widens the named CHECK in place.
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS lml_cache CASCADE")
+            await conn.execute("CREATE SCHEMA lml_cache")
+            await conn.execute(
+                "CREATE TABLE lml_cache.album_streaming_url_cache ("
+                "  service TEXT NOT NULL,"
+                "  artist_normalized TEXT NOT NULL,"
+                "  album_normalized TEXT NOT NULL,"
+                "  url TEXT,"
+                "  last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),"
+                "  PRIMARY KEY (service, artist_normalized, album_normalized),"
+                "  CONSTRAINT album_streaming_url_cache_service_valid CHECK ("
+                "    service IN ('apple_music_album', 'spotify_album')"
+                "  )"
+                ")"
+            )
+
+        # Pre-ALTER: bandcamp violates the frozen constraint.
+        with pytest.raises(asyncpg.PostgresError):
+            async with pg_pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO lml_cache.album_streaming_url_cache "
+                    "(service, artist_normalized, album_normalized, url) "
+                    "VALUES ('bandcamp', 'x', 'y', 'https://x.bandcamp.com/album/y')"
+                )
+
+        # Re-boot: the ALTER widens the CHECK so bandcamp now inserts.
+        await set_up_streaming_url_cache_schema(pg_source)
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO lml_cache.album_streaming_url_cache "
+                "(service, artist_normalized, album_normalized, url) "
+                "VALUES ('bandcamp', 'x', 'y', 'https://x.bandcamp.com/album/y')"
+            )
+            row = await conn.fetchrow(
+                "SELECT url FROM lml_cache.album_streaming_url_cache WHERE service = 'bandcamp'"
+            )
+        assert row["url"] == "https://x.bandcamp.com/album/y"
 
 
 @pytest.mark.pg

--- a/tests/unit/test_bandcamp_url_parser.py
+++ b/tests/unit/test_bandcamp_url_parser.py
@@ -1,0 +1,64 @@
+"""Unit tests for ``release.bandcamp_url_parser.bandcamp_album_id_from_url``.
+
+The lookup post-process mints ``entity.release_identity.bandcamp_album_url``
+from a freshly-resolved Bandcamp album URL. The cache registry's
+``url_to_external_id`` extractor for the ``bandcamp`` service is this parser.
+
+Unlike Apple / Spotify — whose external_id is an *ID extracted from* the URL —
+Bandcamp's external_id IS the canonical album URL itself (the
+``bandcamp_album_url TEXT UNIQUE`` identity column). So the extractor returns
+the parser's canonical form (lowercased host, trailing slash stripped, query /
+fragment dropped) so two callers passing equivalent URLs collapse onto the same
+``entity.release_identity`` row — and a non-Bandcamp / malformed URL surfaces as
+``None`` (the post-process then skips the mint rather than poisoning the graph).
+
+This shares its parsing with ``release.url_parser.parse_url`` (the same parser
+``identity._validate_bandcamp_album_url`` validates against), so the canonical
+form the extractor emits round-trips cleanly through the validator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from release.bandcamp_url_parser import bandcamp_album_id_from_url
+
+# Canonical Bandcamp album URL (WXYC freeform default: Juana Molina / DOGA).
+_CANONICAL = "https://juanamolina.bandcamp.com/album/doga"
+
+
+class TestBandcampAlbumIdFromUrl:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            # Already-canonical album URL — the shape the resolver surfaces.
+            (_CANONICAL, _CANONICAL),
+            # Trailing slash is stripped to the canonical form.
+            (f"{_CANONICAL}/", _CANONICAL),
+            # Query string / fragment are dropped.
+            (f"{_CANONICAL}?from=search", _CANONICAL),
+            (f"{_CANONICAL}#track", _CANONICAL),
+            # Mixed-case host lowercases to the canonical form.
+            ("https://JuanaMolina.bandcamp.com/album/doga", _CANONICAL),
+        ],
+    )
+    def test_returns_canonical_url_for_bandcamp_album(self, url, expected):
+        assert bandcamp_album_id_from_url(url) == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Not an album path (artist root / track / music index).
+            "https://juanamolina.bandcamp.com",
+            "https://juanamolina.bandcamp.com/track/doga",
+            "https://juanamolina.bandcamp.com/music",
+            # Wrong host — a /album/ path on another domain must not match.
+            "https://example.com/album/doga",
+            # Discogs URL parses to a non-bandcamp source — not our concern.
+            "https://www.discogs.com/release/123456",
+            "",
+            "not a url",
+        ],
+    )
+    def test_returns_none_for_non_bandcamp_album(self, url):
+        assert bandcamp_album_id_from_url(url) is None

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -135,6 +135,30 @@ class TestBulkLookupEndpoint:
         assert mock_lookup.await_args.kwargs.get("allow_release_resolution_fallback") is False
 
     @pytest.mark.asyncio
+    async def test_bulk_does_not_forward_bandcamp_client(self, app_client):
+        """The bulk drain must NOT run the Bandcamp leg: its client is rate-
+        limited to 1 req/s, so a per-item live probe would serialize a 35k-album
+        drain into hours of requests against Bandcamp. The handler passes
+        bandcamp=None so the post-process skips the Bandcamp leg on bulk (the
+        search-URL fallback still applies). LML#573 PR-3."""
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_no_match_response(),
+        ) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={"items": [{"artist": "Juana Molina", "album": "DOGA"}]},
+                )
+
+        assert resp.status_code == 200
+        assert mock_lookup.await_count == 1
+        assert mock_lookup.await_args.kwargs.get("bandcamp") is None
+
+    @pytest.mark.asyncio
     async def test_results_preserve_input_order(self, app_client):
         """Even with mixed match/no_match/error, response[i] corresponds to request[i]."""
 

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -3658,6 +3658,39 @@ class TestBandcampStreamingUrlPostprocessWiring:
         assert captured["bandcamp_url_at_call"] is None
 
     @pytest.mark.asyncio
+    async def test_empty_string_spotify_link_normalized_to_none(self):
+        # Same empty-string asymmetry for spotify_url: it is a post-process
+        # service (spotify_album) whose templated search fallback was deleted in
+        # PR-1, so an un-normalized '' would skip the cache/probe leg AND surface
+        # the empty string straight to the client. Normalizing to None lets the
+        # post-process leg run and prevents the bare '' from leaking.
+        item = make_library_item(id=42, artist="Juana Molina", title="DOGA")
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": "",
+                "apple_music_url": None,
+                "youtube_music_url": None,
+                "bandcamp_url": None,
+                "soundcloud_url": None,
+            }
+        )
+
+        # Real post-process is a no-op here (no pg / entity_store passed), so the
+        # surfaced spotify_url reflects only the update-dict normalization.
+        results = await enrich_artwork_results(
+            [(item, None)],
+            AsyncMock(),
+            song="la paradoja",
+            album="DOGA",
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched.spotify_url is None
+
+    @pytest.mark.asyncio
     async def test_search_fallback_applies_when_postprocess_leaves_url_none(self):
         # Post-process is a no-op (flag off / cache miss / client absent); the
         # deferred search-URL fallback still fills bandcamp_url.

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -3618,6 +3618,46 @@ class TestBandcampStreamingUrlPostprocessWiring:
         assert enriched.bandcamp_url == album_url
 
     @pytest.mark.asyncio
+    async def test_empty_string_streaming_link_normalized_to_none_for_postprocess(self):
+        # A librarian-curated streaming_links row can carry an empty-string
+        # bandcamp_url (library.db returns the column verbatim, no '' -> None
+        # coercion). It must be normalized to None in the `update` dict so the
+        # post-process active-filter (`is None`) and the deferred search-URL
+        # fallback (`not …`) agree: an empty string must NOT silently disable
+        # the cache/probe leg while still triggering the search fallback.
+        item = make_library_item(id=42, artist="Juana Molina", title="DOGA")
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": None,
+                "apple_music_url": None,
+                "youtube_music_url": None,
+                "bandcamp_url": "",
+                "soundcloud_url": None,
+            }
+        )
+        captured = {}
+
+        async def _capture(update, **kwargs):
+            captured["bandcamp_url_at_call"] = update["bandcamp_url"]
+
+        with patch(
+            "lookup.orchestrator.apply_streaming_url_postprocess",
+            new=AsyncMock(side_effect=_capture),
+        ):
+            await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                song="la paradoja",
+                album="DOGA",
+                bandcamp=AsyncMock(),
+                library_db=library_db,
+            )
+
+        assert captured["bandcamp_url_at_call"] is None
+
+    @pytest.mark.asyncio
     async def test_search_fallback_applies_when_postprocess_leaves_url_none(self):
         # Post-process is a no-op (flag off / cache miss / client absent); the
         # deferred search-URL fallback still fills bandcamp_url.

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -3547,3 +3547,93 @@ class TestSiblingOverrideProbeDivergence:
         # Probe gave no contradicting signal — override survives.
         assert enriched.spotify_url == override_spotify
         assert enriched.apple_music_url == override_apple
+
+
+class TestBandcampStreamingUrlPostprocessWiring:
+    """LML#573 PR-3: the orchestrator must thread the Bandcamp client into the
+    streaming-URL cache post-process, AND defer Bandcamp's templated search-URL
+    fallback until *after* the post-process so a resolved album page wins over
+    the generic search link (the post-process only fires when the field is
+    ``None``, so a pre-filled search URL would silently disable the leg)."""
+
+    @pytest.mark.asyncio
+    async def test_bandcamp_client_threaded_into_postprocess_clients(self):
+        item = make_library_item(artist="Juana Molina", title="DOGA")
+        bandcamp = AsyncMock()
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock(return_value=None)
+        apple_music.find_track_url = AsyncMock(return_value=None)
+        spotify = AsyncMock()
+
+        with patch(
+            "lookup.orchestrator.apply_streaming_url_postprocess",
+            new=AsyncMock(),
+        ) as postprocess:
+            await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                song="la paradoja",
+                album="DOGA",
+                apple_music=apple_music,
+                spotify=spotify,
+                bandcamp=bandcamp,
+            )
+
+        postprocess.assert_awaited_once()
+        clients = postprocess.await_args.kwargs["clients"]
+        assert clients["bandcamp"] is bandcamp
+        assert clients["apple_music"] is apple_music
+        assert clients["spotify"] is spotify
+
+    @pytest.mark.asyncio
+    async def test_postprocess_sees_bandcamp_url_none_then_resolved_url_wins(self):
+        # The post-process's active-filter only fires for a service whose URL
+        # field is ``None``. If the templated search fallback pre-filled
+        # bandcamp_url, the leg would be silently disabled — so the field MUST
+        # still be None when the post-process runs. Capture it at call time to
+        # pin the ordering, then resolve a real album page and assert it wins.
+        item = make_library_item(artist="Juana Molina", title="DOGA")
+        album_url = "https://juanamolina.bandcamp.com/album/doga"
+        captured = {}
+
+        async def _resolve(update, **kwargs):
+            captured["bandcamp_url_at_call"] = update["bandcamp_url"]
+            update["bandcamp_url"] = album_url
+
+        with patch(
+            "lookup.orchestrator.apply_streaming_url_postprocess",
+            new=AsyncMock(side_effect=_resolve),
+        ):
+            results = await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                song="la paradoja",
+                album="DOGA",
+                bandcamp=AsyncMock(),
+            )
+
+        # Ordering invariant: the search fallback had not yet run.
+        assert captured["bandcamp_url_at_call"] is None
+        _, enriched = results[0]
+        assert enriched.bandcamp_url == album_url
+
+    @pytest.mark.asyncio
+    async def test_search_fallback_applies_when_postprocess_leaves_url_none(self):
+        # Post-process is a no-op (flag off / cache miss / client absent); the
+        # deferred search-URL fallback still fills bandcamp_url.
+        item = make_library_item(artist="Juana Molina", title="DOGA")
+
+        with patch(
+            "lookup.orchestrator.apply_streaming_url_postprocess",
+            new=AsyncMock(),
+        ):
+            results = await enrich_artwork_results(
+                [(item, None)],
+                AsyncMock(),
+                song="la paradoja",
+                album="DOGA",
+            )
+
+        _, enriched = results[0]
+        assert enriched.bandcamp_url is not None
+        assert enriched.bandcamp_url.startswith("https://bandcamp.com/search?q=")

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -180,6 +180,44 @@ class TestHandleLookup:
         assert mock_lookup.await_args.kwargs.get("caller_budget_ms") is None
 
     @pytest.mark.asyncio
+    async def test_bandcamp_client_forwarded_to_perform_lookup(
+        self, mock_db, mock_discogs, mock_settings
+    ):
+        """LML#573 PR-3: the Bandcamp client dependency must flow into
+        perform_lookup so the streaming-URL cache post-process can run the
+        Bandcamp leg. Without this the leg is dead even with the flag on.
+        """
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from main import app
+        from streaming.dependencies import get_bandcamp_client
+
+        sentinel = object()
+        response = LookupResponse(results=[], search_type="direct")
+
+        with (
+            override_deps(
+                app,
+                {
+                    get_library_db: mock_db,
+                    get_discogs_service: mock_discogs,
+                    get_posthog_client: None,
+                    get_settings: mock_settings,
+                    get_bandcamp_client: sentinel,
+                },
+            ),
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        assert mock_lookup.await_args.kwargs.get("bandcamp") is sentinel
+
+    @pytest.mark.asyncio
     async def test_extended_flag_forwarded_to_perform_lookup(self, app_client):
         """When the request body sets extended=true, the LookupRequest carried
         into perform_lookup must reflect that. The router is a thin layer;

--- a/tests/unit/test_lookup_streaming_url_postprocess.py
+++ b/tests/unit/test_lookup_streaming_url_postprocess.py
@@ -60,6 +60,7 @@ _CASES: dict[str, dict] = {
         "url_field": "apple_music_url",
         "client_attr": "apple_music",
         "flag_setting": "lml_persist_streaming_url_apple_music",
+        "probe_timeout_s": 4.0,
         "resolved_url": "https://music.apple.com/us/album/foo/1234567890",
         "external_id": "1234567890",
         # Matches the parser's \d{6,} floor but fails the validator's
@@ -70,10 +71,27 @@ _CASES: dict[str, dict] = {
         "url_field": "spotify_url",
         "client_attr": "spotify",
         "flag_setting": "lml_persist_streaming_url_spotify",
+        "probe_timeout_s": 4.0,
         "resolved_url": "https://open.spotify.com/album/1A2GTWGt0LBTGQAyA3OKAf",
         "external_id": "1A2GTWGt0LBTGQAyA3OKAf",
         # No numeric/22-char ID to parse — surfaces URL, skips mint.
         "unmintable_but_parseable_url": "https://open.spotify.com/album/short",
+    },
+    "bandcamp": {
+        "url_field": "bandcamp_url",
+        "client_attr": "bandcamp",
+        "flag_setting": "lml_persist_streaming_url_bandcamp",
+        # Looser than Apple/Spotify (4.0): Bandcamp's 1 req/s rate limit makes
+        # burst queue waits the dominant cost; tightened to 4.0 once the offline
+        # warmer (#548) lands. See WXYC/library-metadata-lookup#573.
+        "probe_timeout_s": 9.0,
+        # Bandcamp's external_id IS the canonical album URL (no opaque ID), so
+        # resolved_url == external_id after canonicalization.
+        "resolved_url": "https://juanamolina.bandcamp.com/album/doga",
+        "external_id": "https://juanamolina.bandcamp.com/album/doga",
+        # A non-Bandcamp URL: the extractor returns None (parse_url rejects the
+        # host) so the URL surfaces but the mint is skipped.
+        "unmintable_but_parseable_url": "https://example.com/album/doga",
     },
 }
 
@@ -87,6 +105,7 @@ def _settings(*enabled_services: str, master: bool = True) -> SimpleNamespace:
         "lml_persist_streaming_urls": master,
         "lml_persist_streaming_url_apple_music": False,
         "lml_persist_streaming_url_spotify": False,
+        "lml_persist_streaming_url_bandcamp": False,
     }
     for service in enabled_services:
         flags[_FLAG_BY_SERVICE[service]] = True
@@ -583,26 +602,31 @@ class TestSentryProjection:
 
 
 class TestRegistryInvariants:
-    """The cache registry is the 2-entry subset; guards keep it from drifting."""
+    """The cache registry is a subset of the identity registry; guards keep it
+    from drifting."""
 
     def test_parametrize_keys_match_cache_config(self):
         assert set(_CASES) == set(STREAMING_URL_CACHE_CONFIG.keys())
 
     def test_cache_config_is_subset_of_release_source_config(self):
-        # PR-1 parity invariant: every cached service must be identity-mintable.
+        # Parity invariant: every cached service must be identity-mintable.
         assert set(STREAMING_URL_CACHE_CONFIG.keys()) <= set(RELEASE_SOURCE_CONFIG.keys())
 
     def test_cache_config_matches_table_check_constraint_allowlist(self):
         # The cache table's named CHECK constraint pins the allowed ``service``
-        # values from ``_PR1_SERVICES``. A registry service NOT in that
-        # allowlist would fail every UPSERT at runtime; an allowlist value with
-        # no registry entry would be dead. Lock them together.
-        from entity.streaming_url_cache import _PR1_SERVICES
+        # values from ``_SERVICES``. A registry service NOT in that allowlist
+        # would fail every UPSERT at runtime; an allowlist value with no
+        # registry entry would be dead. Lock them together.
+        from entity.streaming_url_cache import _SERVICES
 
-        assert set(STREAMING_URL_CACHE_CONFIG.keys()) == set(_PR1_SERVICES)
+        assert set(STREAMING_URL_CACHE_CONFIG.keys()) == set(_SERVICES)
 
-    def test_cache_config_ships_exactly_apple_and_spotify(self):
-        assert set(STREAMING_URL_CACHE_CONFIG.keys()) == {"apple_music_album", "spotify_album"}
+    def test_cache_config_ships_apple_spotify_and_bandcamp(self):
+        assert set(STREAMING_URL_CACHE_CONFIG.keys()) == {
+            "apple_music_album",
+            "spotify_album",
+            "bandcamp",
+        }
 
     @pytest.mark.parametrize("service", list(_CASES))
     def test_cache_config_fields_match_expectations(self, service):
@@ -611,7 +635,7 @@ class TestRegistryInvariants:
         assert cfg.url_field == case["url_field"]
         assert cfg.client_attr == case["client_attr"]
         assert cfg.flag_setting == case["flag_setting"]
-        assert cfg.probe_timeout_s == 4.0
+        assert cfg.probe_timeout_s == case["probe_timeout_s"]
         # The service key doubles as the mint source; the subset invariant
         # (test_cache_config_is_subset_of_release_source_config) guarantees it
         # keys into RELEASE_SOURCE_CONFIG, so there's no mint_source field.
@@ -648,6 +672,18 @@ class TestPerServiceTimeoutResolution:
     def test_spotify_entry_has_no_env_var(self):
         # New service — no back-compat env knob; static per-service default.
         assert STREAMING_URL_CACHE_CONFIG["spotify_album"].timeout_env_var is None
+
+    def test_bandcamp_entry_has_no_env_var(self):
+        # New service — no back-compat env knob; static per-service default.
+        assert STREAMING_URL_CACHE_CONFIG["bandcamp"].timeout_env_var is None
+
+    def test_bandcamp_effective_timeout_is_static_nine_seconds(self, monkeypatch):
+        from lookup.timeouts import APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR
+
+        # Apple's env must not bleed into Bandcamp; its ceiling stays the loose
+        # 9.0s static default (tightened once the offline warmer lands).
+        monkeypatch.setenv(APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR, "1500")
+        assert mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG["bandcamp"]) == 9.0
 
     def test_apple_effective_timeout_honors_env_override(self, monkeypatch):
         from lookup.timeouts import APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR

--- a/tests/unit/test_streaming_url_cache_schema.py
+++ b/tests/unit/test_streaming_url_cache_schema.py
@@ -44,26 +44,28 @@ class TestCanonicalDDLReference:
     def test_has_named_check_constraint(self):
         ddl = _SQL_REFERENCE.read_text()
         assert "CONSTRAINT album_streaming_url_cache_service_valid CHECK" in ddl
-        # PR-1 ships exactly Apple + Spotify in the constraint.
+        # PR-3 ships Apple + Spotify + Bandcamp in the constraint.
         assert "'apple_music_album'" in ddl
         assert "'spotify_album'" in ddl
+        assert "'bandcamp'" in ddl
 
-    def test_check_constraint_allowlist_matches_pr1_services(self):
+    def test_check_constraint_allowlist_matches_services(self):
         # The .sql is a hand-maintained mirror of the runtime DDL, which
-        # generates its IN-list from ``_PR1_SERVICES``. A substring check would
-        # stay green if PR-3 edited ``_PR1_SERVICES`` but forgot the .sql; parse
-        # the IN-list and assert exact-set equality so the mirror can't drift.
+        # generates its IN-list from ``_SERVICES``. A substring check would stay
+        # green if a future PR edited ``_SERVICES`` but forgot the .sql; parse
+        # the first IN-list (the CREATE TABLE CHECK) and assert exact-set
+        # equality so the mirror can't drift.
         import re
 
-        from entity.streaming_url_cache import _PR1_SERVICES
+        from entity.streaming_url_cache import _SERVICES
 
         ddl = _SQL_REFERENCE.read_text()
         match = re.search(r"service\s+IN\s*\(([^)]*)\)", ddl)
         assert match is not None, "CHECK constraint IN-list not found in the .sql reference"
         sql_services = set(re.findall(r"'([^']+)'", match.group(1)))
-        assert sql_services == set(_PR1_SERVICES), (
-            f".sql CHECK allowlist {sql_services} drifted from _PR1_SERVICES "
-            f"{set(_PR1_SERVICES)} — update entity/streaming_url_cache.sql"
+        assert sql_services == set(_SERVICES), (
+            f".sql CHECK allowlist {sql_services} drifted from _SERVICES "
+            f"{set(_SERVICES)} — update entity/streaming_url_cache.sql"
         )
 
     def test_has_composite_primary_key(self):
@@ -75,20 +77,60 @@ class TestCanonicalDDLReference:
 class TestSetUpStreamingUrlCacheSchema:
     """``set_up_streaming_url_cache_schema`` runs exactly the idempotent DDL."""
 
-    async def test_creates_schema_then_table(self):
+    async def test_creates_schema_table_then_alters_check(self):
         pg = AsyncMock(spec=PgSource)
         pg.execute = AsyncMock(return_value="CREATE")
 
         await set_up_streaming_url_cache_schema(pg)
 
-        # Exactly two executes — schema, then table. No backfill.
-        assert pg.execute.await_count == 2
+        # Exactly three executes — schema, table, then the idempotent CHECK
+        # ALTER (so a pre-existing prod table picks up new service values that
+        # CREATE TABLE IF NOT EXISTS cannot add). No backfill.
+        assert pg.execute.await_count == 3
         schema_sql = pg.execute.await_args_list[0].args[0]
         table_sql = pg.execute.await_args_list[1].args[0]
+        alter_sql = pg.execute.await_args_list[2].args[0]
         assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in schema_sql
         assert "CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache" in table_sql
         assert "CONSTRAINT album_streaming_url_cache_service_valid CHECK" in table_sql
         assert "PRIMARY KEY (service, artist_normalized, album_normalized)" in table_sql
+        assert "ALTER TABLE lml_cache.album_streaming_url_cache" in alter_sql
+        assert "DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid" in alter_sql
+        assert "ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK" in alter_sql
+
+    async def test_alter_check_admits_the_full_service_set(self):
+        # The ALTER's IN-list must carry every ``_SERVICES`` value (including
+        # bandcamp) so an existing prod table gets the widened allowlist.
+        import re
+
+        from entity.streaming_url_cache import _SERVICES
+
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="ALTER")
+
+        await set_up_streaming_url_cache_schema(pg)
+
+        alter_sql = pg.execute.await_args_list[2].args[0]
+        in_list = re.search(r"ADD CONSTRAINT.*?service\s+IN\s*\(([^)]*)\)", alter_sql, re.DOTALL)
+        assert in_list is not None, "ADD CONSTRAINT IN-list not found in the ALTER"
+        alter_services = set(re.findall(r"'([^']+)'", in_list.group(1)))
+        assert alter_services == set(_SERVICES)
+        assert "bandcamp" in alter_services
+
+    async def test_bootstrap_is_idempotent(self):
+        # Re-running the bootstrap issues the byte-identical DDL each time: the
+        # DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT pair is a safe no-op on a
+        # table whose constraint already matches.
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="ALTER")
+
+        await set_up_streaming_url_cache_schema(pg)
+        first = [call.args[0] for call in pg.execute.await_args_list]
+        pg.execute.reset_mock()
+        await set_up_streaming_url_cache_schema(pg)
+        second = [call.args[0] for call in pg.execute.await_args_list]
+
+        assert first == second
 
     async def test_does_not_probe_or_backfill_the_old_apple_table(self):
         # Regression guard for #573 PR-2: the grandfathered


### PR DESCRIPTION
## What

Wires **Bandcamp** into the polymorphic `lml_cache.album_streaming_url_cache` post-process — the third service after Apple Music + Spotify (PR-1, #597). With `LML_PERSIST_STREAMING_URL_BANDCAMP` + the master `LML_PERSIST_STREAMING_URLS` both on, `/lookup` runs a cache-backed Bandcamp album probe with the **request's** `(artist, album)`, persists the result so future lookups short-circuit the upstream API, and mints the canonical album URL into `entity.release_identity.bandcamp_album_url` on live resolutions.

## Why it's more than a one-line registry add

- **Bandcamp's external_id IS the canonical album URL** (no opaque ID), so `release/bandcamp_url_parser.py` reuses `release.url_parser.parse_url` to emit the same canonical form the identity validator expects — round-tripping cleanly through `validate_and_canonicalize_external_id`.
- **Looser 9.0s probe ceiling** (vs the 4.0s default): Bandcamp's 1 req/s rate limit makes burst queue waits the dominant cost. Drops to 4.0s once the offline warmer (#548) lands.
- **Idempotent CHECK `ALTER`**: `CREATE TABLE IF NOT EXISTS` can't widen an already-created prod table's named constraint, so the bootstrap now issues `ALTER … DROP CONSTRAINT IF EXISTS … ADD CONSTRAINT …`. Both the CREATE-time CHECK and the ALTER are generated from one `_SERVICES` tuple (renamed from `_PR1_SERVICES`) so they can't drift. LML-owned `lml_cache.*` → lifespan-bootstrapped, no alembic.
- **Deferred search-URL fallback** (the load-bearing subtlety): the post-process active-filter only fires when its URL field is `None`. Bandcamp's templated `https://bandcamp.com/search?q=` fallback pre-filled `bandcamp_url` for nearly every result, which would have silently disabled the leg. The search URL is now applied *after* the post-process, only when the cache/probe (and any librarian `streaming_links` override) leaves it empty. Priority: **direct link > cache/probe > search URL**.
- Client threaded `router → perform_lookup → enrich_artwork_results → clients={…, "bandcamp": …}` on both `/lookup` and `/lookup/bulk`.

## Tests (TDD throughout)

- `tests/unit/test_bandcamp_url_parser.py` — canonicalization + rejection of non-Bandcamp/malformed URLs.
- `test_lookup_streaming_url_postprocess.py` — Bandcamp resolve/persist/mint, skip conditions, registry invariants, 9.0s ceiling.
- `test_streaming_url_cache_schema.py` — CHECK admits `bandcamp`; the bootstrap `ALTER` is idempotent.
- `test_enrichment.py` — client threaded into the post-process; search fallback deferred (the post-process sees `bandcamp_url=None`) and only applied on a miss.
- `test_lookup_router.py` — Bandcamp client forwarded into `perform_lookup`.
- `tests/integration/test_streaming_url_persistent_lookup.py` (`-m pg`) — Bandcamp round-trip + the `ALTER` widening a pre-existing frozen table, against real PostgreSQL.

Local: `ruff check`/`format` clean, full unit suite green, `-m pg` suite green (21 passed against a local PG 16).

## Scope

Bandcamp only. **Deezer** stays out — double-blocked on a `wxyc-shared` `deezer_url` field and an `entity.release_identity.deezer_album_id` column (the three-repo dance); its sparse-row guard prerequisite already landed in #640.

Closes #643. Part of #573 · epic #595. (Does **not** close #573 — Deezer remains.)
