### PR TITLE
perf(#278): parallelize bulk-resolve-libraries per-input lookups

### DIFF
--- a/identity/router.py
+++ b/identity/router.py
@@ -22,10 +22,13 @@ from asyncpg.exceptions import PostgresError
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import ValidationError
 
+from core.bulk_concurrency import max_concurrency_from_env
 from entity.store import EntityStore, Identity
 from generated.api_models import (
+    BulkResolveInput,
     BulkResolveLibrariesRequest,
     BulkResolveLibrariesResponse,
+    BulkResolveResult,
     ReleaseIdentityResolveRequest,
     ReleaseIdentityResolveResponse,
 )
@@ -46,6 +49,19 @@ from identity.release_validation import (
 
 # Per api.yaml: max 1,000 inputs per request; over-cap returns 413.
 _BULK_RESOLVE_INPUT_CAP = 1000
+
+# Default ceiling on concurrent per-input lookups (LML#278). The discogs-cache
+# asyncpg pool is built with ``max_size=5`` (``core.dependencies._build_discogs_pool``),
+# and each per-input coroutine holds at most one pooled connection at a time —
+# ``resolve_library_name``'s three legs and ``compose_for_identity``'s provenance
+# read are sequential awaits within a single coroutine, never concurrent — so a
+# semaphore sized to the pool's ``max_size`` saturates the pool without
+# coroutines queueing on ``pool.acquire()`` (which would otherwise block up to the
+# pool's 10 s acquire timeout). Overridable at runtime via the shared
+# ``LML_BULK_MAX_CONCURRENT`` env knob (see ``core.bulk_concurrency``); the
+# default IS the pool max, per the issue's "default to the asyncpg pool's
+# max_size" acceptance criterion.
+_BULK_RESOLVE_DEFAULT_CONCURRENCY = 5
 
 logger = logging.getLogger(__name__)
 
@@ -223,6 +239,67 @@ async def bulk_resolve_libraries(
     inputs_count = len(request.inputs)
     logger.info("bulk resolve start: inputs=%d", inputs_count)
 
+    # Per-input lookups dispatch concurrently under a semaphore (LML#278).
+    # Worst case drops from ~3,000 sequential PG round-trips for a 1,000-row
+    # miss-heavy batch to ~``ceil(N / max_concurrent)`` waves. The semaphore is
+    # sized to the discogs-cache pool's ``max_size`` (see
+    # ``_BULK_RESOLVE_DEFAULT_CONCURRENCY``) so we parallelize without exhausting
+    # the asyncpg pool. ``min(..., inputs_count)`` avoids over-allocating permits
+    # for small batches; ``max(1, ...)`` keeps ``Semaphore(0)`` (which would
+    # deadlock any acquire) off the table for an empty-input request.
+    max_concurrent = max_concurrency_from_env(_BULK_RESOLVE_DEFAULT_CONCURRENCY)
+    semaphore = asyncio.Semaphore(max(1, min(max_concurrent, inputs_count)))
+
+    async def _resolve_one(input_row: BulkResolveInput) -> BulkResolveResult:
+        """Compose one verdict, gated by the shared pool semaphore.
+
+        Holds a single permit across the whole per-input path so the in-flight
+        connection count never exceeds the pool. A ``PostgresError`` / ``OSError``
+        raised here surfaces as ``HTTPException(503)``; ``asyncio.gather`` (default
+        ``return_exceptions=False``) propagates the first such failure to the
+        awaiting handler, which fails the whole batch closed — never a 200 with
+        partial results. The caller cannot distinguish "row had no identity"
+        from "PG died before this row was tried", so the fail-closed posture is
+        load-bearing (same contract as ``/identity/bulk``).
+        """
+        async with semaphore:
+            if is_compilation_artist(input_row.artist_name):
+                return compilation_result(input_row.library_id)
+
+            try:
+                # Three-leg fall-through lookup (issues #274 / #276): exact
+                # match first (handles the 99.8% dominant case where Backend's
+                # `library.artist_name` shape equals storage), then
+                # case-insensitive `LOWER()` (catches pure case drift), then
+                # canonical form (catches diacritic / `&`-vs-`and` / smart-quote
+                # / etc. divergence when storage happens to be canonical).
+                # Strictly ≥ legacy `get_identity()` hit rate.
+                identity: Identity | None = await store.resolve_library_name(input_row.artist_name)
+            except (PostgresError, OSError):
+                logger.exception(
+                    "Entity store query failed mid-bulk-resolve for library_id=%d artist_name=%r",
+                    input_row.library_id,
+                    input_row.artist_name,
+                )
+                raise HTTPException(
+                    status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
+                ) from None
+
+            try:
+                # `compose_for_identity` issues its own
+                # `get_latest_provenance_by_source` query — that second round-trip
+                # is covered by the same permit, so a resolved input never holds
+                # two pool connections at once.
+                return await compose_for_identity(input_row.library_id, identity, store)
+            except (PostgresError, OSError):
+                logger.exception(
+                    "Provenance fetch failed mid-bulk-resolve for library_id=%d",
+                    input_row.library_id,
+                )
+                raise HTTPException(
+                    status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
+                ) from None
+
     # Explicit `http.server` span (LML#430). Defense-in-depth against the
     # FastApiIntegration's automatic transaction not landing for this endpoint
     # — `op:http.server span.description:*bulk-resolve-libraries*` queries in
@@ -236,70 +313,30 @@ async def bulk_resolve_libraries(
         http_span.set_data("http.method", "POST")
         http_span.set_data("http.target", "/api/v1/identity/bulk-resolve-libraries")
         http_span.set_data("lml.bulk_resolve.inputs", inputs_count)
+        http_span.set_data("lml.bulk_resolve.max_concurrent", max_concurrent)
 
-        results = []
         try:
-            for input_row in request.inputs:
-                if is_compilation_artist(input_row.artist_name):
-                    results.append(compilation_result(input_row.library_id))
-                    continue
-
-                try:
-                    # Three-leg fall-through lookup (issues #274 / #276): exact
-                    # match first (handles the 99.8% dominant case where
-                    # Backend's `library.artist_name` shape equals storage),
-                    # then case-insensitive `LOWER()` (catches pure case
-                    # drift), then canonical form (catches diacritic /
-                    # `&`-vs-`and` / smart-quote / etc. divergence when
-                    # storage happens to be canonical). Strictly ≥ legacy
-                    # `get_identity()` hit rate.
-                    identity: Identity | None = await store.resolve_library_name(
-                        input_row.artist_name
-                    )
-                except (PostgresError, OSError):
-                    # Fail closed on partial PG failure — the caller cannot
-                    # distinguish "row had no identity" from "PG died before
-                    # this row was tried". Same posture as ``/identity/bulk``.
-                    logger.exception(
-                        "Entity store query failed mid-bulk-resolve for "
-                        "library_id=%d artist_name=%r",
-                        input_row.library_id,
-                        input_row.artist_name,
-                    )
-                    http_span.set_data("http.status_code", 503)
-                    raise HTTPException(
-                        status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
-                    ) from None
-
-                try:
-                    result = await compose_for_identity(input_row.library_id, identity, store)
-                except (PostgresError, OSError):
-                    logger.exception(
-                        "Provenance fetch failed mid-bulk-resolve for library_id=%d",
-                        input_row.library_id,
-                    )
-                    http_span.set_data("http.status_code", 503)
-                    raise HTTPException(
-                        status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL
-                    ) from None
-                results.append(result)
+            # `gather` preserves input order (results[i] <-> inputs[i]) regardless
+            # of completion order, satisfying the api.yaml ordering contract.
+            results = await asyncio.gather(*(_resolve_one(r) for r in request.inputs))
         except asyncio.CancelledError:
-            # Client aborted mid-loop. The sequential per-input loop has no
-            # gather/sentinel structure (unlike PR #417's `/lookup/bulk`
-            # shape), so CancelledError raised at the next `await` point is
-            # the only abort signal we get. Pin 499 on the span before
+            # Client aborted mid-batch. Cancelling the handler task propagates
+            # into the in-flight `gather` (and thus its children), so permits are
+            # released as the children unwind. Pin 499 on the span before
             # re-raising so the audit-style query
-            # `op:http.server http.status_code:499` surfaces these in Sentry,
-            # and emit a warn log so Railway also carries the record.
-            # CancelledError is re-raised (not converted to HTTPException) —
-            # the asyncio cancellation contract requires this, and the client
-            # is gone anyway so there is nobody to read a 499 response.
+            # `op:http.server http.status_code:499` surfaces these in Sentry, and
+            # emit a warn log so Railway also carries the record. CancelledError
+            # is re-raised (not converted to HTTPException) — the asyncio
+            # cancellation contract requires this, and the client is gone anyway
+            # so there is nobody to read a 499 response.
             http_span.set_data("http.status_code", 499)
-            logger.warning(
-                "bulk resolve aborted by client: inputs=%d processed=%d",
-                inputs_count,
-                len(results),
-            )
+            logger.warning("bulk resolve aborted by client: inputs=%d", inputs_count)
+            raise
+        except HTTPException as exc:
+            # Fail-closed 503 (or any explicit status) from a per-input failure.
+            # Pin the status on the span before re-raising so the trace carries
+            # the real outcome rather than an unset code.
+            http_span.set_data("http.status_code", exc.status_code)
             raise
 
         # Exit signal pairs with the entry log so operators can confirm

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -6,10 +6,13 @@ internals are covered separately in `test_bulk_resolve_composer.py`.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import sentry_sdk
+from asyncpg.exceptions import PostgresError
 from httpx import ASGITransport, AsyncClient
 
 from entity.store import Identity
@@ -538,3 +541,184 @@ class TestBulkResolveObservability:
         assert "bulk-resolve-libraries" in span_name, (
             f"Expected http.server span name to include 'bulk-resolve-libraries'; got {span_name!r}"
         )
+
+
+class TestBulkResolveConcurrency:
+    """Per-input lookups fan out concurrently under a pool-bound semaphore (#278).
+
+    Before #278 the handler iterated inputs serially — worst-case latency for a
+    1,000-row miss-heavy batch was ~3,000 sequential PG round-trips. #278
+    dispatches the per-input work via ``asyncio.gather`` capped by a semaphore
+    sized to the discogs-cache pool's ``max_size`` so we parallelize without
+    exhausting the asyncpg pool. These tests pin:
+
+    1. Concurrency actually happens (total elapsed ≈ one slow lookup, not N).
+    2. The semaphore caps in-flight lookups at the configured bound.
+    3. ``asyncio.gather`` preserves input order even when completion order
+       differs (slowest input first).
+    4. A ``PostgresError`` raised by any one input still fails the whole batch
+       closed with 503 — never a 200 carrying partial results.
+    """
+
+    @pytest.mark.asyncio
+    async def test_per_input_lookups_run_concurrently(self, app_client, mock_entity_store):
+        """N lookups each sleeping DELAY finish in ~DELAY, not N×DELAY.
+
+        With the default cap (the pool ``max_size`` of 5) and N=5 inputs, all
+        five ``resolve_library_name`` calls overlap, so wall-clock is dominated
+        by a single sleep. The serial implementation would take ~5×DELAY; this
+        asserts a 3× margin below that to stay robust on slow CI.
+        """
+        delay = 0.05
+        n = 5
+
+        async def slow_lookup(name: str):
+            await asyncio.sleep(delay)
+            return None
+
+        mock_entity_store.resolve_library_name.side_effect = slow_lookup
+
+        inputs = [
+            {"library_id": i, "artist_name": f"Artist {i}", "album_title": "x"} for i in range(n)
+        ]
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            start = time.perf_counter()
+            resp = await ac.post("/api/v1/identity/bulk-resolve-libraries", json={"inputs": inputs})
+            elapsed = time.perf_counter() - start
+
+        assert resp.status_code == 200
+        assert len(resp.json()["results"]) == n
+        # Serial would be n * delay = 0.25s. Concurrent is ~delay. A 3×-delay
+        # ceiling cleanly separates the two without being CI-flaky.
+        assert elapsed < (n * delay) / 2, (
+            f"Expected concurrent dispatch (~{delay:.2f}s) but took {elapsed:.3f}s; "
+            "per-input lookups appear to still be running serially."
+        )
+
+    @pytest.mark.asyncio
+    async def test_semaphore_bounds_in_flight_lookups(
+        self, app_client, mock_entity_store, monkeypatch
+    ):
+        """The semaphore caps concurrent in-flight lookups at the configured bound.
+
+        Sets ``LML_BULK_MAX_CONCURRENT=2`` and posts 6 inputs. A counter tracks
+        how many ``resolve_library_name`` calls overlap; the observed peak must
+        equal the bound (2) — proving the work both parallelizes *and* is capped
+        so the asyncpg pool can't be exhausted.
+        """
+        monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "2")
+
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+
+        async def tracked_lookup(name: str):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.02)
+            async with lock:
+                in_flight -= 1
+            return None
+
+        mock_entity_store.resolve_library_name.side_effect = tracked_lookup
+
+        inputs = [
+            {"library_id": i, "artist_name": f"Artist {i}", "album_title": "x"} for i in range(6)
+        ]
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/api/v1/identity/bulk-resolve-libraries", json={"inputs": inputs})
+
+        assert resp.status_code == 200
+        assert len(resp.json()["results"]) == 6
+        assert max_in_flight == 2, (
+            f"Expected the semaphore to cap in-flight lookups at 2; observed peak "
+            f"{max_in_flight}. <2 means no parallelism; >2 means the bound leaked."
+        )
+
+    @pytest.mark.asyncio
+    async def test_input_order_preserved_under_staggered_completion(
+        self, app_client, mock_entity_store
+    ):
+        """gather preserves input order even when the first input finishes last.
+
+        The earliest input sleeps the longest so completion order is the reverse
+        of input order. ``results[i]`` must still correspond to ``inputs[i]``.
+        """
+        identities = {
+            "First": _identity("First", id=1, discogs_artist_id=11),
+            "Second": _identity("Second", id=2, discogs_artist_id=22),
+            "Third": _identity("Third", id=3, discogs_artist_id=33),
+        }
+        # Slowest first, fastest last → completion order is reversed.
+        delays = {"First": 0.06, "Second": 0.03, "Third": 0.0}
+
+        async def staggered_lookup(name: str):
+            await asyncio.sleep(delays[name])
+            return identities[name]
+
+        mock_entity_store.resolve_library_name.side_effect = staggered_lookup
+        mock_entity_store.get_latest_provenance_by_source.return_value = {}
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={
+                    "inputs": [
+                        {"library_id": 1, "artist_name": "First", "album_title": "x"},
+                        {"library_id": 2, "artist_name": "Second", "album_title": "x"},
+                        {"library_id": 3, "artist_name": "Third", "album_title": "x"},
+                    ]
+                },
+            )
+
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert [r["library_id"] for r in results] == [1, 2, 3]
+        assert [r["main"]["discogs_artist_id"] for r in results] == [11, 22, 33]
+
+    @pytest.mark.asyncio
+    async def test_postgres_error_mid_batch_returns_503_not_partial(
+        self, app_client, mock_entity_store
+    ):
+        """A PostgresError on any input fails the whole batch closed with 503.
+
+        Fail-closed posture must survive the gather refactor: the caller cannot
+        distinguish "row had no identity" from "PG died before this row was
+        tried", so a partial 200 would silently cache wrong no-match verdicts.
+        """
+
+        async def maybe_fail(name: str):
+            if name == "Boom":
+                raise PostgresError("simulated mid-batch PG failure")
+            return None
+
+        mock_entity_store.resolve_library_name.side_effect = maybe_fail
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={
+                    "inputs": [
+                        {"library_id": 1, "artist_name": "Fine One", "album_title": "x"},
+                        {"library_id": 2, "artist_name": "Boom", "album_title": "x"},
+                        {"library_id": 3, "artist_name": "Fine Two", "album_title": "x"},
+                    ]
+                },
+            )
+
+        assert resp.status_code == 503
+        # No partial results leak: the body is the 503 error envelope, not a
+        # 200 `results` payload.
+        assert "results" not in resp.json()

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -501,6 +501,58 @@ class TestBulkResolveObservability:
         )
 
     @pytest.mark.asyncio
