### PR TITLE
feat(#672): cut over to volume-only streaming lineage, drop the release dual-write

### DIFF
--- a/.github/workflows/refresh-streaming.yml
+++ b/.github/workflows/refresh-streaming.yml
@@ -25,12 +25,11 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
-# Workflow-level GITHUB_TOKEN scope. The library.db download and (transitional)
-# release dual-write use GITHUB_TOKEN; the streaming_availability.db round-trip
-# uses ADMIN_TOKEN against the Railway volume. contents:write is required for the
-# release asset write.
+# Workflow-level GITHUB_TOKEN scope. The only release interaction is downloading
+# library.db (a read); the streaming_availability.db round-trip uses ADMIN_TOKEN
+# against the Railway volume, not GITHUB_TOKEN. contents:read is the safe floor.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   refresh:
@@ -124,13 +123,3 @@ jobs:
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           PRODUCTION_URL: ${{ secrets.PRODUCTION_URL }}
-
-      # TRANSITIONAL dual-write (LML#672 rollout step 1): keep the release asset
-      # warm until discogs-etl reads the volume and one sync cycle is verified.
-      # Removed in the cutover PR (rollout step 3), retiring this asset.
-      - name: Upload to GitHub Release (transitional dual-write)
-        run: |
-          gh release upload streaming-data-v1 streaming_availability.db --clobber 2>/dev/null || \
-          gh release create streaming-data-v1 streaming_availability.db --title "Streaming availability data" --notes "Pre-computed streaming service URLs for WXYC library releases. Updated weekly by the refresh-streaming workflow."
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,7 +38,7 @@ Three classes of pin in `.github/workflows/*.yml` exist for supply-chain reasons
 - **Workflow-level `permissions:`** scoped to the minimum each workflow needs:
   - `ci.yml`, `cross-cache-identity-flags.yml`, `set-railway-var.yml`: `contents: read` (no GITHUB_TOKEN writes).
   - `charset-corpus-drift.yml`: `contents: read` plus `packages: read` (the reusable workflow pulls `@wxyc/shared` from `npm.pkg.github.com`).
-  - `refresh-streaming.yml`: `contents: write` (downloads `library.db` from, and transitionally dual-writes `streaming_availability.db` to, the `streaming-data-v1` GitHub Release via `GH_TOKEN`). The canonical `streaming_availability.db` round-trip itself goes to the Railway **volume** via `ADMIN_TOKEN` + `PRODUCTION_URL` (see [Streaming Database Backup](#streaming-database-backup-upload--download)), not GITHUB_TOKEN.
+  - `refresh-streaming.yml`: `contents: read` (its only release interaction is downloading `library.db` via `GH_TOKEN` — a read). The canonical `streaming_availability.db` round-trip goes to the Railway **volume** via `ADMIN_TOKEN` + `PRODUCTION_URL` (see [Streaming Database Backup](#streaming-database-backup-upload--download)), not GITHUB_TOKEN.
   Failure mode is silent — a job that needs a missing scope (e.g. `pull-requests: write`) fails its API call but the workflow stays green. When adding a step that needs to comment on PRs, push tags, mint releases, etc., explicitly grant the scope at the job level (or widen the workflow-level floor only if every job in the file needs it).
 - **Reusable-workflow refs pinned to `@gha/v1`**, not `@main` — `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@gha/v1` (in `ci.yml`) and `WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1` (in `charset-corpus-drift.yml`). The publishing repos treat `gha/v1` as a moving major tag — re-pointed forward on non-breaking changes, frozen on breaking changes (which get a fresh `gha/v2`). Don't downgrade either to `@main`; if a `gha/v2` migration arrives, follow the procedure at the top of the publishing repo's CLAUDE.md.
 
@@ -78,7 +78,7 @@ The volume is now the enforced single source. Every writer round-trips it (downl
 - The occasional manual Apple + `track_streaming` run: same download → enrich → upload round-trip, so it never clobbers the weekly incremental and vice versa.
 - `sync-library.yml` (WXYC/discogs-etl, daily): reads the volume via `GET /admin/download-streaming-db` to enrich `library.db`.
 
-During the cutover the release asset is still **dual-written** by `refresh-streaming.yml` as a safety net; it is retired once discogs-etl is confirmed reading the volume (the release keeps hosting `library.db`).
+The `streaming_availability.db` release asset has been **retired** (LML#672 cutover): nothing writes or reads it anymore. The `streaming-data-v1` release still hosts **`library.db`** (written by discogs-etl `sync-library.yml`, read by `refresh-streaming.yml` as the input catalog).
 
 ### Coverage-regression guard on upload
 


### PR DESCRIPTION
**PR-3 of #672** (the cutover). Closes #672.

The volume-canonical rollout is verified end-to-end. After #676 (LML guard + volume round-trip) and WXYC/discogs-etl#290 (consume the volume) merged, a manually-dispatched discogs-etl `sync-library.yml` run executed the new path in CI:

```
volume streaming_availability.db OK: 65272 albums          # GET /admin/download-streaming-db hard-fail download
Streaming links apple_music_url count: 294 (floor 100)     # floor assertion passed
Uploaded to production successfully (64782 rows)            # prod library.db now carries 294 Apple links, automated
```

So production `library.db` gets Apple links via the volume with **no manual merge** — the rollout gate is met. With the consumption side proven, this retires the transitional dual-write.

## Changes
- **`refresh-streaming.yml`**: remove the "Upload to GitHub Release (transitional dual-write)" step. The `streaming_availability.db` release asset is now neither written nor read — the Railway volume is the sole lineage. Downgrade `permissions:` from `contents: write` to `contents: read` (the only remaining release interaction is downloading `library.db`, a read).
- **`docs/deployment.md`**: replace the "dual-written during cutover" note with the final state (asset retired; `streaming-data-v1` still hosts `library.db`), and update the CI-pin permissions note.

## Out-of-band
The `streaming_availability.db` asset on the `streaming-data-v1` release is deleted manually after this merges (it's no longer recreated by any workflow).

## Acceptance criteria (#672) — all met
- [x] Prod `library.db` `apple_music_url` non-zero and stays current without a manual merge (294, automated — verified above).
- [x] Release asset and volume can't silently diverge (single source after this PR).
- [x] `POST /admin/upload-streaming-db` coverage-regression guard (#676).
- [x] `refresh-streaming.yml` no longer enriches from an empty db on a flaked fetch (#676).
- [x] `sync-library.yml` hard-fails the fetch + asserts the apple floor (WXYC/discogs-etl#290).
- [x] `docs/deployment.md` updated for the single lineage + Railway-uptime failure mode (#676 + this PR).
- [x] No weekly-refresh wallclock regression (download + Spotify/Deezer incremental + upload < old release-create path).