### PR TITLE
feat(688): surface Discogs master_id in /lookup response (single + bulk)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -497,7 +497,7 @@ class DiscogsCacheService:
         try:
             release_row = await self.pool.fetchrow(
                 "SELECT id, title, release_year, artwork_url, released, "
-                "artwork_checked_at, not_found "
+                "artwork_checked_at, not_found, master_id "
                 "FROM release WHERE id = $1",
                 release_id,
             )
@@ -683,6 +683,11 @@ class DiscogsCacheService:
                 extra_artists=extra_artist_credits,
                 labels=label_credits,
                 released=release_row["released"],
+                # LML#688: nullable, recently-added column. ``.get`` tolerates
+                # cache rows written before master_id was plumbed (and partial
+                # test doubles); a real ``SELECT … master_id`` row always carries
+                # the key, None when Discogs has no master for the release.
+                master_id=release_row.get("master_id"),
                 videos=videos,
             )
 
@@ -754,22 +759,24 @@ class DiscogsCacheService:
                     """
                     INSERT INTO release (
                         id, title, release_year, artwork_url, released,
-                        artwork_checked_at, not_found
+                        artwork_checked_at, not_found, master_id
                     )
-                    VALUES ($1, $2, $3, $4, $5, now(), FALSE)
+                    VALUES ($1, $2, $3, $4, $5, now(), FALSE, $6)
                     ON CONFLICT (id) DO UPDATE SET
                         title = EXCLUDED.title,
                         release_year = EXCLUDED.release_year,
                         artwork_url = EXCLUDED.artwork_url,
                         released = EXCLUDED.released,
                         artwork_checked_at = EXCLUDED.artwork_checked_at,
-                        not_found = FALSE
+                        not_found = FALSE,
+                        master_id = EXCLUDED.master_id
                     """,
                     release.release_id,
                     release.title,
                     release.year,
                     release.artwork_url,
                     release.released,
+                    release.master_id,
                 )
 
                 # Delete + re-insert all artists (clean replacement)

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -209,6 +209,12 @@ class DiscogsSearchResult(BaseModel):
     artwork_url: str | None = None
     confidence: float = 0.0
     # Enriched fields (populated after initial search by orchestrator)
+    # LML#688: the release's Discogs master_id, populated by the orchestrator
+    # from the resolved release so a catalog-popularity caller can collapse
+    # pressings/formats of one logical album by the master. `None` when the
+    # release has no master (one-offs, self-released) or for the streaming-only
+    # sentinel (release_id == 0).
+    master_id: int | None = None
     release_year: int | None = None
     artist_bio: str | None = None
     wikipedia_url: str | None = None
@@ -237,6 +243,7 @@ class DiscogsSearchResult(BaseModel):
             artist=self.artist,
             release_id=self.release_id,
             release_url=self.release_url,
+            master_id=self.master_id,
             artwork_url=self.artwork_url,
             confidence=self.confidence,
             release_year=self.release_year,

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -874,6 +874,11 @@ class DiscogsService:
 
                 return ReleaseMetadataResponse(
                     release_id=release_id,
+                    # LML#688: surface the release's Discogs master_id so a
+                    # caller (Backend catalog-popularity) can collapse multiple
+                    # pressings/formats of one logical album by the master.
+                    # `None` when Discogs has no master for this release.
+                    master_id=data.get("master_id"),
                     title=data.get("title", ""),
                     artist=artist_name,
                     year=data.get("year"),

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -872,13 +872,25 @@ class DiscogsService:
                     if v.get("uri")
                 ]
 
