### PR TITLE
feat(#334): fuzzy fallback on track-title substring miss in validate_track_on_release

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -45,6 +45,12 @@ class CacheUnavailableError(Exception):
 # on a release. Tied to that constant by intent, not duplicated by accident.
 _ARTIST_FUZZY_MATCH_THRESHOLD = 70
 
+# Mirrors ``_TRACK_TITLE_FUZZY_MATCH_THRESHOLD`` in ``discogs/service.py`` (LML#334)
+# — the track-title fuzzy fallback applied here after the bidirectional substring
+# gate misses. Must score the same as the API path so cache hits and misses agree
+# on whether a (possibly misspelled) track title is on a release.
+_TRACK_TITLE_FUZZY_MATCH_THRESHOLD = 85
+
 # Default TTL for a negative-cache entry (7 days, matching the
 # migration's column default). 7 days is conservative: tracks that
 # eventually land on Discogs (new releases) shouldn't be pinned negative
@@ -1450,7 +1456,17 @@ class DiscogsCacheService:
                 item_title = normalize_for_track_comparison(row["title"])
 
                 if track_lower not in item_title and item_title not in track_lower:
-                    continue
+                    # Fuzzy title fallback (LML#334): typographic noise that leaves
+                    # token content intact (singular/plural, a dropped interior word,
+                    # dash-vs-paren suffix) misses the substring gate but clears the
+                    # token_set_ratio floor. Mirrors the API path's
+                    # ``_iter_title_matched_items``.
+                    if (
+                        not item_title
+                        or fuzz.token_set_ratio(track_lower, item_title)
+                        < _TRACK_TITLE_FUZZY_MATCH_THRESHOLD
+                    ):
+                        continue
 
                 seq = row["sequence"]
                 artists_for_track = track_artists.get(seq, [])

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -83,6 +83,19 @@ _MAX_RETRY_DELAY_SECONDS = 60.0
 # clears the bar (~70.6) while unrelated artists score well below 50. See LML#210.
 _ARTIST_FUZZY_MATCH_THRESHOLD = 70
 
+# Fuzzy fallback for `validate_track_on_release` track-title matching (LML#334).
+# The bidirectional substring gate loses on typographic noise that leaves token
+# content intact: a singular/plural typo ("tower of dub" vs "Towers Of Dub"), a
+# dropped interior word ("smells teen spirit" vs "Smells Like Teen Spirit"), or a
+# dash-vs-paren suffix ("de la soul - radio edit" vs "de la soul (radio edit)").
+# token_set_ratio is order- and stopword-tolerant. The threshold is stricter than
+# the artist-side 70 because track titles are short, so a single shared token can
+# score 50+; 85 lets the substitutions above through (each scores >= 96) while
+# rejecting one-shared-token adversarial near-misses ("towers of dub" vs "towers
+# of london" scores ~82). Mirrored in `discogs/cache_service.py` so cache hits and
+# misses agree on the verdict.
+_TRACK_TITLE_FUZZY_MATCH_THRESHOLD = 85
+
 
 def _approx_semaphore_queue_depth(semaphore: asyncio.Semaphore) -> int:
     """Return an approximate count of waiters queued behind ``semaphore``.
@@ -1443,12 +1456,20 @@ def _iter_title_matched_items(
     The shared title-match step behind both tracklist scans —
     :func:`_scan_tracklist_for_match` (validation) and
     :func:`_scan_tracklist_for_credit` (credit recovery, LML#660): a bidirectional
-    substring on the normalized title. Centralized so the two scans' title rule
-    can't drift apart. ``track_lower`` is pre-normalized by the caller.
+    substring on the normalized title, then a ``token_set_ratio`` fuzzy fallback
+    (LML#334) so typographic noise that leaves token content intact — singular/
+    plural, a dropped interior word, dash-vs-paren suffixes — still matches.
+    Centralized so the two scans' title rule can't drift apart. ``track_lower`` is
+    pre-normalized by the caller.
     """
     for item in release.tracklist or []:
         item_title = normalize_for_track_comparison(item.title)
         if track_lower in item_title or item_title in track_lower:
+            yield item
+        elif (
+            item_title
+            and fuzz.token_set_ratio(track_lower, item_title) >= _TRACK_TITLE_FUZZY_MATCH_THRESHOLD
+        ):
             yield item
 
 

--- a/tests/integration/test_validate_band_track_credits.py
+++ b/tests/integration/test_validate_band_track_credits.py
@@ -49,3 +49,21 @@ async def test_validate_track_on_release_still_rejects_unrelated_artist():
     finally:
         await service.close()
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_validate_track_on_release_tolerates_track_title_typo():
+    """The canonical LML#334 repro: the singular typo ``tower of dub`` (the
+    original user query) validates against release 674529 (Live 93) by The Orb.
+
+    The bidirectional substring gate rejects ``tower`` vs ``towers``; the
+    ``token_set_ratio`` fuzzy fallback (~96, over the 85 floor) recovers it, and
+    the release-level credit (``The Orb``) validates the artist. Exercises the
+    real Discogs tracklist end-to-end.
+    """
+    service = DiscogsService(token=DISCOGS_TOKEN)
+    try:
+        result = await service.validate_track_on_release(674529, "tower of dub", "The Orb")
+    finally:
+        await service.close()
+    assert result is True

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1075,6 +1075,115 @@ class TestValidateTrackOnRelease:
         assert paterson_result is False
 
     @pytest.mark.asyncio
+    async def test_track_title_singular_plural_typo_validates_via_fuzzy(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Singular/plural typo survives the cache-path fuzzy title fallback (LML#334).
+
+        Mirrors the API path: ``tower of dub`` against the cached ``Towers Of Dub``
+        row on Live 93. The substring gate fails on the trailing ``s``; the
+        ``token_set_ratio`` fallback (~96) clears the 85 floor and the release-level
+        credit (``The Orb``) validates the artist.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[
+                    {"track_sequence": 5, "artist_name": "Alex Paterson"},
+                    {"track_sequence": 5, "artist_name": "Kris Weston"},
+                    {"track_sequence": 5, "artist_name": "Thomas Fehlmann"},
+                ],
+                release_track=[{"sequence": 5, "title": "Towers Of Dub"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Orb"})
+        result = await cache_service.validate_track_on_release(13938, "tower of dub", "The Orb")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_track_title_missing_word_validates_via_fuzzy(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """A missing interior word survives the cache-path fuzzy title fallback.
+
+        ``smells teen spirit`` (request dropped ``like``) vs cached
+        ``Smells Like Teen Spirit`` scores 100. LML#334.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[],
+                release_track=[{"sequence": 1, "title": "Smells Like Teen Spirit"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Artist"})
+        result = await cache_service.validate_track_on_release(
+            1, "smells teen spirit", "The Artist"
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_track_title_fuzzy_rejects_no_token_overlap(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Cache-path title fuzzy fallback rejects titles with no token overlap.
+
+        Artist trivially matches, so ``False`` isolates the title gate:
+        ``towers of dub`` vs ``a perfect day`` scores ~31. LML#334.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[],
+                release_track=[{"sequence": 1, "title": "A Perfect Day"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Artist"})
+        result = await cache_service.validate_track_on_release(1, "towers of dub", "The Artist")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_track_title_fuzzy_rejects_one_shared_token(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """One shared significant token stays below the 85 floor on the cache path.
+
+        ``towers of dub`` vs ``towers of london`` scores ~82 — the adversarial
+        near-miss the threshold rejects. Artist trivially matches. LML#334.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[],
+                release_track=[{"sequence": 1, "title": "Towers Of London"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Artist"})
+        result = await cache_service.validate_track_on_release(1, "towers of dub", "The Artist")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_track_title_fuzzy_rejects_partial_phrase_overlap(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """A shared leading phrase with divergent tail stays rejected on the cache path.
+
+        ``smells like teen spirit`` vs ``smells like the bicep`` scores ~73. LML#334.
+        """
+        mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[],
+                release_track=[{"sequence": 1, "title": "Smells Like The Bicep"}],
+            )
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": "The Artist"})
+        result = await cache_service.validate_track_on_release(
+            1, "smells like teen spirit", "The Artist"
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
     async def test_query_filters_release_track_artist_to_extra_zero(
         self, cache_service, mock_asyncpg_pool
     ):

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -1888,6 +1888,115 @@ class TestValidateTrackOnRelease:
         assert result is False
 
     @pytest.mark.asyncio
+    async def test_track_title_singular_plural_typo_validates_via_fuzzy(self, service):
+        """Singular/plural track-title typo survives the fuzzy title fallback (LML#334).
+
+        The canonical motivating query: ``tower of dub`` (the user's singular typo)
+        against ``Towers Of Dub`` on Live 93. The trailing ``s`` breaks the
+        bidirectional substring gate, but ``token_set_ratio`` scores ~96, well over
+        the 85 floor. The release-level credit (``The Orb``) then validates the artist.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=674529,
+            title="Live 93",
+            artist="The Orb",
+            release_url="https://discogs.com/release/674529",
+            tracklist=[
+                TrackItem(
+                    position="5",
+                    title="Towers Of Dub",
+                    artists=["Alex Paterson", "Kris Weston", "Thomas Fehlmann"],
+                ),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(674529, "tower of dub", "The Orb")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_track_title_missing_word_validates_via_fuzzy(self, service):
+        """A missing interior word in the requested title survives the fuzzy fallback.
+
+        ``smells teen spirit`` (the request dropped ``like``) is neither a substring
+        of nor a superstring of ``Smells Like Teen Spirit``, but ``token_set_ratio``
+        scores 100 (the request tokens are a subset). LML#334.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Some Album",
+            artist="The Artist",
+            release_url="https://discogs.com/release/1",
+            tracklist=[
+                TrackItem(position="1", title="Smells Like Teen Spirit"),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(1, "smells teen spirit", "The Artist")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_track_title_fuzzy_rejects_no_token_overlap(self, service):
+        """The title fuzzy fallback must reject titles with no token overlap (LML#334).
+
+        Artist trivially matches, so a ``False`` result isolates the title gate:
+        ``towers of dub`` vs ``a perfect day`` scores ~31, far below the 85 floor.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Some Album",
+            artist="The Artist",
+            release_url="https://discogs.com/release/1",
+            tracklist=[
+                TrackItem(position="1", title="A Perfect Day"),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(1, "towers of dub", "The Artist")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_track_title_fuzzy_rejects_one_shared_token(self, service):
+        """One shared significant token must stay below the 85 floor (LML#334).
+
+        ``towers of dub`` vs ``towers of london`` scores ~82 — the adversarial
+        near-miss the threshold is tuned to reject. Artist trivially matches so
+        only the title gate can fail the validation.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Some Album",
+            artist="The Artist",
+            release_url="https://discogs.com/release/1",
+            tracklist=[
+                TrackItem(position="1", title="Towers Of London"),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(1, "towers of dub", "The Artist")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_track_title_fuzzy_rejects_partial_phrase_overlap(self, service):
+        """A shared leading phrase but divergent tail stays rejected (LML#334).
+
+        ``smells like teen spirit`` vs ``smells like the bicep`` scores ~73.
+        """
+        release = ReleaseMetadataResponse(
+            release_id=1,
+            title="Some Album",
+            artist="The Artist",
+            release_url="https://discogs.com/release/1",
+            tracklist=[
+                TrackItem(position="1", title="Smells Like The Bicep"),
+            ],
+        )
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(
+                1, "smells like teen spirit", "The Artist"
+            )
+        assert result is False
+
+    @pytest.mark.asyncio
     async def test_cache_validated(self, service_with_cache):
         service_with_cache.cache_service.validate_track_on_release = AsyncMock(return_value=True)
 


### PR DESCRIPTION
Closes #334

## Problem

`validate_track_on_release` gated track-title comparisons on a bidirectional substring check:

```python
if track_lower not in item_title and item_title not in track_lower:
    continue
```

This rejected common typographic noise that leaves token content intact — a singular/plural typo (`tower of dub` vs `Towers Of Dub`), a dropped interior word (`smells teen spirit` vs `Smells Like Teen Spirit`), or a dash-vs-paren suffix (`de la soul - radio edit` vs `de la soul (radio edit)`) — killing the whole match before the artist-side check could run. The artist side already had a `token_set_ratio` fallback (LML#210, load-bearing again after LML#328); the track-title side did not. This asymmetry is what the issue describes.

## Change

Adds a `rapidfuzz.fuzz.token_set_ratio` fallback after the substring gate misses, at a conservative threshold of **85**:

- Stricter than the artist-side 70 because track titles are short and a single shared token can score 50+.
- Lets the common substitutions through (`tower of dub`→`Towers Of Dub` ~96, `smells teen spirit`→`Smells Like Teen Spirit` 100, `de la soul - radio edit`→`de la soul (radio edit)` 100) while rejecting adversarial near-misses (`towers of dub`→`towers of london` ~82, `smells like teen spirit`→`smells like the bicep` ~73, no-overlap pairs ~31).

Both paths the issue calls out gain the fallback with a mirrored constant so cache hits and misses can't disagree on the verdict:

- **API path** — the shared `_iter_title_matched_items` helper in `discogs/service.py` (post-#328 refactor centralized the title rule here; it also feeds the LML#660 credit-recovery scan, so both stay consistent by design).
- **Cache path** — the substring gate in `discogs/cache_service.py:validate_track_on_release`.

## Testing

- `uv run --no-sync python -m pytest` (full default suite, excludes `pg`/`external_api` via pyproject addopts): **3307 passed, 1 skipped, 231 deselected, 2 xfailed**.
- `ruff check .` and `ruff format --check .`: clean.
- New unit tests on **both** paths (`tests/unit/test_discogs_service.py` and `tests/unit/test_cache_service.py`), confirmed RED before the implementation:
  - Positive: `tower of dub` vs `Towers Of Dub` (singular/plural) → validates; `smells teen spirit` vs `Smells Like Teen Spirit` (missing word) → validates.
  - Negative (must stay rejected): `towers of dub` vs `a perfect day` (no overlap), vs `towers of london` (one shared token, ~82), and `smells like teen spirit` vs `smells like the bicep` (~73).
  - All pre-existing `TestValidateTrackOnRelease` cases (API + cache) and the `TestGetTrackCreditOnRelease` cases still pass.
- New `external_api` integration test (`tests/integration/test_validate_band_track_credits.py`, mirrors the #328 sibling, self-skips without `DISCOGS_TOKEN`): the misspelled `tower of dub` validates against the real release 674529 (Live 93 / The Orb) end-to-end.

### Scope note

The issue's full-pipeline e2e bullet (`LookupRequest(song="tower of dub", artist="The Orb", album=None)` → single direct match) describes the user-visible outcome this fix enables. The behavior that actually changed lives in `validate_track_on_release`; it is pinned directly by the unit tests on both paths and exercised against the real Discogs tracklist by the gated `external_api` integration test. Threshold calibration against a labeled corpus remains out of scope per the issue.