### PR TITLE
test(#685): guarantee bulk /lookup honors per-item extended (cache-only)

### DIFF
--- a/lookup/router.py
+++ b/lookup/router.py
@@ -414,6 +414,29 @@ async def handle_lookup(
     Amortizes per-row cold-cache cost two ways: one HTTP roundtrip per N
     items instead of N roundtrips, and the in-process TTL/LRU caches stay
     warm across all N items in a batch.
+
+    Per-item ``extended`` is honored (LML#685): each item is a full
+    ``LookupRequest`` forwarded verbatim to ``perform_lookup``, so an item with
+    ``extended: true`` gets the same extended-only ``DiscogsMatchResult`` fields
+    on its top-1 match as the single ``/lookup`` route — byte-identical contract
+    (the 8 ``album_metadata`` columns BS#1442 backfills — ``discogs_artist_id``,
+    ``label``, ``full_release_date``, ``genres``, ``styles``, ``tracklist``,
+    ``artist_image_url``, ``profile_tokens`` — plus ``writer_credits``, LML#699).
+
+    ``extended`` is Discogs-ceiling-safe: it is CACHE-ONLY on this path. It
+    plucks fields from the release/artist objects ``fetch_top1_release_details``
+    already fetched (which run regardless of ``extended``, feeding the base
+    ``release_year`` / ``artist_bio`` / ``wikipedia_url`` scalars), plus a
+    cache-only bio parse and a local MusicBrainz PG query — never a new Discogs
+    fetch. So flipping ``extended`` on adds ZERO incremental Discogs calls.
+
+    Note the one bio-warm fan-out is gated on the SEPARATE ``warm_cache`` flag,
+    NOT ``extended``: ``warm_cache: true`` schedules ``_warm_bio_cache``, which
+    fires per-bio-ref live Discogs calls. It defaults off and BS#1442 leaves it
+    unset, so the drain is safe today — but unlike ``bandcamp`` /
+    ``allow_release_resolution_fallback`` it is NOT hard-pinned here, so a caller
+    that sets it per item would re-open that fan-out mid-drain. Hard-pinning it
+    off on bulk (mirroring those two flags) is a candidate follow-up.
     """,
     responses={
         200: {"description": "Per-item verdicts in input order."},

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -135,6 +135,69 @@ class TestBulkLookupEndpoint:
         assert mock_lookup.await_args.kwargs.get("allow_release_resolution_fallback") is False
 
     @pytest.mark.asyncio
+    async def test_bulk_forwards_per_item_extended_true(self, app_client):
+        """A bulk item that sets ``extended: true`` reaches perform_lookup with
+        ``request.extended is True`` — the model path (BulkLookupRequest →
+        LookupRequest items) must not strip it (LML#685).
+
+        This is the contract BS#1442's 35k-row album_metadata backfill relies
+        on: the bulk drain is the only Discogs-ceiling-safe way to request the
+        extended DiscogsMatchResult fields at that scale. ``perform_lookup``
+        reads ``request.extended`` identically to the single ``/lookup`` route,
+        so forwarding the flag intact is the whole contract.
+        """
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_no_match_response(),
+        ) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={
+                        "items": [
+                            {"artist": "Stereolab", "album": "Aluminum Tunes", "extended": True}
+                        ]
+                    },
+                )
+
+        assert resp.status_code == 200
+        assert mock_lookup.await_count == 1
+        assert mock_lookup.await_args.kwargs["request"].extended is True
+
+    @pytest.mark.asyncio
+    async def test_bulk_omitted_extended_defaults_off(self, app_client):
+        """Omitting ``extended`` preserves today's bulk contract for non-iOS
+        callers (request-o-matic): the extended payload stays off (LML#685 — no
+        behavior change for non-extended bulk callers).
+
+        The bulk route forwards the item untouched, so ``perform_lookup`` sees
+        the ``LookupRequest.extended`` wire default of ``None`` — no accidental
+        opt-in. (In production ``perform_lookup`` coerces ``None`` to off via
+        ``extended_mode = bool(request.extended)``; that coercion is exercised
+        by the orchestrator-level tests, not here — ``perform_lookup`` is mocked
+        on this route test.)
+        """
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_no_match_response(),
+        ) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk",
+                    json={"items": [{"artist": "Juana Molina", "album": "DOGA"}]},
+                )
+
+        assert resp.status_code == 200
+        assert mock_lookup.await_count == 1
+        assert mock_lookup.await_args.kwargs["request"].extended is None
+
+    @pytest.mark.asyncio
     async def test_bulk_does_not_forward_bandcamp_client(self, app_client):
         """The bulk drain must NOT run the Bandcamp leg: its client is rate-
         limited to 1 req/s, so a per-item live probe would serialize a 35k-album

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -991,6 +991,89 @@ class TestEnrichArtworkResultsExtended:
         assert match.wikipedia_url == "https://en.wikipedia.org/wiki/Artist"
         assert match.spotify_url == "https://open.spotify.com/search/Artist%20Song"
 
+    @pytest.mark.asyncio
+    async def test_extended_adds_no_incremental_discogs_calls(self):
+        """Bulk-safety pin (LML#685): flipping ``extended`` on adds ZERO live
+        Discogs API calls.
+
+        The bulk backfill (BS#1442) drains ~35k albums through this same
+        enrichment path with ``extended=True``. Its only safety margin is that
+        every extended field is plucked from the already-fetched ``top1_release``
+        / ``top1_details`` — or a cache-only bio parse / local MusicBrainz PG
+        query — never a new Discogs fetch. ``fetch_top1_release_details`` runs
+        ``get_release`` + ``get_artist_details`` regardless of ``extended`` (they
+        feed the base ``release_year`` / ``artist_bio`` / ``wikipedia_url``
+        scalars), so the extended payload rides those already-paid fetches.
+
+        This pins the invariant directly: with identical input, ``get_release``
+        and ``get_artist_details`` fire the SAME number of times whether
+        ``extended`` is False or True. ``warm_cache`` stays at its default
+        (False) — that is the separate flag that WOULD fan out per-ref Discogs
+        calls via ``_warm_bio_cache``, and the bulk drain must never set it.
+        """
+
+        def _make_service() -> AsyncMock:
+            svc = AsyncMock()
+            svc.get_release.return_value = ReleaseMetadataResponse(
+                release_id=10154369,
+                title="Aluminum Tunes",
+                artist="Stereolab",
+                year=1997,
+                label="Duophonic Ultra High Frequency Disks",
+                artist_id=42,
+                genres=["Electronic", "Rock"],
+                styles=["Indie Rock", "Experimental"],
+                tracklist=[TrackItem(position="1", title="Olv 26", artists=[])],
+                released="1997-09-22",
+                release_url="https://discogs.com/release/10154369",
+            )
+            svc.get_artist_details.return_value = ArtistDetails(
+                artist_id=42,
+                name="Stereolab",
+                profile="French-British band founded in 1990. See [a42].",
+                image_url="https://img.discogs.com/stereolab.jpg",
+                urls=["https://en.wikipedia.org/wiki/Stereolab"],
+            )
+            return svc
+
+        def _call_kwargs(svc: AsyncMock) -> dict:
+            item = make_library_item(artist="Stereolab", title="Aluminum Tunes")
+            artwork = make_discogs_result(
+                release_id=10154369, artist="Stereolab", album="Aluminum Tunes"
+            )
+            return {
+                "items_with_artwork": [(item, artwork)],
+                "discogs_service": svc,
+                "song": "Olv 26",
+                "artist": "Stereolab",
+            }
+
+        base_svc = _make_service()
+        await enrich_artwork_results(**_call_kwargs(base_svc), extended=False)
+
+        extended_svc = _make_service()
+        result = await enrich_artwork_results(**_call_kwargs(extended_svc), extended=True)
+
+        # The extended run actually populated the top-1 extended payload...
+        _, enriched = result[0]
+        assert enriched is not None
+        assert enriched.discogs_artist_id == 42
+        assert enriched.tracklist is not None
+
+        # ...yet made no MORE Discogs API calls than the non-extended run — and
+        # exactly the one release + one artist fetch the base path already pays.
+        assert extended_svc.get_release.call_count == base_svc.get_release.call_count == 1
+        assert (
+            extended_svc.get_artist_details.call_count
+            == base_svc.get_artist_details.call_count
+            == 1
+        )
+        # Method-agnostic backstop: total interactions with the Discogs service
+        # are identical on-vs-off, so a FUTURE extended branch that reached a
+        # different Discogs method (not just the two named above) would still
+        # trip this pin.
+        assert len(extended_svc.mock_calls) == len(base_svc.mock_calls)
+
 
 class TestMbTracklistRescue:
     """``mb_pg`` rescue: when the top-1 result has no Discogs artwork AND


### PR DESCRIPTION
Closes #685.

## What

Verify-and-guarantee that `POST /api/v1/lookup/bulk` honors per-item `extended` and surfaces the extended `DiscogsMatchResult` fields, ahead of [WXYC/Backend-Service#1442](https://github.com/WXYC/Backend-Service/issues/1442)'s 35k-row `album_metadata` backfill — the bulk path is the only Discogs-ceiling-safe way to request those fields at that scale.

Inspection (per the issue) confirmed the machinery is **already fully wired**: `handle_bulk_lookup` forwards each item verbatim as a `LookupRequest` into `perform_lookup`, and the bulk call site already pins `allow_release_resolution_fallback=False` + `bandcamp=None`. So this is the issue's "if it already works, the deliverable is the test + a one-line guarantee" branch — no production behavior change.

## Pins added

1. **Forwarding** (`test_bulk_forwards_per_item_extended_true`): a bulk item with `extended: true` reaches `perform_lookup` with `request.extended is True` — the `BulkLookupRequest` → `LookupRequest` model path doesn't strip it.
2. **Default off** (`test_bulk_omitted_extended_defaults_off`): omitting `extended` forwards the `None` wire default (no accidental opt-in; `perform_lookup` coerces `None`→off via `bool(request.extended)` in production).
3. **No incremental Discogs fan-out** (`test_extended_adds_no_incremental_discogs_calls`) — the actual bulk-safety criterion: flipping `extended` on adds **zero** live Discogs calls. `get_release`/`get_artist_details` call counts are invariant on-vs-off (they run regardless of `extended`, feeding the base `release_year`/`artist_bio`/`wikipedia_url` scalars), plus a method-agnostic total-`mock_calls` backstop. The extended payload rides those already-paid fetches + a cache-only bio parse + a local MusicBrainz PG query — never a new Discogs fetch. (Mutation-checked: the pin goes red if an `extended` branch issues a stray Discogs call.)

Plus a guarantee in the `/lookup/bulk` route docstring enumerating the extended-only fields (the 8 `album_metadata` columns BS#1442 backfills **+ `writer_credits`**, LML#699).

## Review notes folded in

Two independent review passes (correctness + docstring-accuracy) ran on the diff:
- **Field count corrected**: the issue says "8 fields"; the true extended-only payload is **9** (`writer_credits` is `extended`-gated in code but lacks the "Populated only when extended" description string). Docstring + tests reworded to name the 8 backfill columns + `writer_credits`.
- **Honest `warm_cache` framing**: the one bio-warm Discogs fan-out (`_warm_bio_cache`) is gated on the **separate `warm_cache` flag**, not `extended`. It defaults off and BS#1442 leaves it unset (safe today) — but unlike `bandcamp` / `allow_release_resolution_fallback`, the bulk route does **not** hard-pin it, so a caller setting it per item would re-open the fan-out mid-drain. The docstring states this plainly rather than implying enforcement.

## Follow-up (not in this PR)

Hard-pinning `warm_cache=False` on the bulk path (mirroring the two sibling flags) would convert that operational contract into a code guarantee. It's a **pre-existing** bulk-path gap this PR merely documents — kept out per the "don't fold pre-existing debt into the change under review" rule. `perform_lookup`'s signature is frozen (epic #722), so the fix is an item `model_copy(update={"warm_cache": False})` in the bulk route, not a kwarg. Recommend filing as a standalone LML hardening ticket.

## Epic gating

Gates PR 6a ([#729](https://github.com/WXYC/library-metadata-lookup/issues/729)) of the orchestrator-decomposition epic ([#722](https://github.com/WXYC/library-metadata-lookup/issues/722)): these tests become extra pinning for the enrichment-cluster move to `lookup/enrichment/`.

## Testing

- `tests/unit/test_bulk_lookup_endpoint.py` + `tests/unit/test_enrichment.py`: green
- Full unit suite (`-m "not pg and not external_api"`): 3180 passed
- `ruff check .` + `ruff format --check`: clean