### PR TITLE
Add trigram fuzzy-match fallback to DiscogsReconciler

### DIFF
--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -318,7 +318,17 @@ async def run_discogs_stage(
                     source="discogs",
                     external_id=str(match.discogs_artist_id),
                     method=match.method,
-                    confidence=confidence_for_method(match.method),
+                    # Equality/bridge stages keep #233's per-method §3.4.1 band
+                    # (member_group stays 0.85, not 1.0). The new trigram_fallback
+                    # row instead logs its RAW pg_trgm similarity — the borderline
+                    # audit value #215 exists to capture, safe to log because
+                    # trigram_fallback is reconciliation-internal and dropped
+                    # before Backend's wire contract.
+                    confidence=(
+                        match.confidence
+                        if match.method == "trigram_fallback"
+                        else confidence_for_method(match.method)
+                    ),
                 )
                 matched_count += 1
             else:

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -11,8 +11,15 @@ Resolves WXYC library artist names to Discogs artist IDs via a cascade:
    ``Y``). Each transform is a pure-Python derivation; the SQL path is the
    same equality cascade reused on the variant strings, so no new index or
    query plan is added.
+6. Trigram fuzzy fallback — for names that survive every equality stage, run a
+   pg_trgm ``similarity()`` query against ``release_artist`` and accept the best
+   candidate whose similarity clears a threshold (default 0.85). This is the
+   only stage that is not an equality lookup: it rescues typos, "th"/"the",
+   "&"/"and", and bracket-annotation residue that the symmetric normalization
+   pair did not already collapse, without picking up incidental token overlap.
+   See WXYC/library-metadata-lookup#215 (parent #211).
 
-Matching uses ``wxyc_identity_match_artist(col)`` on the column and
+Stages 1–5 use ``wxyc_identity_match_artist(col)`` on the column and
 ``to_identity_match_form(name)`` (aliased here as ``normalize_artist_name``)
 on the input — the symmetric pair specified by wiki
 ``plans/library-hook-canonicalization.md`` §3.3.5. The discogs-cache
@@ -22,6 +29,11 @@ collapse the same case + diacritic + leading-article + paren-suffix axes
 identically. The cache-side functional GIN trigram index rebuild over the
 new function expression is tracked separately; ``= ANY(...)`` exact lookups
 fall back to per-row evaluation in the meantime.
+
+Stage 6 (trigram) deliberately uses ``lower(f_unaccent(col))`` rather than
+``wxyc_identity_match_artist(col)`` so it hits the existing GIN trigram index
+from ``discogs-etl/schema/create_indexes.sql`` — the same expression used by
+``discogs/cache_service.py:search_artists_by_name``.
 
 Ported from semantic-index ``reconciliation.py``.
 """
@@ -69,6 +81,33 @@ SELECT DISTINCT wxyc_identity_match_artist(nv.name) AS name, nv.artist_id
 FROM artist_name_variation nv
 WHERE wxyc_identity_match_artist(nv.name) = ANY($1)\
 """
+
+# Stage 6: pg_trgm fuzzy fallback against ``release_artist``. Per-name (single
+# ``$1``) query — by the time the cascade reaches here the unmatched set is
+# small, and the ``%`` operator rides the existing functional GIN trigram index
+# on ``lower(f_unaccent(artist_name))``. Mirrors
+# ``discogs/cache_service.py:search_artists_by_name``; the ``extra = 0`` /
+# ``artist_id IS NOT NULL`` filters keep the candidate universe identical to the
+# Stage 1 exact match. Returns the single best candidate by descending
+# similarity; the caller applies the acceptance threshold in Python so it stays
+# trivially tunable (and so the score is available to record as confidence).
+_TRIGRAM_FALLBACK_SQL = """\
+SELECT ra.artist_id, ra.artist_name,
+       similarity(lower(f_unaccent(ra.artist_name)), lower(f_unaccent($1))) AS score
+FROM release_artist ra
+WHERE ra.extra = 0
+  AND ra.artist_id IS NOT NULL
+  AND lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($1))
+ORDER BY score DESC
+LIMIT 1\
+"""
+
+# Starting trigram acceptance threshold (WXYC/library-metadata-lookup#215).
+# pg_trgm ``similarity()`` is in [0, 1]; 0.85 catches typo / "th"-vs-"the" /
+# "&"-vs-"and" / bracket-annotation rescues without admitting incidental
+# substring overlap (e.g. "Hot 8" vs "Hot 8 Brass Band" scores well under it).
+# Tunable per the issue's validation plan via the ``trigram_threshold`` ctor arg.
+_DEFAULT_TRIGRAM_THRESHOLD = 0.85
 
 
 _BRACKET_ANNOTATION_RE = re.compile(r"\s*\[[^\]]*\]")
