### PR TITLE
test(#706): endpoint + unit invariants pin the streaming probe off the /lookup hot path (PR2)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,62 @@
 """Shared test fixtures for pytest."""
 
+import asyncio
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 from wxyc_fastapi.observability import RequestTelemetry
 
 from discogs.service import DiscogsApiCheckResult
+from lookup import streaming_url_postprocess as _streaming_mod
+from lookup.streaming_url_postprocess import set_suppress_streaming_warm
 from services.parser import MessageType, ParsedRequest
 from tests.factories import make_library_item
+
+
+def reset_streaming_warm_state() -> None:
+    """Reset the LML#706 streaming-warm module globals to a pristine state.
+
+    The warm machinery is process-global by design (one bound per worker, not
+    per request): the lazily-built semaphore, the dedup set, the strong-ref
+    task set, and the bulk-suppression ContextVar. Any test module that
+    touches the ``/lookup`` post-process should call this from an autouse
+    fixture (setup AND teardown) so a leaked dedup key, a semaphore bound to
+    a prior event loop, or a stuck suppression flag can't leak across tests.
+    Single source of truth — the unit and integration suites previously
+    carried diverging per-file copies of this reset.
+    """
+    _streaming_mod._streaming_warm_semaphore = None
+    _streaming_mod._streaming_warm_in_flight.clear()
+    _streaming_mod._background_tasks.clear()
+    set_suppress_streaming_warm(False)
+
+
+async def drain_streaming_warm_tasks(timeout_s: float = 5.0) -> None:
+    """Await every scheduled streaming-URL warm, bounded by ``timeout_s``.
+
+    Loops because a task's done-callbacks (which discard it from the set and
+    clear its dedup key) run after the ``gather`` returns, so one pass can
+    observe a non-empty set. The deadline converts two regression shapes that
+    would otherwise hang CI forever (the repo has no pytest-timeout and the
+    workflow no ``timeout-minutes``) into an immediate, diagnosable failure:
+    a warm that never completes blocks the ``gather`` until the deadline; a
+    broken discard done-callback leaves completed tasks in the set and would
+    busy-spin, which the per-iteration deadline check cuts off.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while _streaming_mod._background_tasks:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            pytest.fail(
+                f"streaming-warm drain exceeded {timeout_s}s; "
+                f"{len(_streaming_mod._background_tasks)} task(s) still tracked, "
+                f"in-flight keys: {_streaming_mod._streaming_warm_in_flight}"
+            )
+        await asyncio.wait_for(
+            asyncio.gather(*list(_streaming_mod._background_tasks), return_exceptions=True),
+            timeout=remaining,
+        )
 
 
 def make_lml_telemetry() -> RequestTelemetry:

--- a/tests/integration/test_api_lookup_hard_timeout.py
+++ b/tests/integration/test_api_lookup_hard_timeout.py
@@ -1,24 +1,24 @@
 """End-to-end ``/api/v1/lookup`` latency-architecture guards.
 
-Two endpoint-level invariants live here, both deterministic (no wall-clock
-thresholds beyond generous fail-fast ceilings):
+Two endpoint-level invariants live here:
 
 * **LML#370 hard cap surfaces as ``LookupResponse.timeout``** — when
   ``execute_search_pipeline``'s hard cap fires (loop gate or per-strategy
   ``asyncio.wait_for``), ``perform_lookup`` must project ``state.timed_out``
   into the response shape so callers can distinguish "no match" (empty
   ``results``, ``timeout: False``) from "ran out of time" (``timeout: True``).
+  (This test carries the file's one genuine latency assertion — the
+  ``elapsed < 1.5`` bound proving the hard cap limits wall time.)
 
 * **LML#706 streaming probe stays off the response path** — the whole-endpoint
-  guard for the #706 cold-tail fix. A cold lookup (streaming-URL cache miss)
-  must return while the live probe is still blocked on a test-controlled
-  ``asyncio.Event``, proving the inline external fan-out cannot silently
-  re-block ``/lookup``. Causality, not timing: the response completing while
-  the gate is closed is the assertion; releasing the gate and draining
-  ``_background_tasks`` then confirms the warm ran to completion off-path.
+  guard for the #706 cold-tail fix, deterministic causality with fail-fast
+  ceilings rather than latency thresholds. A cold lookup (streaming-URL cache
+  miss) must return while the live probe is still blocked on a
+  test-controlled ``asyncio.Event``; releasing the gate and draining the warm
+  tasks then confirms the probe + mint ran to completion off-path.
 
-This is a pure TestClient + mocked-dependency file — no `pg` or `external_api`
-marker, runs in the default suite.
+This is an httpx-ASGITransport + mocked-dependency file — no `pg` or
+`external_api` marker, runs in the default suite.
 """
 
 import asyncio
@@ -30,11 +30,13 @@ import pytest
 import pytest_asyncio
 
 from clients.streaming.apple_music import AppleMusicClient
-from discogs.models import DiscogsSearchResponse
+from discogs.models import DiscogsSearchResponse, TrackReleasesResponse
 from entity.sources import PgSource
 from entity.store import EntityStore
 from entity.streaming_url_cache import ResolveOutcome
 from lookup import streaming_url_postprocess as streaming_mod
+from tests.conftest import drain_streaming_warm_tasks, reset_streaming_warm_state
+from tests.factories import make_discogs_result
 
 
 class TestApiLookupHardTimeout:
@@ -110,25 +112,19 @@ class TestApiLookupHardTimeout:
 # ---------------------------------------------------------------------------
 
 
-async def _drain_background_tasks() -> None:
-    """Await every scheduled warm so its done-callbacks run (clearing the task
-    set and the dedup key), letting post-drain assertions observe the result."""
-    while streaming_mod._background_tasks:
-        await asyncio.gather(*list(streaming_mod._background_tasks), return_exceptions=True)
+# Bounded drain shared with the unit suite (single source of truth for the
+# subtle while-loop-because-done-callbacks-run-late semantics).
+_drain_background_tasks = drain_streaming_warm_tasks
 
 
 @pytest.fixture(autouse=True)
 def _reset_warm_state():
-    """Isolate the post-process module's process-global warm state (semaphore,
-    dedup set, task set) — same reset the unit suite uses, so a leaked dedup
-    key or a semaphore bound to a prior event loop can't leak across tests."""
-    streaming_mod._streaming_warm_semaphore = None
-    streaming_mod._streaming_warm_in_flight.clear()
-    streaming_mod._background_tasks.clear()
+    """Isolate the post-process module's process-global warm state around every
+    test, via the shared ``tests.conftest.reset_streaming_warm_state`` (the
+    same reset the unit suite delegates to)."""
+    reset_streaming_warm_state()
     yield
