### PR TITLE
fix(#759): PR-B review fixes — parse containment, fixture leak-proofing, honest comments

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -100,18 +100,31 @@ _ARTIST_SEARCH_CACHE = create_ttl_cache(maxsize=2000, ttl=3600)
 # dict collapse is correct for its library-name inputs (the corpus was
 # filtered around exactly those artists), but the bare-name resolver must
 # see every id an overloaded form points at — "ambiguous names must not
-# mint" is unenforceable on a collapsed result. Keep the per-leg predicates
-# (``extra = 0``, NOT NULL filters, ``wxyc_identity_match_artist`` on the
-# column side) byte-compatible with the reconciler so both consumers see the
-# same candidate universe.
+# mint" is unenforceable on a collapsed result.
+#
+# Candidate-universe parity with the reconciler: the *matching* predicates
+# (``extra = 0``, ``wxyc_identity_match_artist(col) = ANY($1)``) match its
+# SQL byte-for-byte and must stay that way. The ``IS NOT NULL`` id filters
+# here have no counterpart in the reconciler's SQL because it drops NULL
+# ids Python-side (the ``if row[...] is not None`` comprehensions in its
+# ``_member_match`` / ``_alias_match`` / ``_name_variation_match``) — same
+# universe, filtered on a different side of the wire. Don't "fix" either
+# side to match the other.
 #
 # All four legs for the whole batch ride one round-trip (UNION ALL + a
 # ``leg`` label column); the batched PG pre-pass budget for a resolve
-# request is 1-3 round-trips total. Inputs are pre-normalized
-# identity-match forms — ``wxyc_etl.text.to_identity_match_form`` on the
-# Python side, ``wxyc_identity_match_artist(col)`` on the column side, the
-# symmetric pair from wiki ``plans/library-hook-canonicalization.md``
-# §3.3.5 (same as the reconciler; rides the same functional indexes).
+# request is 1-3 round-trips total. That's the *wire* cost only: no
+# expression index over ``wxyc_identity_match_artist(...)`` exists yet
+# (the discogs-etl index build is tracked separately — see the reconciler
+# module docstring), so ``= ANY(...)`` evaluates the function per row and
+# each call is four sequential scans of large tables on the shared
+# discogs-cache PG. Acceptable for the offline resolver/drain tier this
+# serves; do NOT wire these queries into the /lookup hot path until the
+# expression indexes land. Inputs are pre-normalized identity-match forms
+# — ``wxyc_etl.text.to_identity_match_form`` on the Python side,
+# ``wxyc_identity_match_artist(col)`` on the column side, the symmetric
+# pair from wiki ``plans/library-hook-canonicalization.md`` §3.3.5 (same
+# as the reconciler).
 _ARTIST_EQUALITY_CANDIDATES_SQL = """\
 SELECT 'exact' AS leg,
        wxyc_identity_match_artist(ra.artist_name) AS form,
@@ -459,6 +472,12 @@ class DiscogsCacheService:
         candidate sets and how they deliberately diverge from the
         reconciler's first-match-wins cascade.
 
+        One round-trip is the wire cost, not the execution cost: with no
+        ``wxyc_identity_match_artist`` expression index deployed yet, each
+        call sequential-scans four large tables on the shared discogs-cache
+        PG. Offline resolver/drain tier only — do not call from the
+        /lookup hot path (see the SQL comment).
+
         Args:
             forms: Identity-match forms, pre-normalized on the Python side
                 via ``wxyc_etl.text.to_identity_match_form`` (the symmetric
@@ -477,17 +496,14 @@ class DiscogsCacheService:
         try:
             rows = await self.pool.fetch(_ARTIST_EQUALITY_CANDIDATES_SQL, forms)
             results = {form: ArtistEqualityCandidates() for form in forms}
-            leg_sets = {
-                "exact": lambda c: c.exact,
-                "member": lambda c: c.member,
-                "alias": lambda c: c.alias,
-                "name_variation": lambda c: c.name_variation,
-            }
             for row in rows:
-                candidates = results.get(row["form"])
-                if candidates is None:
-                    continue
-                leg_sets[row["leg"]](candidates).update(row["artist_ids"])
+                # The SQL's leg labels are the dataclass field names, and
+                # ``= ANY($1)`` guarantees every returned form is an input
+                # form — direct access, so any future violation of either
+                # invariant fails LOUDLY (KeyError/AttributeError → wrapped
+                # below) instead of silently dropping candidate ids, which
+                # would let an ambiguous name read as unique and mint.
+                getattr(results[row["form"]], row["leg"]).update(row["artist_ids"])
             return results
         except Exception as e:
             logger.error(f"Cache artist_equality_candidates failed: {e}")
@@ -524,14 +540,23 @@ class DiscogsCacheService:
         """
         if not names:
             return {}
+        if threshold < 0.3:
+            # pg_trgm's session ``similarity_threshold`` floor (default 0.3)
+            # pre-filters the ``%`` operator before ``similarity() >= $2``
+            # runs, so a lower threshold would silently drop candidates in
+            # the [threshold, floor) gap. Reject loudly.
+            raise ValueError(
+                f"threshold {threshold} is below pg_trgm's similarity_threshold floor (0.3); "
+                "candidates in the gap would be silently dropped by the % pre-filter"
+            )
         try:
             rows = await self.pool.fetch(_ARTIST_TRIGRAM_CANDIDATES_SQL, names, threshold)
             results: dict[str, set[int]] = {name: set() for name in names}
             for row in rows:
-                candidates = results.get(row["input"])
-                if candidates is None:
-                    continue
-                candidates.update(row["artist_ids"])
+                # ``unnest($1)`` guarantees every returned input is an input
+                # key — direct access so a violation fails loudly (wrapped
+                # below) rather than silently dropping a candidate set.
+                results[row["input"]].update(row["artist_ids"])
             return results
         except Exception as e:
             logger.error(f"Cache artist_trigram_candidates failed: {e}")

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -192,6 +192,14 @@ GROUP BY q.input\
 # the resolver should count either.
 _ARTIST_TRIGRAM_CANDIDATE_THRESHOLD = 0.85
 
+# The ``%`` pre-filter floor: ``artist_trigram_candidates`` pins the
+# ``pg_trgm.similarity_threshold`` GUC to this value with ``SET LOCAL`` and
+# rejects caller thresholds below it. Guard and pin MUST move together —
+# single-sourced here so they can't drift (a guard lowered without the pin
+# reintroduces the silent [threshold, floor) candidate drop).
+_PG_TRGM_FLOOR = 0.3
+_SET_PG_TRGM_FLOOR_SQL = f"SET LOCAL pg_trgm.similarity_threshold = {_PG_TRGM_FLOOR}"
+
 
 def _negative_cache_key_hash(artist: str | None, track: str, artist_as_keyword: bool) -> bytes:
     """Hash the (artist, track, artist_as_keyword) tuple into a stable 32-byte key.
@@ -553,17 +561,18 @@ class DiscogsCacheService:
                 constant fails a dry run, not the first real batch.
             CacheUnavailableError: If the database is unreachable.
         """
-        if threshold < 0.3:
+        if threshold < _PG_TRGM_FLOOR:
             raise ValueError(
-                f"threshold {threshold} is below pg_trgm's similarity_threshold floor (0.3); "
-                "candidates in the gap would be silently dropped by the % pre-filter"
+                f"threshold {threshold} is below pg_trgm's similarity_threshold floor "
+                f"({_PG_TRGM_FLOOR}); candidates in the gap would be silently dropped "
+                "by the % pre-filter"
             )
         if not names:
             return {}
         try:
             async with self.pool.acquire() as conn:
                 async with conn.transaction():
-                    await conn.execute("SET LOCAL pg_trgm.similarity_threshold = 0.3")
+                    await conn.execute(_SET_PG_TRGM_FLOOR_SQL)
                     rows = await conn.fetch(_ARTIST_TRIGRAM_CANDIDATES_SQL, names, threshold)
             results: dict[str, set[int]] = {name: set() for name in names}
             for row in rows:

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -104,12 +104,14 @@ _ARTIST_SEARCH_CACHE = create_ttl_cache(maxsize=2000, ttl=3600)
 #
 # Candidate-universe parity with the reconciler: the *matching* predicates
 # (``extra = 0``, ``wxyc_identity_match_artist(col) = ANY($1)``) match its
-# SQL byte-for-byte and must stay that way. The ``IS NOT NULL`` id filters
-# here have no counterpart in the reconciler's SQL because it drops NULL
-# ids Python-side (the ``if row[...] is not None`` comprehensions in its
-# ``_member_match`` / ``_alias_match`` / ``_name_variation_match``) — same
-# universe, filtered on a different side of the wire. Don't "fix" either
-# side to match the other.
+# SQL byte-for-byte and must stay that way. NULL-id filtering differs by
+# leg: the exact leg's ``artist_id IS NOT NULL`` matches the reconciler's
+# ``_EXACT_MATCH_SQL`` byte-for-byte too, but the member/alias/
+# name_variation ``IS NOT NULL`` filters here have no SQL counterpart —
+# the reconciler drops those NULL ids Python-side (the ``if row[...] is
+# not None`` comprehensions in its ``_member_match`` / ``_alias_match`` /
+# ``_name_variation_match``; ``_exact_match`` carries a redundant one).
+# Same universe either way. Don't "fix" either side to match the other.
 #
 # All four legs for the whole batch ride one round-trip (UNION ALL + a
 # ``leg`` label column); the batched PG pre-pass budget for a resolve
@@ -168,10 +170,10 @@ GROUP BY wxyc_identity_match_artist(nv.name)\
 # the reconciler this returns the full above-threshold candidate set per
 # input, not the top-1 — trigram evidence feeds corroboration/telemetry
 # only and must expose every neighbor. The threshold is applied in SQL
-# because no caller needs the scores; note pg_trgm's session
-# ``similarity_threshold`` (``show_limit()``, default 0.3) pre-filters the
-# ``%`` operator, so a threshold below that floor would silently drop
-# candidates in the gap (same caveat as the reconciler's Stage 6).
+# because no caller needs the scores. The ``%`` operator's pre-filter
+# floor (the ``pg_trgm.similarity_threshold`` GUC) is pinned to 0.3 with
+# ``SET LOCAL`` in the executing transaction, and thresholds below it are
+# rejected up front — see ``artist_trigram_candidates``.
 _ARTIST_TRIGRAM_CANDIDATES_SQL = """\
 SELECT q.input,
        array_agg(DISTINCT ra.artist_id) AS artist_ids
@@ -524,33 +526,45 @@ class DiscogsCacheService:
         to both sides so the ``%`` operator rides the existing GIN trigram
         index, mirroring the reconciler's Stage 6 asymmetry note.
 
+        The query runs in its own transaction with ``SET LOCAL
+        pg_trgm.similarity_threshold = 0.3``: the GUC is settable at
+        server/database/role scope, so without the pin a DBA tuning the
+        shared discogs-cache could raise the ``%`` pre-filter floor above
+        a caller's ``threshold`` and silently drop candidates in the gap.
+        ``SET LOCAL`` reverts at transaction end — no session pollution on
+        the pooled connection. (Same posture as the canonicalization
+        scripts' explicit ``SET``.)
+
         Args:
             names: Raw artist names as received (first-occurrence verbatim
                 per deduped form, by the resolver's convention).
             threshold: Minimum pg_trgm similarity [0, 1] for a candidate to
-                count. Values below pg_trgm's session floor (default 0.3)
-                silently drop candidates in the gap — see the SQL comment.
+                count. Must be >= 0.3 (the pinned ``%`` pre-filter floor);
+                lower values raise ``ValueError`` because candidates in the
+                [threshold, 0.3) gap would be silently dropped.
 
         Returns:
             Candidate ``artist_id`` sets keyed by input name — every key
             present, empty set when nothing cleared the threshold.
 
         Raises:
+            ValueError: If ``threshold`` is below the 0.3 pre-filter floor.
+                Raised even for an empty ``names`` batch so a misconfigured
+                constant fails a dry run, not the first real batch.
             CacheUnavailableError: If the database is unreachable.
         """
-        if not names:
-            return {}
         if threshold < 0.3:
-            # pg_trgm's session ``similarity_threshold`` floor (default 0.3)
-            # pre-filters the ``%`` operator before ``similarity() >= $2``
-            # runs, so a lower threshold would silently drop candidates in
-            # the [threshold, floor) gap. Reject loudly.
             raise ValueError(
                 f"threshold {threshold} is below pg_trgm's similarity_threshold floor (0.3); "
                 "candidates in the gap would be silently dropped by the % pre-filter"
             )
+        if not names:
+            return {}
         try:
-            rows = await self.pool.fetch(_ARTIST_TRIGRAM_CANDIDATES_SQL, names, threshold)
+            async with self.pool.acquire() as conn:
+                async with conn.transaction():
+                    await conn.execute("SET LOCAL pg_trgm.similarity_threshold = 0.3")
+                    rows = await conn.fetch(_ARTIST_TRIGRAM_CANDIDATES_SQL, names, threshold)
             results: dict[str, set[int]] = {name: set() for name in names}
             for row in rows:
                 # ``unnest($1)`` guarantees every returned input is an input

--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -118,9 +118,10 @@ _request_context_var: ContextVar[dict[str, str] | None] = ContextVar(
 def request_context(method: str, cache_state: str = "no_pg") -> Iterator[None]:
     """Tag downstream ``_request_with_retry`` spans for the duration of the block.
 
-    Used by ``fallthrough`` itself and by the three production methods that
+    Used by ``fallthrough`` itself and by the four production methods that
     bypass the seam (``search_releases_by_album_title``, ``get_label_image``,
-    ``get_master`` — all API-only with no L2 cache leg) plus the four
+    ``get_master``, ``search_artists`` — all API-only with no L2 cache
+    leg) plus the four
     seam methods that have a ``cache is None`` fallback branch
     (``search_releases_by_track``, ``get_release``, ``get_artist_details``,
     ``search``). ``validate_track_on_release`` also has a ``cache is None``

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -857,13 +857,13 @@ class DiscogsService:
           measured single-page observation. Titles are raw Discogs strings,
           "(N)" disambiguator intact (see ``DiscogsArtistSearchResult``).
         - ``None``: couldn't ask — 429-exhausted, network error, non-2xx,
-          or a body whose shape defeats parsing (a partially-understood
-          page could yield a false-unique ``candidate_count``, so the
-          whole observation is untrusted). Callers must treat ``None`` as
-          *unknown*, never as a confirmed-empty verdict — in particular,
-          never coalesce it away with ``results or []`` / ``if not
-          results``, which silently turns "couldn't ask" into "measured
-          zero".
+          or a body containing anything unparseable, including a single
+          malformed result item (a partially-understood page could yield
+          a false-unique ``candidate_count``, so the whole observation is
+          untrusted). Callers must treat ``None`` as *unknown*, never as
+          a confirmed-empty verdict — in particular, never coalesce it
+          away with ``results or []`` / ``if not results``, which
+          silently turns "couldn't ask" into "measured zero".
 
         Raises:
             ValueError: on blank/whitespace-only ``name`` — a caller error,
@@ -899,7 +899,14 @@ class DiscogsService:
                 artist_id = item.get("id")
                 title = item.get("title")
                 if artist_id is None or not title:
-                    continue
+                    # Any malformed item distrusts the WHOLE page: silently
+                    # skipping it would return a truncated page as a trusted
+                    # measurement — dropping a null-id "Popsicle (2)" leaves
+                    # candidate_count=1, a false-unique that mints wrong.
+                    logger.warning(
+                        f"search_artists distrusting page for '{name}': malformed item {item!r}"
+                    )
+                    return None
                 results.append(DiscogsArtistSearchResult(artist_id=artist_id, title=title))
         except Exception as e:
             logger.warning(f"search_artists failed for '{name}': {e}")

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -441,7 +441,7 @@ class DiscogsService:
         # via ``apply_request_ctx_tags`` (a no-op when no context is active —
         # the case for the small handful of legacy direct-call tests).
         # Production callers enter via ``fallthrough()`` (dominant) or via
-        # the ``request_context()`` helper (the three API-only methods that
+        # the ``request_context()`` helper (the four API-only methods that
         # bypass the seam and the four ``cache is None`` fallback branches).
 
         # The semaphore wraps a single attempt, not the whole retry loop
@@ -857,10 +857,20 @@ class DiscogsService:
           measured single-page observation. Titles are raw Discogs strings,
           "(N)" disambiguator intact (see ``DiscogsArtistSearchResult``).
         - ``None``: couldn't ask — 429-exhausted, network error, non-2xx,
-          or unparseable body. Callers must treat it as *unknown*, never
-          as a confirmed-empty verdict.
+          or a body whose shape defeats parsing (a partially-understood
+          page could yield a false-unique ``candidate_count``, so the
+          whole observation is untrusted). Callers must treat ``None`` as
+          *unknown*, never as a confirmed-empty verdict — in particular,
+          never coalesce it away with ``results or []`` / ``if not
+          results``, which silently turns "couldn't ask" into "measured
+          zero".
 
         Raises:
+            ValueError: on blank/whitespace-only ``name`` — a caller error,
+                not a measurement. Returning ``[]`` here would fabricate a
+                "Discogs answered, zero candidates" observation for a probe
+                that was never sent; the resolver short-circuits empty
+                identity-match forms before this tier.
             DiscogsBreakerOpenError: propagated from ``_request_with_retry``
                 when the LML#755 saturation breaker sheds the call, so the
                 resolver can short-circuit the rest of its batch to
@@ -868,10 +878,11 @@ class DiscogsService:
                 remaining name.
         """
         if not name or not name.strip():
-            return []
+            raise ValueError("search_artists requires a non-blank name")
 
         params: dict[str, Any] = {"type": "artist", "q": name, "per_page": 100}
 
+        add_discogs_breadcrumb("search_artists", {"name": name})
         with request_context("search_artists"):
             async with timed_api():
                 response = await self._request_with_retry("GET", "/database/search", params=params)
@@ -883,17 +894,17 @@ class DiscogsService:
         try:
             response.raise_for_status()
             data = response.json()
+            results: list[DiscogsArtistSearchResult] = []
+            for item in data.get("results", []):
+                artist_id = item.get("id")
+                title = item.get("title")
+                if artist_id is None or not title:
+                    continue
+                results.append(DiscogsArtistSearchResult(artist_id=artist_id, title=title))
         except Exception as e:
             logger.warning(f"search_artists failed for '{name}': {e}")
             return None
 
-        results: list[DiscogsArtistSearchResult] = []
-        for item in data.get("results", []):
-            artist_id = item.get("id")
-            title = item.get("title")
-            if artist_id is None or not title:
-                continue
-            results.append(DiscogsArtistSearchResult(artist_id=artist_id, title=title))
         return results
 
     def _process_search_result(self, result: dict, seen_albums: set) -> ReleaseInfo | None:

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -108,10 +108,16 @@ WHERE wxyc_identity_match_artist(nv.name) = ANY($1)\
 # trivially tunable (and so the score is available to record as confidence).
 # Note: the ``%`` operator pre-filters to rows above pg_trgm's session
 # ``similarity_threshold`` (``show_limit()``, default 0.3) before the Python
-# ``trigram_threshold`` is applied, so configuring a ``trigram_threshold`` below
-# that floor would silently drop candidates in the gap. The shipped default
-# (0.85) and the issue's tuning band sit well above 0.3, so this never bites in
-# practice.
+# ``trigram_threshold`` is applied. Two hazards: a ``trigram_threshold``
+# configured below the floor silently drops candidates in the gap (the shipped
+# 0.85 default and the issue's tuning band sit well above 0.3, so that
+# direction never bites in practice), and — unguarded here — a GUC raised
+# ABOVE ``trigram_threshold`` at server/database/role scope would silently
+# drop candidates in [``trigram_threshold``, GUC) with no error. The #759
+# sibling (``discogs/cache_service.py:artist_trigram_candidates``) pins the
+# floor with ``SET LOCAL`` in its own transaction; pinning this leg the same
+# way is deliberately deferred (this script is behavior-frozen under #759) —
+# tracked in WXYC/library-metadata-lookup#763.
 _TRIGRAM_FALLBACK_SQL = """\
 SELECT ra.artist_id, ra.artist_name,
        similarity(lower(f_unaccent(ra.artist_name)), lower(f_unaccent($1))) AS score

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -65,9 +65,12 @@ logger = logging.getLogger(__name__)
 # exactly those artists — but the resolver's inputs void that warranty, so it
 # must see every id an overloaded form points at. When editing either side,
 # keep the *matching* predicates (``extra = 0``, the
-# ``wxyc_identity_match_artist(col) = ANY($1)`` comparison) byte-compatible;
-# NULL-id filtering intentionally differs in mechanism (Python-side ``is not
-# None`` comprehensions here, SQL ``IS NOT NULL`` there) — same universe.
+# ``wxyc_identity_match_artist(col) = ANY($1)`` comparison) byte-compatible.
+# NULL-id filtering differs by leg: ``_EXACT_MATCH_SQL``'s ``artist_id IS
+# NOT NULL`` matches the resolver's exact leg byte-for-byte, while the
+# member/alias/name_variation legs filter NULL ids Python-side here (the
+# ``is not None`` comprehensions below) and in SQL there — same universe
+# either way; don't "fix" either side to match the other.
 _EXACT_MATCH_SQL = """\
 SELECT DISTINCT wxyc_identity_match_artist(ra.artist_name) AS artist_name, ra.artist_id
 FROM release_artist ra

--- a/scripts/entity_resolution/discogs.py
+++ b/scripts/entity_resolution/discogs.py
@@ -63,8 +63,11 @@ logger = logging.getLogger(__name__)
 # collapse (SELECT DISTINCT + dict comprehension) is correct for its
 # library-name inputs — the discogs-cache corpus was pair-filtered around
 # exactly those artists — but the resolver's inputs void that warranty, so it
-# must see every id an overloaded form points at. Keep the per-leg predicates
-# here and there byte-compatible when editing either side.
+# must see every id an overloaded form points at. When editing either side,
+# keep the *matching* predicates (``extra = 0``, the
+# ``wxyc_identity_match_artist(col) = ANY($1)`` comparison) byte-compatible;
+# NULL-id filtering intentionally differs in mechanism (Python-side ``is not
+# None`` comprehensions here, SQL ``IS NOT NULL`` there) — same universe.
 _EXACT_MATCH_SQL = """\
 SELECT DISTINCT wxyc_identity_match_artist(ra.artist_name) AS artist_name, ra.artist_id
 FROM release_artist ra
@@ -122,6 +125,9 @@ LIMIT 1\
 # "&"-vs-"and" / bracket-annotation rescues without admitting incidental
 # substring overlap (e.g. "Hot 8" vs "Hot 8 Brass Band" scores well under it).
 # Tunable per the issue's validation plan via the ``trigram_threshold`` ctor arg.
+# Mirrored by ``_ARTIST_TRIGRAM_CANDIDATE_THRESHOLD`` in
+# ``discogs/cache_service.py`` (the #759 resolver's evidence leg) — retune
+# both together, or corroboration telemetry and reconciler acceptance drift.
 _DEFAULT_TRIGRAM_THRESHOLD = 0.85
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -59,6 +59,57 @@ async def pg_pool():
         yield pool
 
 
+# ---------------------------------------------------------------------------
+# Shared discogs-cache stubbing helpers (reconciler / #759 candidate-set SQL)
+# ---------------------------------------------------------------------------
+
+# IMMUTABLE f_unaccent wrapper mirroring discogs-cache, so trigram operators
+# can ride a functional GIN index. Idempotent. Shared by every fixture that
+# stubs discogs-cache tables on a bare PG (``test_entity_resolution.py``,
+# ``test_artist_candidate_sets.py``) so the schema mirror can't drift
+# per-file — the suites it backs exist to prove SQL that must stay
+# predicate-compatible across two modules.
+F_UNACCENT_WRAPPER_SQL = (
+    "CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text "
+    "AS $$ SELECT unaccent('unaccent', $1) $$ "
+    "LANGUAGE sql IMMUTABLE PARALLEL SAFE"
+)
+
+# Stub DDL for the four discogs-cache tables read by the reconciler cascade
+# legs (``scripts/entity_resolution/discogs.py``) and the #759 candidate-set
+# queries (``discogs/cache_service.py``). One shared map so the stub shape
+# the two suites test against can't silently diverge.
+RECONCILER_TABLE_DDL: dict[str, str] = {
+    "release_artist": (
+        "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0"
+    ),
+    "artist_member": "artist_id INTEGER, member_id INTEGER, member_name TEXT",
+    "artist_alias": "artist_id INTEGER, alias_name TEXT",
+    "artist_name_variation": "artist_id INTEGER, name TEXT",
+}
+
+
+async def skip_unless_wxyc_identity_match_artist(conn) -> None:
+    """``pytest.skip`` unless ``wxyc_identity_match_artist`` is deployed.
+
+    The function family ships via alembic 0004 from WXYC/discogs-etl and
+    depends on the ``wxyc_unaccent`` text-search dictionary (a server-side
+    rules file), so CI's plain ``postgres:16-alpine`` service container
+    doesn't have it. See ``TestDiscogsReconciliationSQLSmoke`` for the
+    provisioning TODO.
+    """
+    exists = await conn.fetchval(
+        "SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = $1)",
+        "wxyc_identity_match_artist",
+    )
+    if not exists:
+        pytest.skip(
+            "wxyc_identity_match_artist not deployed -- needs alembic 0004 "
+            "from WXYC/discogs-etl. CI's plain postgres-16 service container "
+            "doesn't have it."
+        )
+
+
 @pytest_asyncio.fixture
 async def pg_pool_large():
     """Real asyncpg pool (``max_size=4``); skips on connect failure.

--- a/tests/integration/test_artist_candidate_sets.py
+++ b/tests/integration/test_artist_candidate_sets.py
@@ -21,13 +21,16 @@ Data safety: both fixtures **skip** when the tables they seed already exist
 posture as ``TestTrigramFallbackSQLIntegration``.
 """
 
-from typing import ClassVar
-
 import pytest
 import pytest_asyncio
 from wxyc_etl.text import to_identity_match_form
 
 from discogs.cache_service import DiscogsCacheService
+from tests.integration.conftest import (
+    F_UNACCENT_WRAPPER_SQL,
+    RECONCILER_TABLE_DDL,
+    skip_unless_wxyc_identity_match_artist,
+)
 
 
 @pytest.mark.pg
@@ -42,28 +45,11 @@ class TestArtistEqualityCandidatesPG:
     surface in LML's own suite.
     """
 
-    _TABLES: ClassVar[dict[str, str]] = {
-        "release_artist": (
-            "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0"
-        ),
-        "artist_member": "artist_id INTEGER, member_id INTEGER, member_name TEXT",
-        "artist_alias": "artist_id INTEGER, alias_name TEXT",
-        "artist_name_variation": "artist_id INTEGER, name TEXT",
-    }
-
     @pytest_asyncio.fixture(autouse=True)
     async def seed_equality_tables(self, pg_pool):
         async with pg_pool.acquire() as conn:
-            fn_exists = await conn.fetchval(
-                "SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = $1)",
-                "wxyc_identity_match_artist",
-            )
-            if not fn_exists:
-                pytest.skip(
-                    "wxyc_identity_match_artist not deployed -- needs alembic 0004 "
-                    "from WXYC/discogs-etl (see TestDiscogsReconciliationSQLSmoke)"
-                )
-            for table_name in self._TABLES:
+            await skip_unless_wxyc_identity_match_artist(conn)
+            for table_name in RECONCILER_TABLE_DDL:
                 pre_existing = await conn.fetchval(
                     "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
                     "WHERE table_schema = current_schema() AND table_name = $1)",
@@ -74,40 +60,48 @@ class TestArtistEqualityCandidatesPG:
                         f"{table_name} already present -- refusing to seed into a real "
                         "discogs-cache (data-safety posture)"
                     )
-            for table_name, columns in self._TABLES.items():
-                await conn.execute(f"CREATE TABLE {table_name} ({columns})")
-            await conn.executemany(
-                "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "
-                "VALUES ($1, $2, $3, $4)",
-                [
-                    # Overload family: the "(N)" suffix collapses under the
-                    # identity-match form, so both must land in ONE form's set.
-                    (1, 111, "Popsicle", 0),
-                    (2, 222, "Popsicle (2)", 0),
-                    # Leading-article collapse.
-                    (3, 333, "The Tubs", 0),
-                    (4, 4242, "Stereolab", 0),
-                    # ``extra = 1`` credit: invisible to the exact leg.
-                    (5, 9999, "Stereolab", 1),
-                ],
-            )
-            await conn.execute(
-                "INSERT INTO artist_member (artist_id, member_id, member_name) "
-                "VALUES (4242, 200, 'Laetitia Sadier')"
-            )
-            await conn.execute(
-                "INSERT INTO artist_alias (artist_id, alias_name) "
-                "VALUES (555, 'Chuquimamani-Condori')"
-            )
-            # Diacritic-free cache form; queried below with the umlaut input.
-            await conn.execute(
-                "INSERT INTO artist_name_variation (artist_id, name) VALUES (666, 'Nilufer Yanya')"
-            )
+        # Creation and seeding happen inside the try: a mid-seed failure must
+        # still drop whatever was created, or the leaked tables trip the
+        # data-safety skip above and silently disable this class on every
+        # subsequent run against a persistent test PG.
+        created: list[str] = []
         try:
+            async with pg_pool.acquire() as conn:
+                for table_name, columns in RECONCILER_TABLE_DDL.items():
+                    await conn.execute(f"CREATE TABLE {table_name} ({columns})")
+                    created.append(table_name)
+                await conn.executemany(
+                    "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "
+                    "VALUES ($1, $2, $3, $4)",
+                    [
+                        # Overload family: the "(N)" suffix collapses under the
+                        # identity-match form, so both must land in ONE form's set.
+                        (1, 111, "Popsicle", 0),
+                        (2, 222, "Popsicle (2)", 0),
+                        # Leading-article collapse.
+                        (3, 333, "The Tubs", 0),
+                        (4, 4242, "Stereolab", 0),
+                        # ``extra = 1`` credit: invisible to the exact leg.
+                        (5, 9999, "Stereolab", 1),
+                    ],
+                )
+                await conn.execute(
+                    "INSERT INTO artist_member (artist_id, member_id, member_name) "
+                    "VALUES (4242, 200, 'Laetitia Sadier')"
+                )
+                await conn.execute(
+                    "INSERT INTO artist_alias (artist_id, alias_name) "
+                    "VALUES (555, 'Chuquimamani-Condori')"
+                )
+                # Diacritic-free cache form; queried below with the umlaut input.
+                await conn.execute(
+                    "INSERT INTO artist_name_variation (artist_id, name) "
+                    "VALUES (666, 'Nilufer Yanya')"
+                )
             yield
         finally:
             async with pg_pool.acquire() as conn:
-                for table_name in self._TABLES:
+                for table_name in created:
                     await conn.execute(f"DROP TABLE IF EXISTS {table_name}")
 
     @pytest.mark.asyncio
@@ -200,32 +194,29 @@ class TestArtistTrigramCandidatesPG:
                     "discogs-cache (data-safety posture)"
                 )
 
-            # IMMUTABLE f_unaccent wrapper mirroring discogs-cache. Idempotent.
-            await conn.execute(
-                "CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text "
-                "AS $$ SELECT unaccent('unaccent', $1) $$ "
-                "LANGUAGE sql IMMUTABLE PARALLEL SAFE"
-            )
-            await conn.execute(
-                "CREATE TABLE release_artist ("
-                "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0)"
-            )
-            await conn.executemany(
-                "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "
-                "VALUES ($1, $2, $3, $4)",
-                [
-                    (1, 4242, "Stereolab", 0),
-                    # Two distinct artists with the identical name: the
-                    # candidate set must carry both (the reconciler's top-1
-                    # would pick one arbitrarily).
-                    (2, 5001, "Popsicle", 0),
-                    (3, 5002, "Popsicle", 0),
-                    (4, 5499521, "Nilufer Yanya", 0),  # diacritic-free cache form
-                    (5, 7777, "Hot 8 Brass Band", 0),
-                    (6, 9999, "Stereolab", 1),  # extra credit: excluded
-                ],
-            )
+        # Creation and seeding inside the try — see seed_equality_tables for
+        # why a mid-seed failure must still drop the table.
         try:
+            async with pg_pool.acquire() as conn:
+                await conn.execute(F_UNACCENT_WRAPPER_SQL)
+                await conn.execute(
+                    f"CREATE TABLE release_artist ({RECONCILER_TABLE_DDL['release_artist']})"
+                )
+                await conn.executemany(
+                    "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "
+                    "VALUES ($1, $2, $3, $4)",
+                    [
+                        (1, 4242, "Stereolab", 0),
+                        # Two distinct artists with the identical name: the
+                        # candidate set must carry both (the reconciler's top-1
+                        # would pick one arbitrarily).
+                        (2, 5001, "Popsicle", 0),
+                        (3, 5002, "Popsicle", 0),
+                        (4, 5499521, "Nilufer Yanya", 0),  # diacritic-free cache form
+                        (5, 7777, "Hot 8 Brass Band", 0),
+                        (6, 9999, "Stereolab", 1),  # extra credit: excluded
+                    ],
+                )
             yield
         finally:
             async with pg_pool.acquire() as conn:

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -9,7 +9,6 @@ Requires: DATABASE_URL_TEST env var or Docker postgres on port 5433.
 
 from __future__ import annotations
 
-from typing import ClassVar
 from unittest.mock import AsyncMock
 
 import pytest
@@ -28,7 +27,14 @@ from scripts.entity_resolution.discogs import DiscogsReconciler, ReconciliationM
 
 # ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
 # there for the ``source._dsn`` wiring and ``monkeypatch.setenv`` calls below.
-from tests.integration.conftest import DATABASE_URL
+# The stub-schema helpers are shared with ``test_artist_candidate_sets.py`` so
+# the discogs-cache mirrors can't drift per-file.
+from tests.integration.conftest import (
+    DATABASE_URL,
+    F_UNACCENT_WRAPPER_SQL,
+    RECONCILER_TABLE_DDL,
+    skip_unless_wxyc_identity_match_artist,
+)
 
 
 @pytest_asyncio.fixture
@@ -215,15 +221,6 @@ class TestDiscogsReconciliationSQLSmoke:
     source tree and is vendored byte-for-byte into each cache repo.
     """
 
-    _STUB_TABLES: ClassVar[dict[str, str]] = {
-        "release_artist": (
-            "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0"
-        ),
-        "artist_member": "artist_id INTEGER, member_id INTEGER, member_name TEXT",
-        "artist_alias": "artist_id INTEGER, alias_name TEXT",
-        "artist_name_variation": "artist_id INTEGER, name TEXT",
-    }
-
     @pytest_asyncio.fixture(autouse=True)
     async def ensure_reconciler_schema(self, pg_pool):
         """Skip when ``wxyc_identity_match_artist`` isn't deployed, otherwise
@@ -238,18 +235,9 @@ class TestDiscogsReconciliationSQLSmoke:
         stubs we created get dropped, so cross-test pollution can't accrete.
         """
         async with pg_pool.acquire() as conn:
-            exists = await conn.fetchval(
-                "SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = $1)",
-                "wxyc_identity_match_artist",
-            )
-            if not exists:
-                pytest.skip(
-                    "wxyc_identity_match_artist not deployed -- needs alembic 0004 "
-                    "from WXYC/discogs-etl. CI's plain postgres-16 service container "
-                    "doesn't have it. See class docstring for the TODO."
-                )
+            await skip_unless_wxyc_identity_match_artist(conn)
             created_tables: set[str] = set()
-            for table_name, columns in self._STUB_TABLES.items():
+            for table_name, columns in RECONCILER_TABLE_DDL.items():
                 pre_existing = await conn.fetchval(
                     "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
                     "WHERE table_schema = current_schema() AND table_name = $1)",
@@ -382,14 +370,9 @@ class TestTrigramFallbackSQLIntegration:
 
             # IMMUTABLE f_unaccent wrapper mirroring discogs-cache, so the
             # trigram operator can ride a functional GIN index. Idempotent.
+            await conn.execute(F_UNACCENT_WRAPPER_SQL)
             await conn.execute(
-                "CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text "
-                "AS $$ SELECT unaccent('unaccent', $1) $$ "
-                "LANGUAGE sql IMMUTABLE PARALLEL SAFE"
-            )
-            await conn.execute(
-                "CREATE TABLE release_artist ("
-                "release_id INTEGER, artist_id INTEGER, artist_name TEXT, extra INTEGER DEFAULT 0)"
+                f"CREATE TABLE release_artist ({RECONCILER_TABLE_DDL['release_artist']})"
             )
             await conn.executemany(
                 "INSERT INTO release_artist (release_id, artist_id, artist_name, extra) "

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -2313,6 +2313,28 @@ class TestArtistEqualityCandidates:
         with pytest.raises(CacheUnavailableError):
             await cache_service.artist_equality_candidates(["stereolab"])
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_row",
+        [
+            # A form the batch never asked for (= ANY invariant violated).
+            {"leg": "exact", "form": "not in batch", "artist_ids": [1]},
+            # A leg label with no dataclass field (SQL/dataclass drift).
+            {"leg": "group", "form": "stereolab", "artist_ids": [1]},
+        ],
+    )
+    async def test_invariant_violation_fails_loudly(
+        self, cache_service, mock_asyncpg_pool, bad_row
+    ):
+        """A row violating the SQL↔dataclass invariants must raise (wrapped
+        as CacheUnavailableError), never be silently skipped — a silent
+        drop is how an ambiguous name reads as unique and mints wrong.
+        Pins the direct-access contract so a future editor can't quietly
+        restore ``.get(...) + continue`` defensiveness."""
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[bad_row])
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.artist_equality_candidates(["stereolab"])
+
 
 # ---------------------------------------------------------------------------
 # artist_trigram_candidates (LML#759)
@@ -2361,16 +2383,32 @@ class TestArtistTrigramCandidates:
         """``pg_trgm.similarity_threshold`` is a GUC settable at server/
         database/role scope, so the module's 0.3-floor assumption is
         falsifiable by a DBA tuning the shared cache — the query must pin
-        it with ``SET LOCAL`` inside its own transaction."""
+        it with ``SET LOCAL`` inside its own transaction, BEFORE the fetch.
+
+        The ordering is the contract: ``SET LOCAL`` outside a transaction
+        is a WARNING no-op on real PostgreSQL, and the pg integration
+        tests can't catch a hoist because the server default equals the
+        pin — so this test records the event sequence explicitly.
+        """
         conn = mock_asyncpg_pool._mock_conn
-        conn.fetch = AsyncMock(return_value=[])
+        events: list[str] = []
+        tx_ctx = conn._mock_tx_ctx
+        tx_ctx.__aenter__ = AsyncMock(side_effect=lambda: events.append("tx_enter") or tx_ctx)
+        tx_ctx.__aexit__ = AsyncMock(side_effect=lambda *a: events.append("tx_exit") or False)
+
+        async def record_execute(sql, *args):
+            if "similarity_threshold" in sql:
+                assert "SET LOCAL" in sql
+                events.append("set_local")
+
+        async def record_fetch(*args):
+            events.append("fetch")
+            return []
+
+        conn.execute = AsyncMock(side_effect=record_execute)
+        conn.fetch = AsyncMock(side_effect=record_fetch)
         await cache_service.artist_trigram_candidates(["Stereolab"])
-        set_calls = [
-            c.args[0] for c in conn.execute.await_args_list if "similarity_threshold" in c.args[0]
-        ]
-        assert set_calls, "expected SET LOCAL pg_trgm.similarity_threshold before the query"
-        assert "SET LOCAL" in set_calls[0]
-        conn.transaction.assert_called_once()
+        assert events == ["tx_enter", "set_local", "fetch", "tx_exit"]
 
     @pytest.mark.asyncio
     async def test_multi_id_candidate_set_not_collapsed(self, cache_service, mock_asyncpg_pool):
@@ -2401,5 +2439,15 @@ class TestArtistTrigramCandidates:
     async def test_db_error_wrapped_as_cache_unavailable(self, cache_service, mock_asyncpg_pool):
         conn = mock_asyncpg_pool._mock_conn
         conn.fetch = AsyncMock(side_effect=RuntimeError("conn refused"))
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.artist_trigram_candidates(["Stereolab"])
+
+    @pytest.mark.asyncio
+    async def test_unknown_input_row_fails_loudly(self, cache_service, mock_asyncpg_pool):
+        """A row keyed by an input the batch never sent (unnest invariant
+        violated) must raise, not be silently skipped — same loud-failure
+        contract as the equality legs."""
+        conn = mock_asyncpg_pool._mock_conn
+        conn.fetch = AsyncMock(return_value=[{"input": "not in batch", "artist_ids": [1]}])
         with pytest.raises(CacheUnavailableError):
             await cache_service.artist_trigram_candidates(["Stereolab"])

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -2358,6 +2358,16 @@ class TestArtistTrigramCandidates:
         assert result["Popsicle"] == {5001, 5002}
 
     @pytest.mark.asyncio
+    async def test_threshold_below_pg_trgm_floor_raises(self, cache_service, mock_asyncpg_pool):
+        """A threshold under pg_trgm's session ``similarity_threshold`` floor
+        (default 0.3) would silently drop candidates in the gap — the ``%``
+        operator pre-filters at the floor before ``similarity() >= $2`` runs.
+        Reject loudly instead of under-returning."""
+        with pytest.raises(ValueError, match="0.3"):
+            await cache_service.artist_trigram_candidates(["Stereolab"], threshold=0.2)
+        mock_asyncpg_pool.fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_db_error_wrapped_as_cache_unavailable(self, cache_service, mock_asyncpg_pool):
         mock_asyncpg_pool.fetch = AsyncMock(side_effect=RuntimeError("conn refused"))
         with pytest.raises(CacheUnavailableError):

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -2320,55 +2320,86 @@ class TestArtistEqualityCandidates:
 
 
 class TestArtistTrigramCandidates:
+    """The trigram query runs on an acquired connection inside a transaction
+    so ``SET LOCAL pg_trgm.similarity_threshold`` can pin the ``%``
+    pre-filter floor — assertions target ``pool._mock_conn``."""
+
     @pytest.mark.asyncio
     async def test_empty_input_short_circuits_without_query(self, cache_service, mock_asyncpg_pool):
         assert await cache_service.artist_trigram_candidates([]) == {}
-        mock_asyncpg_pool.fetch.assert_not_awaited()
+        mock_asyncpg_pool._mock_conn.fetch.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_batched_single_round_trip_keyed_by_input(self, cache_service, mock_asyncpg_pool):
-        mock_asyncpg_pool.fetch = AsyncMock(
-            return_value=[{"input": "Nilüfer Yanya", "artist_ids": [5499521]}]
-        )
+        conn = mock_asyncpg_pool._mock_conn
+        conn.fetch = AsyncMock(return_value=[{"input": "Nilüfer Yanya", "artist_ids": [5499521]}])
         result = await cache_service.artist_trigram_candidates(["Nilüfer Yanya", "Hot 8"])
-        mock_asyncpg_pool.fetch.assert_awaited_once()
+        conn.fetch.assert_awaited_once()
         assert result == {"Nilüfer Yanya": {5499521}, "Hot 8": set()}
 
     @pytest.mark.asyncio
     async def test_default_threshold_bound_in_query(self, cache_service, mock_asyncpg_pool):
-        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        conn = mock_asyncpg_pool._mock_conn
+        conn.fetch = AsyncMock(return_value=[])
         await cache_service.artist_trigram_candidates(["Stereolab"])
-        args = mock_asyncpg_pool.fetch.await_args.args
+        args = conn.fetch.await_args.args
         assert args[1] == ["Stereolab"]
         assert args[2] == pytest.approx(0.85)
 
     @pytest.mark.asyncio
     async def test_threshold_override_passed_through(self, cache_service, mock_asyncpg_pool):
-        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+        conn = mock_asyncpg_pool._mock_conn
+        conn.fetch = AsyncMock(return_value=[])
         await cache_service.artist_trigram_candidates(["Stereolab"], threshold=0.4)
-        args = mock_asyncpg_pool.fetch.await_args.args
+        args = conn.fetch.await_args.args
         assert args[2] == pytest.approx(0.4)
 
     @pytest.mark.asyncio
+    async def test_pins_session_similarity_floor_in_transaction(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """``pg_trgm.similarity_threshold`` is a GUC settable at server/
+        database/role scope, so the module's 0.3-floor assumption is
+        falsifiable by a DBA tuning the shared cache — the query must pin
+        it with ``SET LOCAL`` inside its own transaction."""
+        conn = mock_asyncpg_pool._mock_conn
+        conn.fetch = AsyncMock(return_value=[])
+        await cache_service.artist_trigram_candidates(["Stereolab"])
+        set_calls = [
+            c.args[0] for c in conn.execute.await_args_list if "similarity_threshold" in c.args[0]
+        ]
+        assert set_calls, "expected SET LOCAL pg_trgm.similarity_threshold before the query"
+        assert "SET LOCAL" in set_calls[0]
+        conn.transaction.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_multi_id_candidate_set_not_collapsed(self, cache_service, mock_asyncpg_pool):
-        mock_asyncpg_pool.fetch = AsyncMock(
-            return_value=[{"input": "Popsicle", "artist_ids": [5001, 5002]}]
-        )
+        conn = mock_asyncpg_pool._mock_conn
+        conn.fetch = AsyncMock(return_value=[{"input": "Popsicle", "artist_ids": [5001, 5002]}])
         result = await cache_service.artist_trigram_candidates(["Popsicle"])
         assert result["Popsicle"] == {5001, 5002}
 
     @pytest.mark.asyncio
     async def test_threshold_below_pg_trgm_floor_raises(self, cache_service, mock_asyncpg_pool):
-        """A threshold under pg_trgm's session ``similarity_threshold`` floor
-        (default 0.3) would silently drop candidates in the gap — the ``%``
+        """A threshold under pg_trgm's pinned ``similarity_threshold`` floor
+        (0.3) would silently drop candidates in the gap — the ``%``
         operator pre-filters at the floor before ``similarity() >= $2`` runs.
         Reject loudly instead of under-returning."""
         with pytest.raises(ValueError, match="0.3"):
             await cache_service.artist_trigram_candidates(["Stereolab"], threshold=0.2)
-        mock_asyncpg_pool.fetch.assert_not_awaited()
+        mock_asyncpg_pool._mock_conn.fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bad_threshold_raises_even_on_empty_batch(self, cache_service, mock_asyncpg_pool):
+        """The guard must fire before the empty-batch short-circuit: a
+        misconfigured threshold constant should fail a dry-run whose batch
+        happens to be empty, not surface mid-way through the first real one."""
+        with pytest.raises(ValueError, match="0.3"):
+            await cache_service.artist_trigram_candidates([], threshold=0.2)
 
     @pytest.mark.asyncio
     async def test_db_error_wrapped_as_cache_unavailable(self, cache_service, mock_asyncpg_pool):
-        mock_asyncpg_pool.fetch = AsyncMock(side_effect=RuntimeError("conn refused"))
+        conn = mock_asyncpg_pool._mock_conn
+        conn.fetch = AsyncMock(side_effect=RuntimeError("conn refused"))
         with pytest.raises(CacheUnavailableError):
             await cache_service.artist_trigram_candidates(["Stereolab"])

--- a/tests/unit/test_discogs_request_telemetry.py
+++ b/tests/unit/test_discogs_request_telemetry.py
@@ -283,10 +283,10 @@ async def test_no_tag_when_called_outside_seam(service, captured_spans):
 async def test_request_context_tags_direct_caller_spans(
     service, captured_spans, _ensure_skip_cache_clear
 ):
-    """``search_releases_by_album_title``, ``get_label_image``, ``get_master``
-    each call ``_request_with_retry`` directly (no fallthrough). The
-    ``request_context`` helper they wrap their call in must propagate the
-    method tag + cache_state=no_pg the same way the seam does."""
+    """``search_releases_by_album_title``, ``get_label_image``, ``get_master``,
+    and ``search_artists`` each call ``_request_with_retry`` directly (no
+    fallthrough). The ``request_context`` helper they wrap their call in must
+    propagate the method tag + cache_state=no_pg the same way the seam does."""
     with request_context("get_label_image"):
         await _drive_request_with_retry(service)
 

--- a/tests/unit/test_discogs_request_telemetry.py
+++ b/tests/unit/test_discogs_request_telemetry.py
@@ -1,7 +1,7 @@
 """Tests for the LML#537 rate-limiter telemetry tags.
 
 When the ``fallthrough`` seam (or the ``request_context`` helper used by
-the three API-only methods that bypass it) falls through to the API leg,
+the four API-only methods that bypass it) falls through to the API leg,
 it sets ``_request_context_var`` carrying the seam's ``label`` and the
 resolved ``cache_state``. ``_request_with_retry`` reads that contextvar
 inside its ``lml.discogs.semaphore`` and ``lml.discogs.rate_limiter``
@@ -21,8 +21,9 @@ Covered:
    handful of legacy tests) don't have a contextvar set; spans should
    not blow up and should not carry the tags.
 5. **request_context helper** — used by ``search_releases_by_album_title``,
