### PR TITLE
feat(#759): Discogs artist-search + candidate-set cache primitives (PR B)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -12,6 +12,7 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 import asyncio
 import hashlib
 import logging
+from dataclasses import dataclass, field
 
 from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison
@@ -38,6 +39,23 @@ class CacheUnavailableError(Exception):
     """Raised when the PostgreSQL cache is unreachable."""
 
     pass
+
+
+@dataclass
+class ArtistEqualityCandidates:
+    """Per-form candidate id sets from the four equality legs (LML#759).
+
+    One entry per queried identity-match form; a leg with no matches is an
+    empty set (a measured zero, distinct from "not queried"). Sets — not a
+    single id — because the bare-name resolver's conflict rule needs every
+    candidate an overloaded form points at; collapsing to one would let an
+    ambiguous name mint.
+    """
+
+    exact: set[int] = field(default_factory=set)
+    member: set[int] = field(default_factory=set)
+    alias: set[int] = field(default_factory=set)
+    name_variation: set[int] = field(default_factory=set)
 
 
 # Mirrors ``_ARTIST_FUZZY_MATCH_THRESHOLD`` in ``discogs/service.py`` — the
@@ -72,6 +90,92 @@ _NEGATIVE_CACHE_DEFAULT_TTL_SECONDS = 604_800
 # ``create_ttl_cache`` so ``clear_all_caches()`` resets it alongside the
 # Discogs API memory caches. Per WXYC/library-metadata-lookup#359.
 _ARTIST_SEARCH_CACHE = create_ttl_cache(maxsize=2000, ttl=3600)
+
+# --- LML#759 candidate-set queries -----------------------------------------
+#
+# These are the reconciler's cascade legs (scripts/entity_resolution/
+# discogs.py) deliberately rewritten to return candidate SETS via
+# ``array_agg(DISTINCT ...)`` instead of ``SELECT DISTINCT`` rows. The
+# divergence is intentional, not drift: the reconciler's first-match-wins
+# dict collapse is correct for its library-name inputs (the corpus was
+# filtered around exactly those artists), but the bare-name resolver must
+# see every id an overloaded form points at — "ambiguous names must not
+# mint" is unenforceable on a collapsed result. Keep the per-leg predicates
+# (``extra = 0``, NOT NULL filters, ``wxyc_identity_match_artist`` on the
+# column side) byte-compatible with the reconciler so both consumers see the
+# same candidate universe.
+#
+# All four legs for the whole batch ride one round-trip (UNION ALL + a
+# ``leg`` label column); the batched PG pre-pass budget for a resolve
+# request is 1-3 round-trips total. Inputs are pre-normalized
+# identity-match forms — ``wxyc_etl.text.to_identity_match_form`` on the
+# Python side, ``wxyc_identity_match_artist(col)`` on the column side, the
+# symmetric pair from wiki ``plans/library-hook-canonicalization.md``
+# §3.3.5 (same as the reconciler; rides the same functional indexes).
+_ARTIST_EQUALITY_CANDIDATES_SQL = """\
+SELECT 'exact' AS leg,
+       wxyc_identity_match_artist(ra.artist_name) AS form,
+       array_agg(DISTINCT ra.artist_id) AS artist_ids
+FROM release_artist ra
+WHERE ra.extra = 0
+  AND ra.artist_id IS NOT NULL
+  AND wxyc_identity_match_artist(ra.artist_name) = ANY($1)
+GROUP BY wxyc_identity_match_artist(ra.artist_name)
+UNION ALL
+SELECT 'member' AS leg,
+       wxyc_identity_match_artist(am.member_name) AS form,
+       array_agg(DISTINCT am.member_id) AS artist_ids
+FROM artist_member am
+WHERE am.member_id IS NOT NULL
+  AND wxyc_identity_match_artist(am.member_name) = ANY($1)
+GROUP BY wxyc_identity_match_artist(am.member_name)
+UNION ALL
+SELECT 'alias' AS leg,
+       wxyc_identity_match_artist(aa.alias_name) AS form,
+       array_agg(DISTINCT aa.artist_id) AS artist_ids
+FROM artist_alias aa
+WHERE aa.artist_id IS NOT NULL
+  AND wxyc_identity_match_artist(aa.alias_name) = ANY($1)
+GROUP BY wxyc_identity_match_artist(aa.alias_name)
+UNION ALL
+SELECT 'name_variation' AS leg,
+       wxyc_identity_match_artist(nv.name) AS form,
+       array_agg(DISTINCT nv.artist_id) AS artist_ids
+FROM artist_name_variation nv
+WHERE nv.artist_id IS NOT NULL
+  AND wxyc_identity_match_artist(nv.name) = ANY($1)
+GROUP BY wxyc_identity_match_artist(nv.name)\
+"""
+
+# Batched analog of the reconciler's Stage 6 ``_TRIGRAM_FALLBACK_SQL``:
+# ``unnest`` the input names and let the pg_trgm ``%`` operator ride the
+# existing functional GIN index on ``lower(f_unaccent(artist_name))`` per
+# outer row (same expression as ``search_artists_by_name``; deliberately
+# NOT ``wxyc_identity_match_artist``, which has no trigram index). Unlike
+# the reconciler this returns the full above-threshold candidate set per
+# input, not the top-1 — trigram evidence feeds corroboration/telemetry
+# only and must expose every neighbor. The threshold is applied in SQL
+# because no caller needs the scores; note pg_trgm's session
+# ``similarity_threshold`` (``show_limit()``, default 0.3) pre-filters the
+# ``%`` operator, so a threshold below that floor would silently drop
+# candidates in the gap (same caveat as the reconciler's Stage 6).
+_ARTIST_TRIGRAM_CANDIDATES_SQL = """\
+SELECT q.input,
+       array_agg(DISTINCT ra.artist_id) AS artist_ids
+FROM unnest($1::text[]) AS q(input)
+JOIN release_artist ra
+  ON ra.extra = 0
+ AND ra.artist_id IS NOT NULL
+ AND lower(f_unaccent(ra.artist_name)) % lower(f_unaccent(q.input))
+ AND similarity(lower(f_unaccent(ra.artist_name)), lower(f_unaccent(q.input))) >= $2
+GROUP BY q.input\
+"""
+
+# Mirrors ``_DEFAULT_TRIGRAM_THRESHOLD`` in ``scripts/entity_resolution/
+# discogs.py`` — the acceptance floor validated in LML#215. Tied by intent:
+# a candidate the reconciler would not accept as a match is not evidence
+# the resolver should count either.
+_ARTIST_TRIGRAM_CANDIDATE_THRESHOLD = 0.85
 
 
 def _negative_cache_key_hash(artist: str | None, track: str, artist_as_keyword: bool) -> bytes:
@@ -343,6 +447,95 @@ class DiscogsCacheService:
         except Exception as e:
             logger.error(f"Cache search_artists_by_name failed: {e}")
             raise CacheUnavailableError(f"Cache search_artists_by_name failed: {e}") from e
+
+    async def artist_equality_candidates(
+        self, forms: list[str]
+    ) -> dict[str, ArtistEqualityCandidates]:
+        """Batched equality-leg candidate sets for identity-match forms (LML#759).
+
+        The bare-name resolver's tier-2 evidence pass: exact / member /
+        alias / name_variation legs for every form in one round-trip. See
+        the ``_ARTIST_EQUALITY_CANDIDATES_SQL`` comment for why these are
+        candidate sets and how they deliberately diverge from the
+        reconciler's first-match-wins cascade.
+
+        Args:
+            forms: Identity-match forms, pre-normalized on the Python side
+                via ``wxyc_etl.text.to_identity_match_form`` (the symmetric
+                partner of the SQL's ``wxyc_identity_match_artist``).
+                Passing raw names silently misses.
+
+        Returns:
+            One ``ArtistEqualityCandidates`` per input form — every key
+            present, with empty sets for legs that had no candidates.
+
+        Raises:
+            CacheUnavailableError: If the database is unreachable.
+        """
+        if not forms:
+            return {}
+        try:
+            rows = await self.pool.fetch(_ARTIST_EQUALITY_CANDIDATES_SQL, forms)
+            results = {form: ArtistEqualityCandidates() for form in forms}
+            leg_sets = {
+                "exact": lambda c: c.exact,
+                "member": lambda c: c.member,
+                "alias": lambda c: c.alias,
+                "name_variation": lambda c: c.name_variation,
+            }
+            for row in rows:
+                candidates = results.get(row["form"])
+                if candidates is None:
+                    continue
+                leg_sets[row["leg"]](candidates).update(row["artist_ids"])
+            return results
+        except Exception as e:
+            logger.error(f"Cache artist_equality_candidates failed: {e}")
+            raise CacheUnavailableError(f"Cache artist_equality_candidates failed: {e}") from e
+
+    async def artist_trigram_candidates(
+        self,
+        names: list[str],
+        *,
+        threshold: float = _ARTIST_TRIGRAM_CANDIDATE_THRESHOLD,
+    ) -> dict[str, set[int]]:
+        """Batched trigram-neighbor candidate sets for raw names (LML#759).
+
+        The resolver's fuzzy evidence leg — yield telemetry and
+        near-miss counting only, never a veto or a verdict (the #759
+        conflict rule is scoped to the equality legs). Takes RAW names,
+        not identity-match forms: the SQL applies ``lower(f_unaccent(...))``
+        to both sides so the ``%`` operator rides the existing GIN trigram
+        index, mirroring the reconciler's Stage 6 asymmetry note.
+
+        Args:
+            names: Raw artist names as received (first-occurrence verbatim
+                per deduped form, by the resolver's convention).
+            threshold: Minimum pg_trgm similarity [0, 1] for a candidate to
+                count. Values below pg_trgm's session floor (default 0.3)
+                silently drop candidates in the gap — see the SQL comment.
+
+        Returns:
+            Candidate ``artist_id`` sets keyed by input name — every key
+            present, empty set when nothing cleared the threshold.
+
+        Raises:
+            CacheUnavailableError: If the database is unreachable.
+        """
+        if not names:
+            return {}
+        try:
+            rows = await self.pool.fetch(_ARTIST_TRIGRAM_CANDIDATES_SQL, names, threshold)
+            results: dict[str, set[int]] = {name: set() for name in names}
+            for row in rows:
+                candidates = results.get(row["input"])
+                if candidates is None:
+                    continue
+                candidates.update(row["artist_ids"])
+            return results
+        except Exception as e:
+            logger.error(f"Cache artist_trigram_candidates failed: {e}")
+            raise CacheUnavailableError(f"Cache artist_trigram_candidates failed: {e}") from e
 
     async def search_releases_by_title(self, title: str, *, limit: int = 5) -> list[dict]:
         """Fuzzy-match an album/release title against ``release.title``.

--- a/discogs/models.py
+++ b/discogs/models.py
@@ -306,6 +306,21 @@ class DiscogsSearchResponse(BaseModel):
     cached: bool = False
 
 
+class DiscogsArtistSearchResult(BaseModel):
+    """One artist hit from a ``/database/search?type=artist`` page (LML#759).
+
+    ``title`` is the raw Discogs artist title with any "(N)" disambiguator
+    intact. The bare-name resolver's overload detection normalizes it via
+    ``to_identity_match_form`` — which strips the parenthetical — so
+    "Popsicle (2)" collides with "Popsicle" and the family reads as
+    ambiguous. Stripping the suffix here would erase that signal, and
+    provenance wants the true Discogs string anyway.
+    """
+
+    artist_id: int
+    title: str
+
+
 class EnrichedDiscogsMatchResult(_GeneratedDiscogsMatchResult):
     """Extends the generated DiscogsMatchResult with enriched metadata fields.
 

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -38,6 +38,7 @@ from discogs.models import (
     ArtistCredit,
     ArtistDetails,
     ArtistRef,
+    DiscogsArtistSearchResult,
     DiscogsSearchRequest,
     DiscogsSearchResponse,
     DiscogsSearchResult,
@@ -832,6 +833,68 @@ class DiscogsService:
             total=len(releases[:limit]),
             cached=False,
         )
+
+    async def search_artists(self, name: str) -> list[DiscogsArtistSearchResult] | None:
+        """Search Discogs artists by name — one ``type=artist`` page (LML#759).
+
+        The tier-3 exact-form uniqueness probe for the bare-name artist
+        resolver: ``/database/search?type=artist&per_page=100``, single page
+        by design. The resolver treats page 1 as the observation universe —
+        a name whose exact-form family doesn't fit on one page is ambiguous
+        long before page 2 — so no pagination crawl, ever.
+
+        API-only — no cache leg. The discogs-cache is a pair-wise-filtered
+        ~50K biased sample, so for bare touring names it can corroborate but
+        never decide (the whole point of #759's verify-before-mint model);
+        the cache evidence legs live in
+        ``cache_service.artist_equality_candidates`` /
+        ``artist_trigram_candidates``.
+
+        The return distinction is load-bearing for ``candidate_count``
+        (null never means zero):
+
+        - ``list`` (possibly empty): Discogs answered; the list is the
+          measured single-page observation. Titles are raw Discogs strings,
+          "(N)" disambiguator intact (see ``DiscogsArtistSearchResult``).
+        - ``None``: couldn't ask — 429-exhausted, network error, non-2xx,
+          or unparseable body. Callers must treat it as *unknown*, never
+          as a confirmed-empty verdict.
+
+        Raises:
+            DiscogsBreakerOpenError: propagated from ``_request_with_retry``
+                when the LML#755 saturation breaker sheds the call, so the
+                resolver can short-circuit the rest of its batch to
+                ``escalation_unavailable`` instead of paying one shed per
+                remaining name.
+        """
+        if not name or not name.strip():
+            return []
+
+        params: dict[str, Any] = {"type": "artist", "q": name, "per_page": 100}
+
+        with request_context("search_artists"):
+            async with timed_api():
+                response = await self._request_with_retry("GET", "/database/search", params=params)
+
+        if response is None:
+            return None
+        get_cache_stats_recorder().record_api_call()
+
+        try:
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            logger.warning(f"search_artists failed for '{name}': {e}")
+            return None
+
+        results: list[DiscogsArtistSearchResult] = []
+        for item in data.get("results", []):
+            artist_id = item.get("id")
+            title = item.get("title")
+            if artist_id is None or not title:
+                continue
+            results.append(DiscogsArtistSearchResult(artist_id=artist_id, title=title))
+        return results
 
     def _process_search_result(self, result: dict, seen_albums: set) -> ReleaseInfo | None:
         """Process a single search result into a ReleaseInfo.

--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -17,6 +17,7 @@ from pydantic import (
     RootModel,
     confloat,
     conint,
+    constr,
 )
 
 
@@ -735,6 +736,67 @@ class DeviceToken(BaseModel):
     expires_at: AwareDatetime
 
 
+class Venue(BaseModel):
+    id: int
+    slug: str = Field(..., description='Stable scraper seed key (e.g. "cats-cradle").')
+    name: str
+    city: str
+    state: str
+    address: str
+
+
+class ConcertStatus(StrEnum):
+    on_sale = "on_sale"
+    sold_out = "sold_out"
+    cancelled = "cancelled"
+    rescheduled = "rescheduled"
+
+
+class Concert(BaseModel):
+    id: int
+    venue: Venue
+    starts_on: date_aliased = Field(
+        ..., description="Venue-local (America/New_York) calendar date."
+    )
+    starts_at: AwareDatetime = Field(
+        ..., description="Exact start instant; null for date-only events."
+    )
+    doors_at: AwareDatetime = Field(
+        ..., description="Doors-open instant, when the source publishes one."
+    )
+    headlining_artist_raw: str = Field(
+        ..., description="Headliner billing string exactly as the source displays it."
+    )
+    headlining_artist_id: int = Field(
+        ...,
+        description="WXYC catalog artist id when the resolver matched the headliner; null otherwise. A non-null id is what `curated=true` filters on.",
+    )
+    title: str = Field(
+        ...,
+        description="Event name as the source displays it, when distinct from the artist billing.",
+    )
+    supporting_artists_raw: list[str] = Field(
+        ..., description="Supporting-act billing strings, in source order."
+    )
+    ticket_url: str
+    image_url: str
+    event_url: str = Field(
+        ...,
+        description="The venue's own event-detail page, distinct from `ticket_url` (often a third-party seller like Etix/Ticketmaster). Null when no venue page is known; clients fall back to `ticket_url`.",
+    )
+    price_min: float = Field(..., description="Dollars. Free events carry price_min = 0.")
+    price_max: float = Field(..., description="Dollars.")
+    age_restriction: str = Field(
+        ..., description='Source-displayed age restriction (e.g. "18+", "All Ages").'
+    )
+    status: ConcertStatus
+
+
+class ConcertsResponse(BaseModel):
+    concerts: list[Concert]
+    pagination: PaginationInfo
+
+
 class DeviceAuthCodeRequest(BaseModel):
     client_id: str = Field(
         ..., description="The client ID of the application requesting authorization."
@@ -1299,6 +1361,71 @@ class ArtistSearchAliasesBulkResponse(BaseModel):
         description="Input names with no `entity.identity` row in LML — i.e., LML doesn't know any external IDs for these. BS can choose to retry later (after a discogs-cache rebuild and entity-resolution campaign) or leave them.\n",
     )
     cache_stats: CacheStats | None = None
+
+
+class ArtistResolveMethod(StrEnum):
+    identity_store = "identity_store"
+    api_search = "api_search"
+
+
+class ArtistResolveCacheLeg(StrEnum):
+    cache_exact = "cache_exact"
+    cache_member = "cache_member"
+    cache_alias = "cache_alias"
+    cache_name_variation = "cache_name_variation"
+    cache_trigram = "cache_trigram"
+
+
+class ArtistResolveUnresolvedReason(StrEnum):
+    not_found = "not_found"
+    ambiguous = "ambiguous"
+    escalation_unavailable = "escalation_unavailable"
+
+
+class ArtistResolveResult(BaseModel):
+    name: str = Field(..., description="Verbatim echo of the input name at this index.")
+    discogs_artist_id: int | None = Field(
+        None, description="The resolved Discogs artist id. Present iff resolved."
+    )
+    canonical_name: str | None = Field(
+        None,
+        description="The raw Discogs artist title, disambiguation suffix included (e.g. `Popsicle (2)`) — the true Discogs string, kept for provenance; callers render their own input name. Present iff resolved via `api_search`: `entity.identity` rows store no Discogs title, so `identity_store` resolutions omit it.\n",
+    )
+    method: ArtistResolveMethod | None = Field(
+        None, description="What decided the resolution. Present iff resolved.\n"
+    )
+    cache_corroboration: list[ArtistResolveCacheLeg] = Field(
+        ...,
+        description="Cache legs that produced at least one candidate for this name's identity-match form, on BOTH verdict kinds — the per-leg yield telemetry sizing a possible v2 alias arm. On resolved verdicts, listed equality legs necessarily agreed with the deciding tier (a disagreeing equality leg forces `ambiguous`), while `cache_trigram` entries are fuzzy near-misses that never veto. Empty when no leg produced candidates, and always empty on `identity_store` short-circuits — the store decides before cache evidence is consulted, and implementations report an empty array there.\n",
+    )
+    unresolved_reason: ArtistResolveUnresolvedReason | None = Field(
+        None, description="Why the name did not resolve. Present iff unresolved.\n"
+    )
+    candidate_count: int | None = Field(
+        None,
+        description='Exact-form candidates the API tier observed: 1 on resolved via `api_search`, 0 on not_found; on ambiguous, >= 2 for an overloaded family, or exactly 1 when the ambiguity is an equality-leg cache conflict. Always serialized — never omitted; null when the API tier did not run (identity_store short-circuit, escalation_unavailable) — null means "not measured," never zero.\n',
+    )
+
+
+class Name(RootModel[constr(min_length=1, max_length=255)]):
+    root: constr(min_length=1, max_length=255)
+
+
+class ArtistResolveBulkRequest(BaseModel):
+    names: list[Name] = Field(
+        ...,
+        description="Bare artist names to resolve, verbatim. Inputs are deduplicated internally on their normalized identity-match form: duplicate positions receive the shared verdict, and only the first occurrence's verbatim string mints.\n",
+        max_length=25,
+        min_length=1,
+    )
+    dry_run: bool | None = Field(
+        False,
+        description="Run every tier identically — including live Discogs API verification — but skip the `entity.identity` write-back. No partial-write mode.\n",
+    )
+
+
+class ArtistResolveBulkResponse(BaseModel):
+    results: list[ArtistResolveResult]
 
 
 class CacheRefreshSourceOutcome(StrEnum):
@@ -2002,6 +2129,10 @@ class FlowsheetV2TrackEntry(FlowsheetV2Base):
     )
     styles: list[str] | None = Field(
         None, description="Discogs style tags (finer-grained than genres)."
+    )
+    upcoming_show: Concert | None = Field(
+        None,
+        description="An optional embedded upcoming Triangle-area concert whose headliner is this track's resolved catalog artist, attached server-side at feed-assembly time so the iOS \"Touring Soon\" Box Office CTA renders inline with no second round-trip.\n\nMatch rule (mirrors `GET /concerts?curated=true`): the track's resolved artist — `flowsheet.album_id → library.artist_id` — is matched against `concerts.headlining_artist_id` on curated, non-tombstoned, upcoming rows (`headlining_artist_id IS NOT NULL`, `removed_at IS NULL`, `starts_on >= today` America/New_York). When an artist has several upcoming dates the **soonest** wins (`ORDER BY starts_on ASC LIMIT 1`), so at most one concert rides each playcut.\n\nAbsent/null when the track has no resolved artist (free-form entries with no `album_id`, or an `album_id` whose library row has no matched artist) or when that artist has no curated upcoming date. The field is additive and optional — older app builds that don't decode it are unaffected. Reuses the `Concert` schema verbatim so iOS decodes one type across the Touring Soon tab and the playcut CTA; the `BoxOfficeTicketPresenter` reads `id`, `title` / `headlining_artist_raw`, `venue` (name + city), `starts_on`, `doors_at`, `status`, `price_min` / `price_max`, `ticket_url`, and `image_url` off it.\n",
     )
 
 

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -56,6 +56,15 @@ from entity.sources import PgSource
 
 logger = logging.getLogger(__name__)
 
+# NOTE(LML#759): ``discogs/cache_service.py`` carries a candidate-SET rewrite
+# of these same legs (``_ARTIST_EQUALITY_CANDIDATES_SQL`` /
+# ``_ARTIST_TRIGRAM_CANDIDATES_SQL``) for the bare-name artist resolver. The
+# divergence is intentional, not drift: this cascade's first-match-wins
+# collapse (SELECT DISTINCT + dict comprehension) is correct for its
+# library-name inputs — the discogs-cache corpus was pair-filtered around
+# exactly those artists — but the resolver's inputs void that warranty, so it
+# must see every id an overloaded form points at. Keep the per-leg predicates
+# here and there byte-compatible when editing either side.
 _EXACT_MATCH_SQL = """\
 SELECT DISTINCT wxyc_identity_match_artist(ra.artist_name) AS artist_name, ra.artist_id
 FROM release_artist ra

--- a/tests/integration/test_artist_candidate_sets.py
+++ b/tests/integration/test_artist_candidate_sets.py
@@ -1,0 +1,255 @@
+"""pg integration tests for the LML#759 candidate-set queries.
+
+Exercises ``DiscogsCacheService.artist_equality_candidates`` and
+``artist_trigram_candidates`` against real PostgreSQL. These are the
+reconciler cascade legs rewritten to return candidate SETS — the load-bearing
+behavior under test is anti-collapse: an overloaded form must surface every
+candidate id, where the reconciler's first-match-wins collapse (correct for
+its library-name inputs) would silently pick one.
+
+Two classes with different infrastructure requirements, mirroring the split
+in ``test_entity_resolution.py``:
+
+- ``TestArtistEqualityCandidatesPG`` needs ``wxyc_identity_match_artist``
+  (alembic 0004 from WXYC/discogs-etl) and self-skips without it — CI's
+  plain postgres-16 service container doesn't have it.
+- ``TestArtistTrigramCandidatesPG`` only needs ``pg_trgm`` + ``unaccent``
+  contrib, both provisionable on CI.
+
+Data safety: both fixtures **skip** when the tables they seed already exist
+(a live discogs-cache) rather than writing into real cache data — the same
+posture as ``TestTrigramFallbackSQLIntegration``.
+"""
+
+from typing import ClassVar
+
+import pytest
+import pytest_asyncio
+from wxyc_etl.text import to_identity_match_form
+
+from discogs.cache_service import DiscogsCacheService
+
+
+@pytest.mark.pg
+class TestArtistEqualityCandidatesPG:
+    """Equality legs end to end: Python ``to_identity_match_form`` on the
+    input side, ``wxyc_identity_match_artist`` on the column side.
+
+    Because inputs are normalized in Python and columns in SQL, every
+    passing assertion here is also a normalization-parity check for the
+    axis it seeds (case, leading article, paren suffix, diacritics) —
+    parity itself is locked upstream in wxyc-etl, this makes a break
+    surface in LML's own suite.
+    """
+
+    _TABLES: ClassVar[dict[str, str]] = {
+        "release_artist": (
+            "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0"
+        ),
+        "artist_member": "artist_id INTEGER, member_id INTEGER, member_name TEXT",
+        "artist_alias": "artist_id INTEGER, alias_name TEXT",
+        "artist_name_variation": "artist_id INTEGER, name TEXT",
+    }
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def seed_equality_tables(self, pg_pool):
+        async with pg_pool.acquire() as conn:
+            fn_exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = $1)",
+                "wxyc_identity_match_artist",
+            )
+            if not fn_exists:
+                pytest.skip(
+                    "wxyc_identity_match_artist not deployed -- needs alembic 0004 "
+                    "from WXYC/discogs-etl (see TestDiscogsReconciliationSQLSmoke)"
+                )
+            for table_name in self._TABLES:
+                pre_existing = await conn.fetchval(
+                    "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = current_schema() AND table_name = $1)",
+                    table_name,
+                )
+                if pre_existing:
+                    pytest.skip(
+                        f"{table_name} already present -- refusing to seed into a real "
+                        "discogs-cache (data-safety posture)"
+                    )
+            for table_name, columns in self._TABLES.items():
+                await conn.execute(f"CREATE TABLE {table_name} ({columns})")
+            await conn.executemany(
+                "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "
+                "VALUES ($1, $2, $3, $4)",
+                [
+                    # Overload family: the "(N)" suffix collapses under the
+                    # identity-match form, so both must land in ONE form's set.
+                    (1, 111, "Popsicle", 0),
+                    (2, 222, "Popsicle (2)", 0),
+                    # Leading-article collapse.
+                    (3, 333, "The Tubs", 0),
+                    (4, 4242, "Stereolab", 0),
+                    # ``extra = 1`` credit: invisible to the exact leg.
+                    (5, 9999, "Stereolab", 1),
+                ],
+            )
+            await conn.execute(
+                "INSERT INTO artist_member (artist_id, member_id, member_name) "
+                "VALUES (4242, 200, 'Laetitia Sadier')"
+            )
+            await conn.execute(
+                "INSERT INTO artist_alias (artist_id, alias_name) "
+                "VALUES (555, 'Chuquimamani-Condori')"
+            )
+            # Diacritic-free cache form; queried below with the umlaut input.
+            await conn.execute(
+                "INSERT INTO artist_name_variation (artist_id, name) VALUES (666, 'Nilufer Yanya')"
+            )
+        try:
+            yield
+        finally:
+            async with pg_pool.acquire() as conn:
+                for table_name in self._TABLES:
+                    await conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+
+    @pytest.mark.asyncio
+    async def test_overload_family_returns_full_candidate_set(self, pg_pool):
+        """ "Popsicle" and "Popsicle (2)" share a form — the exact leg must
+        return BOTH ids. This is the anti-collapse property the resolver's
+        "ambiguous names must not mint" rule depends on."""
+        svc = DiscogsCacheService(pg_pool)
+        form = to_identity_match_form("Popsicle")
+        result = await svc.artist_equality_candidates([form])
+        assert result[form].exact == {111, 222}
+
+    @pytest.mark.asyncio
+    async def test_leading_article_collapse(self, pg_pool):
+        svc = DiscogsCacheService(pg_pool)
+        form = to_identity_match_form("The Tubs")
+        result = await svc.artist_equality_candidates([form])
+        assert result[form].exact == {333}
+
+    @pytest.mark.asyncio
+    async def test_extra_credit_excluded_from_exact_leg(self, pg_pool):
+        svc = DiscogsCacheService(pg_pool)
+        form = to_identity_match_form("Stereolab")
+        result = await svc.artist_equality_candidates([form])
+        assert result[form].exact == {4242}
+
+    @pytest.mark.asyncio
+    async def test_member_alias_and_variation_legs(self, pg_pool):
+        svc = DiscogsCacheService(pg_pool)
+        member_form = to_identity_match_form("Laetitia Sadier")
+        alias_form = to_identity_match_form("Chuquimamani-Condori")
+        # Umlaut input against the diacritic-free cache row: the Python and
+        # SQL normalizers must collapse the axis identically.
+        variation_form = to_identity_match_form("Nilüfer Yanya")
+        result = await svc.artist_equality_candidates([member_form, alias_form, variation_form])
+        assert result[member_form].member == {200}
+        assert result[member_form].exact == set()
+        assert result[alias_form].alias == {555}
+        assert result[variation_form].name_variation == {666}
+
+    @pytest.mark.asyncio
+    async def test_unmatched_form_is_measured_zero(self, pg_pool):
+        """A form with no candidates anywhere still gets a key with four
+        empty sets — "no candidates" must be distinguishable from "not
+        queried"."""
+        svc = DiscogsCacheService(pg_pool)
+        form = to_identity_match_form("Csillagrablók")
+        result = await svc.artist_equality_candidates([form])
+        assert form in result
+        assert result[form].exact == set()
+        assert result[form].member == set()
+        assert result[form].alias == set()
+        assert result[form].name_variation == set()
+
+    @pytest.mark.asyncio
+    async def test_whole_batch_in_one_call(self, pg_pool):
+        svc = DiscogsCacheService(pg_pool)
+        forms = [
+            to_identity_match_form("Popsicle"),
+            to_identity_match_form("Stereolab"),
+            to_identity_match_form("Wishy"),
+        ]
+        result = await svc.artist_equality_candidates(forms)
+        assert set(result.keys()) == set(forms)
+        assert result[to_identity_match_form("Popsicle")].exact == {111, 222}
+        assert result[to_identity_match_form("Stereolab")].exact == {4242}
+        assert result[to_identity_match_form("Wishy")].exact == set()
+
+
+@pytest.mark.pg
+class TestArtistTrigramCandidatesPG:
+    """Trigram evidence leg against real pg_trgm + ``f_unaccent``."""
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def seed_trigram_fixture(self, pg_pool):
+        async with pg_pool.acquire() as conn:
+            try:
+                await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+                await conn.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+            except Exception as e:  # locked-down Postgres without contrib
+                pytest.skip(f"pg_trgm/unaccent extensions unavailable: {e}")
+
+            release_artist_exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema = current_schema() AND table_name = 'release_artist')"
+            )
+            if release_artist_exists:
+                pytest.skip(
+                    "release_artist already present -- refusing to seed into a real "
+                    "discogs-cache (data-safety posture)"
+                )
+
+            # IMMUTABLE f_unaccent wrapper mirroring discogs-cache. Idempotent.
+            await conn.execute(
+                "CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text "
+                "AS $$ SELECT unaccent('unaccent', $1) $$ "
+                "LANGUAGE sql IMMUTABLE PARALLEL SAFE"
+            )
+            await conn.execute(
+                "CREATE TABLE release_artist ("
+                "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0)"
+            )
+            await conn.executemany(
+                "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "
+                "VALUES ($1, $2, $3, $4)",
+                [
+                    (1, 4242, "Stereolab", 0),
+                    # Two distinct artists with the identical name: the
+                    # candidate set must carry both (the reconciler's top-1
+                    # would pick one arbitrarily).
+                    (2, 5001, "Popsicle", 0),
+                    (3, 5002, "Popsicle", 0),
+                    (4, 5499521, "Nilufer Yanya", 0),  # diacritic-free cache form
+                    (5, 7777, "Hot 8 Brass Band", 0),
+                    (6, 9999, "Stereolab", 1),  # extra credit: excluded
+                ],
+            )
+        try:
+            yield
+        finally:
+            async with pg_pool.acquire() as conn:
+                await conn.execute("DROP TABLE IF EXISTS release_artist")
+
+    @pytest.mark.asyncio
+    async def test_batched_call_covers_hit_near_miss_and_overload(self, pg_pool):
+        """One round-trip, three names, three distinct verdict shapes:
+        diacritic-collapsed hit, substring near-miss rejected at the 0.85
+        floor (the LML#215 motivating case), and an identical-name pair
+        returned as a full set."""
+        svc = DiscogsCacheService(pg_pool)
+        result = await svc.artist_trigram_candidates(["Nilüfer Yanya", "Hot 8", "Popsicle"])
+        assert result["Nilüfer Yanya"] == {5499521}
+        assert result["Hot 8"] == set()
+        assert result["Popsicle"] == {5001, 5002}
+
+    @pytest.mark.asyncio
+    async def test_threshold_applied_in_sql(self, pg_pool):
+        """The typo "Stereolabs" scores under the 0.85 default (empty set)
+        but clears a lowered floor — proving the gate is the bound
+        threshold, not an exact-string coincidence."""
+        svc = DiscogsCacheService(pg_pool)
+        at_default = await svc.artist_trigram_candidates(["Stereolabs"])
+        assert at_default["Stereolabs"] == set()
+        lowered = await svc.artist_trigram_candidates(["Stereolabs"], threshold=0.4)
+        assert lowered["Stereolabs"] == {4242}  # extra=1 row 9999 stays excluded

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -2234,3 +2234,131 @@ class TestRecordLookupNegative:
         mock_asyncpg_pool.execute = AsyncMock(side_effect=RuntimeError("conn lost"))
         # Should not raise.
         await cache_service.record_lookup_negative("anything", "anywhere", False)
