### PR TITLE
fix(#631): break row-less artist tiebreak by Discogs rank, not lowest release_id (forward-port from #656)

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1054,15 +1054,20 @@ def _select_rowless_artist_release(
     collaborations credited "<artist> & <other>" among them — so the survivors
     are releases credited to the artist alone.
 
-    Among the survivors, sort by Discogs ``confidence`` descending with a stable
-    ``release_id`` tiebreak. Note the upstream query is artist-only
+    Among the survivors, take the highest Discogs ``confidence``, breaking a tie
+    by **input order**. The upstream query is artist-only
     (``DiscogsSearchRequest(artist=token)`` in ``lookup_releases_by_artist``), so
     ``calculate_confidence`` scores every exact-credit match identically (~0.4,
     no album term) — confidence only separates an exact credit from a fuzzier
-    diacritic variant, and in the common all-identical-credit case the
-    deterministic ``release_id`` tiebreak is the effective selector. True
-    relevance ranking (community have/want counts) needs a per-release
-    ``get_release`` fetch and is deferred to #633.
+    diacritic variant, so the input-order tiebreak is the effective selector in
+    the common all-identical-credit case. ``lookup_releases_by_artist`` returns
+    the list ``service.search`` already sorted by confidence descending — a
+    *stable* sort that preserves Discogs' own result order within a confidence
+    tie — so first-survivor-wins surfaces the release Discogs ranked highest,
+    not the oldest-cataloged pressing a ``release_id`` tiebreak would pick.
+    Deterministic for a given Discogs response. True community-count ranking
+    (have/want) needs a per-release ``get_release`` fetch and is deferred to
+    #633.
 
     A non-positive ``release_id`` is dropped before selection: such an id would
     fail ``_resolve_fallback_artwork``'s ``release_id > 0`` guard downstream and
@@ -1078,7 +1083,12 @@ def _select_rowless_artist_release(
     ]
     if not own:
         return None
-    best = min(own, key=lambda r: (-r.confidence, r.release_id))
+    # Highest confidence wins; ties break by input index (ascending), so the
+    # first survivor — Discogs' highest-ranked release within a confidence tie —
+    # is chosen rather than the lowest release_id (the oldest pressing). ``own``
+    # preserves ``discogs_releases`` order, which ``service.search`` sorted by
+    # confidence descending with a stable sort.
+    best = min(enumerate(own), key=lambda iv: (-iv[1].confidence, iv[0]))[1]
     # One album-title fallback feeds both the synthetic row's title and the
     # carried release's album_title, so they can't drift.
     album_title = best.album or ""

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -357,17 +357,22 @@ class TestSearchSongAsArtistRowless:
         assert discogs_titles is None
 
     @pytest.mark.asyncio
-    async def test_tiebreak_picks_lowest_release_id_on_equal_confidence(
+    async def test_tiebreak_preserves_discogs_order_on_equal_confidence(
         self, enable_nonlibrary_release
     ):
         """The *effective* production selector. The artist-only Discogs query
         carries no album term, so ``calculate_confidence`` scores every
         exact-credit match identically (~0.4) — the confidence key ties and the
-        deterministic ``release_id`` tiebreak decides. Among equal-confidence own
-        releases the lowest ``release_id`` wins. The earlier selection test feeds
-        distinct confidences (0.8 vs 0.2), a spread this path never produces, so
-        this pins the tiebreak that actually governs selection in production.
-        (True relevance ranking is deferred to #633.)"""
+        tie is broken by input order. ``lookup_releases_by_artist`` returns the
+        list ``service.search`` already sorted by confidence descending (a stable
+        sort preserving Discogs' own relevance order within a tie), so the first
+        survivor — the release Discogs ranked highest — wins. The earlier
+        selection test feeds distinct confidences (0.8 vs 0.2), a spread this
+        path never produces, so this pins the tiebreak that actually governs
+        selection in production. Note the winner (release_id 900) is NOT the
+        lowest release_id (210): the tiebreak follows Discogs' ranking, not the
+        oldest-cataloged pressing. (True community-count ranking is deferred to
+        #633.)"""
         db = AsyncMock()
         db.exact_title = AsyncMock(return_value=[])
         db.search = AsyncMock(return_value=[])
@@ -389,8 +394,8 @@ class TestSearchSongAsArtistRowless:
 
         assert len(items) == 1
         resolved = discogs_titles[0]
-        assert resolved.release_id == 210
-        assert items[0].title == "Estrela Acesa"
+        assert resolved.release_id == 900
+        assert items[0].title == "Grandeza"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Forward-ports the LML#631 row-less artist **tiebreak fix** that missed #656's merge. #656 was squash-merged at head `2c90784` at the same moment this commit (`6a9aace`) was pushed on top, so the branch advanced past the PR head and the fix was orphaned — `main` still has the old tiebreak. This PR carries just that one commit onto current `main` (cleanly, atop the #660 work that has since landed).

## The fix

`_select_rowless_artist_release` picks the release that represents a non-library artist request. The artist-only Discogs query (`DiscogsSearchRequest(artist=token)`) carries no album term, so `calculate_confidence` scores every exact-credit match identically (~0.4) and the confidence key ties in the common case. The prior

```python
best = min(own, key=lambda r: (-r.confidence, r.release_id))
```

then broke that tie on **lowest `release_id`** — the earliest-cataloged pressing — discarding the relevance order `service.search` had already sorted the list into. For a non-library artist (the target population, which misses the library-filtered PG cache and so hits the live API path), that surfaced an arbitrary old pressing to the DJ in Slack rather than the release Discogs ranked first.

Break the tie by **input index** instead:

```python
best = min(enumerate(own), key=lambda iv: (-iv[1].confidence, iv[0]))[1]
```

Highest-confidence still wins; on a tie the first survivor — Discogs' top-ranked release — is chosen, since `service.search` sorts by confidence descending with a stable sort that preserves Discogs' own order within a tie. Deterministic for a given Discogs response. True community-count ranking (have/want) still needs a per-release `get_release` fetch and stays deferred.

## Tests

Retargets the tiebreak test onto the new rule: `test_tiebreak_preserves_discogs_order_on_equal_confidence`. The data is a clean discriminator — the first input element (`release_id=900`) is *not* the lowest `release_id` (`210`), so input-order and lowest-id disagree and the test pins the former. Confirmed it fails against the old code, passes against the new.

Full suite: 3230 passed (pg/external_api deselected). Lint + format clean.

## Context

Surfaced in the max-effort review of #656. The other review findings (#4 vacuous flag-off assertion, #5 settings-cache hygiene, #8 album-title double-compute) were in `2c90784` and **did** land via #656's merge — only this tiebreak commit was orphaned by the race. Related: #625 (parent epic), #631 (the row-less SONG_AS_ARTIST work), #656 (the merged PR).