-    streaming_mod._streaming_warm_in_flight.clear()
-    streaming_mod._background_tasks.clear()
-    streaming_mod._streaming_warm_semaphore = None
+    reset_streaming_warm_state()
 
 
 @pytest_asyncio.fixture
@@ -137,30 +133,53 @@ async def offpath_harness(library_db, test_settings, monkeypatch):
     runs Apple-only, with the cache peek forced to a genuine miss and the live
     probe gated on a test-controlled ``asyncio.Event``.
 
-    The two patches sit at the same seams the unit suite uses
-    (``peek_cached_streaming_url`` / ``resolve_streaming_url_with_cache``), but
-    the request travels the real router → orchestrator → post-process chain, so
-    a synchronous probe reintroduced ANYWHERE on that chain deadlocks the
-    response against the closed gate and fails the test's outer ``wait_for``.
+    Guarded seams — stated precisely, because each has a boundary:
 
-    Yields a namespace: ``client`` (httpx AsyncClient), ``gate`` (the Event the
-    probe blocks on), ``probed`` (list of ``(service, artist, album)`` awaits),
-    ``apple`` (the Apple client mock), ``entity_store``.
+    * ``resolve_streaming_url_with_cache`` / ``peek_cached_streaming_url`` are
+      patched **on the post-process module's bindings**
+      (``lookup.streaming_url_postprocess``). A regression that re-inlines the
+      probe through those bindings deadlocks the response against the closed
+      gate and trips the outer ``wait_for``. A future call site that imports
+      the resolver directly from ``entity.streaming_url_cache`` would NOT be
+      intercepted here — if you add one, extend this harness.
+    * The Apple client guards the client boundary: the track-level probes
+      (``find_track_url`` / ``find_track_metadata``) resolve to ``None`` and
+      are ALLOWED (the deliberately-synchronous artwork-bearing path — #706
+      kept artwork synchronous), while the album-level methods
+      (``find_album_match`` / ``search_album`` / ``search_song``) raise if
+      awaited, so a direct-client bypass of the resolver fails loudly.
 