@@ -128,26 +167,46 @@ def _preprocessing_variants(canonical: str) -> list[str]:
 
 @dataclass
 class ReconciliationMatch:
-    """Result of a successful Discogs reconciliation."""
+    """Result of a successful Discogs reconciliation.
+
+    ``confidence`` is 1.0 for the equality stages (exact / member / alias /
+    name_variation / name_preprocessing) and the pg_trgm ``similarity()`` score
+    for ``trigram_fallback`` matches, so the borderline-match audit called for
+    in WXYC/library-metadata-lookup#215 can read the fuzzy score straight from
+    ``entity.reconciliation_log.confidence``.
+    """
 
     discogs_artist_id: int
-    method: str  # exact_match, member_group, alias_match, name_variation, name_preprocessing
+    # exact_match, member_group, alias_match, name_variation, name_preprocessing,
+    # trigram_fallback
+    method: str
+    confidence: float = 1.0
 
 
 class DiscogsReconciler:
     """Batch reconciler for WXYC library artist names against Discogs data.
 
     Uses a cascade of matching strategies: exact name match, member/group
-    lookup, then alias/name-variation fallback.
+    lookup, alias/name-variation fallback, name preprocessing, and finally a
+    pg_trgm trigram fuzzy fallback (WXYC/library-metadata-lookup#215).
 
     Args:
         pg: PgSource connected to the discogs-cache database.
         batch_size: Maximum names per SQL query (default 1000).
+        trigram_threshold: Minimum pg_trgm similarity [0, 1] for the Stage 6
+            fuzzy fallback to accept a candidate (default 0.85).
     """
 
-    def __init__(self, pg: PgSource, batch_size: int = 1000) -> None:
+    def __init__(
+        self,
+        pg: PgSource,
+        batch_size: int = 1000,
+        *,
+        trigram_threshold: float = _DEFAULT_TRIGRAM_THRESHOLD,
+    ) -> None:
         self._pg = pg
         self._batch_size = batch_size