-   ``get_label_image``, ``get_master`` (the three API-only methods that
-   bypass ``fallthrough``); spans get tagged the same as the seam path.
+   ``get_label_image``, ``get_master``, ``search_artists`` (the four
+   API-only methods that bypass ``fallthrough``); spans get tagged the
+   same as the seam path.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -3185,21 +3185,26 @@ class TestSearchArtists:
             await service.search_artists("The Tubs")
 
     @pytest.mark.asyncio
-    async def test_skips_malformed_result_items(self, service):
-        mock_resp = make_artist_search_response(
-            [
-                {"title": "No Id", "type": "artist"},
-                {"id": None, "title": "Null Id", "type": "artist"},
-                {"id": 5, "type": "artist"},  # no title
-                {"id": 7, "title": "", "type": "artist"},  # empty title
-                {"id": 9, "title": "L'Rain", "type": "artist"},
-            ]
-        )
-        with patch.object(
-            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
-        ):
-            results = await service.search_artists("L'Rain")
-        assert results == [DiscogsArtistSearchResult(artist_id=9, title="L'Rain")]
+    async def test_malformed_item_distrusts_whole_page(self, service):
+        """A page containing ANY malformed item (missing/null id, missing/
+        empty title) is an observation we don't fully understand → ``None``.
+        Silently skipping the bad item would return a truncated page as a
+        trusted measurement — e.g. dropping a null-id "Popsicle (2)" leaves
+        ``candidate_count=1``, a false-unique that mints the wrong artist."""
+        malformed_variants = [
+            {"title": "No Id", "type": "artist"},
+            {"id": None, "title": "Null Id", "type": "artist"},
+            {"id": 5, "type": "artist"},  # no title
+            {"id": 7, "title": "", "type": "artist"},  # empty title
+        ]
+        for bad_item in malformed_variants:
+            mock_resp = make_artist_search_response(
+                [{"id": 9, "title": "L'Rain", "type": "artist"}, bad_item]
+            )
+            with patch.object(
+                service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+            ):
+                assert await service.search_artists("L'Rain") is None, f"item={bad_item!r}"
 
     @pytest.mark.asyncio
     async def test_wrong_shaped_body_returns_none(self, service):

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -3202,10 +3202,48 @@ class TestSearchArtists:
         assert results == [DiscogsArtistSearchResult(artist_id=9, title="L'Rain")]
 
     @pytest.mark.asyncio
