### PR TITLE
feat(#700): cancel in-flight gather on client disconnect in bulk-resolve-libraries

### DIFF
--- a/identity/router.py
+++ b/identity/router.py
@@ -16,13 +16,14 @@ Provides:
 import asyncio
 import logging
 from collections import Counter
+from typing import Any
 
 import sentry_sdk
 from asyncpg.exceptions import PostgresError
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import ValidationError
 
-from core.bulk_concurrency import max_concurrency_from_env
+from core.bulk_concurrency import cancel_and_drain, max_concurrency_from_env, watch_disconnect
 from entity.store import EntityStore, Identity
 from generated.api_models import (
     BulkResolveInput,
@@ -315,22 +316,67 @@ async def bulk_resolve_libraries(
         http_span.set_data("lml.bulk_resolve.inputs", inputs_count)
         http_span.set_data("lml.bulk_resolve.max_concurrent", max_concurrent)
 
+        # Race the gather against a client-disconnect sentinel (LML#700). uvicorn
+        # does not propagate a client socket close into the handler, so a plain
+        # `await asyncio.gather(...)` runs the in-flight per-input tasks — and the
+        # discogs-cache pool permits they hold (bounded by `max_concurrent`) — to
+        # completion against a client that is already gone. The sentinel lets a
+        # disconnect cancel the outstanding gather promptly instead. Mirrors the
+        # `/lookup/bulk` shape (lookup/router.py) and reuses the shared
+        # `watch_disconnect` / `cancel_and_drain` helpers rather than forking the
+        # logic.
+        #
+        # `gather` preserves input order (results[i] <-> inputs[i]) regardless of
+        # completion order, satisfying the api.yaml ordering contract.
+        #
+        # Spawning the sentinel must happen *after* `await http_request.json()`
+        # above has fully consumed the request body — `watch_disconnect` awaits
+        # `request.receive()`, which would otherwise swallow the `http.request`
+        # body messages the JSON parser needs.
+        gather_future = asyncio.gather(*(_resolve_one(r) for r in request.inputs))
+        sentinel_task = asyncio.create_task(
+            watch_disconnect(http_request),
+            name="lml.bulk_resolve.disconnect_sentinel",
+        )
+        waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
+
         try:
-            # `gather` preserves input order (results[i] <-> inputs[i]) regardless
-            # of completion order, satisfying the api.yaml ordering contract.
-            results = await asyncio.gather(*(_resolve_one(r) for r in request.inputs))
-        except asyncio.CancelledError:
-            # Client aborted mid-batch. Cancelling the handler task propagates
-            # into the in-flight `gather` (and thus its children), so permits are
-            # released as the children unwind. Pin 499 on the span before
-            # re-raising so the audit-style query
-            # `op:http.server http.status_code:499` surfaces these in Sentry, and
-            # emit a warn log so Railway also carries the record. CancelledError
-            # is re-raised (not converted to HTTPException) — the asyncio
-            # cancellation contract requires this, and the client is gone anyway
-            # so there is nobody to read a 499 response.
+            done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
+        except BaseException:
+            # Outer cancellation (server shutdown / timeout middleware) must
+            # propagate to both children AND drain them, not just signal them — a
+            # bare `.cancel()` is asynchronous, so the pool permits stay held
+            # until the tasks observe the cancel and unwind.
+            await cancel_and_drain(gather_future)
+            await cancel_and_drain(sentinel_task)
+            raise
+
+        if sentinel_task in done and not gather_future.done():
+            # Client departed first. Cancel + drain the gather so the per-input
+            # tasks unwind and their permits free promptly instead of after the
+            # whole batch finishes. The tag is global-scope (filterable across
+            # routes as `lml.client_aborted:true`); the 499 + warn log mirror the
+            # `/lookup/bulk` abort branch. 499 = Nginx "client closed request" —
+            # nobody reads the body, but it pins the span/log for triage.
+            sentry_sdk.set_tag("lml.client_aborted", "true")
+            await cancel_and_drain(gather_future)
             http_span.set_data("http.status_code", 499)
             logger.warning("bulk resolve aborted by client: inputs=%d", inputs_count)
+            raise HTTPException(status_code=499, detail="client disconnected")
+
+        # Work finished first (or failed). Drain the still-pending sentinel so it
+        # doesn't leak, then surface the gather's outcome.
+        await cancel_and_drain(sentinel_task)
+        try:
+            results = gather_future.result()
+        except asyncio.CancelledError:
+            # Server-driven cancellation surfaced through the gather (shutdown /
+            # outer timeout), or a child observed a cancel — distinct from the
+            # client-disconnect branch above, which the sentinel handles. Pin 499
+            # and re-raise per the asyncio cancellation contract; the client is
+            # gone so there is nobody to read a 499 response.
+            http_span.set_data("http.status_code", 499)
+            logger.warning("bulk resolve aborted (cancelled): inputs=%d", inputs_count)
             raise
         except HTTPException as exc:
             # Fail-closed 503 (or any explicit status) from a per-input failure.

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -739,8 +739,10 @@ class TestBulkResolveConcurrency:
         assert [r["main"]["discogs_artist_id"] for r in results] == [11, 22, 33]
 
     @pytest.mark.asyncio
-    async def test_client_disconnect_cancels_in_flight_lookups(self, app_client, mock_entity_store):
-        """Mid-batch client disconnect aborts the gather with 499; queued items never run.
+    async def test_client_disconnect_cancels_in_flight_lookups(
+        self, app_client, mock_entity_store, monkeypatch
+    ):
+        """Mid-batch client disconnect cancels in-flight lookups; queued ones never start.
 
         Adopts the ``/lookup/bulk`` disconnect-cancellation pattern (LML#700):
         without it, a caller that hangs up mid-request leaves the in-flight
@@ -752,11 +754,33 @@ class TestBulkResolveConcurrency:
         "detects" the disconnect after a short delay; the real receive-channel
         mechanism is exercised in production by uvicorn. The slow lookup outlasts
         the sentinel so the abort fires while work is still in flight.
+
+        The load-bearing assertion is ``cancelled == started``: every lookup that
+        actually entered (the in-flight items, bounded by the pinned concurrency)
+        must receive ``CancelledError``. A regression that returns 499 but leaves
+        the gather draining in the background (the LML#700 bug) leaves the
+        in-flight items sleeping — ``cancelled == 0 != started`` — so this fails.
+        ``await_count``-style counts alone can't catch that: the semaphore already
+        bounds in-flight lookups below the batch size whether or not the cancel
+        lands. Concurrency is pinned (not read from the production default) so a
+        future pool-size change can't silently make the batch fit under one wave.
         """
+        monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "3")
+        concurrency = 3
+        batch_size = 9
+
+        started = 0
+        cancelled = 0
 
         async def slow_lookup(name: str):
-            await asyncio.sleep(5)
-            return None
+            nonlocal started, cancelled
+            started += 1
+            try:
+                await asyncio.sleep(5)
+                return None
+            except asyncio.CancelledError:
+                cancelled += 1
+                raise
 
         mock_entity_store.resolve_library_name.side_effect = slow_lookup
 
@@ -764,7 +788,8 @@ class TestBulkResolveConcurrency:
             await asyncio.sleep(0.05)
 
         inputs = [
-            {"library_id": i, "artist_name": f"Artist {i}", "album_title": "x"} for i in range(20)
+            {"library_id": i, "artist_name": f"Artist {i}", "album_title": "x"}
+            for i in range(batch_size)
         ]
 
         with patch("identity.router.watch_disconnect", fake_sentinel):
@@ -777,12 +802,18 @@ class TestBulkResolveConcurrency:
                 )
 
         assert resp.status_code == 499, f"Expected 499 on client disconnect, got {resp.status_code}"
-        # Default concurrency is 5, so at most 5 lookups can be in flight when the
-        # sentinel fires; the other 15 are queued behind the semaphore and never
-        # start. If the gather ran to completion all 20 would have been awaited.
-        assert mock_entity_store.resolve_library_name.await_count < 20, (
-            f"All {mock_entity_store.resolve_library_name.await_count}/20 lookups ran — "
-            "abort did not cancel in-flight items"
+        # Queued lookups never start: the semaphore caps in-flight at `concurrency`
+        # and each in-flight lookup is still sleeping when the sentinel fires.
+        assert 0 < started <= concurrency, (
+            f"Expected 1..{concurrency} in-flight lookups, got {started}; "
+            f"{batch_size - started} should have stayed queued behind the semaphore"
+        )
+        # Every in-flight lookup received the cancel and unwound — the actual proof
+        # that the disconnect cancelled the outstanding gather rather than letting
+        # it drain in the background against a departed client.
+        assert cancelled == started, (
+            f"{started - cancelled} of {started} in-flight lookup(s) were never "
+            "cancelled — the disconnect did not cancel the outstanding gather"
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -739,6 +739,151 @@ class TestBulkResolveConcurrency:
         assert [r["main"]["discogs_artist_id"] for r in results] == [11, 22, 33]
 
     @pytest.mark.asyncio
+    async def test_client_disconnect_cancels_in_flight_lookups(self, app_client, mock_entity_store):
+        """Mid-batch client disconnect aborts the gather with 499; queued items never run.
+
+        Adopts the ``/lookup/bulk`` disconnect-cancellation pattern (LML#700):
+        without it, a caller that hangs up mid-request leaves the in-flight
+        per-input tasks — and the discogs-cache pool permits they hold — running
+        to completion against a client that is already gone. The sentinel race
+        cancels the outstanding gather promptly instead.
+
+        Patches ``identity.router.watch_disconnect`` with a sentinel that
+        "detects" the disconnect after a short delay; the real receive-channel
+        mechanism is exercised in production by uvicorn. The slow lookup outlasts
+        the sentinel so the abort fires while work is still in flight.
+        """
+
+        async def slow_lookup(name: str):
+            await asyncio.sleep(5)
+            return None
+
+        mock_entity_store.resolve_library_name.side_effect = slow_lookup
+
+        async def fake_sentinel(_request):
+            await asyncio.sleep(0.05)
+
+        inputs = [
+            {"library_id": i, "artist_name": f"Artist {i}", "album_title": "x"} for i in range(20)
+        ]
+
+        with patch("identity.router.watch_disconnect", fake_sentinel):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await asyncio.wait_for(
+                    ac.post("/api/v1/identity/bulk-resolve-libraries", json={"inputs": inputs}),
+                    timeout=3.0,
+                )
+
+        assert resp.status_code == 499, f"Expected 499 on client disconnect, got {resp.status_code}"
+        # Default concurrency is 5, so at most 5 lookups can be in flight when the
+        # sentinel fires; the other 15 are queued behind the semaphore and never
+        # start. If the gather ran to completion all 20 would have been awaited.
+        assert mock_entity_store.resolve_library_name.await_count < 20, (
+            f"All {mock_entity_store.resolve_library_name.await_count}/20 lookups ran — "
+            "abort did not cancel in-flight items"
+        )
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_unwinds_per_item_tasks_cleanly(
+        self, app_client, mock_entity_store, monkeypatch
+    ):
+        """Cancellation reaches each per-input coroutine, which unwinds via `finally`.
+
+        Permit release is the downstream consequence: the per-input semaphore in
+        ``bulk_resolve_libraries`` releases via ``async with semaphore`` __aexit__
+        only if the cancel actually reaches the per-input coroutine. Proxy
+        assertion: count ``started`` (each lookup entered) and ``cleaned_up``
+        (each that exited via ``finally``). On clean propagation
+        ``started == cleaned_up``; if the cancel never reaches the per-item tasks
+        they keep running and ``started > cleaned_up`` — the LML#700 bug.
+        """
+        monkeypatch.setenv("LML_BULK_MAX_CONCURRENT", "2")
+
+        started = 0
+        cleaned_up = 0
+
+        async def slow_lookup(name: str):
+            nonlocal started, cleaned_up
+            started += 1
+            try:
+                await asyncio.sleep(5)
+                return None
+            finally:
+                cleaned_up += 1
+
+        mock_entity_store.resolve_library_name.side_effect = slow_lookup
+
+        async def fake_sentinel(_request):
+            await asyncio.sleep(0.05)
+
+        inputs = [
+            {"library_id": i, "artist_name": f"Artist {i}", "album_title": "x"} for i in range(6)
+        ]
+
+        with patch("identity.router.watch_disconnect", fake_sentinel):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await asyncio.wait_for(
+                    ac.post("/api/v1/identity/bulk-resolve-libraries", json={"inputs": inputs}),
+                    timeout=3.0,
+                )
+
+        assert resp.status_code == 499
+        assert started > 0, "no lookups started — test mis-configured"
+        assert started == cleaned_up, (
+            f"{started - cleaned_up} lookup(s) started but never cleaned up — "
+            "cancellation did not propagate into the per-input tasks"
+        )
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_sets_sentry_tag(self, app_client, mock_entity_store):
+        """`lml.client_aborted=true` lands on the active Sentry scope on abort.
+
+        Filterable in the trace explorer (`lml.client_aborted:true`) to surface
+        aborted batches for triage — same global-scope tag the `/lookup/bulk`
+        abort branch sets, so a single filter spans both bulk routes.
+        """
+        captured_tags: dict[str, str] = {}
+        original_set_tag = sentry_sdk.set_tag
+
+        def capture_tag(key, value):
+            captured_tags[key] = value
+            return original_set_tag(key, value)
+
+        async def slow_lookup(name: str):
+            await asyncio.sleep(5)
+            return None
+
+        mock_entity_store.resolve_library_name.side_effect = slow_lookup
+
+        async def fake_sentinel(_request):
+            await asyncio.sleep(0.05)
+
+        inputs = [
+            {"library_id": i, "artist_name": f"Artist {i}", "album_title": "x"} for i in range(4)
+        ]
+
+        with (
+            patch("identity.router.watch_disconnect", fake_sentinel),
+            patch("identity.router.sentry_sdk.set_tag", side_effect=capture_tag),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await asyncio.wait_for(
+                    ac.post("/api/v1/identity/bulk-resolve-libraries", json={"inputs": inputs}),
+                    timeout=3.0,
+                )
+
+        assert resp.status_code == 499
+        assert captured_tags.get("lml.client_aborted") == "true", (
+            f"Expected lml.client_aborted=true tag; got {captured_tags!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_postgres_error_mid_batch_returns_503_not_partial(
         self, app_client, mock_entity_store
     ):


### PR DESCRIPTION
Closes #700.

## Problem

`bulk_resolve_libraries` runs its per-input lookups concurrently via `asyncio.gather` (added in #694). Unlike the sibling `/lookup/bulk` handler, it did not watch for client disconnect: uvicorn does not propagate a client socket close into the handler, so a caller that hung up mid-request left the in-flight per-input tasks — and the discogs-cache pool permits they hold (bounded by the concurrency cap of 5) — running to completion against a client that was already gone, freeing only when the work finished naturally.

The pre-existing `except asyncio.CancelledError` block gave a false impression that a plain gather already handled this; in fact that branch only ever fired under *server-driven* cancellation, never a client disconnect.

## Change

Adopt the `/lookup/bulk` disconnect-cancellation pattern in `bulk_resolve_libraries`:

- Race the gather against a `watch_disconnect` sentinel via `asyncio.wait(FIRST_COMPLETED)`.
- On a client win, `cancel_and_drain` the gather so the per-input tasks unwind and their pool permits free promptly (not after the whole batch finishes), then short-circuit with `499`, the global `lml.client_aborted` tag, and a warn log.
- Reuse the shared `watch_disconnect` / `cancel_and_drain` helpers from `core/bulk_concurrency` rather than forking the logic.
- Correct the now-misleading `CancelledError` comment so it honestly backstops server-driven cancellation alongside the sentinel-handled client-disconnect path.

Order-preservation, the 503 fail-closed posture, and the concurrency bound established by #694 are all preserved.

## Tests

Three new unit tests in `TestBulkResolveConcurrency`, mirroring `/lookup/bulk`'s `TestBulkLookupClientAbort`:

- `test_client_disconnect_cancels_in_flight_lookups` — disconnect mid-batch returns 499; queued items never start.
- `test_client_disconnect_unwinds_per_item_tasks_cleanly` — cancellation reaches each per-input coroutine (`started == cleaned_up`), so permits free.
- `test_client_disconnect_sets_sentry_tag` — `lml.client_aborted=true` lands on the active scope.

## Verification

- `tests/unit/test_bulk_resolve_libraries_endpoint.py`: 20 passed (17 baseline + 3 new) — existing order-preservation, 503 fail-closed, semaphore-bound, and 499-on-span tests all still green.
- `tests/integration/test_bulk_resolve_libraries.py` (`-m pg`): 7 passed.
- `ruff check` + `ruff format --check`: clean.

## Context

Surfaced during post-merge `/code-review max` of #694; deferred as out-of-scope for the perf-only PR. Hardening, not a regression — the pre-#694 serial loop did not cancel on disconnect either. Bounded impact (≤5 permits, short-lived wasted PG work), only under real client-abort pressure.