+        self._trigram_threshold = trigram_threshold
 
     async def reconcile_batch(
         self,
@@ -157,8 +216,9 @@ class DiscogsReconciler:
     ) -> dict[str, ReconciliationMatch]:
         """Reconcile a list of artist names against Discogs data.
 
-        Runs through the cascade: exact match -> member/group -> alias -> name variation.
-        Only unmatched names cascade to the next strategy.
+        Runs through the cascade: exact match -> member/group -> alias -> name
+        variation -> name preprocessing -> trigram fuzzy fallback. Only
+        unmatched names cascade to the next strategy.
 
         Args:
             names: Canonical artist names from the WXYC library.
@@ -278,6 +338,26 @@ class DiscogsReconciler:
                     v: c for v, c in variant_to_canonical.items() if c not in results
                 }
 
+        # Stage 6: Trigram fuzzy fallback. Names that survived every equality
+        # stage get one pg_trgm ``similarity()`` query each against the original
+        # canonical (the SQL applies ``lower(f_unaccent(...))`` on the input
+        # side). The best candidate is accepted only if its score clears
+        # ``self._trigram_threshold``; the score rides along as the match
+        # confidence. Sorted iteration keeps diff-driven prod audits
+        # reproducible, matching the Stage 5 rationale above.
+        if unmatched:
+            for normalized_name in sorted(unmatched):
+                canonical = normalized_to_canonical[normalized_name]
+                if canonical in results:
+                    continue
+                hit = await self._trigram_match(canonical)
+                if hit is None:
+                    continue
+                artist_id, score = hit
+                results[canonical] = ReconciliationMatch(
+                    artist_id, "trigram_fallback", confidence=score
+                )
+
         return results
 
     async def _exact_match(self, normalized_names: list[str]) -> dict[str, int]:
@@ -311,6 +391,32 @@ class DiscogsReconciler:
         if not rows:
             return {}
         return {row["name"]: row["artist_id"] for row in rows if row["artist_id"] is not None}
+
+    async def _trigram_match(self, name: str) -> tuple[int, float] | None:
+        """Stage 6: pg_trgm fuzzy fallback against release_artist.
+
+        Runs ``_TRIGRAM_FALLBACK_SQL`` for a single canonical name and returns
+        ``(artist_id, score)`` for the highest-similarity candidate whose score
+        clears ``self._trigram_threshold``, else ``None``. The threshold is
+        applied here (not in SQL) so it stays trivially tunable and the score is
+        available to record as the match confidence.
+
+        Args:
+            name: Original canonical artist name. The SQL applies
+                ``lower(f_unaccent(...))`` on this input side, mirroring
+                ``discogs/cache_service.py:search_artists_by_name``.
+        """
+        rows = await self._pg.fetchall(_TRIGRAM_FALLBACK_SQL, name)
+        if not rows:
+            return None
+        top = rows[0]
+        artist_id = top["artist_id"]
+        if artist_id is None:
+            return None
+        score = float(top["score"])
+        if score < self._trigram_threshold:
+            return None
+        return artist_id, score
 
     def _batches(self, items: list[str]) -> list[list[str]]:
         """Split items into batches of self._batch_size."""

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -91,6 +91,12 @@ WHERE wxyc_identity_match_artist(nv.name) = ANY($1)\
 # Stage 1 exact match. Returns the single best candidate by descending
 # similarity; the caller applies the acceptance threshold in Python so it stays
 # trivially tunable (and so the score is available to record as confidence).
+# Note: the ``%`` operator pre-filters to rows above pg_trgm's session
+# ``similarity_threshold`` (``show_limit()``, default 0.3) before the Python
+# ``trigram_threshold`` is applied, so configuring a ``trigram_threshold`` below
+# that floor would silently drop candidates in the gap. The shipped default
+# (0.85) and the issue's tuning band sit well above 0.3, so this never bites in
+# practice.
 _TRIGRAM_FALLBACK_SQL = """\
 SELECT ra.artist_id, ra.artist_name,
        similarity(lower(f_unaccent(ra.artist_name)), lower(f_unaccent($1))) AS score

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -175,7 +175,14 @@ class TestDiscogsReconciliationIntegration:
         assert len(results) >= 1, f"Expected at least 1 match, got {len(results)}"
         for _name, match in results.items():
             assert match.discogs_artist_id > 0
-            assert match.method in ("exact_match", "member_group", "alias_match", "name_variation")
+            assert match.method in (
+                "exact_match",
+                "member_group",
+                "alias_match",
+                "name_variation",
+                "name_preprocessing",
+                "trigram_fallback",
+            )
 
 
 @pytest.mark.pg
@@ -335,6 +342,127 @@ class TestDiscogsReconciliationSQLSmoke:
             f"Missing wxyc_identity_match_* functions: {sorted(missing)}. "
             "Re-run alembic 0004 from WXYC/discogs-etl against this cache."
         )
