### PR TITLE
feat(#660): anchor SONG_AS_TRACK carry-through on the per-track credit

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -1404,6 +1404,35 @@ class DiscogsService:
         # ``T | None`` here is always bool in practice.
         return bool(validated)
 
+    async def get_track_credit_on_release(self, release_id: int, track: str) -> str | None:
+        """Recover the per-track credit for ``track`` on a release (LML#660).
+
+        Where :meth:`validate_track_on_release` answers "is *this* artist on the
+        track?", this answers "*which* artist is credited for this track?" — the
+        SONG_AS_TRACK carry-through has no typed artist to validate against, so it
+        recovers the track's actual credited performer from the release tracklist
+        to anchor the row-less resolve (and the #632 cache key) on a real artist
+        instead of the release-level "Various" marker. This supersedes the LML#649
+        stopgap that suppressed the carry-through under that "Various" anchor.
+
+        Read-only: rides ``get_release`` (its own read-through cache) and never
+        writes. Returns the joined per-track credit, or ``None`` when the release
+        can't be fetched, no track title matches, or the matched track carries
+        only a release-level credit (empty ``artists``).
+
+        Args:
+            release_id: Discogs release ID to fetch.
+            track: Track title to locate in the tracklist.
+
+        Returns:
+            The matched track's per-track credit (``artists`` joined), or ``None``.
+        """
+        release = await self.get_release(release_id)
+        if release is None:
+            return None
+        track_lower = normalize_for_track_comparison(track)
+        return _scan_tracklist_for_credit(release, track_lower)
+
 
 def _scan_tracklist_for_match(
     release: ReleaseMetadataResponse,
@@ -1466,3 +1495,31 @@ def _scan_tracklist_for_match(
 
     logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")
     return False
+
+
+def _scan_tracklist_for_credit(release: ReleaseMetadataResponse, track_lower: str) -> str | None:
+    """Return the per-track credit for the title-matched track, or ``None`` (LML#660).
+
+    The credit-recovery counterpart to :func:`_scan_tracklist_for_match`: same
+    bidirectional-substring title rule, but artist-blind — it surfaces *which*
+    artist the track credits rather than checking a supplied one. The first
+    title-matched track that carries a per-track ``artists`` list wins; its
+    credit is joined with a space, matching the joined form
+    ``_scan_tracklist_for_match``'s LML#210 fuzzy fallback validates against, so
+    the recovered anchor re-validates consistently on the resolve path. A
+    title-matched track with no per-track ``artists`` (release-level-only credit)
+    is skipped; when none carries one, ``None`` is returned and the caller falls
+    back to LML#649 suppression rather than anchor on the release-level "Various".
+
+    ``track_lower`` is pre-normalized by the caller (single
+    ``normalize_for_track_comparison`` call), mirroring ``_scan_tracklist_for_match``.
+    """
+    for item in release.tracklist or []:
+        item_title = normalize_for_track_comparison(item.title)
+        if track_lower not in item_title and item_title not in track_lower:
+            continue
+        if item.artists:
+            joined = " ".join(a.strip() for a in item.artists if a and a.strip())
+            if joined:
+                return joined
+    return None

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+from collections.abc import Iterator
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
@@ -1434,6 +1435,23 @@ class DiscogsService:
         return _scan_tracklist_for_credit(release, track_lower)
 
 
+def _iter_title_matched_items(
+    release: ReleaseMetadataResponse, track_lower: str
+) -> Iterator[TrackItem]:
+    """Yield tracklist items whose normalized title matches ``track_lower``.
+
+    The shared title-match step behind both tracklist scans —
+    :func:`_scan_tracklist_for_match` (validation) and
+    :func:`_scan_tracklist_for_credit` (credit recovery, LML#660): a bidirectional
+    substring on the normalized title. Centralized so the two scans' title rule
+    can't drift apart. ``track_lower`` is pre-normalized by the caller.
+    """
+    for item in release.tracklist or []:
+        item_title = normalize_for_track_comparison(item.title)
+        if track_lower in item_title or item_title in track_lower:
+            yield item
+
+
 def _scan_tracklist_for_match(
     release: ReleaseMetadataResponse,
     release_id: int,
@@ -1450,12 +1468,7 @@ def _scan_tracklist_for_match(
     ``normalize_for_track_comparison`` / ``normalize_artist_for_validation``)
     so the inner loop is hot-path arithmetic.
     """
-    for item in release.tracklist or []:
-        item_title = normalize_for_track_comparison(item.title)
-        # Check if track title matches
-        if track_lower not in item_title and item_title not in track_lower:
-            continue
-
+    for item in _iter_title_matched_items(release, track_lower):
         # Per-track credits first (compilations, or tracks crediting the
         # writers/performers). A positive hit short-circuits.
         if item.artists:
@@ -1514,10 +1527,7 @@ def _scan_tracklist_for_credit(release: ReleaseMetadataResponse, track_lower: st
     ``track_lower`` is pre-normalized by the caller (single
     ``normalize_for_track_comparison`` call), mirroring ``_scan_tracklist_for_match``.
     """
-    for item in release.tracklist or []:
-        item_title = normalize_for_track_comparison(item.title)
-        if track_lower not in item_title and item_title not in track_lower:
-            continue
+    for item in _iter_title_matched_items(release, track_lower):
         if item.artists:
             joined = " ".join(a.strip() for a in item.artists if a and a.strip())
             if joined:

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1280,13 +1280,15 @@ async def _recover_track_credit(
     cache key, or ``None`` when none is recoverable (the caller then suppresses,
     preserving the LML#649 fallback).
     """
-    # Compilations first: a V/A comp is where the per-track credit lives; an
-    # own-artist release usually carries only the release-level credit. Stable
-    # within each group, so the ordering is deterministic.
-    ordered = sorted(raw_releases, key=lambda r: not r.is_compilation)
+    # Drop id-less releases before the budget cap: an unfetchable release must not
+    # burn a fetch slot (the cap bounds *real* fetches), else a creditful release
+    # behind id-less ones could fall outside the window. Then compilations first:
+    # a V/A comp is where the per-track credit lives; an own-artist release usually
+    # carries only the release-level credit. Stable within each group, so the
+    # ordering is deterministic; ``bool()`` coerces ``is_compilation``'s ``None``.
+    fetchable = [r for r in raw_releases if r.release_id]
+    ordered = sorted(fetchable, key=lambda r: not bool(r.is_compilation))
     for release in ordered[:_MAX_CREDIT_RECOVERY_FETCHES]:
-        if not release.release_id:
-            continue
         credit = await discogs_service.get_track_credit_on_release(release.release_id, track)
         if credit:
             return credit
@@ -1472,9 +1474,9 @@ async def _match_track_releases_to_library(
         # own credit — the only artist signal a song-only query carries. Either
         # way this bypasses ``require_artist`` (no library row to re-filter; the
         # per-track credit check settles the artist).
-        anchor_artist = artist or next(
-            (r.artist for r in raw_releases if r.artist and r.artist.strip()), ""
-        )
+        anchor_artist = (
+            artist or next((r.artist for r in raw_releases if r.artist and r.artist.strip()), "")
+        ).strip()
         # LML#660: a compilation-marker anchor ("Various") — or no anchor at all —
         # is not a usable per-track artist. SONG_AS_TRACK on a V/A comp lands here
         # with the release-level "Various" credit, the exact case the carry-through
@@ -1487,7 +1489,7 @@ async def _match_track_releases_to_library(
         # rather than surface an imprecise, collision-prone item — the LML#649
         # fallback, preserved. SWAPPED and TRACK_ON_COMPILATION carry a typed
         # artist and never reach this recovery.
-        if not anchor_artist.strip() or is_compilation_artist(anchor_artist.strip()):
+        if not anchor_artist or is_compilation_artist(anchor_artist):
             recovered = await _recover_track_credit(discogs_service, raw_releases, track)
             if not recovered:
                 logger.info(

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1255,6 +1255,44 @@ async def _rehydrate_resolved_release(
     )
 
 
+# How many candidate releases the SONG_AS_TRACK carry-through fetches while
+# recovering a per-track credit before giving up and suppressing (LML#660). The
+# credit is a track-level property, so the first release that carries it answers
+# the question; the cap only bounds the worst case (a popular track whose comps
+# all credit at release level). Mirrors the resolve path's ``max_validations=5``.
+_MAX_CREDIT_RECOVERY_FETCHES = 5
+
+
+async def _recover_track_credit(
+    discogs_service: DiscogsService,
+    raw_releases: list[ReleaseInfo],
+    track: str,
+) -> str | None:
+    """Recover ``track``'s actual per-track credit from the surfaced releases (LML#660).
+
+    The SONG_AS_TRACK carry-through carries no typed artist, so it can't anchor
+    the row-less resolve on a query artist; falling back to the release-level
+    credit yields "Various" for a V/A comp — the LML#649 hazard this replaces.
+    This walks the releases the track probe already surfaced (compilations first,
+    since that is where Discogs files per-track credits), fetching each — bounded
+    by :data:`_MAX_CREDIT_RECOVERY_FETCHES` — until one exposes the track's own
+    per-track ``artists``. Returns that credit to anchor the resolve and the #632
+    cache key, or ``None`` when none is recoverable (the caller then suppresses,
+    preserving the LML#649 fallback).
+    """
+    # Compilations first: a V/A comp is where the per-track credit lives; an
+    # own-artist release usually carries only the release-level credit. Stable
+    # within each group, so the ordering is deterministic.
+    ordered = sorted(raw_releases, key=lambda r: not r.is_compilation)
+    for release in ordered[:_MAX_CREDIT_RECOVERY_FETCHES]:
+        if not release.release_id:
+            continue
+        credit = await discogs_service.get_track_credit_on_release(release.release_id, track)
+        if credit:
+            return credit
+    return None
+
+
 async def _match_track_releases_to_library(
     db: LibraryDB,
     discogs_service: DiscogsService | None,
@@ -1437,24 +1475,31 @@ async def _match_track_releases_to_library(
         anchor_artist = artist or next(
             (r.artist for r in raw_releases if r.artist and r.artist.strip()), ""
         )
-        # LML#649: a compilation-marker anchor ("Various") is not a usable
-        # per-track artist. SONG_AS_TRACK on a V/A comp falls back here to the
-        # release-level credit, which is "Various" for the exact case the
-        # carry-through targets. Resolving under it would (a) validate only
-        # against the release-level "Various" credit — blind to the track's
-        # actual performer (validate_track_on_release's release-artist fallback)
-        # — and (b) key the #632 cache on ``("various", <title>, True)``,
-        # collapsing same-titled tracks across different comps onto one row (the
-        # second add could surface the first comp's release). Suppress the
-        # carry-through rather than surface an imprecise, collision-prone item;
-        # the precise fix plumbs the per-track credit as the anchor. SWAPPED and
-        # TRACK_ON_COMPILATION carry a typed artist and never reach this.
-        if is_compilation_artist(anchor_artist.strip()):
+        # LML#660: a compilation-marker anchor ("Various") — or no anchor at all —
+        # is not a usable per-track artist. SONG_AS_TRACK on a V/A comp lands here
+        # with the release-level "Various" credit, the exact case the carry-through
+        # targets. Anchoring on it would (a) validate only against that release-
+        # level credit, blind to the track's actual performer, and (b) key the
+        # #632 cache on ``("various", <title>, True)``, collapsing same-titled
+        # tracks across different comps onto one row. So recover the track's
+        # *actual per-track credit* from the release tracklist (LML#660) and anchor
+        # on that instead. When none is recoverable, suppress the carry-through
+        # rather than surface an imprecise, collision-prone item — the LML#649
+        # fallback, preserved. SWAPPED and TRACK_ON_COMPILATION carry a typed
+        # artist and never reach this recovery.
+        if not anchor_artist.strip() or is_compilation_artist(anchor_artist.strip()):
+            recovered = await _recover_track_credit(discogs_service, raw_releases, track)
+            if not recovered:
+                logger.info(
+                    f"{label}: suppressing row-less carry-through — no per-track "
+                    f"credit recoverable for '{track}' (anchor would be '{anchor_artist}')"
+                )
+                return matched_items, matched_via_by_id, {}
             logger.info(
-                f"{label}: suppressing row-less carry-through — anchor artist "
-                f"'{anchor_artist}' is a compilation marker, not a per-track credit"
+                f"{label}: anchoring row-less carry-through on recovered per-track "
+                f"credit '{recovered}' (release-level anchor was '{anchor_artist}')"
             )
-            return matched_items, matched_via_by_id, {}
+            anchor_artist = recovered
         resolved = await _resolve_nonlibrary_release(
             discogs_service,
             pg,

--- a/tests/integration/test_lookup_nonlibrary_release.py
+++ b/tests/integration/test_lookup_nonlibrary_release.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
+from wxyc_etl.text import to_match_form
 
 from discogs.models import (
     DiscogsSearchResponse,
@@ -110,6 +111,10 @@ def _base_discogs_mock() -> AsyncMock:
     svc.validate_track_on_release = AsyncMock(return_value=True)
     svc.search_releases_by_album_title = AsyncMock(return_value=_empty_track_releases())
     svc.get_release = AsyncMock(return_value=_spine_release_metadata())
+    # LML#660: no per-track credit recoverable by default, so a SONG_AS_TRACK V/A
+    # carry-through suppresses (the preserved LML#649 fallback) unless a test
+    # opts into a recovered credit. Keeps unrelated tests on the safe default.
+    svc.get_track_credit_on_release = AsyncMock(return_value=None)
     return svc
 
 
@@ -400,29 +405,29 @@ async def test_song_as_track_flag_off_no_rowless(library_db):
 
 
 @pytest.mark.asyncio
-async def test_song_as_track_various_anchor_suppresses_rowless(
+async def test_song_as_track_no_recoverable_credit_suppresses_rowless(
     library_db, enable_nonlibrary_release
 ):
-    """LML#649: a song-only V/A-comp miss whose only artist signal is the
-    release-level "Various" credit must NOT surface row-less, even flag-on.
+    """LML#660 fallback (preserving LML#649): a song-only V/A-comp miss whose
+    track exposes NO per-track credit must NOT surface row-less, even flag-on.
 
-    The anchor falls back to the surfaced release's own credit, which is the
-    compilation marker "Various" for a real V/A comp (the case the carry-through
-    targets). That is not a usable per-track artist: resolving under it validates
-    only against the release-level "Various" credit (blind to the track's actual
-    performer) and would key the #632 cache on ``("various", <title>, True)``,
-    colliding same-titled tracks across different comps. Until the per-track
-    credit is plumbed through, suppress the carry-through rather than surface an
-    imprecise, collision-prone item.
+    The anchor falls back to the surfaced release's own credit — the compilation
+    marker "Various" for a real V/A comp — so the carry-through tries to recover
+    the track's actual per-track credit (LML#660). When the tracklist carries
+    only a release-level credit (``get_track_credit_on_release`` returns ``None``),
+    there is no usable per-track artist: anchoring on "Various" would validate
+    blind to the performer and key the #632 cache on ``("various", <title>, True)``,
+    colliding same-titled tracks across different comps. So suppress rather than
+    surface an imprecise, collision-prone item.
 
-    The sibling ``..._surfaces_rowless_when_flag_on`` overrides
-    ``artist=SPINE_ARTIST`` — a real release credit — and still surfaces; this
-    pins the realistic default-``Various`` case that override hid.
+    The sibling ``..._surfaces_via_per_track_credit`` recovers a real credit and
+    surfaces; this pins the no-credit case that must still suppress.
     """
     svc = _base_discogs_mock()
     svc.lookup_releases_by_artist = AsyncMock(return_value=[])
     # Default _spine_release() credits the comp to "Various" — the realistic V/A
-    # shape, not the artist=SPINE_ARTIST the masking test substitutes.
+    # shape — and the base mock's ``get_track_credit_on_release`` returns None
+    # (no per-track credit recoverable), so the carry-through must suppress.
     svc.search_releases_by_track = AsyncMock(return_value=_track_releases(_spine_release()))
 
     response = await _run_song_as_track(library_db, svc)
@@ -434,16 +439,17 @@ async def test_song_as_track_various_anchor_suppresses_rowless(
 
 
 @pytest.mark.asyncio
-async def test_song_as_track_various_anchor_never_writes_632_cache(
+async def test_song_as_track_no_credit_never_writes_632_cache(
     library_db, enable_nonlibrary_release
 ):
-    """LML#649 AC3: the song-only V/A path must never write the #632 cache under
-    a "Various" anchor — that ``("various", <title>, True)`` key is what collides
-    distinct same-titled tracks across different comps. Suppressing the
-    carry-through means no resolve, hence no cache write at all.
+    """LML#660 / LML#649 AC3: when no per-track credit is recoverable the song-only
+    V/A path must never write the #632 cache under a "Various" anchor — that
+    ``("various", <title>, True)`` key is what collides distinct same-titled tracks
+    across different comps. Suppressing the carry-through means no resolve, hence no
+    cache write at all.
 
-    Contrast ``test_track_on_compilation_threads_pg_and_writes_cache``, where a
-    *typed* artist anchor legitimately writes ``(SPINE_ARTIST, SPINE_TRACK)``.
+    Contrast ``..._writes_632_cache_under_per_track_credit``, where a recovered
+    per-track credit legitimately writes ``(<credit>, SPINE_TRACK)``.
     """
     svc = _base_discogs_mock()
     svc.lookup_releases_by_artist = AsyncMock(return_value=[])
@@ -455,6 +461,108 @@ async def test_song_as_track_various_anchor_never_writes_632_cache(
     # No row was written under any key — in particular nothing under "various".
     assert pg.execute_calls == 0
     assert pg.store == {}
+
+
+@pytest.mark.asyncio
+async def test_song_as_track_writes_632_cache_under_per_track_credit(
+    library_db, enable_nonlibrary_release
+):
+    """LML#660 AC2: the song-only V/A path keys the #632 cache on the recovered
+    per-track credit — never ``("various", <title>, True)``. That distinct-per-
+    performer key is what prevents same-titled tracks across comps from colliding.
+    """
+    svc = _base_discogs_mock()
+    svc.lookup_releases_by_artist = AsyncMock(return_value=[])
+    svc.search_releases_by_track = AsyncMock(return_value=_track_releases(_spine_release()))
+    svc.get_track_credit_on_release = AsyncMock(return_value=SPINE_ARTIST)
+    pg = _RecordingPg()
+
+    await _run_song_as_track(library_db, svc, pg=pg)
+
+    # Exactly one row, keyed on the normalized per-track credit — not "various".
+    assert pg.execute_calls == 1
+    keys = list(pg.store.keys())
+    assert len(keys) == 1
+    artist_key, _title_key, is_track = keys[0]
+    assert is_track is True
+    assert "various" not in artist_key
+    assert artist_key == to_match_form(SPINE_ARTIST)
+    assert pg.store[keys[0]] == SPINE_RELEASE_ID
+
+
+@pytest.mark.asyncio
+async def test_song_as_track_various_anchor_surfaces_via_per_track_credit(
+    library_db, enable_nonlibrary_release
+):
+    """LML#660: a song-only V/A-comp miss now surfaces row-less, anchored on the
+    track's *actual per-track credit* recovered from the release tracklist — not
+    the release-level "Various" marker that LML#649 suppressed.
+
+    The default ``_spine_release()`` credits the comp to "Various" (the realistic
+    V/A shape). The anchor would fall back to that marker, so the carry-through
+    recovers the per-track credit instead: ``get_track_credit_on_release`` returns
+    the real performer, which anchors the resolve, and the row-less item surfaces
+    with the correct Discogs identity and the per-track artist."""
+    svc = _base_discogs_mock()
+    svc.lookup_releases_by_artist = AsyncMock(return_value=[])
+    svc.search_releases_by_track = AsyncMock(return_value=_track_releases(_spine_release()))
+    # The tracklist scan surfaces the track's real credit (the LML#660 anchor).
+    svc.get_track_credit_on_release = AsyncMock(return_value=SPINE_ARTIST)
+
+    response = await _run_song_as_track(library_db, svc)
+
+    assert len(response.results) == 1
+    item = response.results[0]
+    assert item.library_item.id == 0
+    assert item.artwork is not None
+    assert item.artwork.release_id == SPINE_RELEASE_ID
+    # Anchored on the per-track credit, not the release-level "Various".
+    assert item.library_item.artist == SPINE_ARTIST
+    assert response.search_type == "compilation"
+    svc.get_track_credit_on_release.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_same_titled_tracks_on_different_comps_do_not_collide(
+    library_db, enable_nonlibrary_release
+):
+    """LML#660 AC3 (regression): two performers' same-titled tracks on different
+    V/A comps must resolve to DIFFERENT releases under DIFFERENT #632 cache keys.
+
+    Under the LML#649-era "Various" anchor both would have keyed
+    ``("various", <title>, True)`` and collided onto one row — the second add could
+    surface the first comp's release. Anchoring on the per-track credit keys them
+    apart: distinct performers → distinct keys → distinct releases.
+    """
+    pg = _RecordingPg()
+    release_one, release_two = 11111111, 22222222
+    credit_one, credit_two = "Juana Molina", "Jessica Pratt"
+
+    # Comp 1: the spine-titled track credited to Juana Molina -> resolves to R1.
+    svc1 = _base_discogs_mock()
+    svc1.lookup_releases_by_artist = AsyncMock(return_value=[])
+    svc1.search_releases_by_track = AsyncMock(
+        return_value=_track_releases(_spine_release(release_id=release_one))
+    )
+    svc1.get_track_credit_on_release = AsyncMock(return_value=credit_one)
+    await _run_song_as_track(library_db, svc1, pg=pg)
+
+    # Comp 2: the same-titled track credited to Jessica Pratt -> resolves to R2.
+    svc2 = _base_discogs_mock()
+    svc2.lookup_releases_by_artist = AsyncMock(return_value=[])
+    svc2.search_releases_by_track = AsyncMock(
+        return_value=_track_releases(_spine_release(release_id=release_two))
+    )
+    svc2.get_track_credit_on_release = AsyncMock(return_value=credit_two)
+    await _run_song_as_track(library_db, svc2, pg=pg)
+
+    # Two distinct keys (distinct credits) -> two distinct releases. No collision.
+    key_one = (to_match_form(credit_one), to_match_form(SPINE_TRACK), True)
+    key_two = (to_match_form(credit_two), to_match_form(SPINE_TRACK), True)
+    assert len(pg.store) == 2
+    assert pg.store[key_one] == release_one
+    assert pg.store[key_two] == release_two
+    assert all("various" not in artist_key for artist_key, _, _ in pg.store)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -1936,6 +1936,105 @@ class TestValidateTrackOnRelease:
 
 
 # ---------------------------------------------------------------------------
+# get_track_credit_on_release (LML#660)
+# ---------------------------------------------------------------------------
+
+
+class TestGetTrackCreditOnRelease:
+    """The per-track credit recovery behind the SONG_AS_TRACK carry-through.
+
+    Unlike ``validate_track_on_release`` (which answers "is *this* artist on the
+    track?"), this answers "*which* artist is credited for this track?" — the
+    song-only path has no typed artist to validate against, so it recovers the
+    track's actual performer from the release tracklist to anchor the row-less
+    resolve (LML#660, replacing the LML#649 "Various"-suppression stopgap).
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_per_track_credit_on_compilation(self, service):
+        """A V/A comp whose matched track carries its own ``artists`` credit
+        returns that credit — not the release-level "Various"."""
+        release = ReleaseMetadataResponse(
+            release_id=36907527,
+            title="When There Is No Sun",
+            artist="Various",
+            release_url="https://discogs.com/release/36907527",
+            tracklist=[
+                TrackItem(position="1", title="Intro", artists=["Some Other Act"]),
+                TrackItem(
+                    position="2",
+                    title="Message to Black Youth",
+                    artists=["A Guy Called Gerald"],
+                ),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            credit = await service.get_track_credit_on_release(36907527, "Message to Black Youth")
+        assert credit == "A Guy Called Gerald"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_track_credit_is_release_level_only(self, service):
+        """A title-matched track carrying no per-track ``artists`` (the credit
+        lives only at release level) yields ``None`` — the caller must NOT anchor
+        on the release-level "Various"; it falls back to LML#649 suppression."""
+        release = ReleaseMetadataResponse(
+            release_id=36907527,
+            title="When There Is No Sun",
+            artist="Various",
+            release_url="https://discogs.com/release/36907527",
+            tracklist=[
+                TrackItem(position="1", title="Message to Black Youth", artists=[]),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            credit = await service.get_track_credit_on_release(36907527, "Message to Black Youth")
+        assert credit is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_track_title_matches(self, service):
+        release = ReleaseMetadataResponse(
+            release_id=36907527,
+            title="When There Is No Sun",
+            artist="Various",
+            release_url="https://discogs.com/release/36907527",
+            tracklist=[
+                TrackItem(position="1", title="A Completely Different Track", artists=["Someone"]),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            credit = await service.get_track_credit_on_release(36907527, "Message to Black Youth")
+        assert credit is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_release_unfetchable(self, service):
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=None):
+            credit = await service.get_track_credit_on_release(36907527, "Message to Black Youth")
+        assert credit is None
+
+    @pytest.mark.asyncio
+    async def test_joins_collaboration_per_track_credit(self, service):
+        """A multi-artist track returns the space-joined credit — the same form
+        ``_scan_tracklist_for_match``'s LML#210 fuzzy fallback validates against,
+        so the recovered anchor re-validates on the resolve path."""
+        release = ReleaseMetadataResponse(
+            release_id=34993109,
+            title="A V/A Comp",
+            artist="Various",
+            release_url="https://discogs.com/release/34993109",
+            tracklist=[
+                TrackItem(
+                    position="1",
+                    title="A Star Is Born",
+                    artists=["Bill Orcutt", "Tashi Shelley", "Robbie Miller"],
+                ),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            credit = await service.get_track_credit_on_release(34993109, "A Star Is Born")
+        assert credit == "Bill Orcutt Tashi Shelley Robbie Miller"
+
+
+# ---------------------------------------------------------------------------
 # get_artist_image
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_nonlibrary_release_resolution.py
+++ b/tests/unit/test_nonlibrary_release_resolution.py
@@ -373,3 +373,32 @@ class TestRecoverTrackCredit:
 
         assert credit is None
         assert svc.get_track_credit_on_release.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_idless_releases_do_not_consume_fetch_budget(self, monkeypatch):
+        """A release with no usable ``release_id`` is unfetchable, so it must not
+        burn a slot of the fetch budget — the cap bounds *real* fetches. A creditful
+        release sitting behind id-less ones is still reached within the cap."""
+        from lookup import orchestrator
+        from lookup.orchestrator import _recover_track_credit
+
+        monkeypatch.setattr(orchestrator, "_MAX_CREDIT_RECOVERY_FETCHES", 2)
+        svc = AsyncMock()
+        svc.get_track_credit_on_release = AsyncMock(return_value=ARTIST)
+
+        idless = ReleaseInfo(
+            album="No Id Comp",
+            artist="Various",
+            release_id=0,
+            release_url="https://www.discogs.com/release/0",
+            is_compilation=True,
+        )
+        # Two id-less comps ahead of the one creditful release. With the cap at 2,
+        # counting the id-less releases against the budget would stop before the
+        # creditful release and miss the credit.
+        releases = [idless, idless, _release()]
+
+        credit = await _recover_track_credit(svc, releases, TRACK)
+
+        assert credit == ARTIST
+        svc.get_track_credit_on_release.assert_awaited_once_with(RELEASE_ID, TRACK)

--- a/tests/unit/test_nonlibrary_release_resolution.py
+++ b/tests/unit/test_nonlibrary_release_resolution.py
@@ -301,3 +301,75 @@ async def test_album_title_wave_gated_on_album_presence(monkeypatch, album, expe
     bounded.assert_awaited_once()
     _args, kwargs = bounded.await_args
     assert kwargs.get("also_probe_album_title") == expected_probe
+
+
+# ---------------------------------------------------------------------------
+# _recover_track_credit (LML#660): the SONG_AS_TRACK per-track-credit anchor
+# ---------------------------------------------------------------------------
+
+
+def _non_comp_release(release_id: int) -> ReleaseInfo:
+    return ReleaseInfo(
+        album="Some Single",
+        artist="Various",
+        release_id=release_id,
+        release_url=f"https://www.discogs.com/release/{release_id}",
+        is_compilation=False,
+    )
+
+
+class TestRecoverTrackCredit:
+    @pytest.mark.asyncio
+    async def test_returns_first_recoverable_per_track_credit(self):
+        from lookup.orchestrator import _recover_track_credit
+
+        svc = AsyncMock()
+        svc.get_track_credit_on_release = AsyncMock(return_value=ARTIST)
+
+        credit = await _recover_track_credit(svc, [_release()], TRACK)
+
+        assert credit == ARTIST
+        svc.get_track_credit_on_release.assert_awaited_once_with(RELEASE_ID, TRACK)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_release_exposes_credit(self):
+        from lookup.orchestrator import _recover_track_credit
+
+        svc = AsyncMock()
+        svc.get_track_credit_on_release = AsyncMock(return_value=None)
+
+        credit = await _recover_track_credit(svc, [_release(), _non_comp_release(99)], TRACK)
+
+        assert credit is None
+
+    @pytest.mark.asyncio
+    async def test_scans_compilations_before_own_releases(self):
+        """The per-track credit lives on the V/A comp, so comps are fetched first
+        even when an own-artist release precedes them in the probe results."""
+        from lookup.orchestrator import _recover_track_credit
+
+        svc = AsyncMock()
+        svc.get_track_credit_on_release = AsyncMock(return_value=ARTIST)
+
+        # Own-release first in input order; the comp must still be scanned first.
+        credit = await _recover_track_credit(svc, [_non_comp_release(99), _release()], TRACK)
+
+        assert credit == ARTIST
+        svc.get_track_credit_on_release.assert_awaited_once_with(RELEASE_ID, TRACK)
+
+    @pytest.mark.asyncio
+    async def test_bounds_fetches_to_the_cap(self, monkeypatch):
+        """A popular track with many credit-less candidates must not fan out an
+        unbounded number of release fetches."""
+        from lookup import orchestrator
+        from lookup.orchestrator import _recover_track_credit
+
+        monkeypatch.setattr(orchestrator, "_MAX_CREDIT_RECOVERY_FETCHES", 3)
+        svc = AsyncMock()
+        svc.get_track_credit_on_release = AsyncMock(return_value=None)
+        releases = [_non_comp_release(i) for i in range(1, 11)]
+
+        credit = await _recover_track_credit(svc, releases, TRACK)
+
+        assert credit is None
+        assert svc.get_track_credit_on_release.await_count == 3


### PR DESCRIPTION
Closes #660.

Precise follow-up to #649, which shipped an MVP stopgap. When the SONG_AS_TRACK row-less carry-through fell back to a release-level "Various" credit, #649 **suppressed** the carry-through entirely — closing the `("various", <title>, True)` #632 cache-key collision and the wrong-but-present identity hazard, but at the cost of surfacing nothing row-less for the exact non-library V/A-compilation case the #628 feature was built to serve. This restores precise coverage by anchoring on the track's **actual credited artist** instead of suppressing.

## Approach

The per-track credit is unreachable from the release *search* result (Discogs `/database/search` carries no tracklist), so it's recovered from a release *fetch* — the same source `validate_track_on_release` already walks.

- **`discogs/service.py`** — `DiscogsService.get_track_credit_on_release(release_id, track)` fetches the release and returns the matched track's per-track credit (the answer to "*which* artist?", vs `validate_track_on_release`'s "is *this* artist?"). Backed by `_scan_tracklist_for_credit`, the artist-blind counterpart to `_scan_tracklist_for_match` — same bidirectional title rule, joins `item.artists` with a space (the form #210's fuzzy fallback validates against, so the recovered anchor re-validates consistently). Read-only; rides `get_release`'s cache.
- **`lookup/orchestrator.py`** — `_recover_track_credit(...)` walks the already-surfaced `raw_releases` (compilations first, bounded by `_MAX_CREDIT_RECOVERY_FETCHES=5`) and returns the first recoverable credit. The carry-through, when the anchor is absent or a compilation marker, recovers the per-track credit and anchors `_resolve_nonlibrary_release` + `_make_rowless_item` on it. The #649 `is_compilation_artist` suppression guard is replaced; when **no** credit is recoverable, the carry-through still suppresses (the #649 fallback, preserved) so a "Various" anchor is never resolved or cached.

Because distinct performers now key the #632 cache distinctly, two same-titled tracks on different comps resolve to **different** releases instead of colliding onto one row. SWAPPED_INTERPRETATION and TRACK_ON_COMPILATION carry a typed artist and never reach the recovery, so they are unchanged. Gated behind `lml_resolve_nonlibrary_release` (default off), same as #628/#649.

## Acceptance criteria

- [x] SONG_AS_TRACK carry-through for a non-library V/A comp surfaces a row-less item anchored on the **per-track credit**, with the correct Discogs identity.
- [x] The #632 cache is keyed on the per-track credit, never `("various", <title>, True)`.
- [x] Two distinct same-titled tracks on different comps resolve to **different** releases (regression test).
- [x] No per-track credit recoverable → carry-through suppressed (the #649 fallback preserved).
- [x] The #649 `is_compilation_artist(anchor_artist.strip())` suppression guard removed/replaced; its integration tests updated (the `..._suppresses_rowless` case becomes a surfaces-precisely case; a no-credit suppression case is kept).
- [x] SWAPPED / TRACK_ON_COMPILATION behavior unchanged.
- [x] Unit + integration coverage per the bug-fix protocol; full default suite + lint/format/typecheck green.

## Tests (TDD)

- **Unit** — `get_track_credit_on_release`: comp credit, release-level-only → `None`, no title match → `None`, unfetchable → `None`, collaboration join. `_recover_track_credit`: first-credit, none → `None`, compilations-first, bounded fetches.
- **Integration** (`test_lookup_nonlibrary_release.py`) — V/A comp surfaces via per-track credit; #632 keyed on the credit (never `"various"`); same-titled-tracks-on-different-comps no-collision regression; no-credit suppression preserved.

Local: full default suite **3208 passed**, 1 skipped, 2 xfailed; `ruff check` + `ruff format` clean; `mypy .` clean.

## Related

- #625 (epic — parent)
- #649 (the MVP suppression this refines)
- #628 (the row-less carry-through)
- #632 (the positive-resolution cache being keyed)
- #646 (sibling follow-up — the album-title-probe arm)