-    async def test_blank_name_short_circuits_without_api_call(self, service):
+    async def test_wrong_shaped_body_returns_none(self, service):
+        """A 200 body that parses as JSON but isn't the expected shape is
+        "couldn't measure" → ``None``, never an uncaught exception. An
+        intermediary (CDN error page, proxy) can 200 with anything."""
+        for body in [{"results": None}, ["not", "a", "dict"], "a string", {"results": "nope"}]:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json.return_value = body
+            with patch.object(
+                service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+            ):
+                assert await service.search_artists("Wishy") is None, f"body={body!r}"
+
+    @pytest.mark.asyncio
+    async def test_wrong_typed_item_returns_none(self, service):
+        """An item whose fields defeat model validation means the page shape
+        isn't understood — the whole observation is untrusted (``None``),
+        because a partially-read page could produce a false-unique
+        ``candidate_count`` and mint a wrong identity."""
+        mock_resp = make_artist_search_response(
+            [
+                {"id": 9, "title": "L'Rain", "type": "artist"},
+                {"id": [1], "title": "Bad Id Shape", "type": "artist"},
+            ]
+        )
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            assert await service.search_artists("L'Rain") is None
+
+    @pytest.mark.asyncio
+    async def test_blank_name_raises_value_error(self, service):
+        """Blank input is a caller error, not a measurement: returning ``[]``
+        would fabricate a "Discogs answered, zero candidates" observation for
+        a probe that was never sent. The resolver short-circuits empty
+        identity-match forms before this tier."""
         with patch.object(service, "_request_with_retry", new_callable=AsyncMock) as mock_req:
-            assert await service.search_artists("") == []
-            assert await service.search_artists("   ") == []
+            with pytest.raises(ValueError, match="blank"):
+                await service.search_artists("")
+            with pytest.raises(ValueError, match="blank"):
+                await service.search_artists("   ")
         mock_req.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #761 (PR B of the #759 plan), which was merged while its code-review pass was still in flight — this PR carries the review's fixes. All findings came from a multi-angle review of the #761 diff; each behavioral fix landed test-first.

## Correctness

- **`search_artists` parse containment**: the entire body parse (`raise_for_status`, `json()`, shape handling, model construction) now sits inside the try, so a 200 response whose body defeats parsing (`{"results": null}`, non-dict bodies, wrong-typed item fields) maps to the documented `None` ("couldn't measure") instead of escaping as `TypeError`/`ValidationError`. A partially-understood page could yield a false-unique `candidate_count` and mint a wrong identity, so the whole observation is untrusted on any parse failure.
- **Blank names raise `ValueError`**: returning `[]` fabricated a "Discogs answered, zero candidates" observation for a probe that was never sent (`" "` passes the wire contract's `minLength: 1`). The resolver (PR C) short-circuits empty identity-match forms before this tier.
- **Trigram threshold floor enforced**: `artist_trigram_candidates` rejects thresholds below pg_trgm's `similarity_threshold` floor (0.3), where the `%` pre-filter would silently drop candidates in the `[threshold, floor)` gap.
- **Loud invariant violations**: both candidate-set methods now use direct key/attribute access (`results[form]`, `getattr(candidates, leg)`) instead of `.get(...)` + `continue` — a violation now fails loudly as `CacheUnavailableError` instead of silently dropping candidate ids, which is exactly the ambiguous-name-mints failure the sets exist to prevent.

## Honest comments

- The "byte-compatible with the reconciler" instruction was false at introduction: the `IS NOT NULL` predicates here have no counterpart in the reconciler's SQL (it drops NULL ids Python-side). Both files' comments now scope byte-compat to the matching predicates and pin the NULL-filtering difference as intentional.
- The "rides the existing `wxyc_identity_match_artist` functional indexes" claim (inherited from the issue text) is false — no such expression index exists in discogs-etl; `= ANY(...)` evaluates the function per row. The comment and docstring now state the real cost (four sequential scans per call on the shared PG) and pin the method to the offline resolver/drain tier: **do not wire into the /lookup hot path** until the indexes land.
- The reconciler's 0.85 trigram threshold now back-references its `cache_service` mirror so a #215 retune moves both together.
- `search_artists` now emits the `add_discogs_breadcrumb` its API-only siblings emit, and the stale "three API-only methods" enumerations (fallthrough docstring, `_request_with_retry` comment, telemetry test header) count four.

## Test infrastructure

- **Fixture leak-proofing**: both pg fixtures in `test_artist_candidate_sets.py` now create + seed inside the `try`, so a mid-seed failure still drops created tables. Previously one transient error leaked tables into the persistent test PG, and the data-safety guard then silently self-skipped the class on every later run.
- **Shared stub helpers**: the `f_unaccent` wrapper SQL, the reconciler stub-table DDL, and the `wxyc_identity_match_artist` skip guard are extracted to `tests/integration/conftest.py` and consumed by both `test_artist_candidate_sets.py` and `test_entity_resolution.py`, so the discogs-cache schema mirrors can't drift per-file.

Local checks: ruff + format clean, mypy clean, full default suite and pg suite green apart from the pre-existing environment-dependent failures reproduced identically on base. New tests: wrong-shaped-body → `None`, wrong-typed-item → `None`, blank-name → `ValueError`, sub-floor threshold → `ValueError`.

## Related

- #759 (parent), #761 (PR B, merged), WXYC/wxyc-shared#218 (PR A, merged)
