### PR TITLE
fix(#663): recover the SONG_AS_ARTIST row-less credit from the packed live-path title

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1068,6 +1068,45 @@ async def search_song_as_artist(
     return [], None
 
 
+# LML#663: ``r.artist`` is a reliable credit only on the PG-cache path (the clean
+# ``artist_name`` column). On the live Discogs path it is title-derived —
+# ``DiscogsService._parse_title`` splits the search title on ``" - "`` and yields
+# ``artist=""`` when the title has no such separator, packing the whole title into
+# ``r.album``. A self-titled release (title is just the artist name) or one whose
+# title uses a non-ASCII dash then drops a genuine own-release, so a cold-cache
+# request falls through to not-found while a warm-cache one surfaces it. This
+# separator set recovers the leading credit from such a packed title.
+_PACKED_TITLE_SEPARATOR = re.compile(r"\s[-–—]\s")
+
+
+def _own_release_credit(r: DiscogsSearchResult, token_form: str) -> tuple[str, str] | None:
+    """``(artist, album_title)`` to surface when ``r`` credits the typed token, else None.
+
+    Recovers a title-derived-empty credit the live Discogs path left in ``r.album``
+    (LML#663). Still requires exact normalized-equality to ``token_form``, so V/A
+    "Various" and collaborations stay excluded — the gate is re-sourced, not loosened.
+    """
+    clean = (r.artist or "").strip()
+    if normalize_for_comparison(clean) == token_form:
+        return clean, r.album or ""
+    if clean:
+        # A non-empty credit that simply differs — a real mismatch (coincidental
+        # token hit, V/A "Various", or a collaboration). Drop without recovery.
+        return None
+    # Empty title-derived credit: the live path packed the whole Discogs title into
+    # ``r.album``. Recover the artist from it.
+    packed = (r.album or "").strip()
+    if not packed:
+        return None
+    if normalize_for_comparison(packed) == token_form:
+        # Self-titled: the title is just the artist name.
+        return packed, packed
+    parts = _PACKED_TITLE_SEPARATOR.split(packed, maxsplit=1)
+    if len(parts) == 2 and normalize_for_comparison(parts[0]) == token_form:
+        return parts[0].strip(), parts[1].strip()
+    return None
+
+
 def _select_rowless_artist_release(
     token: str, discogs_releases: list[DiscogsSearchResult]
 ) -> tuple[LibraryItem, ResolvedRelease] | None:
@@ -1102,10 +1141,14 @@ def _select_rowless_artist_release(
     malformed-upstream path.
     """
     token_form = normalize_for_comparison(token)
+    # (release, (recovered_artist, album_title)) for every release crediting the
+    # typed token. ``_own_release_credit`` recovers a credit the live Discogs path
+    # left title-derived-empty (LML#663), so a cold-cache request matches the
+    # warm-cache (clean ``r.artist``) outcome instead of dropping to not-found.
     own = [
-        r
+        (r, credit)
         for r in discogs_releases
-        if r.release_id > 0 and normalize_for_comparison(r.artist or "") == token_form
+        if r.release_id > 0 and (credit := _own_release_credit(r, token_form)) is not None
     ]
     if not own:
         return None
@@ -1114,16 +1157,17 @@ def _select_rowless_artist_release(
     # is chosen rather than the lowest release_id (the oldest pressing). ``own``
     # preserves ``discogs_releases`` order, which ``service.search`` sorted by
     # confidence descending with a stable sort.
-    best = min(enumerate(own), key=lambda iv: (-iv[1].confidence, iv[0]))[1]
-    # One album-title fallback feeds both the synthetic row's title and the
+    best, (best_artist, best_album) = min(
+        enumerate(own), key=lambda iv: (-iv[1][0].confidence, iv[0])
+    )[1]
+    # One recovered album title feeds both the synthetic row's title and the
     # carried release's album_title, so they can't drift.
-    album_title = best.album or ""
-    item = _make_rowless_item(artist=best.artist or token, title=album_title)
+    item = _make_rowless_item(artist=best_artist or token, title=best_album)
     resolved = ResolvedRelease(
         release_id=best.release_id,
         release_url=best.release_url,
         is_compilation=False,
-        album_title=album_title,
+        album_title=best_album,
     )
     return item, resolved
 

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -397,6 +397,87 @@ class TestSearchSongAsArtistRowless:
         assert resolved.release_id == 900
         assert items[0].title == "Grandeza"
 
+    @pytest.mark.asyncio
+    async def test_emits_rowless_for_self_titled_live_path_credit(self, enable_nonlibrary_release):
+        """LML#663: on the live Discogs path the credit is title-derived —
+        ``_parse_title`` splits the search title on ``" - "`` and yields
+        ``artist=""`` when there is no separator (a self-titled release whose
+        title is just the artist name), packing the name into ``album``. The
+        warm-cache (PG) path has the clean credit and surfaces row-less; the gate
+        must recover the credit from the packed title so the cold/live path
+        produces the *same* outcome instead of dropping to not-found — the
+        warm/cold asymmetry #663 fixes.
+        """
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[make_discogs_result(release_id=556, artist="", album="Sessa")],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sessa", AsyncMock())
+
+        assert len(items) == 1
+        assert items[0].id == 0
+        assert items[0].artist == "Sessa"
+        assert discogs_titles is not None
+        assert discogs_titles[0].release_id == 556
+
+    @pytest.mark.asyncio
+    async def test_emits_rowless_for_packed_title_credit(self, enable_nonlibrary_release):
+        """LML#663: an ``"Artist <sep> Album"`` title whose separator the ASCII
+        ``" - "`` split missed (e.g. a non-ASCII en/em dash) lands whole in
+        ``album`` with ``artist=""``. Recover the leading credit and surface the
+        remainder as the row-less album title — not the packed string.
+        """
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[
+                make_discogs_result(release_id=557, artist="", album="Sessa – Estrela Acesa")
+            ],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sessa", AsyncMock())
+
+        assert len(items) == 1
+        assert items[0].id == 0
+        assert items[0].artist == "Sessa"
+        assert items[0].title == "Estrela Acesa"
+        assert discogs_titles[0].release_id == 557
+
+    @pytest.mark.asyncio
+    async def test_empty_credit_recovery_excludes_va_and_other_artists(
+        self, enable_nonlibrary_release
+    ):
+        """LML#663 constraint: recovering the credit from the packed title must
+        not loosen the gate. An empty title-derived credit whose packed title is
+        a V/A ``"Various"`` comp or a *different* artist stays excluded — the gate
+        still requires exact normalized-equality to the typed token, so only the
+        artist's own releases survive.
+        """
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[])
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_artist",
+            new_callable=AsyncMock,
+            return_value=[
+                make_discogs_result(release_id=560, artist="", album="Various"),
+                make_discogs_result(release_id=561, artist="", album="Tom Zé – Estudando O Samba"),
+            ],
+        ):
+            items, discogs_titles = await search_song_as_artist(db, "Sessa", AsyncMock())
+
+        assert items == []
+        assert discogs_titles is None
+
 
 # ---------------------------------------------------------------------------
 # search_library_with_fallback -- artist+song path (lines 260-265)


### PR DESCRIPTION
Closes #663.

## Problem

The LML#631 row-less selector `_select_rowless_artist_release` gated candidates on `normalize_for_comparison(r.artist or "") == token_form`. `r.artist` is a clean credit only on the **PG-cache** path (the `artist_name` column); on the **live Discogs** path it is title-derived — `DiscogsService._parse_title` splits the search title on `" - "` and returns `("", title)` when there is no separator, packing the whole title into `r.album`. A **self-titled** release (title is just the artist name) or one whose title uses a **non-ASCII dash** then yielded `artist=""`, failed the gate, and was silently dropped — so a cold-cache/live request fell through to **not-found** while a warm-cache request for the same artist surfaced the row-less release.

Because the discogs-cache PG is filtered by `library.db`, a **non-library** artist (this feature's entire target) usually misses PG and hits the live path, so the unreliable path is the *common* one. Path-dependent recall, and untested — every prior `TestSearchSongAsArtistRowless` case mocked a clean `artist`.

## Fix

A new `_own_release_credit(r, token_form)` helper recovers the credit from the packed title before giving up:

- **Self-titled** — the whole title normalizes-equal to the token → surface it (artist == album == the name).
- **Packed `"Artist <sep> Album"`** the ASCII `" - "` split missed (e.g. en/em dash) → recover the leading credit and surface the remainder as the album title (not the packed string).

It still requires **exact normalized-equality** to the typed token, so V/A `"Various"` comps and collaborations stay excluded — the gate is **re-sourced, not loosened** (an empty title-derived credit makes equality stricter, never looser, so no false-positive/mis-credit).

### Why no `get_release` fetch (divergence from sibling #660)

#660 had to fetch each release because per-track credits live only in the release tracklist. Here the release credit is already present in the search result's **own title**, so recovery needs **no `get_release` fan-out on the cold path** — the per-request Discogs cost the bulk kill switch (#652) exists to bound. Selection logic (confidence + Discogs-order tiebreak) is unchanged.

## Tests (TDD, `tests/unit/test_orchestrator_gaps.py::TestSearchSongAsArtistRowless`)

Red-first, then green:

- `test_emits_rowless_for_self_titled_live_path_credit` — `artist=""`, `album="Sessa"` → row-less surfaces (the warm/cold parity case, pairs with the existing clean-credit test).
- `test_emits_rowless_for_packed_title_credit` — `artist=""`, `album="Sessa – Estrela Acesa"` → recovers `Sessa` + surfaces `Estrela Acesa`.
- `test_empty_credit_recovery_excludes_va_and_other_artists` — empty-credit `"Various"` and a different artist stay excluded (constraint guard).

Local CI parity green: `ruff check` / `ruff format --check`, `mypy`, full default suite (3286 passed). No `generated/` or flag changes.

Dark behind `LML_RESOLVE_NONLIBRARY_RELEASE` — no production impact until the flag is enabled; this is the last pre-enable matcher-quality residual of the #625 epic.