### PR TITLE
docs(#627): regenerate API models with the row-less result shape

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -848,7 +848,10 @@ class LookupRequest(BaseModel):
 
 
 class LibraryCatalogItem(BaseModel):
-    id: int = Field(..., description="Unique identifier in the library database")
+    id: int = Field(
+        ...,
+        description='Unique identifier in the library database. `0` means there is no WXYC catalog row for this result (a row-less / "(external)" item, e.g. a Discogs-only library miss); any positive value is a real shelved release.\n',
+    )
     title: str | None = Field(None, description="Album/release title")
     artist: str | None = Field(None, description="Artist name")
     call_letters: str | None = Field(None, description="Library call letter code")
@@ -1652,8 +1655,14 @@ class EnhancedRequest(SongRequest):
 class DiscogsMatchResult(BaseModel):
     album: str | None = Field(None, description="Release title")
     artist: str | None = Field(None, description="Release artist")
-    release_id: int = Field(..., description="Discogs release ID")
-    release_url: str = Field(..., description="URL to the release on Discogs")
+    release_id: int = Field(
+        ...,
+        description='Discogs release ID. `> 0` is a real release identity; `0` is the streaming-only sentinel (paired with `release_url == ""`, BS#1185) and is not a linkable Discogs release.\n',
+    )
+    release_url: str = Field(
+        ...,
+        description="URL to the release on Discogs. Non-empty for a real release identity; the empty string accompanies the `release_id == 0` streaming-only sentinel.\n",
+    )
     artwork_url: str | None = Field(None, description="Artwork image URL")
     confidence: confloat(ge=0.0, le=1.0) | None = Field(0, description="Match confidence score")
     release_year: int | None = Field(None, description="Release year from Discogs")


### PR DESCRIPTION
## What

Regenerates `generated/api_models.py` from the wxyc-shared api.yaml change that documents the **row-less Discogs-identity result shape** (`library_item.id == 0` + `artwork.release_id > 0`, distinct from the BS#1185 `release_id == 0` sentinel). Docstring-only diff — three `Field(...)` descriptions on the generated models; no type or field changes.

This is the "document" half of #627's AC #1. The other two ACs are already satisfied:

- **AC #1 source** — the api.yaml description edits: wxyc-shared PR (linked below).
- **AC #2 parity test** — already on `main` via `55107d0` (`tests/unit/test_rowless_result_contract.py`, 5 passing).

## ⚠️ Draft — blocked on the wxyc-shared PR (merge order)

`scripts/generate_api_models.sh` in CI downloads `api.yaml` from **wxyc-shared `main`**, then the drift job runs `git diff --exit-code generated/`. Until the wxyc-shared doc PR (WXYC/wxyc-shared#185) merges, CI regenerates the **old** docstrings and this PR's drift check is **red — expected**.

Unblock sequence:
1. Merge the wxyc-shared doc PR.
2. Mark this PR ready for review; re-run CI (drift now passes against the updated `main`).
3. Merge. Closing this closes #627.

Locally verified internally consistent: regenerating against the wxyc-shared `627` branch produces **zero diff** from the committed `generated/api_models.py`.

Closes #627