-    The Apple client's track-level probes (``find_track_url`` /
-    ``find_track_metadata``) resolve to ``None`` — those calls are the
-    deliberately-synchronous artwork-bearing path and are ALLOWED (#706 kept
-    them on the hot path; artwork stays synchronous). ``find_album_match`` —
-    the album-level probe behind the resolver — raises if awaited, guarding
-    the resolver seam against a direct-client-call bypass.
+    Environment: the orchestrator reads flags via a direct, ``@lru_cache``d
+    ``get_settings()`` call (not DI), so the fixture sets env and busts the
+    cache (setup + teardown). The DI-injected settings object is given the
+    same streaming flags so the two surfaces agree — a refactor that threads
+    DI settings into the post-process must not flip the feature off. The
+    row-less resolve-family flags are pinned OFF so the guarded pipeline path
+    is identical on every machine regardless of ambient env/.env; the two
+    DI seams not centrally mocked (``get_discogs_cache_service`` /
+    ``get_musicbrainz_pg``) are overridden to ``None`` so no ambient
+    ``DATABASE_URL_*`` can open real connections mid-test.
+
+    Yields a namespace: ``client`` (httpx AsyncClient), ``gate`` (the Event
+    the probe blocks on), ``probed`` (list of ``(service, artist, album)``
+    awaits), ``apple`` (the Apple client mock), ``discogs`` (the Discogs
+    service mock — reassign ``.search`` for the Discogs-match variant),
+    ``entity_store``.
+
+    Teardown is exception-safe: the gate is released and any still-pending
+    warms are cancelled + drained before overrides/cache are restored, so an
+    assertion failure mid-test doesn't spray "Task was destroyed but it is
+    pending!" noise over the real failure.
     """
     from httpx import ASGITransport, AsyncClient
 
     from config.settings import get_settings
     from core.dependencies import (
         get_discogs_cache_pg,
+        get_discogs_cache_service,
         get_discogs_service,
         get_library_db,
+        get_musicbrainz_pg,
         get_posthog_client,
     )
     from identity.dependencies import get_entity_store
@@ -171,22 +190,37 @@ async def offpath_harness(library_db, test_settings, monkeypatch):
         get_spotify_client,
     )
 
-    # The orchestrator reads these via a direct ``get_settings()`` call (not
-    # DI), and ``get_settings`` is ``@lru_cache``d — env alone is not enough
-    # once any earlier test (or import-time caller) has populated the cache
-    # with the flags at their defaults. Set env, then bust the cache; bust it
-    # again on teardown so the flag-enabled Settings can't leak onward.
-    # Apple-only keeps warm-counting deterministic (one warm per cold request).
+    # Apple-only keeps warm-counting deterministic (one warm per cold
+    # request). Spotify/Bandcamp are disabled by their client overrides
+    # (None) below — the post-process skips a service with no client
+    # regardless of its flag, so no per-service flag pinning is needed.
     monkeypatch.setenv("LML_PERSIST_STREAMING_URLS", "true")
     monkeypatch.setenv("LML_PERSIST_STREAMING_URL_APPLE_MUSIC", "true")
-    monkeypatch.setenv("LML_PERSIST_STREAMING_URL_SPOTIFY", "false")
-    monkeypatch.setenv("LML_PERSIST_STREAMING_URL_BANDCAMP", "false")
+    # Pin the row-less resolve family OFF: these are read via direct
+    # get_settings()/os.getenv on the same response path, and ambient env (or
+    # a repo-root .env) would otherwise route the guarded lookup through
+    # different pipeline branches per machine.
+    monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "false")
+    monkeypatch.setenv("LML_RESOLVE_COMPILATION_RELEASE", "false")
+    monkeypatch.setenv("LML_RESOLVE_ARTIST_CANONICAL", "false")
     # The warm wraps the probe in Apple's per-call wait_for ceiling (4s
     # default). The gated probe deliberately blocks until the test releases
     # it, so widen the ceiling — otherwise a slow CI box could time the warm
-    # out before the release and flake the post-drain assertions.
-    monkeypatch.setenv("LML_APPLE_MUSIC_LOOKUP_TIMEOUT_MS", "60000")
+    # out before the release and flake the post-drain assertions. 15s is
+    # >1000x the observed post-release drain latency.
+    monkeypatch.setenv("LML_APPLE_MUSIC_LOOKUP_TIMEOUT_MS", "15000")
     get_settings.cache_clear()
+
+    # Make the DI-injected settings agree with the env-derived ones the
+    # orchestrator reads directly — otherwise a refactor that threads DI
+    # settings into the post-process would silently disable the feature under
+    # test and fail these guards with a misleading zero-warms signal.
+    flagged_settings = test_settings.model_copy(
+        update={
+            "lml_persist_streaming_urls": True,
+            "lml_persist_streaming_url_apple_music": True,
+        }
+    )
 
     gate = asyncio.Event()
     probed: list[tuple[str, str, str]] = []
@@ -198,22 +232,28 @@ async def offpath_harness(library_db, test_settings, monkeypatch):
             url="https://music.apple.com/us/album/gated/1234567890", source="live_resolved"
         )
 
+    def _raise_if_awaited(method: str) -> AsyncMock:
+        return AsyncMock(
+            side_effect=AssertionError(
+                f"{method} awaited directly on the response path — album-level "
+                "Apple calls must go through resolve_streaming_url_with_cache "
+                "in a background warm"
+            )
+        )
+
     apple = AsyncMock(spec=AppleMusicClient)
     apple.find_track_url = AsyncMock(return_value=None)
     apple.find_track_metadata = AsyncMock(return_value=None)
-    apple.find_album_match = AsyncMock(
-        side_effect=AssertionError(
-            "find_album_match awaited directly — the album probe must go "
-            "through resolve_streaming_url_with_cache in a background warm"
-        )
-    )
+    apple.find_album_match = _raise_if_awaited("find_album_match")
+    apple.search_album = _raise_if_awaited("search_album")
+    apple.search_song = _raise_if_awaited("search_song")
 
-    # A Discogs service that finds nothing: enrichment must still run (a None
+    # Default Discogs service finds nothing: enrichment must still run (a None
     # service skips Step 4 artwork entirely and with it the whole enrichment
     # block), and the empty search drives the LML#401 no-Discogs-match branch —
     # the synthesized streaming-only result whose URL fields are exactly what
     # the post-process backstops. This is the production cold shape from the
-    # #706 incident: album absent from the Discogs catalog, streaming cache cold.
+    # #706 incident. The Discogs-match variant test reassigns ``.search``.
     discogs = AsyncMock(
         spec_set=[
             "search",
@@ -225,7 +265,11 @@ async def offpath_harness(library_db, test_settings, monkeypatch):
     )
     discogs.cache_service = None
     discogs.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
-    discogs.search_releases_by_track = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+    # NB: the real method returns TrackReleasesResponse (consumers read
+    # .releases) — a DiscogsSearchResponse stub here would AttributeError→500
+    # the moment a request pair misses the library seed and the track-probing
+    # strategies run.
+    discogs.search_releases_by_track = AsyncMock(return_value=TrackReleasesResponse(releases=[]))
     discogs.get_release = AsyncMock(return_value=None)
     discogs.validate_track_on_release = AsyncMock(return_value=False)
 
@@ -237,39 +281,58 @@ async def offpath_harness(library_db, test_settings, monkeypatch):
     # answer for this harness.
     entity_store.get_identity = AsyncMock(return_value=None)
 
-    app.dependency_overrides[get_library_db] = lambda: library_db
-    app.dependency_overrides[get_discogs_service] = lambda: discogs
-    app.dependency_overrides[get_posthog_client] = lambda: None
-    app.dependency_overrides[get_settings] = lambda: test_settings
-    app.dependency_overrides[get_entity_store] = lambda: entity_store
-    app.dependency_overrides[get_discogs_cache_pg] = lambda: AsyncMock(spec=PgSource)
-    app.dependency_overrides[get_apple_music_client] = lambda: apple
-    app.dependency_overrides[get_spotify_client] = lambda: None
-    app.dependency_overrides[get_bandcamp_client] = lambda: None
+    try:
+        app.dependency_overrides[get_library_db] = lambda: library_db
+        app.dependency_overrides[get_discogs_service] = lambda: discogs
+        app.dependency_overrides[get_posthog_client] = lambda: None
+        app.dependency_overrides[get_settings] = lambda: flagged_settings
+        app.dependency_overrides[get_entity_store] = lambda: entity_store
+        app.dependency_overrides[get_discogs_cache_pg] = lambda: AsyncMock(spec=PgSource)
+        # Neither seam is exercised by these tests; without an override each
+        # falls through to its real factory, which reads ambient env/.env and
+        # can open a real PG pool (up to a 10s connect) inside the first
+        # request — a flake indistinguishable from the regression under guard.
+        app.dependency_overrides[get_discogs_cache_service] = lambda: None
+        app.dependency_overrides[get_musicbrainz_pg] = lambda: None
+        app.dependency_overrides[get_apple_music_client] = lambda: apple
+        app.dependency_overrides[get_spotify_client] = lambda: None
+        app.dependency_overrides[get_bandcamp_client] = lambda: None
 
-    with (
-        patch.object(
-            streaming_mod,
-            "peek_cached_streaming_url",
-            new=AsyncMock(return_value=(None, False)),
-        ),
-        patch.object(
-            streaming_mod,
-            "resolve_streaming_url_with_cache",
-            new=AsyncMock(side_effect=gated_resolve),
-        ),
-    ):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            yield SimpleNamespace(
-                client=client,
-                gate=gate,
-                probed=probed,
-                apple=apple,
-                entity_store=entity_store,
-            )
-
-    app.dependency_overrides.clear()
-    get_settings.cache_clear()
+        with (
+            patch.object(
+                streaming_mod,
+                "peek_cached_streaming_url",
+                new=AsyncMock(return_value=(None, False)),
+            ),
+            patch.object(
+                streaming_mod,
+                "resolve_streaming_url_with_cache",
+                new=AsyncMock(side_effect=gated_resolve),
+            ),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                yield SimpleNamespace(
+                    client=client,
+                    gate=gate,
+                    probed=probed,
+                    apple=apple,
+                    discogs=discogs,
+                    entity_store=entity_store,
+                )
+    finally:
+        # Unblock and reap any warms a failed test left parked on the gate so
+        # the loop closes cleanly (no destroyed-pending-task noise burying the
+        # real assertion failure).
+        gate.set()
+        pending = list(streaming_mod._background_tasks)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
 
 
 class TestApiLookupStreamingProbeOffPath:
@@ -278,10 +341,12 @@ class TestApiLookupStreamingProbeOffPath:
         """The #706 invariant, endpoint-level: a cold lookup completes while the
         live probe is gate-blocked, then the released warm completes off-path.
 
