### PR TITLE
perf(#599): cache-back the P3283 Bandcamp fetch in the Wikidata reconciler

### DIFF
--- a/scripts/entity_resolution/wikidata.py
+++ b/scripts/entity_resolution/wikidata.py
@@ -4,7 +4,8 @@ Resolves:
 - Discogs artist ID -> Wikidata QID (via wikidata-cache P1953 mapping or SPARQL)
 - QID -> Discogs artist/master/release ID (via SPARQL P1953 / P1954 / P2206)
 - Artist name -> QID (via SPARQL name search for musicians/musical groups)
-- QID -> streaming platform IDs (Spotify P1902, Apple Music P2850, Bandcamp P3283)
+- QID -> streaming platform IDs (Bandcamp P3283 via wikidata-cache or SPARQL;
+  Spotify P1902 / Apple Music P2850 via SPARQL)
 
 Ported from semantic-index ``wikidata_client.py`` and ``reconciliation.py``.
 """
@@ -25,6 +26,19 @@ _CACHE_DISCOGS_TO_QID_SQL = """\
 SELECT discogs_artist_id, qid
 FROM discogs_mapping
 WHERE discogs_artist_id = ANY($1)\
+"""
+
+# Cache-first read for the Bandcamp profile ID (Wikidata P3283), mirroring the
+# Discogs->QID bridge above. The WXYC wikidata-cache captures P3283 into the
+# generic ``discogs_mapping(qid, property, discogs_id)`` table (the slug lands
+# in ``discogs_id``), so a local join resolves the slug with no rate-limited
+# SPARQL round-trip. Proven query: ``scripts/bandcamp_pipeline.py`` Wikidata
+# slug loader. Keyed by QID here because that is the handle the caller holds.
+# See WXYC/library-metadata-lookup#599.
+_CACHE_QID_TO_BANDCAMP_SQL = """\
+SELECT qid, discogs_id
+FROM discogs_mapping
+WHERE property = 'P3283' AND qid = ANY($1)\
 """
 
 # Templates use ``{values}`` / ``{name}`` placeholders substituted via
@@ -257,8 +271,29 @@ class WikidataReconciler:
     async def fetch_streaming_ids(self, qids: list[str]) -> dict[str, StreamingIds]:
         """Fetch streaming platform IDs for Wikidata entities.
 
-        Queries P1902 (Spotify), P2850 (Apple Music), P3283 (Bandcamp)
-        using OPTIONAL clauses for partial results.
+        Cache-first for the Bandcamp profile ID (P3283): the wikidata-cache
+        already holds P3283 in ``discogs_mapping``, so a QID whose Bandcamp ID
+        is in the cache is resolved from a local join and is *not* sent through
+        the rate-limited (~1 req/s) SPARQL endpoint — this removes the SPARQL
+        bottleneck from the offline ``bandcamp_id`` backfill (#599). Cache
+        misses fall back to the existing SPARQL path, which queries P1902
+        (Spotify), P2850 (Apple Music) and P3283 (Bandcamp) with OPTIONAL
+        clauses for partial results.
+
+        Trade-off (intended, #599 acceptance criteria #1 + #3): on a P3283
+        cache hit the returned ``StreamingIds`` carries **only** ``bandcamp_id``
+        — ``spotify_artist_id`` and ``apple_music_artist_id`` come back ``None``
+        because the QID is never sent to SPARQL. Skipping the rate-limited
+        endpoint is the whole point, and the wikidata-cache currently exposes
+        only P3283 (P1902 is mislabeled in the cache filter; P2850 is not yet
+        wired — both deferred), so a cache hit cannot also supply Spotify/Apple.
+        The sole caller (``scripts/entity_resolution/__main__.py`` streaming
+        stage) persists all three columns, so for a cache-hit QID it writes the
+        ``bandcamp_id`` and leaves Spotify/Apple unset until those properties
+        are added to the cache (and the caller's "has any streaming id" gate is
+        relaxed to re-admit Bandcamp-only rows — tracked with the P1902/P2850
+        caching follow-up). The ``bandcamp_id`` values written are identical to
+        the SPARQL path. Cache misses still fetch all three properties.
 
         Args:
             qids: List of Wikidata QIDs to fetch streaming IDs for.
@@ -270,6 +305,31 @@ class WikidataReconciler:
         if not qids:
             return {}
 
+        result: dict[str, StreamingIds] = {}
+        remaining = list(qids)
+
+        # Stage 1: wikidata-cache P3283 (Bandcamp). Mirrors the Discogs->QID
+        # bridge in ``resolve_qids_from_discogs_ids``. A non-empty slug counts
+        # as a hit and shrinks the SPARQL workload.
+        if self._wikidata_pg is not None:
+            rows = await self._wikidata_pg.fetchall(_CACHE_QID_TO_BANDCAMP_SQL, list(qids))
+            hits: set[str] = set()
+            for row in rows:
+                slug = row["discogs_id"]
+                if slug:
+                    result[row["qid"]] = StreamingIds(bandcamp_id=slug)
+                    hits.add(row["qid"])
+            if hits:
+                remaining = [qid for qid in remaining if qid not in hits]
+
+        # Stage 2: SPARQL fallback for cache misses (all three properties).
+        if remaining:
+            result.update(await self._fetch_streaming_ids_via_sparql(remaining))
+
+        return result
+
+    async def _fetch_streaming_ids_via_sparql(self, qids: list[str]) -> dict[str, StreamingIds]:
+        """Fetch P1902 / P2850 / P3283 for ``qids`` via SPARQL OPTIONAL clauses."""
         # Prefix with ``wd:`` so the rendered ``VALUES ?item { ... }`` clause is
         # syntactically valid SPARQL — bare ``Q378288`` is a parse error.
         items = [f"wd:{qid}" for qid in qids]

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -6,6 +6,7 @@ import pytest
 
 from entity.sources import SparqlSource
 from scripts.entity_resolution.wikidata import (
+    _CACHE_QID_TO_BANDCAMP_SQL,
     _SPARQL_DISCOGS_TO_QID,
     _SPARQL_QID_TO_DISCOGS_ARTIST,
     _SPARQL_QID_TO_DISCOGS_MASTER,
@@ -199,6 +200,122 @@ class TestStreamingIdFetch:
         assert ids.spotify_artist_id == "abc123"
         assert ids.apple_music_artist_id is None
         assert ids.bandcamp_id is None
+
+
+class TestStreamingIdCacheBacking:
+    """``fetch_streaming_ids`` consults the wikidata-cache (P3283 Bandcamp)
+    before SPARQL, mirroring ``resolve_qids_from_discogs_ids``.
+
+    WXYC/library-metadata-lookup#599: the wikidata-cache already carries the
+    Bandcamp profile ID (P3283) in the generic ``discogs_mapping`` table, so a
+    cache hit resolves the slug with no rate-limited SPARQL round-trip.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bandcamp_id_from_cache_skips_sparql(
+        self, reconciler, mock_wikidata_pg, mock_sparql
+    ):
+        """A P3283 cache hit returns the Bandcamp slug and fires no SPARQL."""
+        mock_wikidata_pg.fetchall = AsyncMock(
+            return_value=[{"qid": "Q378288", "discogs_id": "autechre"}]
+        )
+        result = await reconciler.fetch_streaming_ids(["Q378288"])
+        assert result["Q378288"].bandcamp_id == "autechre"
+        # The whole point: no rate-limited SPARQL round-trip on a cache hit.
+        mock_sparql.query_batched.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_bandcamp_only_no_spotify_apple(
+        self, reconciler, mock_wikidata_pg, mock_sparql
+    ):
+        """Intended trade-off (#599 criteria #1 + #3): skipping SPARQL for a
+        cache hit means that QID yields *only* ``bandcamp_id`` — Spotify and
+        Apple Music are ``None`` because the cache exposes only P3283. The
+        caller persists ``bandcamp_id`` and leaves Spotify/Apple unset for that
+        QID until P1902/P2850 are also cached (tracked as a follow-up). This
+        test pins the deliberate consequence so it can't regress silently.
+        """
+        mock_wikidata_pg.fetchall = AsyncMock(
+            return_value=[{"qid": "Q378288", "discogs_id": "autechre"}]
+        )
+        result = await reconciler.fetch_streaming_ids(["Q378288"])
+        ids = result["Q378288"]
+        assert ids.bandcamp_id == "autechre"
+        assert ids.spotify_artist_id is None
+        assert ids.apple_music_artist_id is None
+        mock_sparql.query_batched.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_query_targets_p3283_keyed_by_qid(self, reconciler, mock_wikidata_pg):
+        """The cache stage runs the P3283 query, passing the input QIDs as args."""
+        mock_wikidata_pg.fetchall = AsyncMock(return_value=[])
+        await reconciler.fetch_streaming_ids(["Q378288", "Q123"])
+        mock_wikidata_pg.fetchall.assert_called_once()
+        sql_arg, qids_arg = mock_wikidata_pg.fetchall.call_args.args
+        assert sql_arg is _CACHE_QID_TO_BANDCAMP_SQL
+        assert "P3283" in sql_arg
+        assert set(qids_arg) == {"Q378288", "Q123"}
+
+    @pytest.mark.asyncio
+    async def test_sparql_fires_only_for_cache_misses(
+        self, reconciler, mock_wikidata_pg, mock_sparql
+    ):
+        """Cache hit for one QID; the other falls through to SPARQL alone."""
+        mock_wikidata_pg.fetchall = AsyncMock(
+            return_value=[{"qid": "Q378288", "discogs_id": "autechre"}]
+        )
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q123"},
+                    "spotifyId": {"type": "literal", "value": "abc123"},
+                }
+            ]
+        )
+        result = await reconciler.fetch_streaming_ids(["Q378288", "Q123"])
+
+        # Cache-resolved QID carries the Bandcamp slug from the local join.
+        assert result["Q378288"].bandcamp_id == "autechre"
+        # SPARQL ran exactly once and only for the cache miss.
+        mock_sparql.query_batched.assert_called_once()
+        _template_arg, items_arg = mock_sparql.query_batched.call_args.args
+        assert items_arg == ["wd:Q123"]
+        assert result["Q123"].spotify_artist_id == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_blank_cache_slug_falls_through_to_sparql(
+        self, reconciler, mock_wikidata_pg, mock_sparql
+    ):
+        """A row with a null/blank slug is treated as a miss, not a hit."""
+        mock_wikidata_pg.fetchall = AsyncMock(return_value=[{"qid": "Q378288", "discogs_id": None}])
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q378288"},
+                    "bandcampId": {"type": "literal", "value": "autechre"},
+                }
+            ]
+        )
+        result = await reconciler.fetch_streaming_ids(["Q378288"])
+        mock_sparql.query_batched.assert_called_once()
+        _template_arg, items_arg = mock_sparql.query_batched.call_args.args
+        assert items_arg == ["wd:Q378288"]
+        assert result["Q378288"].bandcamp_id == "autechre"
+
+    @pytest.mark.asyncio
+    async def test_no_cache_goes_straight_to_sparql(self, reconciler_no_cache, mock_sparql):
+        """With wikidata_pg=None, the SPARQL-only path is unchanged (#599 safe default)."""
+        mock_sparql.query_batched = AsyncMock(
+            return_value=[
+                {
+                    "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q378288"},
+                    "bandcampId": {"type": "literal", "value": "autechre"},
+                }
+            ]
+        )
+        result = await reconciler_no_cache.fetch_streaming_ids(["Q378288"])
+        assert result["Q378288"].bandcamp_id == "autechre"
+        mock_sparql.query_batched.assert_called_once()
 
 
 class TestGracefulDegradation:

--- a/tests/unit/test_wikidata_reconciliation.py
+++ b/tests/unit/test_wikidata_reconciliation.py
@@ -283,11 +283,16 @@ class TestStreamingIdCacheBacking:
         assert result["Q123"].spotify_artist_id == "abc123"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("empty_slug", [None, ""])
     async def test_blank_cache_slug_falls_through_to_sparql(
-        self, reconciler, mock_wikidata_pg, mock_sparql
+        self, reconciler, mock_wikidata_pg, mock_sparql, empty_slug
     ):
-        """A row with a null/blank slug is treated as a miss, not a hit."""
-        mock_wikidata_pg.fetchall = AsyncMock(return_value=[{"qid": "Q378288", "discogs_id": None}])
+        """A row with a null or empty-string slug is treated as a miss, not a
+        hit — the ``if slug:`` guard rejects both falsy forms so the QID still
+        reaches SPARQL (and can come back with a real Bandcamp ID there)."""
+        mock_wikidata_pg.fetchall = AsyncMock(
+            return_value=[{"qid": "Q378288", "discogs_id": empty_slug}]
+        )
         mock_sparql.query_batched = AsyncMock(
             return_value=[
                 {


### PR DESCRIPTION
Closes #599.

## What

`WikidataReconciler.fetch_streaming_ids` sent every QID through the rate-limited (~1 req/s) Wikidata SPARQL endpoint to read the Bandcamp profile ID (P3283), even though the wikidata-cache already captures P3283 into the generic `discogs_mapping(qid, property, discogs_id)` table. This adds a cache-first stage that mirrors the existing `resolve_qids_from_discogs_ids` bridge:

- **Stage 1 (cache):** read the slug from a local join — `SELECT qid, discogs_id FROM discogs_mapping WHERE property = 'P3283' AND qid = ANY($1)` — keyed by QID. A non-empty slug counts as a hit and shrinks the SPARQL workload.
- **Stage 2 (SPARQL fallback):** the existing path runs **only for cache misses**, querying P1902 / P2850 / P3283 with OPTIONAL clauses. The SPARQL body is extracted into `_fetch_streaming_ids_via_sparql` so both stages stay legible.

This removes the SPARQL bottleneck from the offline `bandcamp_id` backfill (issue acceptance criterion #1) and feeds the Bandcamp cache-warmer (#548 / #573 PR-3) the artist subdomain up front, so the runtime scrape can skip Bandcamp's cold-start `app_autocomplete` call.

## Intended trade-off (made explicit + tested)

Skipping SPARQL for a cache hit has a deliberate consequence the issue scopes for: **a P3283 cache hit returns `bandcamp_id` alone; `spotify_artist_id` / `apple_music_artist_id` come back `None`** because that QID is never sent to SPARQL and the cache exposes only P3283 today.

This is what the issue's acceptance criteria call for — #1 ("SPARQL fires only for cache misses") *requires* skipping hit QIDs, and #3 deliberately scopes its no-change guarantee to `bandcamp_id` only (not Spotify/Apple). The issue's own "optional P1902/P2850 from cache" note anticipates it.

Consequence for the sole caller (`scripts/entity_resolution/__main__.py` streaming stage), which persists all three columns: for a cache-hit QID it writes the `bandcamp_id` and leaves Spotify/Apple unset until those properties are added to the cache (P1902 is mislabeled in the wikidata-cache filter; P2850 not yet wired — both deferred). Completing Spotify/Apple for cache-hit QIDs is the follow-up tracked alongside the P1902/P2850 caching, and will also need the caller's "has any streaming id" gate relaxed to re-admit Bandcamp-only rows. The docstring states this plainly and `test_cache_hit_returns_bandcamp_only_no_spotify_apple` pins it so it can't regress silently.

## Scope / safety

- **`bandcamp_id` values are unchanged** — the cache returns the same slug the SPARQL `bandcampId` binding would.
- **Pure read** against the existing external wikidata-cache (port 5435) via the already-wired `wikidata_pg` `PgSource`. No `CREATE TABLE`, no `lml_cache.*` bootstrap — no schema-ownership change.
- `wikidata_pg=None` keeps the original SPARQL-only behavior intact.

## Coverage (issue acceptance criterion #2)

The precise `wxyc_library`-join query needs the port-5435 cache running (down locally; the join stays the criterion for the next cache build). Recorded proxy from the issue: of WXYC's 109 most-played artists, **57 (52%)** carry a Wikidata Bandcamp ID — well above the global ~5.8%-of-Discogs-artists ratio, because WXYC's rotation skews contemporary indie/electronic. Upper bound (the played head); an additive first-guess, not a replacement for scraping.

## Testing

- TDD: new `TestStreamingIdCacheBacking` class in `tests/unit/test_wikidata_reconciliation.py` covering: P3283 cache hit skips SPARQL entirely; cache hit returns Bandcamp-only with Spotify/Apple `None` (the intended trade-off); the cache query targets P3283 keyed by QID; SPARQL fires **only** for cache misses (mixed hit/miss); a blank/null slug falls through to SPARQL; `wikidata_pg=None` goes straight to SPARQL.
- `uv run --no-sync python -m pytest tests/unit/test_wikidata_reconciliation.py` -> 25 passed (19 prior + 6 new).
- Full fast suite (`-m 'not pg and not external_api'`) -> 3302 passed, 1 skipped, 230 deselected (infra-marked, left to CI), 2 xfailed.
- `ruff check .` + `ruff format --check .` clean.