+    async def test_503_pinned_on_span_when_per_input_lookup_fails(
+        self, app_client, mock_entity_store
+    ):
+        """A per-input PG failure pins ``http.status_code=503`` on the span.
+
+        The #278 gather refactor moved the span-status pin: the old serial loop
+        set 503 on the span inside each per-input ``except`` block, whereas the
+        gather path raises ``HTTPException`` out of the child coroutine (which
+        runs *before* the span is opened, so it can't touch the span) and pins
+        the status in the handler's outer ``except HTTPException`` instead. This
+        characterizes that relocation so a future edit that drops the outer
+        catch can't silently close the span with no status on the 503 path —
+        the audit-style ``op:http.server http.status_code:503`` query depends
+        on it.
+        """
+        from unittest.mock import MagicMock
+
+        async def maybe_fail(name: str):
+            if name == "Boom":
+                raise PostgresError("simulated mid-batch PG failure")
+            return None
+
+        mock_entity_store.resolve_library_name.side_effect = maybe_fail
+
+        span_mock = MagicMock()
+        span_cm = MagicMock()
+        span_cm.__enter__ = MagicMock(return_value=span_mock)
+        span_cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("identity.router.sentry_sdk.start_span", return_value=span_cm):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/identity/bulk-resolve-libraries",
+                    json={
+                        "inputs": [
+                            {"library_id": 1, "artist_name": "Fine One", "album_title": "x"},
+                            {"library_id": 2, "artist_name": "Boom", "album_title": "x"},
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 503
+        status_calls = [
+            c for c in span_mock.set_data.call_args_list if c.args[0] == "http.status_code"
+        ]
+        assert any(c.args[1] == 503 for c in status_calls), (
+            f"Expected http.status_code=503 pinned on the span; saw: {status_calls}"
+        )
+
+    @pytest.mark.asyncio
     async def test_http_server_span_emitted(self, app_client, mock_entity_store):
         """An explicit Sentry `http.server` span wraps the handler.
 


### PR DESCRIPTION
Closes #278.

## Problem

`bulk_resolve_libraries` (`identity/router.py`) iterated inputs serially. After #277's three-leg fall-through, each miss costs up to 3 sequential PG round-trips, so a 1,000-row miss-heavy batch was ~3,000 sequential queries — 3-6 s of wall-clock at LML's intra-Railway latency, and that grows linearly as bulk traffic ramps once BS#802 turns the endpoint on.

## Change

Replace the serial `for` loop with an `asyncio.gather` over the inputs, each gated by a shared `asyncio.Semaphore`:

- **Concurrency, pool-bounded.** The semaphore is sized to the discogs-cache asyncpg pool's `max_size` (5, per `core.dependencies._build_discogs_pool`). Each per-input coroutine holds at most one pooled connection at a time — `resolve_library_name`'s three legs and `compose_for_identity`'s provenance read are sequential awaits inside a single coroutine — so a semaphore of pool-max saturates the pool without coroutines queueing on `pool.acquire()`. Worst case drops to ~`ceil(N / max_concurrent)` waves: sub-second for N=1,000.
- **Deliberate, settings-driven cap.** Default is the pool `max_size`; overridable via the shared `LML_BULK_MAX_CONCURRENT` env knob (`core.bulk_concurrency.max_concurrency_from_env`), same mechanism the other bulk endpoints use. `Semaphore(max(1, min(cap, n_inputs)))` avoids over-allocating permits and keeps `Semaphore(0)` off the table.
- **Order preserved.** `gather` returns results in input order, so `results[i]` still corresponds to `inputs[i]` regardless of completion order.
- **503 fail-closed preserved.** A `PostgresError`/`OSError` on any input raises `HTTPException(503)` inside `_resolve_one`; `gather` (default `return_exceptions=False`) propagates the first failure to the handler, failing the whole batch closed rather than returning a 200 with partial verdicts. The caller can't distinguish "no identity" from "PG died before this row was tried", so this posture is load-bearing.
- **Observability preserved.** Entry/exit INFO logs, the explicit `http.server` span, and the mid-batch client-abort 499 span pin all survive; the span now also carries `lml.bulk_resolve.max_concurrent`.

Single production file touched: `identity/router.py`.

## Testing

New unit coverage in `tests/unit/test_bulk_resolve_libraries_endpoint.py` (`TestBulkResolveConcurrency`):

- `test_per_input_lookups_run_concurrently` — N lookups each sleeping DELAY finish in ~DELAY, not N×DELAY (RED against the serial loop).
- `test_semaphore_bounds_in_flight_lookups` — with `LML_BULK_MAX_CONCURRENT=2` and 6 inputs, observed peak in-flight equals 2 (RED against the serial loop, which never exceeds 1).
- `test_input_order_preserved_under_staggered_completion` — slowest input first; results stay in input order.
- `test_postgres_error_mid_batch_returns_503_not_partial` — a `PostgresError` on one input returns 503 with no `results` payload.

Commands run:

- `uv run --no-sync python -m pytest tests/unit/test_bulk_resolve_libraries_endpoint.py` — 16 passed (12 existing + 4 new); concurrency tests re-run 3× with no flakiness.
- `uv run --no-sync python -m pytest` (default suite, excludes `pg`/`external_api`) — 3301 passed, 1 skipped, 230 deselected, 2 xfailed.
- `uv run --no-sync ruff check .` and `ruff format --check` on the changed files — clean.

The `pg`-tier integration tests for this endpoint (`tests/integration/test_bulk_resolve_libraries.py`) are behavior-preserving under this change (order, verdicts, 503/413 unchanged; the app's entity-store pool `max_size=5` ≥ those batch sizes) and run in CI.