-        The 10s ``wait_for`` is a fail-fast ceiling, not a latency assertion:
-        with the gate closed the probe can never finish, so a synchronous
-        probe anywhere on the response path parks the request on the gate and
-        trips the ceiling.
+        The 5s ``wait_for`` is a fail-fast ceiling, not a latency assertion
+        (the happy path measures ~10ms): with the gate closed the probe can
+        never finish, so a synchronous probe on the response path parks the
+        request on the gate and trips the ceiling. The causality proof IS the
+        request completing — program order guarantees the gate is still closed
+        here (only this test body ever sets it, below).
         """
         h = offpath_harness
         resp = await asyncio.wait_for(
@@ -293,13 +358,10 @@ class TestApiLookupStreamingProbeOffPath:
                     "raw_message": "Stereolab - Aluminum Tunes",
                 },
             ),
-            timeout=10.0,
+            timeout=5.0,
         )
 
-        # Causality: the response is complete and the gate was never released,
-        # so nothing on the response path waited for the probe.
         assert resp.status_code == 200
-        assert not h.gate.is_set()
         # Eventual consistency: the first (cold) lookup surfaces no Apple URL —
         # neither the gated probe's URL nor anything else Apple-shaped.
         assert "music.apple.com" not in resp.text
@@ -319,6 +381,52 @@ class TestApiLookupStreamingProbeOffPath:
         h.apple.find_album_match.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_discogs_match_branch_also_keeps_probe_off_path(self, offpath_harness):
+        """Same causality on the Discogs-MATCH enrichment branch.
+
+        The default harness exercises only the empty-Discogs LML#401 synthesis
+        branch. But the artwork-bearing match branch is where a synchronous
+        streaming resolve is likeliest to be bolted on next — it already hosts
+        the one deliberately-synchronous Apple probe (``find_track_url``, the
+        happy path). Reassign the search mock so the request binds a real
+        Discogs result, then assert the same off-path invariant, plus that the
+        allowed track-level probe DID run synchronously (pinning the artwork
+        carve-out rather than assuming it).
+        """
+        h = offpath_harness
+        match = make_discogs_result(
+            release_id=8001, album="Emperor Tomato Ketchup", artist="Stereolab"
+        )
+        h.discogs.search = AsyncMock(return_value=DiscogsSearchResponse(results=[match]))
+
+        resp = await asyncio.wait_for(
+            h.client.post(
+                "/api/v1/lookup",
+                json={
+                    "artist": "Stereolab",
+                    "album": "Emperor Tomato Ketchup",
+                    "raw_message": "Stereolab - Emperor Tomato Ketchup",
+                },
+            ),
+            timeout=5.0,
+        )
+
+        assert resp.status_code == 200
+        assert "music.apple.com" not in resp.text
+        assert len(streaming_mod._background_tasks) == 1
+
+        h.gate.set()
+        await _drain_background_tasks()
+
+        assert h.probed == [("apple_music_album", "Stereolab", "Emperor Tomato Ketchup")]
+        assert not streaming_mod._streaming_warm_in_flight
+        # The happy-path track probe is the ALLOWED synchronous Apple call
+        # (URL-only; artwork on this branch comes from the Discogs row) — it
+        # must have run in-request, unlike the album-level probe.
+        h.apple.find_track_url.assert_awaited()
+        h.apple.find_album_match.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_concurrent_cold_lookups_all_return_before_any_probe_releases(
         self, offpath_harness
     ):
@@ -333,7 +441,7 @@ class TestApiLookupStreamingProbeOffPath:
             ("Jessica Pratt", "On Your Own Love Again"),
             ("Cat Power", "Moon Pix"),
             ("Juana Molina", "DOGA"),
-            ("Grimes", "Visions"),
+            ("Autechre", "Confield"),
         ]
 
         responses = await asyncio.wait_for(
@@ -350,12 +458,12 @@ class TestApiLookupStreamingProbeOffPath:
                     for artist, album in requests
                 )
             ),
-            timeout=20.0,
+            timeout=10.0,
         )
 
-        # All five responses returned; no probe has been allowed to finish.
+        # All five responses returned while every probe was still gate-blocked
+        # (program order: the gate is set only below).
         assert [r.status_code for r in responses] == [200] * 5
-        assert not h.gate.is_set()
         # One warm per distinct (service, artist, album) — request-internal
         # duplicate misses (multi-row results) dedup to a single task.
         assert len(streaming_mod._background_tasks) == 5

--- a/tests/integration/test_api_lookup_hard_timeout.py
+++ b/tests/integration/test_api_lookup_hard_timeout.py
@@ -1,19 +1,40 @@
-"""End-to-end test: LML#370 hard cap surfaces as ``LookupResponse.timeout``.
+"""End-to-end ``/api/v1/lookup`` latency-architecture guards.
 
-When ``execute_search_pipeline``'s hard cap fires (loop gate or per-strategy
-``asyncio.wait_for``), ``perform_lookup`` must project ``state.timed_out``
-into the response shape so callers can distinguish "no match" (empty
-``results``, ``timeout: False``) from "ran out of time" (``timeout: True``).
+Two endpoint-level invariants live here, both deterministic (no wall-clock
+thresholds beyond generous fail-fast ceilings):
 
-This is a pure TestClient + mocked-strategy test — no `pg` or `external_api`
+* **LML#370 hard cap surfaces as ``LookupResponse.timeout``** — when
+  ``execute_search_pipeline``'s hard cap fires (loop gate or per-strategy
+  ``asyncio.wait_for``), ``perform_lookup`` must project ``state.timed_out``
+  into the response shape so callers can distinguish "no match" (empty
+  ``results``, ``timeout: False``) from "ran out of time" (``timeout: True``).
+
+* **LML#706 streaming probe stays off the response path** — the whole-endpoint
+  guard for the #706 cold-tail fix. A cold lookup (streaming-URL cache miss)
+  must return while the live probe is still blocked on a test-controlled
+  ``asyncio.Event``, proving the inline external fan-out cannot silently
+  re-block ``/lookup``. Causality, not timing: the response completing while
+  the gate is closed is the assertion; releasing the gate and draining
+  ``_background_tasks`` then confirms the warm ran to completion off-path.
+
+This is a pure TestClient + mocked-dependency file — no `pg` or `external_api`
 marker, runs in the default suite.
 """
 
 import asyncio
 import time
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import pytest_asyncio
+
+from clients.streaming.apple_music import AppleMusicClient
+from discogs.models import DiscogsSearchResponse
+from entity.sources import PgSource
+from entity.store import EntityStore
+from entity.streaming_url_cache import ResolveOutcome
+from lookup import streaming_url_postprocess as streaming_mod
 
 
 class TestApiLookupHardTimeout:
