### PR TITLE
fix(#125): scope concurrent Bandcamp lookup to the discovered slug

### DIFF
--- a/scripts/bandcamp_pipeline.py
+++ b/scripts/bandcamp_pipeline.py
@@ -194,6 +194,7 @@ async def phase_lookup(
     *,
     artist_fallback: bool = False,
     limit: int | None = None,
+    slug: str | None = None,
 ) -> list[dict]:
     """Phase 2: Album-level matching using known slugs.
 
@@ -202,11 +203,15 @@ async def phase_lookup(
         db: ResultsDB instance.
         artist_fallback: If True, write artist-level URL when no album match.
         limit: Maximum number of distinct slugs to process.
+        slug: If provided, only process albums with this exact slug. The
+            concurrent consumer passes the freshly discovered slug so a queue
+            event fetches one catalog instead of re-scanning every pending
+            catalog (#125).
 
     Returns:
         List of match result dicts for bandcamp_matches.json.
     """
-    rows = await db.get_pending_bandcamp_lookup()
+    rows = await db.get_pending_bandcamp_lookup(slug=slug)
 
     if not rows:
         log.info("No albums pending Bandcamp lookup")
@@ -310,8 +315,10 @@ async def run_concurrent(
             if slug is None:
                 break
 
-            # Process the newly discovered slug's albums
-            new_results = await phase_lookup(client, db, artist_fallback=artist_fallback)
+            # Process only the newly discovered slug's albums (#125): without
+            # the slug filter, phase_lookup re-scanned the entire pending set
+            # on every queue event, re-scraping every still-pending catalog.
+            new_results = await phase_lookup(client, db, artist_fallback=artist_fallback, slug=slug)
             all_results.extend(new_results)
 
     await asyncio.gather(search_producer(), lookup_consumer())

--- a/scripts/streaming_availability/results_db.py
+++ b/scripts/streaming_availability/results_db.py
@@ -343,17 +343,31 @@ class ResultsDB:
         cursor = await self._db.execute(query)
         return list(await cursor.fetchall())
 
-    async def get_pending_bandcamp_lookup(self, limit: int | None = None) -> list[aiosqlite.Row]:
-        """Get albums with a slug but no album-level bandcamp_url."""
+    async def get_pending_bandcamp_lookup(
+        self, limit: int | None = None, slug: str | None = None
+    ) -> list[aiosqlite.Row]:
+        """Get albums with a slug but no album-level bandcamp_url.
+
+        Args:
+            limit: Maximum number of rows to return.
+            slug: If provided, restrict to albums with this exact
+                ``bandcamp_slug``. The concurrent consumer uses this to process
+                only a newly discovered slug instead of re-scanning the whole
+                pending set on every queue event (#125).
+        """
         assert self._db is not None
         query = (
             "SELECT * FROM albums "
             "WHERE bandcamp_slug IS NOT NULL AND bandcamp_slug != '' "
             "AND bandcamp_url IS NULL AND is_compilation = 0"
         )
+        params: list = []
+        if slug is not None:
+            query += " AND bandcamp_slug = ?"
+            params.append(slug)
         if limit is not None:
             query += f" LIMIT {limit}"
-        cursor = await self._db.execute(query)
+        cursor = await self._db.execute(query, params)
         return list(await cursor.fetchall())
 
     async def get_all_results(self) -> list[aiosqlite.Row]:

--- a/tests/unit/test_bandcamp_pipeline.py
+++ b/tests/unit/test_bandcamp_pipeline.py
@@ -581,6 +581,69 @@ class TestConcurrentPipeline:
 
         assert len(results) >= 1
 
+    @pytest.mark.asyncio
+    async def test_queue_event_only_fetches_new_slug(self, db):
+        """A queue event must fetch only the newly discovered slug's catalog.
+
+        Regression for #125: the consumer used to call phase_lookup() with no
+        filter on every queue event, re-scanning the entire pending set. Any
+        album that never matched stayed pending forever, so each newly
+        discovered slug re-fetched every still-pending catalog -- O(slugs x
+        catalogs) instead of one fetch per slug.
+        """
+        from scripts.bandcamp_pipeline import run_concurrent
+
+        # Stereolab already has a slug but its catalog will NOT match its
+        # album, so it stays pending (bandcamp_url NULL) for the whole run.
+        # Autechre is discovered by search and arrives via the queue.
+        await db.insert_albums(
+            [
+                _make_album(),
+                _make_album(
+                    normalized_artist="autechre",
+                    normalized_title="confield",
+                    display_artist="Autechre",
+                    display_title="Confield",
+                ),
+            ]
+        )
+        all_rows = await db.get_pending("spotify", limit=10)
+        stereolab_id = next(r["id"] for r in all_rows if r["display_artist"] == "Stereolab")
+        autechre_id = next(r["id"] for r in all_rows if r["display_artist"] == "Autechre")
+
+        await db.update_bandcamp_slug(stereolab_id, "stereolab")
+        await db.update_result(autechre_id, "spotify", "not_found")
+
+        mock_client = AsyncMock()
+        mock_client.search_artist = AsyncMock(
+            return_value=[
+                {"name": "Autechre", "url": "https://autechre.bandcamp.com", "slug": "autechre"}
+            ]
+        )
+
+        async def fake_catalog(slug):
+            if slug == "autechre":
+                return [
+                    {"url": "https://autechre.bandcamp.com/album/confield", "title": "Confield"}
+                ]
+            # Stereolab's catalog never matches "Aluminum Tunes"
+            return [
+                {
+                    "url": "https://stereolab.bandcamp.com/album/something-else",
+                    "title": "Something Else",
+                }
+            ]
+
+        mock_client.fetch_artist_catalog = AsyncMock(side_effect=fake_catalog)
+
+        await run_concurrent(mock_client, db)
+
+        fetched = [call.args[0] for call in mock_client.fetch_artist_catalog.call_args_list]
+        # Stereolab is fetched exactly once (the initial pre-existing pass);
+        # the autechre queue event must NOT re-scrape it.
+        assert fetched.count("stereolab") == 1, fetched
+        assert fetched.count("autechre") == 1, fetched
+
 
 class TestProcessBatched:
     @pytest.mark.asyncio

--- a/tests/unit/test_results_db.py
+++ b/tests/unit/test_results_db.py
@@ -386,3 +386,26 @@ class TestGetPendingBandcampLookup:
             await db.update_bandcamp_slug(r["id"], "someslug")
         pending = await db.get_pending_bandcamp_lookup(limit=1)
         assert len(pending) == 1
+
+    @pytest.mark.asyncio
+    async def test_slug_filter_restricts_to_one_slug(self, db):
+        await db.insert_albums(
+            [
+                _make_album(),
+                _make_album(
+                    normalized_artist="autechre",
+                    normalized_title="confield",
+                    display_artist="Autechre",
+                    display_title="Confield",
+                    library_ids=[3],
+                    formats=["cd"],
+                ),
+            ]
+        )
+        all_rows = await db.get_pending("spotify", limit=10)
+        for r in all_rows:
+            await db.update_bandcamp_slug(r["id"], r["display_artist"].lower())
+
+        pending = await db.get_pending_bandcamp_lookup(slug="autechre")
+        assert len(pending) == 1
+        assert pending[0]["bandcamp_slug"] == "autechre"


### PR DESCRIPTION
Closes #125.

## Problem

`run_concurrent`'s `lookup_consumer` called `phase_lookup()` with no filter on every queue event, and `phase_lookup()` always queried the entire pending set (`bandcamp_slug IS NOT NULL AND bandcamp_url IS NULL`). Albums that never matched stay pending for the whole run, so each newly discovered slug re-scraped every still-pending catalog -- O(slugs x catalogs) work. In the field this turned one useful pass into a ~2-hour run that re-fetched all 2,686 catalogs to handle a single newly discovered slug.

## Fix

Thread an optional `slug` filter through `get_pending_bandcamp_lookup()` and `phase_lookup()`, and pass the freshly dequeued slug from the consumer loop so a queue event fetches exactly one catalog. The pre-existing-slug pass before the loop is unchanged (it still drains the full pending set once), as the issue prescribes.

## Tests (TDD)

- `test_queue_event_only_fetches_new_slug` -- regression test: an already-pending unmatched slug must be fetched exactly once; the new slug's queue event must not re-scrape it. Fails before the fix (`['stereolab', 'stereolab', 'autechre']`), passes after.
- `test_slug_filter_restricts_to_one_slug` -- DB-layer coverage for the new filter.
- Full unit suite: 2946 passed; `ruff check` + `ruff format --check` clean.

Unblocks the offline Phase-2 drain (#661).