+
+
+@pytest.mark.pg
+class TestTrigramFallbackSQLIntegration:
+    """Exercise the Stage 6 ``_TRIGRAM_FALLBACK_SQL`` against real pg_trgm.
+
+    The full ``reconcile_batch`` cascade needs ``wxyc_identity_match_artist``
+    (alembic 0004, absent on CI's plain ``postgres:16-alpine``), so this class
+    drives the Stage 6 method ``_trigram_match`` directly — it only depends on
+    ``pg_trgm`` + ``f_unaccent``, both provisionable from contrib on the CI
+    service container. See WXYC/library-metadata-lookup#215 (parent #211).
+
+    Data safety: ``release_artist`` is a real, multi-million-row table on a live
+    discogs-cache. This fixture **skips** if that table already exists rather
+    than stubbing over it; it only creates (and on teardown drops) the table
+    when absent, so it can never clobber real cache data. Same posture as
+    ``TestDiscogsReconciliationSQLSmoke``'s ``created_tables`` guard.
+    """
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def set_up_trigram_fixture(self, pg_pool):
+        async with pg_pool.acquire() as conn:
+            try:
+                await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+                await conn.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+            except Exception as e:  # locked-down Postgres without contrib
+                pytest.skip(f"pg_trgm/unaccent extensions unavailable: {e}")
+
+            release_artist_exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = current_schema() AND table_name = 'release_artist')"
+            )
+            if release_artist_exists:
+                pytest.skip(
+                    "release_artist already present -- refusing to stub over real "
+                    "discogs-cache data (run the cascade test against a live cache instead)"
+                )
+
+            # IMMUTABLE f_unaccent wrapper mirroring discogs-cache, so the
+            # trigram operator can ride a functional GIN index. Idempotent.
+            await conn.execute(
+                "CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text "
+                "AS $$ SELECT unaccent('unaccent', $1) $$ "
+                "LANGUAGE sql IMMUTABLE PARALLEL SAFE"
+            )
+            await conn.execute(
+                "CREATE TABLE release_artist ("
+                "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0)"
+            )
+            await conn.executemany(
+                "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "
+                "VALUES ($1, $2, $3, $4)",
+                [
+                    (1, 4242, "Stereolab", 0),
+                    (2, 5499521, "Nilufer Yanya", 0),  # diacritic-free cache form
+                    (3, 7777, "Hot 8 Brass Band", 0),
+                    # ``extra = 1`` credit that must be invisible to the fallback,
+                    # mirroring the Stage 1 ``extra = 0`` filter.
+                    (4, 9999, "Stereolab", 1),
+                ],
+            )
+        try:
+            yield
+        finally:
+            async with pg_pool.acquire() as conn:
+                await conn.execute("DROP TABLE IF EXISTS release_artist")
+
+    @pytest.mark.asyncio
+    async def test_diacritic_variant_clears_default_threshold(self, pg_source):
+        """``Nilüfer Yanya`` (umlaut) matches the diacritic-free cache row at 1.0.
+
+        ``f_unaccent`` collapses both sides to ``nilufer yanya`` → similarity 1.0,
+        well over the 0.85 floor; proves the operator + f_unaccent path end to end.
+        """
+        reconciler = DiscogsReconciler(pg_source)
+        hit = await reconciler._trigram_match("Nilüfer Yanya")
+        assert hit is not None
+        artist_id, score = hit
+        assert artist_id == 5499521
+        assert score >= 0.85
+
+    @pytest.mark.asyncio
+    async def test_sub_unit_fuzzy_match_resolves_when_threshold_lowered(self, pg_source):
+        """A genuine sub-1.0 fuzzy hit (typo ``Stereolabs``) resolves once the
+        threshold is set below its pg_trgm score — proving the gate is the
+        threshold, not an exact-string coincidence."""
+        reconciler = DiscogsReconciler(pg_source, trigram_threshold=0.4)
+        hit = await reconciler._trigram_match("Stereolabs")  # trailing 's'
+        assert hit is not None
+        artist_id, score = hit
+        assert artist_id == 4242
+        assert 0.4 <= score < 1.0
+
+    @pytest.mark.asyncio
+    async def test_substring_near_miss_rejected_at_default_threshold(self, pg_source):
+        """``Hot 8`` must NOT match ``Hot 8 Brass Band`` — incidental substring
+        overlap scores well under the 0.85 floor (the issue's motivating case)."""
+        reconciler = DiscogsReconciler(pg_source)
+        hit = await reconciler._trigram_match("Hot 8")
+        assert hit is None
+
+    @pytest.mark.asyncio
+    async def test_extra_credit_excluded_from_fallback(self, pg_source):
+        """The ``extra = 1`` Stereolab row (artist_id 9999) is filtered out, so the
+        only Stereolab candidate is the primary ``extra = 0`` row (4242)."""
+        reconciler = DiscogsReconciler(pg_source)
+        hit = await reconciler._trigram_match("Stereolab")
+        assert hit is not None
+        artist_id, _score = hit
+        assert artist_id == 4242
+
+    @pytest.mark.asyncio
+    async def test_raw_sql_score_in_unit_interval(self, pg_source):
+        """``_TRIGRAM_FALLBACK_SQL`` parses, executes, and returns a float
+        similarity in [0, 1] for a fuzzy query."""
+        from scripts.entity_resolution.discogs import _TRIGRAM_FALLBACK_SQL
+
+        rows = await pg_source.fetchall(_TRIGRAM_FALLBACK_SQL, "Stereolab")
+        assert rows, "expected at least the Stereolab primary-credit candidate"
+        score = float(rows[0]["score"])
+        assert 0.0 <= score <= 1.0
 
 
 @pytest.mark.pg