@@ -82,3 +103,267 @@ class TestApiLookupHardTimeout:
         body = resp.json()
         # Field is present and false (or omitted, which the consumer reads as false).
         assert body.get("timeout") is False or "timeout" not in body
+
+
+# ---------------------------------------------------------------------------
+# LML#706: the streaming-URL live probe must stay off the /lookup response path.
+# ---------------------------------------------------------------------------
+
+
+async def _drain_background_tasks() -> None:
+    """Await every scheduled warm so its done-callbacks run (clearing the task
+    set and the dedup key), letting post-drain assertions observe the result."""
+    while streaming_mod._background_tasks:
+        await asyncio.gather(*list(streaming_mod._background_tasks), return_exceptions=True)
+
+
+@pytest.fixture(autouse=True)
+def _reset_warm_state():
+    """Isolate the post-process module's process-global warm state (semaphore,
+    dedup set, task set) — same reset the unit suite uses, so a leaked dedup
+    key or a semaphore bound to a prior event loop can't leak across tests."""
+    streaming_mod._streaming_warm_semaphore = None
+    streaming_mod._streaming_warm_in_flight.clear()
+    streaming_mod._background_tasks.clear()
+    yield
+    streaming_mod._streaming_warm_in_flight.clear()
+    streaming_mod._background_tasks.clear()
+    streaming_mod._streaming_warm_semaphore = None
+
+
+@pytest_asyncio.fixture
+async def offpath_harness(library_db, test_settings, monkeypatch):
+    """A full ``/lookup`` app client wired so the streaming-URL post-process
+    runs Apple-only, with the cache peek forced to a genuine miss and the live
+    probe gated on a test-controlled ``asyncio.Event``.
+
+    The two patches sit at the same seams the unit suite uses
+    (``peek_cached_streaming_url`` / ``resolve_streaming_url_with_cache``), but
+    the request travels the real router → orchestrator → post-process chain, so
+    a synchronous probe reintroduced ANYWHERE on that chain deadlocks the
+    response against the closed gate and fails the test's outer ``wait_for``.
+
+    Yields a namespace: ``client`` (httpx AsyncClient), ``gate`` (the Event the
+    probe blocks on), ``probed`` (list of ``(service, artist, album)`` awaits),
+    ``apple`` (the Apple client mock), ``entity_store``.
+
+    The Apple client's track-level probes (``find_track_url`` /
+    ``find_track_metadata``) resolve to ``None`` — those calls are the
+    deliberately-synchronous artwork-bearing path and are ALLOWED (#706 kept
+    them on the hot path; artwork stays synchronous). ``find_album_match`` —
+    the album-level probe behind the resolver — raises if awaited, guarding
+    the resolver seam against a direct-client-call bypass.
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    from config.settings import get_settings
+    from core.dependencies import (
+        get_discogs_cache_pg,
+        get_discogs_service,
+        get_library_db,
+        get_posthog_client,
+    )
+    from identity.dependencies import get_entity_store
+    from main import app
+    from streaming.dependencies import (
+        get_apple_music_client,
+        get_bandcamp_client,
+        get_spotify_client,
+    )
+
+    # The orchestrator reads these via a direct ``get_settings()`` call (not
+    # DI), and ``get_settings`` is ``@lru_cache``d — env alone is not enough
+    # once any earlier test (or import-time caller) has populated the cache
+    # with the flags at their defaults. Set env, then bust the cache; bust it
+    # again on teardown so the flag-enabled Settings can't leak onward.
+    # Apple-only keeps warm-counting deterministic (one warm per cold request).
+    monkeypatch.setenv("LML_PERSIST_STREAMING_URLS", "true")
+    monkeypatch.setenv("LML_PERSIST_STREAMING_URL_APPLE_MUSIC", "true")
+    monkeypatch.setenv("LML_PERSIST_STREAMING_URL_SPOTIFY", "false")
+    monkeypatch.setenv("LML_PERSIST_STREAMING_URL_BANDCAMP", "false")
+    # The warm wraps the probe in Apple's per-call wait_for ceiling (4s
+    # default). The gated probe deliberately blocks until the test releases
+    # it, so widen the ceiling — otherwise a slow CI box could time the warm
+    # out before the release and flake the post-drain assertions.
+    monkeypatch.setenv("LML_APPLE_MUSIC_LOOKUP_TIMEOUT_MS", "60000")
+    get_settings.cache_clear()
+
+    gate = asyncio.Event()
+    probed: list[tuple[str, str, str]] = []
+
+    async def gated_resolve(pg, client, *, service, artist, album, **kwargs):
+        probed.append((service, artist, album))
+        await gate.wait()
+        return ResolveOutcome(
+            url="https://music.apple.com/us/album/gated/1234567890", source="live_resolved"
+        )
+
+    apple = AsyncMock(spec=AppleMusicClient)
+    apple.find_track_url = AsyncMock(return_value=None)
+    apple.find_track_metadata = AsyncMock(return_value=None)
+    apple.find_album_match = AsyncMock(
+        side_effect=AssertionError(
+            "find_album_match awaited directly — the album probe must go "
+            "through resolve_streaming_url_with_cache in a background warm"
+        )
+    )
+
+    # A Discogs service that finds nothing: enrichment must still run (a None
+    # service skips Step 4 artwork entirely and with it the whole enrichment
+    # block), and the empty search drives the LML#401 no-Discogs-match branch —
+    # the synthesized streaming-only result whose URL fields are exactly what
+    # the post-process backstops. This is the production cold shape from the
+    # #706 incident: album absent from the Discogs catalog, streaming cache cold.
+    discogs = AsyncMock(
+        spec_set=[
+            "search",
+            "search_releases_by_track",
+            "validate_track_on_release",
+            "get_release",
+            "cache_service",
+        ]
+    )
+    discogs.cache_service = None
+    discogs.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+    discogs.search_releases_by_track = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+    discogs.get_release = AsyncMock(return_value=None)
+    discogs.validate_track_on_release = AsyncMock(return_value=False)
+
+    entity_store = MagicMock(spec=EntityStore)
+    entity_store.mint_or_get_release_identity = AsyncMock(return_value=(7, True))
+    # The lookup pipeline reconciles artist identity via get_identity; an
+    # auto-generated AsyncMock return would flow into the ReconciledIdentity
+    # Pydantic model and 500 the request — "no identity row" is the neutral
+    # answer for this harness.
+    entity_store.get_identity = AsyncMock(return_value=None)
+
+    app.dependency_overrides[get_library_db] = lambda: library_db
+    app.dependency_overrides[get_discogs_service] = lambda: discogs
+    app.dependency_overrides[get_posthog_client] = lambda: None
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_entity_store] = lambda: entity_store
+    app.dependency_overrides[get_discogs_cache_pg] = lambda: AsyncMock(spec=PgSource)
+    app.dependency_overrides[get_apple_music_client] = lambda: apple
+    app.dependency_overrides[get_spotify_client] = lambda: None
+    app.dependency_overrides[get_bandcamp_client] = lambda: None
+
+    with (
+        patch.object(
+            streaming_mod,
+            "peek_cached_streaming_url",
+            new=AsyncMock(return_value=(None, False)),
+        ),
+        patch.object(
+            streaming_mod,
+            "resolve_streaming_url_with_cache",
+            new=AsyncMock(side_effect=gated_resolve),
+        ),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            yield SimpleNamespace(
+                client=client,
+                gate=gate,
+                probed=probed,
+                apple=apple,
+                entity_store=entity_store,
+            )
+
+    app.dependency_overrides.clear()
+    get_settings.cache_clear()
+
+
+class TestApiLookupStreamingProbeOffPath:
+    @pytest.mark.asyncio
+    async def test_cold_lookup_returns_while_probe_is_still_blocked(self, offpath_harness):
+        """The #706 invariant, endpoint-level: a cold lookup completes while the
+        live probe is gate-blocked, then the released warm completes off-path.
+
+        The 10s ``wait_for`` is a fail-fast ceiling, not a latency assertion:
+        with the gate closed the probe can never finish, so a synchronous
+        probe anywhere on the response path parks the request on the gate and
+        trips the ceiling.
+        """
+        h = offpath_harness
+        resp = await asyncio.wait_for(
+            h.client.post(
+                "/api/v1/lookup",
+                json={
+                    "artist": "Stereolab",
+                    "album": "Aluminum Tunes",
+                    "raw_message": "Stereolab - Aluminum Tunes",
+                },
+            ),
+            timeout=10.0,
+        )
+
+        # Causality: the response is complete and the gate was never released,
+        # so nothing on the response path waited for the probe.
+        assert resp.status_code == 200
+        assert not h.gate.is_set()
+        # Eventual consistency: the first (cold) lookup surfaces no Apple URL —
+        # neither the gated probe's URL nor anything else Apple-shaped.
+        assert "music.apple.com" not in resp.text
+        # Exactly one warm was scheduled for the (apple, artist, album) miss.
+        assert len(streaming_mod._background_tasks) == 1
+
+        # Release the gate: the warm must run the probe + mint to completion.
+        h.gate.set()
+        await _drain_background_tasks()
+
+        assert h.probed == [("apple_music_album", "Stereolab", "Aluminum Tunes")]
+        h.entity_store.mint_or_get_release_identity.assert_awaited_once_with(
+            source="apple_music_album", external_id="1234567890"
+        )
+        assert not streaming_mod._streaming_warm_in_flight
+        # The album-level client probe was never bypass-called directly.
+        h.apple.find_album_match.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_lookups_all_return_before_any_probe_releases(
+        self, offpath_harness
+    ):
+        """K=5 concurrent cold lookups (distinct albums) all complete while
+        every probe is still gate-blocked — the congestion shape from the #706
+        incident (cold requests stacking up behind synchronous fan-out) cannot
+        re-form. Same causality assertion as above, N-wide.
+        """
+        h = offpath_harness
+        requests = [
+            ("Stereolab", "Dots and Loops"),
+            ("Jessica Pratt", "On Your Own Love Again"),
+            ("Cat Power", "Moon Pix"),
+            ("Juana Molina", "DOGA"),
+            ("Grimes", "Visions"),
+        ]
+
+        responses = await asyncio.wait_for(
+            asyncio.gather(
+                *(
+                    h.client.post(
+                        "/api/v1/lookup",
+                        json={
+                            "artist": artist,
+                            "album": album,
+                            "raw_message": f"{artist} - {album}",
+                        },
+                    )
+                    for artist, album in requests
+                )
+            ),
+            timeout=20.0,
+        )
+
+        # All five responses returned; no probe has been allowed to finish.
+        assert [r.status_code for r in responses] == [200] * 5
+        assert not h.gate.is_set()
+        # One warm per distinct (service, artist, album) — request-internal
+        # duplicate misses (multi-row results) dedup to a single task.
+        assert len(streaming_mod._background_tasks) == 5
+
+        h.gate.set()
+        await _drain_background_tasks()
+
+        assert sorted(h.probed) == sorted(
+            ("apple_music_album", artist, album) for artist, album in requests
+        )
+        assert not streaming_mod._streaming_warm_in_flight

--- a/tests/unit/test_lookup_streaming_url_postprocess.py
+++ b/tests/unit/test_lookup_streaming_url_postprocess.py
@@ -61,6 +61,7 @@ from lookup.streaming_url_postprocess import (
     apply_streaming_url_postprocess,
     set_suppress_streaming_warm,
 )
+from tests.conftest import drain_streaming_warm_tasks, reset_streaming_warm_state
 
 # Per-service test data. The cache module is service-agnostic; what differs per
 # service is the URL field, client attr, per-service flag, and a
@@ -115,22 +116,16 @@ _ALBUM = "Hold Onto Me Infinity"
 
 @pytest.fixture(autouse=True)
 def _reset_warm_state():
-    """Isolate the module-global warm state (semaphore, dedup set, task set, and
-    the bulk-suppression ContextVar).
+    """Isolate the module-global warm state around every test.
 
-    These are process-global by design (one warm per worker, not per request).
-    Reset around every test so a leaked dedup key, a semaphore bound to a prior
-    event loop, or a stuck suppression flag can't leak across tests.
+    Delegates to the shared ``tests.conftest.reset_streaming_warm_state`` so
+    this file and the endpoint-level suite in
+    ``tests/integration/test_api_lookup_hard_timeout.py`` reset the exact same
+    globals — the two used to carry diverging per-file copies.
     """
