### PR TITLE
feat(#233): emit per-method confidence from entity_resolution per §3.4.1

### DIFF
--- a/entity/store.py
+++ b/entity/store.py
@@ -256,12 +256,20 @@ ORDER BY bind.name, i.id ASC\
 # pick the latest attempt — matching the "most recent matcher decision" notion
 # §3.4.1.1 needs to compose from. Sub-0.70 rows are NOT excluded here; the
 # composer applies Rule 6 (sidecar-floor exclusion) separately.
+#
+# `id DESC` is the stable tie-break (LML#233): at identical `created_at`
+# (microsecond collisions are possible on burst writes) `DISTINCT ON` would
+# otherwise pick an arbitrary row, so two back-to-back `bulk-resolve` calls
+# could return different `provenance[].method` / confidence for the same
+# identity and spuriously invalidate the caller's cache. The serial `id`
+# is monotonic with insertion order, so `id DESC` deterministically keeps the
+# latest-written row.
 _LATEST_LOG_BY_SOURCE_SQL = """\
 SELECT DISTINCT ON (source)
        source, external_id, confidence, method
 FROM entity.reconciliation_log
 WHERE identity_id = $1
-ORDER BY source, created_at DESC\
+ORDER BY source, created_at DESC, id DESC\
 """
 
 

--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -50,6 +50,71 @@ _LIBRARY_ARTISTS_SQL = (
     "SELECT DISTINCT artist FROM library WHERE artist IS NOT NULL ORDER BY artist"
 )
 
+# Per-method confidence written to ``entity.reconciliation_log`` (LML#233).
+#
+# The plan §3.4.1 matrix locks a confidence band per resolution method;
+# Backend's §3.2.2 write-contract sanity-check rejects any row whose
+# ``(method, confidence)`` pair falls outside its band. Before this map the
+# Discogs stage wrote a flat ``confidence=1.0`` for every method, so a
+# ``member_group`` row (band 0.80–0.89) was silently dropped at Backend's
+# writer.
+#
+# §3.4.1 bands (inclusive):
+#   exact_match     1.00 (exact)
+#   name_variation  0.90–0.99
+#   member_group    0.80–0.89
+#   alias_match     0.75–0.84
+#   trigram         0.70–0.95   (not emitted by these stages)
+#   llm             0.60–0.79   (not emitted by these stages)
+#   inherited       parent × 0.95 (not emitted by these stages)
+#
+# Values sit mid-band so a future calibration pass can nudge them without
+# crossing a band edge. Methods that are not §3.4.1 matrix entries
+# (``name_preprocessing`` and the Wikidata / MusicBrainz bridge + search
+# methods) are scored inside the ``name_variation`` band — a deterministic
+# cross-source ID bridge sits at the high end, a name lookup at the floor.
+# The bulk-resolve composer (``identity/bulk_resolve.py``) only surfaces the
+# enum-named matrix methods on the wire, so these extra entries never reach
+# Backend's §3.2.2 check, but they keep the raw log rows honest and bounded.
+METHOD_CONFIDENCE: dict[str, float] = {
+    # Discogs cascade (scripts/entity_resolution/discogs.py) — §3.4.1 matrix.
+    "exact_match": 1.00,  # §3.4.1: 1.00
+    "name_variation": 0.92,  # §3.4.1: 0.90–0.99
+    "member_group": 0.85,  # §3.4.1: 0.80–0.89
+    "alias_match": 0.80,  # §3.4.1: 0.75–0.84
+    # Stage 5 re-runs the equality cascade on cheap name derivations (article
+    # strip, "&"→"and", bracket strip, multi-credit split). Floor of the
+    # name_variation band to reflect the extra derivation step.
+    "name_preprocessing": 0.90,
+    # Wikidata stage (run_wikidata_stage): a QID bridged deterministically
+    # from an already-reconciled Discogs ID is a graph join, not a fuzzy
+    # match — high end of the name_variation band. A SPARQL name search is a
+    # name lookup — band floor.
+    "discogs_bridge": 0.95,
+    "name_search": 0.90,
+    # MusicBrainz stage (run_musicbrainz_stage): deterministic QID→MBID
+    # bridge vs. direct name match, same reasoning as the Wikidata leg.
+    "qid_bridge": 0.95,
+    "name_match": 0.90,
+}
+
+# Fallback for any method absent from ``METHOD_CONFIDENCE`` — a value inside
+# member_group's §3.4.1 band (0.80–0.89). Conservative but always inside a
+# valid band, so an unforeseen method can never write an out-of-band row.
+_DEFAULT_METHOD_CONFIDENCE = 0.85
+
+
+def confidence_for_method(method: str) -> float:
+    """Return the §3.4.1 confidence for ``method`` (LML#233).
+
+    Looks ``method`` up in ``METHOD_CONFIDENCE``, falling back to
+    ``_DEFAULT_METHOD_CONFIDENCE`` (inside member_group's band) for any method
+    not in the table. The returned value is always inside a §3.4.1 band, so
+    every ``entity.reconciliation_log`` write passes Backend's §3.2.2
+    write-contract sanity-check.
+    """
+    return METHOD_CONFIDENCE.get(method, _DEFAULT_METHOD_CONFIDENCE)
+
 
 class OrphanDrainAbortError(RuntimeError):
     """Raised when orphan count exceeds the drain-safety threshold.
@@ -253,7 +318,7 @@ async def run_discogs_stage(
                     source="discogs",
                     external_id=str(match.discogs_artist_id),
                     method=match.method,
-                    confidence=1.0,
+                    confidence=confidence_for_method(match.method),
                 )
                 matched_count += 1
             else:
@@ -291,6 +356,7 @@ async def run_wikidata_stage(
                     source="wikidata",
                     external_id=qid,
                     method="discogs_bridge",
+                    confidence=confidence_for_method("discogs_bridge"),
                 )
                 qid_bridged += 1
 
@@ -310,6 +376,7 @@ async def run_wikidata_stage(
                 source="wikidata",
                 external_id=found_qid,
                 method="name_search",
+                confidence=confidence_for_method("name_search"),
             )
             name_searched += 1
 
@@ -375,6 +442,7 @@ async def run_musicbrainz_stage(
                     source="musicbrainz",
                     external_id=mbid,
                     method="qid_bridge",
+                    confidence=confidence_for_method("qid_bridge"),
                 )
                 mb_resolved += 1
 
@@ -401,6 +469,7 @@ async def run_musicbrainz_stage(
                     source="musicbrainz",
                     external_id=mbid,
                     method="name_match",
+                    confidence=confidence_for_method("name_match"),
                 )
                 mb_resolved += 1
 

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -10,6 +10,7 @@ Requires: DATABASE_URL_TEST env var or Docker postgres on port 5433.
 from __future__ import annotations
 
 from typing import ClassVar
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -19,10 +20,11 @@ from entity.store import EntityStore
 from scripts.entity_resolution.__main__ import (
     OrphanDrainAbortError,
     prune_orphan_identities,
+    run_discogs_stage,
     seed_identities,
 )
 from scripts.entity_resolution.dedup import EntityDeduplicator
-from scripts.entity_resolution.discogs import DiscogsReconciler
+from scripts.entity_resolution.discogs import DiscogsReconciler, ReconciliationMatch
 
 # ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
 # there for the ``source._dsn`` wiring and ``monkeypatch.setenv`` calls below.
@@ -731,3 +733,82 @@ class TestDeduplicationIntegration:
         # The merged record should have both discogs and musicbrainz IDs
         assert remaining[0]["discogs_artist_id"] == 12
         assert remaining[0]["musicbrainz_artist_id"] == "mbid-1"
+
+
+# §3.4.1 locked bands (inclusive) keyed by method, mirroring Backend's §3.2.2
+# write-contract sanity-check ranges. A row whose (method, confidence) lands
+# outside its band would be rejected by Backend's writer.
+_METHOD_BANDS_341: dict[str, tuple[float, float]] = {
+    "exact_match": (1.00, 1.00),
+    "name_variation": (0.90, 0.99),
+    "member_group": (0.80, 0.89),
+    "alias_match": (0.75, 0.84),
+}
+
+
+@pytest.mark.pg
+class TestDiscogsStageConfidencePersisted:
+    """LML#233: `run_discogs_stage` persists per-method confidence to PG.
+
+    Runs the real `EntityStore` write path against PostgreSQL with a stubbed
+    reconciler so the assertion covers the REAL-column round-trip (confidence
+    is stored as a 4-byte `REAL`, so we assert bands, not float equality).
+    """
+
+    @pytest.mark.parametrize("method", list(_METHOD_BANDS_341))
+    @pytest.mark.asyncio
+    async def test_logged_confidence_within_341_band(self, pg_source, method):
+        store = EntityStore(pg_source)
+        await store.upsert_identity(library_name="Stereolab")
+
+        reconciler = AsyncMock()
+        reconciler.reconcile_batch = AsyncMock(
+            return_value={"Stereolab": ReconciliationMatch(discogs_artist_id=2154, method=method)}
+        )
+
+        await run_discogs_stage(store, reconciler, batch_size=1000)
+
+        rows = await pg_source.fetchall(
+            "SELECT method, confidence FROM entity.reconciliation_log WHERE source = 'discogs'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["method"] == method
+        lo, hi = _METHOD_BANDS_341[method]
+        # Pad the band by the float32 storage epsilon so e.g. 0.85 → 0.8500000238
+        # doesn't fall foul of an exact band edge.
+        assert lo - 1e-6 <= rows[0]["confidence"] <= hi + 1e-6
+
+
+@pytest.mark.pg
+class TestLatestProvenanceTiebreak:
+    """LML#233: identical `created_at` rows resolve deterministically by id."""
+
+    @pytest.mark.asyncio
+    async def test_identical_created_at_breaks_by_id_desc(self, pg_source):
+        store = EntityStore(pg_source)
+        identity = await store.upsert_identity(library_name="Stereolab")
+
+        # Two discogs rows for the same identity at the SAME created_at (a SQL
+        # literal so both rows land on the identical microsecond); the
+        # second-inserted (higher id) row must win the DISTINCT ON pick.
+        await pg_source.execute(
+            "INSERT INTO entity.reconciliation_log "
+            "(identity_id, source, external_id, confidence, method, created_at) "
+            "VALUES ($1, 'discogs', '111', 0.85, 'member_group', "
+            "TIMESTAMPTZ '2026-01-01 00:00:00+00')",
+            identity.id,
+        )
+        await pg_source.execute(
+            "INSERT INTO entity.reconciliation_log "
+            "(identity_id, source, external_id, confidence, method, created_at) "
+            "VALUES ($1, 'discogs', '222', 1.0, 'exact_match', "
+            "TIMESTAMPTZ '2026-01-01 00:00:00+00')",
+            identity.id,
+        )
+
+        # Repeat the read to prove stability — without the id tiebreak PG could
+        # return either row on each call.
+        for _ in range(5):
+            prov = await store.get_latest_provenance_by_source(identity.id)
+            assert prov["discogs"].external_id == "222"
+            assert prov["discogs"].method == "exact_match"

--- a/tests/unit/test_entity_resolution_confidence.py
+++ b/tests/unit/test_entity_resolution_confidence.py
@@ -1,0 +1,232 @@
+"""Unit tests for per-method confidence emission (LML#233).
+
+`scripts/entity_resolution/__main__.py` historically wrote `confidence=1.0`
+for every successful Discogs match regardless of `match.method`, and the
+Wikidata / MusicBrainz stages wrote no confidence at all. Backend's plan
+§3.2.2 write-contract sanity-check rejects any `(method, confidence)` row that
+falls outside the per-method band documented in §3.4.1, so a
+`member_group, 1.00` row was silently dropped.
+
+These tests pin the §3.4.1 confidence matrix at the point where each stage
+writes to `entity.reconciliation_log`:
+
+| Method          | Range       |
+|-----------------|-------------|
+| `exact_match`   | 1.00        |
+| `name_variation`| 0.90–0.99   |
+| `member_group`  | 0.80–0.89   |
+| `alias_match`   | 0.75–0.84   |
+
+The mock-store layer keeps the assertions on the value handed to
+`log_reconciliation` rather than the PG round-trip (covered separately by the
+`pg`-marked integration test).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from entity.store import Identity
+from scripts.entity_resolution.__main__ import (
+    METHOD_CONFIDENCE,
+    run_discogs_stage,
+    run_musicbrainz_stage,
+    run_wikidata_stage,
+)
+from scripts.entity_resolution.discogs import ReconciliationMatch
+
+# §3.4.1 locked bands (inclusive) for the matrix methods the Discogs cascade
+# can emit. `exact_match` is a point value; the rest are ranges.
+DISCOGS_METHOD_BANDS: dict[str, tuple[float, float]] = {
+    "exact_match": (1.00, 1.00),
+    "name_variation": (0.90, 0.99),
+    "member_group": (0.80, 0.89),
+    "alias_match": (0.75, 0.84),
+}
+
+
+def _confidence_for_logged_method(store: AsyncMock, method: str) -> float:
+    """Pull the confidence handed to log_reconciliation for a given method."""
+    for call in store.log_reconciliation.await_args_list:
+        if call.kwargs.get("method") == method:
+            return call.kwargs["confidence"]
+    raise AssertionError(
+        f"no log_reconciliation call recorded method={method!r}; "
+        f"calls: {[c.kwargs for c in store.log_reconciliation.await_args_list]}"
+    )
+
+
+def _discogs_store(identity: Identity) -> AsyncMock:
+    store = AsyncMock()
+    store.get_identities_by_status = AsyncMock(return_value=[identity])
+    store.upsert_identity = AsyncMock(return_value=identity)
+    store.update_status = AsyncMock()
+    store.log_reconciliation = AsyncMock()
+    return store
+
+
+class TestDiscogsStageConfidence:
+    @pytest.mark.parametrize(("method", "band"), list(DISCOGS_METHOD_BANDS.items()))
+    @pytest.mark.asyncio
+    async def test_method_confidence_within_341_band(self, method, band):
+        """Each Discogs cascade method logs a confidence inside its §3.4.1 band."""
+        identity = Identity(id=1, library_name="Stereolab")
+        store = _discogs_store(identity)
+        reconciler = AsyncMock()
+        reconciler.reconcile_batch = AsyncMock(
+            return_value={"Stereolab": ReconciliationMatch(discogs_artist_id=2154, method=method)}
+        )
+
+        await run_discogs_stage(store, reconciler, batch_size=1000)
+
+        confidence = _confidence_for_logged_method(store, method)
+        lo, hi = band
+        assert lo <= confidence <= hi, (
+            f"method={method}: confidence {confidence} outside §3.4.1 band {band}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_member_group_is_not_full_confidence(self):
+        """The exact regression in LML#233: member_group must not log 1.00."""
+        identity = Identity(id=1, library_name="Stereolab")
+        store = _discogs_store(identity)
+        reconciler = AsyncMock()
+        reconciler.reconcile_batch = AsyncMock(
+            return_value={
+                "Stereolab": ReconciliationMatch(discogs_artist_id=2154, method="member_group")
+            }
+        )
+
+        await run_discogs_stage(store, reconciler, batch_size=1000)
+
+        assert _confidence_for_logged_method(store, "member_group") < 0.90
+
+    @pytest.mark.asyncio
+    async def test_name_preprocessing_logs_non_null_in_band(self):
+        """`name_preprocessing` is not a §3.4.1 matrix method but still gets a
+        bounded, non-null confidence (it re-runs the cascade on derived names)."""
+        identity = Identity(id=1, library_name="The Microphones")
+        store = _discogs_store(identity)
+        reconciler = AsyncMock()
+        reconciler.reconcile_batch = AsyncMock(
+            return_value={
+                "The Microphones": ReconciliationMatch(
+                    discogs_artist_id=7, method="name_preprocessing"
+                )
+            }
+        )
+
+        await run_discogs_stage(store, reconciler, batch_size=1000)
+
+        confidence = _confidence_for_logged_method(store, "name_preprocessing")
+        assert confidence is not None
+        assert 0.70 <= confidence <= 1.00
+
+
+class TestMethodConfidenceMap:
+    def test_every_mapped_value_is_within_a_valid_band(self):
+        """No mapped confidence may exceed 1.0 or fall below the 0.70 sidecar floor."""
+        for method, confidence in METHOD_CONFIDENCE.items():
+            assert 0.70 <= confidence <= 1.00, f"{method}={confidence} out of bounds"
+
+    def test_matrix_methods_match_their_341_bands(self):
+        for method, (lo, hi) in DISCOGS_METHOD_BANDS.items():
+            assert method in METHOD_CONFIDENCE, f"{method} missing from METHOD_CONFIDENCE"
+            assert lo <= METHOD_CONFIDENCE[method] <= hi
+
+
+class TestWikidataStageConfidence:
+    @pytest.mark.asyncio
+    async def test_discogs_bridge_logs_confidence(self):
+        """Stage-1 QID bridge writes a bounded confidence (was: no confidence)."""
+        identity = Identity(
+            id=1,
+            library_name="Stereolab",
+            discogs_artist_id=2154,
+            reconciliation_status="reconciled",
+        )
+        store = AsyncMock()
+        # "reconciled" twice (stage 1 + stage 3), "no_match" empty (stage 2).
+        store.get_identities_by_status = AsyncMock(
+            side_effect=lambda status: [identity] if status == "reconciled" else []
+        )
+        store.upsert_identity = AsyncMock(return_value=identity)
+        store.update_status = AsyncMock()
+        store.log_reconciliation = AsyncMock()
+
+        reconciler = AsyncMock()
+        reconciler.resolve_qids_from_discogs_ids = AsyncMock(return_value={2154: "Q483507"})
+        reconciler.search_musician_by_name = AsyncMock(return_value=None)
+        reconciler.fetch_streaming_ids = AsyncMock(return_value={})
+
+        await run_wikidata_stage(store, reconciler)
+
+        confidence = _confidence_for_logged_method(store, "discogs_bridge")
+        assert confidence is not None
+        assert 0.70 <= confidence <= 1.00
+
+    @pytest.mark.asyncio
+    async def test_name_search_logs_confidence(self):
+        """Stage-2 name search writes a bounded confidence."""
+        identity = Identity(id=2, library_name="Juana Molina", reconciliation_status="no_match")
+        store = AsyncMock()
+        store.get_identities_by_status = AsyncMock(
+            side_effect=lambda status: [identity] if status == "no_match" else []
+        )
+        store.upsert_identity = AsyncMock(return_value=identity)
+        store.update_status = AsyncMock()
+        store.log_reconciliation = AsyncMock()
+
+        reconciler = AsyncMock()
+        reconciler.search_musician_by_name = AsyncMock(return_value="Q1234")
+
+        await run_wikidata_stage(store, reconciler)
+
+        confidence = _confidence_for_logged_method(store, "name_search")
+        assert confidence is not None
+        assert 0.70 <= confidence <= 1.00
+
+
+class TestMusicBrainzStageConfidence:
+    @pytest.mark.asyncio
+    async def test_qid_bridge_logs_confidence(self):
+        identity = Identity(
+            id=1,
+            library_name="Stereolab",
+            wikidata_qid="Q483507",
+            reconciliation_status="reconciled",
+        )
+        store = AsyncMock()
+        store.get_identities_by_status = AsyncMock(return_value=[identity])
+        store.upsert_identity = AsyncMock(return_value=identity)
+        store.log_reconciliation = AsyncMock()
+
+        reconciler = AsyncMock()
+        reconciler.resolve_from_qids = AsyncMock(return_value={"Q483507": "mbid-abc"})
+        reconciler.resolve_from_names = AsyncMock(return_value={})
+
+        await run_musicbrainz_stage(store, reconciler)
+
+        confidence = _confidence_for_logged_method(store, "qid_bridge")
+        assert confidence is not None
+        assert 0.70 <= confidence <= 1.00
+
+    @pytest.mark.asyncio
+    async def test_name_match_logs_confidence(self):
+        identity = Identity(id=3, library_name="Cat Power", reconciliation_status="reconciled")
+        store = AsyncMock()
+        store.get_identities_by_status = AsyncMock(return_value=[identity])
+        store.upsert_identity = AsyncMock(return_value=identity)
+        store.log_reconciliation = AsyncMock()
+
+        reconciler = AsyncMock()
+        reconciler.resolve_from_qids = AsyncMock(return_value={})
+        reconciler.resolve_from_names = AsyncMock(return_value={"Cat Power": "mbid-xyz"})
+
+        await run_musicbrainz_stage(store, reconciler)
+
+        confidence = _confidence_for_logged_method(store, "name_match")
+        assert confidence is not None
+        assert 0.70 <= confidence <= 1.00

--- a/tests/unit/test_entity_store.py
+++ b/tests/unit/test_entity_store.py
@@ -6,6 +6,7 @@ import pytest
 
 from entity.store import (
     _GET_IDENTITY_LOWER_SQL,
+    _LATEST_LOG_BY_SOURCE_SQL,
     EntityStore,
 )
 
@@ -370,6 +371,19 @@ class TestLogReconciliation:
         call_args = mock_pg.execute.call_args
         assert "entity.reconciliation_log" in call_args[0][0]
         assert "INSERT" in call_args[0][0]
+
+
+class TestLatestLogBySourceSQL:
+    def test_includes_id_tiebreak_for_stable_distinct_on(self):
+        """Locks the LML#233 stable tie-break.
+
+        `DISTINCT ON (source)` picks an arbitrary row when two log rows for
+        the same source share a `created_at` (microsecond collisions are
+        possible on burst writes). Adding `id DESC` after `created_at DESC`
+        makes the pick deterministic: the latest-inserted row wins, so
+        back-to-back `bulk-resolve` calls return identical provenance.
+        """
+        assert "ORDER BY source, created_at DESC, id DESC" in _LATEST_LOG_BY_SOURCE_SQL
 
 
 class TestGetIdentitiesByStatus:


### PR DESCRIPTION
## Summary

`scripts/entity_resolution/__main__.py` wrote a flat `confidence=1.0` for every successful Discogs match regardless of `match.method`, and the Wikidata / MusicBrainz stages wrote no confidence at all. Under plan [§3.2.2](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md#322-lml-write-contract), Backend's writer rejects any `entity.reconciliation_log` row whose `(method, confidence)` pair falls outside the per-method band locked in [§3.4.1](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md#341-confidence-matrix-locked-before-any-backfill-writes) — so a `member_group` row (band 0.80–0.89) carrying `1.00` was silently dropped, capping every entity_resolution-sourced reconciliation campaign.

## Changes

- **`METHOD_CONFIDENCE` map + `confidence_for_method` helper** in `scripts/entity_resolution/__main__.py`; all three stages (`run_discogs_stage`, `run_wikidata_stage`, `run_musicbrainz_stage`) route through it.
  - §3.4.1 matrix methods land mid-band: `exact_match` 1.00, `name_variation` 0.92, `member_group` 0.85, `alias_match` 0.80.
  - Non-matrix methods the stages also emit (`name_preprocessing`, and the Wikidata/MusicBrainz `discogs_bridge` / `qid_bridge` / `name_search` / `name_match` legs) are scored inside the `name_variation` band — deterministic ID bridges at the high end (0.95), name lookups at the floor (0.90).
  - A `member_group`-band default (0.85) ensures an unforeseen method can never write an out-of-band row.
- **ORDER BY tie-break** (bundled per the issue): `_LATEST_LOG_BY_SOURCE_SQL` in `entity/store.py` gains `id DESC` after `created_at DESC`, so `DISTINCT ON (source)` resolves deterministically when two log rows share a `created_at` (microsecond collisions on burst writes). Without it, back-to-back `bulk-resolve` calls could return different `provenance[].method` / confidence for the same identity and spuriously invalidate the caller's cache.

## Testing

- **Unit** (`tests/unit/test_entity_resolution_confidence.py`): parametrizes over each Discogs cascade method and asserts the confidence handed to `log_reconciliation` falls within its §3.4.1 band; pins the `member_group ≠ 1.00` regression; covers the Wikidata / MusicBrainz bridge + search legs now emitting bounded, non-null confidence.
- **Unit** (`tests/unit/test_entity_store.py`): pins `_LATEST_LOG_BY_SOURCE_SQL` carrying the `created_at DESC, id DESC` stable tie-break.
- **Integration / `pg`** (`tests/integration/test_entity_resolution.py`): runs the real `EntityStore` write path against PostgreSQL and asserts persisted `(method, confidence)` rows land in their §3.4.1 bands (REAL-column round-trip, band assertions); proves identical-`created_at` rows resolve deterministically by `id`.
- Full fast suite: `3310 passed, 1 skipped`. Local `pg` suite: `20 passed, 7 skipped` (skips need the large discogs-cache fixture). `ruff check` + `ruff format --check` clean.

Closes #233
