### PR TITLE
refactor(#723): extract lookup/matching.py + lookup/concurrency.py from the orchestrator

### DIFF
--- a/lookup/concurrency.py
+++ b/lookup/concurrency.py
@@ -1,0 +1,142 @@
+"""Bounded-concurrency machinery for the lookup pipeline's Discogs fan-out.
+
+Home of ``_chunked_gather`` and the LML#543 per-invocation API-call cap it
+enforces. Extracted verbatim from ``lookup/orchestrator.py`` (LML#723).
+"""
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable, Coroutine
+from typing import Any
+
+from wxyc_fastapi.observability import get_cache_stats, get_cache_stats_recorder
+
+from core.search import (
+    SEARCH_API_CALL_CAP_FIRED_STAT_KEY,
+    _record_cap_fire_for_runner,
+    resolve_positive_int_env,
+)
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_MAX_API_CALLS_DEFAULT = 15
+"""Default per-invocation cap on Discogs API calls dispatched FROM a single
+``_chunked_gather`` invocation (validation tail of one strategy leg). Sized
+above the warm-cache ``extended=true`` happy-path window (8-14 calls measured
+on the validation tail of one leg) so legitimately-busy lookups don't trip,
+while still bounding the zero-canonical failing tail flagged in LML#543
+(15-24 calls / 16-17s wall-time per failing leg). See ``LML_SEARCH_MAX_API_CALLS``
+in ``docs/env-vars.md`` for the per-invocation scope and why we don't try
+to make this request-wide."""
+
+_SEARCH_MAX_API_CALLS_ENV_VAR = "LML_SEARCH_MAX_API_CALLS"
+
+
+async def _chunked_gather[T, R](
+    items: list[T],
+    worker: Callable[[T], Coroutine[Any, Any, R]],
+    chunk_size: int,
+) -> AsyncIterator[tuple[T, R]]:
+    """Run ``worker`` over ``items`` in chunks of ``chunk_size``, yielding
+    ``(item, result)`` pairs in input order.
+
+    The next chunk is not dispatched until the caller has finished iterating
+    the previous one, so a caller that breaks out after its accumulator
+    saturates never pays for the un-fired chunks. This restores the pre-PR
+    (#534) early-exit behavior in ``search_song_as_track`` /
+    ``search_compilations_for_track`` (LML#536) without giving up
+    within-chunk parallelism.
+
+    Between chunks the per-request Discogs API-call counter
+    (``stats["api_calls"]``) is consulted against ``LML_SEARCH_MAX_API_CALLS``
+    *relative to a baseline captured at entry*. When the delta crosses the
+    cap, the generator returns early so the remaining chunks never dispatch
+    — the safety floor for the zero-canonical validation tail flagged in
+    LML#543. Calls that have already started in the current chunk are
+    awaited to completion; the gate is between chunks, not mid-chunk, so the
+    actual ceiling is ``cap + chunk_size - 1``.
+
+    The baseline makes the cap per-invocation, not request-wide, on purpose:
+
+    * The bulk endpoint (``/api/v1/lookup/bulk``) shares one cache_stats dict
+      across concurrent items (router shares stats so PostHog aggregates
+      reflect the batch). A request-wide cap would starve items late in the
+      batch.
+    * ``search_compilations_for_track`` invokes us twice — main loop, then
+      the LML#319/#237 album-title fallback. A request-wide cap means the
+      fallback never gets a chunk dispatched once the main loop has spent.
+
+    The cross-strategy stop is handled at the runner layer
+    (:func:`core.search.execute_search_pipeline`) via the per-task
+    :data:`core.search._cap_fire_count_var` ContextVar — isolated per
+    pipeline invocation so concurrent bulk items can't poison each other.
+
+    Wall time: ``ceil(N / chunk_size)`` × slowest task per chunk in the
+    no-exit case. The orchestrator's three call sites pass
+    ``MAX_SEARCH_RESULTS`` as the chunk size so that one full chunk can
+    satisfy the response cap on its own — the dominant case for high-fanout
+    requests. The cap also lines up with the 5-permit global Discogs
+    semaphore in ``discogs/service.py`` (``get_semaphore()``): per-request
+    fan-out is bounded here; cross-request total load is bounded there.
+    """
+    assert chunk_size > 0, f"chunk_size must be positive, got {chunk_size}"
+    api_call_cap = resolve_positive_int_env(
+        _SEARCH_MAX_API_CALLS_ENV_VAR, _SEARCH_MAX_API_CALLS_DEFAULT
+    )
+    # Baseline-relative cap. ``get_cache_stats()`` returns ``None`` outside a
+    # request context, in which case ``baseline`` stays 0 and the cap is inert
+    # (warm-path callers and unit tests that don't initialize cache stats are
+    # unaffected). Inside a request, the cap counts API calls dispatched FROM
+    # this invocation only — see docstring for why we don't aggregate request-wide.
+    stats = get_cache_stats()
+    baseline = stats.get("api_calls", 0) if stats is not None else 0
+    for start in range(0, len(items), chunk_size):
+        if stats is not None:
+            spent = stats.get("api_calls", 0) - baseline
+            if spent >= api_call_cap:
+                _record_search_api_call_cap_fired(
+                    cap=api_call_cap,
+                    spent=int(spent),
+                    items_remaining=len(items) - start,
+                    items_total=len(items),
+                )
+                return
+        chunk = items[start : start + chunk_size]
+        chunk_results = await asyncio.gather(*[worker(it) for it in chunk])
+        for it, res in zip(chunk, chunk_results, strict=True):
+            yield it, res
+
+
+def _record_search_api_call_cap_fired(
+    *, cap: int, spent: int, items_remaining: int, items_total: int
+) -> None:
+    """Record an LML#543 cap-fire on both observability surfaces.
+
+    Telemetry — counter on the request-scoped cache-stats dict (each leg that
+    trips its own per-invocation cap adds 1). Projects onto the Sentry
+    transaction as ``lml.cache.search_api_call_cap_fired`` via the router's
+    :func:`_project_cache_stats_to_transaction`; filter on
+    ``lml.cache.search_api_call_cap_fired:>0`` for the cap-fire slice in
+    PostHog/Sentry.
+
+    Control flow — bumps the per-pipeline-invocation counter the runner reads
+    (:data:`core.search._cap_fire_count_var`). That channel is a per-task
+    ContextVar, isolated from sibling bulk items even when they fire the cap
+    concurrently. The control channel is intentionally separate from the
+    telemetry counter so the latter can stay batch-aggregated for PostHog.
+
+    Logs one WARN per cap-fire; ``search_compilations_for_track`` can yield
+    up to two per lookup (main loop + LML#319/#237 album-title fallback) on
+    a pathological case.
+    """
+    get_cache_stats_recorder().record(SEARCH_API_CALL_CAP_FIRED_STAT_KEY)
+    _record_cap_fire_for_runner()
+    logger.warning(
+        "%s reached (cap=%d, spent=%d in this leg, %d/%d items remaining) — "
+        "bailing _chunked_gather",
+        _SEARCH_MAX_API_CALLS_ENV_VAR,
+        cap,
+        spent,
+        items_remaining,
+        items_total,
+    )

--- a/lookup/matching.py
+++ b/lookup/matching.py
@@ -1,0 +1,386 @@
+"""Pure matching predicates, filters, and score floors for the lookup pipeline.
+
+Leaf module: no service handles, no I/O, no async. Everything here operates on
+already-fetched values (`LibraryItem` rows, parsed request fields, title
+strings), so it can be imported from any layer of `lookup/` — and unit-tested
+without mocks. Extracted verbatim from ``lookup/orchestrator.py`` (LML#723).
+"""
+
+import logging
+import re
+
+from wxyc_etl.text import is_compilation_artist
+from wxyc_etl.text import to_match_form as normalize_for_comparison
+
+from core.text import strip_leading_article
+from discogs.models import ReleaseInfo
+from library.models import LibraryItem
+from services.parser import ParsedRequest
+
+logger = logging.getLogger(__name__)
+
+MAX_SEARCH_RESULTS = 5
+"""Maximum number of results to return from search operations."""
+
+SELF_TITLED_PATTERNS = frozenset({"s/t", "s.t.", "self-titled", "self titled"})
+"""Common abbreviations for self-titled albums (case-insensitive exact match)."""
+
+
+def is_self_titled(title: str) -> bool:
+    """Check if an album title indicates a self-titled release.
+
+    Args:
+        title: Album title to check
+
+    Returns:
+        True if title is a common self-titled abbreviation (e.g. "S/t", "S.T.")
+    """
+    return title.strip().lower() in SELF_TITLED_PATTERNS
+
+
+def map_library_format_to_discogs(fmt: str | None) -> str | None:
+    """Map a WXYC library format value to a Discogs API format parameter.
+
+    Library format values like "cd", "vinyl - 12\\"", "cd x 2" are mapped to
+    the corresponding Discogs search API format terms ("CD", "12\\"", etc.).
+
+    Returns None if the format is not recognized or is empty.
+    """
+    if not fmt:
+        return None
+    normalized = fmt.strip().lower()
+    if normalized.startswith("cdr"):
+        return "CDr"
+    if normalized.startswith("cd"):
+        return "CD"
+    if 'vinyl - 12"' in normalized or "vinyl - 12" in normalized:
+        return '12"'
+    if 'vinyl - 7"' in normalized or "vinyl - 7" in normalized:
+        return '7"'
+    if 'vinyl - 10"' in normalized or "vinyl - 10" in normalized:
+        return '10"'
+    if normalized.startswith("vinyl"):
+        return "Vinyl"
+    return None
+
+
+_FETCH_LIMIT = MAX_SEARCH_RESULTS * 10
+"""Internal fetch limit for FTS queries that are post-filtered by artist.
+
+FTS5 ranks results by term frequency, not by artist-prefix relevance, so the
+target artist's entries may fall outside a tight SQL LIMIT.  Fetching more rows
+ensures enough candidates survive ``filter_results_by_artist`` before we trim
+back to ``MAX_SEARCH_RESULTS``.
+"""
+
+
+def limit_results(results: list) -> list:
+    """Limit results to MAX_SEARCH_RESULTS."""
+    return results[:MAX_SEARCH_RESULTS]
+
+
+def artist_matches_item(item: LibraryItem, artist: str) -> bool:
+    """Check if a library item matches the given artist name.
+
+    Compares against both ``item.artist`` and ``item.alternate_artist_name``.
+    Tolerates a leading-article asymmetry between query and catalog —
+    library catalogers commonly file "The Black Dog" as "Black Dog
+    Productions" while user input and Discogs credits keep the article,
+    and the reverse ("Beatles" vs "The Beatles") also occurs. Both sides
+    are compared as-is first; on miss, both are also compared with the
+    leading article stripped. The stripped path is skipped when stripping
+    leaves the query empty so a bare "The" doesn't match arbitrary rows.
+    """
+    artist_normalized = normalize_for_comparison(artist)
+    artist_no_article = strip_leading_article(artist_normalized)
+
+    for candidate in (item.artist, item.alternate_artist_name):
+        if not candidate:
+            continue
+        cand_normalized = normalize_for_comparison(candidate)
+        if cand_normalized.startswith(artist_normalized):
+            return True
+        if artist_no_article and strip_leading_article(cand_normalized).startswith(
+            artist_no_article
+        ):
+            return True
+    return False
+
+
+def library_artist_for(parsed: ParsedRequest) -> str | None:
+    """The artist name the *library-side* legs should search/match against.
+
+    Library channel of the two-channel seam (WXYC/library-metadata-lookup#626):
+    the fuzzy correction on ``parsed.library_artist`` when present, else the
+    typed ``parsed.artist``. Read by ``db.search`` query construction and the
+    ``artist_matches_item`` match-backs — never by the Discogs-facing probes or
+    ``validate_release_for_track``, which always use the typed ``parsed.artist``.
+    """
+    return parsed.library_artist or parsed.artist
+
+
+def filter_results_by_artist(
+    results: list[LibraryItem],
+    artist: str | None,
+) -> list[LibraryItem]:
+    """Filter library results to only include those matching the artist.
+
+    Requires the searched artist name to appear at the START of the result's
+    artist field (case-insensitive).
+    """
+    if not artist:
+        return results
+
+    filtered = []
+    for item in results:
+        if artist_matches_item(item, artist):
+            filtered.append(item)
+
+    if len(filtered) < len(results):
+        logger.info(
+            f"Filtered {len(results)} results to {len(filtered)} matching artist '{artist}'"
+        )
+
+    return filtered
+
+
+def _release_matches_library_row(release: ReleaseInfo, item: LibraryItem) -> bool:
+    """Predicate: does ``release``'s artist credit match ``item``'s library artist?
+
+    Compilation-aware: for VA releases (``release.is_compilation``), any library
+    row whose artist field is itself a compilation marker (e.g., "Various
+    Artists - Rock - D") qualifies. For non-compilations, the library row's
+    artist must prefix-match the Discogs release artist via the existing
+    ``artist_matches_item`` rules.
+    """
+    if release.is_compilation and is_compilation_artist(item.artist or ""):
+        return True
+    if item.artist and artist_matches_item(item, release.artist):
+        return True
+    return False
+
+
+# Minimum fuzzy score (0-100) for accepting a library-row title as a genuine
+# album match for the DJ-typed album. Mirrors the 80-floor in
+# `clients/streaming/apple_music._APPLE_MUSIC_MATCH_FLOOR` and the
+# streaming-availability batch matcher. When the artist-fallback branches
+# of `search_library_with_fallback` surface a row whose title doesn't clear
+# this floor against the typed album, the row would otherwise carry the
+# matched Discogs release's `release_year` / `apple_music_url` / `spotify_url`
+# / `discogs_url` / `artwork_url` onto a flowsheet row tagged with a
+# completely different album — the contamination shape documented in #400
+# (~184k rows; 16,532 distinct Discogs URLs each attached to many distinct
+# DJ-typed `(artist, album)` pairs). #390 / #398 tightened the result
+# verification; this tightens the LML lookup result itself.
+_ALBUM_MATCH_FLOOR = 80.0
+
+# Lenient artist-overlap backstop for the album-title fallback's
+# ``skip_artist_match_filter=True`` path (``process_release``). That path
+# intentionally drops the strict prefix filter so reordered/collaborative
+# credits (e.g. "Orcutt, Bill / Shelley, Chris / Miller, Mette" for a typed
+# "Orcutt Shelley Miller") still reach ``validate_track_on_release``. But that
+# validator checks the *Discogs release*, not the surfaced *library row*, so a
+# pure album-title fuzz collision can bind a wrong-artist row (the "Galaxy
+# Garden" → "Galaxy to Galaxy" by Galaxy 2 Galaxy case for a "Lone" request).
+# This floor rejects rows whose artist shares essentially no fuzzy overlap with
+# the request. Deliberately far below the usual 70/80 floors: reordered
+# collaborators score ~65 (must survive) while coincidental collisions score
+# ~17 (must drop). Measured on those two anchors; keep the margin if retuning.
+_FALLBACK_ARTIST_SIMILARITY_FLOOR = 40.0
+
+
+def _filter_results_by_album_match(
+    results: list[LibraryItem],
+    album: str | None,
+) -> list[LibraryItem]:
+    """Drop library rows whose title doesn't clear `_ALBUM_MATCH_FLOOR` against
+    the typed album. No-ops when `album` is empty or whitespace-only.
+    """
+    if not album or not album.strip():
+        return results
+    from rapidfuzz import fuzz
+
+    norm_album = normalize_for_comparison(album)
+    kept: list[LibraryItem] = []
+    for item in results:
+        title_norm = normalize_for_comparison(item.title or "")
+        if fuzz.token_set_ratio(norm_album, title_norm) >= _ALBUM_MATCH_FLOOR:
+            kept.append(item)
+    if len(kept) < len(results):
+        logger.info(
+            f"Album-match floor dropped {len(results) - len(kept)} of {len(results)} "
+            f"artist-fallback candidates against typed album '{album}'"
+        )
+    return kept
+
+
+# Minimum fuzzy score for promoting an artist-fallback row whose *title*
+# matches the requested "song" — i.e. recognising the parsed song as the
+# album the user actually wanted. Set higher than `_ALBUM_MATCH_FLOOR`
+# because the consequence here is asserting the user's intent (album,
+# not track); a borderline match should *not* override the song-not-found
+# message.
+_SONG_AS_ALBUM_TITLE_FLOOR = 90.0
+
+
+def _filter_results_by_song_as_album_title(
+    results: list[LibraryItem],
+    song: str | None,
+) -> list[LibraryItem]:
+    """Pick artist-fallback rows whose title matches the requested song.
+
+    Handles the request shape "on patrol, sun araw" — request-o-matic routes
+    it as ``song="On Patrol"`` / ``artist="Sun Araw"``, but the user typed
+    an album name. The artist+song FTS branch of
+    ``search_library_with_fallback`` surfaces the matching album because
+    the album title contains the song words; per-result track validation
+    then reasonably comes back empty (no track titled "On Patrol" exists on
+    that album — it IS the album) and ``song_not_found`` stays set,
+    producing the misleading 'not on any album' context message about a
+    result sitting in its own list.
+
+    Floor is ``_SONG_AS_ALBUM_TITLE_FLOOR`` (>= 90 via
+    ``rapidfuzz.fuzz.token_set_ratio``) — high enough that a coincidental
+    word overlap won't override the song-not-found path.
+
+    Returns the subset of ``results`` whose normalised title clears the
+    floor against the normalised song. Empty input or whitespace-only song
+    returns ``[]`` cleanly.
+    """
+    if not song or not song.strip() or not results:
+        return []
+    from rapidfuzz import fuzz
+
+    norm_song = normalize_for_comparison(song)
+    matches: list[LibraryItem] = []
+    for item in results:
+        title_norm = normalize_for_comparison(item.title or "")
+        if fuzz.token_set_ratio(norm_song, title_norm) >= _SONG_AS_ALBUM_TITLE_FLOOR:
+            matches.append(item)
+    return matches
+
+
+# V/A series suffixes catalogued in WXYC library as "<base>, vol. N" or close
+# variants. See WXYC/library-metadata-lookup#531 — Discogs returns the canonical
+# release with a long parenthetical subtitle ("Disco Not Disco (Post Punk,
+# Electro & Leftfield Disco Classics 1974-1986)") while the library keeps the
+# terse series identifier ("Disco Not Disco, vol. 1"), so the standard
+# length-sensitive fuzz.ratio path in ``album_title_acceptable`` rejects them.
+_VA_VOLUME_SUFFIX_RE = re.compile(r"[,\s]+vol(?:\.|ume)?\s+\w+\s*$", re.IGNORECASE)
+
+
+def _va_series_base(library_title_lower: str) -> str | None:
+    """If ``library_title_lower`` is a ``<base>, vol. N`` series identifier,
+    return the lowercased ``<base>``. Otherwise return ``None``.
+
+    Strips trailing ``, vol. N`` / ``, volume N`` / `` vol. N`` / `` volume N``
+    (and ``vol N`` without the dot). The numeric tail is ``\\w+`` so roman
+    numerals ("vol. III") and mixed identifiers ("vol. 2a") also match.
+    """
+    match = _VA_VOLUME_SUFFIX_RE.search(library_title_lower)
+    if not match:
+        return None
+    base = library_title_lower[: match.start()].rstrip(" ,")
+    return base or None
+
+
+def _va_series_title_match(query_lower: str, item: LibraryItem) -> bool:
+    """Special-case for V/A series releases catalogued as ``<base>, vol. N``.
+
+    The library files V/A compilations under a terse ``<base>, vol. N`` series
+    identifier (filing convention preserved in ``library.artist_name``), while
+    Discogs returns the canonical release with a long descriptive subtitle. Neither the prefix branch nor the
+    length-sensitive ``fuzz.ratio`` branch of ``album_title_acceptable`` can
+    bridge that asymmetry, so V/A series rows stay hidden.
+
+    This accepts when:
+
+    1. The library item is a V/A row (``is_compilation_artist`` on the artist
+       string — gate keeps the looser path from grandfathering non-V/A albums
+       with the same shape, e.g. an artist's own ``Live Sessions, vol. 2``).
+    2. The library title parses as ``<base>, vol. N`` (or close-cousin
+       ``vol. N`` / ``volume N`` variants).
+    3. The Discogs query title starts with ``<base>`` followed by a
+       non-alphanumeric boundary — protects against base-prefix collisions like
+       ``Disco`` matching every Discogs release that happens to start with
+       that word.
+
+    Returns True when all three hold; the caller then bypasses
+    ``album_title_acceptable`` for this row.
+
+    See WXYC/library-metadata-lookup#531.
+    """
+    if not is_compilation_artist(item.artist or ""):
+        return False
+    library_title_lower = (item.title or "").lower()
+    base = _va_series_base(library_title_lower)
+    if not base:
+        return False
+    if not query_lower.startswith(base):
+        return False
+    # Require a word boundary after the base so "Disco" doesn't grandfather
+    # every Discogs release whose title starts with that token.
+    tail = query_lower[len(base) :]
+    if tail and tail[0].isalnum():
+        return False
+    return True
+
+
+def album_title_acceptable(query_lower: str, result_lower: str) -> bool:
+    """Check if a library album title is an acceptable match for a Discogs album title.
+
+    Uses prefix matching (handles parenthetical suffixes like edition names) and
+    length-sensitive fuzz.ratio to reject subset matches that token_set_ratio
+    would incorrectly accept.
+
+    Also rejects numbered series albums (e.g., "Chicago V" vs "Chicago 16",
+    "Led Zeppelin II" vs "Led Zeppelin IV") by checking that when titles share
+    a long common prefix, the short distinguishing suffixes are also similar.
+    """
+    from rapidfuzz import fuzz
+
+    if query_lower.startswith(result_lower) or result_lower.startswith(query_lower):
+        return True
+
+    # Find common prefix length
+    common = 0
+    for a, b in zip(query_lower, result_lower, strict=False):
+        if a != b:
+            break
+        common += 1
+
+    # Reject numbered series: titles that share a dominant prefix but differ
+    # in a short identifier suffix (e.g., "V" vs "16", "II" vs "IV").
+    if common > 0:
+        remainder_q = query_lower[common:].strip()
+        remainder_r = result_lower[common:].strip()
+        min_len = min(len(query_lower), len(result_lower))
+        if (
+            remainder_q
+            and remainder_r
+            and len(remainder_q) <= 5
+            and len(remainder_r) <= 5
+            and common >= min_len * 0.5
+        ):
+            if fuzz.ratio(remainder_q, remainder_r) < 50:
+                return False
+
+    return fuzz.ratio(query_lower, result_lower) >= 50
+
+
+# Strip *all* trailing parenthetical suffixes from a Discogs album query before
+# search. See WXYC/library-metadata-lookup#531 — Discogs ``release.title`` often
+# carries a long descriptive subtitle in parentheses (e.g. ``Disco Not Disco
+# (Post Punk, Electro & Leftfield Disco Classics 1974-1986)``) and routinely
+# stacks multiple groups (``Album (Deluxe Edition) (Remastered)``, ``Album
+# (Live) (Bonus Track)``). The library catalogues only the base (``Disco Not
+# Disco, vol. 1``); the full Discogs title fails the FTS5 query in different
+# ways depending on its shape (see the block comment on the retry in
+# ``search_album_fuzzy``). Stripping the parenthetical(s) produces a query that
+# FTS5 surfaces to the right rows, and the existing prefix branch in
+# ``album_title_acceptable`` accepts the library row via
+# ``result.startswith(query)``. The ``+`` makes this idempotent over stacked
+# groups so a single ``sub`` call peels all trailing parens — ``Album (Live)
+# (Remastered)`` strips to ``Album``, not ``Album (Live)`` which would still be
+# an FTS5 syntax error.
+_TRAILING_PARENTHETICAL_RE = re.compile(r"(?:\s*\([^)]*\)\s*)+$")

--- a/lookup/matching.py
+++ b/lookup/matching.py
@@ -1,9 +1,10 @@
 """Pure matching predicates, filters, and score floors for the lookup pipeline.
 
 Leaf module: no service handles, no I/O, no async. Everything here operates on
-already-fetched values (`LibraryItem` rows, parsed request fields, title
-strings), so it can be imported from any layer of `lookup/` — and unit-tested
-without mocks. Extracted verbatim from ``lookup/orchestrator.py`` (LML#723).
+already-fetched value objects (`LibraryItem` rows, Discogs `ReleaseInfo`
+models, parsed request fields, title strings), so it can be imported from any
+layer of `lookup/` — and unit-tested without mocks. Extracted verbatim from
+``lookup/orchestrator.py`` (LML#723).
 """
 
 import logging
@@ -289,9 +290,10 @@ def _va_series_title_match(query_lower: str, item: LibraryItem) -> bool:
 
     The library files V/A compilations under a terse ``<base>, vol. N`` series
     identifier (filing convention preserved in ``library.artist_name``), while
-    Discogs returns the canonical release with a long descriptive subtitle. Neither the prefix branch nor the
-    length-sensitive ``fuzz.ratio`` branch of ``album_title_acceptable`` can
-    bridge that asymmetry, so V/A series rows stay hidden.
+    Discogs returns the canonical release with a long descriptive subtitle.
+    Neither the prefix branch nor the length-sensitive ``fuzz.ratio`` branch
+    of ``album_title_acceptable`` can bridge that asymmetry, so V/A series
+    rows stay hidden.
 
     This accepts when:
 

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -10,7 +10,7 @@ import logging
 import os
 import random
 import re
-from collections.abc import AsyncIterator, Callable, Coroutine
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from functools import partial
 from typing import Any
@@ -21,7 +21,6 @@ from wxyc_etl.text import is_compilation_artist
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 from wxyc_fastapi.observability import (
     RequestTelemetry,
-    get_cache_stats,
     get_cache_stats_recorder,
 )
 
@@ -38,13 +37,9 @@ from clients.streaming.matching import (
 from clients.streaming.spotify import SpotifyClient
 from config.settings import get_settings
 from core.search import (
-    SEARCH_API_CALL_CAP_FIRED_STAT_KEY,
-    _record_cap_fire_for_runner,
     execute_search_pipeline,
     get_search_type_from_state,
-    resolve_positive_int_env,
 )
-from core.text import strip_leading_article
 from discogs.cache_service import DiscogsCacheService
 from discogs.lookup import lookup_releases_by_artist, lookup_releases_by_track
 from discogs.markup_parser import (
@@ -80,10 +75,28 @@ from generated.api_models import (
 )
 from library.db import STOPWORDS, LibraryDB
 from library.models import LibraryItem
+from lookup.concurrency import _chunked_gather
 from lookup.external_search import (
     search_external_albums,
     search_external_artists,
     search_external_tracks,
+)
+from lookup.matching import (
+    _FALLBACK_ARTIST_SIMILARITY_FLOOR,
+    _FETCH_LIMIT,
+    _TRAILING_PARENTHETICAL_RE,
+    MAX_SEARCH_RESULTS,
+    _filter_results_by_album_match,
+    _filter_results_by_song_as_album_title,
+    _release_matches_library_row,
+    _va_series_title_match,
+    album_title_acceptable,
+    artist_matches_item,
+    filter_results_by_artist,
+    is_self_titled,
+    library_artist_for,
+    limit_results,
+    map_library_format_to_discogs,
 )
 from lookup.models import LookupRequest, LookupResponse, LookupResultItem
 from lookup.release_resolution import (
@@ -102,12 +115,6 @@ from release.musicbrainz_resolver import resolve_tracklist_via_musicbrainz
 from services.parser import MessageType, ParsedRequest
 
 logger = logging.getLogger(__name__)
-
-MAX_SEARCH_RESULTS = 5
-"""Maximum number of results to return from search operations."""
-
-SELF_TITLED_PATTERNS = frozenset({"s/t", "s.t.", "self-titled", "self titled"})
-"""Common abbreviations for self-titled albums (case-insensitive exact match)."""
 
 COMPILATION_ARTIST_SEARCH_FORM = "Various"
 """The bare form Discogs's search endpoint accepts for compilation artists."""
@@ -136,129 +143,6 @@ refs each still leave headroom for the read path.
 
 _warm_cache_semaphore: asyncio.Semaphore | None = None
 """Lazily-constructed (needs a running event loop). Re-bind on the first call."""
-
-
-_SEARCH_MAX_API_CALLS_DEFAULT = 15
-"""Default per-invocation cap on Discogs API calls dispatched FROM a single
-``_chunked_gather`` invocation (validation tail of one strategy leg). Sized
-above the warm-cache ``extended=true`` happy-path window (8-14 calls measured
-on the validation tail of one leg) so legitimately-busy lookups don't trip,
-while still bounding the zero-canonical failing tail flagged in LML#543
-(15-24 calls / 16-17s wall-time per failing leg). See ``LML_SEARCH_MAX_API_CALLS``
-in ``docs/env-vars.md`` for the per-invocation scope and why we don't try
-to make this request-wide."""
-
-_SEARCH_MAX_API_CALLS_ENV_VAR = "LML_SEARCH_MAX_API_CALLS"
-
-
-async def _chunked_gather[T, R](
-    items: list[T],
-    worker: Callable[[T], Coroutine[Any, Any, R]],
-    chunk_size: int,
-) -> AsyncIterator[tuple[T, R]]:
-    """Run ``worker`` over ``items`` in chunks of ``chunk_size``, yielding
-    ``(item, result)`` pairs in input order.
-
-    The next chunk is not dispatched until the caller has finished iterating
-    the previous one, so a caller that breaks out after its accumulator
-    saturates never pays for the un-fired chunks. This restores the pre-PR
-    (#534) early-exit behavior in ``search_song_as_track`` /
-    ``search_compilations_for_track`` (LML#536) without giving up
-    within-chunk parallelism.
-
-    Between chunks the per-request Discogs API-call counter
-    (``stats["api_calls"]``) is consulted against ``LML_SEARCH_MAX_API_CALLS``
-    *relative to a baseline captured at entry*. When the delta crosses the
-    cap, the generator returns early so the remaining chunks never dispatch
-    — the safety floor for the zero-canonical validation tail flagged in
-    LML#543. Calls that have already started in the current chunk are
-    awaited to completion; the gate is between chunks, not mid-chunk, so the
-    actual ceiling is ``cap + chunk_size - 1``.
-
-    The baseline makes the cap per-invocation, not request-wide, on purpose:
-
-    * The bulk endpoint (``/api/v1/lookup/bulk``) shares one cache_stats dict
-      across concurrent items (router shares stats so PostHog aggregates
-      reflect the batch). A request-wide cap would starve items late in the
-      batch.
-    * ``search_compilations_for_track`` invokes us twice — main loop, then
-      the LML#319/#237 album-title fallback. A request-wide cap means the
-      fallback never gets a chunk dispatched once the main loop has spent.
-
-    The cross-strategy stop is handled at the runner layer
-    (:func:`core.search.execute_search_pipeline`) via the per-task
-    :data:`core.search._cap_fire_count_var` ContextVar — isolated per
-    pipeline invocation so concurrent bulk items can't poison each other.
-
-    Wall time: ``ceil(N / chunk_size)`` × slowest task per chunk in the
-    no-exit case. The orchestrator's three call sites pass
-    ``MAX_SEARCH_RESULTS`` as the chunk size so that one full chunk can
-    satisfy the response cap on its own — the dominant case for high-fanout
-    requests. The cap also lines up with the 5-permit global Discogs
-    semaphore in ``discogs/service.py`` (``get_semaphore()``): per-request
-    fan-out is bounded here; cross-request total load is bounded there.
-    """
-    assert chunk_size > 0, f"chunk_size must be positive, got {chunk_size}"
-    api_call_cap = resolve_positive_int_env(
-        _SEARCH_MAX_API_CALLS_ENV_VAR, _SEARCH_MAX_API_CALLS_DEFAULT
-    )
-    # Baseline-relative cap. ``get_cache_stats()`` returns ``None`` outside a
-    # request context, in which case ``baseline`` stays 0 and the cap is inert
-    # (warm-path callers and unit tests that don't initialize cache stats are
-    # unaffected). Inside a request, the cap counts API calls dispatched FROM
-    # this invocation only — see docstring for why we don't aggregate request-wide.
-    stats = get_cache_stats()
-    baseline = stats.get("api_calls", 0) if stats is not None else 0
-    for start in range(0, len(items), chunk_size):
-        if stats is not None:
-            spent = stats.get("api_calls", 0) - baseline
-            if spent >= api_call_cap:
-                _record_search_api_call_cap_fired(
-                    cap=api_call_cap,
-                    spent=int(spent),
-                    items_remaining=len(items) - start,
-                    items_total=len(items),
-                )
-                return
-        chunk = items[start : start + chunk_size]
-        chunk_results = await asyncio.gather(*[worker(it) for it in chunk])
-        for it, res in zip(chunk, chunk_results, strict=True):
-            yield it, res
-
-
-def _record_search_api_call_cap_fired(
-    *, cap: int, spent: int, items_remaining: int, items_total: int
-) -> None:
-    """Record an LML#543 cap-fire on both observability surfaces.
-
-    Telemetry — counter on the request-scoped cache-stats dict (each leg that
-    trips its own per-invocation cap adds 1). Projects onto the Sentry
-    transaction as ``lml.cache.search_api_call_cap_fired`` via the router's
-    :func:`_project_cache_stats_to_transaction`; filter on
-    ``lml.cache.search_api_call_cap_fired:>0`` for the cap-fire slice in
-    PostHog/Sentry.
-
-    Control flow — bumps the per-pipeline-invocation counter the runner reads
-    (:data:`core.search._cap_fire_count_var`). That channel is a per-task
-    ContextVar, isolated from sibling bulk items even when they fire the cap
-    concurrently. The control channel is intentionally separate from the
-    telemetry counter so the latter can stay batch-aggregated for PostHog.
-
-    Logs one WARN per cap-fire; ``search_compilations_for_track`` can yield
-    up to two per lookup (main loop + LML#319/#237 album-title fallback) on
-    a pathological case.
-    """
-    get_cache_stats_recorder().record(SEARCH_API_CALL_CAP_FIRED_STAT_KEY)
-    _record_cap_fire_for_runner()
-    logger.warning(
-        "%s reached (cap=%d, spent=%d in this leg, %d/%d items remaining) — "
-        "bailing _chunked_gather",
-        _SEARCH_MAX_API_CALLS_ENV_VAR,
-        cap,
-        spent,
-        items_remaining,
-        items_total,
-    )
 
 
 _ProbeResult = TrackReleasesResponse | tuple[TrackReleasesResponse | None, str | None]
@@ -699,99 +583,6 @@ def _log_artist_identity_split_gate(
         logger.info("artist_identity_split_gate %s", payload)
 
 
-def is_self_titled(title: str) -> bool:
-    """Check if an album title indicates a self-titled release.
-
-    Args:
-        title: Album title to check
-
-    Returns:
-        True if title is a common self-titled abbreviation (e.g. "S/t", "S.T.")
-    """
-    return title.strip().lower() in SELF_TITLED_PATTERNS
-
-
-def map_library_format_to_discogs(fmt: str | None) -> str | None:
-    """Map a WXYC library format value to a Discogs API format parameter.
-
-    Library format values like "cd", "vinyl - 12\\"", "cd x 2" are mapped to
-    the corresponding Discogs search API format terms ("CD", "12\\"", etc.).
-
-    Returns None if the format is not recognized or is empty.
-    """
-    if not fmt:
-        return None
-    normalized = fmt.strip().lower()
-    if normalized.startswith("cdr"):
-        return "CDr"
-    if normalized.startswith("cd"):
-        return "CD"
-    if 'vinyl - 12"' in normalized or "vinyl - 12" in normalized:
-        return '12"'
-    if 'vinyl - 7"' in normalized or "vinyl - 7" in normalized:
-        return '7"'
-    if 'vinyl - 10"' in normalized or "vinyl - 10" in normalized:
-        return '10"'
-    if normalized.startswith("vinyl"):
-        return "Vinyl"
-    return None
-
-
-_FETCH_LIMIT = MAX_SEARCH_RESULTS * 10
-"""Internal fetch limit for FTS queries that are post-filtered by artist.
-
-FTS5 ranks results by term frequency, not by artist-prefix relevance, so the
-target artist's entries may fall outside a tight SQL LIMIT.  Fetching more rows
-ensures enough candidates survive ``filter_results_by_artist`` before we trim
-back to ``MAX_SEARCH_RESULTS``.
-"""
-
-
-def limit_results(results: list) -> list:
-    """Limit results to MAX_SEARCH_RESULTS."""
-    return results[:MAX_SEARCH_RESULTS]
-
-
-def artist_matches_item(item: LibraryItem, artist: str) -> bool:
-    """Check if a library item matches the given artist name.
-
-    Compares against both ``item.artist`` and ``item.alternate_artist_name``.
-    Tolerates a leading-article asymmetry between query and catalog —
-    library catalogers commonly file "The Black Dog" as "Black Dog
-    Productions" while user input and Discogs credits keep the article,
-    and the reverse ("Beatles" vs "The Beatles") also occurs. Both sides
-    are compared as-is first; on miss, both are also compared with the
-    leading article stripped. The stripped path is skipped when stripping
-    leaves the query empty so a bare "The" doesn't match arbitrary rows.
-    """
-    artist_normalized = normalize_for_comparison(artist)
-    artist_no_article = strip_leading_article(artist_normalized)
-
-    for candidate in (item.artist, item.alternate_artist_name):
-        if not candidate:
-            continue
-        cand_normalized = normalize_for_comparison(candidate)
-        if cand_normalized.startswith(artist_normalized):
-            return True
-        if artist_no_article and strip_leading_article(cand_normalized).startswith(
-            artist_no_article
-        ):
-            return True
-    return False
-
-
-def library_artist_for(parsed: ParsedRequest) -> str | None:
-    """The artist name the *library-side* legs should search/match against.
-
-    Library channel of the two-channel seam (WXYC/library-metadata-lookup#626):
-    the fuzzy correction on ``parsed.library_artist`` when present, else the
-    typed ``parsed.artist``. Read by ``db.search`` query construction and the
-    ``artist_matches_item`` match-backs — never by the Discogs-facing probes or
-    ``validate_release_for_track``, which always use the typed ``parsed.artist``.
-    """
-    return parsed.library_artist or parsed.artist
-
-
 async def resolve_albums_for_track(
     parsed: ParsedRequest,
     discogs_service: DiscogsService | None = None,
@@ -834,31 +625,6 @@ async def resolve_albums_for_track(
             logger.warning(f"Track lookup failed: {e}")
             return [], True
     return [parsed.album] if parsed.album else [], False
-
-
-def filter_results_by_artist(
-    results: list[LibraryItem],
-    artist: str | None,
-) -> list[LibraryItem]:
-    """Filter library results to only include those matching the artist.
-
-    Requires the searched artist name to appear at the START of the result's
-    artist field (case-insensitive).
-    """
-    if not artist:
-        return results
-
-    filtered = []
-    for item in results:
-        if artist_matches_item(item, artist):
-            filtered.append(item)
-
-    if len(filtered) < len(results):
-        logger.info(
-            f"Filtered {len(results)} results to {len(filtered)} matching artist '{artist}'"
-        )
-
-    return filtered
 
 
 async def _narrow_swapped_by_track(
@@ -1668,76 +1434,6 @@ async def search_song_as_track(
     )
 
 
-def _release_matches_library_row(release: ReleaseInfo, item: LibraryItem) -> bool:
-    """Predicate: does ``release``'s artist credit match ``item``'s library artist?
-
-    Compilation-aware: for VA releases (``release.is_compilation``), any library
-    row whose artist field is itself a compilation marker (e.g., "Various
-    Artists - Rock - D") qualifies. For non-compilations, the library row's
-    artist must prefix-match the Discogs release artist via the existing
-    ``artist_matches_item`` rules.
-    """
-    if release.is_compilation and is_compilation_artist(item.artist or ""):
-        return True
-    if item.artist and artist_matches_item(item, release.artist):
-        return True
-    return False
-
-
-# Minimum fuzzy score (0-100) for accepting a library-row title as a genuine
-# album match for the DJ-typed album. Mirrors the 80-floor in
-# `clients/streaming/apple_music._APPLE_MUSIC_MATCH_FLOOR` and the
-# streaming-availability batch matcher. When the artist-fallback branches
-# of `search_library_with_fallback` surface a row whose title doesn't clear
-# this floor against the typed album, the row would otherwise carry the
-# matched Discogs release's `release_year` / `apple_music_url` / `spotify_url`
-# / `discogs_url` / `artwork_url` onto a flowsheet row tagged with a
-# completely different album — the contamination shape documented in #400
-# (~184k rows; 16,532 distinct Discogs URLs each attached to many distinct
-# DJ-typed `(artist, album)` pairs). #390 / #398 tightened the result
-# verification; this tightens the LML lookup result itself.
-_ALBUM_MATCH_FLOOR = 80.0
-
-# Lenient artist-overlap backstop for the album-title fallback's
-# ``skip_artist_match_filter=True`` path (``process_release``). That path
-# intentionally drops the strict prefix filter so reordered/collaborative
-# credits (e.g. "Orcutt, Bill / Shelley, Chris / Miller, Mette" for a typed
-# "Orcutt Shelley Miller") still reach ``validate_track_on_release``. But that
-# validator checks the *Discogs release*, not the surfaced *library row*, so a
-# pure album-title fuzz collision can bind a wrong-artist row (the "Galaxy
-# Garden" → "Galaxy to Galaxy" by Galaxy 2 Galaxy case for a "Lone" request).
-# This floor rejects rows whose artist shares essentially no fuzzy overlap with
-# the request. Deliberately far below the usual 70/80 floors: reordered
-# collaborators score ~65 (must survive) while coincidental collisions score
-# ~17 (must drop). Measured on those two anchors; keep the margin if retuning.
-_FALLBACK_ARTIST_SIMILARITY_FLOOR = 40.0
-
-
-def _filter_results_by_album_match(
-    results: list[LibraryItem],
-    album: str | None,
-) -> list[LibraryItem]:
-    """Drop library rows whose title doesn't clear `_ALBUM_MATCH_FLOOR` against
-    the typed album. No-ops when `album` is empty or whitespace-only.
-    """
-    if not album or not album.strip():
-        return results
-    from rapidfuzz import fuzz
-
-    norm_album = normalize_for_comparison(album)
-    kept: list[LibraryItem] = []
-    for item in results:
-        title_norm = normalize_for_comparison(item.title or "")
-        if fuzz.token_set_ratio(norm_album, title_norm) >= _ALBUM_MATCH_FLOOR:
-            kept.append(item)
-    if len(kept) < len(results):
-        logger.info(
-            f"Album-match floor dropped {len(results) - len(kept)} of {len(results)} "
-            f"artist-fallback candidates against typed album '{album}'"
-        )
-    return kept
-
-
 async def _library_miss_discogs_search(
     parsed: ParsedRequest,
     discogs_service: DiscogsService | None,
@@ -1794,52 +1490,6 @@ async def _library_miss_discogs_search(
         title=best.album or album,
     )
     return library_item, best
-
-
-# Minimum fuzzy score for promoting an artist-fallback row whose *title*
-# matches the requested "song" — i.e. recognising the parsed song as the
-# album the user actually wanted. Set higher than `_ALBUM_MATCH_FLOOR`
-# because the consequence here is asserting the user's intent (album,
-# not track); a borderline match should *not* override the song-not-found
-# message.
-_SONG_AS_ALBUM_TITLE_FLOOR = 90.0
-
-
-def _filter_results_by_song_as_album_title(
-    results: list[LibraryItem],
-    song: str | None,
-) -> list[LibraryItem]:
-    """Pick artist-fallback rows whose title matches the requested song.
-
-    Handles the request shape "on patrol, sun araw" — request-o-matic routes
-    it as ``song="On Patrol"`` / ``artist="Sun Araw"``, but the user typed
-    an album name. The artist+song FTS branch of
-    :func:`search_library_with_fallback` surfaces the matching album because
-    the album title contains the song words; per-result track validation
-    then reasonably comes back empty (no track titled "On Patrol" exists on
-    that album — it IS the album) and ``song_not_found`` stays set,
-    producing the misleading 'not on any album' context message about a
-    result sitting in its own list.
-
-    Floor is ``_SONG_AS_ALBUM_TITLE_FLOOR`` (>= 90 via
-    ``rapidfuzz.fuzz.token_set_ratio``) — high enough that a coincidental
-    word overlap won't override the song-not-found path.
-
-    Returns the subset of ``results`` whose normalised title clears the
-    floor against the normalised song. Empty input or whitespace-only song
-    returns ``[]`` cleanly.
-    """
-    if not song or not song.strip() or not results:
-        return []
-    from rapidfuzz import fuzz
-
-    norm_song = normalize_for_comparison(song)
-    matches: list[LibraryItem] = []
-    for item in results:
-        title_norm = normalize_for_comparison(item.title or "")
-        if fuzz.token_set_ratio(norm_song, title_norm) >= _SONG_AS_ALBUM_TITLE_FLOOR:
-            matches.append(item)
-    return matches
 
 
 async def search_library_with_fallback(
@@ -2439,131 +2089,6 @@ async def search_compilations_for_track(
             return [rowless], discogs_titles
 
     return limit_results(results), discogs_titles
-
-
-# V/A series suffixes catalogued in WXYC library as "<base>, vol. N" or close
-# variants. See WXYC/library-metadata-lookup#531 — Discogs returns the canonical
-# release with a long parenthetical subtitle ("Disco Not Disco (Post Punk,
-# Electro & Leftfield Disco Classics 1974-1986)") while the library keeps the
-# terse series identifier ("Disco Not Disco, vol. 1"), so the standard
-# length-sensitive fuzz.ratio path in ``album_title_acceptable`` rejects them.
-_VA_VOLUME_SUFFIX_RE = re.compile(r"[,\s]+vol(?:\.|ume)?\s+\w+\s*$", re.IGNORECASE)
-
-
-def _va_series_base(library_title_lower: str) -> str | None:
-    """If ``library_title_lower`` is a ``<base>, vol. N`` series identifier,
-    return the lowercased ``<base>``. Otherwise return ``None``.
-
-    Strips trailing ``, vol. N`` / ``, volume N`` / `` vol. N`` / `` volume N``
-    (and ``vol N`` without the dot). The numeric tail is ``\\w+`` so roman
-    numerals ("vol. III") and mixed identifiers ("vol. 2a") also match.
-    """
-    match = _VA_VOLUME_SUFFIX_RE.search(library_title_lower)
-    if not match:
-        return None
-    base = library_title_lower[: match.start()].rstrip(" ,")
-    return base or None
-
-
-def _va_series_title_match(query_lower: str, item: LibraryItem) -> bool:
-    """Special-case for V/A series releases catalogued as ``<base>, vol. N``.
-
-    The library files V/A compilations under a terse ``<base>, vol. N`` series
-    identifier (filing convention preserved in ``library.artist_name``), while
-    Discogs returns the canonical release with a long descriptive subtitle. Neither the prefix branch nor the
-    length-sensitive ``fuzz.ratio`` branch of ``album_title_acceptable`` can
-    bridge that asymmetry, so V/A series rows stay hidden.
-
-    This accepts when:
-
-    1. The library item is a V/A row (``is_compilation_artist`` on the artist
-       string — gate keeps the looser path from grandfathering non-V/A albums
-       with the same shape, e.g. an artist's own ``Live Sessions, vol. 2``).
-    2. The library title parses as ``<base>, vol. N`` (or close-cousin
-       ``vol. N`` / ``volume N`` variants).
-    3. The Discogs query title starts with ``<base>`` followed by a
-       non-alphanumeric boundary — protects against base-prefix collisions like
-       ``Disco`` matching every Discogs release that happens to start with
-       that word.
-
-    Returns True when all three hold; the caller then bypasses
-    ``album_title_acceptable`` for this row.
-
-    See WXYC/library-metadata-lookup#531.
-    """
-    if not is_compilation_artist(item.artist or ""):
-        return False
-    library_title_lower = (item.title or "").lower()
-    base = _va_series_base(library_title_lower)
-    if not base:
-        return False
-    if not query_lower.startswith(base):
-        return False
-    # Require a word boundary after the base so "Disco" doesn't grandfather
-    # every Discogs release whose title starts with that token.
-    tail = query_lower[len(base) :]
-    if tail and tail[0].isalnum():
-        return False
-    return True
-
-
-def album_title_acceptable(query_lower: str, result_lower: str) -> bool:
-    """Check if a library album title is an acceptable match for a Discogs album title.
-
-    Uses prefix matching (handles parenthetical suffixes like edition names) and
-    length-sensitive fuzz.ratio to reject subset matches that token_set_ratio
-    would incorrectly accept.
-
-    Also rejects numbered series albums (e.g., "Chicago V" vs "Chicago 16",
-    "Led Zeppelin II" vs "Led Zeppelin IV") by checking that when titles share
-    a long common prefix, the short distinguishing suffixes are also similar.
-    """
-    from rapidfuzz import fuzz
-
-    if query_lower.startswith(result_lower) or result_lower.startswith(query_lower):
-        return True
-
-    # Find common prefix length
-    common = 0
-    for a, b in zip(query_lower, result_lower, strict=False):
-        if a != b:
-            break
-        common += 1
-
-    # Reject numbered series: titles that share a dominant prefix but differ
-    # in a short identifier suffix (e.g., "V" vs "16", "II" vs "IV").
-    if common > 0:
-        remainder_q = query_lower[common:].strip()
-        remainder_r = result_lower[common:].strip()
-        min_len = min(len(query_lower), len(result_lower))
-        if (
-            remainder_q
-            and remainder_r
-            and len(remainder_q) <= 5
-            and len(remainder_r) <= 5
-            and common >= min_len * 0.5
-        ):
-            if fuzz.ratio(remainder_q, remainder_r) < 50:
-                return False
-
-    return fuzz.ratio(query_lower, result_lower) >= 50
-
-
-# Strip *all* trailing parenthetical suffixes from a Discogs album query before
-# search. See WXYC/library-metadata-lookup#531 — Discogs ``release.title`` often
-# carries a long descriptive subtitle in parentheses (e.g. ``Disco Not Disco
-# (Post Punk, Electro & Leftfield Disco Classics 1974-1986)``) and routinely
-# stacks multiple groups (``Album (Deluxe Edition) (Remastered)``, ``Album
-# (Live) (Bonus Track)``). The library catalogues only the base (``Disco Not
-# Disco, vol. 1``); the full Discogs title fails the FTS5 query in different
-# ways depending on its shape (see the block comment on the retry below).
-# Stripping the parenthetical(s) produces a query that FTS5 surfaces to the
-# right rows, and the existing prefix branch in ``album_title_acceptable``
-# accepts the library row via ``result.startswith(query)``. The ``+`` makes
-# this idempotent over stacked groups so a single ``sub`` call peels all
-# trailing parens — ``Album (Live) (Remastered)`` strips to ``Album``, not
-# ``Album (Live)`` which would still be an FTS5 syntax error.
-_TRAILING_PARENTHETICAL_RE = re.compile(r"(?:\s*\([^)]*\)\s*)+$")
 
 
 async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryItem]:

--- a/scripts/measure_artwork_match_floor.py
+++ b/scripts/measure_artwork_match_floor.py
@@ -58,11 +58,10 @@ from discogs.cache_service import DiscogsCacheService
 from discogs.models import DiscogsSearchRequest, DiscogsSearchResult
 from discogs.service import DiscogsService
 from library.db import LibraryDB
+from lookup.matching import is_self_titled, map_library_format_to_discogs
 from lookup.orchestrator import (
     COMPILATION_ARTIST_CANONICAL_FORM,
     COMPILATION_ARTIST_SEARCH_FORM,
-    is_self_titled,
-    map_library_format_to_discogs,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")

--- a/tests/integration/test_alternate_artist.py
+++ b/tests/integration/test_alternate_artist.py
@@ -6,7 +6,7 @@ import pytest
 import pytest_asyncio
 
 from library.db import LibraryDB
-from lookup.orchestrator import filter_results_by_artist
+from lookup.matching import filter_results_by_artist
 
 
 class TestAlternateArtistIntegration:

--- a/tests/unit/test_album_match_floor.py
+++ b/tests/unit/test_album_match_floor.py
@@ -26,10 +26,8 @@ from __future__ import annotations
 
 import pytest
 
-from lookup.orchestrator import (
-    _ALBUM_MATCH_FLOOR,
-    search_library_with_fallback,
-)
+from lookup.matching import _ALBUM_MATCH_FLOOR
+from lookup.orchestrator import search_library_with_fallback
 from services.parser import MessageType, ParsedRequest
 from tests.factories import make_library_item
 

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -11,7 +11,7 @@ from discogs.matching import (
     strip_discogs_suffix,
 )
 from discogs.service import calculate_confidence
-from lookup.orchestrator import is_self_titled, map_library_format_to_discogs
+from lookup.matching import is_self_titled, map_library_format_to_discogs
 
 # ---------------------------------------------------------------------------
 # strip_discogs_suffix

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -4,9 +4,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from lookup.matching import _va_series_title_match, album_title_acceptable
 from lookup.orchestrator import (
-    _va_series_title_match,
-    album_title_acceptable,
     fetch_artwork_for_items,
     filter_results_by_track_validation,
     resolve_albums_for_track,

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -28,14 +28,13 @@ from generated.api_models import (
     DiscogsTrackReleasesResponse,
     TrackMatchSource,
 )
+from lookup.matching import artist_matches_item, filter_results_by_artist
 from lookup.orchestrator import (
     ROWLESS_LIBRARY_ID,
     ROWLESS_NO_ALBUM_CONFIDENCE,
     _resolve_fallback_artwork,
-    artist_matches_item,
     build_context_message,
     fetch_artwork_for_items,
-    filter_results_by_artist,
     filter_results_by_track_validation,
     find_library_albums_with_cached_track,
     resolve_albums_for_track,
@@ -3030,7 +3029,7 @@ class TestSearchSongAsTrack:
         # ``_chunked_gather``, which the three call sites pin to
         # ``MAX_SEARCH_RESULTS``. Pin the invariant against the same constant
         # so the test still tracks if the value is tuned later.
-        from lookup.orchestrator import MAX_SEARCH_RESULTS as _CAP
+        from lookup.matching import MAX_SEARCH_RESULTS as _CAP
 
         await search_song_as_track(db, "t", discogs_service=svc)
 
@@ -3061,7 +3060,7 @@ class TestSearchSongAsTrack:
         the function must surface exactly ``MAX_SEARCH_RESULTS`` results and
         fire at most ``MAX_SEARCH_RESULTS`` validate calls.
         """
-        from lookup.orchestrator import MAX_SEARCH_RESULTS
+        from lookup.matching import MAX_SEARCH_RESULTS
 
         n_candidates = MAX_SEARCH_RESULTS * 3
         items = [
@@ -3280,7 +3279,7 @@ class TestSearchCompilationsEarlyExit:
         cost lever isn't just rate-limiter pressure — it's wall time and
         Discogs quota.
         """
-        from lookup.orchestrator import MAX_SEARCH_RESULTS
+        from lookup.matching import MAX_SEARCH_RESULTS
 
         n_candidates = MAX_SEARCH_RESULTS * 3
         items = [
@@ -3373,7 +3372,7 @@ def _fire_cap_via_recorder():
     """Drive the production cap-fire site so tests exercise both
     ``record_search_api_call_cap_fired`` paths (telemetry counter + runner
     ContextVar bump) without duplicating the helper's body."""
-    from lookup.orchestrator import _record_search_api_call_cap_fired
+    from lookup.concurrency import _record_search_api_call_cap_fired
 
     _record_search_api_call_cap_fired(cap=3, spent=5, items_remaining=10, items_total=15)
 
@@ -3427,7 +3426,7 @@ class TestApiCallCap:
             init_cache_stats,
         )
 
-        from lookup.orchestrator import MAX_SEARCH_RESULTS
+        from lookup.matching import MAX_SEARCH_RESULTS
 
         monkeypatch.setenv("LML_SEARCH_MAX_API_CALLS", "3")
         init_cache_stats()
@@ -3498,7 +3497,8 @@ class TestApiCallCap:
             init_cache_stats,
         )
 
-        from lookup.orchestrator import MAX_SEARCH_RESULTS, _chunked_gather
+        from lookup.concurrency import _chunked_gather
+        from lookup.matching import MAX_SEARCH_RESULTS
 
         monkeypatch.setenv("LML_SEARCH_MAX_API_CALLS", "3")
         init_cache_stats()


### PR DESCRIPTION
First motion PR of the orchestrator decomposition (#722). Verbatim relocation, no behavior change.

## What moved

- **`lookup/matching.py`** (new, pure — no I/O): `MAX_SEARCH_RESULTS`, `SELF_TITLED_PATTERNS`, `is_self_titled`, `map_library_format_to_discogs`, `_FETCH_LIMIT`, `limit_results`, `artist_matches_item`, `library_artist_for`, `filter_results_by_artist`, `_release_matches_library_row`, `_ALBUM_MATCH_FLOOR`, `_FALLBACK_ARTIST_SIMILARITY_FLOOR`, `_filter_results_by_album_match`, `_SONG_AS_ALBUM_TITLE_FLOOR`, `_filter_results_by_song_as_album_title`, `_VA_VOLUME_SUFFIX_RE`, `_va_series_base`, `_va_series_title_match`, `album_title_acceptable`, `_TRAILING_PARENTHETICAL_RE`
- **`lookup/concurrency.py`** (new): `_chunked_gather`, `_record_search_api_call_cap_fired`, `_SEARCH_MAX_API_CALLS_DEFAULT`, `_SEARCH_MAX_API_CALLS_ENV_VAR`

`lookup/orchestrator.py`: 4,485 → 4,017 lines. The orchestrator imports the 15 names its remaining code still consumes; `SELF_TITLED_PATTERNS` and `_ALBUM_MATCH_FLOOR` have no remaining orchestrator consumers and are not imported (no re-exports).

## How to review

Commit 1 is the move — review with `git diff --color-moved=zebra`; the only non-moved lines are the two module docstrings, loggers, and import blocks. Commit 2 is the test-import rewire (5 files, 13/16 lines).

## Verification

- Full unit suite: 3,167 passed. The single failure (`test_lookup_inflight_cap.py::test_queued_request_completes_after_permit_frees`) is a pre-existing #706 timing flake — it fails identically on untouched `origin/main` under full-suite load and passes in isolation; filing separately.
- Stale-patch audit clean: no `lookup.orchestrator.*` reference in `tests/` names a moved symbol; the `lookup_releases_by_track`/`logger`/`sentry_sdk` patch targets all reference code still living in the orchestrator.
- `ruff check` + `ruff format --check` clean. Notes for the plan: the `core/search.py` docstrings reference `_chunked_gather` without a file path, so no doc edit was needed; two annotated constants the manifest missed (`SONG_AS_TRACK_CONFIDENCE`, `ROWLESS_NO_ALBUM_CONFIDENCE`) stay put and will be assigned in PR 3/4a.

Closes #723

Part of #722 (PR 1 of 9).