+
+
+# ---------------------------------------------------------------------------
+# artist_equality_candidates (LML#759)
+# ---------------------------------------------------------------------------
+
+
+class TestArtistEqualityCandidates:
+    """LML#759 tier-2 evidence legs, rewritten as candidate SETS.
+
+    The reconciler's ``SELECT DISTINCT`` + dict-comprehension collapse
+    silently picks one arbitrary candidate when a form is overloaded — it
+    cannot honor "ambiguous names must not mint." These queries must return
+    the full per-form id set for each equality leg instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_input_short_circuits_without_query(self, cache_service, mock_asyncpg_pool):
+        assert await cache_service.artist_equality_candidates([]) == {}
+        mock_asyncpg_pool.fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_single_round_trip_with_forms_array(self, cache_service, mock_asyncpg_pool):
+        """All four legs for the whole batch ride one query — the batched
+        PG pre-pass budget in #759 is 1-3 round-trips for the request."""
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.artist_equality_candidates(["popsicle", "wishy"])
+        mock_asyncpg_pool.fetch.assert_awaited_once()
+        args = mock_asyncpg_pool.fetch.await_args.args
+        assert args[1] == ["popsicle", "wishy"]
+
+    @pytest.mark.asyncio
+    async def test_overloaded_form_keeps_full_candidate_set(self, cache_service, mock_asyncpg_pool):
+        """Two exact-leg ids for one form must BOTH come back — the
+        anti-collapse property this method exists for."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[{"leg": "exact", "form": "popsicle", "artist_ids": [111, 222]}]
+        )
+        result = await cache_service.artist_equality_candidates(["popsicle"])
+        assert result["popsicle"].exact == {111, 222}
+
+    @pytest.mark.asyncio
+    async def test_legs_route_to_their_own_sets(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[
+                {"leg": "exact", "form": "stereolab", "artist_ids": [4242]},
+                {"leg": "member", "form": "laetitia sadier", "artist_ids": [200]},
+                {"leg": "alias", "form": "stereolab", "artist_ids": [300]},
+                {"leg": "name_variation", "form": "stereolab", "artist_ids": [400]},
+            ]
+        )
+        result = await cache_service.artist_equality_candidates(["stereolab", "laetitia sadier"])
+        assert result["stereolab"].exact == {4242}
+        assert result["stereolab"].alias == {300}
+        assert result["stereolab"].name_variation == {400}
+        assert result["stereolab"].member == set()
+        assert result["laetitia sadier"].member == {200}
+        assert result["laetitia sadier"].exact == set()
+
+    @pytest.mark.asyncio
+    async def test_forms_without_rows_get_empty_sets(self, cache_service, mock_asyncpg_pool):
+        """A miss is a measured zero on every leg — the key must exist so
+        the resolver never confuses "no candidates" with "not queried"."""
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[{"leg": "exact", "form": "sessa", "artist_ids": [7]}]
+        )
+        result = await cache_service.artist_equality_candidates(["sessa", "wishy"])
+        assert set(result.keys()) == {"sessa", "wishy"}
+        assert result["wishy"].exact == set()
+        assert result["wishy"].member == set()
+        assert result["wishy"].alias == set()
+        assert result["wishy"].name_variation == set()
+
+    @pytest.mark.asyncio
+    async def test_db_error_wrapped_as_cache_unavailable(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=RuntimeError("conn refused"))
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.artist_equality_candidates(["stereolab"])
+
+
+# ---------------------------------------------------------------------------
+# artist_trigram_candidates (LML#759)
+# ---------------------------------------------------------------------------
+
+
+class TestArtistTrigramCandidates:
+    @pytest.mark.asyncio
+    async def test_empty_input_short_circuits_without_query(self, cache_service, mock_asyncpg_pool):
+        assert await cache_service.artist_trigram_candidates([]) == {}
+        mock_asyncpg_pool.fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_batched_single_round_trip_keyed_by_input(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[{"input": "Nilüfer Yanya", "artist_ids": [5499521]}]
+        )
+        result = await cache_service.artist_trigram_candidates(["Nilüfer Yanya", "Hot 8"])
+        mock_asyncpg_pool.fetch.assert_awaited_once()
+        assert result == {"Nilüfer Yanya": {5499521}, "Hot 8": set()}
+
+    @pytest.mark.asyncio
+    async def test_default_threshold_bound_in_query(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.artist_trigram_candidates(["Stereolab"])
+        args = mock_asyncpg_pool.fetch.await_args.args
+        assert args[1] == ["Stereolab"]
+        assert args[2] == pytest.approx(0.85)
+
+    @pytest.mark.asyncio
+    async def test_threshold_override_passed_through(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        await cache_service.artist_trigram_candidates(["Stereolab"], threshold=0.4)
+        args = mock_asyncpg_pool.fetch.await_args.args
+        assert args[2] == pytest.approx(0.4)
+
+    @pytest.mark.asyncio
+    async def test_multi_id_candidate_set_not_collapsed(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(
+            return_value=[{"input": "Popsicle", "artist_ids": [5001, 5002]}]
+        )
+        result = await cache_service.artist_trigram_candidates(["Popsicle"])
+        assert result["Popsicle"] == {5001, 5002}
+
+    @pytest.mark.asyncio
+    async def test_db_error_wrapped_as_cache_unavailable(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=RuntimeError("conn refused"))
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.artist_trigram_candidates(["Stereolab"])

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -8,7 +8,9 @@ import httpx
 import pytest
 
 import discogs.service as discogs_service_module
+from discogs.breaker import DiscogsBreakerOpenError
 from discogs.models import (
+    DiscogsArtistSearchResult,
     DiscogsSearchRequest,
     DiscogsSearchResponse,
     ReleaseMetadataResponse,
@@ -3053,3 +3055,168 @@ class TestGetMaster:
         ):
             result = await service.get_master(456)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# search_artists (LML#759)
+# ---------------------------------------------------------------------------
+
+
+def make_artist_search_response(results: list[dict]) -> MagicMock:
+    """Build a mock 200 response for ``/database/search?type=artist``."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "pagination": {"page": 1, "pages": 3, "per_page": 100},
+        "results": results,
+    }
+    return mock_resp
+
+
+class TestSearchArtists:
+    """LML#759 tier-3 primitive: single-page ``type=artist`` search.
+
+    The ``[]``-vs-``None`` return distinction is load-bearing: ``[]`` means
+    "asked Discogs, zero candidates" (→ ``not_found``, ``candidate_count=0``)
+    while ``None`` means "couldn't ask" (→ ``escalation_unavailable``,
+    ``candidate_count=null``). Null never means zero.
+    """
+
+    @pytest.mark.asyncio
+    async def test_builds_single_page_artist_search(self, service):
+        """One GET /database/search with type=artist, q, per_page=100 — and
+        never a second page, even when pagination advertises more."""
+        mock_resp = make_artist_search_response([{"id": 123, "title": "Wishy", "type": "artist"}])
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ) as mock_req:
+            results = await service.search_artists("Wishy")
+
+        mock_req.assert_awaited_once_with(
+            "GET",
+            "/database/search",
+            params={"type": "artist", "q": "Wishy", "per_page": 100},
+        )
+        assert results == [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+
+    @pytest.mark.asyncio
+    async def test_preserves_raw_discogs_title(self, service):
+        """The "(N)" disambiguator must survive — stripping it here would blind
+        the resolver's exact-form overload detection (LML#759)."""
+        mock_resp = make_artist_search_response(
+            [
+                {"id": 111, "title": "Popsicle", "type": "artist"},
+                {"id": 222, "title": "Popsicle (2)", "type": "artist"},
+            ]
+        )
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            results = await service.search_artists("Popsicle")
+
+        assert [r.title for r in results] == ["Popsicle", "Popsicle (2)"]
+        assert [r.artist_id for r in results] == [111, 222]
+
+    @pytest.mark.asyncio
+    async def test_zero_results_returns_empty_list_not_none(self, service):
+        mock_resp = make_artist_search_response([])
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            results = await service.search_artists("Csillagrablók")
+        assert results == []
+        assert results is not None
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_returns_none(self, service):
+        """``_request_with_retry`` → ``None`` (429-exhausted / network error)
+        maps to ``None``: couldn't ask, not measured."""
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=None
+        ):
+            results = await service.search_artists("REZN")
+        assert results is None
+
+    @pytest.mark.asyncio
+    async def test_server_error_returns_none(self, service):
+        """A 5xx terminal response is "couldn't ask" — never an empty
+        measurement."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 502
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "502", request=MagicMock(), response=MagicMock(status_code=502)
+            )
+        )
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            results = await service.search_artists("SiM")
+        assert results is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_none(self, service):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.side_effect = ValueError("bad json")
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            results = await service.search_artists("glaive")
+        assert results is None
+
+    @pytest.mark.asyncio
+    async def test_breaker_open_propagates(self, service):
+        """A breaker shed must propagate as ``DiscogsBreakerOpenError`` so the
+        resolver can short-circuit the rest of the batch to
+        ``escalation_unavailable`` — swallowing it into ``None`` would cost
+        one shed round-trip per remaining name."""
+        with (
+            patch.object(
+                service,
+                "_request_with_retry",
+                new_callable=AsyncMock,
+                side_effect=DiscogsBreakerOpenError("open"),
+            ),
+            pytest.raises(DiscogsBreakerOpenError),
+        ):
+            await service.search_artists("The Tubs")
+
+    @pytest.mark.asyncio
+    async def test_skips_malformed_result_items(self, service):
+        mock_resp = make_artist_search_response(
+            [
+                {"title": "No Id", "type": "artist"},
+                {"id": None, "title": "Null Id", "type": "artist"},
+                {"id": 5, "type": "artist"},  # no title
+                {"id": 7, "title": "", "type": "artist"},  # empty title
+                {"id": 9, "title": "L'Rain", "type": "artist"},
+            ]
+        )
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            results = await service.search_artists("L'Rain")
+        assert results == [DiscogsArtistSearchResult(artist_id=9, title="L'Rain")]
+
+    @pytest.mark.asyncio
+    async def test_blank_name_short_circuits_without_api_call(self, service):
+        with patch.object(service, "_request_with_retry", new_callable=AsyncMock) as mock_req:
+            assert await service.search_artists("") == []
+            assert await service.search_artists("   ") == []
+        mock_req.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_records_api_call_stat(self, service):
+        mock_resp = make_artist_search_response([{"id": 1, "title": "Sessa", "type": "artist"}])
+        recorder = MagicMock()
+        with (
+            patch.object(
+                service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+            ),
+            patch.object(discogs_service_module, "get_cache_stats_recorder", return_value=recorder),
+        ):
+            await service.search_artists("Sessa")
+        recorder.record_api_call.assert_called_once()


### PR DESCRIPTION
Part of #759 (PR B of the 4-PR delivery plan; contract PR A is WXYC/wxyc-shared#218, merged as wxyc-shared 1.18.0). Adds the two primitives the bare-name resolver endpoint (PR C) composes — no endpoint, no write-back, no behavior change for existing callers.

## `DiscogsService.search_artists` (`discogs/service.py`)

The tier-3 exact-form uniqueness probe: one `GET /database/search?type=artist&per_page=100` page, single page by design (a name whose exact-form family doesn't fit on page 1 is ambiguous long before page 2). Routed through `_request_with_retry` so it rides the shared 50/min limiter, the 5-permit semaphore, and the #755 saturation breaker — anything else silently opts out of all three.

Return semantics are load-bearing for the contract's `candidate_count` (null never means zero):

- `list` (possibly empty) — Discogs answered; titles are raw Discogs strings with the "(N)" disambiguator intact (the resolver's overload detection normalizes both sides via `to_identity_match_form`, so stripping here would blind it).
- `None` — couldn't ask (429-exhausted, network error, non-2xx, unparseable body) → `escalation_unavailable`, not `not_found`.
- `DiscogsBreakerOpenError` propagates so a mid-batch breaker trip short-circuits the rest of the resolver's batch instead of paying one shed per remaining name.

## `DiscogsCacheService` candidate-set queries (`discogs/cache_service.py`)

The reconciler's cascade legs rewritten to return candidate **sets**:

- `artist_equality_candidates(forms)` — exact / member / alias / name_variation for the whole batch in **one** round-trip (UNION ALL + leg label + `array_agg(DISTINCT id)`), keyed by identity-match form, every input key present with measured-zero empty sets.
- `artist_trigram_candidates(names)` — batched `unnest` analog of the reconciler's Stage 6 pg_trgm fallback, full above-threshold set per raw name (threshold 0.85, bound in SQL; same `lower(f_unaccent(...))` expression so it rides the existing GIN index).

Why sets: the reconciler's `SELECT DISTINCT` + dict-comprehension collapse silently picks an arbitrary candidate on ambiguity — correct for its library-filtered inputs, but the resolver's bare touring names void that warranty, and "ambiguous names must not mint" is unenforceable on a collapsed result. `scripts/entity_resolution/discogs.py` is behavior-untouched; cross-reference comments in both files pin the divergence as intentional, and the per-leg predicates (`extra = 0`, NOT NULL, `wxyc_identity_match_artist` column-side) stay byte-compatible with the reconciler.

## Tests

- 22 unit tests: params/single-page pinning, raw-title preservation, `[]`-vs-`None`, breaker propagation, malformed-item skip, api-call stat; per-leg routing, anti-collapse, measured-zero keys, threshold binding, `CacheUnavailableError` wrapping.
- 8 `pg` integration tests (`tests/integration/test_artist_candidate_sets.py`): overload family ("Popsicle" / "Popsicle (2)") returns both ids from one form; leading-article + diacritic collapse through the symmetric Python/SQL normalizer pair (doubling as a normalization-parity canary); `extra = 1` exclusion; trigram near-miss rejection at the 0.85 floor and identical-name pair returned as a full set. Fixtures follow the established postures: equality class self-skips without `wxyc_identity_match_artist` (alembic 0004), both classes refuse to seed over pre-existing tables (data safety). Verified locally against postgresql@16 with the vendored wxyc-etl function family deployed — 8/8 executed, no skips.

Local CI replication: `ruff check` + `ruff format --check` clean, `mypy . --ignore-missing-imports` clean, full default suite and `pg` suite green apart from pre-existing environment-dependent failures reproduced identically on the untouched base commit.

## Related

- #759 (parent), WXYC/wxyc-shared#218 (PR A, merged), WXYC/Backend-Service#1614 (consumer)