+                # LML#688: surface the release's Discogs master_id so a caller
+                # (Backend catalog-popularity) can collapse multiple pressings/
+                # formats of one logical album by the master. Discogs returns the
+                # integer ``master_id: 0`` (a sentinel, not an absent key) for a
+                # release with no master — the same no-master value the canonical
+                # discogs_client treats as falsy and that this repo already guards
+                # as ``master_id <= 0`` in ``markup_parser``. Normalize any
+                # non-positive / non-int to ``None`` so the wire contract
+                # (``null`` for no master) holds AND a cold-API write-back never
+                # persists ``master_id = 0`` into the PG cache (cache_service
+                # write_release warms straight from this value).
+                raw_master_id = data.get("master_id")
+                master_id = (
+                    raw_master_id if isinstance(raw_master_id, int) and raw_master_id > 0 else None
+                )
+
                 return ReleaseMetadataResponse(
                     release_id=release_id,
-                    # LML#688: surface the release's Discogs master_id so a
-                    # caller (Backend catalog-popularity) can collapse multiple
-                    # pressings/formats of one logical album by the master.
-                    # `None` when Discogs has no master for this release.
-                    master_id=data.get("master_id"),
+                    master_id=master_id,
                     title=data.get("title", ""),
                     artist=artist_name,
                     year=data.get("year"),

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1232,6 +1232,10 @@ class DiscogsReleaseVideo(BaseModel):
 
 class DiscogsReleaseMetadata(BaseModel):
     release_id: int
+    master_id: int | None = Field(
+        None,
+        description="Discogs master ID for this release, when the release belongs to a master. `null` when Discogs has no master (one-offs, self-released). Lets a caller collapse multiple pressings/formats of one logical album into a single record keyed on the master.\n",
+    )
     title: str
     artist: str
     year: int | None = None
@@ -1691,6 +1695,10 @@ class DiscogsMatchResult(BaseModel):
     release_id: int = Field(
         ...,
         description='Discogs release ID. `> 0` is a real release identity; `0` is the streaming-only sentinel (paired with `release_url == ""`, BS#1185) and is not a linkable Discogs release.\n',
+    )
+    master_id: int | None = Field(
+        None,
+        description="Discogs master ID for the release, when the release belongs to a master. `null` when Discogs has no master for this release (one-offs, self-released) or for the streaming-only sentinel (`release_id == 0`). Lets a caller collapse multiple pressings/formats of one logical album into a single record keyed on the master. Populated from the resolved release's `master_id` field on `/lookup` (single and bulk).\n",
     )
     release_url: str = Field(
         ...,

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -3480,6 +3480,20 @@ async def enrich_artwork_results(
         is_album_derived_eligible = is_top1 and library_row_acceptable
         year_result = top1_year if is_album_derived_eligible else probe_release_year
 
+        # LML#688: the resolved release's Discogs master_id, gated like the
+        # other release-sourced fields (top-1 + acceptable library row). Lets a
+        # catalog-popularity caller (Backend) collapse pressings/formats of one
+        # logical album by the master. ``None`` when the release has no master
+        # (one-offs, self-released) or the top-1 release never resolved. Unlike
+        # the extended-only fields below, it rides the album-derived gate alone
+        # (not ``extended``): it is a lightweight release-identity integer that
+        # the non-extended bulk-drain path also needs to group by.
+        master_id_result = (
+            top1_release.master_id
+            if is_album_derived_eligible and top1_release is not None
+            else None
+        )
+
         # LML#504: library-row hop. ``artist_matches_item``
         # (orchestrator.py:527) and ``library/db.py``'s ``_fuzzy_search``
         # both consult ``item.artist`` AND ``item.alternate_artist_name``
@@ -3583,6 +3597,7 @@ async def enrich_artwork_results(
 
         update: dict[str, Any] = {
             "release_year": year_result,
+            "master_id": master_id_result,
             "artist_bio": artist_bio,
             "wikipedia_url": wikipedia_url,
             # spotify_url / bandcamp_url are normalized to None (like

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -526,6 +526,35 @@ class TestWriteRelease:
         )
 
     @pytest.mark.asyncio
+    async def test_release_upsert_persists_master_id(self, cache_service, mock_asyncpg_pool):
+        """LML#688: the release upsert must persist master_id so a cold API
+        fetch warms the field into PG (matching the value discogs-etl seeds),
+        and the ON CONFLICT path refreshes it from EXCLUDED on re-upsert."""
+        release = ReleaseMetadataResponse(
+            release_id=28138,
+            title="Confield",
+            artist="Autechre",
+            year=2001,
+            master_id=12345,
+            release_url="https://discogs.com/release/28138",
+        )
+
+        await cache_service.write_release(release)
+
+        conn = mock_asyncpg_pool._mock_conn
+        release_sql = conn.execute.call_args_list[0][0][0]
+        assert "master_id" in release_sql, (
+            "release upsert must persist master_id (LML#688 cache-warm path)"
+        )
+        assert "master_id = EXCLUDED.master_id" in release_sql, (
+            "ON CONFLICT must refresh master_id from EXCLUDED on re-upsert"
+        )
+        release_params = conn.execute.call_args_list[0][0][1:]
+        assert 12345 in release_params, (
+            f"master_id value must be bound into the upsert params; got: {release_params!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_error_raises(self, cache_service, mock_asyncpg_pool):
         mock_asyncpg_pool.acquire.return_value.__aenter__ = AsyncMock(side_effect=Exception("fail"))
         release = ReleaseMetadataResponse(
@@ -812,6 +841,92 @@ class TestGetReleaseEnriched:
         # Backward compat scalars
         assert result.artist == "Autechre"
         assert result.label == "Warp Records"
+
+    @pytest.mark.asyncio
+    async def test_reads_master_id(self, cache_service, mock_asyncpg_pool):
+        """LML#688: a master-bearing cached release surfaces its master_id.
+
+        ``get_release`` is read-through (in-memory → PG → API). WXYC library
+        releases are pre-warmed into discogs-cache PG by discogs-etl, so the PG
+        tier — not the API path — serves essentially every library lookup.
+        ``master_id`` must be plumbed through this path or the catalog-popularity
+        caller (BS#1486) sees ``None`` for exactly the releases it cares about.
+        """
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 28138,
+                "title": "Confield",
+                "release_year": 2001,
+                "artwork_url": None,
+                "released": None,
+                "artwork_checked_at": None,
+                "not_found": False,
+                "master_id": 9999,
+            }
+        )
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_artist=[
+                    {"artist_id": 77, "artist_name": "Autechre", "extra": 0, "role": None}
+                ],
+            )
+        )
+
+        result = await cache_service.get_release(28138)
+        assert result is not None
+        assert result.master_id == 9999
+
+    @pytest.mark.asyncio
+    async def test_master_less_release_surfaces_none(self, cache_service, mock_asyncpg_pool):
+        """A release with no Discogs master surfaces master_id=None, not an error."""
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 1,
+                "title": "Self-Released EP",
+                "release_year": 2019,
+                "artwork_url": None,
+                "released": None,
+                "artwork_checked_at": None,
+                "not_found": False,
+                "master_id": None,
+            }
+        )
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_artist=[
+                    {"artist_id": 5, "artist_name": "Some Artist", "extra": 0, "role": None}
+                ],
+            )
+        )
+
+        result = await cache_service.get_release(1)
+        assert result is not None
+        assert result.master_id is None
+
+    @pytest.mark.asyncio
+    async def test_get_release_select_includes_master_id(self, cache_service, mock_asyncpg_pool):
+        """Pin master_id in the parent release SELECT so a future refactor that
+        drops the column can't silently regress the cache-warm path (LML#688)."""
+        mock_asyncpg_pool.fetchrow = AsyncMock(
+            return_value={
+                "id": 1,
+                "title": "X",
+                "release_year": 2000,
+                "artwork_url": None,
+                "released": None,
+                "artwork_checked_at": None,
+                "not_found": False,
+                "master_id": 42,
+            }
+        )
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=make_fetch_router())
+
+        await cache_service.get_release(1)
+
+        select_sql = mock_asyncpg_pool.fetchrow.call_args.args[0]
+        assert "master_id" in select_sql, (
+            f"the parent release SELECT must fetch master_id (LML#688); got: {select_sql!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_discogs_models.py
+++ b/tests/unit/test_discogs_models.py
@@ -44,6 +44,28 @@ class TestToMatchResult:
         assert match.artwork_url is None
         assert match.confidence == 0.0
 
+    def test_threads_master_id_when_present(self):
+        """LML#688: a search result carrying a master_id surfaces it on the match."""
+        result = DiscogsSearchResult(
+            album="DOGA",
+            artist="Juana Molina",
+            release_id=12345,
+            release_url="https://discogs.com/release/12345",
+            master_id=67890,
+        )
+        match = result.to_match_result()
+        assert match.master_id == 67890
+
+    def test_master_id_defaults_to_none(self):
+        """A master-less search result surfaces master_id=None on the match."""
+        result = DiscogsSearchResult(
+            release_id=1,
+            release_url="https://discogs.com/release/1",
+        )
+        assert result.master_id is None
+        match = result.to_match_result()
+        assert match.master_id is None
+
 
 # ---------------------------------------------------------------------------
 # ArtistCredit / LabelCredit models

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -2418,6 +2418,36 @@ class TestGetReleaseExtractsMasterId:
         assert result is not None
         assert result.master_id is None
 
+    @pytest.mark.asyncio
+    async def test_master_id_zero_sentinel_surfaces_none(self, service):
+        """Discogs returns the integer ``master_id: 0`` for a release with no
+        master (the same no-master sentinel the canonical discogs_client treats
+        as falsy, and that this repo already guards as ``master_id <= 0`` in
+        ``markup_parser``). It must normalize to ``None`` so the wire contract
+        (``null`` for no master) holds and a cold-API write-back doesn't poison
+        the PG cache with ``master_id = 0``."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "Edits",
+            "artists": [{"id": 3, "name": "Chuquimamani-Condori"}],
+            "labels": [],
+            "tracklist": [],
+            "images": [],
+            "genres": ["Electronic"],
+            "styles": [],
+            "master_id": 0,
+        }
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_release(99999)
+
+        assert result is not None
+        assert result.master_id is None
+
 
 # ---------------------------------------------------------------------------
 # get_artist_details

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -2363,6 +2363,63 @@ class TestGetReleaseEnrichedParsing:
 
 
 # ---------------------------------------------------------------------------
+# get_release extracts master_id (LML#688 / Phase-2 catalog popularity)
+# ---------------------------------------------------------------------------
+
+
+class TestGetReleaseExtractsMasterId:
+    @pytest.mark.asyncio
+    async def test_extracts_master_id_when_present(self, service):
+        """A release that belongs to a Discogs master surfaces its master_id."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "DOGA",
+            "artists": [{"id": 1, "name": "Juana Molina"}],
+            "labels": [{"id": 2, "name": "Sonamos"}],
+            "tracklist": [],
+            "images": [],
+            "genres": ["Rock"],
+            "styles": [],
+            "master_id": 123456,
+        }
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_release(28138)
+
+        assert result is not None
+        assert result.master_id == 123456
+
+    @pytest.mark.asyncio
+    async def test_master_id_is_none_when_absent(self, service):
+        """A master-less release (one-off / self-released) surfaces master_id=None."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "title": "Edits",
+            "artists": [{"id": 3, "name": "Chuquimamani-Condori"}],
+            "labels": [],
+            "tracklist": [],
+            "images": [],
+            "genres": ["Electronic"],
+            "styles": [],
+            # no master_id key
+        }
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_release(99999)
+
+        assert result is not None
+        assert result.master_id is None
+
+
+# ---------------------------------------------------------------------------
 # get_artist_details
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -412,6 +412,79 @@ class TestEnrichArtworkResultsExtended:
         assert "French-British band" in enriched.artist_bio
 
     @pytest.mark.asyncio
+    async def test_populates_master_id_on_top1_from_resolved_release(self):
+        """LML#688: the resolved release's master_id lands on the enriched top-1
+        result so a catalog-popularity caller can collapse pressings by master.
+
+        master_id is a release-identity fact (like release_id), so it surfaces
+        whenever the release resolves — independent of ``extended`` mode. This
+        is the same enrichment path the bulk /lookup route runs per item, so a
+        passing assertion here covers the bulk path's master_id carriage too.
+        """
+        item = make_library_item(artist="Juana Molina", title="DOGA")
+        artwork = make_discogs_result(release_id=10154369, artist="Juana Molina", album="DOGA")
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=10154369,
+            master_id=777001,
+            title="DOGA",
+            artist="Juana Molina",
+            year=2022,
+            artist_id=42,
+            release_url="https://discogs.com/release/10154369",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=42,
+            name="Juana Molina",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            song="la paradoja",
+            artist="Juana Molina",
+            extended=True,
+        )
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.master_id == 777001
+
+    @pytest.mark.asyncio
+    async def test_master_less_release_surfaces_null_master_id(self):
+        """A master-less release (one-off / self-released) surfaces master_id=None."""
+        item = make_library_item(artist="Chuquimamani-Condori", title="Edits")
+        artwork = make_discogs_result(
+            release_id=20154369, artist="Chuquimamani-Condori", album="Edits"
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=20154369,
+            master_id=None,
+            title="Edits",
+            artist="Chuquimamani-Condori",
+            year=2023,
+            artist_id=43,
+            release_url="https://discogs.com/release/20154369",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=43,
+            name="Chuquimamani-Condori",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            song="Call Your Name",
+            artist="Chuquimamani-Condori",
+            extended=True,
+        )
+        _, enriched = results[0]
+        assert enriched is not None
+        assert enriched.master_id is None
+
+    @pytest.mark.asyncio
     async def test_extended_false_leaves_new_fields_unset(self):
         """With extended=False the response shape is unchanged.
 


