### PR TITLE
fix(#649): suppress SONG_AS_TRACK row-less carry-through under a "Various" anchor

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1202,7 +1202,12 @@ async def _match_track_releases_to_library(
     ``search_releases_by_track`` probe + the per-track ``validate_track_on_release``
     credit check. The #632 cache is keyed on the typed anchor artist (the kernel's
     ``artist`` for SWAPPED; the surfaced release's own credit for SONG_AS_TRACK,
-    which has no typed artist).
+    which has no typed artist). **LML#649:** when that SONG_AS_TRACK fallback
+    credit is a compilation marker ("Various" for a V/A comp), it is not a usable
+    per-track artist — the carry-through is suppressed entirely rather than
+    resolved/validated/cached under it (which would validate only against the
+    release-level "Various" credit and collide same-titled tracks across comps on
+    the ``("various", <title>, True)`` cache key).
 
     Returns:
         Tuple of (library_items, matched_via_by_id, discogs_titles).
@@ -1332,6 +1337,24 @@ async def _match_track_releases_to_library(
         anchor_artist = artist or next(
             (r.artist for r in raw_releases if r.artist and r.artist.strip()), ""
         )
+        # LML#649: a compilation-marker anchor ("Various") is not a usable
+        # per-track artist. SONG_AS_TRACK on a V/A comp falls back here to the
+        # release-level credit, which is "Various" for the exact case the
+        # carry-through targets. Resolving under it would (a) validate only
+        # against the release-level "Various" credit — blind to the track's
+        # actual performer (validate_track_on_release's release-artist fallback)
+        # — and (b) key the #632 cache on ``("various", <title>, True)``,
+        # collapsing same-titled tracks across different comps onto one row (the
+        # second add could surface the first comp's release). Suppress the
+        # carry-through rather than surface an imprecise, collision-prone item;
+        # the precise fix plumbs the per-track credit as the anchor. SWAPPED and
+        # TRACK_ON_COMPILATION carry a typed artist and never reach this.
+        if is_compilation_artist(anchor_artist.strip()):
+            logger.info(
+                f"{label}: suppressing row-less carry-through — anchor artist "
+                f"'{anchor_artist}' is a compilation marker, not a per-track credit"
+            )
+            return matched_items, matched_via_by_id, {}
         resolved = await _resolve_nonlibrary_release(
             discogs_service,
             pg,

--- a/tests/integration/test_lookup_nonlibrary_release.py
+++ b/tests/integration/test_lookup_nonlibrary_release.py
@@ -305,7 +305,11 @@ async def test_song_as_track_surfaces_rowless_when_flag_on(library_db, enable_no
     # SONG_AS_ARTIST: no releases by the song-as-artist name.
     svc.lookup_releases_by_artist = AsyncMock(return_value=[])
     # Song-only probe surfaces the spine release (its own artist credit anchors
-    # the row-less resolve, since there is no typed artist here).
+    # the row-less resolve, since there is no typed artist here). The
+    # ``artist=SPINE_ARTIST`` override is load-bearing post-LML#649: a *real*
+    # release credit anchors and surfaces, whereas the realistic default
+    # ``"Various"`` credit is suppressed (see
+    # ``test_song_as_track_various_anchor_suppresses_rowless``).
     svc.search_releases_by_track = AsyncMock(
         return_value=_track_releases(_spine_release(artist=SPINE_ARTIST))
     )
@@ -336,6 +340,64 @@ async def test_song_as_track_flag_off_no_rowless(library_db):
         r.library_item.id == 0 and r.artwork is not None and r.artwork.release_id > 0
         for r in response.results
     )
+
+
+@pytest.mark.asyncio
+async def test_song_as_track_various_anchor_suppresses_rowless(
+    library_db, enable_nonlibrary_release
+):
+    """LML#649: a song-only V/A-comp miss whose only artist signal is the
+    release-level "Various" credit must NOT surface row-less, even flag-on.
+
+    The anchor falls back to the surfaced release's own credit, which is the
+    compilation marker "Various" for a real V/A comp (the case the carry-through
+    targets). That is not a usable per-track artist: resolving under it validates
+    only against the release-level "Various" credit (blind to the track's actual
+    performer) and would key the #632 cache on ``("various", <title>, True)``,
+    colliding same-titled tracks across different comps. Until the per-track
+    credit is plumbed through, suppress the carry-through rather than surface an
+    imprecise, collision-prone item.
+
+    The sibling ``..._surfaces_rowless_when_flag_on`` overrides
+    ``artist=SPINE_ARTIST`` — a real release credit — and still surfaces; this
+    pins the realistic default-``Various`` case that override hid.
+    """
+    svc = _base_discogs_mock()
+    svc.lookup_releases_by_artist = AsyncMock(return_value=[])
+    # Default _spine_release() credits the comp to "Various" — the realistic V/A
+    # shape, not the artist=SPINE_ARTIST the masking test substitutes.
+    svc.search_releases_by_track = AsyncMock(return_value=_track_releases(_spine_release()))
+
+    response = await _run_song_as_track(library_db, svc)
+
+    assert not any(
+        r.library_item.id == 0 and r.artwork is not None and r.artwork.release_id > 0
+        for r in response.results
+    )
+
+
+@pytest.mark.asyncio
+async def test_song_as_track_various_anchor_never_writes_632_cache(
+    library_db, enable_nonlibrary_release
+):
+    """LML#649 AC3: the song-only V/A path must never write the #632 cache under
+    a "Various" anchor — that ``("various", <title>, True)`` key is what collides
+    distinct same-titled tracks across different comps. Suppressing the
+    carry-through means no resolve, hence no cache write at all.
+
+    Contrast ``test_track_on_compilation_threads_pg_and_writes_cache``, where a
+    *typed* artist anchor legitimately writes ``(SPINE_ARTIST, SPINE_TRACK)``.
+    """
+    svc = _base_discogs_mock()
+    svc.lookup_releases_by_artist = AsyncMock(return_value=[])
+    svc.search_releases_by_track = AsyncMock(return_value=_track_releases(_spine_release()))
+    pg = _RecordingPg()
+
+    await _run_song_as_track(library_db, svc, pg=pg)
+
+    # No row was written under any key — in particular nothing under "various".
+    assert pg.execute_calls == 0
+    assert pg.store == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

For a song-only query routed to SONG_AS_TRACK, the #628 row-less carry-through has no typed artist, so its anchor falls back to the release-level credit (`ReleaseInfo.artist`), which is `"Various"` for a V/A compilation — the exact case the feature targets. That `anchor_artist` fed both the #632 cache key and the resolve/validate call:

1. **Cache-key collision.** The `release_resolution_cache` row keyed `("various", <track_title>, True)` collapses two distinct tracks that share a title across different V/A comps (e.g. two songs titled "Intro") onto one row — the second add could surface the *first* comp's release.
2. **Validation imprecision.** `validate_track_on_release(..., "Various")` falls back to the release-level "Various" credit rather than the track's actual performer, losing per-track precision.

Flag-gated off (`lml_resolve_nonlibrary_release`, default False), so no production impact today; in-spec-by-omission for #628, not a regression.

## Fix (MVP)

When the SONG_AS_TRACK anchor resolves to a compilation marker (`is_compilation_artist`), suppress the carry-through entirely — no resolve, no validate, no #632 cache write — rather than surface an imprecise, collision-prone row-less item. A "Various" credit is not a usable per-track artist; what a live resolve under it would surface is validated only by track-title presence on a Various-credited release (blind to the performer), so for the common-title case it is actively misleading. SWAPPED and TRACK_ON_COMPILATION carry a typed artist and never reach this point.

This is the minimum-viable fix the issue calls out ("do not cache, and do not validate, under a pure-Various anchor"). The precise end state — plumbing the per-track credit through `_process_search_result` as the anchor — is the larger follow-up (sibling #646).

## Tests

- `test_song_as_track_various_anchor_suppresses_rowless` — the realistic default-`Various` comp surfaces nothing row-less (the prior surfacing test masked this by overriding `artist=SPINE_ARTIST`).
- `test_song_as_track_various_anchor_never_writes_632_cache` — asserts `pg.execute_calls == 0`, so nothing is keyed under `("various", …)` and no cross-track collision is possible.
- Annotated the sibling `..._surfaces_rowless_when_flag_on` so its `SPINE_ARTIST` override reads as load-bearing (a real release credit still surfaces).

Both new tests were confirmed RED against the unfixed kernel before the guard landed.

## Acceptance criteria

- [x] SONG_AS_TRACK carry-through for a V/A comp does not cache under "Various".
- [x] A SONG_AS_TRACK test with `_spine_release(artist="Various")` pins the real anchor behavior.
- [x] No two distinct same-titled tracks collide under the `("various", <title>, True)` cache key.

## Checks

`ruff format --check` + `ruff check` + `mypy` clean; full default suite 3180 passed / 1 skipped / 2 xfailed locally.

Closes #649
