### PR TITLE
perf(discogs): release semaphore permit before 429 retry sleep

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -381,60 +381,78 @@ class DiscogsService:
         # the ``request_context()`` helper (the three API-only methods that
         # bypass the seam and the four ``cache is None`` fallback branches).
 
-        # Explicit acquire/release (not `async with semaphore:`) so the wait
-        # is wrapped in a Sentry span. The 5-permit semaphore is the dominant
-        # source of pre-request dark time on backfill cascades — sampling the
-        # queue depth right before the await gives the trace explorer a
-        # relative-load signal per call. See WXYC/library-metadata-lookup#358.
-        with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.semaphore") as span:
-            span.set_data("lml.semaphore.queue_depth", _approx_semaphore_queue_depth(semaphore))
-            apply_request_ctx_tags(span)
-            await semaphore.acquire()
-        try:
-            for attempt in range(max_retries + 1):
+        # The semaphore wraps a single attempt, not the whole retry loop
+        # (LML#569). A 429's inter-attempt ``asyncio.sleep(Retry-After)`` runs
+        # *outside* the held permit, so a caller riding out a 30-60s rate-limit
+        # window no longer parks one of the 5 permits for that whole window and
+        # amplifies ``lml.discogs.semaphore`` acquire-wait for unrelated callers
+        # (the last unhandled tail of #537, cause #3). The egress cap is still
+        # the per-attempt ``rate_limiter.acquire()`` below — releasing the
+        # semaphore during the sleep does not bypass the AsyncLimiter.
+        #
+        # The per-attempt try/finally guarantees exactly one release per
+        # acquire: cancellation mid-sleep (sleep is outside the block) or a
+        # raise inside the request leaves no leaked permit and never
+        # double-releases. As a result the ``lml.discogs.semaphore`` /
+        # ``lml.discogs.rate_limiter`` spans now fire once per attempt rather
+        # than once per request — a span-count schema change documented in the
+        # #569 PR (no current dashboard/alert aggregates on that count).
+        for attempt in range(max_retries + 1):
+            # Explicit acquire/release (not `async with semaphore:`) so the wait
+            # is wrapped in a Sentry span. The 5-permit semaphore is the dominant
+            # source of pre-request dark time on backfill cascades — sampling the
+            # queue depth right before the await gives the trace explorer a
+            # relative-load signal per call. See WXYC/library-metadata-lookup#358.
+            with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.semaphore") as span:
+                span.set_data("lml.semaphore.queue_depth", _approx_semaphore_queue_depth(semaphore))
+                apply_request_ctx_tags(span)
+                await semaphore.acquire()
+
+            try:
                 with sentry_sdk.start_span(
                     op="lock.acquire", name="lml.discogs.rate_limiter"
                 ) as span:
                     apply_request_ctx_tags(span)
                     await rate_limiter.acquire()
 
-                try:
-                    response = await client.request(method, path, params=params)
+                response = await client.request(method, path, params=params)
 
-                    # Log rate limit remaining for observability
-                    remaining = response.headers.get("X-Discogs-Ratelimit-Remaining")
-                    if remaining:
-                        logger.debug(f"Discogs rate limit remaining: {remaining}")
+                # Log rate limit remaining for observability
+                remaining = response.headers.get("X-Discogs-Ratelimit-Remaining")
+                if remaining:
+                    logger.debug(f"Discogs rate limit remaining: {remaining}")
+            except httpx.RequestError as e:
+                logger.error(
+                    "Discogs request failed: %s %s -> %s: %r",
+                    method,
+                    path,
+                    type(e).__name__,
+                    e,
+                    exc_info=True,
+                )
+                return None
+            finally:
+                # Released before the retry sleep below, on success, and on any
+                # error/cancellation in this attempt — one release per acquire.
+                semaphore.release()
 
-                    if response.status_code == 429:
-                        if attempt < max_retries:
-                            retry_after = response.headers.get("Retry-After")
-                            delay = _compute_retry_delay(attempt, retry_after)
-                            logger.warning(
-                                f"Discogs rate limit hit, retrying in {delay:.2f}s "
-                                f"(attempt {attempt + 1}/{max_retries + 1}, "
-                                f"Retry-After={retry_after})"
-                            )
-                            await asyncio.sleep(delay)
-                            continue
-                        else:
-                            logger.error("Discogs rate limit hit, max retries exhausted")
-                            return None
+            if response.status_code != 429:
+                return response
 
