### PR TITLE
fix(#640): harden streaming extractor guard — total-failure re-raise + AttributeError

### DIFF
--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -409,18 +409,33 @@ def record_match_telemetry(
         logger.warning("Failed to emit matcher telemetry: %s", e)
 
 
-# Adapter extractors subscript raw API dicts directly (e.g. Spotify's
-# ``x["artists"][0]["name"]``, Deezer's ``x["artist"]["name"]``). A sparse or
-# malformed upstream row — a missing key, an empty ``artists`` list, a null
-# where a dict is expected — makes one of them raise mid-loop. Without a
-# per-item guard that exception propagates out of the matcher and aborts the
-# whole match, erasing every well-formed row in the same response (LML#640).
-# The guard catches exactly these extraction-shaped errors and skips the one
-# bad row; a genuine programming error in an extractor (e.g. calling a
-# non-callable) is not in this set and still surfaces loudly rather than being
-# silently swallowed for every row. Kept narrow on purpose — it wraps only the
-# extractor calls, never the scoring.
-_EXTRACTION_ERRORS = (KeyError, IndexError, TypeError)
+# Adapter extractors pull fields out of raw upstream rows either by subscripting
+# (Spotify's ``x["artists"][0]["name"]``, Deezer's ``x["artist"]["name"]``) or by
+# attribute access (the orchestrator's ``lambda r: r.artist`` over a
+# ``DiscogsSearchResult``). A sparse or malformed row makes one of them raise
+# mid-loop, and these four exception types ARE those extraction shapes: KeyError
+# (missing key), IndexError (empty ``artists`` list), TypeError (subscripting a
+# null), AttributeError (attribute on None / wrong type — the failure mode of the
+# attribute-style extractors that the typed matcher's real callers pass). Without
+# a guard the exception aborts the whole match and erases every well-formed row in
+# the same response (LML#640).
+#
+# The guard skips one offending row. It deliberately does NOT try to tell a
+# "sparse upstream row" apart from a "buggy extractor" by exception type — both
+# raise the same types, so that split is undecidable per row.
+#
+# The two matchers then diverge on what a *total* failure means, because they
+# feed different pipelines:
+#   - ``find_best_match`` feeds the streaming-check path, which HAS an
+#     errored-source retry channel (``streaming/orchestrator.py``, LML#376). So
+#     if EVERY row fails extraction — a systemic break, not a sparse row — it
+#     re-raises; the orchestrator marks the source errored and retries instead
+#     of persisting a definitive no-match.
+#   - ``find_best_typed_match`` feeds the lookup pipeline, which has no such
+#     channel (a raise there 500s the request or is swallowed back to None). So
+#     it never re-raises: a wholesale-malformed response degrades to a graceful
+#     ``None`` and the pipeline falls through.
+_EXTRACTION_ERRORS = (KeyError, IndexError, TypeError, AttributeError)
 
 
 def find_best_match(
@@ -440,6 +455,11 @@ def find_best_match(
     highest-scoring result as a dict with url, confidence, matched_artist,
     matched_title, and optionally id.
 
+    A row whose extractor raises an extraction-shaped error (see
+    ``_EXTRACTION_ERRORS``) is skipped and logged rather than aborting the whole
+    match (LML#640) — except when *every* row fails, which re-raises (see
+    Raises).
+
     Args:
         results: Raw result dicts from a streaming service API.
         query_artist: Artist name to match against.
@@ -451,10 +471,21 @@ def find_best_match(
 
     Returns:
         Best match dict, or None if no acceptable match found.
+
+    Raises:
+        KeyError | IndexError | TypeError | AttributeError: when a non-empty
+        ``results`` is passed and *every* row fails extraction — a systemic
+        break (upstream shape change or broken extractor), surfaced so the
+        caller can treat the source as errored and retry (LML#376) rather than
+        record a definitive no-match. A sparse minority never raises.
     """
     best: dict | None = None
     best_score = 0.0
+    total = 0
+    extraction_failures = 0
+    last_error: Exception | None = None
     for item in results:
+        total += 1
         # Extract every field up front, inside the guard, so a sparse row is
         # skipped whichever extractor trips — including ``url_fn``/``id_fn``,
         # which only feed a floor-clearing winner. Evaluating them per-row (vs.
@@ -466,6 +497,8 @@ def find_best_match(
             result_url = url_fn(item)
             result_id = id_fn(item) if id_fn is not None else None
         except _EXTRACTION_ERRORS as exc:
+            extraction_failures += 1
+            last_error = exc
             logger.warning("Skipping malformed result row in find_best_match: %s", exc)
             continue
         artist_score = score_match(query_artist, result_artist)
@@ -488,6 +521,12 @@ def find_best_match(
             if id_fn is not None:
                 match["id"] = result_id
             best = match
+    # Every row failed extraction → systemic break, not a sparse minority. Surface
+    # it (LML#376 errored-source retry) instead of silently returning None. This
+    # still raises strictly less than the pre-LML#640 code, which aborted on the
+    # first bad row regardless of the others.
+    if last_error is not None and extraction_failures == total:
+        raise last_error
     return best
 
 
@@ -524,10 +563,24 @@ def find_best_typed_match[T](
 
     None-valued extractors score as 0 against any non-empty query. Ties
     resolve to the first candidate reaching the score, preserving input
-    order.
+    order. An extractor that *raises* (vs. returns None) is treated as a
+    malformed candidate: the row is skipped and logged rather than scored
+    (LML#640). The real callers pass attribute extractors (``lambda r:
+    r.artist``), whose failure mode is ``AttributeError``, so
+    ``_EXTRACTION_ERRORS`` includes it — a ``None``/wrong-type candidate is
+    skipped, not fatal.
 
-    Iterables are materialized to a list internally — a single-pass
-    generator is safe.
+    Unlike ``find_best_match``, this does NOT re-raise on total extraction
+    failure. Its callers are the lookup pipeline (``lookup/orchestrator.py``),
+    which has no errored-source retry channel: ``fetch_one`` would swallow a
+    raise back to ``None`` and ``_library_miss_discogs_search`` would let it
+    500 the request. So a wholesale-malformed ``results`` degrades to ``None``
+    (a clean no-match the pipeline can fall through), not an exception. The
+    errored-source signal (LML#376) belongs only to the streaming path that
+    ``find_best_match`` feeds.
+
+    Results are consumed in a single pass, so a generator argument is safe (it
+    is not materialized).
     """
     artist_variants = [v for v in _as_variants(query_artist) if v and v.strip()]
     title_variants = [v for v in _as_variants(query_title) if v and v.strip()]
@@ -537,9 +590,9 @@ def find_best_typed_match[T](
     best: T | None = None
     best_score = 0.0
     for item in results:
-        # Same per-item guard as ``find_best_match`` — the orchestrator lookup
-        # path runs through here, so a malformed candidate must be skipped, not
-        # fatal (LML#640).
+        # Per-item guard, as in ``find_best_match``: a malformed candidate is
+        # skipped, not fatal (LML#640). No total-failure re-raise here — the
+        # lookup pipeline wants a graceful ``None`` (see docstring).
         try:
             r_artist = artist_fn(item) or ""
             r_title = title_fn(item) or ""

--- a/scripts/revalidate_misses.py
+++ b/scripts/revalidate_misses.py
@@ -113,15 +113,31 @@ async def run(args) -> None:
 
             for artist, title in queries:
                 results = await spotify.search_album(artist, title)
-                match = find_best_match(
-                    results,
-                    artist,
-                    title,
-                    artist_fn=_SPOTIFY_ARTIST,
-                    title_fn=_SPOTIFY_TITLE,
-                    url_fn=_SPOTIFY_URL,
-                    id_fn=_SPOTIFY_ID,
-                )
+                try:
+                    match = find_best_match(
+                        results,
+                        artist,
+                        title,
+                        artist_fn=_SPOTIFY_ARTIST,
+                        title_fn=_SPOTIFY_TITLE,
+                        url_fn=_SPOTIFY_URL,
+                        id_fn=_SPOTIFY_ID,
+                    )
+                except Exception as exc:
+                    # find_best_match re-raises only when EVERY row of a response
+                    # fails extraction — rare here, since these extractors use
+                    # .get() defaults (it takes e.g. "artists": [] on every row to
+                    # trip an IndexError). Still, a long batch must not abort on one
+                    # bad page: log and treat this query as a miss so the loop
+                    # continues, as the sibling streaming scripts likewise guard
+                    # their own find_best_match calls. (LML#640)
+                    logger.warning(
+                        "Extraction failed for every row of '%s - %s'; skipping query: %s",
+                        artist,
+                        title,
+                        exc,
+                    )
+                    continue
                 if match and (best_match is None or match["confidence"] > best_match["confidence"]):
                     best_match = match
 

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -1,5 +1,6 @@
 """Unit tests for clients/streaming/matching.py."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -561,6 +562,11 @@ class TestFindBestMatchSparseRowGuard:
     ``find_best_match`` and aborted the whole match — the well-formed rows in
     the same response were lost with it. The guard skips (and logs) just the
     bad row.
+
+    A *sparse minority* is skipped, but *total* extraction failure (every row
+    raises) re-raises: that is a systemic upstream break, not a sparse row, and
+    the streaming orchestrator must see it as an errored source to retry
+    (LML#376) rather than a persisted no-match.
     """
 
     @pytest.mark.parametrize(
@@ -652,19 +658,147 @@ class TestFindBestMatchSparseRowGuard:
         assert best is not None
         assert best["url"] == "https://open.spotify.com/album/good"
 
-    def test_only_sparse_rows_returns_none_without_raising(self):
+    def test_all_rows_failing_extraction_reraises(self):
+        """Total extraction failure re-raises (it is a systemic break, not a
+        sparse row). Skipping every row and returning None would silently
+        convert a broken upstream into a persisted no-match and suppress the
+        LML#376 errored-source retry. Deliberately reverses the earlier
+        all-sparse -> None behavior.
+        """
+        from clients.streaming.matching import find_best_match
+
+        # Row 1 raises KeyError (no "artist"); row 2 raises TypeError (None
+        # subscript). Asserting BOTH rows logged a warning — and that the LAST
+        # row's error (TypeError) is what escapes — proves the loop caught each
+        # row then re-raised at the aggregate, not that it aborted on row 1
+        # (which would log zero warnings and raise KeyError).
+        with patch("clients.streaming.matching.logger") as mock_logger:
+            with pytest.raises(TypeError) as excinfo:
+                find_best_match(
+                    [
+                        {"title": "X", "link": "http://x"},
+                        {"artist": None, "title": "Y", "link": "http://y"},
+                    ],
+                    "Juana Molina",
+                    "DOGA",
+                    **_DEEZER_EXTRACTORS,
+                )
+        assert mock_logger.warning.call_count == 2
+        # The genuine upstream error object is surfaced (the row-2 null subscript),
+        # not a freshly synthesized exception — so the orchestrator's errored-source
+        # diagnostics carry the real cause.
+        assert "subscriptable" in str(excinfo.value)
+
+    def test_partial_failure_does_not_reraise(self):
+        """A sparse minority (at least one row extracts cleanly) is tolerated —
+        only total failure re-raises."""
         from clients.streaming.matching import find_best_match
 
         best = find_best_match(
-            [
-                {"title": "X", "link": "http://x"},
-                {"artist": None, "title": "Y", "link": "http://y"},
-            ],
+            [{"title": "X", "link": "http://x"}, _DEEZER_GOOD],
             "Juana Molina",
             "DOGA",
             **_DEEZER_EXTRACTORS,
         )
-        assert best is None
+        assert best is not None
+        assert best["url"] == "https://www.deezer.com/album/good"
+
+    def test_clean_floor_rejected_row_is_not_an_extraction_failure(self):
+        """The re-raise boundary is ``extraction_failures == total``, NOT
+        ``best is None``. A row that extracts cleanly but loses the 80/80 floor
+        is a *successful* extraction, so pairing it with a malformed row must
+        return None WITHOUT re-raising — a legitimate no-match, not a systemic
+        break. Guards against a future `if best is None: raise` mis-refactor.
+        """
+        from clients.streaming.matching import find_best_match
+
+        # Extracts fine, but the title is for a different album → fails the floor.
+        clean_but_wrong = {
+            "artist": {"name": "Juana Molina"},
+            "title": "Halo",
+            "link": "http://other",
+        }
+        malformed = {"title": "X", "link": "http://x"}  # KeyError in artist_fn
+        best = find_best_match(
+            [clean_but_wrong, malformed],
+            "Juana Molina",
+            "DOGA",
+            **_DEEZER_EXTRACTORS,
+        )
+        assert best is None  # floor-rejected + one skipped row → no match, no raise
+
+    def test_id_fn_raise_is_skipped_not_fatal(self):
+        """``id_fn`` is evaluated inside the guard and feeds the output dict, so
+        a row whose only fault is a raising ``id_fn`` must be skipped, not abort
+        the match — pins that id_fn extraction stays inside the try.
+
+        ``bad_id`` is an EXACT match (would win the floor on a tie as the first
+        row), so if ``id_fn`` were evaluated lazily on the winner instead of
+        eagerly inside the guard, it would be selected and then crash. The
+        tracking ``id_fn`` also asserts it actually ran on the bad row — i.e.
+        the skip is caused by id_fn raising, not by the row losing on score.
+        """
+        from clients.streaming.matching import find_best_match
+
+        # Clears artist/title/url but has no "id" key -> id_fn raises KeyError.
+        # Placed first and exact so it is the would-be winner.
+        bad_id = {
+            "name": "DOGA",
+            "artists": [{"name": "Juana Molina"}],
+            "external_urls": {"spotify": "http://bad"},
+        }
+        seen_ids = []
+
+        def tracking_id_fn(x):
+            seen_ids.append(x.get("external_urls", {}).get("spotify"))
+            return x["id"]  # raises KeyError on bad_id
+
+        best = find_best_match(
+            [bad_id, {**_SPOTIFY_GOOD, "id": "good-id"}],
+            "Juana Molina",
+            "DOGA",
+            **_SPOTIFY_EXTRACTORS,
+            id_fn=tracking_id_fn,
+        )
+        assert best is not None
+        assert best["id"] == "good-id"
+        # id_fn ran on the bad row (proving it is inside the per-row guard, not
+        # deferred to the winner) and on the good row.
+        assert "http://bad" in seen_ids
+
+    def test_skip_does_not_perturb_winner(self):
+        """Skipping a bad row leaves the winner and its combined score identical
+        to the no-skip case — the 80/80 floor math is untouched."""
+        from clients.streaming.matching import find_best_match
+
+        with_skip = find_best_match(
+            [{"title": "X", "link": "http://x"}, _DEEZER_GOOD],
+            "Juana Molina",
+            "DOGA",
+            **_DEEZER_EXTRACTORS,
+        )
+        without_skip = find_best_match([_DEEZER_GOOD], "Juana Molina", "DOGA", **_DEEZER_EXTRACTORS)
+        assert with_skip is not None and without_skip is not None
+        assert with_skip["confidence"] == without_skip["confidence"]
+        assert with_skip["url"] == without_skip["url"]
+
+    def test_skipped_rows_logged_once_per_bad_row(self):
+        """Cardinality: one warning per skipped row, not one per call. Two bad
+        rows alongside a good one -> exactly two warnings."""
+        from clients.streaming.matching import find_best_match
+
+        with patch("clients.streaming.matching.logger") as mock_logger:
+            find_best_match(
+                [
+                    {"title": "X", "link": "http://x"},
+                    {"artist": None, "title": "Y", "link": "http://y"},
+                    _DEEZER_GOOD,
+                ],
+                "Juana Molina",
+                "DOGA",
+                **_DEEZER_EXTRACTORS,
+            )
+        assert mock_logger.warning.call_count == 2
 
     def test_skipped_row_is_logged(self):
         from clients.streaming.matching import find_best_match
@@ -706,6 +840,86 @@ class TestFindBestMatchSparseRowGuard:
             title_fn=lambda x: x["title"],
         )
         assert best is good
+
+    def test_typed_match_attribute_error_is_skipped(self):
+        """The real orchestrator callers use attribute extractors
+        (``lambda r: r.artist``) on objects; a ``None``/wrong-type item raises
+        ``AttributeError`` — which must be caught, else the guard is inert for
+        its only production call shape."""
+        from clients.streaming.matching import find_best_typed_match
+
+        good = SimpleNamespace(artist="Juana Molina", album="DOGA")
+        best = find_best_typed_match(
+            [None, good],  # None.artist -> AttributeError
+            query_artist="Juana Molina",
+            query_title="DOGA",
+            artist_fn=lambda r: r.artist,
+            title_fn=lambda r: r.album,
+        )
+        assert best is good
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            pytest.param({"artist": [], "title": "DOGA"}, id="index-error"),
+            pytest.param({"artist": None, "title": "DOGA"}, id="type-error-null-subscript"),
+        ],
+    )
+    def test_typed_match_index_and_type_errors_skipped(self, bad):
+        """The typed guard must cover the same IndexError/TypeError shapes as
+        ``find_best_match`` — its error set must not drift from the sibling's."""
+        from clients.streaming.matching import find_best_typed_match
+
+        good = {"artist": {"name": "Juana Molina"}, "title": "DOGA"}
+        best = find_best_typed_match(
+            [bad, good],
+            query_artist="Juana Molina",
+            query_title="DOGA",
+            artist_fn=lambda x: (
+                x["artist"][0] if isinstance(x["artist"], list) else x["artist"]["name"]
+            ),
+            title_fn=lambda x: x["title"],
+        )
+        assert best is good
+
+    def test_typed_match_skip_on_variant_list_query_path(self):
+        """The production caller (orchestrator) passes variant LISTS for the
+        query, not scalars — exercise the guard on that branch too."""
+        from clients.streaming.matching import find_best_typed_match
+
+        good = {"artist": {"name": "Various Artists"}, "title": "Disco Not Disco"}
+        bad = {"title": "Disco Not Disco"}  # KeyError in artist_fn
+        best = find_best_typed_match(
+            [bad, good],
+            query_artist=["Various", "Various Artists"],
+            query_title=["Disco Not Disco"],
+            artist_fn=lambda x: x["artist"]["name"],
+            title_fn=lambda x: x["title"],
+        )
+        assert best is good
+
+    def test_typed_match_total_failure_returns_none_not_raises(self):
+        """The typed matcher must NOT re-raise on total extraction failure —
+        unlike ``find_best_match``. Its callers are the lookup pipeline
+        (``lookup/orchestrator.py``): ``fetch_one`` would swallow a raise back
+        to None and ``_library_miss_discogs_search`` would let it 500 the
+        request, and neither maps it to an errored-source retry (LML#376 lives
+        on the streaming path that find_best_match feeds). So a wholesale-
+        malformed response must degrade to a graceful None, with every item
+        still skipped+logged.
+        """
+        from clients.streaming.matching import find_best_typed_match
+
+        with patch("clients.streaming.matching.logger") as mock_logger:
+            best = find_best_typed_match(
+                [None, None],  # each item: None.artist -> AttributeError, caught
+                query_artist="Juana Molina",
+                query_title="DOGA",
+                artist_fn=lambda r: r.artist,
+                title_fn=lambda r: r.album,
+            )
+        assert best is None
+        assert mock_logger.warning.call_count == 2  # both caught, neither fatal
 
 
 class TestRecordMatchTelemetry:
@@ -951,6 +1165,28 @@ class TestFindBestSourceMatchEmits:
                 service="deezer",
             )
         assert match is None
+        mock_sentry.start_span.assert_not_called()
+
+    def test_total_extraction_failure_propagates_and_skips_telemetry(self):
+        """The wrapper is the real streaming seam (every adapter funnels through
+        it), so pin that a total extraction failure propagates the re-raise out
+        of ``find_best_source_match`` — that is what reaches the orchestrator's
+        errored-source mapping (LML#376) — and does NOT emit match telemetry
+        (there is no winner to record).
+        """
+        from clients.streaming.matching import find_best_source_match
+
+        with patch("clients.streaming.matching.sentry_sdk") as mock_sentry:
+            with pytest.raises((KeyError, IndexError, TypeError, AttributeError)):
+                find_best_source_match(
+                    [{"title": "X", "link": "http://x"}],  # all malformed (Deezer shape)
+                    "Juana Molina",
+                    "DOGA",
+                    artist_fn=lambda x: x["artist"]["name"],
+                    title_fn=lambda x: x["title"],
+                    url_fn=lambda x: x["link"],
+                    service="deezer",
+                )
         mock_sentry.start_span.assert_not_called()
 
     def test_service_is_required(self):


### PR DESCRIPTION
Follow-up to #642 (which fixed [#640](https://github.com/WXYC/library-metadata-lookup/issues/640)). #642 merged without a `/code-review max` pass; this PR is the result of running that review to convergence over the merged guard.

## 1. Self-contradictory guard comment
The `_EXTRACTION_ERRORS` comment claimed a non-callable extractor "surfaces loudly" — but calling a non-callable raises `TypeError`, which the guard **catches**. The example documented the opposite of the behavior. Rewrote it.

## 2. The typed-path guard was inert for its only real callers
`find_best_typed_match`'s production callers (`lookup/orchestrator.py:1278`, `:2376`) pass attribute extractors `lambda r: r.artist` over `DiscogsSearchResult`. A `None`/wrong-type item raises `AttributeError`, which was **not** in `(KeyError, IndexError, TypeError)` — so the guard could never fire on the real call shape. Added `AttributeError` so a malformed candidate is skipped, not fatal.

## 3. Total extraction failure → re-raise, but only on the streaming path
The streaming orchestrator (`streaming/orchestrator.py:89-114`, LML#376) treats a **raised** `find_album_match` as an *errored source → retry* but a **returned `None`** as a *confirmed absence*. #642's "skip every row → return None" converted a wholesale-malformed upstream response into a clean miss, suppressing the retry and persisting `on_streaming=False`.

**`find_best_match`** (dict matcher → streaming adapters → orchestrator) now skips a sparse minority but **re-raises when every row fails extraction** (`extraction_failures == total`), restoring the errored-source signal. It still raises strictly *less* than the pre-#640 code (which aborted on the first bad row), so no caller is newly broken vs long-standing behavior.

**`find_best_typed_match`** (typed matcher → lookup pipeline) deliberately does **NOT** re-raise. The lookup pipeline has no errored-source channel: a raise there would 500 a request (`_library_miss_discogs_search` calls it outside its try/except) or be swallowed back to `None` (`fetch_one`), and neither retries. So the typed matcher degrades a wholesale-malformed response to a graceful `None` and the pipeline falls through. (An earlier revision of this PR re-raised symmetrically; the review caught that the typed path has no consumer for it.)

## Regression the review caught in the fix
The re-raise reintroduced an unguarded crash path in `scripts/revalidate_misses.py` — the one `find_best_match` caller without a surrounding `try/except` (the sibling streaming scripts already wrap theirs). A totally-malformed Spotify page (`artists: []` on every row → `IndexError`) would have aborted the whole batch. That call site now logs and skips the page.

## Tests
- `find_best_match`: total-vs-partial failure; **boundary** — a row that extracts cleanly but fails the 80/80 floor is *not* an extraction failure, so it must return `None` without raising (pins `extraction_failures == total`, not `best is None`); the real last-row exception object escapes (not a synthetic).
- `id_fn`-raise skipped, proven via a tracking extractor to run **inside** the guard (not deferred to the winner); log cardinality; winner + confidence unchanged by a skip.
- `find_best_source_match` (the wrapper every adapter funnels through) propagates the re-raise and emits **no** telemetry.
- `find_best_typed_match`: returns `None` (does **not** raise) on total failure; AttributeError/IndexError/TypeError + variant-list skip shapes.

## Verification
Local: `ruff check` + `ruff format --check` clean, `mypy . --ignore-missing-imports` clean, full suite `3124 passed, 1 skipped, 2 xfailed`.

## Behavior-change callout for the reviewer
On the **streaming path only**, this reverses #642's `test_only_sparse_rows_returns_none_without_raising` (now `test_all_rows_failing_extraction_reraises`): a response where *every* row fails extraction now re-raises (→ errored-source retry) instead of returning a clean miss — including the N=1 case (a single malformed result). If you'd rather total-malformation stay a clean miss, that's the one knob to discuss; it's isolated to the post-loop re-raise in `find_best_match`.

Refs #640. Follow-up to #642.