### PR TITLE
A2/A4: row-less cached-track release_id + soft no-album confidence (#629)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -88,6 +88,7 @@ from lookup.models import LookupRequest, LookupResponse, LookupResultItem
 from lookup.release_resolution import (
     ResolvedRelease,
     merge_wave_b_compilations,
+    prerank_candidates_for_validation,
     rank_resolved_releases,
     resolve_release_for_track,
     resolve_release_for_track_cached,
@@ -1028,14 +1029,16 @@ this floor is replaced with ``library_identity.confidence`` per row.
 
 
 ROWLESS_NO_ALBUM_CONFIDENCE: float = 0.8
-"""Soft confidence for a row-less non-library release surfaced by a *no-album*
-query (A2, LML#629).
+"""Soft confidence for a row-less non-library release that was not album-matched
+(A2, LML#629).
 
-A song-only / artist+song query validates the (artist, track) pair, but with no
-typed album the bound release is the best-ranked candidate (prefer-own-release,
-then stable release_id) — not a user-confirmed album. Carrying a confidence
-below the album-typed 1.0 lets a consumer (request-o-matic) treat it as soft.
-Album-typed binds keep the full 1.0: the user named the album.
+Applied when a row-less bind is *not* a user-confirmed album — either because the
+request typed no album (song-only / artist+song), or because the binding route
+never matched the release against the typed album. The latter is the cached-track
+safety net (A4), which picks by track only; it stamps this on the seam so the
+bind stays soft even when an album was typed. An album-ranked carry-through
+(A1/#628 with a typed album) keeps the full 1.0 — the typed album shaped the
+pick. Lets a consumer (request-o-matic) treat the soft results as tentative.
 """
 
 # Synthetic library-id for a row-less result — a Discogs release with no WXYC
@@ -2484,26 +2487,28 @@ async def find_library_albums_with_cached_track(
     # surface the best one row-less so its release_id (hence discogs_url) still
     # binds via #628's {0: ResolvedRelease} seam. Gated on the same flag as the
     # other carry-through sites: when off, fetch_artwork_for_items won't bind a
-    # row-less item, so we preserve the pre-#629 drop. No-album ordering (the
-    # #629 rule prerank_candidates_for_validation applies on the bounded resolve
-    # path): prefer the artist's own release (is_compilation=False) over a
-    # compilation, then stable release_id. Cache rows are already track-confirmed
-    # by the trigram query, so no re-validation is needed.
+    # row-less item, so we preserve the pre-#629 drop. Cache rows are already
+    # track-confirmed by the trigram query, so no re-validation is needed.
+    #
+    # Ordering reuses the shared #629 no-album rule (prefer is_compilation=False,
+    # then stable release_id) instead of restating it — keeping this path and the
+    # bounded-resolve path on one definition. There is no typed album to rank
+    # against here (the cache keyed on track only), so confidence is soft: the
+    # pick was never album-matched, and the soft value rides the seam so the bind
+    # surfaces it even when the request did type an album.
     if not get_settings().lml_resolve_nonlibrary_release:
         return [], {}
-    best = min(
-        (r for r in cached_releases if r.release_id),
-        key=lambda r: (r.is_compilation, r.release_id),
-        default=None,
-    )
-    if best is None:
+    ranked = prerank_candidates_for_validation([r for r in cached_releases if r.release_id], None)
+    if not ranked:
         return [], {}
+    best = ranked[0]
     rowless = _make_rowless_item(artist=artist or "", title=best.album)
     resolved = ResolvedRelease(
         release_id=best.release_id,
         release_url=best.release_url or "",
         is_compilation=bool(best.is_compilation),
         album_title=best.album or "",
+        confidence=ROWLESS_NO_ALBUM_CONFIDENCE,
     )
     return [rowless], {ROWLESS_LIBRARY_ID: resolved}
 
@@ -2563,25 +2568,35 @@ async def _bind_resolved_release(
     year/label/genres via ``get_release`` exactly as for a floor-matched result.
 
     The floor was never a validation backstop — it is a search disambiguator,
-    and validation already settled the artist — so ``confidence`` is the
+    and validation already settled the artist — so ``confidence`` defaults to the
     maximum 1.0.
 
-    **A2 soft confidence (LML#629):** a *row-less* (id==0) bind from a *no-album*
-    query carries ``ROWLESS_NO_ALBUM_CONFIDENCE`` instead. The (artist, track)
-    pair validated, but with no typed album the release is the best-ranked guess,
-    not a user-confirmed album — so a consumer can treat it as soft. An in-library
-    bind, or a row-less bind for an album-typed query, keeps the full 1.0.
+    **A2 soft confidence (LML#629):** a *row-less* (id==0) bind is softened in two
+    cases, and the result takes the lower (softer) of the two signals:
+
+    - **No typed album in the request** — the release is the best-ranked guess,
+      not a user-confirmed album, so any row-less bind drops to
+      ``ROWLESS_NO_ALBUM_CONFIDENCE``.
+    - **The seam already carries a soft confidence** (``release.confidence``) —
+      the cached-track safety net (A4) picks by track only and never
+      album-matches, so it stamps the seam soft *regardless* of a typed album;
+      the bind can't tell A4 from an album-ranked carry-through otherwise. An
+      album-ranked carry-through (A1/#628 with a typed album) leaves the seam at
+      1.0, so a typed-album request keeps the full confidence there.
+
+    An in-library bind (id != 0) is never softened.
     """
     artwork_url = await _resolve_fallback_artwork(discogs_service, release.release_id)
-    no_album = not (album or "").strip()
-    soft = item.id == ROWLESS_LIBRARY_ID and no_album
+    confidence = release.confidence
+    if item.id == ROWLESS_LIBRARY_ID and not (album or "").strip():
+        confidence = min(confidence, ROWLESS_NO_ALBUM_CONFIDENCE)
     return DiscogsSearchResult(
         release_id=release.release_id,
         release_url=release.release_url,
         album=release.album_title,
         artist=item.artist,
         artwork_url=artwork_url,
-        confidence=ROWLESS_NO_ALBUM_CONFIDENCE if soft else 1.0,
+        confidence=confidence,
     )
 
 
@@ -2754,7 +2769,9 @@ async def fetch_artwork_for_items(
                         release_id=best.release_id if best is not None else None,
                     )
                     if best is not None:
-                        return await _bind_resolved_release(discogs_service, best, item)
+                        return await _bind_resolved_release(
+                            discogs_service, best, item, album=request_album
+                        )
                 return None
             if not result.artwork_url:
                 fallback = await _resolve_fallback_artwork(discogs_service, result.release_id)

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -2498,7 +2498,12 @@ async def find_library_albums_with_cached_track(
     # surfaces it even when the request did type an album.
     if not get_settings().lml_resolve_nonlibrary_release:
         return [], {}
-    ranked = prerank_candidates_for_validation([r for r in cached_releases if r.release_id], None)
+    # Require a title as well as an id: a title-less release would surface a
+    # degenerate row-less item (title=""), exactly what the sibling rehydrate
+    # path (_rehydrate_resolved_release) guards against.
+    ranked = prerank_candidates_for_validation(
+        [r for r in cached_releases if r.release_id and r.album], None
+    )
     if not ranked:
         return [], {}
     best = ranked[0]
@@ -2509,6 +2514,10 @@ async def find_library_albums_with_cached_track(
         is_compilation=bool(best.is_compilation),
         album_title=best.album or "",
         confidence=ROWLESS_NO_ALBUM_CONFIDENCE,
+    )
+    logger.info(
+        f"cached-track safety net: surfacing row-less Discogs release "
+        f"{best.release_id} ('{best.album}') — track-confirmed in cache, not in library"
     )
     return [rowless], {ROWLESS_LIBRARY_ID: resolved}
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1026,6 +1026,18 @@ When LML graduates onto ``library_identity`` per cross-cache-identity (#25),
 this floor is replaced with ``library_identity.confidence`` per row.
 """
 
+
+ROWLESS_NO_ALBUM_CONFIDENCE: float = 0.8
+"""Soft confidence for a row-less non-library release surfaced by a *no-album*
+query (A2, LML#629).
+
+A song-only / artist+song query validates the (artist, track) pair, but with no
+typed album the bound release is the best-ranked candidate (prefer-own-release,
+then stable release_id) — not a user-confirmed album. Carrying a confidence
+below the album-typed 1.0 lets a consumer (request-o-matic) treat it as soft.
+Album-typed binds keep the full 1.0: the user named the album.
+"""
+
 # Synthetic library-id for a row-less result — a Discogs release with no WXYC
 # catalog row. Shared by the Step-3a library-miss search and the #628 A1
 # carry-through: Step-3b excludes it from re-validation, fetch_artwork_for_items
@@ -2402,7 +2414,7 @@ async def find_library_albums_with_cached_track(
     limit: int = MAX_SEARCH_RESULTS,
     *,
     match_artist: str | None = None,
-) -> list[LibraryItem]:
+) -> tuple[list[LibraryItem], dict[int, ResolvedRelease]]:
     """Find WXYC library albums whose Discogs cache entry lists ``song`` by ``artist``.
 
     Used as a safety net after ``filter_results_by_track_validation`` fails to
@@ -2418,15 +2430,25 @@ async def find_library_albums_with_cached_track(
     ``match_artist`` defaults to ``artist`` to preserve single-channel behavior
     for callers that don't distinguish the two.
 
-    Cache-only by design: skips any API fallback path. Returns ``[]`` cleanly
-    when the cache is unavailable, fails, or has nothing for the query.
+    Returns ``(items, discogs_titles)``. On the in-library path ``items`` are the
+    promoted WXYC rows and ``discogs_titles`` is empty. **A4 carry-through
+    (LML#629):** when the cache confirms the track on a release but *no* library
+    row artist-matches — and ``lml_resolve_nonlibrary_release`` is on — a single
+    **row-less** ``LibraryItem(id=0)`` is returned with the resolved release on
+    the ``{0: ResolvedRelease}`` seam, reusing #628's carry-through so the
+    ``release_id`` (hence ``discogs_url``) still surfaces instead of being
+    dropped for want of a matching catalog row.
+
+    Cache-only by design: skips any API fallback path. Returns ``([], {})``
+    cleanly when the cache is unavailable, fails, or has nothing for the query —
+    and, with the flag off, when nothing artist-matches (pre-#629 behavior).
     """
     if not discogs_service or not song or not artist:
-        return []
+        return [], {}
     match_against = match_artist or artist
     cache_service = getattr(discogs_service, "cache_service", None)
     if cache_service is None:
-        return []
+        return [], {}
 
     try:
         cached_releases = await cache_service.search_releases_by_track(
@@ -2434,10 +2456,10 @@ async def find_library_albums_with_cached_track(
         )
     except Exception as e:
         logger.warning(f"Cache lookup for track-album promotion failed: {e}")
-        return []
+        return [], {}
 
     if not cached_releases:
-        return []
+        return [], {}
 
     matches: list[LibraryItem] = []
     seen_ids: set[int] = set()
@@ -2452,9 +2474,38 @@ async def find_library_albums_with_cached_track(
             matches.append(item)
             seen_ids.add(item.id)
             if len(matches) >= limit:
-                return matches
+                return matches, {}
 
-    return matches
+    if matches:
+        return matches, {}
+
+    # A4 carry-through (LML#629): the cache confirmed the track on a release, but
+    # no WXYC library row artist-matches. Rather than drop a resolvable release,
+    # surface the best one row-less so its release_id (hence discogs_url) still
+    # binds via #628's {0: ResolvedRelease} seam. Gated on the same flag as the
+    # other carry-through sites: when off, fetch_artwork_for_items won't bind a
+    # row-less item, so we preserve the pre-#629 drop. No-album ordering (the
+    # #629 rule prerank_candidates_for_validation applies on the bounded resolve
+    # path): prefer the artist's own release (is_compilation=False) over a
+    # compilation, then stable release_id. Cache rows are already track-confirmed
+    # by the trigram query, so no re-validation is needed.
+    if not get_settings().lml_resolve_nonlibrary_release:
+        return [], {}
+    best = min(
+        (r for r in cached_releases if r.release_id),
+        key=lambda r: (r.is_compilation, r.release_id),
+        default=None,
+    )
+    if best is None:
+        return [], {}
+    rowless = _make_rowless_item(artist=artist or "", title=best.album)
+    resolved = ResolvedRelease(
+        release_id=best.release_id,
+        release_url=best.release_url or "",
+        is_compilation=bool(best.is_compilation),
+        album_title=best.album or "",
+    )
+    return [rowless], {ROWLESS_LIBRARY_ID: resolved}
 
 
 async def _resolve_fallback_artwork(discogs_service: DiscogsService, release_id: int) -> str | None:
@@ -2499,6 +2550,8 @@ async def _bind_resolved_release(
     discogs_service: DiscogsService,
     release: ResolvedRelease,
     item: LibraryItem,
+    *,
+    album: str | None = None,
 ) -> DiscogsSearchResult:
     """Trust-and-bind an already-validated ``ResolvedRelease`` (LML#604).
 
@@ -2512,15 +2565,23 @@ async def _bind_resolved_release(
     The floor was never a validation backstop — it is a search disambiguator,
     and validation already settled the artist — so ``confidence`` is the
     maximum 1.0.
+
+    **A2 soft confidence (LML#629):** a *row-less* (id==0) bind from a *no-album*
+    query carries ``ROWLESS_NO_ALBUM_CONFIDENCE`` instead. The (artist, track)
+    pair validated, but with no typed album the release is the best-ranked guess,
+    not a user-confirmed album — so a consumer can treat it as soft. An in-library
+    bind, or a row-less bind for an album-typed query, keeps the full 1.0.
     """
     artwork_url = await _resolve_fallback_artwork(discogs_service, release.release_id)
+    no_album = not (album or "").strip()
+    soft = item.id == ROWLESS_LIBRARY_ID and no_album
     return DiscogsSearchResult(
         release_id=release.release_id,
         release_url=release.release_url,
         album=release.album_title,
         artist=item.artist,
         artwork_url=artwork_url,
-        confidence=1.0,
+        confidence=ROWLESS_NO_ALBUM_CONFIDENCE if soft else 1.0,
     )
 
 
@@ -2530,6 +2591,7 @@ async def fetch_artwork_for_items(
     discogs_titles: dict[int, ResolvedRelease] | None = None,
     *,
     song: str | None = None,
+    album: str | None = None,
     allow_release_resolution_fallback: bool = True,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Fetch artwork for multiple library items in parallel.
@@ -2542,11 +2604,18 @@ async def fetch_artwork_for_items(
     ``allow_release_resolution_fallback`` is the bulk kill switch — the
     /lookup/bulk drain passes ``False`` so the 35k-album backfill never triggers
     the per-row Discogs fan-out.
+
+    ``album`` (the request-level typed album, when present) only gates the A2
+    soft-confidence on a row-less carried bind (LML#629): a no-album query's
+    row-less release binds at ``ROWLESS_NO_ALBUM_CONFIDENCE`` rather than 1.0.
     """
     if not discogs_service:
         return [(item, None) for item in items]
 
     discogs_titles = discogs_titles or {}
+    # Bound to a distinct name: ``fetch_one`` rebinds a local ``album`` (the
+    # per-item search title), which would shadow this request-level value.
+    request_album = album
     settings = get_settings()
     resolve_compilation_release = settings.lml_resolve_compilation_release
     resolve_nonlibrary_release = settings.lml_resolve_nonlibrary_release
@@ -2574,7 +2643,9 @@ async def fetch_artwork_for_items(
                 resolve_nonlibrary_release and item.id == ROWLESS_LIBRARY_ID
             )
             if bind_carried and resolved is not None:
-                return await _bind_resolved_release(discogs_service, resolved, item)
+                return await _bind_resolved_release(
+                    discogs_service, resolved, item, album=request_album
+                )
 
             album = resolved.album_title if resolved is not None else item.title
 
@@ -3679,7 +3750,7 @@ async def perform_lookup(
                     # tracklist contains this song?" — and promote the matching
                     # library album. Catches the case where the upstream
                     # track→releases lookup missed a release the cache holds.
-                    promoted = await find_library_albums_with_cached_track(
+                    promoted, promoted_titles = await find_library_albums_with_cached_track(
                         db,
                         parsed.song,
                         parsed.artist,
@@ -3688,6 +3759,9 @@ async def perform_lookup(
                     )
                     if promoted:
                         library_results = promoted
+                        # A4 (LML#629): a row-less promotion carries its resolved
+                        # release on the seam so Step 4 binds discogs_url by id.
+                        discogs_titles = {**discogs_titles, **promoted_titles}
                         song_not_found = False
                     else:
                         # Last resort before declaring song-not-found: the
@@ -3741,6 +3815,7 @@ async def perform_lookup(
                 discogs_service,
                 discogs_titles,
                 song=parsed.song,
+                album=parsed.album,
                 allow_release_resolution_fallback=allow_release_resolution_fallback,
             )
 

--- a/lookup/release_resolution.py
+++ b/lookup/release_resolution.py
@@ -46,6 +46,12 @@ class ResolvedRelease:
     release_url: str
     is_compilation: bool
     album_title: str
+    # Confidence the binding step stamps on the surfaced result. Defaults to the
+    # full 1.0 (a track-validated, album-ranked carry-through). The cached-track
+    # safety net (LML#629 A4) sets it soft because it picks by track only and
+    # never album-matches — so the soft value must ride the seam to the bind,
+    # which otherwise can't distinguish A4 from an album-ranked carry-through.
+    confidence: float = 1.0
 
 
 def merge_wave_b_compilations(
@@ -182,7 +188,9 @@ def prerank_candidates_for_validation(
     """
     album_query = (album or "").strip()
     if not album_query:
-        return sorted(candidates, key=lambda r: (r.is_compilation, r.release_id))
+        # ``ReleaseInfo.is_compilation`` is ``bool | None``; coerce so a ``None``
+        # never lands in the sort tuple (``None < False`` raises TypeError).
+        return sorted(candidates, key=lambda r: (bool(r.is_compilation), r.release_id))
     return sorted(
         candidates,
         key=lambda r: (-score_match(album_query, r.album), r.release_id),

--- a/tests/integration/test_lookup_cached_track_rowless.py
+++ b/tests/integration/test_lookup_cached_track_rowless.py
@@ -61,8 +61,10 @@ def enable_nonlibrary_release(monkeypatch):
 @pytest.fixture
 def disable_nonlibrary_release(monkeypatch):
     """Force the flag off + reset the settings lru-cache so the flag-off assertion
-    is self-contained, not dependent on a prior test's fixture teardown."""
-    monkeypatch.delenv("LML_RESOLVE_NONLIBRARY_RELEASE", raising=False)
+    is self-contained, not dependent on a prior test's fixture teardown. Sets the
+    env var to "false" rather than unsetting it so it also overrides a developer's
+    local .env (Settings reads env_file=".env"; setenv takes precedence)."""
+    monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "false")
     from config.settings import get_settings
 
     get_settings.cache_clear()

--- a/tests/integration/test_lookup_cached_track_rowless.py
+++ b/tests/integration/test_lookup_cached_track_rowless.py
@@ -1,0 +1,145 @@
+"""A4 end-to-end: the cached-track safety net surfaces a non-library release
+row-less through ``perform_lookup`` (LML#629).
+
+The unit tests in ``tests/unit/test_cached_track_safety_net.py`` pin what
+``find_library_albums_with_cached_track`` *returns*; they cannot see the caller
+wiring. This drives the real pipeline down the Step-3b cached-track branch:
+
+1. artist+song (no album) for the seeded ``Lee 'Scratch' Perry`` cluster — the
+   artist-fallback surfaces real library rows (``real_results`` non-empty), so we
+   enter the ``if real_results and parsed.song and parsed.artist`` block;
+2. ``validate_track_on_release`` confirms nothing, so ``song_not_found`` holds and
+   the ``elif song_not_found`` branch calls the cached-track safety net;
+3. the PG cache confirms the track on a release the library does NOT carry, so no
+   row artist-matches → A4 surfaces it row-less.
+
+The load-bearing assertion is ``artwork.release_id > 0`` on the response: it
+proves the resolved id survives the caller's ``discogs_titles`` merge
+(``orchestrator.py`` Step-3b), the ``fetch_artwork_for_items`` bind, AND the
+``enrich_artwork_results`` LML#487/#628 title-gate bypass — the chain that would
+otherwise collapse to the BS#1185 ``release_id=0`` sentinel. None of that is
+covered by the unit tests or by the A2 carry-through integration tests (which run
+with ``cache_service=None``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.models import (
+    DiscogsSearchResponse,
+    ReleaseInfo,
+    ReleaseMetadataResponse,
+    TrackReleasesResponse,
+)
+from lookup.models import LookupRequest
+from lookup.orchestrator import ROWLESS_NO_ALBUM_CONFIDENCE, perform_lookup
+from tests.conftest import make_lml_telemetry
+
+ARTIST = "Lee 'Scratch' Perry"  # seeded cluster (six albums), no "Bucky Skank" row
+SONG = "Bucky Skank"
+
+# A real Lee Perry LP the seeded library does NOT carry, so the cache-confirmed
+# release fuzzy-matches no library row and must surface row-less.
+NONLIB_RELEASE_ID = 99999
+NONLIB_ALBUM = "Roast Fish Collie Weed & Corn Bread"
+NONLIB_RELEASE_URL = f"https://www.discogs.com/release/{NONLIB_RELEASE_ID}"
+
+
+@pytest.fixture
+def enable_nonlibrary_release(monkeypatch):
+    monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "true")
+    from config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _cache_release() -> ReleaseInfo:
+    return ReleaseInfo(
+        album=NONLIB_ALBUM,
+        artist=ARTIST,
+        release_id=NONLIB_RELEASE_ID,
+        release_url=NONLIB_RELEASE_URL,
+        is_compilation=False,
+    )
+
+
+def _empty_track_releases() -> TrackReleasesResponse:
+    return TrackReleasesResponse(track="", artist="", releases=[], total=0, cached=False)
+
+
+def _service(*, with_cache_hit: bool) -> AsyncMock:
+    """A mock service whose only track-confirmation channel is the PG cache.
+
+    The live track probes return nothing (so the artist-fallback rows survive to
+    Step-3b unvalidated), and the cache holds the non-library release.
+    """
+    svc = AsyncMock()
+    svc.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+    svc.search_releases_by_track = AsyncMock(return_value=_empty_track_releases())
+    svc.search_releases_by_album_title = AsyncMock(return_value=_empty_track_releases())
+    # Nothing validates on the live path -> song_not_found holds into Step-3b.
+    svc.validate_track_on_release = AsyncMock(return_value=False)
+    svc.get_release = AsyncMock(
+        return_value=ReleaseMetadataResponse(
+            release_id=NONLIB_RELEASE_ID,
+            title=NONLIB_ALBUM,
+            artist=ARTIST,
+            release_url=NONLIB_RELEASE_URL,
+            artwork_url="https://i.discogs.com/roast.jpg",
+        )
+    )
+
+    cache = AsyncMock()
+    cache.search_releases_by_track = AsyncMock(
+        return_value=[_cache_release()] if with_cache_hit else []
+    )
+    svc.cache_service = cache
+    return svc
+
+
+async def _run(library_db, svc):
+    request = LookupRequest(artist=ARTIST, song=SONG, raw_message=f"{ARTIST} - {SONG}")
+    return await perform_lookup(
+        request, library_db, svc, telemetry=make_lml_telemetry(), discogs_cache_pg=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_cached_track_surfaces_rowless_release_end_to_end(
+    library_db, enable_nonlibrary_release
+):
+    """The cache confirms the track on a non-library release; the safety net
+    surfaces it row-less and the resolved release_id survives to the response."""
+    svc = _service(with_cache_hit=True)
+
+    response = await _run(library_db, svc)
+
+    rowless = [r for r in response.results if r.library_item.id == 0 and r.artwork is not None]
+    assert len(rowless) == 1
+    item = rowless[0]
+    # The chain held: caller merged the seam, fetch bound by id, enrich's #628
+    # bypass kept the id off the sentinel.
+    assert item.artwork.release_id == NONLIB_RELEASE_ID
+    assert item.artwork.release_id > 0
+    assert item.artwork.release_url == NONLIB_RELEASE_URL
+    # No typed album -> A2 soft confidence on the A4 path too.
+    assert item.artwork.confidence == ROWLESS_NO_ALBUM_CONFIDENCE
+
+
+@pytest.mark.asyncio
+async def test_cached_track_flag_off_no_rowless_release(library_db):
+    """Flag off: the safety net stays inert — no row-less Discogs identity
+    surfaces (pre-#629 drop preserved)."""
+    svc = _service(with_cache_hit=True)
+
+    response = await _run(library_db, svc)
+
+    assert not any(
+        r.library_item.id == 0 and r.artwork is not None and r.artwork.release_id > 0
+        for r in response.results
+    )

--- a/tests/integration/test_lookup_cached_track_rowless.py
+++ b/tests/integration/test_lookup_cached_track_rowless.py
@@ -58,6 +58,18 @@ def enable_nonlibrary_release(monkeypatch):
     get_settings.cache_clear()
 
 
+@pytest.fixture
+def disable_nonlibrary_release(monkeypatch):
+    """Force the flag off + reset the settings lru-cache so the flag-off assertion
+    is self-contained, not dependent on a prior test's fixture teardown."""
+    monkeypatch.delenv("LML_RESOLVE_NONLIBRARY_RELEASE", raising=False)
+    from config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
 def _cache_release() -> ReleaseInfo:
     return ReleaseInfo(
         album=NONLIB_ALBUM,
@@ -132,7 +144,7 @@ async def test_cached_track_surfaces_rowless_release_end_to_end(
 
 
 @pytest.mark.asyncio
-async def test_cached_track_flag_off_no_rowless_release(library_db):
+async def test_cached_track_flag_off_no_rowless_release(library_db, disable_nonlibrary_release):
     """Flag off: the safety net stays inert — no row-less Discogs identity
     surfaces (pre-#629 drop preserved)."""
     svc = _service(with_cache_hit=True)

--- a/tests/integration/test_lookup_nonlibrary_no_album.py
+++ b/tests/integration/test_lookup_nonlibrary_no_album.py
@@ -1,0 +1,147 @@
+"""A2 no-album carry-through: artist+song (no typed album) resolvable non-library
+tracks surface row-less, prefer the artist's own release over a compilation, and
+carry a *soft* confidence (LML#629).
+
+#628 already routes the no-album shapes (song-only via SONG_AS_TRACK, artist+song
+via TRACK_ON_COMPILATION) through the row-less carry-through; #633 added the
+bounded resolve whose ``prerank_candidates_for_validation`` applies the #629
+no-album rule (prefer ``is_compilation=False``, then stable ``release_id``). This
+suite pins that end-to-end through ``perform_lookup`` and adds the A2 soft
+confidence: with no typed album the bound release is the best-ranked guess, so it
+binds below the album-typed 1.0.
+
+Driven against the real seeded ``library_db`` with a mock ``DiscogsService``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.models import (
+    DiscogsSearchResponse,
+    ReleaseInfo,
+    ReleaseMetadataResponse,
+    TrackReleasesResponse,
+)
+from lookup.models import LookupRequest
+from lookup.orchestrator import ROWLESS_NO_ALBUM_CONFIDENCE, perform_lookup
+from tests.conftest import make_lml_telemetry
+
+ARTIST = "A Guy Called Gerald"
+TRACK = "Message to Black Youth"
+
+COMP_RELEASE_ID = 36907527
+COMP_ALBUM = "When There Is No Sun"  # a Various-Artists compilation, not in library
+
+OWN_RELEASE_ID = 12345
+OWN_ALBUM = "Black Secret Technology"  # the artist's own LP, not in library
+
+
+@pytest.fixture
+def enable_nonlibrary_release(monkeypatch):
+    monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "true")
+    from config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _comp_release() -> ReleaseInfo:
+    return ReleaseInfo(
+        album=COMP_ALBUM,
+        artist="Various",
+        release_id=COMP_RELEASE_ID,
+        release_url=f"https://www.discogs.com/release/{COMP_RELEASE_ID}",
+        is_compilation=True,
+    )
+
+
+def _own_release() -> ReleaseInfo:
+    return ReleaseInfo(
+        album=OWN_ALBUM,
+        artist=ARTIST,
+        release_id=OWN_RELEASE_ID,
+        release_url=f"https://www.discogs.com/release/{OWN_RELEASE_ID}",
+        is_compilation=False,
+    )
+
+
+def _track_releases(*releases: ReleaseInfo) -> TrackReleasesResponse:
+    return TrackReleasesResponse(
+        track=TRACK, artist=ARTIST, releases=list(releases), total=len(releases), cached=False
+    )
+
+
+def _empty_track_releases() -> TrackReleasesResponse:
+    return TrackReleasesResponse(track="", artist="", releases=[], total=0, cached=False)
+
+
+def _base_discogs_mock() -> AsyncMock:
+    svc = AsyncMock()
+    svc.cache_service = None
+    svc.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+    svc.validate_track_on_release = AsyncMock(return_value=True)
+    svc.search_releases_by_album_title = AsyncMock(return_value=_empty_track_releases())
+
+    async def _get_release(release_id: int) -> ReleaseMetadataResponse:
+        return ReleaseMetadataResponse(
+            release_id=release_id,
+            title=OWN_ALBUM if release_id == OWN_RELEASE_ID else COMP_ALBUM,
+            artist=ARTIST if release_id == OWN_RELEASE_ID else "Various",
+            release_url=f"https://www.discogs.com/release/{release_id}",
+            artwork_url="https://i.discogs.com/cover.jpg",
+        )
+
+    svc.get_release = AsyncMock(side_effect=_get_release)
+    return svc
+
+
+async def _run(library_db, svc):
+    """Drive perform_lookup with an artist+song (no typed album) request."""
+    request = LookupRequest(artist=ARTIST, song=TRACK, raw_message=f"{ARTIST} - {TRACK}")
+    return await perform_lookup(
+        request, library_db, svc, telemetry=make_lml_telemetry(), discogs_cache_pg=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_artist_song_no_album_surfaces_rowless_with_soft_confidence(
+    library_db, enable_nonlibrary_release
+):
+    """A resolvable non-library track with no typed album surfaces row-less with a
+    real discogs_url, carrying the soft no-album confidence."""
+    svc = _base_discogs_mock()
+    svc.search_releases_by_track = AsyncMock(return_value=_track_releases(_own_release()))
+
+    response = await _run(library_db, svc)
+
+    assert len(response.results) == 1
+    item = response.results[0]
+    assert item.library_item.id == 0
+    assert item.artwork is not None
+    assert item.artwork.release_id == OWN_RELEASE_ID
+    assert item.artwork.release_url == f"https://www.discogs.com/release/{OWN_RELEASE_ID}"
+    # A2: no typed album -> soft confidence (not the album-typed 1.0).
+    assert item.artwork.confidence == ROWLESS_NO_ALBUM_CONFIDENCE
+
+
+@pytest.mark.asyncio
+async def test_no_album_prefers_own_album_over_compilation(library_db, enable_nonlibrary_release):
+    """When the track sits on both the artist's own LP and a V/A compilation, the
+    no-album ordering surfaces the own LP — even with the comp probed first."""
+    svc = _base_discogs_mock()
+    # Comp listed first to prove the prefer-own-release ordering flips it.
+    svc.search_releases_by_track = AsyncMock(
+        return_value=_track_releases(_comp_release(), _own_release())
+    )
+
+    response = await _run(library_db, svc)
+
+    assert len(response.results) == 1
+    item = response.results[0]
+    assert item.library_item.id == 0
+    assert item.artwork is not None
+    assert item.artwork.release_id == OWN_RELEASE_ID

--- a/tests/integration/test_lookup_nonlibrary_release.py
+++ b/tests/integration/test_lookup_nonlibrary_release.py
@@ -38,7 +38,7 @@ from discogs.models import (
     TrackReleasesResponse,
 )
 from lookup.models import LookupRequest
-from lookup.orchestrator import perform_lookup
+from lookup.orchestrator import ROWLESS_NO_ALBUM_CONFIDENCE, perform_lookup
 from tests.conftest import make_lml_telemetry
 
 # A real-looking Discogs release id + canonical URL for the non-library
@@ -318,6 +318,10 @@ async def test_song_as_track_surfaces_rowless_when_flag_on(library_db, enable_no
     assert item.artwork is not None
     assert item.artwork.release_id == SPINE_RELEASE_ID
     assert item.artwork.release_url == SPINE_RELEASE_URL
+    # A2 (LML#629): a song-only (no typed album) row-less result is soft. Pin it
+    # here so a future reversion of the no-album confidence is caught on the
+    # #628 SONG_AS_TRACK path, not only on the new #629 tests.
+    assert item.artwork.confidence == ROWLESS_NO_ALBUM_CONFIDENCE
     # Pin routing: SONG_AS_TRACK (song-only, no typed artist), not SWAPPED.
     assert response.search_type == "compilation"
 

--- a/tests/unit/test_cached_track_safety_net.py
+++ b/tests/unit/test_cached_track_safety_net.py
@@ -1,0 +1,119 @@
+"""Unit tests for the A4 cached-track safety net (LML#629).
+
+``find_library_albums_with_cached_track`` consults the local Discogs PG cache
+("which releases by this artist contain this track?") after per-result track
+validation confirmed nothing. Pre-#629 it returned only WXYC library rows whose
+fuzzy match cleared ``artist_matches_item`` and *dropped* any cache-confirmed
+release with no artist-matching row — losing a resolvable ``release_id`` the
+cache already held.
+
+A4 threads that ``release_id`` out: when the cache confirms the track on a
+release but no library row artist-matches, the safety net surfaces the release
+**row-less** (``LibraryItem(id=0)`` + ``{0: ResolvedRelease}`` on the
+``discogs_titles`` seam) instead of returning empty — reusing #628's
+carry-through shape. No-album ordering (the #629 rule) prefers the artist's own
+release (``is_compilation=False``) over a compilation, then stable
+``release_id``.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.models import ReleaseInfo
+from lookup.orchestrator import ROWLESS_LIBRARY_ID, find_library_albums_with_cached_track
+from lookup.release_resolution import ResolvedRelease
+
+
+@pytest.fixture
+def enable_nonlibrary_release(monkeypatch):
+    """Turn on LML_RESOLVE_NONLIBRARY_RELEASE so the A4 row-less carry-through fires."""
+    monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "true")
+    from config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _cache_release(album, artist, release_id, *, is_compilation=False):
+    return ReleaseInfo(
+        album=album,
+        artist=artist,
+        release_id=release_id,
+        release_url=f"https://www.discogs.com/release/{release_id}",
+        is_compilation=is_compilation,
+    )
+
+
+@pytest.mark.asyncio
+async def test_surfaces_rowless_release_id_when_no_library_row_matches(
+    mock_library_db, mock_discogs_service, enable_nonlibrary_release
+):
+    """Cache confirms the track on a release the WXYC library doesn't carry →
+    surface it row-less carrying the resolved ``release_id`` rather than dropping
+    to empty."""
+    mock_discogs_service.cache_service = AsyncMock()
+    mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+        return_value=[_cache_release("Some Bootleg Compilation", "Lee Perry", 1000)]
+    )
+    mock_library_db.search.return_value = []
+
+    items, discogs_titles = await find_library_albums_with_cached_track(
+        mock_library_db, "Bucky Skank", "Lee 'Scratch' Perry", mock_discogs_service
+    )
+
+    assert len(items) == 1
+    assert items[0].id == ROWLESS_LIBRARY_ID
+    resolved = discogs_titles[ROWLESS_LIBRARY_ID]
+    assert isinstance(resolved, ResolvedRelease)
+    assert resolved.release_id == 1000
+    assert resolved.release_url == "https://www.discogs.com/release/1000"
+    assert resolved.album_title == "Some Bootleg Compilation"
+
+
+@pytest.mark.asyncio
+async def test_prefers_own_release_over_compilation_when_no_library_row_matches(
+    mock_library_db, mock_discogs_service, enable_nonlibrary_release
+):
+    """No-album ordering (#629): when the track sits on both the artist's own
+    release and a compilation, surface the own release (``is_compilation=False``)
+    even when the comp sorts first by ``release_id``."""
+    mock_discogs_service.cache_service = AsyncMock()
+    mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+        return_value=[
+            _cache_release("Various: Reggae Hits", "Various", 1000, is_compilation=True),
+            _cache_release("Roast Fish Collie Weed & Corn Bread", "Lee Perry", 2000),
+        ]
+    )
+    mock_library_db.search.return_value = []
+
+    items, discogs_titles = await find_library_albums_with_cached_track(
+        mock_library_db, "Bucky Skank", "Lee 'Scratch' Perry", mock_discogs_service
+    )
+
+    assert items[0].id == ROWLESS_LIBRARY_ID
+    resolved = discogs_titles[ROWLESS_LIBRARY_ID]
+    assert resolved.release_id == 2000
+    assert resolved.is_compilation is False
+
+
+@pytest.mark.asyncio
+async def test_flag_off_preserves_drop_when_no_library_row_matches(
+    mock_library_db, mock_discogs_service
+):
+    """Without ``lml_resolve_nonlibrary_release`` the A4 carry-through stays off:
+    a cache-confirmed release with no artist-matching row drops to empty exactly
+    as it did pre-#629 (fetch_artwork_for_items would not bind a row-less item)."""
+    mock_discogs_service.cache_service = AsyncMock()
+    mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+        return_value=[_cache_release("Some Bootleg Compilation", "Lee Perry", 1000)]
+    )
+    mock_library_db.search.return_value = []
+
+    items, discogs_titles = await find_library_albums_with_cached_track(
+        mock_library_db, "Bucky Skank", "Lee 'Scratch' Perry", mock_discogs_service
+    )
+
+    assert items == []
+    assert discogs_titles == {}

--- a/tests/unit/test_cached_track_safety_net.py
+++ b/tests/unit/test_cached_track_safety_net.py
@@ -21,7 +21,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from discogs.models import ReleaseInfo
-from lookup.orchestrator import ROWLESS_LIBRARY_ID, find_library_albums_with_cached_track
+from lookup.orchestrator import (
+    ROWLESS_LIBRARY_ID,
+    ROWLESS_NO_ALBUM_CONFIDENCE,
+    find_library_albums_with_cached_track,
+)
 from lookup.release_resolution import ResolvedRelease
 
 
@@ -96,6 +100,27 @@ async def test_prefers_own_release_over_compilation_when_no_library_row_matches(
     resolved = discogs_titles[ROWLESS_LIBRARY_ID]
     assert resolved.release_id == 2000
     assert resolved.is_compilation is False
+
+
+@pytest.mark.asyncio
+async def test_rowless_release_carries_soft_seam_confidence(
+    mock_library_db, mock_discogs_service, enable_nonlibrary_release
+):
+    """The A4 pick is by track only — never album-matched — so it stamps the seam
+    with a soft confidence. That soft value must ride the seam so the bind stays
+    soft even when the request typed an album (the bind can't otherwise tell A4
+    from an album-ranked carry-through)."""
+    mock_discogs_service.cache_service = AsyncMock()
+    mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+        return_value=[_cache_release("Some Bootleg Compilation", "Lee Perry", 1000)]
+    )
+    mock_library_db.search.return_value = []
+
+    _, discogs_titles = await find_library_albums_with_cached_track(
+        mock_library_db, "Bucky Skank", "Lee 'Scratch' Perry", mock_discogs_service
+    )
+
+    assert discogs_titles[ROWLESS_LIBRARY_ID].confidence == ROWLESS_NO_ALBUM_CONFIDENCE
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cached_track_safety_net.py
+++ b/tests/unit/test_cached_track_safety_net.py
@@ -43,8 +43,10 @@ def enable_nonlibrary_release(monkeypatch):
 @pytest.fixture
 def disable_nonlibrary_release(monkeypatch):
     """Force the flag off + reset the settings lru-cache so the flag-off assertion
-    is self-contained, not dependent on a prior test's fixture teardown."""
-    monkeypatch.delenv("LML_RESOLVE_NONLIBRARY_RELEASE", raising=False)
+    is self-contained, not dependent on a prior test's fixture teardown. Sets the
+    env var to "false" rather than unsetting it so it also overrides a developer's
+    local .env (Settings reads env_file=".env"; setenv takes precedence)."""
+    monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "false")
     from config.settings import get_settings
 
     get_settings.cache_clear()

--- a/tests/unit/test_cached_track_safety_net.py
+++ b/tests/unit/test_cached_track_safety_net.py
@@ -40,6 +40,18 @@ def enable_nonlibrary_release(monkeypatch):
     get_settings.cache_clear()
 
 
+@pytest.fixture
+def disable_nonlibrary_release(monkeypatch):
+    """Force the flag off + reset the settings lru-cache so the flag-off assertion
+    is self-contained, not dependent on a prior test's fixture teardown."""
+    monkeypatch.delenv("LML_RESOLVE_NONLIBRARY_RELEASE", raising=False)
+    from config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
 def _cache_release(album, artist, release_id, *, is_compilation=False):
     return ReleaseInfo(
         album=album,
@@ -124,8 +136,28 @@ async def test_rowless_release_carries_soft_seam_confidence(
 
 
 @pytest.mark.asyncio
+async def test_drops_title_less_cache_release(
+    mock_library_db, mock_discogs_service, enable_nonlibrary_release
+):
+    """A cache release with a valid release_id but no album title must not surface
+    a degenerate row-less item (parity with the rehydrate-path empty-title guard)."""
+    mock_discogs_service.cache_service = AsyncMock()
+    mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
+        return_value=[_cache_release("", "Lee Perry", 1000)]
+    )
+    mock_library_db.search.return_value = []
+
+    items, discogs_titles = await find_library_albums_with_cached_track(
+        mock_library_db, "Bucky Skank", "Lee 'Scratch' Perry", mock_discogs_service
+    )
+
+    assert items == []
+    assert discogs_titles == {}
+
+
+@pytest.mark.asyncio
 async def test_flag_off_preserves_drop_when_no_library_row_matches(
-    mock_library_db, mock_discogs_service
+    mock_library_db, mock_discogs_service, disable_nonlibrary_release
 ):
     """Without ``lml_resolve_nonlibrary_release`` the A4 carry-through stays off:
     a cache-confirmed release with no artist-matching row drops to empty exactly

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -29,6 +29,8 @@ from generated.api_models import (
     TrackMatchSource,
 )
 from lookup.orchestrator import (
+    ROWLESS_LIBRARY_ID,
+    ROWLESS_NO_ALBUM_CONFIDENCE,
     _resolve_fallback_artwork,
     artist_matches_item,
     build_context_message,
@@ -1366,9 +1368,7 @@ class TestRowlessNoAlbumConfidence:
         )
         return svc
 
-    def _rowless(self):
-        from lookup.orchestrator import ROWLESS_LIBRARY_ID
-
+    def _rowless(self, *, confidence: float = 1.0):
         item = make_library_item(
             id=ROWLESS_LIBRARY_ID,
             artist="Lee 'Scratch' Perry",
@@ -1379,6 +1379,7 @@ class TestRowlessNoAlbumConfidence:
             release_url="https://www.discogs.com/release/1000",
             is_compilation=False,
             album_title="Roast Fish Collie Weed & Corn Bread",
+            confidence=confidence,
         )
         return item, {ROWLESS_LIBRARY_ID: resolved}
 
@@ -1412,6 +1413,24 @@ class TestRowlessNoAlbumConfidence:
         bound = results[0][1]
         assert bound is not None
         assert bound.confidence == 1.0
+
+    @pytest.mark.asyncio
+    async def test_soft_seam_stays_soft_even_with_typed_album(self, enable_nonlibrary_release):
+        """A row-less release whose seam confidence is already soft (the A4
+        cached-track pick, never album-matched) must NOT be promoted to 1.0 just
+        because the request typed an album — the bind takes the softer signal.
+        Without this, A4 would stamp 'user-confirmed album' on a release it never
+        matched to the typed album."""
+        item, discogs_titles = self._rowless(confidence=ROWLESS_NO_ALBUM_CONFIDENCE)
+        svc = self._svc()
+
+        results = await fetch_artwork_for_items(
+            [item], svc, discogs_titles, song="Bucky Skank", album="A Typed Album"
+        )
+
+        bound = results[0][1]
+        assert bound is not None
+        assert bound.confidence == ROWLESS_NO_ALBUM_CONFIDENCE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -1151,7 +1151,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
         )
         mock_library_db.search.return_value = [maritime]
 
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db,
             "Bucky Skank",
             "Lee 'Scratch' Perry",
@@ -1175,7 +1175,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
         row = make_library_item(id=42, artist="Stereolab", title="Aluminum Tunes")
         mock_library_db.search.return_value = [row]
 
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db,
             "Cybele's Reverie",
             "Stereolb",  # typed (misspelled)
@@ -1202,7 +1202,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
         row = make_library_item(id=42, artist="Stereolab", title="Aluminum Tunes")
         mock_library_db.search.return_value = [row]
 
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db,
             "Cybele's Reverie",
             "Stereolb",  # typed (misspelled), no correction supplied
@@ -1213,7 +1213,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
 
     @pytest.mark.asyncio
     async def test_returns_empty_without_discogs_service(self, mock_library_db):
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db, "Song", "Artist", None
         )
         assert result == []
@@ -1222,7 +1222,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
     async def test_returns_empty_without_cache_service(self, mock_library_db, mock_discogs_service):
         """No PG cache attached → helper is a no-op (we don't fall back to the API)."""
         mock_discogs_service.cache_service = None
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db, "Song", "Artist", mock_discogs_service
         )
         assert result == []
@@ -1232,18 +1232,12 @@ class TestFindLibraryAlbumsWithCachedTrack:
         self, mock_library_db, mock_discogs_service
     ):
         mock_discogs_service.cache_service = AsyncMock()
-        assert (
-            await find_library_albums_with_cached_track(
-                mock_library_db, None, "Artist", mock_discogs_service
-            )
-            == []
-        )
-        assert (
-            await find_library_albums_with_cached_track(
-                mock_library_db, "Song", None, mock_discogs_service
-            )
-            == []
-        )
+        assert await find_library_albums_with_cached_track(
+            mock_library_db, None, "Artist", mock_discogs_service
+        ) == ([], {})
+        assert await find_library_albums_with_cached_track(
+            mock_library_db, "Song", None, mock_discogs_service
+        ) == ([], {})
         # Cache should never be consulted when inputs are insufficient
         mock_discogs_service.cache_service.search_releases_by_track.assert_not_called()
 
@@ -1253,7 +1247,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
     ):
         mock_discogs_service.cache_service = AsyncMock()
         mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(return_value=[])
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db, "Song", "Artist", mock_discogs_service
         )
         assert result == []
@@ -1269,7 +1263,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
         )
         mock_library_db.search.return_value = []
 
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db, "Song", "Lee Perry", mock_discogs_service
         )
         assert result == []
@@ -1288,7 +1282,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
         )
         mock_library_db.search.return_value = [wrong_artist]
 
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db, "Bucky Skank", "Lee 'Scratch' Perry", mock_discogs_service
         )
         assert result == []
@@ -1310,7 +1304,7 @@ class TestFindLibraryAlbumsWithCachedTrack:
         )
         mock_library_db.search.return_value = [maritime]
 
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db,
             "Bucky Skank",
             "Lee 'Scratch' Perry",
@@ -1328,13 +1322,96 @@ class TestFindLibraryAlbumsWithCachedTrack:
         mock_discogs_service.cache_service.search_releases_by_track = AsyncMock(
             side_effect=RuntimeError("cache offline")
         )
-        result = await find_library_albums_with_cached_track(
+        result, _ = await find_library_albums_with_cached_track(
             mock_library_db,
             "Song",
             "Artist",
             mock_discogs_service,
         )
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: row-less no-album soft confidence (A2, LML#629)
+# ---------------------------------------------------------------------------
+
+
+class TestRowlessNoAlbumConfidence:
+    """A no-album (song-only / artist+song) query that surfaces a row-less
+    non-library release should carry a *soft* confidence so a consumer can treat
+    it as tentative — the artist + track were validated, but with no typed album
+    the chosen release is the best-ranked guess, not a user-confirmed one. When
+    an album *was* typed, the bound release keeps full confidence (1.0)."""
+
+    @pytest.fixture
+    def enable_nonlibrary_release(self, monkeypatch):
+        monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "true")
+        from config.settings import get_settings
+
+        get_settings.cache_clear()
+        yield
+        get_settings.cache_clear()
+
+    def _svc(self) -> AsyncMock:
+        svc = AsyncMock()
+        svc.cache_service = None
+        svc.get_release = AsyncMock(
+            return_value=ReleaseMetadataResponse(
+                release_id=1000,
+                title="Roast Fish Collie Weed & Corn Bread",
+                artist="Lee 'Scratch' Perry",
+                release_url="https://www.discogs.com/release/1000",
+                artwork_url="https://i.discogs.com/roast.jpg",
+            )
+        )
+        return svc
+
+    def _rowless(self):
+        from lookup.orchestrator import ROWLESS_LIBRARY_ID
+
+        item = make_library_item(
+            id=ROWLESS_LIBRARY_ID,
+            artist="Lee 'Scratch' Perry",
+            title="Roast Fish Collie Weed & Corn Bread",
+        )
+        resolved = ResolvedRelease(
+            release_id=1000,
+            release_url="https://www.discogs.com/release/1000",
+            is_compilation=False,
+            album_title="Roast Fish Collie Weed & Corn Bread",
+        )
+        return item, {ROWLESS_LIBRARY_ID: resolved}
+
+    @pytest.mark.asyncio
+    async def test_no_album_rowless_bind_carries_soft_confidence(self, enable_nonlibrary_release):
+        item, discogs_titles = self._rowless()
+        svc = self._svc()
+
+        results = await fetch_artwork_for_items(
+            [item], svc, discogs_titles, song="Bucky Skank", album=None
+        )
+
+        bound = results[0][1]
+        assert bound is not None
+        assert bound.release_id == 1000
+        assert bound.confidence < 1.0
+
+    @pytest.mark.asyncio
+    async def test_album_typed_rowless_bind_keeps_full_confidence(self, enable_nonlibrary_release):
+        item, discogs_titles = self._rowless()
+        svc = self._svc()
+
+        results = await fetch_artwork_for_items(
+            [item],
+            svc,
+            discogs_titles,
+            song="Bucky Skank",
+            album="Roast Fish Collie Weed & Corn Bread",
+        )
+
+        bound = results[0][1]
+        assert bound is not None
+        assert bound.confidence == 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #629. Sub-issue of #625 (the non-library-resolution epic), fronting **A4** and the residual of **A2**.

## A4 — cached-track safety net threads `release_id`

`find_library_albums_with_cached_track` confirmed a track on a Discogs release via the PG cache but **dropped** it whenever no WXYC library row artist-matched (`if not artist_matches_item(...): continue`), returning bare `LibraryItem`s — the resolved `release_id` never threaded out. A song-only / artist+song add for such a release lost resolution entirely.

It now surfaces the best cache-confirmed release **row-less**, reusing #628's `{0: ResolvedRelease}` carry-through seam so the `release_id` (hence `discogs_url`) still binds in Step 4. Specifics:

- Return type widens to `tuple[list[LibraryItem], dict[int, ResolvedRelease]]` (the same 2-tuple `search_compilations_for_track` already uses); the `perform_lookup` caller unpacks it and merges the resolved map into `discogs_titles`.
- Ordering follows the **#629 no-album rule** — prefer the artist's own release (`is_compilation=False`) over a compilation, then stable `release_id`.
- Gated on `lml_resolve_nonlibrary_release`, matching the other carry-through sites: flag-off preserves the exact pre-#629 drop (`fetch_artwork_for_items` only binds a row-less item when the flag is on).
- Cache rows are already track-confirmed by the trigram query, so this is **pure cache reuse — no new uncached Discogs path** (acceptance criterion).

## A2 — soft confidence on no-album results

A row-less bind from a no-album (song-only / artist+song) query now carries `ROWLESS_NO_ALBUM_CONFIDENCE` (0.8) instead of 1.0. The (artist, track) pair validated, but with no typed album the chosen release is the best-ranked guess, not a user-confirmed album — so a consumer (request-o-matic) can treat it as soft. Album-typed binds keep the full 1.0. `parsed.album` is threaded through `fetch_artwork_for_items` → `_bind_resolved_release` to gate it.

**Scope note:** A2's "route the no-album shapes through the carry-through" and the prefer-own-release ordering already shipped via #628 and #633 (`prerank_candidates_for_validation`). The new integration test pins them as regression guards rather than re-implementing them.

## Tests (TDD)

- `tests/unit/test_cached_track_safety_net.py` (new TDD seed) — row-less surfacing with `release_id`, prefer-own-over-comp ordering, flag-off drop.
- `tests/integration/test_lookup_nonlibrary_no_album.py` (new TDD seed) — end-to-end: artist+song no-album → row-less `discogs_url`, own-album-over-comp, soft confidence.
- `tests/unit/test_orchestrator_helpers.py` — new `TestRowlessNoAlbumConfidence` (soft vs full), and the existing 11 cached-track tests updated to the tuple contract.

Full suite green (3185 passed), `ruff check` + `ruff format --check`, and `mypy . --ignore-missing-imports` all clean locally.

## Acceptance criteria

- [x] song-only / artist+song (no album) non-library query returns a resolved `discogs_url` (A2), best-ranked by prefer-own-release.
- [x] `find_library_albums_with_cached_track` threads `release_id` and stops dropping on the artist gate (A4).
- [x] Reuses #628's carry-through + #633's bound (no new uncached path).
- [x] Unit + integration coverage.

## Related

- #625 (parent epic), #628 (carry-through spine), #633 (bounded resolve / no-album ordering), #583 (library-miss Step 3a), #400 (typed-match floor)