-    mod._streaming_warm_semaphore = None
-    mod._streaming_warm_in_flight.clear()
-    mod._background_tasks.clear()
-    set_suppress_streaming_warm(False)
+    reset_streaming_warm_state()
     yield
-    mod._streaming_warm_in_flight.clear()
-    mod._background_tasks.clear()
-    mod._streaming_warm_semaphore = None
-    set_suppress_streaming_warm(False)
+    reset_streaming_warm_state()
 
 
 def _settings(*enabled_services: str, master: bool = True) -> SimpleNamespace:
@@ -193,11 +188,9 @@ def _patch_resolver(**kwargs):
     return patch.object(mod, "resolve_streaming_url_with_cache", new=AsyncMock(**kwargs))
 
 
-async def _drain_background_tasks() -> None:
-    """Await every scheduled warm so its done-callbacks run (clearing the task
-    set and the dedup key), letting post-drain assertions observe the result."""
-    while mod._background_tasks:
-        await asyncio.gather(*list(mod._background_tasks), return_exceptions=True)
+# Bounded drain shared with the endpoint-level suite (single source of truth
+# for the subtle while-loop-because-done-callbacks-run-late semantics).
+_drain_background_tasks = drain_streaming_warm_tasks
 
 
 async def _run(update, *, settings, clients=None, entity_store=None, pg=None):
