### PR TITLE
fix(#659): per-caller PostHog event_prefix for missing-key attribution

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -18,6 +18,8 @@ from entity.sources import PgSource
 from library.db import LibraryDB
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from posthog import Posthog
 
 logger = logging.getLogger(__name__)
@@ -283,13 +285,35 @@ async def close_musicbrainz_pg() -> None:
     await _close_musicbrainz_pg_singleton()
 
 
-def get_posthog_client(settings: Settings = Depends(get_settings)) -> Posthog | None:
-    """Get PostHog client instance, gated on the ``ENABLE_TELEMETRY`` flag.
+def _make_posthog_client_dep(event_prefix: str) -> Callable[..., Posthog | None]:
+    """Build a PostHog-client FastAPI dependency bound to one caller's prefix.
 
-    The shared ``wxyc_fastapi`` singleton handles the missing-API-key warn-once
-    behavior; this wrapper short-circuits when telemetry is disabled entirely.
+    This dependency is injected by multiple endpoints, but the shared
+    ``wxyc_fastapi`` singleton keys its missing-API-key warn-once diagnostic by
+    ``event_prefix``. A single hardcoded prefix attributes every warning to one
+    caller and, because the warn-once set is keyed by prefix, suppresses the
+    warning for all other callers (LML#659). Binding the prefix per caller —
+    each as its own module-level callable with a stable identity, so FastAPI
+    ``dependency_overrides`` (keyed by callable identity) keep working — gives
+    every endpoint its own one-time missing-key warning under its own
+    ``caller=`` label.
+
+    Like the original wrapper, the returned dependency short-circuits to ``None``
+    when telemetry is disabled entirely, before touching the shared singleton.
     """
-    if not settings.enable_telemetry:
-        logger.debug("Telemetry disabled")
-        return None
-    return _shared_posthog_client(event_prefix="lookup")
+
+    def _dep(settings: Settings = Depends(get_settings)) -> Posthog | None:
+        if not settings.enable_telemetry:
+            logger.debug("Telemetry disabled")
+            return None
+        return _shared_posthog_client(event_prefix=event_prefix)
+
+    _dep.__name__ = f"get_posthog_client[{event_prefix}]"
+    return _dep
+
+
+# Per-caller PostHog dependencies. ``get_posthog_client`` keeps its name and
+# identity so the lookup routers and the many dependency-override tests that key
+# on it are undisturbed; streaming-check gets its own prefix (LML#659).
+get_posthog_client = _make_posthog_client_dep("lookup")
+get_streaming_posthog_client = _make_posthog_client_dep("streaming_check")

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -11,7 +11,7 @@
 - `SPOTIFY_CLIENT_ID` -- Spotify client ID for streaming availability checks
 - `SPOTIFY_CLIENT_SECRET` -- Spotify client secret for streaming availability checks
 - `SENTRY_DSN` -- Sentry error tracking. Init lives in [`wxyc-fastapi`](https://github.com/WXYC/wxyc-fastapi); LML calls `init_sentry(service_name="library-metadata-lookup", environment=settings.environment, ...)` at startup. The default `HttpxIntegration` is on, so outbound calls (Discogs, Spotify, Deezer, Apple Music, Bandcamp) are traced.
-- `POSTHOG_API_KEY` -- PostHog telemetry. Client construction lives in `wxyc-fastapi` as a process-wide singleton; LML's `core/dependencies.get_posthog_client` only wraps it with the LML-side `enable_telemetry` flag. The shared client warns once per process when this is unset.
+- `POSTHOG_API_KEY` -- PostHog telemetry. Client construction lives in `wxyc-fastapi` as a process-wide singleton; LML wraps it with the LML-side `enable_telemetry` flag via per-caller dependencies built by `core/dependencies._make_posthog_client_dep` (`get_posthog_client` for `/lookup`, `get_streaming_posthog_client` for `/api/v1/streaming-check`). When this is unset the shared singleton warns once per caller `event_prefix`, so each endpoint surfaces its own missing-key warning under its own `caller=` label (LML#659).
 - `LIBRARY_DB_PATH` -- Path to SQLite database (default: `library.db`)
 - `ADMIN_TOKEN` -- Bearer token for admin endpoints (upload endpoint)
 - `STREAMING_WEBHOOK_URLS` -- Comma-separated URLs to POST streaming status changes after library.db upload

--- a/streaming/router.py
+++ b/streaming/router.py
@@ -12,7 +12,7 @@ from clients.bandcamp import BandcampClient
 from clients.streaming.apple_music import AppleMusicClient
 from clients.streaming.deezer import DeezerClient
 from clients.streaming.spotify import SpotifyClient
-from core.dependencies import get_posthog_client
+from core.dependencies import get_streaming_posthog_client
 from streaming.dependencies import (
     get_apple_music_client,
     get_bandcamp_client,
@@ -144,7 +144,7 @@ async def handle_streaming_check(
     deezer: DeezerClient = Depends(get_deezer_client),
     apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     bandcamp: BandcampClient = Depends(get_bandcamp_client),
-    posthog_client: Posthog | None = Depends(get_posthog_client),
+    posthog_client: Posthog | None = Depends(get_streaming_posthog_client),
 ) -> StreamingCheckResponse:
     """Check streaming availability across all configured services."""
     # Per-request telemetry (LML#639). The cache-stats bracket and api_calls map

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -14,6 +14,7 @@ from core.dependencies import (
     get_discogs_service,
     get_library_db,
     get_posthog_client,
+    get_streaming_posthog_client,
 )
 
 
@@ -408,3 +409,56 @@ class TestGetPosthogClient:
             client = get_posthog_client(mock_settings)
         assert client is mock_shared.return_value
         mock_shared.assert_called_once_with(event_prefix="lookup")
+
+
+class TestGetStreamingPosthogClient:
+    """The streaming-check endpoint gets its own per-caller prefix (LML#659).
+
+    Reusing the hardcoded ``"lookup"`` prefix mis-attributed the missing-key
+    warning to ``caller=lookup`` and, because the upstream singleton warns once
+    per prefix, suppressed the streaming-check warning entirely.
+    """
+
+    def test_short_circuits_when_telemetry_disabled(self, mock_settings):
+        mock_settings.enable_telemetry = False
+        with patch("core.dependencies._shared_posthog_client") as mock_shared:
+            assert get_streaming_posthog_client(mock_settings) is None
+        mock_shared.assert_not_called()
+
+    def test_delegates_with_streaming_check_event_prefix(self, mock_settings):
+        mock_settings.enable_telemetry = True
+        with patch("core.dependencies._shared_posthog_client") as mock_shared:
+            mock_shared.return_value = Mock()
+            client = get_streaming_posthog_client(mock_settings)
+        assert client is mock_shared.return_value
+        mock_shared.assert_called_once_with(event_prefix="streaming_check")
+
+    def test_has_distinct_identity_from_lookup_dep(self):
+        """FastAPI ``dependency_overrides`` are keyed by callable identity, so the
+        two per-caller deps must be distinct objects to be overridable apart."""
+        assert get_streaming_posthog_client is not get_posthog_client
+
+
+class TestPerCallerMissingKeyWarning:
+    """End-to-end attribution against the real wxyc-fastapi singleton (LML#659).
+
+    With telemetry enabled but ``POSTHOG_API_KEY`` unset, each distinct caller
+    must log its own one-time missing-key warning under its own ``caller=``
+    label — the lookup warning must not suppress the streaming-check one.
+    """
+
+    def test_each_caller_warns_under_its_own_label(self, mock_settings, caplog):
+        import wxyc_fastapi.observability.posthog as upstream
+
+        mock_settings.enable_telemetry = True  # POSTHOG_API_KEY already "" via fixture
+        upstream._warned_prefixes.clear()
+        try:
+            with caplog.at_level("WARNING", logger=upstream.logger.name):
+                assert get_posthog_client(mock_settings) is None
+                assert get_streaming_posthog_client(mock_settings) is None
+        finally:
+            upstream._warned_prefixes.clear()
+
+        warnings = [r.getMessage() for r in caplog.records if "POSTHOG_API_KEY" in r.getMessage()]
+        assert any("caller=lookup" in m for m in warnings)
+        assert any("caller=streaming_check" in m for m in warnings)

--- a/tests/unit/test_streaming_check_router.py
+++ b/tests/unit/test_streaming_check_router.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from config.settings import get_settings
-from core.dependencies import get_posthog_client
+from core.dependencies import get_streaming_posthog_client
 from streaming.dependencies import (
     get_apple_music_client,
     get_bandcamp_client,
@@ -160,7 +160,7 @@ def telemetry_app_client(mock_settings):
             get_deezer_client: AsyncMock(),
             get_apple_music_client: None,
             get_bandcamp_client: None,
-            get_posthog_client: mock_posthog,
+            get_streaming_posthog_client: mock_posthog,
         },
     ):
         yield app, mock_posthog


### PR DESCRIPTION
## Problem

`core/dependencies.get_posthog_client` — the single PostHog-client FastAPI dependency — hardcoded `event_prefix="lookup"`, but it is injected by **both** `/lookup` (`lookup/router.py`) and, since #639, `/api/v1/streaming-check` (`streaming/router.py`).

The shared `wxyc-fastapi` singleton warns **once per `event_prefix`** on a missing `POSTHOG_API_KEY` (keyed in a module-global `_warned_prefixes` set). So with `ENABLE_TELEMETRY=true` and `POSTHOG_API_KEY` unset:

1. The lone warning always read `caller=lookup`, regardless of which endpoint hit it first.
2. Once `lookup` had warned, the streaming-check path (and any future consumer of this dependency) **never emitted its own missing-key warning** — silently swallowed.

An operator debugging "telemetry on but no `streaming_check_*` events" greps logs for `streaming`, finds nothing, and wrongly concludes telemetry is wired when it is globally dark.

## Fix

Replace the hardcoded wrapper with a `_make_posthog_client_dep(event_prefix)` factory that builds **one module-level dependency per caller**, each with a stable callable identity:

- `get_posthog_client = _make_posthog_client_dep("lookup")` — keeps its name and identity, so the lookup routers and the many identity-keyed `dependency_overrides` tests are undisturbed.
- `get_streaming_posthog_client = _make_posthog_client_dep("streaming_check")` — injected by `streaming/router.py`.

Each caller now passes its own prefix, so the shared singleton warns once per caller under its own `caller=` label. The `ENABLE_TELEMETRY` short-circuit and happy-path (key set) behavior are preserved. Emitted event names are unaffected — those come from `RequestTelemetry(event_prefix=...)`, not this wrapper.

## Tests

- `TestGetStreamingPosthogClient` — short-circuit when telemetry disabled; delegates with `event_prefix="streaming_check"`; distinct callable identity from the lookup dep (so overrides don't collide).
- `TestPerCallerMissingKeyWarning` — end-to-end against the real `wxyc-fastapi` singleton with `POSTHOG_API_KEY` unset: asserts both `caller=lookup` and `caller=streaming_check` warnings fire (one does not suppress the other).
- Existing `test_lookup_router.py` and `test_streaming_check_router.py` telemetry tests pass (streaming override updated to the new dependency identity).

Local CI parity: `ruff check .`, `ruff format --check .`, `mypy`, and the full default test set (3222 passed) all green.

Closes #659