### PR TITLE
feat(#631): row-less SONG_AS_ARTIST for non-library listener requests

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -454,7 +454,12 @@ class Outcome:
         return cls(items=[])
 
     @classmethod
-    def found(cls, items: list[LibraryItem]) -> "Outcome":
+    def found(
+        cls,
+        items: list[LibraryItem],
+        *,
+        discogs_titles: "dict[int, ResolvedRelease] | None" = None,
+    ) -> "Outcome":
         """Direct match where the strategy can vouch for the song.
 
         Clears ``state.song_not_found`` because the strategy explicitly
@@ -463,13 +468,19 @@ class Outcome:
         etc.). Use this for the 90% case where success means "the song
         was matched."
 
+        ``discogs_titles`` carries resolved Discogs releases for artwork lookup
+        (defaults to ``None`` — a no-op). SONG_AS_ARTIST's LML#631 row-less path
+        passes ``{0: ResolvedRelease}`` here so ``fetch_artwork_for_items`` binds
+        the non-library release onto the ``id=0`` item instead of falling
+        through to the BS#1185 sentinel.
+
         For ARTIST_PLUS_ALBUM's direct path — where the artist's album was
         found by name but the song's presence on the album wasn't verified —
         use :meth:`album_match` instead, which leaves ``song_not_found``
         alone so a prior album-resolution signal can still drive
         TRACK_ON_COMPILATION downstream.
         """
-        return cls(items=items, song_not_found_after=False)
+        return cls(items=items, song_not_found_after=False, discogs_titles=discogs_titles)
 
     @classmethod
     def album_match(cls, items: list[LibraryItem]) -> "Outcome":

--- a/discogs/lookup.py
+++ b/discogs/lookup.py
@@ -7,7 +7,7 @@ When omitted, a cacheless service is created as a fallback.
 
 import logging
 
-from discogs.models import DiscogsSearchRequest
+from discogs.models import DiscogsSearchRequest, DiscogsSearchResult
 from discogs.service import DiscogsService
 
 logger = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ async def lookup_releases_by_artist(
     artist: str,
     limit: int = 10,
     service: DiscogsService | None = None,
-) -> list[tuple[str, str]]:
+) -> list[DiscogsSearchResult]:
     """Look up releases by an artist using Discogs.
 
     Args:
@@ -90,7 +90,10 @@ async def lookup_releases_by_artist(
             creates a cacheless fallback service.
 
     Returns:
-        List of (artist, album) tuples for releases by or featuring the artist.
+        The ranked ``DiscogsSearchResult`` list for releases by or featuring the
+        artist. Callers that only need album titles read ``r.album``; the LML#631
+        row-less path also reads ``r.release_id`` / ``r.release_url`` to carry the
+        resolved identity for a non-library artist.
     """
     if service is None:
         service = _get_service()
