### PR TITLE
refactor(#725): extract lookup/rowless.py from the orchestrator

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,11 @@ Strategies never mutate `SearchState`; they return an `Outcome` and the runner a
 
 ## Key Files
 
-- `lookup/orchestrator.py` -- Core search logic: `perform_lookup()` and all helper functions
+- `lookup/orchestrator.py` -- Pipeline spine: `perform_lookup()` and the search-strategy implementations (decomposition in progress, LML#722)
+- `lookup/matching.py` -- Pure matching predicates, filters, and score floors
+- `lookup/concurrency.py` -- `_chunked_gather` + the per-invocation Discogs API-call cap
+- `lookup/artist_resolution.py` -- Canonical-artist resolver (`resolve_canonical_artist`) + its flag gates and telemetry projections
+- `lookup/rowless.py` -- Row-less (non-library) release synthesis + credit recovery
 - `lookup/models.py` -- Re-exports generated API contract models (`LookupRequest`, `LookupResponse`, `LookupResultItem`)
 - `generated/api_models.py` -- Pydantic v2 models generated from `wxyc-shared/api.yaml`
 - `lookup/router.py` -- `POST /lookup` endpoint

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -18,7 +18,6 @@ from wxyc_etl.text import is_compilation_artist
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 from wxyc_fastapi.observability import (
     RequestTelemetry,
-    get_cache_stats_recorder,
 )
 
 from clients.bandcamp import BandcampClient
@@ -56,11 +55,6 @@ from discogs.models import (
 )
 from discogs.service import DiscogsService, find_track_position
 from discogs.writer_roles import writer_credits_from_release
-from entity.release_resolution_cache import (
-    ReleaseResolution,
-    get_cached_release_id,
-    set_cached_release_id,
-)
 from entity.sources import PgSource, PgSourceProtocol
 from entity.store import EntityStore, Identity
 from generated.api_models import (
@@ -111,9 +105,15 @@ from lookup.release_resolution import (
     merge_wave_b_compilations,
     prerank_candidates_for_validation,
     rank_resolved_releases,
-    resolve_release_for_track,
     resolve_release_for_track_cached,
     validate_release_for_track,
+)
+from lookup.rowless import (
+    ROWLESS_LIBRARY_ID,
+    _make_rowless_item,
+    _recover_track_credit,
+    _resolve_nonlibrary_release,
+    _select_rowless_artist_release,
 )
 from lookup.strategies import build_strategies
 from lookup.streaming_url_postprocess import apply_streaming_url_postprocess
@@ -464,110 +464,6 @@ async def search_song_as_artist(
     return [], None
 
 
-# LML#663: ``r.artist`` is a reliable credit only on the PG-cache path (the clean
-# ``artist_name`` column). On the live Discogs path it is title-derived —
-# ``DiscogsService._parse_title`` splits the search title on ``" - "`` and yields
-# ``artist=""`` when the title has no such separator, packing the whole title into
-# ``r.album``. A self-titled release (title is just the artist name) or one whose
-# title uses a non-ASCII dash then drops a genuine own-release, so a cold-cache
-# request falls through to not-found while a warm-cache one surfaces it. This
-# separator set recovers the leading credit from such a packed title.
-_PACKED_TITLE_SEPARATOR = re.compile(r"\s[-–—]\s")
-
-
-def _own_release_credit(r: DiscogsSearchResult, token_form: str) -> tuple[str, str] | None:
-    """``(artist, album_title)`` to surface when ``r`` credits the typed token, else None.
-
-    Recovers a title-derived-empty credit the live Discogs path left in ``r.album``
-    (LML#663). Still requires exact normalized-equality to ``token_form``, so V/A
-    "Various" and collaborations stay excluded — the gate is re-sourced, not loosened.
-    """
-    clean = (r.artist or "").strip()
-    if normalize_for_comparison(clean) == token_form:
-        return clean, r.album or ""
-    if clean:
-        # A non-empty credit that simply differs — a real mismatch (coincidental
-        # token hit, V/A "Various", or a collaboration). Drop without recovery.
-        return None
-    # Empty title-derived credit: the live path packed the whole Discogs title into
-    # ``r.album``. Recover the artist from it.
-    packed = (r.album or "").strip()
-    if not packed:
-        return None
-    if normalize_for_comparison(packed) == token_form:
-        # Self-titled: the title is just the artist name.
-        return packed, packed
-    parts = _PACKED_TITLE_SEPARATOR.split(packed, maxsplit=1)
-    if len(parts) == 2 and normalize_for_comparison(parts[0]) == token_form:
-        return parts[0].strip(), parts[1].strip()
-    return None
-
-
-def _select_rowless_artist_release(
-    token: str, discogs_releases: list[DiscogsSearchResult]
-) -> tuple[LibraryItem, ResolvedRelease] | None:
-    """Pick the release that represents a non-library artist request (LML#631).
-
-    Credit gate: keep only releases whose credited artist normalizes-equal to
-    the typed token (the artist-only analog of ``find_best_typed_match``'s
-    floor). A coincidental token→name hit is dropped, as is any release whose
-    credit differs from the token — V/A compilations credited to "Various" and
-    collaborations credited "<artist> & <other>" among them — so the survivors
-    are releases credited to the artist alone.
-
-    Among the survivors, take the highest Discogs ``confidence``, breaking a tie
-    by **input order**. The upstream query is artist-only
-    (``DiscogsSearchRequest(artist=token)`` in ``lookup_releases_by_artist``), so
-    ``calculate_confidence`` scores every exact-credit match identically (~0.4,
-    no album term) — confidence only separates an exact credit from a fuzzier
-    diacritic variant, so the input-order tiebreak is the effective selector in
-    the common all-identical-credit case. ``lookup_releases_by_artist`` returns
-    the list ``service.search`` already sorted by confidence descending — a
-    *stable* sort that preserves Discogs' own result order within a confidence
-    tie — so first-survivor-wins surfaces the release Discogs ranked highest,
-    not the oldest-cataloged pressing a ``release_id`` tiebreak would pick.
-    Deterministic for a given Discogs response. True community-count ranking
-    (have/want) needs a per-release ``get_release`` fetch and is deferred to
-    #633.
-
-    A non-positive ``release_id`` is dropped before selection: such an id would
-    fail ``_resolve_fallback_artwork``'s ``release_id > 0`` guard downstream and
-    collapse to the BS#1185 ``release_id=0`` sentinel — the silent not-found this
-    path exists to kill. Discogs ids are positive, so this only closes a
-    malformed-upstream path.
-    """
-    token_form = normalize_for_comparison(token)
-    # (release, (recovered_artist, album_title)) for every release crediting the
-    # typed token. ``_own_release_credit`` recovers a credit the live Discogs path
-    # left title-derived-empty (LML#663), so a cold-cache request matches the
-    # warm-cache (clean ``r.artist``) outcome instead of dropping to not-found.
-    own = [
-        (r, credit)
-        for r in discogs_releases
-        if r.release_id > 0 and (credit := _own_release_credit(r, token_form)) is not None
-    ]
-    if not own:
-        return None
-    # Highest confidence wins; ties break by input index (ascending), so the
-    # first survivor — Discogs' highest-ranked release within a confidence tie —
-    # is chosen rather than the lowest release_id (the oldest pressing). ``own``
-    # preserves ``discogs_releases`` order, which ``service.search`` sorted by
-    # confidence descending with a stable sort.
-    best, (best_artist, best_album) = min(
-        enumerate(own), key=lambda iv: (-iv[1][0].confidence, iv[0])
-    )[1]
-    # One recovered album title feeds both the synthetic row's title and the
-    # carried release's album_title, so they can't drift.
-    item = _make_rowless_item(artist=best_artist or token, title=best_album)
-    resolved = ResolvedRelease(
-        release_id=best.release_id,
-        release_url=best.release_url,
-        is_compilation=False,
-        album_title=best_album,
-    )
-    return item, resolved
-
-
 SONG_AS_TRACK_CONFIDENCE: float = 0.85
 """Default confidence floor for SONG_AS_TRACK matches.
 
@@ -591,202 +487,6 @@ bind stays soft even when an album was typed. An album-ranked carry-through
 (A1/#628 with a typed album) keeps the full 1.0 — the typed album shaped the
 pick. Lets a consumer (request-o-matic) treat the soft results as tentative.
 """
-
-# Synthetic library-id for a row-less result — a Discogs release with no WXYC
-# catalog row. Shared by the Step-3a library-miss search and the #628 A1
-# carry-through: Step-3b excludes it from re-validation, fetch_artwork_for_items
-# binds its carried release, and Step-6 serializes it with the "(external)"
-# call-number sentinel BS already understands.
-ROWLESS_LIBRARY_ID = 0
-
-# LML#681 observability. Recorded once per flag-gated row-less emission at the
-# single ``_make_rowless_item`` chokepoint that all four
-# ``lml_resolve_nonlibrary_release``-gated producers route through (SONG_AS_ARTIST,
-# the SONG_AS_TRACK + SWAPPED kernel, TRACK_ON_COMPILATION, the A4 cached-track
-# safety net). Deliberately scoped to the flag, NOT to all ``id=0`` items: the
-# LML#583 library-miss search (``_library_miss_discogs_search``) also surfaces
-# ``LibraryItem(id=0)`` but builds it directly — counting it would break the
-# "0 when the flag is off" property and conflate two independent features. Hence
-# the ``nonlibrary_release_surfaced`` name over a generic ``rowless_surfaced``.
-NONLIBRARY_RELEASE_SURFACED_STAT_KEY = "nonlibrary_release_surfaced"
-
-
-def _make_rowless_item(*, artist: str, title: str) -> LibraryItem:
-    """Build the synthetic ``LibraryItem(id=0)`` for a row-less carry-through.
-
-    Carries the resolved release's artist + album title so Step-6's "(external)"
-    catalog item and the Step-4b identity resolution have real names to use. The
-    real Discogs identity rides alongside on the ``discogs_titles`` seam, not on
-    this row.
-
-    LML#681: this is the single chokepoint every flag-gated row-less producer
-    routes through, so recording ``nonlibrary_release_surfaced`` here counts each
-    flag-gated emission exactly once. ``record`` is a silent no-op when
-    ``init_cache_stats`` wasn't called for the current context, so this can't
-    raise on the uninitialized-stats path.
-    """
-    get_cache_stats_recorder().record(NONLIBRARY_RELEASE_SURFACED_STAT_KEY)
-    return LibraryItem(id=ROWLESS_LIBRARY_ID, artist=artist, title=title)
-
-
-async def _resolve_nonlibrary_release(
-    discogs_service: DiscogsService | None,
-    pg: PgSource | None,
-    *,
-    song: str,
-    artist: str,
-    album: str | None,
-    is_track: bool = True,
-) -> ResolvedRelease | None:
-    """Resolve + validate the Discogs release a non-library track sits on (#628).
-
-    The shared kernel behind the A1 carry-through: the three Discogs-aware
-    strategies call this at their library-gate drop point, when a candidate
-    release validated from the inputs but matched no WXYC catalog row. Returns
-    the validated :class:`ResolvedRelease` to surface row-less, or ``None`` when
-    nothing resolves.
-
-    Three layers, in order:
-
-    1. **#632 positive cache read** (``get_cached_release_id``), keyed on the
-       **typed** ``artist`` (never ``library_artist_for`` — the library channel —
-       and never a canonical-swapped probe name). Three-valued
-       :class:`ReleaseResolution`: a fresh hit re-hydrates via ``get_release``; a
-       fresh known miss (``was_present=True, release_id=None``) short-circuits to
-       ``None`` *without* a live probe; an absent/stale entry falls through.
-    2. **Bounded resolve on a cold miss** — the **uncached**
-       ``resolve_release_for_track(..., also_probe_album_title=bool(album),
-       max_validations=5)`` (#633). The album-title wave (#646, gated on a
-       present ``album``) fires the third ``search_releases_by_album_title``
-       probe so a non-library release discoverable *only* by its album title
-       — the #319/#237 trio-collaboration / odd-credit shape the track-artist
-       probes miss — still resolves, at parity with the in-library #604
-       lazy-bind. Deliberately NOT ``resolve_release_for_track_cached``: the L1
-       wrapper's key omits ``max_validations``, so a bounded ``[]`` would
-       coalesce with a default ``[]`` (the #633 landmine). Cold-cache
-       durability comes from the #632 PG cache here instead.
-    3. **#632 cache write-back** — the resolved id, or ``None`` to record a known
-       miss so the next identical add short-circuits.
-
-    ``pg`` is best-effort: ``None`` (or a PG failure, swallowed inside the cache
-    helpers) degrades to an uncached bounded resolve. ``album`` (often absent on
-    the kernel paths) both fires the album-title probe (layer 2) and ranks the
-    validated candidates by title; the bounded resolver returns at most one.
-    """
-    if discogs_service is None or not song or not artist:
-        return None
-
-    cached_positive_unhydrated = False
-    if pg is not None:
-        cached: ReleaseResolution = await get_cached_release_id(
-            pg, artist=artist, title=song, is_track=is_track
-        )
-        if cached.was_present:
-            if cached.release_id is None:
-                # Fresh known miss — the live probe came up empty recently.
-                return None
-            rehydrated = await _rehydrate_resolved_release(discogs_service, cached.release_id)
-            if rehydrated is not None:
-                return rehydrated
-            # The id is cached but its metadata is unfetchable right now; fall
-            # through to a live resolve rather than fabricate a release — but
-            # remember we hold a known-good id so the write-back below doesn't
-            # demote it on a transient outage.
-            cached_positive_unhydrated = True
-
-    candidates = await resolve_release_for_track(
-        song,
-        artist,
-        album,
-        discogs_service,
-        also_probe_album_title=bool(album),
-        max_validations=5,
-    )
-    best = candidates[0] if candidates else None
-
-    # Never overwrite a known-good cached id with a miss: if we already held a
-    # positive entry that merely failed to re-hydrate (transient get_release /
-    # validate outage) and the live resolve also came up empty, leave the
-    # positive entry intact so it self-heals once the outage clears — rather
-    # than pinning a 7-day miss over good data.
-    if pg is not None and not (cached_positive_unhydrated and best is None):
-        await set_cached_release_id(
-            pg,
-            artist=artist,
-            title=song,
-            is_track=is_track,
-            release_id=best.release_id if best is not None else None,
-        )
-
-    return best
-
-
-async def _rehydrate_resolved_release(
-    discogs_service: DiscogsService, release_id: int
-) -> ResolvedRelease | None:
-    """Rebuild a :class:`ResolvedRelease` from a #632 cache-hit release_id.
-
-    The cache stores only the id; ``get_release`` (its own by-id cache) fills in
-    the title + URL. ``is_compilation`` is not needed downstream of
-    ``_bind_resolved_release`` (which keys on id/url/title), so it is left
-    ``False``. Returns ``None`` when the release can't be fetched **or rehydrates
-    to an empty title** (a malformed/title-less but non-404 Discogs release),
-    letting the caller fall through to a live resolve rather than surface a
-    degenerate row-less item with ``title=""``.
-    """
-    try:
-        metadata = await discogs_service.get_release(release_id)
-    except Exception as exc:
-        logger.warning("Row-less cache re-hydrate failed for release %s: %s", release_id, exc)
-        return None
-    if metadata is None or not metadata.release_id or not metadata.title:
-        return None
-    return ResolvedRelease(
-        release_id=metadata.release_id,
-        release_url=metadata.release_url or "",
-        is_compilation=False,
-        album_title=metadata.title or "",
-    )
-
-
-# How many candidate releases the SONG_AS_TRACK carry-through fetches while
-# recovering a per-track credit before giving up and suppressing (LML#660). The
-# credit is a track-level property, so the first release that carries it answers
-# the question; the cap only bounds the worst case (a popular track whose comps
-# all credit at release level). Mirrors the resolve path's ``max_validations=5``.
-_MAX_CREDIT_RECOVERY_FETCHES = 5
-
-
-async def _recover_track_credit(
-    discogs_service: DiscogsService,
-    raw_releases: list[ReleaseInfo],
-    track: str,
-) -> str | None:
-    """Recover ``track``'s actual per-track credit from the surfaced releases (LML#660).
-
-    The SONG_AS_TRACK carry-through carries no typed artist, so it can't anchor
-    the row-less resolve on a query artist; falling back to the release-level
-    credit yields "Various" for a V/A comp — the LML#649 hazard this replaces.
-    This walks the releases the track probe already surfaced (compilations first,
-    since that is where Discogs files per-track credits), fetching each — bounded
-    by :data:`_MAX_CREDIT_RECOVERY_FETCHES` — until one exposes the track's own
-    per-track ``artists``. Returns that credit to anchor the resolve and the #632
-    cache key, or ``None`` when none is recoverable (the caller then suppresses,
-    preserving the LML#649 fallback).
-    """
-    # Drop id-less releases before the budget cap: an unfetchable release must not
-    # burn a fetch slot (the cap bounds *real* fetches), else a creditful release
-    # behind id-less ones could fall outside the window. Then compilations first:
-    # a V/A comp is where the per-track credit lives; an own-artist release usually
-    # carries only the release-level credit. Stable within each group, so the
-    # ordering is deterministic; ``bool()`` coerces ``is_compilation``'s ``None``.
-    fetchable = [r for r in raw_releases if r.release_id]
-    ordered = sorted(fetchable, key=lambda r: not bool(r.is_compilation))
-    for release in ordered[:_MAX_CREDIT_RECOVERY_FETCHES]:
-        credit = await discogs_service.get_track_credit_on_release(release.release_id, track)
-        if credit:
-            return credit
-    return None
 
 
 async def _match_track_releases_to_library(

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -56,7 +56,8 @@ from lookup.models import (
     LookupRequest,
     LookupResponse,
 )
-from lookup.orchestrator import NONLIBRARY_RELEASE_SURFACED_STAT_KEY, perform_lookup
+from lookup.orchestrator import perform_lookup
+from lookup.rowless import NONLIBRARY_RELEASE_SURFACED_STAT_KEY
 from lookup.streaming_url_postprocess import set_suppress_streaming_warm
 from streaming.dependencies import (
     get_apple_music_client,

--- a/lookup/rowless.py
+++ b/lookup/rowless.py
@@ -1,0 +1,332 @@
+"""Row-less / non-library release synthesis for the lookup pipeline.
+
+Home of the LML#628 "A1 carry-through" kernel (``_resolve_nonlibrary_release``
+and its #632 cache re-hydrate ``_rehydrate_resolved_release``), the LML#631
+SONG_AS_ARTIST row-less pick (``_select_rowless_artist_release`` /
+``_own_release_credit``), the LML#660 per-track credit recovery
+(``_recover_track_credit``), and the synthetic ``LibraryItem(id=0)`` chokepoint
+(``ROWLESS_LIBRARY_ID`` / ``NONLIBRARY_RELEASE_SURFACED_STAT_KEY`` /
+``_make_rowless_item``) that every ``lml_resolve_nonlibrary_release``-gated
+row-less producer routes through. Extracted verbatim from
+``lookup/orchestrator.py`` (LML#725).
+"""
+
+import logging
+import re
+
+from wxyc_etl.text import to_match_form as normalize_for_comparison
+from wxyc_fastapi.observability import get_cache_stats_recorder
+
+from discogs.models import DiscogsSearchResult, ReleaseInfo
+from discogs.service import DiscogsService
+from entity.release_resolution_cache import (
+    ReleaseResolution,
+    get_cached_release_id,
+    set_cached_release_id,
+)
+from entity.sources import PgSource
+from library.models import LibraryItem
+from lookup.release_resolution import ResolvedRelease, resolve_release_for_track
+
+logger = logging.getLogger(__name__)
+
+
+# LML#663: ``r.artist`` is a reliable credit only on the PG-cache path (the clean
+# ``artist_name`` column). On the live Discogs path it is title-derived —
+# ``DiscogsService._parse_title`` splits the search title on ``" - "`` and yields
+# ``artist=""`` when the title has no such separator, packing the whole title into
+# ``r.album``. A self-titled release (title is just the artist name) or one whose
+# title uses a non-ASCII dash then drops a genuine own-release, so a cold-cache
+# request falls through to not-found while a warm-cache one surfaces it. This
+# separator set recovers the leading credit from such a packed title.
+_PACKED_TITLE_SEPARATOR = re.compile(r"\s[-–—]\s")
+
+
+def _own_release_credit(r: DiscogsSearchResult, token_form: str) -> tuple[str, str] | None:
+    """``(artist, album_title)`` to surface when ``r`` credits the typed token, else None.
+
+    Recovers a title-derived-empty credit the live Discogs path left in ``r.album``
+    (LML#663). Still requires exact normalized-equality to ``token_form``, so V/A
+    "Various" and collaborations stay excluded — the gate is re-sourced, not loosened.
+    """
+    clean = (r.artist or "").strip()
+    if normalize_for_comparison(clean) == token_form:
+        return clean, r.album or ""
+    if clean:
+        # A non-empty credit that simply differs — a real mismatch (coincidental
+        # token hit, V/A "Various", or a collaboration). Drop without recovery.
+        return None
+    # Empty title-derived credit: the live path packed the whole Discogs title into
+    # ``r.album``. Recover the artist from it.
+    packed = (r.album or "").strip()
+    if not packed:
+        return None
+    if normalize_for_comparison(packed) == token_form:
+        # Self-titled: the title is just the artist name.
+        return packed, packed
+    parts = _PACKED_TITLE_SEPARATOR.split(packed, maxsplit=1)
+    if len(parts) == 2 and normalize_for_comparison(parts[0]) == token_form:
+        return parts[0].strip(), parts[1].strip()
+    return None
+
+
+def _select_rowless_artist_release(
+    token: str, discogs_releases: list[DiscogsSearchResult]
+) -> tuple[LibraryItem, ResolvedRelease] | None:
+    """Pick the release that represents a non-library artist request (LML#631).
+
+    Credit gate: keep only releases whose credited artist normalizes-equal to
+    the typed token (the artist-only analog of ``find_best_typed_match``'s
+    floor). A coincidental token→name hit is dropped, as is any release whose
+    credit differs from the token — V/A compilations credited to "Various" and
+    collaborations credited "<artist> & <other>" among them — so the survivors
+    are releases credited to the artist alone.
+
+    Among the survivors, take the highest Discogs ``confidence``, breaking a tie
+    by **input order**. The upstream query is artist-only
+    (``DiscogsSearchRequest(artist=token)`` in ``lookup_releases_by_artist``), so
+    ``calculate_confidence`` scores every exact-credit match identically (~0.4,
+    no album term) — confidence only separates an exact credit from a fuzzier
+    diacritic variant, so the input-order tiebreak is the effective selector in
+    the common all-identical-credit case. ``lookup_releases_by_artist`` returns
+    the list ``service.search`` already sorted by confidence descending — a
+    *stable* sort that preserves Discogs' own result order within a confidence
+    tie — so first-survivor-wins surfaces the release Discogs ranked highest,
+    not the oldest-cataloged pressing a ``release_id`` tiebreak would pick.
+    Deterministic for a given Discogs response. True community-count ranking
+    (have/want) needs a per-release ``get_release`` fetch and is deferred to
+    #633.
+
+    A non-positive ``release_id`` is dropped before selection: such an id would
+    fail ``_resolve_fallback_artwork``'s ``release_id > 0`` guard downstream and
+    collapse to the BS#1185 ``release_id=0`` sentinel — the silent not-found this
+    path exists to kill. Discogs ids are positive, so this only closes a
+    malformed-upstream path.
+    """
+    token_form = normalize_for_comparison(token)
+    # (release, (recovered_artist, album_title)) for every release crediting the
+    # typed token. ``_own_release_credit`` recovers a credit the live Discogs path
+    # left title-derived-empty (LML#663), so a cold-cache request matches the
+    # warm-cache (clean ``r.artist``) outcome instead of dropping to not-found.
+    own = [
+        (r, credit)
+        for r in discogs_releases
+        if r.release_id > 0 and (credit := _own_release_credit(r, token_form)) is not None
+    ]
+    if not own:
+        return None
+    # Highest confidence wins; ties break by input index (ascending), so the
+    # first survivor — Discogs' highest-ranked release within a confidence tie —
+    # is chosen rather than the lowest release_id (the oldest pressing). ``own``
+    # preserves ``discogs_releases`` order, which ``service.search`` sorted by
+    # confidence descending with a stable sort.
+    best, (best_artist, best_album) = min(
+        enumerate(own), key=lambda iv: (-iv[1][0].confidence, iv[0])
+    )[1]
+    # One recovered album title feeds both the synthetic row's title and the
+    # carried release's album_title, so they can't drift.
+    item = _make_rowless_item(artist=best_artist or token, title=best_album)
+    resolved = ResolvedRelease(
+        release_id=best.release_id,
+        release_url=best.release_url,
+        is_compilation=False,
+        album_title=best_album,
+    )
+    return item, resolved
+
+
+# Synthetic library-id for a row-less result — a Discogs release with no WXYC
+# catalog row. Shared by the Step-3a library-miss search and the #628 A1
+# carry-through: Step-3b excludes it from re-validation, fetch_artwork_for_items
+# binds its carried release, and Step-6 serializes it with the "(external)"
+# call-number sentinel BS already understands.
+ROWLESS_LIBRARY_ID = 0
+
+# LML#681 observability. Recorded once per flag-gated row-less emission at the
+# single ``_make_rowless_item`` chokepoint that all four
+# ``lml_resolve_nonlibrary_release``-gated producers route through (SONG_AS_ARTIST,
+# the SONG_AS_TRACK + SWAPPED kernel, TRACK_ON_COMPILATION, the A4 cached-track
+# safety net). Deliberately scoped to the flag, NOT to all ``id=0`` items: the
+# LML#583 library-miss search (``_library_miss_discogs_search``) also surfaces
+# ``LibraryItem(id=0)`` but builds it directly — counting it would break the
+# "0 when the flag is off" property and conflate two independent features. Hence
+# the ``nonlibrary_release_surfaced`` name over a generic ``rowless_surfaced``.
+NONLIBRARY_RELEASE_SURFACED_STAT_KEY = "nonlibrary_release_surfaced"
+
+
+def _make_rowless_item(*, artist: str, title: str) -> LibraryItem:
+    """Build the synthetic ``LibraryItem(id=0)`` for a row-less carry-through.
+
+    Carries the resolved release's artist + album title so Step-6's "(external)"
+    catalog item and the Step-4b identity resolution have real names to use. The
+    real Discogs identity rides alongside on the ``discogs_titles`` seam, not on
+    this row.
+
+    LML#681: this is the single chokepoint every flag-gated row-less producer
+    routes through, so recording ``nonlibrary_release_surfaced`` here counts each
+    flag-gated emission exactly once. ``record`` is a silent no-op when
+    ``init_cache_stats`` wasn't called for the current context, so this can't
+    raise on the uninitialized-stats path.
+    """
+    get_cache_stats_recorder().record(NONLIBRARY_RELEASE_SURFACED_STAT_KEY)
+    return LibraryItem(id=ROWLESS_LIBRARY_ID, artist=artist, title=title)
+
+
+async def _resolve_nonlibrary_release(
+    discogs_service: DiscogsService | None,
+    pg: PgSource | None,
+    *,
+    song: str,
+    artist: str,
+    album: str | None,
+    is_track: bool = True,
+) -> ResolvedRelease | None:
+    """Resolve + validate the Discogs release a non-library track sits on (#628).
+
+    The shared kernel behind the A1 carry-through: the three Discogs-aware
+    strategies call this at their library-gate drop point, when a candidate
+    release validated from the inputs but matched no WXYC catalog row. Returns
+    the validated :class:`ResolvedRelease` to surface row-less, or ``None`` when
+    nothing resolves.
+
+    Three layers, in order:
+
+    1. **#632 positive cache read** (``get_cached_release_id``), keyed on the
+       **typed** ``artist`` (never ``library_artist_for`` — the library channel —
+       and never a canonical-swapped probe name). Three-valued
+       :class:`ReleaseResolution`: a fresh hit re-hydrates via ``get_release``; a
+       fresh known miss (``was_present=True, release_id=None``) short-circuits to
+       ``None`` *without* a live probe; an absent/stale entry falls through.
+    2. **Bounded resolve on a cold miss** — the **uncached**
+       ``resolve_release_for_track(..., also_probe_album_title=bool(album),
+       max_validations=5)`` (#633). The album-title wave (#646, gated on a
+       present ``album``) fires the third ``search_releases_by_album_title``
+       probe so a non-library release discoverable *only* by its album title
+       — the #319/#237 trio-collaboration / odd-credit shape the track-artist
+       probes miss — still resolves, at parity with the in-library #604
+       lazy-bind. Deliberately NOT ``resolve_release_for_track_cached``: the L1
+       wrapper's key omits ``max_validations``, so a bounded ``[]`` would
+       coalesce with a default ``[]`` (the #633 landmine). Cold-cache
+       durability comes from the #632 PG cache here instead.
+    3. **#632 cache write-back** — the resolved id, or ``None`` to record a known
+       miss so the next identical add short-circuits.
+
+    ``pg`` is best-effort: ``None`` (or a PG failure, swallowed inside the cache
+    helpers) degrades to an uncached bounded resolve. ``album`` (often absent on
+    the kernel paths) both fires the album-title probe (layer 2) and ranks the
+    validated candidates by title; the bounded resolver returns at most one.
+    """
+    if discogs_service is None or not song or not artist:
+        return None
+
+    cached_positive_unhydrated = False
+    if pg is not None:
+        cached: ReleaseResolution = await get_cached_release_id(
+            pg, artist=artist, title=song, is_track=is_track
+        )
+        if cached.was_present:
+            if cached.release_id is None:
+                # Fresh known miss — the live probe came up empty recently.
+                return None
+            rehydrated = await _rehydrate_resolved_release(discogs_service, cached.release_id)
+            if rehydrated is not None:
+                return rehydrated
+            # The id is cached but its metadata is unfetchable right now; fall
+            # through to a live resolve rather than fabricate a release — but
+            # remember we hold a known-good id so the write-back below doesn't
+            # demote it on a transient outage.
+            cached_positive_unhydrated = True
+
+    candidates = await resolve_release_for_track(
+        song,
+        artist,
+        album,
+        discogs_service,
+        also_probe_album_title=bool(album),
+        max_validations=5,
+    )
+    best = candidates[0] if candidates else None
+
+    # Never overwrite a known-good cached id with a miss: if we already held a
+    # positive entry that merely failed to re-hydrate (transient get_release /
+    # validate outage) and the live resolve also came up empty, leave the
+    # positive entry intact so it self-heals once the outage clears — rather
+    # than pinning a 7-day miss over good data.
+    if pg is not None and not (cached_positive_unhydrated and best is None):
+        await set_cached_release_id(
+            pg,
+            artist=artist,
+            title=song,
+            is_track=is_track,
+            release_id=best.release_id if best is not None else None,
+        )
+
+    return best
+
+
+async def _rehydrate_resolved_release(
+    discogs_service: DiscogsService, release_id: int
+) -> ResolvedRelease | None:
+    """Rebuild a :class:`ResolvedRelease` from a #632 cache-hit release_id.
+
+    The cache stores only the id; ``get_release`` (its own by-id cache) fills in
+    the title + URL. ``is_compilation`` is not needed downstream of
+    ``_bind_resolved_release`` (which keys on id/url/title), so it is left
+    ``False``. Returns ``None`` when the release can't be fetched **or rehydrates
+    to an empty title** (a malformed/title-less but non-404 Discogs release),
+    letting the caller fall through to a live resolve rather than surface a
+    degenerate row-less item with ``title=""``.
+    """
+    try:
+        metadata = await discogs_service.get_release(release_id)
+    except Exception as exc:
+        logger.warning("Row-less cache re-hydrate failed for release %s: %s", release_id, exc)
+        return None
+    if metadata is None or not metadata.release_id or not metadata.title:
+        return None
+    return ResolvedRelease(
+        release_id=metadata.release_id,
+        release_url=metadata.release_url or "",
+        is_compilation=False,
+        album_title=metadata.title or "",
+    )
+
+
+# How many candidate releases the SONG_AS_TRACK carry-through fetches while
+# recovering a per-track credit before giving up and suppressing (LML#660). The
+# credit is a track-level property, so the first release that carries it answers
+# the question; the cap only bounds the worst case (a popular track whose comps
+# all credit at release level). Mirrors the resolve path's ``max_validations=5``.
+_MAX_CREDIT_RECOVERY_FETCHES = 5
+
+
+async def _recover_track_credit(
+    discogs_service: DiscogsService,
+    raw_releases: list[ReleaseInfo],
+    track: str,
+) -> str | None:
+    """Recover ``track``'s actual per-track credit from the surfaced releases (LML#660).
+
+    The SONG_AS_TRACK carry-through carries no typed artist, so it can't anchor
+    the row-less resolve on a query artist; falling back to the release-level
+    credit yields "Various" for a V/A comp — the LML#649 hazard this replaces.
+    This walks the releases the track probe already surfaced (compilations first,
+    since that is where Discogs files per-track credits), fetching each — bounded
+    by :data:`_MAX_CREDIT_RECOVERY_FETCHES` — until one exposes the track's own
+    per-track ``artists``. Returns that credit to anchor the resolve and the #632
+    cache key, or ``None`` when none is recoverable (the caller then suppresses,
+    preserving the LML#649 fallback).
+    """
+    # Drop id-less releases before the budget cap: an unfetchable release must not
+    # burn a fetch slot (the cap bounds *real* fetches), else a creditful release
+    # behind id-less ones could fall outside the window. Then compilations first:
+    # a V/A comp is where the per-track credit lives; an own-artist release usually
+    # carries only the release-level credit. Stable within each group, so the
+    # ordering is deterministic; ``bool()`` coerces ``is_compilation``'s ``None``.
+    fetchable = [r for r in raw_releases if r.release_id]
+    ordered = sorted(fetchable, key=lambda r: not bool(r.is_compilation))
+    for release in ordered[:_MAX_CREDIT_RECOVERY_FETCHES]:
+        credit = await discogs_service.get_track_credit_on_release(release.release_id, track)
+        if credit:
+            return credit
+    return None

--- a/tests/unit/test_cached_track_safety_net.py
+++ b/tests/unit/test_cached_track_safety_net.py
@@ -22,11 +22,11 @@ import pytest
 
 from discogs.models import ReleaseInfo
 from lookup.orchestrator import (
-    ROWLESS_LIBRARY_ID,
     ROWLESS_NO_ALBUM_CONFIDENCE,
     find_library_albums_with_cached_track,
 )
 from lookup.release_resolution import ResolvedRelease
+from lookup.rowless import ROWLESS_LIBRARY_ID
 
 
 @pytest.fixture

--- a/tests/unit/test_nonlibrary_release_resolution.py
+++ b/tests/unit/test_nonlibrary_release_resolution.py
@@ -257,7 +257,7 @@ async def test_bounded_resolver_is_used_not_l1_wrapper(monkeypatch):
 
     bounded = AsyncMock(return_value=[])
     monkeypatch.setattr("lookup.rowless.resolve_release_for_track", bounded)
-    # If the L1 wrapper is ever imported into orchestrator and used, this spy
+    # If the L1 wrapper is ever imported into rowless and used, this spy
     # would catch it. It is intentionally NOT referenced by the helper.
     monkeypatch.setattr(
         "lookup.rowless.get_cached_release_id",

--- a/tests/unit/test_nonlibrary_release_resolution.py
+++ b/tests/unit/test_nonlibrary_release_resolution.py
@@ -29,7 +29,7 @@ from discogs.models import (
     TrackReleasesResponse,
 )
 from entity.release_resolution_cache import ReleaseResolution
-from lookup.orchestrator import _resolve_nonlibrary_release
+from lookup.rowless import _resolve_nonlibrary_release
 
 RELEASE_ID = 36907527
 RELEASE_URL = f"https://www.discogs.com/release/{RELEASE_ID}"
@@ -202,9 +202,9 @@ async def test_fresh_known_miss_short_circuits_without_probe(monkeypatch):
     async def _miss(*_a, **_k):
         return ReleaseResolution(release_id=None, was_present=True)
 
-    monkeypatch.setattr("lookup.orchestrator.get_cached_release_id", AsyncMock(side_effect=_miss))
+    monkeypatch.setattr("lookup.rowless.get_cached_release_id", AsyncMock(side_effect=_miss))
     set_spy = AsyncMock()
-    monkeypatch.setattr("lookup.orchestrator.set_cached_release_id", set_spy)
+    monkeypatch.setattr("lookup.rowless.set_cached_release_id", set_spy)
 
     result = await _resolve_nonlibrary_release(
         svc, object(), song=TRACK, artist=ARTIST, album=ALBUM, is_track=True
@@ -256,14 +256,14 @@ async def test_bounded_resolver_is_used_not_l1_wrapper(monkeypatch):
     svc = _resolving_service()
 
     bounded = AsyncMock(return_value=[])
-    monkeypatch.setattr("lookup.orchestrator.resolve_release_for_track", bounded)
+    monkeypatch.setattr("lookup.rowless.resolve_release_for_track", bounded)
     # If the L1 wrapper is ever imported into orchestrator and used, this spy
     # would catch it. It is intentionally NOT referenced by the helper.
     monkeypatch.setattr(
-        "lookup.orchestrator.get_cached_release_id",
+        "lookup.rowless.get_cached_release_id",
         AsyncMock(return_value=ReleaseResolution(release_id=None, was_present=False)),
     )
-    monkeypatch.setattr("lookup.orchestrator.set_cached_release_id", AsyncMock())
+    monkeypatch.setattr("lookup.rowless.set_cached_release_id", AsyncMock())
 
     await _resolve_nonlibrary_release(
         svc, None, song=TRACK, artist=ARTIST, album=ALBUM, is_track=True
@@ -287,12 +287,12 @@ async def test_album_title_wave_gated_on_album_presence(monkeypatch, album, expe
     svc = _resolving_service()
 
     bounded = AsyncMock(return_value=[])
-    monkeypatch.setattr("lookup.orchestrator.resolve_release_for_track", bounded)
+    monkeypatch.setattr("lookup.rowless.resolve_release_for_track", bounded)
     monkeypatch.setattr(
-        "lookup.orchestrator.get_cached_release_id",
+        "lookup.rowless.get_cached_release_id",
         AsyncMock(return_value=ReleaseResolution(release_id=None, was_present=False)),
     )
-    monkeypatch.setattr("lookup.orchestrator.set_cached_release_id", AsyncMock())
+    monkeypatch.setattr("lookup.rowless.set_cached_release_id", AsyncMock())
 
     await _resolve_nonlibrary_release(
         svc, None, song=TRACK, artist=ARTIST, album=album, is_track=True
@@ -321,7 +321,7 @@ def _non_comp_release(release_id: int) -> ReleaseInfo:
 class TestRecoverTrackCredit:
     @pytest.mark.asyncio
     async def test_returns_first_recoverable_per_track_credit(self):
-        from lookup.orchestrator import _recover_track_credit
+        from lookup.rowless import _recover_track_credit
 
         svc = AsyncMock()
         svc.get_track_credit_on_release = AsyncMock(return_value=ARTIST)
@@ -333,7 +333,7 @@ class TestRecoverTrackCredit:
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_release_exposes_credit(self):
-        from lookup.orchestrator import _recover_track_credit
+        from lookup.rowless import _recover_track_credit
 
         svc = AsyncMock()
         svc.get_track_credit_on_release = AsyncMock(return_value=None)
@@ -346,7 +346,7 @@ class TestRecoverTrackCredit:
     async def test_scans_compilations_before_own_releases(self):
         """The per-track credit lives on the V/A comp, so comps are fetched first
         even when an own-artist release precedes them in the probe results."""
-        from lookup.orchestrator import _recover_track_credit
+        from lookup.rowless import _recover_track_credit
 
         svc = AsyncMock()
         svc.get_track_credit_on_release = AsyncMock(return_value=ARTIST)
@@ -361,10 +361,10 @@ class TestRecoverTrackCredit:
     async def test_bounds_fetches_to_the_cap(self, monkeypatch):
         """A popular track with many credit-less candidates must not fan out an
         unbounded number of release fetches."""
-        from lookup import orchestrator
-        from lookup.orchestrator import _recover_track_credit
+        from lookup import rowless
+        from lookup.rowless import _recover_track_credit
 
-        monkeypatch.setattr(orchestrator, "_MAX_CREDIT_RECOVERY_FETCHES", 3)
+        monkeypatch.setattr(rowless, "_MAX_CREDIT_RECOVERY_FETCHES", 3)
         svc = AsyncMock()
         svc.get_track_credit_on_release = AsyncMock(return_value=None)
         releases = [_non_comp_release(i) for i in range(1, 11)]
@@ -379,10 +379,10 @@ class TestRecoverTrackCredit:
         """A release with no usable ``release_id`` is unfetchable, so it must not
         burn a slot of the fetch budget — the cap bounds *real* fetches. A creditful
         release sitting behind id-less ones is still reached within the cap."""
-        from lookup import orchestrator
-        from lookup.orchestrator import _recover_track_credit
+        from lookup import rowless
+        from lookup.rowless import _recover_track_credit
 
-        monkeypatch.setattr(orchestrator, "_MAX_CREDIT_RECOVERY_FETCHES", 2)
+        monkeypatch.setattr(rowless, "_MAX_CREDIT_RECOVERY_FETCHES", 2)
         svc = AsyncMock()
         svc.get_track_credit_on_release = AsyncMock(return_value=ARTIST)
 

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -30,7 +30,6 @@ from generated.api_models import (
 )
 from lookup.matching import artist_matches_item, filter_results_by_artist
 from lookup.orchestrator import (
-    ROWLESS_LIBRARY_ID,
     ROWLESS_NO_ALBUM_CONFIDENCE,
     _resolve_fallback_artwork,
     build_context_message,
@@ -44,6 +43,7 @@ from lookup.orchestrator import (
     search_with_alternative_interpretation,
 )
 from lookup.release_resolution import ResolvedRelease
+from lookup.rowless import ROWLESS_LIBRARY_ID
 from services.parser import MessageType, ParsedRequest
 from tests.factories import make_discogs_result, make_library_item
 

--- a/tests/unit/test_rowless_enrichment.py
+++ b/tests/unit/test_rowless_enrichment.py
@@ -45,7 +45,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from discogs.models import ArtistDetails, ReleaseMetadataResponse, TrackItem
-from lookup.orchestrator import ROWLESS_LIBRARY_ID, enrich_artwork_results
+from lookup.orchestrator import enrich_artwork_results
+from lookup.rowless import ROWLESS_LIBRARY_ID
 from tests.factories import make_discogs_result, make_library_item
 
 # A non-library release that resolves on Discogs. The request album is

--- a/tests/unit/test_rowless_flag_observability.py
+++ b/tests/unit/test_rowless_flag_observability.py
@@ -38,7 +38,7 @@ class TestNonlibraryReleaseSurfacedCounter:
 
     def test_make_rowless_item_increments_counter(self):
         """The single row-less chokepoint records one surfaced emission."""
-        from lookup.orchestrator import (
+        from lookup.rowless import (
             NONLIBRARY_RELEASE_SURFACED_STAT_KEY,
             _make_rowless_item,
         )
@@ -56,10 +56,8 @@ class TestNonlibraryReleaseSurfacedCounter:
         flag-scoped counter — else the "0 when flag off" property breaks and two
         independent features get conflated."""
         from discogs.models import DiscogsSearchResponse
-        from lookup.orchestrator import (
-            NONLIBRARY_RELEASE_SURFACED_STAT_KEY,
-            _library_miss_discogs_search,
-        )
+        from lookup.orchestrator import _library_miss_discogs_search
+        from lookup.rowless import NONLIBRARY_RELEASE_SURFACED_STAT_KEY
         from services.parser import MessageType, ParsedRequest
         from tests.factories import make_discogs_result
 
@@ -318,12 +316,12 @@ class TestPayloadShapeStability:
             RELEASE_RESOLUTION_CACHE_MISS_STAT_KEY,
             RELEASE_RESOLUTION_CACHE_UNAVAILABLE_STAT_KEY,
         )
-        from lookup.orchestrator import NONLIBRARY_RELEASE_SURFACED_STAT_KEY
         from lookup.router import (
             _LML_CACHE_STATS_EXTRA_KEYS,
             LML_RESOLVE_COMPILATION_RELEASE_STAT_KEY,
             LML_RESOLVE_NONLIBRARY_RELEASE_STAT_KEY,
         )
+        from lookup.rowless import NONLIBRARY_RELEASE_SURFACED_STAT_KEY
 
         for key in (
             LML_RESOLVE_NONLIBRARY_RELEASE_STAT_KEY,


### PR DESCRIPTION
Pure code motion, no behavior change — PR 3 of 9 in the orchestrator decomposition. Part of #722 (PR 3 of 9). Closes #725.

## What moved

The row-less / non-library-release synthesis cluster (#628/#631/#632/#660/#663 lineage) moves verbatim from `lookup/orchestrator.py` (3,639 → 3,339 lines) to the new `lookup/rowless.py` (332 lines), with attached comment blocks:

- `_PACKED_TITLE_SEPARATOR` + `_own_release_credit` (LML#663 packed-title credit recovery)
- `_select_rowless_artist_release` (LML#631 SONG_AS_ARTIST row-less pick)
- `ROWLESS_LIBRARY_ID`, `NONLIBRARY_RELEASE_SURFACED_STAT_KEY`, `_make_rowless_item` (the synthetic `id=0` chokepoint)
- `_resolve_nonlibrary_release` (#628 A1 carry-through kernel) + `_rehydrate_resolved_release` (#632 cache re-hydrate)
- `_MAX_CREDIT_RECOVERY_FETCHES` + `_recover_track_credit` (LML#660 per-track credit recovery)

Two constants inside the block **stay behind with their consumers** (grep-verified): `SONG_AS_TRACK_CONFIDENCE` (sole consumer `_match_track_releases_to_library` — moves in PR 4a, #726) and `ROWLESS_NO_ALBUM_CONFIDENCE` (consumers `find_library_albums_with_cached_track` and `_bind_resolved_release` — both move in PR 5, #728).

The orchestrator consumer-imports only what its remaining code uses (`ROWLESS_LIBRARY_ID`, `_make_rowless_item`, `_recover_track_credit`, `_resolve_nonlibrary_release`, `_select_rowless_artist_release`); the now-unconsumed `entity.release_resolution_cache` block, `resolve_release_for_track`, and `get_cache_stats_recorder` imports are pruned. No re-exports.

## Rewires

- **Production**: `lookup/router.py` imports `NONLIBRARY_RELEASE_SURFACED_STAT_KEY` from `lookup.rowless` (the program's only production import change outside the spine).
- `tests/unit/test_nonlibrary_release_resolution.py`: subject functions moved, so everything retargets to `lookup.rowless` — the module import, five local `_recover_track_credit` imports, `setattr(module, "_MAX_CREDIT_RECOVERY_FETCHES", ...)` ×2, and string patches on `get_cached_release_id` ×3 / `set_cached_release_id` ×3 / `resolve_release_for_track` ×2.
- `tests/unit/test_rowless_flag_observability.py`: `NONLIBRARY_RELEASE_SURFACED_STAT_KEY` + `_make_rowless_item` now from `lookup.rowless` (×3 sites); `_library_miss_discogs_search` stays an orchestrator import (moves in PR 4b).
- `tests/unit/test_rowless_enrichment.py`, `tests/unit/test_cached_track_safety_net.py`, `tests/unit/test_orchestrator_helpers.py`: `ROWLESS_LIBRARY_ID` split out to `lookup.rowless`; their subjects (`enrich_artwork_results`, `find_library_albums_with_cached_track`, `ROWLESS_NO_ALBUM_CONFIDENCE`, `fetch_artwork_for_items`, ...) stay orchestrator imports.
- **Deliberately kept on `lookup.orchestrator`**: the `_resolve_nonlibrary_release` patches in `tests/unit/test_album_title_fallback.py` and `tests/integration/test_lookup_nonlibrary_release.py` — the intercepted callers (`search_compilations_for_track`, the strategy paths under `perform_lookup`) still live in the orchestrator and read its module-global consumer import; retargeting to `lookup.rowless` would stop intercepting them.
- **Docs**: sweep found no file-path claim naming `lookup/orchestrator.py` as the home of a moved symbol (`env-vars.md` attaches the path only to the staying strategy functions; `observability-rowless-flag.md` names no file for the chokepoint), so no doc edits.

## How to review

Commit 1 is the move — review with `git diff --color-moved=zebra` (only novel lines: module docstring, imports, logger). Commit 2 is the rewire (imports + patch targets only).

## Verification

- `ruff check .` and `ruff format --check .` clean
- `tests/unit`: 3,176 passed, 1 failed — the known #733 flake (`test_lookup_inflight_cap.py::TestInFlightCapBehavior::test_queued_request_completes_after_permit_frees`), which passes in isolation (14/14 in the file standalone)
- Rowless integration suites (`test_lookup_nonlibrary_release`, `test_lookup_song_as_artist_rowless`, `test_lookup_cached_track_rowless`, `test_lookup_nonlibrary_no_album`): 26 passed; full integration/e2e collection clean
- Whole-repo audit: `grep -rn "lookup\.orchestrator" --include="*.py" .` — every surviving patch target references code still living in `orchestrator.py` (`lookup_releases_by_track/by_artist`, `sentry_sdk`, `asyncio`, `apple_music_lookup_timeout_s`, `resolve_tracklist_via_musicbrainz`, `apply_streaming_url_postprocess`, `_library_miss_discogs_search`, `_log_album_title_fallback`, `fetch_artwork_for_items`, `filter_results_by_track_validation`, `validate_release_for_track`), plus the two deliberate `_resolve_nonlibrary_release` keeps above