@@ -468,7 +461,13 @@ class TestCacheMissEnqueuesBackgroundWarm:
         ):
             await _run(update, settings=_settings(service))
             # Response path complete: the probe was never awaited, not even a
-            # variant that would have returned control immediately.
+            # variant that would have returned control immediately. NOTE: this
+            # also pins that the enqueue loop is the function's tail — a
+            # benign trailing await added after the loop would give the warm
+            # task a slot to start and trip this assertion even though the hot
+            # path stayed probe-free. That's deliberate strictness; if you add
+            # such an await, update this assertion knowingly (the Event-gated
+            # test above still carries the pure does-not-WAIT invariant).
             assert probe_awaits == []
             assert len(mod._background_tasks) == 1
 

--- a/tests/unit/test_lookup_streaming_url_postprocess.py
+++ b/tests/unit/test_lookup_streaming_url_postprocess.py
@@ -439,6 +439,47 @@ class TestCacheMissEnqueuesBackgroundWarm:
         assert not mod._background_tasks
         assert not mod._streaming_warm_in_flight
 
+    async def test_response_path_records_zero_probe_awaits_even_when_probe_raises(self):
+        # PR2 of #706 hardens the Event-gated ordering test above into a
+        # raise-if-awaited spy. The distinction matters: the post-process
+        # contains ``return_exceptions=True`` and the warm swallows every
+        # exception, so a regression that re-inlines the probe would NOT
+        # surface as a raised error — the request would silently block again.
+        # The spy therefore RECORDS each await; the load-bearing assertion is
+        # that the record is empty when the response path returns, regardless
+        # of what the probe does (here: fail fast, the cheapest probe there is
+        # — if even a raise-immediately probe leaves a record before the
+        # response completes, the probe is back on the hot path).
+        service = "apple_music_album"
+        update = _blank_update()
+        probe_awaits: list[str] = []
+
+        async def raise_if_awaited(pg, client, *, service, artist, album, **kwargs):
+            probe_awaits.append(service)
+            raise AssertionError("streaming probe awaited on the /lookup response path")
+
+        with (
+            _patch_cache_peek(None),
+            patch.object(
+                mod,
+                "resolve_streaming_url_with_cache",
+                new=AsyncMock(side_effect=raise_if_awaited),
+            ),
+        ):
+            await _run(update, settings=_settings(service))
+            # Response path complete: the probe was never awaited, not even a
+            # variant that would have returned control immediately.
+            assert probe_awaits == []
+            assert len(mod._background_tasks) == 1
+
+            await _drain_background_tasks()
+
+        # The warm DID run the probe off-path and swallowed its failure.
+        assert probe_awaits == [service]
+        assert update["apple_music_url"] is None
+        assert not mod._background_tasks
+        assert not mod._streaming_warm_in_flight
+
     @pytest.mark.parametrize("service", list(_CASES))
     async def test_background_warm_runs_probe_and_mints_on_live_resolved(self, service):
         case = _CASES[service]


