### PR TITLE
fix(orchestrator): reject wrong-artist rows in album-title fallback

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -2241,20 +2241,34 @@ async def search_compilations_for_track(
                 from rapidfuzz import fuzz as _fuzz
 
                 lib_artist_norm = normalize_for_comparison(lib_artist)
-                matches = [
-                    match
-                    for match in matches
-                    if max(
-                        _fuzz.token_set_ratio(
-                            lib_artist_norm, normalize_for_comparison(match.artist or "")
-                        ),
-                        _fuzz.token_set_ratio(
-                            lib_artist_norm,
-                            normalize_for_comparison(match.alternate_artist_name or ""),
-                        ),
+                discogs_is_compilation = release_info.is_compilation
+                release_album_lower = release_album.lower()
+
+                def _fallback_row_acceptable(match: LibraryItem) -> bool:
+                    # Legitimate Various-Artists compilation rows share no artist
+                    # tokens with a typed solo/track artist, so the fuzzy floor
+                    # would wrongly drop them. Keep them on a title match instead,
+                    # mirroring the strict branch's compilation carve-out above.
+                    # ``is_compilation_artist`` is False for coincidental
+                    # wrong-artist collisions (e.g. "Galaxy 2 Galaxy"), so this
+                    # does not re-open the #717 bug.
+                    if discogs_is_compilation and is_compilation_artist(match.artist or ""):
+                        title_score = _fuzz.ratio(release_album_lower, (match.title or "").lower())
+                        return title_score >= 80
+                    return (
+                        max(
+                            _fuzz.token_set_ratio(
+                                lib_artist_norm, normalize_for_comparison(match.artist or "")
+                            ),
+                            _fuzz.token_set_ratio(
+                                lib_artist_norm,
+                                normalize_for_comparison(match.alternate_artist_name or ""),
+                            ),
+                        )
+                        >= _FALLBACK_ARTIST_SIMILARITY_FLOOR
                     )
-                    >= _FALLBACK_ARTIST_SIMILARITY_FLOOR
-                ]
+
+                matches = [match for match in matches if _fallback_row_acceptable(match)]
 
             if not matches:
                 return []

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -1698,6 +1698,20 @@ def _release_matches_library_row(release: ReleaseInfo, item: LibraryItem) -> boo
 # verification; this tightens the LML lookup result itself.
 _ALBUM_MATCH_FLOOR = 80.0
 
+# Lenient artist-overlap backstop for the album-title fallback's
+# ``skip_artist_match_filter=True`` path (``process_release``). That path
+# intentionally drops the strict prefix filter so reordered/collaborative
+# credits (e.g. "Orcutt, Bill / Shelley, Chris / Miller, Mette" for a typed
+# "Orcutt Shelley Miller") still reach ``validate_track_on_release``. But that
+# validator checks the *Discogs release*, not the surfaced *library row*, so a
+# pure album-title fuzz collision can bind a wrong-artist row (the "Galaxy
+# Garden" → "Galaxy to Galaxy" by Galaxy 2 Galaxy case for a "Lone" request).
+# This floor rejects rows whose artist shares essentially no fuzzy overlap with
+# the request. Deliberately far below the usual 70/80 floors: reordered
+# collaborators score ~65 (must survive) while coincidental collisions score
+# ~17 (must drop). Measured on those two anchors; keep the margin if retuning.
+_FALLBACK_ARTIST_SIMILARITY_FLOOR = 40.0
+
 
 def _filter_results_by_album_match(
     results: list[LibraryItem],
@@ -2218,6 +2232,29 @@ async def search_compilations_for_track(
                                 f"(title_score={title_score:.0f})"
                             )
                 matches = filtered_matches
+            elif matches and lib_artist and skip_artist_match_filter:
+                # The strict prefix filter above is deferred on this path, but
+                # ``validate_track_on_release`` only vets the Discogs release —
+                # not the surfaced library row. Apply a lenient library-side
+                # artist backstop so an album-title fuzz collision can't bind a
+                # wrong-artist row (see ``_FALLBACK_ARTIST_SIMILARITY_FLOOR``).
+                from rapidfuzz import fuzz as _fuzz
+
+                lib_artist_norm = normalize_for_comparison(lib_artist)
+                matches = [
+                    match
+                    for match in matches
+                    if max(
+                        _fuzz.token_set_ratio(
+                            lib_artist_norm, normalize_for_comparison(match.artist or "")
+                        ),
+                        _fuzz.token_set_ratio(
+                            lib_artist_norm,
+                            normalize_for_comparison(match.alternate_artist_name or ""),
+                        ),
+                    )
+                    >= _FALLBACK_ARTIST_SIMILARITY_FLOOR
+                ]
 
             if not matches:
                 return []

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -427,6 +427,79 @@ class TestAlbumTitleFallback:
         )
 
     @pytest.mark.asyncio
+    async def test_fallback_keeps_various_artists_comp_row_despite_zero_artist_overlap(self):
+        """A genuine Various-Artists compilation row must survive the fallback's
+        lenient artist backstop even though its artist string ("Various Artists")
+        shares no tokens with the typed solo artist.
+
+        This is the case ``search_compilations_for_track`` exists to serve: the
+        WXYC library files a compilation under "Various Artists", the user types
+        the *track* artist ("Sun Ra"), and Wave A finds nothing. The album-title
+        fallback fires and ``search_album_fuzzy`` surfaces the VA row on a title
+        match. ``token_set_ratio("Sun Ra", "Various Artists") ≈ 29`` is far below
+        ``_FALLBACK_ARTIST_SIMILARITY_FLOOR`` (40), so a naive floor would drop
+        it — but the Discogs release is a compilation and the row is a
+        compilation artist whose title matches, so the fallback must keep it
+        (mirroring the strict branch's compilation carve-out). ``is_compilation_
+        artist`` is False for the "Galaxy 2 Galaxy" collision, so this carve-out
+        does not re-open the #717 wrong-artist bug.
+        """
+        va_comp_item = make_library_item(
+            id=88123,
+            artist="Various Artists",
+            title="Freedom Jazz Dance",
+        )
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[va_comp_item])
+
+        comp_release = TrackReleasesResponse(
+            track="Space Is the Place",
+            artist=None,
+            releases=[
+                ReleaseInfo(
+                    album="Freedom Jazz Dance",
+                    artist="Various",
+                    release_id=5551234,
+                    release_url="https://www.discogs.com/release/5551234",
+                    is_compilation=True,
+                )
+            ],
+            total=1,
+        )
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        service.search_releases_by_track = AsyncMock(return_value=_empty_response())
+        service.search_releases_by_album_title = AsyncMock(return_value=comp_release)
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="Sun Ra",
+            album="Freedom Jazz Dance",
+            song="Space Is the Place",
+            raw_message="Sun Ra - Space Is the Place",
+        )
+
+        with patch(
+            "lookup.orchestrator.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            results, _titles = await search_compilations_for_track(
+                db, parsed, discogs_service=service
+            )
+
+        assert any(r.id == 88123 for r in results), (
+            "Expected the Various-Artists compilation row 88123 ('Various "
+            "Artists' / 'Freedom Jazz Dance') to surface for track artist 'Sun "
+            "Ra' via the album-title fallback. It is a legitimate compilation "
+            "match (is_compilation_artist + title match), so the lenient artist "
+            f"floor must not drop it. Got: {[(r.id, r.title) for r in results]}"
+        )
+
+    @pytest.mark.asyncio
     async def test_fallback_release_still_rejected_when_validate_track_returns_false(self):
         """Even with skip_artist_match_filter=True, validate_track_on_release
         is the last line of defense — if the Discogs-side fuzzy validator says

--- a/tests/unit/test_album_title_fallback.py
+++ b/tests/unit/test_album_title_fallback.py
@@ -341,6 +341,92 @@ class TestAlbumTitleFallback:
         service.validate_track_on_release.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_fallback_drops_wrong_artist_row_matched_only_by_album_title(self):
+        """Regression: a wrong-*artist* library row matched purely on album-title
+        fuzz must NOT surface through the fallback.
+
+        Repro (Lone / "Galaxy Garden" / "Crystal Caverns 1991"): "Galaxy Garden"
+        isn't in the WXYC library, so Wave A is empty and the album-title
+        fallback fires. Its Discogs candidate is Lone's real "Galaxy Garden"
+        release, but ``search_album_fuzzy(db, "Galaxy Garden")`` fuzz-matches the
+        library row "Galaxy to Galaxy" by *Galaxy 2 Galaxy*
+        (``album_title_acceptable`` → True, token_set_ratio 80). Because the
+        fallback runs ``process_release(..., skip_artist_match_filter=True)`` and
+        ``validate_track_on_release`` validates the (correct) Discogs release, the
+        wrong-artist row surfaces — and, being a non-empty result, structurally
+        preempts the ``_resolve_nonlibrary_release`` carry-through (gated on
+        ``not results``) that would have resolved the correct row-less release.
+
+        The artist ("Galaxy 2 Galaxy") shares essentially no fuzzy overlap with
+        the request ("Lone") — token_set_ratio ~17, far below the reordered-
+        collaborator cases the flag protects (65-70). The fallback must reject it.
+        """
+        wrong_artist_item = make_library_item(
+            id=70229,
+            artist="Galaxy 2 Galaxy",
+            title="Galaxy to Galaxy",
+        )
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        db.search = AsyncMock(return_value=[wrong_artist_item])
+
+        # The album-title fallback probe returns Lone's actual "Galaxy Garden"
+        # release; validate_track_on_release confirms the *release* (as in prod).
+        lone_galaxy_garden = TrackReleasesResponse(
+            track="Crystal Caverns 1991",
+            artist="Lone",
+            releases=[
+                ReleaseInfo(
+                    album="Galaxy Garden",
+                    artist="Lone",
+                    release_id=4030652,
+                    release_url="https://www.discogs.com/release/4030652",
+                    is_compilation=False,
+                )
+            ],
+            total=1,
+        )
+
+        service = AsyncMock()
+        service.cache_service = AsyncMock()
+        service.cache_service.search_artists_by_name = AsyncMock(return_value=[])
+        service.search_releases_by_track = AsyncMock(return_value=_empty_response())
+        service.search_releases_by_album_title = AsyncMock(return_value=lone_galaxy_garden)
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="Lone",
+            album="Galaxy Garden",
+            song="Crystal Caverns 1991",
+            raw_message="Lone - Crystal Caverns 1991",
+        )
+
+        with (
+            patch(
+                "lookup.orchestrator.lookup_releases_by_track",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            # Isolate the fallback's artist gating from the downstream
+            # non-library carry-through (not under test here).
+            patch(
+                "lookup.orchestrator._resolve_nonlibrary_release",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            results, _titles = await search_compilations_for_track(
+                db, parsed, discogs_service=service
+            )
+
+        assert not any(r.id == 70229 for r in results), (
+            "Wrong-artist library row 70229 ('Galaxy 2 Galaxy' / 'Galaxy to "
+            "Galaxy') must not surface for request artist 'Lone' — it matched "
+            "only on album-title fuzz, and its artist has ~zero overlap with the "
+            f"request. Got: {[(r.id, r.title) for r in results]}"
+        )
+
+    @pytest.mark.asyncio
     async def test_fallback_release_still_rejected_when_validate_track_returns_false(self):
         """Even with skip_artist_match_filter=True, validate_track_on_release
         is the last line of defense — if the Discogs-side fuzzy validator says