-                    return response
+            if attempt < max_retries:
+                retry_after = response.headers.get("Retry-After")
+                delay = _compute_retry_delay(attempt, retry_after)
+                logger.warning(
+                    f"Discogs rate limit hit, retrying in {delay:.2f}s "
+                    f"(attempt {attempt + 1}/{max_retries + 1}, "
+                    f"Retry-After={retry_after})"
+                )
+                # Sleep WITHOUT holding the permit; re-acquire on the next pass.
+                await asyncio.sleep(delay)
+                continue
 
-                except httpx.RequestError as e:
-                    logger.error(
-                        "Discogs request failed: %s %s -> %s: %r",
-                        method,
-                        path,
-                        type(e).__name__,
-                        e,
-                        exc_info=True,
-                    )
-                    return None
-        finally:
-            semaphore.release()
+            logger.error("Discogs rate limit hit, max retries exhausted")
+            return None
 
         return None
 

--- a/tests/unit/test_discogs_ratelimit.py
+++ b/tests/unit/test_discogs_ratelimit.py
@@ -24,6 +24,7 @@ re-acquired on the next attempt. These tests pin that behavior:
 from __future__ import annotations
 
 import asyncio
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -44,7 +45,7 @@ class CountingSemaphore(asyncio.Semaphore):
         self.acquire_count = 0
         self.release_count = 0
 
-    async def acquire(self) -> bool:
+    async def acquire(self) -> Literal[True]:
         self.acquire_count += 1
         return await super().acquire()
 