### PR DESCRIPTION
## What

Surfaces the Discogs `master_id` on every `/lookup` result, single and bulk, across **both** tiers of the read-through cache.

**Live/API path (`discogs/service.py`, `discogs/models.py`, `lookup/orchestrator.py`):**
- `get_release` extracts `data.get("master_id")` into `ReleaseMetadataResponse`.
- `DiscogsSearchResult` gains `master_id`, threaded through `to_match_result()` — the single builder both the single-lookup and bulk paths share (`handle_bulk_lookup` -> `perform_lookup` -> the same `enrich_artwork_results`), so one change covers both.
- `enrich_artwork_results` populates `master_id` on the top-1 album-derived result.
- Regenerated `generated/api_models.py` from the updated SSOT.

**PG read-through cache (`discogs/cache_service.py`):**
- `get_release` is read-through (in-memory -> PG -> API). WXYC library releases are pre-warmed into discogs-cache PG by discogs-etl, so the PG tier — not the API path — serves essentially every library lookup. Plumbed `master_id` through the parent `SELECT` + `ReleaseMetadataResponse` builder so cached reads surface it.
- `write_release` now persists `master_id` (INSERT + `ON CONFLICT … master_id = EXCLUDED.master_id`) so a cold API write-back warms the field into PG. The discogs-cache `release` table already carries the column (`discogs-etl` `build_filtered_discogs`).

Without the cache leg, `master_id` would be `None` on the dominant cache-warm path for exactly the releases the consumer cares about — caught in pre-PR review.

## Why

WXYC/Backend-Service#1486 (attribution-corrected catalog popularity) needs a master-level key to collapse multiple pressings of one logical album. `release_id` is per-pressing; the master id is the missing collapse key. This is Phase-2 Track 0.

## Out of scope (deliberate)

The `discogs_master` cache-refresh leg (`cache/dispatch.py` `_NOT_IMPLEMENTED_SOURCES`) and `entity.release_identity.discogs_master_id` writes are untouched — Backend needs the value, not a cached or minted master.

## Merge ordering

Depends on WXYC/wxyc-shared#194 (the SSOT change). The codegen-drift CI check regenerates against wxyc-shared `main`, so it stays red until #194 merges — merge #194 first, then this.

## Tests

TDD throughout. API-path: a release with a master surfaces the id; a master-less release surfaces `null`; the bulk path carries it. Cache-path: cached read surfaces `master_id`, master-less -> `None`, parent-SELECT pin, write persists + refreshes from `EXCLUDED`. Full suite green (3026 unit / 269 integration / ruff / mypy).

Closes #688