--- a/tests/unit/test_discogs_reconciliation.py
+++ b/tests/unit/test_discogs_reconciliation.py
@@ -462,3 +462,120 @@ class TestNormalizationSymmetryGuard:
             "See WXYC/library-metadata-lookup#280."
         )
         assert reconciler_module.normalize_artist_name is not to_match_form
+
+
+class TestTrigramFallbackStage:
+    """Stage 6 trigram fuzzy fallback (WXYC/library-metadata-lookup#215).
+
+    When a canonical survives every equality stage (1 exact, 2 member, 3 alias,
+    4 name_variation) and the Stage 5 preprocessing cascade, a pg_trgm
+    ``similarity()`` query against ``release_artist`` rescues near-misses
+    (typos, "th"/"the", "&"/"and", bracket annotations) whose similarity clears
+    the 0.85 threshold. Matches below the floor are rejected so incidental
+    token overlap (the issue's ``"Hot 8"`` vs ``"Hot 8 Brass Band"`` case) does
+    not leak a false positive.
+
+    These tests mock ``fetchall`` with the trigram row(s) the SQL would return,
+    so they pin the stage's ordering, threshold comparison, method label, and
+    canonical-name passthrough without a live Postgres. The real SQL is
+    exercised against pg_trgm in
+    ``tests/integration/test_entity_resolution.py::TestTrigramFallbackSQLIntegration``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_match_above_threshold_resolves(self, reconciler, mock_pg):
+        """A 0.88-similarity rescue clears the 0.85 floor and resolves as trigram_fallback."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # Stage 1 exact — miss
+                [],  # Stage 2 member — miss
+                [],  # Stage 3 alias — miss
+                [],  # Stage 4 name_variation — miss
+                # Stage 5 yields no variants for this name, so no inner SQL runs;
+                # Stage 6 trigram returns the best candidate at 0.88.
+                [{"artist_id": 321, "artist_name": "stereolab", "score": 0.88}],
+            ]
+        )
+        results = await reconciler.reconcile_batch(["Sterolab"])  # typo: missing 'e'
+        assert "Sterolab" in results
+        assert results["Sterolab"].discogs_artist_id == 321
+        assert results["Sterolab"].method == "trigram_fallback"
+        # The similarity score is recorded as the match confidence so the
+        # borderline-audit (issue §Validation) can query it from reconciliation_log.
+        assert results["Sterolab"].confidence == pytest.approx(0.88)
+
+    @pytest.mark.asyncio
+    async def test_near_miss_below_threshold_rejected(self, reconciler, mock_pg):
+        """A 0.80 best candidate is below the 0.85 floor and must NOT resolve.
+
+        ``"Hot 8"`` vs ``"Hot 8 Brass Band"`` is the issue's motivating
+        false-positive: a short substring with incidental trigram overlap.
+        """
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[
+                [],  # Stage 1
+                [],  # Stage 2
+                [],  # Stage 3
+                [],  # Stage 4
+                [{"artist_id": 999, "artist_name": "hot 8 brass band", "score": 0.80}],
+            ]
+        )
+        results = await reconciler.reconcile_batch(["Hot 8"])
+        assert results == {}
+
+    @pytest.mark.asyncio
+    async def test_exact_threshold_boundary_matches(self, reconciler, mock_pg):
+        """Similarity exactly at 0.85 matches — the comparison is ``>=``, not ``>``."""
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[[], [], [], [], [{"artist_id": 77, "artist_name": "yy", "score": 0.85}]]
+        )
+        results = await reconciler.reconcile_batch(["Xx"])
+        assert "Xx" in results
+        assert results["Xx"].discogs_artist_id == 77
+        assert results["Xx"].method == "trigram_fallback"
+
+    @pytest.mark.asyncio
+    async def test_empty_trigram_result_keeps_no_match(self, reconciler, mock_pg):
+        """No ``%`` candidate at all (empty rowset) leaves the canonical unresolved."""
+        mock_pg.fetchall = AsyncMock(return_value=[])
+        results = await reconciler.reconcile_batch(["Sterolab"])
+        assert results == {}
+
+    @pytest.mark.asyncio
+    async def test_trigram_not_run_when_earlier_stage_matches(self, reconciler, mock_pg):
+        """An exact-match hit short-circuits the cascade — no trigram SQL issued."""
+        mock_pg.fetchall = AsyncMock(return_value=[{"artist_name": "stereolab", "artist_id": 99}])
+        await reconciler.reconcile_batch(["Stereolab"])
+        # Exactly one SQL call: Stage 1. The trigram stage never runs.
+        assert mock_pg.fetchall.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_threshold_is_configurable(self, mock_pg):
+        """A reconciler built with a higher threshold rejects a sub-threshold rescue."""
+        reconciler = DiscogsReconciler(mock_pg, trigram_threshold=0.90)
+        mock_pg.fetchall = AsyncMock(
+            side_effect=[[], [], [], [], [{"artist_id": 5, "artist_name": "yy", "score": 0.88}]]
+        )
+        results = await reconciler.reconcile_batch(["Yy"])
+        assert results == {}  # 0.88 < 0.90
+
+    @pytest.mark.asyncio
+    async def test_default_threshold_is_085(self, mock_pg):
+        """Ship default is 0.85 per the issue rationale."""
+        assert DiscogsReconciler(mock_pg)._trigram_threshold == pytest.approx(0.85)
+
+    @pytest.mark.asyncio
+    async def test_trigram_sql_receives_canonical_and_uses_similarity(self, reconciler, mock_pg):
+        """The trigram query is issued with the original canonical (SQL applies
+        ``lower(f_unaccent(...))``) and uses the ``similarity()`` function plus
+        the ``%`` trigram operator so the existing GIN index applies."""
+        mock_pg.fetchall = AsyncMock(side_effect=[[], [], [], [], []])
+        await reconciler.reconcile_batch(["Sterolab"])
+        last_call = mock_pg.fetchall.await_args_list[-1].args
+        sql_arg, name_arg = last_call
+        assert "similarity(" in sql_arg, "Trigram stage must compute pg_trgm similarity()."
+        assert " % " in sql_arg, "Trigram stage must use the % operator to hit the GIN index."
+        assert name_arg == "Sterolab", (
+            "Trigram stage must pass the original canonical name; the SQL applies "
+            "lower(f_unaccent(...)) on the input side, mirroring search_artists_by_name."
+        )


