### PR TITLE
fix(#701): nudge floor-tier method confidences off the float32 band edge

### DIFF
--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -72,10 +72,15 @@ _LIBRARY_ARTISTS_SQL = (
 # crossing a band edge. Methods that are not §3.4.1 matrix entries
 # (``name_preprocessing`` and the Wikidata / MusicBrainz bridge + search
 # methods) are scored inside the ``name_variation`` band — a deterministic
-# cross-source ID bridge sits at the high end, a name lookup at the floor.
+# cross-source ID bridge sits at the high end, a name lookup at the low end.
 # The bulk-resolve composer (``identity/bulk_resolve.py``) only surfaces the
 # enum-named matrix methods on the wire, so these extra entries never reach
 # Backend's §3.2.2 check, but they keep the raw log rows honest and bounded.
+#
+# Never put a value *on* a band edge: ``entity.reconciliation_log.confidence``
+# is a PostgreSQL ``REAL`` (float32), and ``0.90`` round-trips to
+# ``0.8999999762`` — a hair under the 0.90 floor (LML#701). The low-end name
+# lookups therefore sit at ``0.91``, one float32-safe step above the floor.
 METHOD_CONFIDENCE: dict[str, float] = {
     # Discogs cascade (scripts/entity_resolution/discogs.py) — §3.4.1 matrix.
     "exact_match": 1.00,  # §3.4.1: 1.00
@@ -83,19 +88,20 @@ METHOD_CONFIDENCE: dict[str, float] = {
     "member_group": 0.85,  # §3.4.1: 0.80–0.89
     "alias_match": 0.80,  # §3.4.1: 0.75–0.84
     # Stage 5 re-runs the equality cascade on cheap name derivations (article
-    # strip, "&"→"and", bracket strip, multi-credit split). Floor of the
-    # name_variation band to reflect the extra derivation step.
-    "name_preprocessing": 0.90,
+    # strip, "&"→"and", bracket strip, multi-credit split). Low end of the
+    # name_variation band to reflect the extra derivation step (0.91, not the
+    # 0.90 floor — float32-safe, see LML#701).
+    "name_preprocessing": 0.91,
     # Wikidata stage (run_wikidata_stage): a QID bridged deterministically
     # from an already-reconciled Discogs ID is a graph join, not a fuzzy
     # match — high end of the name_variation band. A SPARQL name search is a
-    # name lookup — band floor.
+    # name lookup — low end of the band (0.91, float32-safe; LML#701).
     "discogs_bridge": 0.95,
-    "name_search": 0.90,
+    "name_search": 0.91,
     # MusicBrainz stage (run_musicbrainz_stage): deterministic QID→MBID
     # bridge vs. direct name match, same reasoning as the Wikidata leg.
     "qid_bridge": 0.95,
-    "name_match": 0.90,
+    "name_match": 0.91,
 }
 
 # Fallback for any method absent from ``METHOD_CONFIDENCE`` — a value inside

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -902,9 +902,12 @@ class TestDiscogsStageConfidencePersisted:
         assert len(rows) == 1
         assert rows[0]["method"] == method
         lo, hi = _METHOD_BANDS_341[method]
-        # Pad the band by the float32 storage epsilon so e.g. 0.85 → 0.8500000238
-        # doesn't fall foul of an exact band edge.
-        assert lo - 1e-6 <= rows[0]["confidence"] <= hi + 1e-6
+        # No epsilon pad (LML#701): the persisted value must read back inside the
+        # band on its own, because `confidence` is a PostgreSQL `REAL` (float32)
+        # and any value placed *on* a band edge (e.g. 0.90 → 0.8999999762) would
+        # round-trip just outside it. The mapped matrix values sit mid-band, so
+        # their float32 forms (e.g. 0.85 → 0.8500000238) stay comfortably within.
+        assert lo <= rows[0]["confidence"] <= hi
 
 
 @pytest.mark.pg

--- a/tests/unit/test_entity_resolution_confidence.py
+++ b/tests/unit/test_entity_resolution_confidence.py
@@ -24,12 +24,14 @@ The mock-store layer keeps the assertions on the value handed to
 
 from __future__ import annotations
 
+import struct
 from unittest.mock import AsyncMock
 
 import pytest
 
 from entity.store import Identity
 from scripts.entity_resolution.__main__ import (
+    _DEFAULT_METHOD_CONFIDENCE,
     METHOD_CONFIDENCE,
     run_discogs_stage,
     run_musicbrainz_stage,
@@ -45,6 +47,29 @@ DISCOGS_METHOD_BANDS: dict[str, tuple[float, float]] = {
     "member_group": (0.80, 0.89),
     "alias_match": (0.75, 0.84),
 }
+
+# The §3.4.1 band *floor* every mapped method's confidence must still read back
+# at-or-above once persisted to ``entity.reconciliation_log.confidence`` — a
+# PostgreSQL ``REAL`` (IEEE-754 binary32) column. Methods that are not §3.4.1
+# matrix entries are scored inside the ``name_variation`` band (floor 0.90).
+# Pins LML#701: ``0.90`` round-trips through float32 to ``0.8999999762``, a hair
+# under the 0.90 floor, so band-floor values must be chosen float32-safe.
+METHOD_BAND_FLOORS: dict[str, float] = {
+    "exact_match": 1.00,
+    "name_variation": 0.90,
+    "member_group": 0.80,
+    "alias_match": 0.75,
+    "name_preprocessing": 0.90,
+    "discogs_bridge": 0.90,
+    "name_search": 0.90,
+    "qid_bridge": 0.90,
+    "name_match": 0.90,
+}
+
+
+def _as_real(value: float) -> float:
+    """Round-trip ``value`` through a PostgreSQL ``REAL`` (IEEE-754 binary32)."""
+    return struct.unpack("f", struct.pack("f", value))[0]
 
 
 def _confidence_for_logged_method(store: AsyncMock, method: str) -> float:
@@ -135,6 +160,33 @@ class TestMethodConfidenceMap:
         for method, (lo, hi) in DISCOGS_METHOD_BANDS.items():
             assert method in METHOD_CONFIDENCE, f"{method} missing from METHOD_CONFIDENCE"
             assert lo <= METHOD_CONFIDENCE[method] <= hi
+
+    def test_band_floors_cover_every_mapped_method(self):
+        """METHOD_BAND_FLOORS must stay in lockstep with METHOD_CONFIDENCE so the
+        REAL round-trip guard can never silently skip a newly added method."""
+        assert set(METHOD_BAND_FLOORS) == set(METHOD_CONFIDENCE)
+
+    def test_real_roundtrip_stays_at_or_above_band_floor(self):
+        """Every mapped confidence must read back ``>=`` its §3.4.1 band floor
+        after a PostgreSQL ``REAL`` (float32) round-trip, with NO epsilon pad.
+
+        Regression for LML#701: ``name_preprocessing`` / ``name_search`` /
+        ``name_match`` were ``0.90``, which round-trips to ``0.8999999762`` — a
+        hair under the 0.90 ``name_variation`` floor. This test fails on any
+        band-floor value chosen without float32 headroom.
+        """
+        for method, floor in METHOD_BAND_FLOORS.items():
+            stored = _as_real(METHOD_CONFIDENCE[method])
+            assert stored >= floor, (
+                f"{method}={METHOD_CONFIDENCE[method]} stored as REAL is {stored!r}, "
+                f"below §3.4.1 floor {floor}"
+            )
+
+    def test_default_confidence_real_roundtrip_inside_band(self):
+        """The sidecar default stays inside member_group's band (0.80–0.89) after
+        a ``REAL`` round-trip — the fallback must never write an out-of-band row."""
+        stored = _as_real(_DEFAULT_METHOD_CONFIDENCE)
+        assert 0.80 <= stored <= 0.89
 
 
 class TestWikidataStageConfidence:


### PR DESCRIPTION
## Problem

The three non-matrix reconciliation methods `name_preprocessing`, `name_search`, and `name_match` in `METHOD_CONFIDENCE` ([`scripts/entity_resolution/__main__.py`](https://github.com/WXYC/library-metadata-lookup/blob/main/scripts/entity_resolution/__main__.py), added in #696) were assigned `0.90` — intended to sit at the bottom of the §3.4.1 `name_variation` band (0.90–0.99). But `entity.reconciliation_log.confidence` is a PostgreSQL `REAL` (float32), and `0.90` round-trips to `0.8999999762` — a hair **under** the 0.90 band floor.

Latent today: `identity/bulk_resolve.py`'s `_normalize_method` strips these reconciliation-internal methods before Backend's §3.2.2 wire-contract band check, so the sub-floor value never hits the contract. It would bite a future calibration/audit pass that reads the column and treats the band edge as exact.

## Fix (issue Option 2)

Nudge the three values to `0.91` rather than migrating the column to `double precision`. Option 1 would pay the cross-repo `entity.*` alembic ownership dance for a 2.4e-8 rounding artifact, and wouldn't address the real smell — a value placed *on* a band edge is fragile in any float width.

`0.91` is float32-safe (`0.91000002`, comfortably `>= 0.90`) and preserves the documented within-band ordering: name lookups (0.91) < recognized variation (0.92) < deterministic ID bridge (0.95). The comment block now records the float32-floor hazard so nobody reintroduces an on-edge value.

## Tests

- **Unit (acceptance-criterion guard):** new `test_real_roundtrip_stays_at_or_above_band_floor` round-trips every mapped confidence through `struct.pack('f', …)` (exactly PG's `REAL`/IEEE-754 binary32) and asserts `>=` band floor **with no epsilon pad** — it fails on a sub-floor float32 value. Plus a lockstep check so a future `METHOD_CONFIDENCE` entry can't silently skip the guard, and a default-confidence round-trip check.
- **Integration:** dropped the `±1e-6` pad in `TestDiscogsStageConfidencePersisted` (the pad the issue flags as "why it isn't caught"), making the pg test a real no-pad floor guard too. All four matrix values are mid-band, so it stays green.

Verified red → green; `ruff check`/`ruff format`/`mypy` clean; default + pg lanes pass locally.

## Acceptance criteria

- [x] Persisted confidence for `name_preprocessing`, `name_search`, `name_match` reads back `>= 0.90` from the `REAL` column.
- [x] A test pins the round-tripped value inside the band without an epsilon pad.
- [x] Option 2 chosen — no alembic migration needed.

Closes #701