@@ -100,4 +103,4 @@ async def lookup_releases_by_artist(
     request = DiscogsSearchRequest(artist=artist)
     response = await service.search(request, limit=limit)
 
-    return [(r.artist or "", r.album or "") for r in response.results]
+    return list(response.results)

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1078,12 +1078,15 @@ def _select_rowless_artist_release(
     if not own:
         return None
     best = min(own, key=lambda r: (-r.confidence, r.release_id))
-    item = _make_rowless_item(artist=best.artist or token, title=best.album or "")
+    # One album-title fallback feeds both the synthetic row's title and the
+    # carried release's album_title, so they can't drift.
+    album_title = best.album or ""
+    item = _make_rowless_item(artist=best.artist or token, title=album_title)
     resolved = ResolvedRelease(
         release_id=best.release_id,
         release_url=best.release_url,
         is_compilation=False,
-        album_title=best.album or "",
+        album_title=album_title,
     )
     return item, resolved
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1046,12 +1046,22 @@ def _select_rowless_artist_release(
 ) -> tuple[LibraryItem, ResolvedRelease] | None:
     """Pick the release that represents a non-library artist request (LML#631).
 
-    Confidence gate: keep only releases whose credited artist normalizes-equal
-    to the typed token (the artist-only analog of ``find_best_typed_match``'s
-    floor). A coincidental token→name hit is dropped. V/A compilations credited
-    to "Various" fail the gate by construction, so the survivors are the artist's
-    own releases. Among them, pick the most-relevant (Discogs ``confidence``
-    descending) with a stable ``release_id`` tiebreak for determinism.
+    Credit gate: keep only releases whose credited artist normalizes-equal to
+    the typed token (the artist-only analog of ``find_best_typed_match``'s
+    floor). A coincidental token→name hit is dropped, as is any release whose
+    credit differs from the token — V/A compilations credited to "Various" and
+    collaborations credited "<artist> & <other>" among them — so the survivors
+    are releases credited to the artist alone.
+
+    Among the survivors, sort by Discogs ``confidence`` descending with a stable
+    ``release_id`` tiebreak. Note the upstream query is artist-only
+    (``DiscogsSearchRequest(artist=token)`` in ``lookup_releases_by_artist``), so
+    ``calculate_confidence`` scores every exact-credit match identically (~0.4,
+    no album term) — confidence only separates an exact credit from a fuzzier
+    diacritic variant, and in the common all-identical-credit case the
+    deterministic ``release_id`` tiebreak is the effective selector. True
+    relevance ranking (community have/want counts) needs a per-release
+    ``get_release`` fetch and is deferred to #633.
 
     A non-positive ``release_id`` is dropped before selection: such an id would
     fail ``_resolve_fallback_artwork``'s ``release_id > 0`` guard downstream and

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -961,8 +961,19 @@ async def search_song_as_artist(
     db: LibraryDB,
     song_as_artist: str,
     discogs_service: DiscogsService | None = None,
-) -> tuple[list[LibraryItem], None]:
-    """Try searching using the parsed song title as an artist name."""
+) -> tuple[list[LibraryItem], dict[int, ResolvedRelease] | None]:
+    """Try searching using the parsed song title as an artist name.
+
+    Primarily serves request-o-matic listener requests. When the typed token is
+    an artist WXYC owns, the library cross-reference returns those rows. When it
+    resolves on Discogs but has no ``library.db`` row, LML#631 surfaces a
+    *row-less* result — ``LibraryItem(id=0)`` paired with the resolved release on
+    the ``discogs_titles`` seam — so rom can post the Discogs context to Slack.
+    The row-less path is gated on ``LML_RESOLVE_NONLIBRARY_RELEASE`` (shared with
+    the #628 carry-through) and on the typed token normalizing-equal to the
+    resolved Discogs artist name; the second tuple element carries that release
+    (``None`` on the library-backed paths, which are unchanged).
+    """
     logger.info(f"Trying song '{song_as_artist}' as artist name")
 
     results = await db.search(query=song_as_artist, limit=_FETCH_LIMIT)
@@ -993,7 +1004,7 @@ async def search_song_as_artist(
         ]
 
     all_matches = await asyncio.gather(
-        *[search_album(album_title) for _, album_title in discogs_releases]
+        *[search_album(release.album or "") for release in discogs_releases]
     )
 
     seen_ids: set[int] = set()
@@ -1012,8 +1023,49 @@ async def search_song_as_artist(
         logger.info(
             f"Found {len(results)} results via Discogs cross-reference for '{song_as_artist}'"
         )
+        return limit_results(results), None
 
-    return limit_results(results), None
+    # LML#631 — no WXYC catalog row for this artist. If the token resolves
+    # cleanly on Discogs, surface the best-representative release row-less so rom
+    # can post Discogs context to Slack. Gated behind the shared non-library flag.
+    if get_settings().lml_resolve_nonlibrary_release:
+        rowless = _select_rowless_artist_release(song_as_artist, discogs_releases)
+        if rowless is not None:
+            item, resolved = rowless
+            logger.info(
+                f"Surfacing row-less Discogs release {resolved.release_id} for "
+                f"non-library artist '{song_as_artist}'"
+            )
+            return [item], {ROWLESS_LIBRARY_ID: resolved}
+
+    return [], None
+
+
+def _select_rowless_artist_release(
+    token: str, discogs_releases: list[DiscogsSearchResult]
+) -> tuple[LibraryItem, ResolvedRelease] | None:
+    """Pick the release that represents a non-library artist request (LML#631).
+
+    Confidence gate: keep only releases whose credited artist normalizes-equal
+    to the typed token (the artist-only analog of ``find_best_typed_match``'s
+    floor). A coincidental token→name hit is dropped. V/A compilations credited
+    to "Various" fail the gate by construction, so the survivors are the artist's
+    own releases. Among them, pick the most-relevant (Discogs ``confidence``
+    descending) with a stable ``release_id`` tiebreak for determinism.
+    """
+    token_form = normalize_for_comparison(token)
+    own = [r for r in discogs_releases if normalize_for_comparison(r.artist or "") == token_form]
+    if not own:
+        return None
+    best = min(own, key=lambda r: (-r.confidence, r.release_id))
+    item = _make_rowless_item(artist=best.artist or token, title=best.album or "")
+    resolved = ResolvedRelease(
+        release_id=best.release_id,
+        release_url=best.release_url,
+        is_compilation=False,
+        album_title=best.album or "",
+    )
+    return item, resolved
 
 
 SONG_AS_TRACK_CONFIDENCE: float = 0.85

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1052,9 +1052,19 @@ def _select_rowless_artist_release(
     to "Various" fail the gate by construction, so the survivors are the artist's
     own releases. Among them, pick the most-relevant (Discogs ``confidence``
     descending) with a stable ``release_id`` tiebreak for determinism.
+
+    A non-positive ``release_id`` is dropped before selection: such an id would
+    fail ``_resolve_fallback_artwork``'s ``release_id > 0`` guard downstream and
+    collapse to the BS#1185 ``release_id=0`` sentinel — the silent not-found this
+    path exists to kill. Discogs ids are positive, so this only closes a
+    malformed-upstream path.
     """
     token_form = normalize_for_comparison(token)
-    own = [r for r in discogs_releases if normalize_for_comparison(r.artist or "") == token_form]
+    own = [
+        r
+        for r in discogs_releases
+        if r.release_id > 0 and normalize_for_comparison(r.artist or "") == token_form
+    ]
     if not own:
         return None
     best = min(own, key=lambda r: (-r.confidence, r.release_id))

--- a/lookup/strategies/song_as_artist.py
+++ b/lookup/strategies/song_as_artist.py
@@ -4,7 +4,9 @@ Fires when the parser produced a song but no artist — typically because the
 parser misread an artist as a song title (e.g. "Laid Back" parsed as song
 instead of artist). The execute func may also cross-reference Discogs for
 releases by the candidate name and intersect with the library. Its tuple
-second element is unused.
+second element carries the row-less ``discogs_titles`` seam (LML#631) when a
+non-library artist resolved on Discogs (``{0: ResolvedRelease}``), and is
+``None`` on the library-backed paths.
 
 Strictly upstream of :class:`lookup.strategies.song_as_track.SongAsTrack` —
 the parser-misread-artist case gets first crack at song-only queries; the
@@ -46,5 +48,7 @@ class SongAsArtist:
         return no_results_and_song_but_no_artist(parsed, state, raw_message)
 
     async def attempt(self, parsed: ParsedRequest, state: SearchState, raw_message: str) -> Outcome:
-        items, _meta = await self.execute(self.db, parsed.song)
-        return Outcome.found(items) if items else Outcome.empty()
+        items, discogs_titles = await self.execute(self.db, parsed.song)
+        if not items:
+            return Outcome.empty()
+        return Outcome.found(items, discogs_titles=discogs_titles or None)

--- a/tests/integration/test_lookup_song_as_artist_rowless.py
+++ b/tests/integration/test_lookup_song_as_artist_rowless.py
@@ -110,15 +110,27 @@ async def test_song_as_artist_surfaces_rowless_when_flag_on(library_db, enable_n
 
 
 @pytest.mark.asyncio
-async def test_song_as_artist_flag_off_no_rowless(library_db):
+async def test_song_as_artist_flag_off_no_rowless(library_db, monkeypatch):
+    # Clear the lru-cached Settings at entry (not just rely on the flag-on
+    # sibling's teardown) so a leaked flag=True cache can't make this exercise
+    # flag-on behavior under reordering / parallel runs.
+    monkeypatch.delenv("LML_RESOLVE_NONLIBRARY_RELEASE", raising=False)
+    from config.settings import get_settings
+
+    get_settings.cache_clear()
+
     svc = _base_mock()
     request = LookupRequest(song=SESSA_ARTIST, raw_message=SESSA_ARTIST)
 
     with _patch_artist_releases():
         response = await perform_lookup(request, library_db, svc, telemetry=make_lml_telemetry())
 
-    # Flag off: no row-less Discogs identity surfaces.
-    assert not any(
-        r.library_item.id == 0 and r.artwork is not None and r.artwork.release_id > 0
-        for r in response.results
-    )
+    get_settings.cache_clear()
+
+    # Flag off: no row-less Discogs identity surfaces. The flag-on sibling
+    # produces exactly one id=0 result (bound artwork) from these same inputs;
+    # with the flag off the lookup falls through to the unresolved outcome, so
+    # assert the concrete empty result set — a bare ``not any(...)`` would pass
+    # vacuously on an empty list even if the gate were deleted or inverted.
+    assert response.results == []
+    assert response.search_type != "song_as_artist"

--- a/tests/integration/test_lookup_song_as_artist_rowless.py
+++ b/tests/integration/test_lookup_song_as_artist_rowless.py
@@ -1,0 +1,124 @@
+"""SONG_AS_ARTIST row-less carry-through (LML#631).
+
+When a listener requests an artist WXYC doesn't own but who resolves cleanly on
+Discogs, SONG_AS_ARTIST surfaces a *row-less* result (``LibraryItem(id=0)`` +
+the resolved release on the ``discogs_titles`` seam) so request-o-matic can post
+the Discogs context to Slack rather than "not found". Gated on the typed token
+normalizing-equal to the resolved Discogs artist name and behind the shared
+``LML_RESOLVE_NONLIBRARY_RELEASE`` flag (the binding side in
+``fetch_artwork_for_items`` already binds any ``id=0`` item under that flag).
+
+Driven end-to-end through ``perform_lookup`` against the real seeded
+``library_db`` with a mock ``DiscogsService``: a ``song``-only request (no
+artist/album) for an artist absent from the seed falls through the earlier
+strategies to SONG_AS_ARTIST, which resolves the release via Discogs and emits
+it row-less. Flag default-off asserts today's behavior (no row-less identity).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from discogs.models import (
+    DiscogsSearchResponse,
+    ReleaseMetadataResponse,
+    TrackReleasesResponse,
+)
+from lookup.models import LookupRequest
+from lookup.orchestrator import perform_lookup
+from tests.conftest import make_lml_telemetry
+from tests.factories import make_discogs_result
+
+# A non-library artist that resolves on Discogs. Distinct from every seeded row.
+SESSA_ARTIST = "Sessa"
+SESSA_ALBUM = "Estrela Acesa"
+SESSA_RELEASE_ID = 5551234
+SESSA_RELEASE_URL = f"https://www.discogs.com/release/{SESSA_RELEASE_ID}"
+
+
+@pytest.fixture
+def enable_nonlibrary_release(monkeypatch):
+    """Turn on LML_RESOLVE_NONLIBRARY_RELEASE (shared with the #628 carry-through)."""
+    monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "true")
+    from config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _empty_track_releases() -> TrackReleasesResponse:
+    return TrackReleasesResponse(track="", artist="", releases=[], total=0, cached=False)
+
+
+def _base_mock() -> AsyncMock:
+    """A mock DiscogsService where every track/compilation probe is empty, so a
+    ``song``-only request falls through to SONG_AS_ARTIST. ``get_release`` backs
+    the row-less artwork fallback (``_resolve_fallback_artwork``)."""
+    svc = AsyncMock()
+    svc.cache_service = None
+    svc.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+    svc.search_releases_by_track = AsyncMock(return_value=_empty_track_releases())
+    svc.search_releases_by_album_title = AsyncMock(return_value=_empty_track_releases())
+    svc.validate_track_on_release = AsyncMock(return_value=False)
+    svc.get_release = AsyncMock(
+        return_value=ReleaseMetadataResponse(
+            release_id=SESSA_RELEASE_ID,
+            title=SESSA_ALBUM,
+            artist=SESSA_ARTIST,
+            release_url=SESSA_RELEASE_URL,
+            artwork_url="https://i.discogs.com/sessa.jpg",
+        )
+    )
+    return svc
+
+
+def _patch_artist_releases():
+    """Patch the artist-search seam so SONG_AS_ARTIST resolves the Sessa release."""
+    return patch(
+        "lookup.orchestrator.lookup_releases_by_artist",
+        new_callable=AsyncMock,
+        return_value=[
+            make_discogs_result(
+                release_id=SESSA_RELEASE_ID,
+                artist=SESSA_ARTIST,
+                album=SESSA_ALBUM,
+                release_url=SESSA_RELEASE_URL,
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_song_as_artist_surfaces_rowless_when_flag_on(library_db, enable_nonlibrary_release):
+    svc = _base_mock()
+    request = LookupRequest(song=SESSA_ARTIST, raw_message=SESSA_ARTIST)
+
+    with _patch_artist_releases():
+        response = await perform_lookup(request, library_db, svc, telemetry=make_lml_telemetry())
+
+    assert response.search_type == "song_as_artist"
+    assert len(response.results) == 1
+    item = response.results[0]
+    assert item.library_item.id == 0
+    assert item.artwork is not None
+    assert item.artwork.release_id == SESSA_RELEASE_ID
+    assert item.artwork.release_id > 0
+    assert item.artwork.release_url == SESSA_RELEASE_URL
+
+
+@pytest.mark.asyncio
+async def test_song_as_artist_flag_off_no_rowless(library_db):
+    svc = _base_mock()
+    request = LookupRequest(song=SESSA_ARTIST, raw_message=SESSA_ARTIST)
+
+    with _patch_artist_releases():
+        response = await perform_lookup(request, library_db, svc, telemetry=make_lml_telemetry())
+
+    # Flag off: no row-less Discogs identity surfaces.
+    assert not any(
+        r.library_item.id == 0 and r.artwork is not None and r.artwork.release_id > 0
+        for r in response.results
+    )

--- a/tests/unit/test_discogs_lookup.py
+++ b/tests/unit/test_discogs_lookup.py
@@ -132,7 +132,11 @@ class TestLookupReleasesByArtist:
 
         result = await lookup_releases_by_artist("Radiohead", service=service)
         assert len(result) == 1
-        assert result[0] == ("Radiohead", "OK Computer")
+        # Widened (LML#631) to surface the full DiscogsSearchResult so the
+        # row-less path can carry release_id / release_url, not just the title.
+        assert result[0].artist == "Radiohead"
+        assert result[0].album == "OK Computer"
+        assert result[0].release_id == 1
 
     @pytest.mark.asyncio
     async def test_no_service_returns_empty(self):
@@ -157,4 +161,7 @@ class TestLookupReleasesByArtist:
         )
 
         result = await lookup_releases_by_artist("Artist", service=service)
-        assert result == [("", "")]
+        # Raw passthrough now — no ``or ""`` coercion; None stays None.
+        assert len(result) == 1
+        assert result[0].artist is None
+        assert result[0].album is None

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -356,6 +356,42 @@ class TestSearchSongAsArtistRowless:
         assert items == []
         assert discogs_titles is None
 
+    @pytest.mark.asyncio
+    async def test_tiebreak_picks_lowest_release_id_on_equal_confidence(
+        self, enable_nonlibrary_release
+    ):
+        """The *effective* production selector. The artist-only Discogs query
+        carries no album term, so ``calculate_confidence`` scores every
+        exact-credit match identically (~0.4) — the confidence key ties and the
+        deterministic ``release_id`` tiebreak decides. Among equal-confidence own
+        releases the lowest ``release_id`` wins. The earlier selection test feeds
+        distinct confidences (0.8 vs 0.2), a spread this path never produces, so
+        this pins the tiebreak that actually governs selection in production.
+        (True relevance ranking is deferred to #633.)"""
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[
+                make_discogs_result(
+                    release_id=900, artist="Sessa", album="Grandeza", confidence=0.4
+                ),
+                make_discogs_result(
+                    release_id=210, artist="Sessa", album="Estrela Acesa", confidence=0.4
+                ),
+                make_discogs_result(release_id=540, artist="Sessa", album="Sessa", confidence=0.4),
+            ],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sessa", AsyncMock())
+
+        assert len(items) == 1
+        resolved = discogs_titles[0]
+        assert resolved.release_id == 210
+        assert items[0].title == "Estrela Acesa"
+
 
 # ---------------------------------------------------------------------------
 # search_library_with_fallback -- artist+song path (lines 260-265)

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -107,7 +107,11 @@ class TestSearchSongAsArtist:
         with patch(
             "lookup.orchestrator.lookup_releases_by_artist",
             new_callable=AsyncMock,
-            return_value=[("Stereolab", "Emperor Tomato Ketchup")],
+            return_value=[
+                make_discogs_result(
+                    release_id=2, artist="Stereolab", album="Emperor Tomato Ketchup"
+                )
+            ],
         ):
             results, _ = await search_song_as_artist(db, "Stereolab", discogs)
 
@@ -142,7 +146,9 @@ class TestSearchSongAsArtist:
         with patch(
             "lookup.orchestrator.lookup_releases_by_artist",
             new_callable=AsyncMock,
-            return_value=[("SomeArtist", "Indie Comp 2020")],
+            return_value=[
+                make_discogs_result(release_id=3, artist="SomeArtist", album="Indie Comp 2020")
+            ],
         ):
             results, _ = await search_song_as_artist(db, "SomeArtist")
 
@@ -159,11 +165,174 @@ class TestSearchSongAsArtist:
         with patch(
             "lookup.orchestrator.lookup_releases_by_artist",
             new_callable=AsyncMock,
-            return_value=[("Artist", ""), ("Artist", None)],
+            return_value=[
+                make_discogs_result(release_id=10, artist="Artist", album=""),
+                make_discogs_result(release_id=11, artist="Artist", album=None),
+            ],
         ):
             results, _ = await search_song_as_artist(db, "Artist")
 
         assert results == []
+
+
+# ---------------------------------------------------------------------------
+# search_song_as_artist -- row-less carry-through (LML#631)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def enable_nonlibrary_release(monkeypatch):
+    """Turn on LML_RESOLVE_NONLIBRARY_RELEASE.
+
+    SONG_AS_ARTIST reuses the #628 carry-through flag: the binding side
+    (``fetch_artwork_for_items``) already binds any ``id=0`` item under this
+    flag, so the rom-path row-less result rides the same switch.
+    """
+    monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "true")
+    from config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+class TestSearchSongAsArtistRowless:
+    """LML#631 — a listener-requested artist that resolves on Discogs but has no
+    ``library.db`` row surfaces row-less (``LibraryItem(id=0)`` + a real
+    ``ResolvedRelease`` on the ``discogs_titles`` seam), so request-o-matic can
+    post the Discogs context to Slack. Gated on the typed token normalizing-equal
+    to the resolved Discogs artist name, behind ``LML_RESOLVE_NONLIBRARY_RELEASE``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_emits_rowless_when_token_matches_discogs_artist(self, enable_nonlibrary_release):
+        """Flag on + no library row + Discogs returns a release credited to the
+        typed artist → emit ``LibraryItem(id=0)`` + ``{0: ResolvedRelease}``."""
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        # Direct artist search and every album cross-reference miss the library.
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[
+                make_discogs_result(
+                    release_id=555,
+                    artist="Sessa",
+                    album="Pequena Vertigem de Amor",
+                )
+            ],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sessa", AsyncMock())
+
+        assert len(items) == 1
+        assert items[0].id == 0
+        assert items[0].artist == "Sessa"
+        assert items[0].title == "Pequena Vertigem de Amor"
+        assert discogs_titles is not None
+        resolved = discogs_titles[0]
+        assert resolved.release_id == 555
+        assert resolved.release_url == "https://discogs.com/release/555"
+
+    @pytest.mark.asyncio
+    async def test_no_rowless_when_token_not_normalize_equal(self, enable_nonlibrary_release):
+        """A coincidental token→artist-name hit that is NOT normalize-equal does
+        not surface a release — the confidence gate floor."""
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[
+                make_discogs_result(release_id=42, artist="Stereolab", album="Dots and Loops")
+            ],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sterolab Typo", AsyncMock())
+
+        assert items == []
+        assert discogs_titles is None
+
+    @pytest.mark.asyncio
+    async def test_no_rowless_when_flag_off(self, monkeypatch):
+        """Flag off → no row-less identity, even when Discogs cleanly resolves
+        the artist (gated rollout)."""
+        monkeypatch.delenv("LML_RESOLVE_NONLIBRARY_RELEASE", raising=False)
+        from config.settings import get_settings
+
+        get_settings.cache_clear()
+
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[make_discogs_result(release_id=555, artist="Sessa", album="Grandeza")],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sessa", AsyncMock())
+
+        get_settings.cache_clear()
+        assert items == []
+        assert discogs_titles is None
+
+    @pytest.mark.asyncio
+    async def test_library_backed_unchanged_with_flag_on(self, enable_nonlibrary_release):
+        """When the Discogs cross-reference hits a real library row, that row is
+        returned (no row-less), even with the flag on — library-backed
+        SONG_AS_ARTIST behavior is unchanged."""
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        lib_item = _item(id=7, artist="Stereolab", title="Dots and Loops")
+        # Direct artist search misses; album cross-reference hits the library row.
+        db.search = AsyncMock(side_effect=[[], [lib_item]])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[
+                make_discogs_result(release_id=99, artist="Stereolab", album="Dots and Loops")
+            ],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Stereolab", AsyncMock())
+
+        assert [i.id for i in items] == [7]
+        assert discogs_titles is None
+
+    @pytest.mark.asyncio
+    async def test_selects_own_release_excluding_va_comp(self, enable_nonlibrary_release):
+        """Selection rule: the V/A comp (credited 'Various') is gated out even
+        with the highest confidence; among the artist's own releases the
+        higher-confidence one wins."""
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[
+                make_discogs_result(
+                    release_id=300, artist="Various", album="Some Comp", confidence=0.99
+                ),
+                make_discogs_result(
+                    release_id=210, artist="Sessa", album="Grandeza", confidence=0.2
+                ),
+                make_discogs_result(
+                    release_id=220, artist="Sessa", album="Estrela Acesa", confidence=0.8
+                ),
+            ],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sessa", AsyncMock())
+
+        assert len(items) == 1
+        assert items[0].id == 0
+        resolved = discogs_titles[0]
+        assert resolved.release_id == 220
+        assert items[0].title == "Estrela Acesa"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -334,6 +334,28 @@ class TestSearchSongAsArtistRowless:
         assert resolved.release_id == 220
         assert items[0].title == "Estrela Acesa"
 
+    @pytest.mark.asyncio
+    async def test_no_rowless_when_resolved_release_id_nonpositive(self, enable_nonlibrary_release):
+        """Defense in depth: a malformed non-positive ``release_id`` must not
+        surface. It would fail the ``release_id > 0`` artwork bypass downstream
+        and silently collapse to the BS#1185 sentinel — the not-found outcome
+        this path exists to kill — so drop it at selection instead."""
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[
+                make_discogs_result(release_id=0, artist="Sessa", album="Grandeza"),
+            ],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sessa", AsyncMock())
+
+        assert items == []
+        assert discogs_titles is None
+
 
 # ---------------------------------------------------------------------------
 # search_library_with_fallback -- artist+song path (lines 260-265)


### PR DESCRIPTION
Closes #631.

## Problem

`search_song_as_artist` reinterprets a request-o-matic listener's typed token as an artist name, looks up that artist's releases on Discogs, and keeps only those that cross-reference a WXYC library row. A non-library artist was dropped even when Discogs cleanly resolved the name — so rom posted "not found" to Slack instead of "here's the Discogs release they mean (not in our library)", losing useful context for the DJ reading the channel.

## Change

When no library row matches and the typed token **normalize-equals** a resolved Discogs artist name, emit the row-less `LibraryItem(id=0)` + `ResolvedRelease` via the #628 `discogs_titles` carry-through (real `release_id`/`release_url`, not the BS#1185 sentinel), gated behind the shared `LML_RESOLVE_NONLIBRARY_RELEASE` flag (default **off**, ships dark).

### Confidence gate + selection rule (the #631 open design question, decided)

`to_match_form(token) == to_match_form(discogs_artist_name)` is the artist-only analog of `find_best_typed_match`'s floor: a coincidental token-to-name hit is dropped, and V/A compilations credited to "Various" fail it by construction — so the survivors are the artist's **own** releases. Among them the most-relevant (Discogs `confidence`, stable `release_id` tiebreak) represents the request. True community-count ranking would need a per-release `get_release` fetch (the cost #633 bounds) and is deferred; the gate already excludes comps and the pick is deterministic.

### Mechanics

- Widen `lookup_releases_by_artist` to return full `DiscogsSearchResult`s, so one fetch serves both the library cross-reference and the row-less identity.
- Thread the `discogs_titles` seam through `SongAsArtist.attempt` and a new optional `Outcome.found(discogs_titles=)`, so `fetch_artwork_for_items` binds the carried release onto the `id=0` item. The binding side already gates any `id=0` item on `LML_RESOLVE_NONLIBRARY_RELEASE`, so reusing that flag (vs. a new one) keeps the change minimal.
- Library-backed SONG_AS_ARTIST is unchanged.

## Tests

- Unit (`test_orchestrator_gaps.py`): gate pass/fail, flag-off, library-backed-unchanged, selection (comp-exclusion + confidence ordering).
- Contract (`test_discogs_lookup.py`): widened `lookup_releases_by_artist` return shape.
- Integration (`test_lookup_song_as_artist_rowless.py`): end-to-end `perform_lookup` — `search_type == "song_as_artist"`, `artwork.release_id > 0`, non-empty `discogs_url`, behind the flag; flag-off asserts today's behavior.

Full suite: 3185 passed (pg/external_api deselected). Lint + format clean.

## Acceptance criteria (#631)

- [x] Non-library artist that resolves on Discogs surfaces a row-less result, gated on typed-token ⟂ Discogs-artist-name normalized equality.
- [x] A coincidental (not normalize-equal) match does **not** surface a release.
- [x] Library-backed SONG_AS_ARTIST behavior unchanged.
- [x] Release-selection rule decided + documented before implementation (own-release-not-comps; documented in `_select_rowless_artist_release`).
- [x] Unit coverage for the gate and the selection rule.

## Related

- #625 (parent), #628 (the row-less carry-through this reuses for emission).
- request-o-matic gets a sibling fix so a row-less `id=0` result doesn't post a malformed `<|WXYC>` Slack link (empty `library_url`); filed alongside.