--- a/tests/unit/test_discogs_ratelimit.py
+++ b/tests/unit/test_discogs_ratelimit.py
@@ -1,0 +1,208 @@
+"""Unit tests for LML#569: release the Discogs concurrency semaphore permit
+before the inter-attempt 429 retry sleep.
+
+``DiscogsService._request_with_retry`` bounds in-process concurrency with a
+5-permit semaphore (``discogs/ratelimit.py``). Before #569, the permit was
+acquired once for the whole retry loop and only released in the method's
+``finally`` — so a caller that hit a 429 and slept for its ``Retry-After``
+(commonly 30-60s) parked its permit for the full sleep, amplifying
+``lml.discogs.semaphore`` acquire-wait for unrelated callers (the last
+unhandled tail of #537, cause #3).
+
+The fix restructures ``_request_with_retry`` so the semaphore wraps a single
+attempt: the permit is released before ``asyncio.sleep(delay)`` and
+re-acquired on the next attempt. These tests pin that behavior:
+
+1. The permit is released before the retry sleep and a concurrent caller is
+   not blocked by a sleeping caller.
+2. A ``429 -> 200`` retry completes successfully and nets to zero held
+   permits (balanced acquire/release, no leak).
+3. Task cancellation during the inter-attempt sleep leaves the semaphore at
+   its pre-call permit count (no leak).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from discogs.service import DiscogsService
+
+
+class CountingSemaphore(asyncio.Semaphore):
+    """A real ``asyncio.Semaphore`` that counts acquire/release calls.
+
+    Lets a test assert that every acquire is balanced by a release (no leak)
+    while still exercising real permit accounting — the buggy whole-loop hold
+    and the fixed per-attempt hold both go through the genuine semaphore.
+    """
+
+    def __init__(self, value: int) -> None:
+        super().__init__(value)
+        self.acquire_count = 0
+        self.release_count = 0
+
+    async def acquire(self) -> bool:
+        self.acquire_count += 1
+        return await super().acquire()
+
+    def release(self) -> None:
+        self.release_count += 1
+        super().release()
+
+
+def _make_service(client: MagicMock) -> DiscogsService:
+    """A real ``DiscogsService`` with a pre-injected mock client.
+
+    ``_get_client`` honors a pre-set ``self._client`` (service.py:294), so the
+    request never leaves the process.
+    """
+    service = DiscogsService(token="test-token")
+    service._client = client
+    return service
+
+
+def _response(status_code: int, headers: dict[str, str] | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    return resp
+
+
+@pytest.fixture
+def fake_limiter() -> MagicMock:
+    """A no-op rate limiter — #569 is about the semaphore, not the egress cap."""
+    limiter = MagicMock()
+    limiter.acquire = AsyncMock()
+    return limiter
+
+
+@pytest.mark.asyncio
+async def test_permit_released_before_retry_sleep_unblocks_concurrent_caller(fake_limiter):
+    """A 429-then-sleep caller must release its permit before sleeping so a
+    second caller can take the (single) permit while the first sleeps.
+
+    With a size-1 semaphore, the buggy whole-loop hold parks the only permit
+    across the sleep and the second caller blocks until the sleeper wakes; the
+    fixed per-attempt hold lets the second caller proceed immediately.
+    """
+    sem = asyncio.Semaphore(1)
+
+    a_entered_sleep = asyncio.Event()
+    allow_a_to_finish = asyncio.Event()
+
+    async def fake_sleep(_delay: float) -> None:
+        # The permit must already be released by the time we get here.
+        assert not sem.locked(), "permit was still held entering the retry sleep"
+        a_entered_sleep.set()
+        await allow_a_to_finish.wait()
+
+    # Caller A: 429 (Retry-After 30) then 200 on retry.
+    client_a = MagicMock()
+    resp_a_ok = _response(200)
+    client_a.request = AsyncMock(side_effect=[_response(429, {"Retry-After": "30"}), resp_a_ok])
+    service_a = _make_service(client_a)
+
+    # Caller B: immediate 200, must not be blocked by A's sleep.
+    client_b = MagicMock()
+    resp_b_ok = _response(200)
+    client_b.request = AsyncMock(return_value=resp_b_ok)
+    service_b = _make_service(client_b)
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=sem),
+        patch("discogs.service.get_rate_limiter", return_value=fake_limiter),
+        patch("discogs.service.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        task_a = asyncio.create_task(service_a._request_with_retry("GET", "/releases/1"))
+
+        # A acquires the only permit, hits 429, releases it, enters the sleep.
+        await asyncio.wait_for(a_entered_sleep.wait(), timeout=1.0)
+
+        # While A sleeps, B must be able to acquire the permit and complete.
+        result_b = await asyncio.wait_for(
+            service_b._request_with_retry("GET", "/releases/2"), timeout=1.0
+        )
+        assert result_b is resp_b_ok
+
+        # Let A wake and finish its retry.
+        allow_a_to_finish.set()
+        result_a = await asyncio.wait_for(task_a, timeout=1.0)
+        assert result_a is resp_a_ok
+
+    # Both callers' permits are balanced — the semaphore is back to full.
+    assert not sem.locked()
+
+
+@pytest.mark.asyncio
+async def test_429_then_200_completes_with_balanced_permit_accounting(fake_limiter):
+    """A ``429 -> 200`` retry returns the 200 and leaves the semaphore balanced.
+
+    The redesign acquires once per attempt (so two acquires for this path),
+    but every acquire is matched by a release and the net held-permit count is
+    zero at the end — no leak.
+    """
+    sem = CountingSemaphore(5)
+
+    client = MagicMock()
+    resp_ok = _response(200)
+    client.request = AsyncMock(side_effect=[_response(429, {"Retry-After": "30"}), resp_ok])
+    service = _make_service(client)
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=sem),
+        patch("discogs.service.get_rate_limiter", return_value=fake_limiter),
+        patch("discogs.service.asyncio.sleep", new=AsyncMock()),
+    ):
+        result = await service._request_with_retry("GET", "/releases/1")
+
+    assert result is resp_ok
+    # Two attempts (429 then 200) -> two acquire/release pairs, net zero.
+    assert sem.acquire_count == 2
+    assert sem.release_count == 2
+    assert sem.acquire_count == sem.release_count
+    assert sem._value == 5  # back to the pre-call permit count
+    assert not sem.locked()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_retry_sleep_leaks_no_permit(fake_limiter):
+    """Cancelling the task while it sleeps between attempts must leave the
+    semaphore at its pre-call permit count — no leaked permit, no double
+    release."""
+    sem = CountingSemaphore(5)
+    assert sem._value == 5
+
+    a_entered_sleep = asyncio.Event()
+
+    async def fake_sleep(_delay: float) -> None:
+        a_entered_sleep.set()
+        # Block forever so the test can cancel us mid-sleep.
+        await asyncio.Event().wait()
+
+    client = MagicMock()
+    # Always 429 so the request keeps trying to sleep between attempts.
+    client.request = AsyncMock(return_value=_response(429, {"Retry-After": "30"}))
+    service = _make_service(client)
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=sem),
+        patch("discogs.service.get_rate_limiter", return_value=fake_limiter),
+        patch("discogs.service.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        task = asyncio.create_task(service._request_with_retry("GET", "/releases/1"))
+        await asyncio.wait_for(a_entered_sleep.wait(), timeout=1.0)
+
+        # The permit must already be released by the time we sleep.
+        assert sem._value == 5, "permit still held entering the retry sleep"
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    # No leak: every acquire was balanced by a release.
+    assert sem._value == 5
+    assert sem.acquire_count == sem.release_count
+    assert not sem.locked()

--- a/tests/unit/test_discogs_ratelimit.py
+++ b/tests/unit/test_discogs_ratelimit.py
@@ -19,6 +19,9 @@ re-acquired on the next attempt. These tests pin that behavior:
    permits (balanced acquire/release, no leak).
 3. Task cancellation during the inter-attempt sleep leaves the semaphore at
    its pre-call permit count (no leak).
+
+The fixture-injected client never issues a real HTTP request, so these tests
+run under the default (no-marker) suite.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Problem

`DiscogsService._request_with_retry` acquired the 5-permit Discogs concurrency semaphore once for the whole retry loop and released it only in the method's `finally`. A caller that hit a 429 and slept for its `Retry-After` (commonly 30-60s) parked its permit for the full sleep. With ~3% of outbound Discogs calls returning 429, this regularly parked permits and amplified `lml.discogs.semaphore` acquire-wait for unrelated callers — the last unhandled tail of #537 (cause #3), deferred out of #568.

24h production Sentry sample (2026-06-14 to 2026-06-15): 66 of ~2,257 Discogs spans were 429 (~3%); 7 `lml.discogs.semaphore` acquire-waits exceeded 10s (p95 29.2s), correlating with the retry sleeps holding permits.

## Change

Restructure `_request_with_retry` so the semaphore wraps a **single attempt** rather than the entire retry loop:

- Each attempt acquires the permit, makes the request under a per-attempt `try/finally` that releases it, then the inter-attempt `asyncio.sleep(Retry-After)` runs **outside** the held permit before the next pass re-acquires.
- The egress cap stays the per-attempt `rate_limiter.acquire()` (`AsyncLimiter(50, 60)`), so releasing the semaphore during the sleep does **not** raise the outbound request rate.
- `_compute_retry_delay` / `Retry-After` honoring is unchanged.
- The per-attempt `try/finally` preserves the one-release-per-acquire contract: no leaked permit on a raise, no double release on cancellation mid-sleep.

### Span schema note

The `lml.discogs.semaphore` and `lml.discogs.rate_limiter` spans now fire **once per attempt** instead of once per request. No Sentry dashboard or alert in this repo aggregates on that span count (grep only turns up these spans in tests and historical plan docs). Single-attempt (non-429) requests — the overwhelming majority — are unaffected and still emit exactly one of each span. The LML#537 method + cache_state tags continue to apply to every attempt's spans (`test_discogs_request_telemetry.py` stays green).

## Testing

New `tests/unit/test_discogs_ratelimit.py` (TDD: confirmed RED against `origin/main`, then GREEN), matching the issue's three acceptance criteria:

1. **Permit released before the retry sleep** — with a size-1 semaphore, a 429-then-sleep caller releases its permit before sleeping, and a second concurrent caller acquires the permit and completes while the first sleeps (the buggy whole-loop hold blocks it).
2. **429 -> 200 balanced accounting** — the retry returns the 200 and the semaphore nets to zero held permits (two acquire/release pairs, balanced, no leak).
3. **Cancellation during the inter-attempt sleep leaks no permit** — cancelling mid-sleep leaves the semaphore at its pre-call permit count.

Run:
- `tests/unit/test_discogs_ratelimit.py` — 3 passed
- `tests/unit/test_discogs_request_telemetry.py`, `test_discogs_service.py`, `test_ratelimit*.py`, `test_discogs_404_tombstone.py` — all pass (span tagging + permit-release-on-exception preserved)
- Full default suite: 3300 passed, 1 skipped, 230 deselected (infra markers), 2 xfailed
- `ruff check .` + `ruff format --check .` clean

## Post-deploy follow-up (from the issue)

24h Sentry check: zero `lml.discogs.semaphore` acquire-waits >10s under continued 429 traffic.

Closes #569