### PR TITLE
test(#567): pin lml.cache.* extra_keys onto the Sentry transaction

### DIFF
--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -453,6 +453,82 @@ class TestHandleLookup:
 
         assert resp.status_code == 200
 
+    def test_extra_keys_seeded_and_projected_onto_transaction(self):
+        """Regression (LML#567): the LML-specific cache_stats extra keys must land
+        as `lml.cache.*` data on the Sentry transaction even when never recorded
+        (value 0).
+
+        Exercises the REAL seeding path — `init_cache_stats(extra_keys=...)`
+        followed by `get_cache_stats()` — rather than a hand-built dict, so the
+        assertion fails if either LML drops one of these keys from
+        `_LML_CACHE_STATS_EXTRA_KEYS` or the upstream `wxyc_fastapi` seeding
+        contract regresses. The original bug was the upstream half: the extras
+        were not seeded with 0, so they appeared only in payloads from the first
+        request that recorded them, and a representative (non-follower) request
+        showed no `lml.cache.memory_cache_inflight_join` at all.
+        """
+        from wxyc_fastapi.observability import get_cache_stats, init_cache_stats
+
+        from lookup.router import (
+            _LML_CACHE_STATS_EXTRA_KEYS,
+            _project_cache_stats_to_transaction,
+        )
+
+        init_cache_stats(extra_keys=_LML_CACHE_STATS_EXTRA_KEYS)
+        stats = get_cache_stats()
+
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+        with patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope):
+            _project_cache_stats_to_transaction(stats)
+
+        projected = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        for key in (
+            "memory_cache_inflight_join",
+            "memory_cache_inflight_retry_after_cancel",
+            "memory_cache_write_failed",
+        ):
+            assert f"lml.cache.{key}" in projected, (
+                f"{key!r} must be seeded by init_cache_stats(extra_keys=...) and "
+                "projected onto the transaction even at zero (LML#567)."
+            )
+            assert projected[f"lml.cache.{key}"] == 0
+
+    def test_recorded_extra_key_value_flows_to_transaction(self):
+        """A recorded extra-key count must flow through the real recorder →
+        get_cache_stats → projection path (LML#567).
+
+        Pins the "even when the dedup fires" half of the report: once a
+        follower-join is actually recorded, its count has to surface as
+        `lml.cache.memory_cache_inflight_join`, not just the seeded zero.
+        """
+        from wxyc_fastapi.observability import (
+            get_cache_stats,
+            get_cache_stats_recorder,
+            init_cache_stats,
+        )
+
+        from lookup.router import (
+            _LML_CACHE_STATS_EXTRA_KEYS,
+            _project_cache_stats_to_transaction,
+        )
+
+        init_cache_stats(extra_keys=_LML_CACHE_STATS_EXTRA_KEYS)
+        recorder = get_cache_stats_recorder()
+        recorder.record("memory_cache_inflight_join")
+        recorder.record("memory_cache_inflight_join")
+        stats = get_cache_stats()
+
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+        with patch("lookup.router.sentry_sdk.get_current_scope", return_value=mock_scope):
+            _project_cache_stats_to_transaction(stats)
+
+        projected = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert projected["lml.cache.memory_cache_inflight_join"] == 2
+
     @pytest.mark.asyncio
     async def test_response_includes_call_number(self, app_client):
         """Regression: call_number must appear in the JSON response."""


### PR DESCRIPTION
Closes #567

## Summary

The 24h post-deploy summarizer for #537 / #544 found that the LML-specific `cache_stats` extras introduced by #545 — `memory_cache_inflight_join`, `memory_cache_inflight_retry_after_cancel`, `memory_cache_write_failed` — were absent from the `lml.cache.*` data attributes on representative `/api/v1/lookup` Sentry transactions.

**Root cause (upstream, already fixed):** the gap was in `wxyc_fastapi`'s `init_cache_stats(extra_keys=...)`. The deployed version did not seed the declared extras with `0`, so each extra surfaced only in payloads from the *first* request that happened to record it. A representative request that is not a dedup-follower records none of the three, so the keys were simply missing from the stats dict and therefore from the projection — even though the projection (`_project_cache_stats_to_transaction`) is key-agnostic and the base keys landed fine.

`wxyc_fastapi` 1.0.0 (the pinned `>=1.0.0,<2.0.0`, published 2026-05-12) now documents and implements `extra_keys` as a **shape guarantee** — every declared key is seeded with `0` via `setdefault`, even when never recorded. With that contract in place and LML already passing `_LML_CACHE_STATS_EXTRA_KEYS` to `init_cache_stats`, the three extras land on the transaction at `0` on current `main`. This was verified by reproducing the real `init_cache_stats(extra_keys=...)` → `get_cache_stats()` → projection path directly.

There is **no in-repo behavioral fix to make** — the LML plumbing (declaring the extras + the numeric projection) was already correct. What was missing was a regression guard, which is exactly the issue's acceptance criterion ("Unit test pins this so a regression fails CI").

## What this PR does

Adds two regression tests to `tests/unit/test_lookup_router.py` that drive the **real** seeding path (not a hand-built stats dict):

- `test_extra_keys_seeded_and_projected_onto_transaction` — `init_cache_stats(extra_keys=_LML_CACHE_STATS_EXTRA_KEYS)` then `get_cache_stats()`, projected via `_project_cache_stats_to_transaction`, asserting the three extras appear as `lml.cache.*` at `0`.
- `test_recorded_extra_key_value_flows_to_transaction` — pins the "even when the dedup fires" half: a recorded follower-join count surfaces as `lml.cache.memory_cache_inflight_join` (value 2), not just the seeded zero.

These fail if LML ever drops a key from `_LML_CACHE_STATS_EXTRA_KEYS`, or if the upstream `wxyc_fastapi` seeding contract regresses — so the silent-absence bug cannot quietly resurface.

## Testing

- `uv run --no-sync python -m pytest tests/unit/test_lookup_router.py tests/unit/test_memory_cache.py -q` — 78 passed.
- `uv run --no-sync python -m pytest tests/unit/ -q` — 3018 passed.
- `uv run --no-sync ruff check .` and `ruff format --check .` — clean.
- RED demonstrated out-of-band: seeding via `init_cache_stats()` *without* `extra_keys` (the pre-fix / regressed condition) leaves all three `lml.cache.*` extras absent from the projection; the new tests catch exactly that.