### PR TITLE
fix(#646): fire album-title wave in the row-less carry-through resolve

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1071,18 +1071,23 @@ async def _resolve_nonlibrary_release(
        fresh known miss (``was_present=True, release_id=None``) short-circuits to
        ``None`` *without* a live probe; an absent/stale entry falls through.
     2. **Bounded resolve on a cold miss** — the **uncached**
-       ``resolve_release_for_track(..., max_validations=5)`` (#633). Deliberately
-       NOT ``resolve_release_for_track_cached``: the L1 wrapper's key omits
-       ``max_validations``, so a bounded ``[]`` would coalesce with a default
-       ``[]`` (the #633 landmine). Cold-cache durability comes from the #632 PG
-       cache here instead.
+       ``resolve_release_for_track(..., also_probe_album_title=bool(album),
+       max_validations=5)`` (#633). The album-title wave (#646, gated on a
+       present ``album``) fires the third ``search_releases_by_album_title``
+       probe so a non-library release discoverable *only* by its album title
+       — the #319/#237 trio-collaboration / odd-credit shape the track-artist
+       probes miss — still resolves, at parity with the in-library #604
+       lazy-bind. Deliberately NOT ``resolve_release_for_track_cached``: the L1
+       wrapper's key omits ``max_validations``, so a bounded ``[]`` would
+       coalesce with a default ``[]`` (the #633 landmine). Cold-cache
+       durability comes from the #632 PG cache here instead.
     3. **#632 cache write-back** — the resolved id, or ``None`` to record a known
        miss so the next identical add short-circuits.
 
     ``pg`` is best-effort: ``None`` (or a PG failure, swallowed inside the cache
     helpers) degrades to an uncached bounded resolve. ``album`` (often absent on
-    the kernel paths) only ranks the validated candidates by title; the bounded
-    resolver returns at most one.
+    the kernel paths) both fires the album-title probe (layer 2) and ranks the
+    validated candidates by title; the bounded resolver returns at most one.
     """
     if discogs_service is None or not song or not artist:
         return None
@@ -1106,7 +1111,12 @@ async def _resolve_nonlibrary_release(
             cached_positive_unhydrated = True
 
     candidates = await resolve_release_for_track(
-        song, artist, album, discogs_service, max_validations=5
+        song,
+        artist,
+        album,
+        discogs_service,
+        also_probe_album_title=bool(album),
+        max_validations=5,
     )
     best = candidates[0] if candidates else None
 

--- a/tests/integration/test_lookup_nonlibrary_release.py
+++ b/tests/integration/test_lookup_nonlibrary_release.py
@@ -277,6 +277,59 @@ async def test_track_on_compilation_threads_pg_and_writes_cache(
     assert pg.store.get((SPINE_ARTIST.lower(), SPINE_TRACK.lower(), True)) == SPINE_RELEASE_ID
 
 
+@pytest.mark.asyncio
+async def test_track_on_compilation_surfaces_rowless_via_album_title_wave(
+    library_db, enable_nonlibrary_release
+):
+    """The row-less carry-through must fire the album-title probe (#646).
+
+    The #319/#237 shape: a non-library release whose per-track credit Discogs
+    files oddly (trio collaboration / odd credit), so the artist-scoped track
+    probes (``search_releases_by_track`` Wave A/B) surface *nothing* — the
+    release is discoverable only by its album title. The in-library #604
+    lazy-bind already fires the album-title wave (``also_probe_album_title``);
+    the #628 carry-through did not, so this non-library release was dropped by
+    ``process_release`` (no library row) *and* missed by the carry-through's
+    track-only resolve.
+
+    Threading ``also_probe_album_title=bool(album)`` into
+    ``_resolve_nonlibrary_release``'s ``resolve_release_for_track`` call closes
+    the gap. The fix lives in the shared helper, so SONG_AS_TRACK and SWAPPED
+    inherit it; TRACK_ON_COMPILATION is the natural home for the trio shape
+    (artist + album typed) and the call site #646 names.
+    """
+    svc = _base_discogs_mock()
+    # Track-artist probe finds nothing — the odd-credit case.
+    svc.search_releases_by_track = AsyncMock(return_value=_empty_track_releases())
+    # The release is reachable only by album title.
+    svc.search_releases_by_album_title = AsyncMock(return_value=_track_releases(_spine_release()))
+
+    request = LookupRequest(
+        artist=SPINE_ARTIST,
+        song=SPINE_TRACK,
+        album=SPINE_ALBUM,
+        raw_message=f"{SPINE_ARTIST} - {SPINE_TRACK}",
+    )
+    response = await perform_lookup(
+        request,
+        library_db,
+        svc,
+        telemetry=make_lml_telemetry(),
+        discogs_cache_pg=None,
+    )
+
+    # Discriminator: the track-artist probe is empty and the library gate drops
+    # the strategy's own album candidate, so the only path to a row-less result
+    # is the carry-through firing its *own* album-title wave inside
+    # resolve_release_for_track. Pre-#646 this list is empty (the carry-through
+    # resolved track-only). The unit test pins the resolver kwarg directly.
+    rowless = [r for r in response.results if r.library_item.id == 0 and r.artwork is not None]
+    assert len(rowless) == 1
+    assert rowless[0].artwork.release_id == SPINE_RELEASE_ID
+    assert rowless[0].artwork.release_id > 0
+    assert rowless[0].artwork.release_url == SPINE_RELEASE_URL
+
+
 # ---------------------------------------------------------------------------
 # SONG_AS_TRACK
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_nonlibrary_release_resolution.py
+++ b/tests/unit/test_nonlibrary_release_resolution.py
@@ -272,3 +272,32 @@ async def test_bounded_resolver_is_used_not_l1_wrapper(monkeypatch):
     bounded.assert_awaited_once()
     _args, kwargs = bounded.await_args
     assert kwargs.get("max_validations") == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("album", "expected_probe"),
+    [(ALBUM, True), (None, False), ("", False)],
+)
+async def test_album_title_wave_gated_on_album_presence(monkeypatch, album, expected_probe):
+    """The bounded resolve fires the album-title wave only when an album is
+    present (#646) — parity with the in-library #604 lazy-bind, which gates the
+    same probe on ``bool(album)``. Without it, a non-library release reachable
+    only by album title (the #319/#237 trio / odd-credit shape) is missed."""
+    svc = _resolving_service()
+
+    bounded = AsyncMock(return_value=[])
+    monkeypatch.setattr("lookup.orchestrator.resolve_release_for_track", bounded)
+    monkeypatch.setattr(
+        "lookup.orchestrator.get_cached_release_id",
+        AsyncMock(return_value=ReleaseResolution(release_id=None, was_present=False)),
+    )
+    monkeypatch.setattr("lookup.orchestrator.set_cached_release_id", AsyncMock())
+
+    await _resolve_nonlibrary_release(
+        svc, None, song=TRACK, artist=ARTIST, album=album, is_track=True
+    )
+
+    bounded.assert_awaited_once()
+    _args, kwargs = bounded.await_args
+    assert kwargs.get("also_probe_album_title") == expected_probe


### PR DESCRIPTION
Closes #646.

Follow-up from the #628 review (finding A — in-spec-by-omission, not a #628 bug).

## Problem

The #628 row-less carry-through (`_resolve_nonlibrary_release`) resolved a non-library release via `resolve_release_for_track(..., max_validations=5)` **without** `also_probe_album_title=True` — so it probed only the artist-scoped track waves (Wave A/B). A release discoverable *only* through the album-title wave — the #319/#237 trio-collaboration / odd-credit shape, where Discogs files the per-track credit unusually (e.g. typed "Orcutt Shelley Miller") — was dropped at `process_release`'s library gate **and** missed by the carry-through's track-only resolve.

In-library trio releases were already covered: the #604 lazy-bind fires the album-title wave on `bool(album)` (orchestrator.py `_resolve_fallback_artwork`'s resolve call). Only the **non-library** case was uncovered — a deliberate omission of #628's spec (`also_probe_album_title=False` default), not a regression.

## Fix

Thread `also_probe_album_title=bool(album)` into the single `resolve_release_for_track` call inside `_resolve_nonlibrary_release`. All three Discogs-aware strategies (`TRACK_ON_COMPILATION`, `SONG_AS_TRACK`, `SWAPPED_INTERPRETATION`) inherit it through the shared helper — both call sites already thread `album` in and delegate the resolver call.

Unlike the in-library #604 caller, this helper keys on the **typed** artist and applies no canonical swap, so `bool(album)` is the whole gate (no `not swapped` clause needed — there's no swap to make the artist-scoped probe authoritative).

### Cost

- One extra Discogs search on a **cold miss only** — the album-title probe joins the existing concurrent `asyncio.gather`.
- Stays inside the `max_validations=5` budget: the album-title candidates merge into the same pre-ranked pool and compete for the existing 5 validation slots, rather than adding validations.
- Amortized by the #632 cache, which short-circuits the resolve entirely on a warm typed-artist key (the cache read precedes the resolver call).
- Scope: the extra album-title wave fires for **every** non-library add with an album typed, across all three strategies (`SONG_AS_TRACK` / `SWAPPED_INTERPRETATION` / `TRACK_ON_COMPILATION`). Song-only adds (no album typed) are unaffected — the `bool(album)` gate is what spares them.

## Tests

- **Integration** (`test_lookup_nonlibrary_release.py`): a non-library release where the track-artist probe returns nothing and the release is reachable only by album title → row-less surfaces with a real `release_id`/`release_url`. Confirmed RED before the fix (`0 == 1`, no row-less item), green after.
- **Unit** (`test_nonlibrary_release_resolution.py`): parametrized over present / `None` / empty album, pinning that the carry-through passes `also_probe_album_title=bool(album)` to the resolver — the isolated discriminator, immune to integration-routing churn.

## Verification

- Full suite: 3170 passed, 1 skipped, 2 xfailed (`-m "not pg and not external_api and not stack and not slow"`).
- `ruff format` + `ruff check`: clean. `mypy . --ignore-missing-imports`: clean (348 files).

## Related

- #628 (the carry-through this extends), #625 (epic), #319 / #237 (the album-title-wave shape this misses), #604 (the in-library lazy-bind at parity), #633 (the `max_validations` bound), #632 (the positive cache that amortizes it).
