### PR TITLE
fix(release-resolution): rank single-artist retrospectives as own-releases in no-album prerank

### DIFF
--- a/lookup/release_resolution.py
+++ b/lookup/release_resolution.py
@@ -188,9 +188,22 @@ def prerank_candidates_for_validation(
     """
     album_query = (album or "").strip()
     if not album_query:
-        # ``ReleaseInfo.is_compilation`` is ``bool | None``; coerce so a ``None``
-        # never lands in the sort tuple (``None < False`` raises TypeError).
-        return sorted(candidates, key=lambda r: (bool(r.is_compilation), r.release_id))
+        # Deprioritize only TRUE Various-Artists compilations — the ``Compilation``
+        # flag AND a compilation-artist credit ("Various") — not single-artist
+        # retrospectives, which Discogs also flags ``Compilation`` yet are the
+        # canonical home of an artist's original tracks. Gating on
+        # ``is_compilation`` alone sank a retrospective below a later plain single
+        # carrying only a remix (the "Me & Mr Jones by Plug" case). Mirrors the
+        # true-V/A test in ``merge_wave_b_compilations``. ``is_compilation`` is
+        # ``bool | None``; ``bool()`` coerces so a ``None`` never lands in the sort
+        # tuple (``None < False`` raises TypeError).
+        return sorted(
+            candidates,
+            key=lambda r: (
+                bool(r.is_compilation) and is_compilation_artist(r.artist or ""),
+                r.release_id,
+            ),
+        )
     return sorted(
         candidates,
         key=lambda r: (-score_match(album_query, r.album), r.release_id),

--- a/tests/unit/test_release_resolution.py
+++ b/tests/unit/test_release_resolution.py
@@ -479,6 +479,43 @@ class TestBoundedEarlyExit:
         assert svc.validate_track_on_release.await_count == 1
         assert svc.validate_track_on_release.await_args.args[0] == 40
 
+    @pytest.mark.asyncio
+    async def test_no_album_single_artist_retrospective_outranks_remix_single(self):
+        """A single-artist retrospective — Discogs flags it ``Compilation`` but it
+        is credited to a real artist, not "Various" — is the canonical home of an
+        artist's original track, so it must rank as an own-release. It must NOT be
+        deprioritized below a later non-compilation single that only carries a
+        remix of the same track.
+
+        Regression for the "Me & Mr Jones by Plug" case: the original lives on the
+        retrospective "Drum 'n' Bass for Papa" (lower id, ``is_compilation=True``),
+        while the remix lives on a plain single (higher id, ``is_compilation=
+        False``). The old ``bool(is_compilation)`` prerank sorted the remix single
+        first and surfaced it; the true-V/A gate ranks the retrospective first.
+        """
+        from lookup.release_resolution import resolve_release_for_track
+
+        retrospective = _single_artist(30, "Drum 'n' Bass For Papa", is_compilation=True)
+        remix_single = _single_artist(70, "Me & Mr. Sutton", is_compilation=False)
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(
+            return_value=_track_response(remix_single, retrospective)
+        )
+        svc.validate_track_on_release = AsyncMock(return_value=True)
+
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album=None,
+            discogs_service=svc,
+            max_validations=5,
+        )
+
+        # The retrospective (id 30) ranks as an own-release and, being the lower
+        # id, is probed first and validates → early-exit on it, not the remix.
+        assert [r.release_id for r in resolved] == [30]
+        assert svc.validate_track_on_release.await_args.args[0] == 30
+
 
 class TestValidateReleaseForTrack:
     """The shared validate+telemetry primitive both strategies delegate to."""


### PR DESCRIPTION
## Problem

`prerank_candidates_for_validation` (`lookup/release_resolution.py`) orders no-album track candidates so the likeliest release is validated first in the bounded (`max_validations`) path used by the non-library carry-through (`_resolve_nonlibrary_release`, LML#628). Its no-album rule was:

```python
return sorted(candidates, key=lambda r: (bool(r.is_compilation), r.release_id))
```

i.e. "prefer own-releases (`is_compilation=False`) over compilations, then stable id." But `is_compilation` (the Discogs `Compilation` format flag) is **also set on single-artist retrospectives**, which are the canonical home of an artist's *original* tracks — not V/A grab-bags. So a track whose original lives on a retrospective is sunk **below** a later plain single that carries only a **remix** of the same track, and the bounded early-exit validates and returns the remix.

This is the same `is_compilation`-alone conflation that `merge_wave_b_compilations` already warns about and guards against with a *true-V/A* test (`is_compilation AND is_compilation_artist(credit)`).

## Repro

The "me and mr. jones by plug" report. The original "Me & Mr Jones" sits on Discogs release `3192` *Drum 'n' Bass for Papa* (format `CD, Compilation` — a single-artist retrospective credited to Plug); the remix "Me & Mr. Jones (Boymerang Remix)" sits on release `1643641` *Me & Mr. Sutton* (format `File`, non-compilation). With no typed album, the old prerank ranked the remix single first.

(Note: this is a *latent* ranking bug. It is not what caused that specific production lookup to return the remix — that was a discogs-cache data outage, WXYC/discogs-etl#298, where release 3192 has no `release_track` rows at all so it never becomes a candidate. This fix ensures the original wins **once the cache is repopulated**.)

## Fix

Gate the no-album deprioritization on *true V/A* only, mirroring `merge_wave_b_compilations`:

```python
key=lambda r: (bool(r.is_compilation) and is_compilation_artist(r.artist or ""), r.release_id)
```

A single-artist retrospective then ranks as an own-release (lower id wins the tie); a genuine "Various"-credited comp is still deprioritized.

## Acceptance criteria

- [x] Failing unit test reproduces the retrospective-vs-remix ordering, then passes with the fix (`tests/unit/test_release_resolution.py::TestBoundedEarlyExit::test_no_album_single_artist_retrospective_outranks_remix_single`).
- [x] The two existing no-album prerank tests still pass (stable id tie-break; true-V/A deprioritized).
- [x] `ruff check` / `ruff format --check` clean.

## Related

- WXYC/discogs-etl#298 — the cache data outage that surfaced this (the actual cause of the Plug lookup returning the remix).
- Sibling follow-up: request-o-matic CI-coverage gap for the album-less Plug path (only asserts `len>0`).

---
Closes #739