### PR TITLE
fix(#684): enrich found_on_compilation results with the validated release artwork

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -2906,6 +2906,7 @@ async def fetch_artwork_for_items(
     song: str | None = None,
     album: str | None = None,
     allow_release_resolution_fallback: bool = True,
+    found_on_compilation: bool = False,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Fetch artwork for multiple library items in parallel.
 
@@ -2921,6 +2922,17 @@ async def fetch_artwork_for_items(
     ``album`` (the request-level typed album, when present) only gates the A2
     soft-confidence on a row-less carried bind (LML#629): a no-album query's
     row-less release binds at ``ROWLESS_NO_ALBUM_CONFIDENCE`` rather than 1.0.
+
+    ``found_on_compilation`` (LML#684): when the result came from
+    ``search_compilations_for_track`` (TRACK_ON_COMPILATION), an in-library row
+    carries an already-validated ``ResolvedRelease`` on the seam. The artist-floor
+    re-search systematically rejects *non*-Various-Artists trio / collaboration
+    credits (the row is filed under one member, e.g. "Bill Orcutt", while Discogs
+    credits the full trio), leaving the result with no artwork. When the floor
+    rejects every candidate and a release is carried, that validated release is
+    trust-bound for artwork — independent of ``lml_resolve_compilation_release``,
+    since binding an already-carried release costs no extra Discogs fan-out
+    (unlike the flag-gated lazy ``resolve_release_for_track`` fallback below).
     """
     if not discogs_service:
         return [(item, None) for item in items]
@@ -3028,6 +3040,24 @@ async def fetch_artwork_for_items(
                 title_fn=lambda r: r.album,
             )
             if result is None:
+                # LML#684: a found-on-compilation in-library row carries a
+                # release the search strategy already resolved AND validated this
+                # same request (via validate_release_for_track in
+                # search_compilations_for_track). The artist-floor re-search above
+                # just rejected every candidate — the systematic failure for a
+                # *non*-Various-Artists trio / collaboration credit (the row is
+                # filed under one member, e.g. "Bill Orcutt", but Discogs credits
+                # the full trio on "Orcutt Shelley Miller", release 34993109).
+                # Trust-bind the carried, validated release for artwork rather than
+                # dropping it. Independent of lml_resolve_compilation_release:
+                # binding an already-carried release costs no extra Discogs fan-out
+                # (only a cached get_release), unlike the lazy fallback below. The
+                # row-less (id==0) carry-through is handled by the flag-gated
+                # bind_carried branch at the top, so it is excluded here.
+                if found_on_compilation and resolved is not None and item.id != ROWLESS_LIBRARY_ID:
+                    return await _bind_resolved_release(
+                        discogs_service, resolved, item, album=request_album
+                    )
                 # Lazy release-resolution fallback (LML#604): the artist floor
                 # rejected every candidate — the systematic failure for a V/A
                 # compilation row filed under the track artist. When the flag is
@@ -3115,6 +3145,7 @@ async def enrich_artwork_results(
     bandcamp: BandcampClient | None = None,
     entity_store: EntityStore | None = None,
     discogs_cache_pg: PgSource | None = None,
+    found_on_compilation: bool = False,
 ) -> list[tuple[LibraryItem, DiscogsSearchResult | None]]:
     """Enrich artwork results with release year, artist details, and streaming links.
 
@@ -3325,6 +3356,16 @@ async def enrich_artwork_results(
             # the feature exists to avoid. The release_id was validated to carry the
             # track, and item.title IS that release's title, so trust the binding.
             or (item.id == ROWLESS_LIBRARY_ID and artwork is not None and artwork.release_id > 0)
+            # LML#684: an in-library found_on_compilation row is the analog of the
+            # row-less carry-through above — TRACK_ON_COMPILATION located the track
+            # on a release that IS shelved, and validate_release_for_track confirmed
+            # the track sits on it. Its release title ("Orcutt-Shelley-Miller")
+            # legitimately differs from the typed album (the trio/collab name
+            # "Orcutt Shelley Miller", which scores 61.9 here), so the sibling-leak
+            # gate would clobber the validated release_id to the release_id=0
+            # sentinel — the silent-no-artwork bug this fix exists to kill. The row
+            # was track-validated, so the leak concern doesn't apply.
+            or (found_on_compilation and artwork is not None and artwork.release_id > 0)
         )
 
         # LML#487: the library row is "acceptable" (a real match for the
@@ -4169,6 +4210,7 @@ async def perform_lookup(
                 song=parsed.song,
                 album=parsed.album,
                 allow_release_resolution_fallback=allow_release_resolution_fallback,
+                found_on_compilation=found_on_compilation,
             )
 
     # The generated LookupRequest models these as bool | None (api.yaml
@@ -4196,6 +4238,7 @@ async def perform_lookup(
                 bandcamp=bandcamp,
                 entity_store=entity_store,
                 discogs_cache_pg=discogs_cache_pg,
+                found_on_compilation=found_on_compilation,
             )
 
     # Project the request-side flags and result-quality signals onto the

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -182,6 +182,11 @@ SEED_ITEMS = [
     (58611, "Disco Not Disco, vol. 2", "Various Artists - Rock - D", "V", 3, 2, "Rock", "CD"),
     # Non-V/A with the same shape — regression guard so the gate stays narrow.
     (60001, "Live Sessions, vol. 2", "Some Band", "S", 4, 2, "Rock", "CD"),
+    # Trio / collaboration filed under one member (LML#684). The Discogs release
+    # crediting the full trio fails the artist floor in the Step-4 artwork
+    # re-search, so the found_on_compilation result must trust-bind the carried
+    # (already-validated) release instead of dropping its artwork.
+    (70001, "Orcutt-Shelley-Miller", "Bill Orcutt", "OR", 1, 1, "Jazz", "Vinyl"),
 ]
 
 

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -620,6 +620,108 @@ class TestVACompilationTrackSearch:
         assert "Now That's What I Call Music 47" in titles
 
 
+class TestFoundOnCompilationArtwork:
+    """LML#684: a found_on_compilation result must carry the matched Discogs
+    release's artwork even when the Step-4 artist-floor re-search rejects the
+    candidate — the systematic failure for a non-Various-Artists trio /
+    collaboration credit.
+
+    Repro (prod, 2026-06-23): ``Orcutt Shelley Miller`` / ``Orcutt Shelley
+    Miller`` / ``A Star Is Born``. The library row is filed under "Bill Orcutt"
+    (release 34993109 credits the full trio), so the floor re-search can't clear
+    it. The release was already validated during the compilation search, so its
+    artwork must be trust-bound rather than dropped (release_id=0 / empty url).
+    """
+
+    @pytest.mark.asyncio
+    async def test_trio_compilation_result_carries_release_artwork(self, library_db):
+        """Seed row (70001, "Orcutt-Shelley-Miller", "Bill Orcutt"). The
+        album-title fallback in search_compilations_for_track locates it via
+        release 34993109; the floor re-search rejects the trio credit; the
+        carried, validated release's artwork is bound."""
+        from wxyc_fastapi.observability import init_cache_stats
+
+        from discogs.service import DiscogsService
+        from lookup.models import LookupRequest
+        from lookup.orchestrator import perform_lookup
+        from tests.conftest import make_lml_telemetry
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(spec=DiscogsService)
+        mock_service.cache_service = None
+
+        # The two artist-scoped probes find nothing — no single canonical entity
+        # exists for the trio (the motivating shape for the album-title fallback).
+        mock_service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="A Star Is Born", artist="Orcutt Shelley Miller", releases=[], total=0
+            )
+        )
+        # The album-title fallback surfaces the trio release. Discogs does NOT
+        # classify it as a compilation; its credit is the full trio.
+        mock_service.search_releases_by_album_title = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="",
+                artist="",
+                releases=[
+                    ReleaseInfo(
+                        album="Orcutt-Shelley-Miller",
+                        artist="Bill Orcutt, Chris Corsano, Sarah Louise",
+                        release_id=34993109,
+                        release_url="https://www.discogs.com/release/34993109",
+                        is_compilation=False,
+                    ),
+                ],
+                total=1,
+                cached=False,
+            )
+        )
+        # The track validates on the trio release.
+        mock_service.validate_track_on_release = AsyncMock(return_value=True)
+        # Step-4 artist-floor re-search returns nothing usable -> None.
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        # The carried release's own cover (trust-bind path).
+        mock_service.get_release = AsyncMock(
+            return_value=ReleaseMetadataResponse(
+                release_id=34993109,
+                title="Orcutt-Shelley-Miller",
+                artist="Bill Orcutt, Chris Corsano, Sarah Louise",
+                release_url="https://www.discogs.com/release/34993109",
+                artwork_url="https://i.discogs.com/osm.jpg",
+            )
+        )
+
+        request = LookupRequest(
+            artist="Orcutt Shelley Miller",
+            album="Orcutt Shelley Miller",
+            song="A Star Is Born",
+            raw_message="Orcutt Shelley Miller - Orcutt Shelley Miller - A Star Is Born",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            response = await perform_lookup(
+                request,
+                library_db,
+                mock_service,
+                make_lml_telemetry(),
+            )
+
+        assert response.found_on_compilation is True, (
+            "Trio compilation hit should set found_on_compilation=True"
+        )
+        assert len(response.results) >= 1
+        top = response.results[0]
+        assert top.library_item.title == "Orcutt-Shelley-Miller"
+        assert top.artwork is not None, "found_on_compilation result must carry artwork (#684)"
+        assert top.artwork.release_id == 34993109
+        assert top.artwork.artwork_url == "https://i.discogs.com/osm.jpg"
+
+
 class TestTrackOnArtistAlbumAndCompilation:
     """Test that tracks on both an artist album and a compilation return both results.
 

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -2148,6 +2148,128 @@ class TestFetchArtworkRowlessBindKillSwitch:
         svc.get_release.assert_awaited()
 
 
+class TestFetchArtworkFoundOnCompilation:
+    """LML#684: a ``found_on_compilation`` in-library result carries a validated
+    ``ResolvedRelease`` on the seam. When the artist-floor re-search rejects the
+    candidate — the systematic failure for a *non*-Various-Artists trio /
+    collaboration credit (e.g. library row filed under "Bill Orcutt" vs the
+    Discogs trio credit on "Orcutt Shelley Miller", release 34993109) — the
+    carried release must still surface its artwork.
+
+    The carried release was already validated by ``validate_release_for_track``
+    during ``search_compilations_for_track``, so trust-binding it costs no extra
+    Discogs fan-out (unlike the ``lml_resolve_compilation_release`` lazy
+    ``resolve_release_for_track`` fallback). The bind is therefore independent of
+    that flag — these tests run with it at its default (off).
+    """
+
+    def _trio_inputs(self):
+        """An in-library row filed under one trio member, its carried (validated)
+        release, and a service whose floor re-search finds nothing (so an
+        unbound result leaves artwork ``None``)."""
+        item = make_library_item(id=42, artist="Bill Orcutt", title="Orcutt-Shelley-Miller")
+        discogs_titles = {
+            42: ResolvedRelease(
+                release_id=34993109,
+                release_url="https://www.discogs.com/release/34993109",
+                is_compilation=False,
+                album_title="Orcutt Shelley Miller",
+            )
+        }
+        svc = AsyncMock()
+        svc.cache_service = None
+        # Floor re-search can't clear the trio credit -> find_best_typed_match -> None.
+        svc.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        svc.get_release = AsyncMock(
+            return_value=ReleaseMetadataResponse(
+                release_id=34993109,
+                title="Orcutt Shelley Miller",
+                artist="Bill Orcutt, Chris Corsano, Sarah Louise",
+                release_url="https://www.discogs.com/release/34993109",
+                artwork_url="https://i.discogs.com/osm.jpg",
+            )
+        )
+        return item, discogs_titles, svc
+
+    @pytest.mark.asyncio
+    async def test_binds_carried_release_when_floor_rejects(self):
+        """found_on_compilation=True + carried release + floor rejection ->
+        trust-bind the carried release's artwork (the #684 acceptance criterion)."""
+        item, discogs_titles, svc = self._trio_inputs()
+
+        results = await fetch_artwork_for_items(
+            [item],
+            svc,
+            discogs_titles=discogs_titles,
+            song="A Star Is Born",
+            album="Orcutt Shelley Miller",
+            found_on_compilation=True,
+        )
+
+        bound = results[0][1]
+        assert bound is not None
+        assert bound.release_id == 34993109
+        assert bound.release_url == "https://www.discogs.com/release/34993109"
+        assert bound.artwork_url == "https://i.discogs.com/osm.jpg"
+        # Art comes from the carried release's own cover via _resolve_fallback_artwork.
+        svc.get_release.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_not_found_on_compilation_leaves_floor_rejection_unbound(self):
+        """Scope guard: the same inputs WITHOUT found_on_compilation keep the
+        pre-#684 behavior — a floor-rejected row with a carried release stays
+        unbound (the flag-off floor path is unchanged for non-compilation hits)."""
+        item, discogs_titles, svc = self._trio_inputs()
+
+        results = await fetch_artwork_for_items(
+            [item],
+            svc,
+            discogs_titles=discogs_titles,
+            song="A Star Is Born",
+            album="Orcutt Shelley Miller",
+            found_on_compilation=False,
+        )
+
+        assert results[0][1] is None
+        svc.get_release.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_floor_match_preferred_over_carried_bind(self):
+        """When the floor re-search DOES clear (the Various-Artists case that
+        already works), the floor result is used as before — the #684 bind is a
+        fallback for the rejection case only, not a replacement for the floor."""
+        item, discogs_titles, svc = self._trio_inputs()
+        # This time the floor search returns a clean, matching candidate.
+        svc.search = AsyncMock(
+            return_value=DiscogsSearchResponse(
+                results=[
+                    make_discogs_result(
+                        release_id=111,
+                        album="Orcutt Shelley Miller",
+                        artist="Bill Orcutt",
+                        artwork_url="https://i.discogs.com/floor.jpg",
+                    )
+                ]
+            )
+        )
+
+        results = await fetch_artwork_for_items(
+            [item],
+            svc,
+            discogs_titles=discogs_titles,
+            song="A Star Is Born",
+            album="Orcutt Shelley Miller",
+            found_on_compilation=True,
+        )
+
+        bound = results[0][1]
+        assert bound is not None
+        assert bound.release_id == 111
+        assert bound.artwork_url == "https://i.discogs.com/floor.jpg"
+        # Floor cleared, so the carried-release trust-bind never fired.
+        svc.get_release.assert_not_awaited()
+
+
 class TestFetchArtworkFallback:
     """Tests for artwork fallback to artist/label images."""
 

--- a/tests/unit/test_rowless_enrichment.py
+++ b/tests/unit/test_rowless_enrichment.py
@@ -233,3 +233,50 @@ class TestRowlessEnrichmentSplit:
         assert enriched.full_release_date is None
         assert enriched.tracklist is None
         assert enriched.artist_image_url is None
+
+    @pytest.mark.asyncio
+    async def test_found_on_compilation_rowbacked_mismatch_keeps_release(self):
+        """LML#684: a row-*backed* found_on_compilation result whose release title
+        differs from the typed album must KEEP its validated release identity (and
+        album-derived payload) — NOT collapse to the BS#1185 release_id=0 sentinel.
+
+        TRACK_ON_COMPILATION located the track on a shelved release and
+        validate_release_for_track confirmed it; the typed album (a trio / collab
+        or compilation-series name) legitimately differs from the release title, so
+        the LML#487 sibling-leak gate must be bypassed for these — the same logic
+        as the row-less carry-through bypass above, just for an in-library row.
+
+        Identical inputs to ``test_rowbacked_album_mismatch_still_suppresses_album_payload``
+        (a real ``id`` + an album that mismatches the release title); only
+        ``found_on_compilation=True`` is added — so this is its mirror image, and
+        together they pin that the exemption keys exactly on that flag.
+        """
+        item = make_library_item(id=999, artist=ARTIST, title=RELEASE_TITLE)
+        artwork = make_discogs_result(release_id=RELEASE_ID, artist=ARTIST, album=RELEASE_TITLE)
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = _resolved_release()
+        discogs_service.get_artist_details.return_value = _artist_details()
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            song=SONG,
+            album=MISMATCHED_ALBUM,
+            artist=ARTIST,
+            extended=True,
+            found_on_compilation=True,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        # The validated release identity survives — not the sentinel.
+        assert enriched.release_id == RELEASE_ID
+        assert enriched.release_url != ""
+        # Album-derived payload populates from the validated release.
+        assert enriched.genres == ["Rock"]
+        assert enriched.styles == ["Folk", "Acoustic"]
+        assert enriched.label == "Drag City"
+        assert enriched.full_release_date == "2015-01-27"
+        assert enriched.tracklist is not None
+        assert enriched.release_year == 2015


### PR DESCRIPTION
Closes #684

## Problem

A `found_on_compilation` `/lookup` result (TRACK_ON_COMPILATION pins a track to a *shelved* release via the album-title fallback) returned an empty artwork block — `artwork.release_id = 0`, `artwork_url = ""` — even though the matched Discogs release carries cover art. Reproducer: `Orcutt Shelley Miller` / `Orcutt Shelley Miller` / `A Star Is Born`, which resolves to release 34993109 but surfaced with no artwork.

## Root cause (two layers)

1. **`fetch_artwork_for_items`** discarded the validated `ResolvedRelease` carried on the `discogs_titles` seam when `lml_resolve_compilation_release` is off (its default), running the Step-4 artist-floor re-search instead. That re-search systematically fails for a *non*-Various-Artists trio / collaboration credit: the library row is filed under one member (`Bill Orcutt`) while Discogs credits the full trio, so the 80/80 floor never clears.
2. Even once artwork is bound, **`enrich_artwork_results`**' LML#477/#487 title gate compares the typed album to the library row title (`Orcutt Shelley Miller` vs `Orcutt-Shelley-Miller` scores 61.9, below the 80 floor) and clobbers the validated `release_id` down to the BS#1185 `release_id=0` sentinel.

## Fix

Thread `found_on_compilation` into both functions:

- `fetch_artwork_for_items` now trust-binds the carried, **already-validated** release when the floor rejects every candidate. This is independent of `lml_resolve_compilation_release` — binding a release already carried on the seam costs no extra Discogs fan-out (only a cached `get_release`), unlike the flag-gated lazy `resolve_release_for_track` fallback. VA compilations whose floor search already succeeds are unchanged; the bind is a fallback for the rejection case only.
- `enrich_artwork_results` extends the existing LML#628 row-less title-gate exemption to in-library `found_on_compilation` rows. The release was track-validated during search (`validate_release_for_track`), so its title legitimately differs from the typed album and the sibling-leak concern the gate guards against does not apply.

Analogous to the already-resolved #200 (direct-hit artwork) and the LML#628 row-less carry-through.

## Testing

TDD: failing tests written first, then the fix.

- `tests/unit/test_orchestrator_helpers.py::TestFetchArtworkFoundOnCompilation` — the trust-bind layer: binds the carried release on floor rejection; scope guard that `found_on_compilation=False` keeps the pre-fix unbound behavior; floor match still preferred when it clears.
- `tests/unit/test_rowless_enrichment.py::test_found_on_compilation_rowbacked_mismatch_keeps_release` — the title-gate exemption layer (mirror image of the existing row-backed-suppression control).
- `tests/integration/test_lookup_pipeline.py::TestFoundOnCompilationArtwork` — full `perform_lookup` pipeline end-to-end on the Orcutt trio repro, asserting `artwork.release_id == 34993109` and a non-empty `artwork_url`. New seed row `(70001, "Orcutt-Shelley-Miller", "Bill Orcutt")`.

Full fast suite: `3302 passed, 1 skipped, 2 xfailed` (markers `not pg and not external_api and not stack and not slow`). `ruff check` + `ruff format --check` clean.