### PR DESCRIPTION
Closes #717.

## Problem

For a non-library release, `/api/v1/lookup` returns the **wrong album** when the caller includes an album title — the shape the Backend enrichment worker always sends, so the iOS app shows incomplete metadata. For **Lone – Galaxy Garden**:

| Query | Result (prod, before) |
|---|---|
| `artist=Lone, album=Galaxy Garden, song=Crystal Caverns 1991` | Wrong album: *Galaxy 2 Galaxy / "Galaxy to Galaxy"* |
| `artist=Lone, song=Crystal Caverns 1991` (no album) | ✅ Lone / Galaxy Garden, fully enriched |

## Root cause

The album-title fallback in `search_compilations_for_track` runs `process_release(..., skip_artist_match_filter=True)`, which drops the library-side artist filter and defers artist gating to `validate_track_on_release`. But that validator vets the **Discogs release**, not the surfaced **library row** — so an album-title fuzz collision (`search_album_fuzzy("Galaxy Garden")` → library "Galaxy to Galaxy" by *Galaxy 2 Galaxy*, `album_title_acceptable` → True) binds a wrong-artist row. Being non-empty, it structurally preempts the `_resolve_nonlibrary_release` carry-through, which is gated on `not results`.

## Fix

Add a lenient library-side artist backstop on the `skip_artist_match_filter=True` path: reject rows whose artist `token_set_ratio` against the request falls below `_FALLBACK_ARTIST_SIMILARITY_FLOOR` (40). Far below the usual 70/80 floors so reordered/collaborative credits survive (the #319/#237 trio ≈ 65) while coincidental collisions drop ("Lone" vs "Galaxy 2 Galaxy" ≈ 17). With the wrong row gone, the non-library resolver runs and returns release year + Discogs + bio + Wikipedia + Apple Music.

## Testing

- New failing-first regression test `test_fallback_drops_wrong_artist_row_matched_only_by_album_title` (RED on `origin/main`, GREEN after) reproducing the Lone / Galaxy Garden surfacing.
- Existing trio/collaborator fallback tests still pass (`skip_artist_match_filter` leniency preserved).
- Full unit suite: 3167 passed (excl. `pg` / `external_api` infra markers). `ruff check` + `ruff format --check` clean.

## Scope note

This is the precedence bug only. A separate concern — ambiguous-artist releases (e.g. "Lone") enriching thinly even when catalogued because artist-identity/artwork gates reject the ambiguous Discogs match — is called out in #717 as a follow-up.