### PR DESCRIPTION
PR2 of the approved [#706](https://github.com/WXYC/library-metadata-lookup/issues/706) plan (see the plan comment on the issue). PR1 was #707 (merged, deployed to prod 2026-06-29). References #706 — the issue closes after PR3 + prod re-measurement, per the plan's staged acceptance.

## What this adds

The durable guard for the #706 fix is an **architectural invariant test**, deterministic and CI-enforced — not a flaky latency threshold. Two levels:

**Unit — raise-if-awaited spy** (`tests/unit/test_lookup_streaming_url_postprocess.py`): hardens PR1's Event-gated ordering test. The distinction matters: the post-process gathers with `return_exceptions=True` and the background warm swallows every exception, so a regression that re-inlines the probe would **silently block the request** rather than raise. The spy records every await; the load-bearing assertion is an empty record when the response path returns — even for a probe that fails fast.

**Endpoint — Event-gated causality** (`tests/integration/test_api_lookup_hard_timeout.py`, now the home of both `/lookup` latency-architecture guards): a cold lookup travels the real router → orchestrator → post-process chain with the live probe blocked on a test-controlled `asyncio.Event`. The response must complete **while the gate is still closed** — causality, not wall-clock. Releasing the gate and draining `_background_tasks` then confirms the warm ran probe + mint to completion off-path. A K=5 concurrent variant pins the same causality N-wide, so the #706 congestion shape (cold requests stacking behind synchronous fan-out) cannot re-form.

## Harness notes

- The orchestrator reads flags via the `lru_cache`d `get_settings()`, so the fixture busts the cache after setting env flags and again on teardown.
- The Apple per-call `wait_for` ceiling is widened via `LML_APPLE_MUSIC_LOOKUP_TIMEOUT_MS` so a slow CI box can't time out the deliberately-blocked probe.
- The track-level `find_track_url` / `find_track_metadata` probes remain **allowed** — artwork is deliberately synchronous (the May iOS-outage lesson). `find_album_match` raises if bypass-called directly, guarding the resolver seam.

## Red verification

All three new guards were run against a sabotage build that re-inlines the probe into `apply_streaming_url_postprocess`: all three fail (the endpoint tests trip their fail-fast ceilings parked on the closed gate; the unit spy records the synchronous await). Reverted, all green: full default suite 3436 passed.

## Deliberate omission

The plan's *optional* enrichment wall-clock budget is not included: by the plan's own analysis it fires late under starvation (a guard, not a cure), and it would introduce a default-off knob on the artwork-bearing path. PR3's in-flight cap is the structural protection; it lands next.