### PR DESCRIPTION
Closes #215 (sub-issue of #211).

## Summary

Adds **Stage 6** to the `DiscogsReconciler` cascade: a pg_trgm fuzzy fallback for canonical artist names that survive every equality stage (1 exact, 2 member/group, 3 alias, 4 name_variation) and the Stage 5 preprocessing cascade.

- Per-name `similarity()` query against `release_artist`, using `lower(f_unaccent(...))` so it rides the existing functional GIN trigram index from discogs-etl's `create_indexes.sql` — the same expression `discogs/cache_service.py:search_artists_by_name` already uses.
- Keeps the `extra = 0` / `artist_id IS NOT NULL` filters so the candidate universe is identical to the Stage 1 exact match.
- Ships at the issue's **0.85** threshold. The threshold is applied in Python (not SQL) so it stays trivially tunable via a new `trigram_threshold` constructor arg.
- `ReconciliationMatch` gains a `confidence` field — `1.0` for the equality stages, the trigram similarity score for `trigram_fallback` — and `run_discogs_stage` now logs `match.confidence`, so the borderline-match audit the issue calls for can read the fuzzy score straight from `entity.reconciliation_log.confidence`.

## Borderline-case audit (the manual follow-up)

The issue's validation plan ("ship at 0.85, audit ~50 borderline matches in the 0.85–0.92 band, raise to 0.88 if false-positive rate >5%, consider 0.82 if <2% with rescues remaining") requires production data that only exists once the stage has run a reconciliation pass. The plumbing is now in place to do that audit without code changes:

```sql
SELECT i.library_name, l.external_id AS discogs_artist_id, l.confidence
FROM entity.reconciliation_log l
JOIN entity.identity i ON i.id = l.identity_id
WHERE l.source = 'discogs' AND l.method = 'trigram_fallback'
  AND l.confidence BETWEEN 0.85 AND 0.92
ORDER BY l.confidence;
```

Tuning is a one-line change to `_DEFAULT_TRIGRAM_THRESHOLD` (or per-run via the constructor arg); no schema or query change needed.

## Testing

- **Unit** (`tests/unit/test_discogs_reconciliation.py::TestTrigramFallbackStage`, 8 tests): stage ordering, the `>=0.85` boundary (a 0.88 rescue resolves; a 0.80 near-miss like `"Hot 8"` vs `"Hot 8 Brass Band"` is rejected), the `trigram_fallback` method label + recorded confidence, configurable/default threshold, no-SQL-when-an-earlier-stage-hits, and canonical-name passthrough (SQL receives the original name, uses `similarity()` + `%`).
- **Integration** (`tests/integration/test_entity_resolution.py::TestTrigramFallbackSQLIntegration`, 5 `pg`-marked tests): exercises the real `_TRIGRAM_FALLBACK_SQL` against pg_trgm — diacritic match at 1.0, a genuine sub-1.0 typo rescue when the threshold is lowered, the substring near-miss rejection at 0.85, the `extra = 1` credit exclusion, and a raw-SQL score-in-[0,1] smoke. The fixture provisions `pg_trgm` + an `f_unaccent` wrapper + a stub `release_artist`, and **skips rather than stubbing** when a real `release_artist` is already present so it can never clobber live discogs-cache data.

Run locally:
- Default suite (no Postgres): `3305 passed, 1 skipped` via `uv run --no-sync python -m pytest`.
- PG suite against a throwaway Postgres 16 on :5433: the new integration class is `5 passed`; the wider `test_entity_resolution.py -m pg` run is `20 passed, 7 skipped` (the 7 skips are the `wxyc_identity_match_artist`-gated smoke tests + the empty-`release_artist` cascade test, unchanged).

`ruff check` and `ruff format --check` are clean.