### PR TITLE
feat(#759): bare-name artist resolver core — tier orchestration + verdict table (PR C1)

### DIFF
--- a/artists/resolver.py
+++ b/artists/resolver.py
@@ -10,9 +10,13 @@ check against the Discogs API. Cache results are evidence (corroboration
 not mint, because nothing self-corrects a wrong row (see the write-back
 note below).
 
-Inputs are trimmed, then validated before any tier runs: NUL-bearing,
-blank, non-encodable, empty-identity-form, and qualifier-only names
-raise ``ValueError`` (the route maps it to 422) rather than receiving an
+Inputs are sanitized (Unicode format characters dropped, whitespace
+trimmed — the normalizer removes Cf characters too, and a ZWSP-bearing
+mint key would be invisible to every store read leg), then validated
+before any tier runs: NUL-bearing, blank, non-encodable,
+empty-identity-form, and bare-parenthesized-number names ("(2)" — a
+Discogs disambiguator whose artist name was lost upstream) raise
+``ValueError`` (the route maps it to 422) rather than receiving an
 in-band verdict — the wire contract's ``not_found`` means "the API tier
 ran and measured zero", which is never true of garbage input, and a NUL
 reaching the tier-2 PG binds would 503 the whole batch as a fake cache
@@ -26,10 +30,16 @@ a raw input carrying a qualifier denotes something other than the bare
 name (a different same-named artist, a scraper artifact, a decoration),
 so qualified inputs get their own group instead of inheriting the bare
 form's verdict: a stored ``Popsicle`` row must never answer for
-``Popsicle (2)``. Qualifiers are detected on the NFKC-folded, lowercased
-raw name so width/case variants ("（２）") key with their ASCII twins —
-the same folds the normalizer itself applies. The deliberate cost: a
-legitimately-decorated name ("!!! (Chk Chk Chk)") resolves only when
+``Popsicle (2)``. Qualifier detection mirrors the normalizer exactly: it
+peels EVERY balanced trailing ()/[] group (nested tails included) from
+the NFKC-folded lowercase name, canonicalizes bare-number groups across
+bracket/width/spacing spellings ("[2]", "( 2 )", "（２）" all key as
+"(2)"), concatenates multi-group tails ("(2)(uk)"), refuses to treat the
+group as a qualifier when peeling would empty the name (the normalizer
+makes the same refusal — "(Smog)" is a resolvable bare name), and the
+group's form is the normalizer's FIXED POINT so multi-qualified inputs
+still see their exact-form family at the API tier. The deliberate cost:
+a legitimately-decorated name ("!!! (Chk Chk Chk)") resolves only when
 Discogs titles the artist with the same qualifier; otherwise it lands
 ``ambiguous``/``not_found`` and surfaces in the drain residual rather
 than risk a wrong mint.
@@ -114,28 +124,114 @@ from generated.api_models import (
 
 logger = logging.getLogger(__name__)
 
-# A trailing parenthesized/bracketed qualifier — Discogs's "(N)" artist
+# Bracket pairs a trailing qualifier may use — Discogs's "(N)" artist
 # disambiguator is the motivating case, but the identity-match form strips
-# ANY trailing group (including "[2]", "(Sweden)", "(1975)"), so qualifier
+# ANY trailing parenthesized/bracketed group (including "[2]", "(Sweden)",
+# "(1975)", and NESTED tails like "(feat. Cindy (2))"), so qualifier
 # detection must cover the same surface or a variant spelling silently
-# rejoins the bare group. Matched against the NFKC-folded lowercase name
-# (below) so fullwidth "（２）" keys identically to "(2)".
-_TRAILING_QUALIFIER_RE = re.compile(r"([(\[][^()\[\]]*[)\]])\s*$")
+# rejoins the bare group. Curly/angle/CJK bracket families are content to
+# the normalizer and stay content here.
+_QUALIFIER_OPENERS = {")": "(", "]": "["}
+
+# The exact garbage shape rejected at validation: a name that IS a bare
+# parenthesized/bracketed number ("(2)", "[2]", "（２）" after folding) —
+# a disambiguator with the artist name lost upstream. Deliberately narrow:
+# a fully-parenthesized NON-numeric name ("(Smog)") is a real artist name
+# the normalizer also refuses to strip, and stays resolvable.
+_BARE_NUMBER_GROUP_RE = re.compile(r"[(\[]\s*(\d+)\s*[)\]]")
 
 
-def _split_trailing_qualifier(name: str) -> tuple[str | None, str]:
-    """Return ``(qualifier, prefix)`` from the NFKC-folded lowercase name.
+def _peel_trailing_group(text: str) -> tuple[str | None, str]:
+    """Split one balanced trailing bracket group off ``text``.
 
-    ``qualifier`` is the folded trailing group text (``None`` when the
-    name has no trailing qualifier); ``prefix`` is the folded text before
-    it. Folding mirrors the normalizer's own width/case folds so this
-    yields one canonical qualifier key per semantic spelling.
+    Returns ``(group, prefix)``, or ``(None, text)`` when the tail is not
+    a balanced ()/[] group. Balance-aware so nested tails the normalizer
+    strips whole ("(feat. Cindy (2))") peel as one group — a regex with a
+    no-brackets-inside class cannot see them.
+    """
+    stripped = text.rstrip()
+    if not stripped or stripped[-1] not in _QUALIFIER_OPENERS:
+        return None, text
+    closer = stripped[-1]
+    opener = _QUALIFIER_OPENERS[closer]
+    depth = 0
+    for i in range(len(stripped) - 1, -1, -1):
+        if stripped[i] == closer:
+            depth += 1
+        elif stripped[i] == opener:
+            depth -= 1
+            if depth == 0:
+                return stripped[i:], stripped[:i]
+    return None, text  # unbalanced tail: content, not a qualifier
+
+
+def _canonical_qualifier_group(group: str) -> str:
+    """One canonical key per semantic qualifier spelling.
+
+    A bare-number group canonicalizes to ``(N)`` — "[2]", "( 2 )", and
+    folded "（２）" all denote the Discogs disambiguator "(2)" (zero-padded
+    "(02)" is NOT the Discogs convention and stays distinct). Other
+    groups just drop internal whitespace so spacing variants share a key;
+    the key is only ever compared against keys built the same way.
+    """
+    match = _BARE_NUMBER_GROUP_RE.fullmatch(group.strip())
+    if match:
+        return f"({match.group(1)})"
+    return re.sub(r"\s+", "", group)
+
+
+def _split_trailing_qualifiers(name: str) -> tuple[str | None, str]:
+    """Return ``(qualifier key, folded remainder)`` for ``name``.
+
+    Peels EVERY balanced trailing group from the NFKC-folded lowercase
+    name (the same width/case folds the normalizer applies) and joins
+    their canonical forms into one key, so "Sault (2) (UK)" keys as
+    ``(2)(uk)`` rather than hiding its inner qualifier. When peeling
+    would leave nothing, the group IS the name, not a qualifier — the
+    normalizer makes the same refusal — so "(Smog)" returns
+    ``(None, "(smog)")`` and stays a resolvable bare name.
     """
     folded = unicodedata.normalize("NFKC", name).lower()
-    match = _TRAILING_QUALIFIER_RE.search(folded)
-    if match is None:
+    remainder = folded
+    groups: list[str] = []
+    while True:
+        group, prefix = _peel_trailing_group(remainder)
+        if group is None or not prefix.strip():
+            break
+        groups.append(group)
+        remainder = prefix
+    if not groups:
         return None, folded
-    return match.group(1), folded[: match.start()]
+    return "".join(_canonical_qualifier_group(g) for g in reversed(groups)), remainder
+
+
+def _fixed_point_form(name: str) -> str:
+    """Iterate ``to_identity_match_form`` to a fixed point.
+
+    The normalizer strips ONE trailing qualifier per pass, so a
+    multi-qualified input's single-pass form ("sault (2)") still carries
+    a tail — comparing API titles or cache binds against it measures
+    false zeroes. The fixed point ("sault") is the base name every family
+    member's own single-pass form can actually equal.
+    """
+    form = to_identity_match_form(name)
+    while form:
+        again = to_identity_match_form(form)
+        if again == form:
+            break
+        form = again
+    return form
+
+
+def _sanitize_name(name: str) -> str:
+    """Drop Unicode format (Cf) characters, then trim whitespace.
+
+    ZWSP/BOM/soft-hyphen survive ``str.strip()`` and would ride into
+    store keys and qualifier detection while the normalizer removes them
+    — a ``"Wishy\\u200b"`` mint would be invisible to every store read
+    leg. Congruent with the normalizer's own treatment.
+    """
+    return "".join(ch for ch in name if unicodedata.category(ch) != "Cf").strip()
 
 
 @dataclass
@@ -144,7 +240,10 @@ class ResolveStats:
 
     Verdict counters count response POSITIONS (duplicates share their
     group's verdict), so they sum to ``names``. ``deduped`` counts unique
-    ``(form, qualifier)`` groups and ``minted`` counts upserts performed.
+    ``(form, qualifier)`` groups and ``minted`` counts SUCCESSFUL upserts
+    (an upsert that returned None — the store's swallowed-failure
+    contract — is logged but not counted, so ``minted`` tracks rows
+    actually persisted, not write attempts).
     ``api_calls`` counts ``search_artists`` probes that returned to the
     resolver — including ``None`` returns (a 429-exhausted or distrusted
     probe still consumed shared-limiter budget). A probe shed by the
@@ -228,32 +327,36 @@ class _FormGroup:
 
 
 def _validate_name(index: int, name: str) -> tuple[str, str | None]:
-    """Return ``(identity-match form, qualifier)`` or raise ValueError.
+    """Return ``(fixed-point identity-match form, qualifier)`` or raise.
 
-    ``name`` arrives pre-trimmed. Garbage input must not receive an
-    in-band verdict: ``not_found`` is a measured zero a consumer may
-    durably negative-cache, and a NUL that reaches the tier-2 PG binds
-    fails the whole batch as a fake cache outage (PG rejects U+0000 in
-    text). The empty-form and qualifier-only rejections are a v1 recall
-    limit for names with no identity content — the band "!!!" survives
-    (its form is "!!!"), but "" and "(2)" have nothing to resolve.
-    The route maps ValueError to 422.
+    ``name`` arrives pre-sanitized (Cf-stripped + trimmed). Garbage input
+    must not receive an in-band verdict: ``not_found`` is a measured zero
+    a consumer may durably negative-cache, and a NUL that reaches the
+    tier-2 PG binds fails the whole batch as a fake cache outage (PG
+    rejects U+0000 in text). The empty-form and bare-number rejections
+    are a v1 recall limit for names with no identity content — "!!!"
+    survives (its form is "!!!") and so does the fully-parenthesized
+    real name "(Smog)", but "" and "(2)" (a Discogs disambiguator whose
+    artist name was lost upstream) have nothing to resolve. The route
+    maps ValueError to 422.
     """
     if "\x00" in name:
         raise ValueError(f"names[{index}] contains U+0000 (NUL); fix the input at its source")
     if not name:
         raise ValueError(f"names[{index}] is blank")
     try:
-        form = to_identity_match_form(name)
+        form = _fixed_point_form(name)
     except UnicodeEncodeError as e:
         raise ValueError(f"names[{index}] is not encodable Unicode (lone surrogate?)") from e
     if not form:
         raise ValueError(f"names[{index}] normalizes to an empty identity-match form")
-    qualifier, prefix = _split_trailing_qualifier(name)
-    if qualifier is not None and not prefix.strip():
+    qualifier, _ = _split_trailing_qualifiers(name)
+    if qualifier is None and _BARE_NUMBER_GROUP_RE.fullmatch(
+        unicodedata.normalize("NFKC", name).strip()
+    ):
         raise ValueError(
-            f"names[{index}] is only a trailing qualifier (e.g. a bare Discogs "
-            "disambiguator) with no artist name before it"
+            f"names[{index}] is only a bare parenthesized number — a Discogs "
+            "disambiguator with no artist name before it"
         )
     return form, qualifier
 
@@ -310,7 +413,7 @@ class BareNameArtistResolver:
         groups: dict[tuple[str, str | None], _FormGroup] = {}
         order: list[_FormGroup] = []
         for index, name in enumerate(names):
-            trimmed = name.strip()
+            trimmed = _sanitize_name(name)
             form, qualifier = _validate_name(index, trimmed)
             key = (form, qualifier)
             group = groups.get(key)
@@ -336,7 +439,7 @@ class BareNameArtistResolver:
                 identity = identities.get(verbatim)
                 if identity is None:
                     continue
-                row_qualifier, _ = _split_trailing_qualifier(identity.library_name)
+                row_qualifier, _ = _split_trailing_qualifiers(identity.library_name)
                 if row_qualifier != group.qualifier:
                     # The store's LOWER/canonical legs can hand back a
                     # bare-form row for a qualified read (the canonical
@@ -357,7 +460,9 @@ class BareNameArtistResolver:
                 # ids — near-duplicate-key accretion contradicting itself.
                 # First-wins would flip the verdict with input order;
                 # conflict means doubt, doubt means NULL. candidate_count
-                # stays null: the API tier never ran, nothing was measured.
+                # stays null (the API tier never ran) and corroboration
+                # stays [] (tier 2 was never consulted) — both documented
+                # in the wire contract's store-conflict arm.
                 logger.warning(
                     "artist-resolve store conflict for form '%s': ids %s",
                     group.form,
@@ -485,11 +590,14 @@ class BareNameArtistResolver:
         stats: ResolveStats,
     ) -> ArtistResolveResult:
         """Apply the verdict table to a measured single-page observation."""
-        # Exact-form family, distinct by artist id (first title per id
-        # wins — page order is the API's relevance order). The
-        # identity-match form strips the trailing qualifier, so
-        # "Popsicle (2)" collides with "Popsicle" — that strip IS the
-        # overload detection.
+        # Exact-form family, distinct by artist id; the setdefault keeps
+        # the first title per id in the API's relevance order.
+        # Deterministic in page CONTENT: Discogs carries one canonical
+        # title per artist id, so the first-title pick only matters under
+        # an API anomaly (one id under two titles on a single page). The
+        # FIXED-POINT identity-match form strips every trailing
+        # qualifier, so "Popsicle (2)" collides with "Popsicle" — that
+        # strip IS the overload detection.
         candidates: dict[int, str] = {}
         try:
             for item in page:
@@ -526,7 +634,7 @@ class BareNameArtistResolver:
             )
 
         ((winner_id, winner_title),) = candidates.items()
-        winner_qualifier, _ = _split_trailing_qualifier(winner_title)
+        winner_qualifier, _ = _split_trailing_qualifiers(winner_title)
         if winner_qualifier != group.qualifier:
             # A "(N)"-titled singleton answering a bare input means the
             # family is overloaded on Discogs and the bare member simply

--- a/artists/resolver.py
+++ b/artists/resolver.py
@@ -60,7 +60,11 @@ Tiers, per group:
    deterministic in batch content where first-wins would flip with input
    order). A Discogs-id-less row does not decide, but for unqualified
    groups its stored key becomes the mint target so the upsert fills
-   that row in place instead of accreting a near-duplicate key.
+   that row in place instead of accreting a near-duplicate key; with no
+   such row the mint keys on the group's min() spelling — deterministic
+   in content, like the probe, so the minted key can't flip with input
+   order (the store's read legs are case-insensitive, so any spelling
+   stays findable).
 2. ``DiscogsCacheService.artist_equality_candidates`` +
    ``artist_trigram_candidates`` — candidate SETS (an equality-leg
    candidate that disagrees with the API winner forces ``ambiguous``;
@@ -133,12 +137,15 @@ logger = logging.getLogger(__name__)
 # the normalizer and stay content here.
 _QUALIFIER_OPENERS = {")": "(", "]": "["}
 
-# The exact garbage shape rejected at validation: a name that IS a bare
-# parenthesized/bracketed number ("(2)", "[2]", "（２）" after folding) —
-# a disambiguator with the artist name lost upstream. Deliberately narrow:
-# a fully-parenthesized NON-numeric name ("(Smog)") is a real artist name
-# the normalizer also refuses to strip, and stays resolvable.
-_BARE_NUMBER_GROUP_RE = re.compile(r"[(\[]\s*(\d+)\s*[)\]]")
+# The exact garbage shape rejected at validation: a name whose identity
+# content IS a bare parenthesized/bracketed ASCII number ("(2)", "[2]",
+# "（２）" after folding, "(2)(3)" after qualifier peeling) — a Discogs
+# disambiguator with the artist name lost upstream. Deliberately narrow:
+# ASCII digits in MATCHED bracket pairs only, because a Discogs
+# disambiguator can never spell any other way (NFKC leaves e.g.
+# Arabic-Indic "٢" unfolded), so a fully-bracketed non-ASCII-digit name
+# is a real artist name under the same doctrine as "(Smog)".
+_BARE_NUMBER_GROUP_RE = re.compile(r"\(\s*([0-9]+)\s*\)|\[\s*([0-9]+)\s*\]")
 
 
 def _peel_trailing_group(text: str) -> tuple[str | None, str]:
@@ -176,7 +183,7 @@ def _canonical_qualifier_group(group: str) -> str:
     """
     match = _BARE_NUMBER_GROUP_RE.fullmatch(group.strip())
     if match:
-        return f"({match.group(1)})"
+        return f"({match.group(1) or match.group(2)})"
     return re.sub(r"\s+", "", group)
 
 
@@ -191,7 +198,13 @@ def _split_trailing_qualifiers(name: str) -> tuple[str | None, str]:
     normalizer makes the same refusal — so "(Smog)" returns
     ``(None, "(smog)")`` and stays a resolvable bare name.
     """
-    folded = unicodedata.normalize("NFKC", name).lower()
+    # Cf-strip here too: the store-row and winner-title callers feed
+    # UNSANITIZED text, and a trailing ZWSP would hide a real qualifier
+    # from the peel (the normalizer strips Cf everywhere, so a stored
+    # "Popsicle (2)\u200b" row is still handed back by the read legs).
+    folded = unicodedata.normalize(
+        "NFKC", "".join(ch for ch in name if unicodedata.category(ch) != "Cf")
+    ).lower()
     remainder = folded
     groups: list[str] = []
     while True:
@@ -269,11 +282,13 @@ class _FormGroup:
 
     form: str
     qualifier: str | None
-    # Key the mint targets: the first occurrence's trimmed verbatim, or
-    # the stored ``library_name`` when tier 1 found a Discogs-id-less row
-    # to fill (unqualified groups only — qualified groups never mint).
-    mint_key: str
-    # Distinct trimmed spellings in position order; tier 1 reads all of
+    # Retargeted mint key: the stored ``library_name`` when tier 1 found
+    # a Discogs-id-less row to fill in place (unqualified groups only —
+    # qualified groups never mint). None means no retarget; the mint then
+    # keys on ``probe``, the same content-deterministic min() spelling,
+    # so the minted library_name cannot flip with caller input order.
+    mint_key: str | None = None
+    # Distinct sanitized spellings in position order; tier 1 reads all of
     # them, tier 3 probes with min() so the observation universe can't
     # depend on input order.
     verbatims: list[str] = field(default_factory=list)
@@ -350,14 +365,15 @@ def _validate_name(index: int, name: str) -> tuple[str, str | None]:
         raise ValueError(f"names[{index}] is not encodable Unicode (lone surrogate?)") from e
     if not form:
         raise ValueError(f"names[{index}] normalizes to an empty identity-match form")
-    qualifier, _ = _split_trailing_qualifiers(name)
-    if qualifier is None and _BARE_NUMBER_GROUP_RE.fullmatch(
-        unicodedata.normalize("NFKC", name).strip()
-    ):
+    # Gate on the FIXED-POINT form so a bare-number base wearing a
+    # qualifier tail ("(2)(3)") is caught too — after peeling, "(2)" is
+    # the group's entire identity content, the exact shape this rejects.
+    if _BARE_NUMBER_GROUP_RE.fullmatch(form):
         raise ValueError(
             f"names[{index}] is only a bare parenthesized number — a Discogs "
             "disambiguator with no artist name before it"
         )
+    qualifier, _ = _split_trailing_qualifiers(name)
     return form, qualifier
 
 
@@ -418,7 +434,7 @@ class BareNameArtistResolver:
             key = (form, qualifier)
             group = groups.get(key)
             if group is None:
-                group = _FormGroup(form=form, qualifier=qualifier, mint_key=trimmed)
+                group = _FormGroup(form=form, qualifier=qualifier)
                 groups[key] = group
             if trimmed not in group.verbatims:
                 group.verbatims.append(trimmed)
@@ -601,7 +617,7 @@ class BareNameArtistResolver:
         candidates: dict[int, str] = {}
         try:
             for item in page:
-                if to_identity_match_form(item.title) == group.form:
+                if _fixed_point_form(item.title) == group.form:
                     candidates.setdefault(item.artist_id, item.title)
         except UnicodeEncodeError:
             # A title the normalizer cannot encode distrusts the WHOLE
@@ -654,6 +670,7 @@ class BareNameArtistResolver:
                 candidate_count=1,
             )
 
+        mint_key = group.mint_key or group.probe
         if not dry_run and group.qualifier is None:
             # discogs_artist_id only — other id columns belong to their own
             # enrichment flows. COALESCE guards NULL-overwrites only; not
@@ -663,7 +680,7 @@ class BareNameArtistResolver:
             # entirely: a qualified key is unreachable via the bare-name
             # reads Backend issues, i.e. pure pollution.
             upserted = await self._entity_store.upsert_identity(
-                group.mint_key, discogs_artist_id=winner_id
+                mint_key, discogs_artist_id=winner_id
             )
             if upserted is None:
                 # upsert_identity's contract allows a None return for a
@@ -671,7 +688,7 @@ class BareNameArtistResolver:
                 # route 503s), so this branch is belt-and-braces.
                 logger.error(
                     "entity.identity write-back failed for '%s' (discogs_artist_id=%d)",
-                    group.mint_key,
+                    mint_key,
                     winner_id,
                 )
             else:

--- a/artists/resolver.py
+++ b/artists/resolver.py
@@ -6,27 +6,59 @@ discogs-cache is a pair-wise-filtered ~50K **biased sample** of Discogs,
 so for bare names it can corroborate but never decide — every
 write-back-eligible resolution must clear a full-universe uniqueness
 check against the Discogs API. Cache results are evidence (corroboration
-/ conflict detection / telemetry), never verdicts; the COALESCE
-never-clobber upsert makes a wrong mint durable, so ambiguous names must
-not mint.
+/ conflict detection / telemetry), never verdicts; ambiguous names must
+not mint, because nothing self-corrects a wrong row (see the write-back
+note below).
 
-Tiers, per unique identity-match form:
+Inputs are validated before any tier runs: NUL-bearing, blank,
+non-encodable, and empty-identity-form names raise ``ValueError`` (the
+route maps it to 422) rather than receiving an in-band verdict — the
+wire contract's ``not_found`` means "the API tier ran and measured
+zero", which is never true of garbage input, and a NUL reaching the
+tier-2 PG binds would 503 the whole batch as a fake cache outage.
 
-1. ``EntityStore.bulk_resolve_library_names`` — true short-circuit,
-   unverified (a pre-existing row is the store's resolved-at-most-once
-   promise). Only a row that actually carries ``discogs_artist_id``
-   decides; a row holding other ids can't answer this endpoint's
-   question and falls through (its stored key becomes the mint target so
-   COALESCE fills the row in place instead of accreting a near-duplicate
-   key).
+Work units are groups keyed on ``(identity_match_form, "(N)" suffix)``.
+The form strips Discogs's trailing "(N)" disambiguator, which is
+load-bearing for overload DETECTION at the API tier — but a raw input
+that carries the suffix denotes a *different artist* than the bare name
+by Discogs convention, so suffixed inputs get their own group instead of
+inheriting the bare form's verdict (a stored ``Popsicle`` row must never
+answer for ``Popsicle (2)``).
+
+Tiers, per group:
+
+1. ``EntityStore.bulk_resolve_library_names`` over **every** distinct
+   verbatim in the group — a group-mate's exact stored row must not be
+   invisible just because a different spelling came first. A row
+   carrying ``discogs_artist_id`` decides (``method: identity_store``);
+   for suffix-bearing groups only an exact ``library_name`` match may
+   decide (the store's canonical read leg strips the suffix too, and a
+   bare-form row must not answer for the suffixed artist). A
+   Discogs-id-less row does not decide, but its stored key becomes the
+   mint target so the upsert fills that row in place instead of
+   accreting a near-duplicate key.
 2. ``DiscogsCacheService.artist_equality_candidates`` +
    ``artist_trigram_candidates`` — candidate SETS (an equality-leg
    candidate that disagrees with the API winner forces ``ambiguous``;
    trigram neighbors are yield telemetry and never veto).
-3. ``DiscogsService.search_artists`` — the exact-form uniqueness check.
-   Serial, never fanned out: the shared limiter paces globally at
-   50/min, so intra-request concurrency can't beat it and only starves
-   interleaved live-lookup traffic of semaphore slots (LML#370/#372).
+3. ``DiscogsService.search_artists`` — the exact-form uniqueness check,
+   probed with a deterministic representative of the group
+   (``min()`` of its verbatims) so the single-page observation universe
+   cannot vary with input order. Serial, never fanned out: the shared
+   limiter paces globally at 50/min, so intra-request concurrency can't
+   beat it and only starves interleaved live-lookup traffic of
+   semaphore slots (LML#370/#372).
+
+Write-back: ``upsert_identity``'s ON CONFLICT arm is
+``COALESCE(EXCLUDED.discogs_artist_id, existing)`` — **new wins when
+non-null**; COALESCE only refuses to overwrite with NULL. Not
+overwriting an existing id therefore rests on the tier-1 read gate,
+which is up to ~30s stale at mint time under the serial API pacing — a
+concurrent writer in that window is silently overwritten (LML#766
+tracks the store-level fill-if-null primitive that closes this).
+Suffix-bearing groups never mint: a "(N)"-keyed row is unreachable via
+the three-leg read and pure pollution (per the #759 design), so a
+suffixed winner is returned to the caller but not persisted.
 
 The deliberate divergence from the reconciler's first-match-wins cascade
 (``scripts/entity_resolution/discogs.py``) is documented on the
@@ -36,12 +68,13 @@ candidate-set queries in ``discogs/cache_service.py``.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 
 from wxyc_etl.text import to_identity_match_form
 
 from discogs.breaker import DiscogsBreakerOpenError
-from discogs.cache_service import ArtistEqualityCandidates, DiscogsCacheService
+from discogs.cache_service import DiscogsCacheService
 from discogs.service import DiscogsService
 from entity.store import EntityStore
 from generated.api_models import (
@@ -53,14 +86,10 @@ from generated.api_models import (
 
 logger = logging.getLogger(__name__)
 
-# ``ArtistEqualityCandidates`` field → wire enum, in enum declaration order
-# so ``cache_corroboration`` lists legs deterministically.
-_EQUALITY_LEGS: tuple[tuple[str, ArtistResolveCacheLeg], ...] = (
-    ("exact", ArtistResolveCacheLeg.cache_exact),
-    ("member", ArtistResolveCacheLeg.cache_member),
-    ("alias", ArtistResolveCacheLeg.cache_alias),
-    ("name_variation", ArtistResolveCacheLeg.cache_name_variation),
-)
+# Discogs's trailing artist disambiguator ("Popsicle (2)"). Applied to the
+# RAW input: the identity-match form strips it, so it is the only signal
+# separating a suffixed input from its bare-form namesake.
+_DISAMBIG_SUFFIX_RE = re.compile(r"\((\d+)\)\s*$")
 
 
 @dataclass
@@ -68,8 +97,12 @@ class ResolveStats:
     """Per-request aggregates for the route's Sentry span + PostHog event.
 
     Verdict counters count response POSITIONS (duplicates share their
-    form's verdict), so they sum to ``names``; ``deduped``, ``api_calls``
-    and ``minted`` count unique work units.
+    group's verdict), so they sum to ``names``. ``deduped`` counts unique
+    ``(form, disambiguator)`` groups and ``minted`` counts upserts
+    performed. ``api_calls`` counts ``search_artists`` probes that
+    reached the outbound path — including ones that came back ``None``
+    (a 429-exhausted or distrusted probe still consumed shared-limiter
+    budget); breaker-shed names never probe and are not counted.
     """
 
     names: int = 0
@@ -84,60 +117,74 @@ class ResolveStats:
 
 @dataclass
 class _FormGroup:
-    """One unique identity-match form: the resolver's unit of work."""
+    """One unique ``(identity-match form, "(N)" suffix)``: the unit of work."""
 
     form: str
+    disambig: int | None
     first_verbatim: str
     # Key the mint targets: the first occurrence's verbatim, or the stored
     # ``library_name`` when tier 1 found a Discogs-id-less row to fill.
     mint_key: str
+    # Distinct raw spellings in position order; tier 1 reads all of them,
+    # tier 3 probes with min() so the verdict can't depend on input order.
+    verbatims: list[str] = field(default_factory=list)
     corroboration: list[ArtistResolveCacheLeg] = field(default_factory=list)
     equality_union: set[int] = field(default_factory=set)
-    # Verdict payload, shared by every input position in the group; the
-    # per-position ``name`` echo is added at fan-back.
-    payload: dict | None = None
+    # The group's verdict; fan-back re-stamps only the per-position name.
+    result: ArtistResolveResult | None = None
+
+    @property
+    def probe(self) -> str:
+        """Deterministic tier-3 query string (content-, not order-, derived)."""
+        return min(self.verbatims)
+
+    def unresolved(
+        self,
+        *,
+        reason: ArtistResolveUnresolvedReason,
+        candidate_count: int | None,
+    ) -> ArtistResolveResult:
+        return ArtistResolveResult(
+            name=self.first_verbatim,
+            discogs_artist_id=None,
+            canonical_name=None,
+            method=None,
+            cache_corroboration=self.corroboration,
+            unresolved_reason=reason,
+            candidate_count=candidate_count,
+        )
 
 
-def _resolved_payload(
-    *,
-    discogs_artist_id: int,
-    method: ArtistResolveMethod,
-    canonical_name: str | None,
-    corroboration: list[ArtistResolveCacheLeg],
-    candidate_count: int | None,
-) -> dict:
-    return {
-        "discogs_artist_id": discogs_artist_id,
-        "canonical_name": canonical_name,
-        "method": method,
-        "cache_corroboration": corroboration,
-        "unresolved_reason": None,
-        "candidate_count": candidate_count,
-    }
+def _validate_name(index: int, name: str) -> str:
+    """Return the identity-match form, or raise ValueError (route → 422).
 
-
-def _unresolved_payload(
-    *,
-    reason: ArtistResolveUnresolvedReason,
-    corroboration: list[ArtistResolveCacheLeg],
-    candidate_count: int | None,
-) -> dict:
-    return {
-        "discogs_artist_id": None,
-        "canonical_name": None,
-        "method": None,
-        "cache_corroboration": corroboration,
-        "unresolved_reason": reason,
-        "candidate_count": candidate_count,
-    }
+    Garbage input must not receive an in-band verdict: ``not_found`` is a
+    measured zero a consumer may durably negative-cache, and a NUL that
+    reaches the tier-2 PG binds fails the whole batch as a fake cache
+    outage (PG rejects U+0000 in text). Note the empty-form rejection is
+    a v1 recall limit for names that are ALL punctuation-stripped by the
+    normalizer (e.g. the band "!!!" survives — its form is "!!!" — but a
+    name normalizing to "" has no queryable identity anywhere in the
+    pipeline).
+    """
+    if "\x00" in name:
+        raise ValueError(f"names[{index}] contains U+0000 (NUL); fix the input at its source")
+    if not name.strip():
+        raise ValueError(f"names[{index}] is blank")
+    try:
+        form = to_identity_match_form(name)
+    except UnicodeEncodeError as e:
+        raise ValueError(f"names[{index}] is not encodable Unicode (lone surrogate?)") from e
+    if not form:
+        raise ValueError(f"names[{index}] normalizes to an empty identity-match form")
+    return form
 
 
 class BareNameArtistResolver:
     """Verdict assembly for ``POST /api/v1/artists/resolve/bulk``.
 
     Args:
-        entity_store: ``entity.identity`` reads (tier 1) and the
-            never-clobber write-back.
+        entity_store: ``entity.identity`` reads (tier 1) and the write-back.
         discogs_cache: The LML#759 candidate-set evidence queries (tier 2).
         discogs_service: The live Discogs API (tier 3). ``None`` when no
             token is configured — PG tiers keep answering and API-needing
@@ -164,6 +211,9 @@ class BareNameArtistResolver:
         verification — but skips the ``entity.identity`` upsert.
 
         Raises:
+            ValueError: on invalid input names (NUL, blank, lone
+                surrogates, empty identity-match form) — caller error,
+                not a measurement; the route maps it to 422.
             CacheUnavailableError: tier-2 PG failure (route → 503).
             PostgresError / OSError: tier-1 or write-back PG failure
                 (route → 503). Discogs API failures never raise — they
@@ -171,127 +221,175 @@ class BareNameArtistResolver:
         """
         stats = ResolveStats(names=len(names))
 
-        # Dedupe on the identity-match form; dict order = first occurrence.
-        groups: dict[str, _FormGroup] = {}
-        for name in names:
-            form = to_identity_match_form(name)
-            if form not in groups:
-                groups[form] = _FormGroup(form=form, first_verbatim=name, mint_key=name)
+        # Group on (form, disambiguator); dict order = first occurrence.
+        # ``order[i]`` is names[i]'s group, so fan-back never re-normalizes.
+        groups: dict[tuple[str, int | None], _FormGroup] = {}
+        order: list[_FormGroup] = []
+        for index, name in enumerate(names):
+            form = _validate_name(index, name)
+            suffix = _DISAMBIG_SUFFIX_RE.search(name)
+            key = (form, int(suffix.group(1)) if suffix else None)
+            group = groups.get(key)
+            if group is None:
+                group = _FormGroup(form=form, disambig=key[1], first_verbatim=name, mint_key=name)
+                groups[key] = group
+            if name not in group.verbatims:
+                group.verbatims.append(name)
+            order.append(group)
         stats.deduped = len(groups)
 
         # --- Tier 1: batched three-leg entity.identity read. -------------
+        # Every distinct verbatim is read (identical strings can't span
+        # groups, so the flattened list stays duplicate-free).
         identities = await self._entity_store.bulk_resolve_library_names(
-            [g.first_verbatim for g in groups.values()]
+            [verbatim for group in groups.values() for verbatim in group.verbatims]
         )
         pending: list[_FormGroup] = []
-        for g in groups.values():
-            identity = identities.get(g.first_verbatim)
-            if identity is not None and identity.discogs_artist_id is not None:
-                g.payload = _resolved_payload(
-                    discogs_artist_id=identity.discogs_artist_id,
-                    method=ArtistResolveMethod.identity_store,
+        for group in groups.values():
+            decided = None
+            fillable = None
+            for verbatim in group.verbatims:
+                identity = identities.get(verbatim)
+                if identity is None:
+                    continue
+                if group.disambig is not None and identity.library_name != verbatim:
+                    # The store's canonical leg strips "(N)" too, so a
+                    # bare-form row can answer a suffixed read. Only an
+                    # exact stored key may decide a suffixed group — the
+                    # suffix exists because the bare name is someone else.
+                    continue
+                if identity.discogs_artist_id is not None:
+                    decided = identity
+                    break
+                if fillable is None:
+                    # Row exists but can't answer — fill IT on mint, in
+                    # place, instead of accreting a near-duplicate key.
+                    fillable = identity
+            if decided is not None:
+                group.result = ArtistResolveResult(
+                    name=group.first_verbatim,
+                    discogs_artist_id=decided.discogs_artist_id,
                     # entity.identity stores no Discogs title.
                     canonical_name=None,
+                    method=ArtistResolveMethod.identity_store,
                     # The store decides before cache evidence is consulted.
-                    corroboration=[],
+                    cache_corroboration=[],
+                    unresolved_reason=None,
                     candidate_count=None,
                 )
                 continue
-            if identity is not None:
-                # Row exists but can't answer — fill IT on mint, in place.
-                g.mint_key = identity.library_name
-            if not g.form:
-                # Nothing queryable: the cache legs key on the form and the
-                # API filter compares forms. candidate_count stays null —
-                # nothing was measured.
-                g.payload = _unresolved_payload(
-                    reason=ArtistResolveUnresolvedReason.not_found,
-                    corroboration=[],
-                    candidate_count=None,
-                )
-                continue
-            pending.append(g)
+            if fillable is not None:
+                group.mint_key = fillable.library_name
+            pending.append(group)
 
         # --- Tier 2: batched cache evidence (corroboration, never verdicts).
         if pending:
+            # Groups can share a form (bare + suffixed); dedupe the binds.
             equality = await self._discogs_cache.artist_equality_candidates(
-                [g.form for g in pending]
+                list(dict.fromkeys(group.form for group in pending))
             )
             trigram = await self._discogs_cache.artist_trigram_candidates(
-                [g.first_verbatim for g in pending]
+                [group.probe for group in pending]
             )
-            for g in pending:
-                legs = equality.get(g.form, ArtistEqualityCandidates())
-                g.corroboration = [
-                    enum_leg for attr, enum_leg in _EQUALITY_LEGS if getattr(legs, attr)
+            for group in pending:
+                # Direct indexing on purpose: both queries promise every
+                # input key present (measured zeroes as empty sets), and a
+                # silent .get() default would mask a contract break that
+                # must fail loudly (a dropped candidate set can mint).
+                legs = equality[group.form]
+                # Leg field names are the wire enum values minus the
+                # "cache_" prefix — a rename fails loudly here.
+                group.corroboration = [
+                    ArtistResolveCacheLeg(f"cache_{leg}") for leg in legs.nonempty_legs()
                 ]
-                if trigram.get(g.first_verbatim):
-                    g.corroboration.append(ArtistResolveCacheLeg.cache_trigram)
+                if trigram[group.probe]:
+                    group.corroboration.append(ArtistResolveCacheLeg.cache_trigram)
                 # Trigram neighbors are excluded on purpose: the conflict
                 # rule is scoped to the equality legs.
-                g.equality_union = legs.exact | legs.member | legs.alias | legs.name_variation
+                group.equality_union = legs.all_candidate_ids()
 
         # --- Tier 3: serial exact-form uniqueness checks. -----------------
         # A breaker trip sheds the REST of the batch immediately — one shed,
         # not one per remaining name (no queueing behind the cool-down).
         service = self._discogs_service
         shed = False
-        for g in pending:
-            if service is None or shed:
-                g.payload = _unresolved_payload(
-                    reason=ArtistResolveUnresolvedReason.escalation_unavailable,
-                    corroboration=g.corroboration,
-                    candidate_count=None,
-                )
-                continue
-            try:
-                page = await service.search_artists(g.first_verbatim)
-            except DiscogsBreakerOpenError:
-                logger.warning(
-                    "artist-resolve breaker shed at '%s'; short-circuiting remaining batch",
-                    g.first_verbatim,
-                )
-                shed = True
-                page = None
+        for group in pending:
+            page = None
+            if service is not None and not shed:
+                try:
+                    page = await service.search_artists(group.probe)
+                except DiscogsBreakerOpenError:
+                    logger.warning(
+                        "artist-resolve breaker shed at '%s'; short-circuiting remaining batch",
+                        group.probe,
+                    )
+                    shed = True
+                else:
+                    stats.api_calls += 1
             if page is None:
-                # Couldn't ask (shed / 429-exhausted / network / distrusted
-                # page) — retryable, and never a measured zero.
-                g.payload = _unresolved_payload(
+                # Couldn't ask (no service / shed / 429-exhausted / network
+                # / distrusted page) — retryable, never a measured zero.
+                group.result = group.unresolved(
                     reason=ArtistResolveUnresolvedReason.escalation_unavailable,
-                    corroboration=g.corroboration,
                     candidate_count=None,
                 )
                 continue
-            stats.api_calls += 1
-            g.payload = await self._api_verdict(g, page, dry_run=dry_run, stats=stats)
+            group.result = await self._api_verdict(group, page, dry_run=dry_run, stats=stats)
 
-        # --- Fan-back: every position gets its form's verdict. -------------
+        # --- Fan-back: every position gets its group's verdict. -----------
         results: list[ArtistResolveResult] = []
-        for name in names:
-            g = groups[to_identity_match_form(name)]
-            assert g.payload is not None  # every group got a verdict above
-            results.append(ArtistResolveResult(name=name, **g.payload))
-            if g.payload["unresolved_reason"] is None:
+        for name, group in zip(names, order, strict=True):
+            if group.result is None:
+                # Not an assert: this guard is control flow, and must
+                # survive python -O.
+                raise RuntimeError(f"artist-resolve group '{group.form}' got no verdict")
+            results.append(group.result.model_copy(update={"name": name}))
+            reason = group.result.unresolved_reason
+            if reason is None:
                 stats.resolved += 1
-            elif g.payload["unresolved_reason"] is ArtistResolveUnresolvedReason.not_found:
+            elif reason == ArtistResolveUnresolvedReason.not_found:
                 stats.not_found += 1
-            elif g.payload["unresolved_reason"] is ArtistResolveUnresolvedReason.ambiguous:
+            elif reason == ArtistResolveUnresolvedReason.ambiguous:
                 stats.ambiguous += 1
-            else:
+            elif reason == ArtistResolveUnresolvedReason.escalation_unavailable:
                 stats.escalation_unavailable += 1
+            else:
+                # The resolver only ever assigns the three reasons above;
+                # anything else is a bug in this module, not bad input.
+                raise RuntimeError(f"artist-resolve produced unknown verdict reason {reason!r}")
         return results, stats
 
     async def _api_verdict(
-        self, g: _FormGroup, page: list, *, dry_run: bool, stats: ResolveStats
-    ) -> dict:
+        self,
+        group: _FormGroup,
+        page: list,
+        *,
+        dry_run: bool,
+        stats: ResolveStats,
+    ) -> ArtistResolveResult:
         """Apply the verdict table to a measured single-page observation."""
-        # Exact-form family, distinct by artist id. The identity-match form
-        # strips the "(N)" disambiguator, so "Popsicle (2)" collides with
-        # "Popsicle" — that strip IS the overload detection.
+        # Exact-form family, distinct by artist id (first title per id
+        # wins — page order is the API's relevance order). The
+        # identity-match form strips the "(N)" disambiguator, so
+        # "Popsicle (2)" collides with "Popsicle" — that strip IS the
+        # overload detection.
         candidates: dict[int, str] = {}
-        for item in page:
-            if to_identity_match_form(item.title) == g.form and item.artist_id not in candidates:
-                candidates[item.artist_id] = item.title
+        try:
+            for item in page:
+                if to_identity_match_form(item.title) == group.form:
+                    candidates.setdefault(item.artist_id, item.title)
+        except UnicodeEncodeError:
+            # A title the normalizer cannot encode distrusts the WHOLE
+            # page (same posture as search_artists's malformed-item
+            # guard): a partially-filtered family could read false-unique
+            # and mint wrong.
+            logger.warning(
+                "artist-resolve distrusting page for '%s': unencodable title", group.probe
+            )
+            return group.unresolved(
+                reason=ArtistResolveUnresolvedReason.escalation_unavailable,
+                candidate_count=None,
+            )
         count = len(candidates)
 
         if count == 0:
@@ -299,49 +397,55 @@ class BareNameArtistResolver:
             # something: alias-shaped matches can't be globally
             # uniqueness-checked, so v1 declines to mint and counts them
             # (in cache_corroboration) to size a possible v2 alias arm.
-            return _unresolved_payload(
+            return group.unresolved(
                 reason=ArtistResolveUnresolvedReason.not_found,
-                corroboration=g.corroboration,
                 candidate_count=0,
             )
         if count >= 2:
             # No auxiliary disambiguation in v1 — never a guess.
-            return _unresolved_payload(
+            return group.unresolved(
                 reason=ArtistResolveUnresolvedReason.ambiguous,
-                corroboration=g.corroboration,
                 candidate_count=count,
             )
 
         ((winner_id, winner_title),) = candidates.items()
-        if g.equality_union - {winner_id}:
+        if group.equality_union - {winner_id}:
             # An equality-leg cache candidate points at a different artist:
             # conflict means doubt, doubt means NULL.
-            return _unresolved_payload(
+            return group.unresolved(
                 reason=ArtistResolveUnresolvedReason.ambiguous,
-                corroboration=g.corroboration,
                 candidate_count=1,
             )
 
-        if not dry_run:
+        if not dry_run and group.disambig is None:
             # discogs_artist_id only — other id columns belong to their own
-            # enrichment flows. COALESCE keeps pre-existing ids intact.
+            # enrichment flows. COALESCE guards NULL-overwrites only; not
+            # clobbering an EXISTING id rests on the tier-1 gate, which is
+            # a stale read by mint time (LML#766 tracks the store-level
+            # fill-if-null fix). Suffix-bearing groups skip the mint
+            # entirely: a "(N)" key is unreachable via the three-leg read.
             upserted = await self._entity_store.upsert_identity(
-                g.mint_key, discogs_artist_id=winner_id
+                group.mint_key, discogs_artist_id=winner_id
             )
             if upserted is None:
+                # upsert_identity's contract allows a None return for a
+                # swallowed failure; today's PgSource raises instead (the
+                # route 503s), so this branch is belt-and-braces.
                 logger.error(
                     "entity.identity write-back failed for '%s' (discogs_artist_id=%d)",
-                    g.mint_key,
+                    group.mint_key,
                     winner_id,
                 )
             else:
                 stats.minted += 1
-        return _resolved_payload(
+        return ArtistResolveResult(
+            name=group.first_verbatim,
             discogs_artist_id=winner_id,
-            method=ArtistResolveMethod.api_search,
             # The raw Discogs title, "(N)" suffix included — provenance
             # wants the true Discogs string.
             canonical_name=winner_title,
-            corroboration=g.corroboration,
+            method=ArtistResolveMethod.api_search,
+            cache_corroboration=group.corroboration,
+            unresolved_reason=None,
             candidate_count=1,
         )

--- a/artists/resolver.py
+++ b/artists/resolver.py
@@ -10,44 +10,67 @@ check against the Discogs API. Cache results are evidence (corroboration
 not mint, because nothing self-corrects a wrong row (see the write-back
 note below).
 
-Inputs are validated before any tier runs: NUL-bearing, blank,
-non-encodable, and empty-identity-form names raise ``ValueError`` (the
-route maps it to 422) rather than receiving an in-band verdict — the
-wire contract's ``not_found`` means "the API tier ran and measured
-zero", which is never true of garbage input, and a NUL reaching the
-tier-2 PG binds would 503 the whole batch as a fake cache outage.
+Inputs are trimmed, then validated before any tier runs: NUL-bearing,
+blank, non-encodable, empty-identity-form, and qualifier-only names
+raise ``ValueError`` (the route maps it to 422) rather than receiving an
+in-band verdict — the wire contract's ``not_found`` means "the API tier
+ran and measured zero", which is never true of garbage input, and a NUL
+reaching the tier-2 PG binds would 503 the whole batch as a fake cache
+outage.
 
-Work units are groups keyed on ``(identity_match_form, "(N)" suffix)``.
-The form strips Discogs's trailing "(N)" disambiguator, which is
-load-bearing for overload DETECTION at the API tier — but a raw input
-that carries the suffix denotes a *different artist* than the bare name
-by Discogs convention, so suffixed inputs get their own group instead of
-inheriting the bare form's verdict (a stored ``Popsicle`` row must never
-answer for ``Popsicle (2)``).
+Work units are groups keyed on ``(identity_match_form, trailing
+qualifier)``. The identity-match form strips a trailing parenthesized or
+bracketed qualifier — Discogs's "(N)" disambiguator is the motivating
+case — which is load-bearing for overload DETECTION at the API tier. But
+a raw input carrying a qualifier denotes something other than the bare
+name (a different same-named artist, a scraper artifact, a decoration),
+so qualified inputs get their own group instead of inheriting the bare
+form's verdict: a stored ``Popsicle`` row must never answer for
+``Popsicle (2)``. Qualifiers are detected on the NFKC-folded, lowercased
+raw name so width/case variants ("（２）") key with their ASCII twins —
+the same folds the normalizer itself applies. The deliberate cost: a
+legitimately-decorated name ("!!! (Chk Chk Chk)") resolves only when
+Discogs titles the artist with the same qualifier; otherwise it lands
+``ambiguous``/``not_found`` and surfaces in the drain residual rather
+than risk a wrong mint.
 
 Tiers, per group:
 
 1. ``EntityStore.bulk_resolve_library_names`` over **every** distinct
    verbatim in the group — a group-mate's exact stored row must not be
-   invisible just because a different spelling came first. A row
-   carrying ``discogs_artist_id`` decides (``method: identity_store``);
-   for suffix-bearing groups only an exact ``library_name`` match may
-   decide (the store's canonical read leg strips the suffix too, and a
-   bare-form row must not answer for the suffixed artist). A
-   Discogs-id-less row does not decide, but its stored key becomes the
-   mint target so the upsert fills that row in place instead of
-   accreting a near-duplicate key.
+   invisible just because a different spelling came first. A row may
+   decide only when its OWN stored key carries the group's qualifier
+   (the store's canonical read leg strips qualifiers too, so a bare-form
+   row can come back for a qualified read; byte-equality is NOT required
+   — a case/width variant of a genuinely-qualified stored key still
+   decides). Rows carrying ``discogs_artist_id`` decide
+   (``method: identity_store``) — unless two distinct ids surface across
+   the group's verbatims, which is the store contradicting itself:
+   conflict means doubt, doubt means NULL (``ambiguous``, and
+   deterministic in batch content where first-wins would flip with input
+   order). A Discogs-id-less row does not decide, but for unqualified
+   groups its stored key becomes the mint target so the upsert fills
+   that row in place instead of accreting a near-duplicate key.
 2. ``DiscogsCacheService.artist_equality_candidates`` +
    ``artist_trigram_candidates`` — candidate SETS (an equality-leg
    candidate that disagrees with the API winner forces ``ambiguous``;
-   trigram neighbors are yield telemetry and never veto).
+   trigram neighbors are yield telemetry and never veto). **Unqualified
+   groups only**: the cache legs key on the qualifier-stripped form, so
+   for a qualified group they cannot distinguish the family member the
+   qualifier names — evidence that can neither corroborate nor veto a
+   specific member is skipped, not consulted (it would also bind
+   non-fixed-point forms like ``sault (2)`` that the SQL normalizer
+   strips differently, measuring false zeroes).
 3. ``DiscogsService.search_artists`` — the exact-form uniqueness check,
-   probed with a deterministic representative of the group
-   (``min()`` of its verbatims) so the single-page observation universe
-   cannot vary with input order. Serial, never fanned out: the shared
-   limiter paces globally at 50/min, so intra-request concurrency can't
-   beat it and only starves interleaved live-lookup traffic of
-   semaphore slots (LML#370/#372).
+   probed with a deterministic representative of the group (``min()`` of
+   its verbatims) so the single-page observation universe cannot vary
+   with input order. The lone exact-form candidate's OWN title qualifier
+   must equal the group's: a "(N)"-titled singleton answering a bare
+   input is evidence of an overloaded family whose bare member missed
+   the page (and vice versa) — ``ambiguous``, never a guess. Serial,
+   never fanned out: the shared limiter paces globally at 50/min, so
+   intra-request concurrency can't beat it and only starves interleaved
+   live-lookup traffic of semaphore slots (LML#370/#372).
 
 Write-back: ``upsert_identity``'s ON CONFLICT arm is
 ``COALESCE(EXCLUDED.discogs_artist_id, existing)`` — **new wins when
@@ -56,9 +79,12 @@ overwriting an existing id therefore rests on the tier-1 read gate,
 which is up to ~30s stale at mint time under the serial API pacing — a
 concurrent writer in that window is silently overwritten (LML#766
 tracks the store-level fill-if-null primitive that closes this).
-Suffix-bearing groups never mint: a "(N)"-keyed row is unreachable via
-the three-leg read and pure pollution (per the #759 design), so a
-suffixed winner is returned to the caller but not persisted.
+Qualifier-bearing groups never mint: a qualified key is unreachable via
+the bare-name reads Backend actually issues (only an exact-leg read of
+the same qualified string finds it — which is also why such a stored row
+may legitimately decide its own group) and is pure pollution per the
+#759 design, so a qualified winner is returned to the caller but not
+persisted.
 
 The deliberate divergence from the reconciler's first-match-wins cascade
 (``scripts/entity_resolution/discogs.py``) is documented on the
@@ -69,14 +95,16 @@ from __future__ import annotations
 
 import logging
 import re
+import unicodedata
 from dataclasses import dataclass, field
 
 from wxyc_etl.text import to_identity_match_form
 
 from discogs.breaker import DiscogsBreakerOpenError
 from discogs.cache_service import DiscogsCacheService
+from discogs.models import DiscogsArtistSearchResult
 from discogs.service import DiscogsService
-from entity.store import EntityStore
+from entity.store import EntityStore, Identity
 from generated.api_models import (
     ArtistResolveCacheLeg,
     ArtistResolveMethod,
@@ -86,10 +114,28 @@ from generated.api_models import (
 
 logger = logging.getLogger(__name__)
 
-# Discogs's trailing artist disambiguator ("Popsicle (2)"). Applied to the
-# RAW input: the identity-match form strips it, so it is the only signal
-# separating a suffixed input from its bare-form namesake.
-_DISAMBIG_SUFFIX_RE = re.compile(r"\((\d+)\)\s*$")
+# A trailing parenthesized/bracketed qualifier — Discogs's "(N)" artist
+# disambiguator is the motivating case, but the identity-match form strips
+# ANY trailing group (including "[2]", "(Sweden)", "(1975)"), so qualifier
+# detection must cover the same surface or a variant spelling silently
+# rejoins the bare group. Matched against the NFKC-folded lowercase name
+# (below) so fullwidth "（２）" keys identically to "(2)".
+_TRAILING_QUALIFIER_RE = re.compile(r"([(\[][^()\[\]]*[)\]])\s*$")
+
+
+def _split_trailing_qualifier(name: str) -> tuple[str | None, str]:
+    """Return ``(qualifier, prefix)`` from the NFKC-folded lowercase name.
+
+    ``qualifier`` is the folded trailing group text (``None`` when the
+    name has no trailing qualifier); ``prefix`` is the folded text before
+    it. Folding mirrors the normalizer's own width/case folds so this
+    yields one canonical qualifier key per semantic spelling.
+    """
+    folded = unicodedata.normalize("NFKC", name).lower()
+    match = _TRAILING_QUALIFIER_RE.search(folded)
+    if match is None:
+        return None, folded
+    return match.group(1), folded[: match.start()]
 
 
 @dataclass
@@ -98,11 +144,14 @@ class ResolveStats:
 
     Verdict counters count response POSITIONS (duplicates share their
     group's verdict), so they sum to ``names``. ``deduped`` counts unique
-    ``(form, disambiguator)`` groups and ``minted`` counts upserts
-    performed. ``api_calls`` counts ``search_artists`` probes that
-    reached the outbound path — including ones that came back ``None``
-    (a 429-exhausted or distrusted probe still consumed shared-limiter
-    budget); breaker-shed names never probe and are not counted.
+    ``(form, qualifier)`` groups and ``minted`` counts upserts performed.
+    ``api_calls`` counts ``search_artists`` probes that returned to the
+    resolver — including ``None`` returns (a 429-exhausted or distrusted
+    probe still consumed shared-limiter budget). A probe shed by the
+    breaker is not counted: usually it was refused at entry before any
+    HTTP left the building, though a mid-flight open may have spent
+    attempts first — the service-level cache-stats counters carry the
+    exact per-request HTTP tally.
     """
 
     names: int = 0
@@ -117,16 +166,17 @@ class ResolveStats:
 
 @dataclass
 class _FormGroup:
-    """One unique ``(identity-match form, "(N)" suffix)``: the unit of work."""
+    """One unique ``(identity-match form, trailing qualifier)`` work unit."""
 
     form: str
-    disambig: int | None
-    first_verbatim: str
-    # Key the mint targets: the first occurrence's verbatim, or the stored
-    # ``library_name`` when tier 1 found a Discogs-id-less row to fill.
+    qualifier: str | None
+    # Key the mint targets: the first occurrence's trimmed verbatim, or
+    # the stored ``library_name`` when tier 1 found a Discogs-id-less row
+    # to fill (unqualified groups only — qualified groups never mint).
     mint_key: str
-    # Distinct raw spellings in position order; tier 1 reads all of them,
-    # tier 3 probes with min() so the verdict can't depend on input order.
+    # Distinct trimmed spellings in position order; tier 1 reads all of
+    # them, tier 3 probes with min() so the observation universe can't
+    # depend on input order.
     verbatims: list[str] = field(default_factory=list)
     corroboration: list[ArtistResolveCacheLeg] = field(default_factory=list)
     equality_union: set[int] = field(default_factory=set)
@@ -134,9 +184,31 @@ class _FormGroup:
     result: ArtistResolveResult | None = None
 
     @property
+    def first_verbatim(self) -> str:
+        return self.verbatims[0]
+
+    @property
     def probe(self) -> str:
         """Deterministic tier-3 query string (content-, not order-, derived)."""
         return min(self.verbatims)
+
+    def resolved(
+        self,
+        *,
+        discogs_artist_id: int,
+        method: ArtistResolveMethod,
+        canonical_name: str | None,
+        candidate_count: int | None,
+    ) -> ArtistResolveResult:
+        return ArtistResolveResult(
+            name=self.first_verbatim,
+            discogs_artist_id=discogs_artist_id,
+            canonical_name=canonical_name,
+            method=method,
+            cache_corroboration=self.corroboration,
+            unresolved_reason=None,
+            candidate_count=candidate_count,
+        )
 
     def unresolved(
         self,
@@ -155,21 +227,21 @@ class _FormGroup:
         )
 
 
-def _validate_name(index: int, name: str) -> str:
-    """Return the identity-match form, or raise ValueError (route → 422).
+def _validate_name(index: int, name: str) -> tuple[str, str | None]:
+    """Return ``(identity-match form, qualifier)`` or raise ValueError.
 
-    Garbage input must not receive an in-band verdict: ``not_found`` is a
-    measured zero a consumer may durably negative-cache, and a NUL that
-    reaches the tier-2 PG binds fails the whole batch as a fake cache
-    outage (PG rejects U+0000 in text). Note the empty-form rejection is
-    a v1 recall limit for names that are ALL punctuation-stripped by the
-    normalizer (e.g. the band "!!!" survives — its form is "!!!" — but a
-    name normalizing to "" has no queryable identity anywhere in the
-    pipeline).
+    ``name`` arrives pre-trimmed. Garbage input must not receive an
+    in-band verdict: ``not_found`` is a measured zero a consumer may
+    durably negative-cache, and a NUL that reaches the tier-2 PG binds
+    fails the whole batch as a fake cache outage (PG rejects U+0000 in
+    text). The empty-form and qualifier-only rejections are a v1 recall
+    limit for names with no identity content — the band "!!!" survives
+    (its form is "!!!"), but "" and "(2)" have nothing to resolve.
+    The route maps ValueError to 422.
     """
     if "\x00" in name:
         raise ValueError(f"names[{index}] contains U+0000 (NUL); fix the input at its source")
-    if not name.strip():
+    if not name:
         raise ValueError(f"names[{index}] is blank")
     try:
         form = to_identity_match_form(name)
@@ -177,7 +249,13 @@ def _validate_name(index: int, name: str) -> str:
         raise ValueError(f"names[{index}] is not encodable Unicode (lone surrogate?)") from e
     if not form:
         raise ValueError(f"names[{index}] normalizes to an empty identity-match form")
-    return form
+    qualifier, prefix = _split_trailing_qualifier(name)
+    if qualifier is not None and not prefix.strip():
+        raise ValueError(
+            f"names[{index}] is only a trailing qualifier (e.g. a bare Discogs "
+            "disambiguator) with no artist name before it"
+        )
+    return form, qualifier
 
 
 class BareNameArtistResolver:
@@ -207,13 +285,19 @@ class BareNameArtistResolver:
     ) -> tuple[list[ArtistResolveResult], ResolveStats]:
         """Resolve a batch of bare names; results are index-aligned with it.
 
+        Each ``results[i].name`` echoes ``names[i]`` byte-for-byte; all
+        internal work (grouping, store reads, probes, mint keys) uses the
+        whitespace-trimmed spelling so a stray trailing space can't mint
+        a padded ``library_name`` the store's exact leg would never find.
+
         ``dry_run`` runs every tier identically — including live API
         verification — but skips the ``entity.identity`` upsert.
 
         Raises:
             ValueError: on invalid input names (NUL, blank, lone
-                surrogates, empty identity-match form) — caller error,
-                not a measurement; the route maps it to 422.
+                surrogates, empty identity-match form, qualifier-only
+                strings) — caller error, not a measurement; the route
+                maps it to 422.
             CacheUnavailableError: tier-2 PG failure (route → 503).
             PostgresError / OSError: tier-1 or write-back PG failure
                 (route → 503). Discogs API failures never raise — they
@@ -221,87 +305,120 @@ class BareNameArtistResolver:
         """
         stats = ResolveStats(names=len(names))
 
-        # Group on (form, disambiguator); dict order = first occurrence.
+        # Group on (form, qualifier); dict order = first occurrence.
         # ``order[i]`` is names[i]'s group, so fan-back never re-normalizes.
-        groups: dict[tuple[str, int | None], _FormGroup] = {}
+        groups: dict[tuple[str, str | None], _FormGroup] = {}
         order: list[_FormGroup] = []
         for index, name in enumerate(names):
-            form = _validate_name(index, name)
-            suffix = _DISAMBIG_SUFFIX_RE.search(name)
-            key = (form, int(suffix.group(1)) if suffix else None)
+            trimmed = name.strip()
+            form, qualifier = _validate_name(index, trimmed)
+            key = (form, qualifier)
             group = groups.get(key)
             if group is None:
-                group = _FormGroup(form=form, disambig=key[1], first_verbatim=name, mint_key=name)
+                group = _FormGroup(form=form, qualifier=qualifier, mint_key=trimmed)
                 groups[key] = group
-            if name not in group.verbatims:
-                group.verbatims.append(name)
+            if trimmed not in group.verbatims:
+                group.verbatims.append(trimmed)
             order.append(group)
         stats.deduped = len(groups)
 
         # --- Tier 1: batched three-leg entity.identity read. -------------
-        # Every distinct verbatim is read (identical strings can't span
-        # groups, so the flattened list stays duplicate-free).
+        # Every distinct trimmed verbatim is read (identical strings can't
+        # span groups, so the flattened list stays duplicate-free).
         identities = await self._entity_store.bulk_resolve_library_names(
             [verbatim for group in groups.values() for verbatim in group.verbatims]
         )
         pending: list[_FormGroup] = []
         for group in groups.values():
-            decided = None
-            fillable = None
+            decided: dict[int, Identity] = {}
+            fillables: list[Identity] = []
             for verbatim in group.verbatims:
                 identity = identities.get(verbatim)
                 if identity is None:
                     continue
-                if group.disambig is not None and identity.library_name != verbatim:
-                    # The store's canonical leg strips "(N)" too, so a
-                    # bare-form row can answer a suffixed read. Only an
-                    # exact stored key may decide a suffixed group — the
-                    # suffix exists because the bare name is someone else.
+                row_qualifier, _ = _split_trailing_qualifier(identity.library_name)
+                if row_qualifier != group.qualifier:
+                    # The store's LOWER/canonical legs can hand back a
+                    # bare-form row for a qualified read (the canonical
+                    # leg strips qualifiers too) — only a row whose OWN
+                    # key carries the group's qualifier may speak for it.
+                    # Compared on the folded qualifier, not byte equality,
+                    # so a case/width variant of a genuinely-qualified
+                    # stored key still decides (refusing it would make the
+                    # name permanently unresolvable here, since qualified
+                    # groups never mint).
                     continue
                 if identity.discogs_artist_id is not None:
-                    decided = identity
-                    break
-                if fillable is None:
-                    # Row exists but can't answer — fill IT on mint, in
-                    # place, instead of accreting a near-duplicate key.
-                    fillable = identity
-            if decided is not None:
-                group.result = ArtistResolveResult(
-                    name=group.first_verbatim,
-                    discogs_artist_id=decided.discogs_artist_id,
-                    # entity.identity stores no Discogs title.
-                    canonical_name=None,
-                    method=ArtistResolveMethod.identity_store,
-                    # The store decides before cache evidence is consulted.
-                    cache_corroboration=[],
-                    unresolved_reason=None,
+                    decided[identity.discogs_artist_id] = identity
+                elif group.qualifier is None:
+                    fillables.append(identity)
+            if len(decided) > 1:
+                # Two verbatims of one group hit store rows with different
+                # ids — near-duplicate-key accretion contradicting itself.
+                # First-wins would flip the verdict with input order;
+                # conflict means doubt, doubt means NULL. candidate_count
+                # stays null: the API tier never ran, nothing was measured.
+                logger.warning(
+                    "artist-resolve store conflict for form '%s': ids %s",
+                    group.form,
+                    sorted(decided),
+                )
+                group.result = group.unresolved(
+                    reason=ArtistResolveUnresolvedReason.ambiguous,
                     candidate_count=None,
                 )
                 continue
-            if fillable is not None:
-                group.mint_key = fillable.library_name
+            if decided:
+                (artist_id,) = decided
+                group.result = group.resolved(
+                    discogs_artist_id=artist_id,
+                    method=ArtistResolveMethod.identity_store,
+                    # entity.identity stores no Discogs title.
+                    canonical_name=None,
+                    # The store decides before cache evidence is consulted;
+                    # corroboration stays empty, count stays unmeasured.
+                    candidate_count=None,
+                )
+                continue
+            if fillables:
+                # Deterministic fill target (content-, not order-, derived):
+                # fill IT in place instead of accreting a near-duplicate key.
+                group.mint_key = min(fillables, key=lambda row: row.library_name).library_name
             pending.append(group)
 
         # --- Tier 2: batched cache evidence (corroboration, never verdicts).
-        if pending:
-            # Groups can share a form (bare + suffixed); dedupe the binds.
+        # Unqualified groups only — the cache legs key on the
+        # qualifier-stripped form and cannot distinguish which family
+        # member a qualifier names, so their evidence can neither
+        # corroborate nor veto a qualified group (and multi-qualifier
+        # forms like "sault (2)" aren't fixed points of the normalizer,
+        # so binding them would measure false zeroes).
+        evidence_groups = [group for group in pending if group.qualifier is None]
+        if evidence_groups:
             equality = await self._discogs_cache.artist_equality_candidates(
-                list(dict.fromkeys(group.form for group in pending))
+                list(dict.fromkeys(group.form for group in evidence_groups))
             )
             trigram = await self._discogs_cache.artist_trigram_candidates(
-                [group.probe for group in pending]
+                [group.probe for group in evidence_groups]
             )
-            for group in pending:
+            for group in evidence_groups:
                 # Direct indexing on purpose: both queries promise every
                 # input key present (measured zeroes as empty sets), and a
                 # silent .get() default would mask a contract break that
                 # must fail loudly (a dropped candidate set can mint).
                 legs = equality[group.form]
                 # Leg field names are the wire enum values minus the
-                # "cache_" prefix — a rename fails loudly here.
-                group.corroboration = [
-                    ArtistResolveCacheLeg(f"cache_{leg}") for leg in legs.nonempty_legs()
-                ]
+                # "cache_" prefix. A missing twin is a SERVER contract
+                # break — RuntimeError, not the ValueError the route maps
+                # to 422 (that would blame the caller for our drift).
+                try:
+                    group.corroboration = [
+                        ArtistResolveCacheLeg(f"cache_{leg}") for leg in legs.nonempty_legs()
+                    ]
+                except ValueError as e:
+                    raise RuntimeError(
+                        f"equality leg has no ArtistResolveCacheLeg twin: {e}"
+                    ) from e
                 if trigram[group.probe]:
                     group.corroboration.append(ArtistResolveCacheLeg.cache_trigram)
                 # Trigram neighbors are excluded on purpose: the conflict
@@ -362,7 +479,7 @@ class BareNameArtistResolver:
     async def _api_verdict(
         self,
         group: _FormGroup,
-        page: list,
+        page: list[DiscogsArtistSearchResult],
         *,
         dry_run: bool,
         stats: ResolveStats,
@@ -370,7 +487,7 @@ class BareNameArtistResolver:
         """Apply the verdict table to a measured single-page observation."""
         # Exact-form family, distinct by artist id (first title per id
         # wins — page order is the API's relevance order). The
-        # identity-match form strips the "(N)" disambiguator, so
+        # identity-match form strips the trailing qualifier, so
         # "Popsicle (2)" collides with "Popsicle" — that strip IS the
         # overload detection.
         candidates: dict[int, str] = {}
@@ -409,6 +526,18 @@ class BareNameArtistResolver:
             )
 
         ((winner_id, winner_title),) = candidates.items()
+        winner_qualifier, _ = _split_trailing_qualifier(winner_title)
+        if winner_qualifier != group.qualifier:
+            # A "(N)"-titled singleton answering a bare input means the
+            # family is overloaded on Discogs and the bare member simply
+            # missed the page (a "(2)" exists only because a namesake
+            # does) — and a bare-titled singleton answering a qualified
+            # input is the bare artist, who is by construction not the
+            # one the qualifier names. Either direction: doubt → NULL.
+            return group.unresolved(
+                reason=ArtistResolveUnresolvedReason.ambiguous,
+                candidate_count=1,
+            )
         if group.equality_union - {winner_id}:
             # An equality-leg cache candidate points at a different artist:
             # conflict means doubt, doubt means NULL.
@@ -417,13 +546,14 @@ class BareNameArtistResolver:
                 candidate_count=1,
             )
 
-        if not dry_run and group.disambig is None:
+        if not dry_run and group.qualifier is None:
             # discogs_artist_id only — other id columns belong to their own
             # enrichment flows. COALESCE guards NULL-overwrites only; not
             # clobbering an EXISTING id rests on the tier-1 gate, which is
             # a stale read by mint time (LML#766 tracks the store-level
-            # fill-if-null fix). Suffix-bearing groups skip the mint
-            # entirely: a "(N)" key is unreachable via the three-leg read.
+            # fill-if-null fix). Qualifier-bearing groups skip the mint
+            # entirely: a qualified key is unreachable via the bare-name
+            # reads Backend issues, i.e. pure pollution.
             upserted = await self._entity_store.upsert_identity(
                 group.mint_key, discogs_artist_id=winner_id
             )
@@ -438,14 +568,11 @@ class BareNameArtistResolver:
                 )
             else:
                 stats.minted += 1
-        return ArtistResolveResult(
-            name=group.first_verbatim,
+        return group.resolved(
             discogs_artist_id=winner_id,
-            # The raw Discogs title, "(N)" suffix included — provenance
-            # wants the true Discogs string.
-            canonical_name=winner_title,
             method=ArtistResolveMethod.api_search,
-            cache_corroboration=group.corroboration,
-            unresolved_reason=None,
+            # The raw Discogs title, qualifier included — provenance wants
+            # the true Discogs string.
+            canonical_name=winner_title,
             candidate_count=1,
         )

--- a/artists/resolver.py
+++ b/artists/resolver.py
@@ -1,0 +1,347 @@
+"""Bare-name artist resolution — tier orchestration for LML#759.
+
+Resolves clean touring-artist names (artists WXYC has never cataloged) to
+Discogs artist identities under the verify-before-mint model: the prod
+discogs-cache is a pair-wise-filtered ~50K **biased sample** of Discogs,
+so for bare names it can corroborate but never decide — every
+write-back-eligible resolution must clear a full-universe uniqueness
+check against the Discogs API. Cache results are evidence (corroboration
+/ conflict detection / telemetry), never verdicts; the COALESCE
+never-clobber upsert makes a wrong mint durable, so ambiguous names must
+not mint.
+
+Tiers, per unique identity-match form:
+
+1. ``EntityStore.bulk_resolve_library_names`` — true short-circuit,
+   unverified (a pre-existing row is the store's resolved-at-most-once
+   promise). Only a row that actually carries ``discogs_artist_id``
+   decides; a row holding other ids can't answer this endpoint's
+   question and falls through (its stored key becomes the mint target so
+   COALESCE fills the row in place instead of accreting a near-duplicate
+   key).
+2. ``DiscogsCacheService.artist_equality_candidates`` +
+   ``artist_trigram_candidates`` — candidate SETS (an equality-leg
+   candidate that disagrees with the API winner forces ``ambiguous``;
+   trigram neighbors are yield telemetry and never veto).
+3. ``DiscogsService.search_artists`` — the exact-form uniqueness check.
+   Serial, never fanned out: the shared limiter paces globally at
+   50/min, so intra-request concurrency can't beat it and only starves
+   interleaved live-lookup traffic of semaphore slots (LML#370/#372).
+
+The deliberate divergence from the reconciler's first-match-wins cascade
+(``scripts/entity_resolution/discogs.py``) is documented on the
+candidate-set queries in ``discogs/cache_service.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from wxyc_etl.text import to_identity_match_form
+
+from discogs.breaker import DiscogsBreakerOpenError
+from discogs.cache_service import ArtistEqualityCandidates, DiscogsCacheService
+from discogs.service import DiscogsService
+from entity.store import EntityStore
+from generated.api_models import (
+    ArtistResolveCacheLeg,
+    ArtistResolveMethod,
+    ArtistResolveResult,
+    ArtistResolveUnresolvedReason,
+)
+
+logger = logging.getLogger(__name__)
+
+# ``ArtistEqualityCandidates`` field → wire enum, in enum declaration order
+# so ``cache_corroboration`` lists legs deterministically.
+_EQUALITY_LEGS: tuple[tuple[str, ArtistResolveCacheLeg], ...] = (
+    ("exact", ArtistResolveCacheLeg.cache_exact),
+    ("member", ArtistResolveCacheLeg.cache_member),
+    ("alias", ArtistResolveCacheLeg.cache_alias),
+    ("name_variation", ArtistResolveCacheLeg.cache_name_variation),
+)
+
+
+@dataclass
+class ResolveStats:
+    """Per-request aggregates for the route's Sentry span + PostHog event.
+
+    Verdict counters count response POSITIONS (duplicates share their
+    form's verdict), so they sum to ``names``; ``deduped``, ``api_calls``
+    and ``minted`` count unique work units.
+    """
+
+    names: int = 0
+    deduped: int = 0
+    resolved: int = 0
+    not_found: int = 0
+    ambiguous: int = 0
+    escalation_unavailable: int = 0
+    api_calls: int = 0
+    minted: int = 0
+
+
+@dataclass
+class _FormGroup:
+    """One unique identity-match form: the resolver's unit of work."""
+
+    form: str
+    first_verbatim: str
+    # Key the mint targets: the first occurrence's verbatim, or the stored
+    # ``library_name`` when tier 1 found a Discogs-id-less row to fill.
+    mint_key: str
+    corroboration: list[ArtistResolveCacheLeg] = field(default_factory=list)
+    equality_union: set[int] = field(default_factory=set)
+    # Verdict payload, shared by every input position in the group; the
+    # per-position ``name`` echo is added at fan-back.
+    payload: dict | None = None
+
+
+def _resolved_payload(
+    *,
+    discogs_artist_id: int,
+    method: ArtistResolveMethod,
+    canonical_name: str | None,
+    corroboration: list[ArtistResolveCacheLeg],
+    candidate_count: int | None,
+) -> dict:
+    return {
+        "discogs_artist_id": discogs_artist_id,
+        "canonical_name": canonical_name,
+        "method": method,
+        "cache_corroboration": corroboration,
+        "unresolved_reason": None,
+        "candidate_count": candidate_count,
+    }
+
+
+def _unresolved_payload(
+    *,
+    reason: ArtistResolveUnresolvedReason,
+    corroboration: list[ArtistResolveCacheLeg],
+    candidate_count: int | None,
+) -> dict:
+    return {
+        "discogs_artist_id": None,
+        "canonical_name": None,
+        "method": None,
+        "cache_corroboration": corroboration,
+        "unresolved_reason": reason,
+        "candidate_count": candidate_count,
+    }
+
+
+class BareNameArtistResolver:
+    """Verdict assembly for ``POST /api/v1/artists/resolve/bulk``.
+
+    Args:
+        entity_store: ``entity.identity`` reads (tier 1) and the
+            never-clobber write-back.
+        discogs_cache: The LML#759 candidate-set evidence queries (tier 2).
+        discogs_service: The live Discogs API (tier 3). ``None`` when no
+            token is configured — PG tiers keep answering and API-needing
+            names report ``escalation_unavailable``.
+    """
+
+    def __init__(
+        self,
+        *,
+        entity_store: EntityStore,
+        discogs_cache: DiscogsCacheService,
+        discogs_service: DiscogsService | None,
+    ) -> None:
+        self._entity_store = entity_store
+        self._discogs_cache = discogs_cache
+        self._discogs_service = discogs_service
+
+    async def resolve(
+        self, names: list[str], *, dry_run: bool = False
+    ) -> tuple[list[ArtistResolveResult], ResolveStats]:
+        """Resolve a batch of bare names; results are index-aligned with it.
+
+        ``dry_run`` runs every tier identically — including live API
+        verification — but skips the ``entity.identity`` upsert.
+
+        Raises:
+            CacheUnavailableError: tier-2 PG failure (route → 503).
+            PostgresError / OSError: tier-1 or write-back PG failure
+                (route → 503). Discogs API failures never raise — they
+                land as per-name ``escalation_unavailable`` verdicts.
+        """
+        stats = ResolveStats(names=len(names))
+
+        # Dedupe on the identity-match form; dict order = first occurrence.
+        groups: dict[str, _FormGroup] = {}
+        for name in names:
+            form = to_identity_match_form(name)
+            if form not in groups:
+                groups[form] = _FormGroup(form=form, first_verbatim=name, mint_key=name)
+        stats.deduped = len(groups)
+
+        # --- Tier 1: batched three-leg entity.identity read. -------------
+        identities = await self._entity_store.bulk_resolve_library_names(
+            [g.first_verbatim for g in groups.values()]
+        )
+        pending: list[_FormGroup] = []
+        for g in groups.values():
+            identity = identities.get(g.first_verbatim)
+            if identity is not None and identity.discogs_artist_id is not None:
+                g.payload = _resolved_payload(
+                    discogs_artist_id=identity.discogs_artist_id,
+                    method=ArtistResolveMethod.identity_store,
+                    # entity.identity stores no Discogs title.
+                    canonical_name=None,
+                    # The store decides before cache evidence is consulted.
+                    corroboration=[],
+                    candidate_count=None,
+                )
+                continue
+            if identity is not None:
+                # Row exists but can't answer — fill IT on mint, in place.
+                g.mint_key = identity.library_name
+            if not g.form:
+                # Nothing queryable: the cache legs key on the form and the
+                # API filter compares forms. candidate_count stays null —
+                # nothing was measured.
+                g.payload = _unresolved_payload(
+                    reason=ArtistResolveUnresolvedReason.not_found,
+                    corroboration=[],
+                    candidate_count=None,
+                )
+                continue
+            pending.append(g)
+
+        # --- Tier 2: batched cache evidence (corroboration, never verdicts).
+        if pending:
+            equality = await self._discogs_cache.artist_equality_candidates(
+                [g.form for g in pending]
+            )
+            trigram = await self._discogs_cache.artist_trigram_candidates(
+                [g.first_verbatim for g in pending]
+            )
+            for g in pending:
+                legs = equality.get(g.form, ArtistEqualityCandidates())
+                g.corroboration = [
+                    enum_leg for attr, enum_leg in _EQUALITY_LEGS if getattr(legs, attr)
+                ]
+                if trigram.get(g.first_verbatim):
+                    g.corroboration.append(ArtistResolveCacheLeg.cache_trigram)
+                # Trigram neighbors are excluded on purpose: the conflict
+                # rule is scoped to the equality legs.
+                g.equality_union = legs.exact | legs.member | legs.alias | legs.name_variation
+
+        # --- Tier 3: serial exact-form uniqueness checks. -----------------
+        # A breaker trip sheds the REST of the batch immediately — one shed,
+        # not one per remaining name (no queueing behind the cool-down).
+        service = self._discogs_service
+        shed = False
+        for g in pending:
+            if service is None or shed:
+                g.payload = _unresolved_payload(
+                    reason=ArtistResolveUnresolvedReason.escalation_unavailable,
+                    corroboration=g.corroboration,
+                    candidate_count=None,
+                )
+                continue
+            try:
+                page = await service.search_artists(g.first_verbatim)
+            except DiscogsBreakerOpenError:
+                logger.warning(
+                    "artist-resolve breaker shed at '%s'; short-circuiting remaining batch",
+                    g.first_verbatim,
+                )
+                shed = True
+                page = None
+            if page is None:
+                # Couldn't ask (shed / 429-exhausted / network / distrusted
+                # page) — retryable, and never a measured zero.
+                g.payload = _unresolved_payload(
+                    reason=ArtistResolveUnresolvedReason.escalation_unavailable,
+                    corroboration=g.corroboration,
+                    candidate_count=None,
+                )
+                continue
+            stats.api_calls += 1
+            g.payload = await self._api_verdict(g, page, dry_run=dry_run, stats=stats)
+
+        # --- Fan-back: every position gets its form's verdict. -------------
+        results: list[ArtistResolveResult] = []
+        for name in names:
+            g = groups[to_identity_match_form(name)]
+            assert g.payload is not None  # every group got a verdict above
+            results.append(ArtistResolveResult(name=name, **g.payload))
+            if g.payload["unresolved_reason"] is None:
+                stats.resolved += 1
+            elif g.payload["unresolved_reason"] is ArtistResolveUnresolvedReason.not_found:
+                stats.not_found += 1
+            elif g.payload["unresolved_reason"] is ArtistResolveUnresolvedReason.ambiguous:
+                stats.ambiguous += 1
+            else:
+                stats.escalation_unavailable += 1
+        return results, stats
+
+    async def _api_verdict(
+        self, g: _FormGroup, page: list, *, dry_run: bool, stats: ResolveStats
+    ) -> dict:
+        """Apply the verdict table to a measured single-page observation."""
+        # Exact-form family, distinct by artist id. The identity-match form
+        # strips the "(N)" disambiguator, so "Popsicle (2)" collides with
+        # "Popsicle" — that strip IS the overload detection.
+        candidates: dict[int, str] = {}
+        for item in page:
+            if to_identity_match_form(item.title) == g.form and item.artist_id not in candidates:
+                candidates[item.artist_id] = item.title
+        count = len(candidates)
+
+        if count == 0:
+            # Even when cache alias/member/name-variation legs found
+            # something: alias-shaped matches can't be globally
+            # uniqueness-checked, so v1 declines to mint and counts them
+            # (in cache_corroboration) to size a possible v2 alias arm.
+            return _unresolved_payload(
+                reason=ArtistResolveUnresolvedReason.not_found,
+                corroboration=g.corroboration,
+                candidate_count=0,
+            )
+        if count >= 2:
+            # No auxiliary disambiguation in v1 — never a guess.
+            return _unresolved_payload(
+                reason=ArtistResolveUnresolvedReason.ambiguous,
+                corroboration=g.corroboration,
+                candidate_count=count,
+            )
+
+        ((winner_id, winner_title),) = candidates.items()
+        if g.equality_union - {winner_id}:
+            # An equality-leg cache candidate points at a different artist:
+            # conflict means doubt, doubt means NULL.
+            return _unresolved_payload(
+                reason=ArtistResolveUnresolvedReason.ambiguous,
+                corroboration=g.corroboration,
+                candidate_count=1,
+            )
+
+        if not dry_run:
+            # discogs_artist_id only — other id columns belong to their own
+            # enrichment flows. COALESCE keeps pre-existing ids intact.
+            upserted = await self._entity_store.upsert_identity(
+                g.mint_key, discogs_artist_id=winner_id
+            )
+            if upserted is None:
+                logger.error(
+                    "entity.identity write-back failed for '%s' (discogs_artist_id=%d)",
+                    g.mint_key,
+                    winner_id,
+                )
+            else:
+                stats.minted += 1
+        return _resolved_payload(
+            discogs_artist_id=winner_id,
+            method=ArtistResolveMethod.api_search,
+            # The raw Discogs title, "(N)" suffix included — provenance
+            # wants the true Discogs string.
+            canonical_name=winner_title,
+            corroboration=g.corroboration,
+            candidate_count=1,
+        )

--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -12,7 +12,7 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 import asyncio
 import hashlib
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 
 from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison
@@ -50,12 +50,36 @@ class ArtistEqualityCandidates:
     single id — because the bare-name resolver's conflict rule needs every
     candidate an overloaded form points at; collapsing to one would let an
     ambiguous name mint.
+
+    Field names are contractually tied to the wire enum
+    ``ArtistResolveCacheLeg`` (each value is ``cache_`` + the field name)
+    and to the SQL's ``leg`` labels in ``_ARTIST_EQUALITY_CANDIDATES_SQL``.
+    The two methods below exist so consumers iterate the legs through ONE
+    enumeration — a leg added here automatically joins both the
+    corroboration telemetry and the resolver's conflict-rule union, where
+    a hand-maintained second list could silently omit it (and a silently
+    missing leg lets an ambiguous name mint).
     """
 
     exact: set[int] = field(default_factory=set)
     member: set[int] = field(default_factory=set)
     alias: set[int] = field(default_factory=set)
     name_variation: set[int] = field(default_factory=set)
+
+    def nonempty_legs(self) -> list[str]:
+        """Names of legs holding at least one candidate, in field order.
+
+        Field order matches the wire enum's declaration order, so
+        corroboration lists built from this are deterministic.
+        """
+        return [f.name for f in fields(self) if getattr(self, f.name)]
+
+    def all_candidate_ids(self) -> set[int]:
+        """Union across every equality leg — the conflict rule's input."""
+        ids: set[int] = set()
+        for f in fields(self):
+            ids |= getattr(self, f.name)
+        return ids
 
 
 # Mirrors ``_ARTIST_FUZZY_MATCH_THRESHOLD`` in ``discogs/service.py`` — the
@@ -544,8 +568,9 @@ class DiscogsCacheService:
         scripts' explicit ``SET``.)
 
         Args:
-            names: Raw artist names as received (first-occurrence verbatim
-                per deduped form, by the resolver's convention).
+            names: Raw artist names as received (one deterministic
+                representative verbatim per deduped group, by the
+                resolver's convention).
             threshold: Minimum pg_trgm similarity [0, 1] for a candidate to
                 count. Must be >= 0.3 (the pinned ``%`` pre-filter floor);
                 lower values raise ``ValueError`` because candidates in the

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -334,7 +334,7 @@ class TestApiVerdicts:
     """Tier 3: the exact-form uniqueness table."""
 
     @pytest.mark.asyncio
-    async def test_unique_exact_form_resolves_and_mints_verbatim(
+    async def test_unique_exact_form_resolves_and_mints(
         self, resolver, entity_store, discogs_service
     ):
         # Page noise whose identity-match form differs must not count.
@@ -666,7 +666,9 @@ class TestDedupe:
 
 
 class TestWriteBack:
-    """Mint rules: verbatim key, discogs_artist_id only, dry_run inverse."""
+    """Mint rules: content-deterministic key (the group's min() spelling,
+    or a fillable stored row's key), discogs_artist_id only, dry_run
+    inverse."""
 
     @pytest.mark.asyncio
     async def test_dry_run_returns_full_verdicts_but_never_upserts(
@@ -1194,7 +1196,7 @@ class TestTierOneRowSelection:
     ):
         """Symmetric guard: a qualified-keyed row handed back for a BARE
         read must not decide the group nor become its fill target — the
-        mint keys on the trimmed verbatim instead."""
+        mint keys on the group's min() spelling instead."""
         entity_store.bulk_resolve_library_names = AsyncMock(
             return_value={"Popsicle": _identity("Popsicle (2)", spotify_artist_id="9dEf")}
         )

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -54,6 +54,15 @@ def _page(*id_title_pairs: tuple[int, str]) -> list[DiscogsArtistSearchResult]:
     return [DiscogsArtistSearchResult(artist_id=i, title=t) for i, t in id_title_pairs]
 
 
+# Order-determinism tests run the same batch content both ways; one shared
+# parametrize so a third ordering (or a rename) lands everywhere at once.
+BOTH_ORDERS = pytest.mark.parametrize(
+    "batch",
+    [["The Tubs", "Tubs"], ["Tubs", "The Tubs"]],
+    ids=["article-first", "bare-first"],
+)
+
+
 @pytest.fixture
 def entity_store():
     store = AsyncMock(spec=EntityStore)
@@ -244,7 +253,7 @@ class TestDisambiguatedInputs:
         self, resolver, entity_store, discogs_service
     ):
         """The confirmed round-1 defect: a stored bare 'Popsicle' row must
-        not fan its id onto 'Popsicle (2)' — the suffix exists because the
+        not fan its id onto 'Popsicle (2)' — the qualifier exists because the
         bare name is someone else."""
         entity_store.bulk_resolve_library_names = AsyncMock(
             return_value={"Popsicle": _identity("Popsicle", discogs_artist_id=10)}
@@ -258,7 +267,7 @@ class TestDisambiguatedInputs:
         assert stats.deduped == 2
         assert results[0].discogs_artist_id == 10
         assert results[0].method == "identity_store"
-        # The suffixed position saw the overloaded family and refused.
+        # The qualified position saw the overloaded family and refused.
         assert results[1].unresolved_reason == "ambiguous"
         assert results[1].candidate_count == 2
         assert results[1].discogs_artist_id is None
@@ -268,8 +277,8 @@ class TestDisambiguatedInputs:
         self, resolver, entity_store, discogs_service
     ):
         """The store's canonical read leg strips '(N)' too, so it can hand
-        back a bare-form row for a suffixed query — only an exact
-        library_name match may decide a suffixed group."""
+        back a bare-form row for a qualified query — only an exact
+        library_name match may decide a qualified group."""
         entity_store.bulk_resolve_library_names = AsyncMock(
             # Keyed by the INPUT name; the row itself is the bare form.
             return_value={"Popsicle (2)": _identity("Popsicle", discogs_artist_id=10)}
@@ -304,7 +313,7 @@ class TestDisambiguatedInputs:
     async def test_qualified_singleton_resolves_without_mint(
         self, resolver, entity_store, discogs_service
     ):
-        """A suffixed group whose exact-form family is a singleton resolves
+        """A qualified group whose exact-form family is a singleton resolves
         via the API — but never mints: a '(N)' key is unreachable via the
         three-leg read and pure pollution in the store."""
         discogs_service.search_artists = AsyncMock(
@@ -629,7 +638,7 @@ class TestEscalationUnavailable:
 class TestDedupe:
     """Inputs dedupe on (fixed-point identity-match form, canonical
     trailing qualifier); verdicts fan back per position; the mint keys on
-    the first occurrence's trimmed verbatim unless tier 1 found a
+    the group's deterministic min() spelling unless tier 1 found a
     Discogs-id-less stored row to fill in place."""
 
     @pytest.mark.asyncio
@@ -644,12 +653,13 @@ class TestDedupe:
 
         assert [r.name for r in results] == ["Wishy", "wishy", "WISHY"]
         assert all(r.discogs_artist_id == 123 for r in results)
-        # One unique group → one API probe (the deterministic min()
-        # representative), one mint, keyed on the FIRST occurrence's
-        # verbatim (two rows for one Discogs id is how the store accretes
-        # near-duplicate keys).
+        # One unique group → one API probe and one mint, both keyed on
+        # the deterministic min() spelling so neither can flip with
+        # caller input order (two rows for one Discogs id is how the
+        # store accretes near-duplicate keys, and the read legs are
+        # case-insensitive so any spelling stays findable).
         discogs_service.search_artists.assert_awaited_once_with("WISHY")
-        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        entity_store.upsert_identity.assert_awaited_once_with("WISHY", discogs_artist_id=123)
         assert stats.names == 3
         assert stats.deduped == 1
         assert stats.resolved == 3
@@ -763,18 +773,6 @@ class TestQualifierGeneralization:
     separates a name from its bare form (round-2 review)."""
 
     @pytest.mark.asyncio
-    async def test_width_variant_qualifier_groups_with_ascii_twin(self, resolver, discogs_service):
-        """NFKC folding keys '（２）' with '(2)': one group, one probe."""
-        discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Popsicle (2)": _page((20, "Popsicle (2)"))})
-        )
-
-        results, stats = await resolver.resolve(["Popsicle (2)", "Popsicle （２）"])
-
-        assert stats.deduped == 1
-        assert [r.discogs_artist_id for r in results] == [20, 20]
-
-    @pytest.mark.asyncio
     async def test_bracket_variant_never_joins_bare_group(
         self, resolver, entity_store, discogs_service
     ):
@@ -798,18 +796,27 @@ class TestQualifierGeneralization:
         entity_store.upsert_identity.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_case_variant_qualified_store_row_decides(
-        self, resolver, entity_store, discogs_service
+    @pytest.mark.parametrize(
+        ("input_name", "stored_key"),
+        [
+            ("POPSICLE (2)", "Popsicle (2)"),
+            ("Popsicle (2)", "Popsicle （2）"),
+            ("Popsicle (2)", "Popsicle (2)\u200b"),
+        ],
+        ids=["case-variant", "width-variant", "cf-tailed-stored-key"],
+    )
+    async def test_folded_variant_qualified_store_row_decides(
+        self, resolver, entity_store, discogs_service, input_name, stored_key
     ):
-        """A stored 'Popsicle (2)' row matched via the LOWER leg for input
-        'POPSICLE (2)' carries the SAME qualifier — it IS that artist's
-        row and must decide (byte-exact comparison would make the name
-        permanently unresolvable, since qualified groups never mint)."""
+        """A stored row whose key is a case/width/Cf variant of the same
+        qualifier IS that artist's row and must decide (byte-exact
+        comparison would make the name permanently unresolvable, since
+        qualified groups never mint)."""
         entity_store.bulk_resolve_library_names = AsyncMock(
-            return_value={"POPSICLE (2)": _identity("Popsicle (2)", discogs_artist_id=20)}
+            return_value={input_name: _identity(stored_key, discogs_artist_id=20)}
         )
 
-        results, stats = await resolver.resolve(["POPSICLE (2)"])
+        results, stats = await resolver.resolve([input_name])
 
         assert results[0].discogs_artist_id == 20
         assert results[0].method == "identity_store"
@@ -910,11 +917,7 @@ class TestStoreConflict:
     NULL — and the verdict must not flip with input order."""
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "batch",
-        [["The Tubs", "Tubs"], ["Tubs", "The Tubs"]],
-        ids=["article-first", "bare-first"],
-    )
+    @BOTH_ORDERS
     async def test_conflicting_store_ids_are_ambiguous_in_both_orders(
         self, resolver, entity_store, discogs_service, batch
     ):
@@ -1107,24 +1110,6 @@ class TestQualifierNormalizerParity:
         assert stats.minted == 1
 
     @pytest.mark.asyncio
-    async def test_width_variant_qualified_store_row_decides(
-        self, resolver, entity_store, discogs_service
-    ):
-        """A stored fullwidth-qualified key ('Popsicle （2）') carries the
-        same canonical qualifier as input 'Popsicle (2)' — it IS that
-        artist's row and decides without an API probe."""
-        entity_store.bulk_resolve_library_names = AsyncMock(
-            return_value={"Popsicle (2)": _identity("Popsicle （2）", discogs_artist_id=20)}
-        )
-
-        results, stats = await resolver.resolve(["Popsicle (2)"])
-
-        assert results[0].discogs_artist_id == 20
-        assert results[0].method == "identity_store"
-        discogs_service.search_artists.assert_not_awaited()
-        assert stats.api_calls == 0
-
-    @pytest.mark.asyncio
     async def test_cf_characters_sanitized_from_mint_key(
         self, resolver, entity_store, discogs_service
     ):
@@ -1159,11 +1144,7 @@ class TestTierOneRowSelection:
     """Round-3 pins for the tier-1 scan's row-configuration matrix."""
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "batch",
-        [["The Tubs", "Tubs"], ["Tubs", "The Tubs"]],
-        ids=["article-first", "bare-first"],
-    )
+    @BOTH_ORDERS
     async def test_decided_beats_fillable_in_both_orders(
         self, resolver, entity_store, discogs_service, batch
     ):
@@ -1186,11 +1167,7 @@ class TestTierOneRowSelection:
         assert stats.api_calls == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "batch",
-        [["The Tubs", "Tubs"], ["Tubs", "The Tubs"]],
-        ids=["article-first", "bare-first"],
-    )
+    @BOTH_ORDERS
     async def test_multi_fillable_fill_target_is_content_deterministic(
         self, resolver, entity_store, discogs_service, batch
     ):
@@ -1259,3 +1236,172 @@ class TestPgFailurePropagation:
 
         with pytest.raises(CacheUnavailableError):
             await resolver.resolve(["Wishy"])
+
+
+class TestRoundFourPins:
+    """Round-4 review pins: fixed-point title filtering, the narrowed
+    ASCII bare-number gate, Cf immunity on the store/title sides, and
+    content-deterministic mint keys."""
+
+    @pytest.mark.asyncio
+    async def test_multi_qualifier_title_matches_identical_input(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A Discogs artist titled exactly like the multi-qualified input
+        must enter the candidate set (the title side of the filter is
+        fixed-point too) and resolve via the qualifier match — without
+        minting (qualified group)."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Sault (2) (UK)": _page((42, "Sault (2) (UK)"))})
+        )
+
+        results, stats = await resolver.resolve(["Sault (2) (UK)"])
+
+        (result,) = results
+        assert result.discogs_artist_id == 42
+        assert result.canonical_name == "Sault (2) (UK)"
+        assert result.method == "api_search"
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.minted == 0
+
+    @pytest.mark.asyncio
+    async def test_multi_qualifier_family_member_blocks_bare_mint(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A multi-qualified family member on the page must count toward
+        the bare input's family — under-detection resolved AND minted the
+        wrong artist (round-4 empirical hole)."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Sault": _page((40, "Sault"), (42, "Sault (2) (UK)"))})
+        )
+
+        results, stats = await resolver.resolve(["Sault"])
+
+        (result,) = results
+        assert result.unresolved_reason == "ambiguous"
+        assert result.candidate_count == 2
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.minted == 0
+
+    @pytest.mark.asyncio
+    async def test_fully_bracketed_non_ascii_digit_name_is_resolvable(
+        self, resolver, discogs_service
+    ):
+        """NFKC never folds Arabic-Indic digits, so no Discogs
+        disambiguator can spell '(٢)' — it is a real name under the
+        '(Smog)' doctrine, not the bare-number garbage shape."""
+        discogs_service.search_artists = AsyncMock(side_effect=_pages({"(٢)": _page((70, "(٢)"))}))
+
+        results, _ = await resolver.resolve(["(٢)"])
+
+        assert results[0].discogs_artist_id == 70
+        assert results[0].method == "api_search"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "garbage",
+        ["(2)(3)", "(2) (3)", "[2]", "(02)"],
+        ids=["stacked-numbers", "spaced-stacked-numbers", "bracket-number", "zero-padded-number"],
+    )
+    async def test_bare_number_bases_rejected_in_every_spelling(
+        self, resolver, entity_store, discogs_service, garbage
+    ):
+        """The gate fires on the FIXED-POINT form, so a bare-number base
+        wearing further qualifier tails is caught too — it must never
+        burn a rate-limited probe or land a negative-cacheable verdict."""
+        with pytest.raises(ValueError, match=r"names\[0\]"):
+            await resolver.resolve([garbage])
+
+        entity_store.bulk_resolve_library_names.assert_not_awaited()
+        discogs_service.search_artists.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cf_tailed_winner_title_still_matches(self, resolver, discogs_service):
+        """A ZWSP-tailed Discogs title must not hide its qualifier from
+        the winner-title match — the splitter Cf-strips its own input."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Popsicle (2)": _page((20, "Popsicle (2)​"))})
+        )
+
+        results, _ = await resolver.resolve(["Popsicle (2)"])
+
+        assert results[0].discogs_artist_id == 20
+
+    @pytest.mark.asyncio
+    @BOTH_ORDERS
+    async def test_mint_key_is_content_deterministic_without_fillable(
+        self, resolver, entity_store, discogs_service, batch
+    ):
+        """With no fillable store row the mint keys on the group's min()
+        spelling — the minted library_name must not flip with caller
+        input order (the store's read legs are case-insensitive, so any
+        spelling stays findable)."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"The Tubs": _page((333, "The Tubs"))})
+        )
+
+        results, _ = await resolver.resolve(batch)
+
+        assert all(r.discogs_artist_id == 333 for r in results)
+        entity_store.upsert_identity.assert_awaited_once_with("The Tubs", discogs_artist_id=333)
+
+    @pytest.mark.asyncio
+    async def test_zero_padded_qualifier_stays_distinct(self, resolver, discogs_service):
+        """'(02)' is not the Discogs disambiguator convention: 'X (02)'
+        and 'X (2)' are separate work units with separate probes."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {
+                    "X (2)": _page((80, "X (2)")),
+                    "X (02)": _page((80, "X (2)")),
+                }
+            )
+        )
+
+        results, stats = await resolver.resolve(["X (2)", "X (02)"])
+
+        assert stats.deduped == 2
+        assert results[0].discogs_artist_id == 80
+        # The zero-padded spelling's winner qualifier '(2)' != '(02)'.
+        assert results[1].unresolved_reason == "ambiguous"
+
+    @pytest.mark.asyncio
+    async def test_nested_number_qualifier_stays_distinct(self, resolver, discogs_service):
+        """'((2))' is not the bare-number shape: it keys as its own
+        qualifier, distinct from '(2)'."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {
+                    "X (2)": _page((80, "X (2)")),
+                    "X ((2))": _page((80, "X (2)")),
+                }
+            )
+        )
+
+        results, stats = await resolver.resolve(["X (2)", "X ((2))"])
+
+        assert stats.deduped == 2
+        assert results[0].discogs_artist_id == 80
+        assert results[1].unresolved_reason == "ambiguous"
+
+    @pytest.mark.asyncio
+    async def test_empty_group_is_a_qualifier_not_bare_noise(
+        self, resolver, entity_store, discogs_service
+    ):
+        """'Wishy ()' must not rejoin the bare 'Wishy' group — the
+        normalizer strips the empty group too, so skipping it as noise
+        would reopen the stored-row-inheritance hole."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Wishy": _identity("Wishy", discogs_artist_id=123)}
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Wishy ()": _page((123, "Wishy"))})
+        )
+
+        results, stats = await resolver.resolve(["Wishy", "Wishy ()"])
+
+        assert stats.deduped == 2
+        assert results[0].discogs_artist_id == 123
+        assert results[0].method == "identity_store"
+        # Bare-titled winner vs '()' qualifier: mismatch → ambiguous.
+        assert results[1].unresolved_reason == "ambiguous"

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -31,11 +31,20 @@ def _identity(library_name: str, **kwargs) -> Identity:
     return Identity(id=1, library_name=library_name, reconciliation_status="reconciled", **kwargs)
 
 
-def _pages(mapping: dict[str, list[DiscogsArtistSearchResult]]):
-    """search_artists side_effect: canned single-page observations by probe."""
+def _pages(mapping: dict[str, list[DiscogsArtistSearchResult] | None]):
+    """search_artists side_effect: canned single-page observations by probe.
+
+    Unmapped probes raise KeyError so a drift in probe derivation fails
+    the test loudly instead of degrading to a vacuous measured-zero
+    not_found (the same "couldn't ask" vs "measured zero" distinction the
+    real service refuses to coalesce). Map a probe to ``None`` to model
+    "couldn't ask", or to ``[]`` for an explicit measured-empty page.
+    """
 
     async def _search(name: str):
-        return mapping.get(name, [])
+        if name not in mapping:
+            raise KeyError(f"unexpected probe {name!r}; test mapped {sorted(mapping)}")
+        return mapping[name]
 
     return _search
 
@@ -93,8 +102,18 @@ class TestInputValidation:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "bad_name",
-        ["   ", "\t", "Ol\x00ga", "\x1c", "\ud800"],
-        ids=["spaces", "tab", "embedded-nul", "separator-control", "lone-surrogate"],
+        ["   ", "\t", "Ol\x00ga", "\x1c", "\ud800", "´", "(2)", " (2) ", "（２）"],
+        ids=[
+            "spaces",
+            "tab",
+            "embedded-nul",
+            "control-char-blank",
+            "lone-surrogate",
+            "empty-form-acute-accent",
+            "qualifier-only",
+            "qualifier-only-padded",
+            "qualifier-only-fullwidth",
+        ],
     )
     async def test_invalid_name_raises_before_any_probe(
         self, resolver, entity_store, discogs_cache, discogs_service, bad_name
@@ -407,8 +426,11 @@ class TestApiVerdicts:
 
         (result,) = results
         assert result.unresolved_reason == "not_found"
-        # A measured zero — the API tier ran and testified.
+        # A measured zero — the API tier ran and testified. The probe
+        # assert keeps this from going vacuous if probe derivation drifts
+        # (_pages also raises on unmapped probes).
         assert result.candidate_count == 0
+        discogs_service.search_artists.assert_awaited_once_with("REZN")
         entity_store.upsert_identity.assert_not_awaited()
         assert stats.not_found == 1
 
@@ -779,3 +801,267 @@ class TestWriteBack:
 
         with pytest.raises(PostgresError):
             await resolver.resolve(["Wishy"])
+
+
+class TestQualifierGeneralization:
+    """Qualifier detection rides the normalizer's own folds: any trailing
+    parenthesized/bracketed group — not just the ASCII "(N)" spelling —
+    separates a name from its bare form (round-2 review)."""
+
+    @pytest.mark.asyncio
+    async def test_width_variant_qualifier_groups_with_ascii_twin(self, resolver, discogs_service):
+        """NFKC folding keys '（２）' with '(2)': one group, one probe."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {"Popsicle (2)": [DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)")]}
+            )
+        )
+
+        results, stats = await resolver.resolve(["Popsicle (2)", "Popsicle （２）"])
+
+        assert stats.deduped == 1
+        assert [r.discogs_artist_id for r in results] == [20, 20]
+
+    @pytest.mark.asyncio
+    async def test_bracket_variant_never_joins_bare_group(
+        self, resolver, entity_store, discogs_service
+    ):
+        """'Popsicle [2]' must not inherit the stored bare row's id — the
+        normalizer strips bracketed qualifiers too, so grouping must
+        treat them as qualified (the round-2 empirical hole)."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Popsicle": _identity("Popsicle", discogs_artist_id=10)}
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {
+                    "Popsicle [2]": [
+                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
+                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
+                    ]
+                }
+            )
+        )
+
+        results, stats = await resolver.resolve(["Popsicle", "Popsicle [2]"])
+
+        assert stats.deduped == 2
+        assert results[0].discogs_artist_id == 10
+        assert results[0].method == "identity_store"
+        assert results[1].unresolved_reason == "ambiguous"
+        assert results[1].discogs_artist_id is None
+        entity_store.upsert_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_case_variant_qualified_store_row_decides(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A stored 'Popsicle (2)' row matched via the LOWER leg for input
+        'POPSICLE (2)' carries the SAME qualifier — it IS that artist's
+        row and must decide (byte-exact comparison would make the name
+        permanently unresolvable, since qualified groups never mint)."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"POPSICLE (2)": _identity("Popsicle (2)", discogs_artist_id=20)}
+        )
+
+        results, stats = await resolver.resolve(["POPSICLE (2)"])
+
+        assert results[0].discogs_artist_id == 20
+        assert results[0].method == "identity_store"
+        discogs_service.search_artists.assert_not_awaited()
+        assert stats.api_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_qualified_groups_skip_cache_evidence(
+        self, resolver, discogs_cache, discogs_service
+    ):
+        """Cache legs key on the qualifier-stripped form and cannot
+        distinguish family members — for qualified groups the evidence is
+        skipped, not consulted."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {"Popsicle (2)": [DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)")]}
+            )
+        )
+
+        results, _ = await resolver.resolve(["Popsicle (2)"])
+
+        assert results[0].discogs_artist_id == 20
+        assert results[0].cache_corroboration == []
+        discogs_cache.artist_equality_candidates.assert_not_awaited()
+        discogs_cache.artist_trigram_candidates.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_decorated_name_is_conservative_never_bare_winner(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A legitimately-decorated input ('!!! (Chk Chk Chk)') resolves
+        only when Discogs titles the artist with the same qualifier; a
+        bare-titled winner is by construction not what the qualifier
+        names — ambiguous, and no mint either way (documented v1 recall
+        tradeoff: never a wrong mint)."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {"!!! (Chk Chk Chk)": [DiscogsArtistSearchResult(artist_id=77, title="!!!")]}
+            )
+        )
+
+        results, _ = await resolver.resolve(["!!! (Chk Chk Chk)"])
+
+        assert results[0].unresolved_reason == "ambiguous"
+        assert results[0].candidate_count == 1
+        entity_store.upsert_identity.assert_not_awaited()
+
+
+class TestWinnerQualifierRule:
+    """The lone exact-form candidate's OWN title qualifier must equal the
+    group's — a mismatch in either direction is family evidence, not a
+    resolution (round-2 review)."""
+
+    @pytest.mark.asyncio
+    async def test_bare_group_never_mints_suffix_titled_winner(
+        self, resolver, entity_store, discogs_service
+    ):
+        """Page 1 for 'Popsicle' holding only 'Popsicle (2)' means the
+        bare member missed the page, not that the family is a singleton —
+        minting id 20 under key 'Popsicle' would be the durable wrong mint
+        the whole design exists to prevent."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {"Popsicle": [DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)")]}
+            )
+        )
+
+        results, stats = await resolver.resolve(["Popsicle"])
+
+        (result,) = results
+        assert result.unresolved_reason == "ambiguous"
+        assert result.candidate_count == 1
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.minted == 0
+
+    @pytest.mark.asyncio
+    async def test_qualified_group_never_resolves_bare_titled_winner(
+        self, resolver, entity_store, discogs_service
+    ):
+        """'Popsicle (2)' with a page holding only bare 'Popsicle' must not
+        hand the suffixed input the bare artist's id — the suffix exists
+        because the bare name is someone else."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {"Popsicle (2)": [DiscogsArtistSearchResult(artist_id=10, title="Popsicle")]}
+            )
+        )
+
+        results, _ = await resolver.resolve(["Popsicle (2)"])
+
+        (result,) = results
+        assert result.unresolved_reason == "ambiguous"
+        assert result.candidate_count == 1
+        assert result.discogs_artist_id is None
+        entity_store.upsert_identity.assert_not_awaited()
+
+
+class TestStoreConflict:
+    """Two group verbatims hitting store rows with different Discogs ids
+    is the store contradicting itself: conflict means doubt, doubt means
+    NULL — and the verdict must not flip with input order."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "batch",
+        [["The Tubs", "Tubs"], ["Tubs", "The Tubs"]],
+        ids=["article-first", "bare-first"],
+    )
+    async def test_conflicting_store_ids_are_ambiguous_in_both_orders(
+        self, resolver, entity_store, discogs_service, batch
+    ):
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={
+                "The Tubs": _identity("The Tubs", discogs_artist_id=111),
+                "Tubs": _identity("Tubs", discogs_artist_id=999),
+            }
+        )
+
+        results, stats = await resolver.resolve(batch)
+
+        assert [r.unresolved_reason for r in results] == ["ambiguous", "ambiguous"]
+        # The API tier never ran — nothing was measured.
+        assert all(r.candidate_count is None for r in results)
+        discogs_service.search_artists.assert_not_awaited()
+        assert stats.api_calls == 0
+        assert stats.ambiguous == 2
+        entity_store.upsert_identity.assert_not_awaited()
+
+
+class TestInputHygiene:
+    @pytest.mark.asyncio
+    async def test_padded_name_mints_trimmed_key_and_echoes_raw(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A stray trailing space must not mint a padded library_name the
+        store's exact leg would never find — internal work uses the
+        trimmed spelling, the response echoes the raw input."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+        )
+
+        results, _ = await resolver.resolve(["Wishy "])
+
+        assert results[0].name == "Wishy "
+        assert results[0].discogs_artist_id == 123
+        (queried,) = entity_store.bulk_resolve_library_names.await_args[0]
+        assert queried == ["Wishy"]
+        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+
+    @pytest.mark.asyncio
+    async def test_padded_and_clean_spellings_share_one_group(self, resolver, discogs_service):
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+        )
+
+        results, stats = await resolver.resolve(["Wishy", " Wishy "])
+
+        assert stats.deduped == 1
+        assert [r.name for r in results] == ["Wishy", " Wishy "]
+        assert all(r.discogs_artist_id == 123 for r in results)
+
+
+class TestStatsInvariants:
+    @pytest.mark.asyncio
+    async def test_verdict_counters_partition_names(self, resolver, entity_store, discogs_service):
+        """resolved + not_found + ambiguous + escalation_unavailable must
+        equal names in a batch exercising every verdict kind at once — the
+        route's telemetry treats the counters as a partition."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Juana Molina": _identity("Juana Molina", discogs_artist_id=187553)}
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {
+                    "Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")],
+                    "REZN": [],
+                    "Popsicle": [
+                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
+                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
+                    ],
+                    "The Tubs": None,  # couldn't ask
+                }
+            )
+        )
+
+        names = ["Juana Molina", "Wishy", "wishy", "REZN", "Popsicle", "The Tubs"]
+        results, stats = await resolver.resolve(names)
+
+        assert stats.names == len(names) == len(results)
+        assert (
+            stats.resolved + stats.not_found + stats.ambiguous + stats.escalation_unavailable
+            == stats.names
+        )
+        assert stats.resolved == 3  # identity hit + Wishy + wishy (dup)
+        assert stats.not_found == 1
+        assert stats.ambiguous == 1
+        assert stats.escalation_unavailable == 1
+        assert stats.deduped == 5
+        assert stats.api_calls == 4
+        assert stats.minted == 1

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -49,6 +49,11 @@ def _pages(mapping: dict[str, list[DiscogsArtistSearchResult] | None]):
     return _search
 
 
+def _page(*id_title_pairs: tuple[int, str]) -> list[DiscogsArtistSearchResult]:
+    """A canned page: one DiscogsArtistSearchResult per (artist_id, title)."""
+    return [DiscogsArtistSearchResult(artist_id=i, title=t) for i, t in id_title_pairs]
+
+
 @pytest.fixture
 def entity_store():
     store = AsyncMock(spec=EntityStore)
@@ -133,9 +138,7 @@ class TestInputValidation:
     ):
         """'!!!' keeps a non-empty identity-match form — the empty-form
         rejection is scoped to true garbage, not avant band names."""
-        discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"!!!": [DiscogsArtistSearchResult(artist_id=77, title="!!!")]})
-        )
+        discogs_service.search_artists = AsyncMock(side_effect=_pages({"!!!": _page((77, "!!!"))}))
 
         results, stats = await resolver.resolve(["!!!"])
 
@@ -183,7 +186,7 @@ class TestIdentityStoreShortCircuit:
             return_value={"Juana Molina": _identity("Juana Molina", discogs_artist_id=187553)}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=77, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((77, "Wishy"))})
         )
 
         await resolver.resolve(["Juana Molina", "Wishy"])
@@ -203,7 +206,7 @@ class TestIdentityStoreShortCircuit:
             return_value={"Wishy": _identity("Wishy", spotify_artist_id="4aBc")}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
 
         results, stats = await resolver.resolve(["Wishy"])
@@ -231,12 +234,13 @@ class TestIdentityStoreShortCircuit:
 
 
 class TestDisambiguatedInputs:
-    """A raw "(N)" suffix denotes a DIFFERENT artist than the bare name:
-    suffixed inputs get their own group and can never inherit the bare
-    form's verdict — never a guess."""
+    """A trailing qualifier denotes a DIFFERENT artist than the bare name
+    (Discogs's "(N)" disambiguator is the motivating case): qualified
+    inputs get their own group and can never inherit the bare form's
+    verdict — never a guess."""
 
     @pytest.mark.asyncio
-    async def test_store_hit_never_answers_suffixed_group(
+    async def test_store_hit_never_answers_qualified_group(
         self, resolver, entity_store, discogs_service
     ):
         """The confirmed round-1 defect: a stored bare 'Popsicle' row must
@@ -246,14 +250,7 @@ class TestDisambiguatedInputs:
             return_value={"Popsicle": _identity("Popsicle", discogs_artist_id=10)}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {
-                    "Popsicle (2)": [
-                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
-                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
-                    ]
-                }
-            )
+            side_effect=_pages({"Popsicle (2)": _page((10, "Popsicle"), (20, "Popsicle (2)"))})
         )
 
         results, stats = await resolver.resolve(["Popsicle", "Popsicle (2)"])
@@ -267,7 +264,7 @@ class TestDisambiguatedInputs:
         assert results[1].discogs_artist_id is None
 
     @pytest.mark.asyncio
-    async def test_canonical_leg_bare_row_cannot_decide_suffixed_group(
+    async def test_canonical_leg_bare_row_cannot_decide_qualified_group(
         self, resolver, entity_store, discogs_service
     ):
         """The store's canonical read leg strips '(N)' too, so it can hand
@@ -278,14 +275,7 @@ class TestDisambiguatedInputs:
             return_value={"Popsicle (2)": _identity("Popsicle", discogs_artist_id=10)}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {
-                    "Popsicle (2)": [
-                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
-                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
-                    ]
-                }
-            )
+            side_effect=_pages({"Popsicle (2)": _page((10, "Popsicle"), (20, "Popsicle (2)"))})
         )
 
         results, _ = await resolver.resolve(["Popsicle (2)"])
@@ -294,7 +284,7 @@ class TestDisambiguatedInputs:
         assert results[0].discogs_artist_id is None
 
     @pytest.mark.asyncio
-    async def test_exact_suffixed_store_row_short_circuits(
+    async def test_exact_qualified_store_row_short_circuits(
         self, resolver, entity_store, discogs_service
     ):
         """A stored row keyed exactly 'Popsicle (2)' IS that artist's row
@@ -311,16 +301,14 @@ class TestDisambiguatedInputs:
         assert stats.api_calls == 0
 
     @pytest.mark.asyncio
-    async def test_suffixed_singleton_resolves_without_mint(
+    async def test_qualified_singleton_resolves_without_mint(
         self, resolver, entity_store, discogs_service
     ):
         """A suffixed group whose exact-form family is a singleton resolves
         via the API — but never mints: a '(N)' key is unreachable via the
         three-leg read and pure pollution in the store."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"Popsicle (2)": [DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)")]}
-            )
+            side_effect=_pages({"Popsicle (2)": _page((20, "Popsicle (2)"))})
         )
 
         results, stats = await resolver.resolve(["Popsicle (2)"])
@@ -342,14 +330,7 @@ class TestApiVerdicts:
     ):
         # Page noise whose identity-match form differs must not count.
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {
-                    "Wishy": [
-                        DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
-                        DiscogsArtistSearchResult(artist_id=456, title="Wishy Washy"),
-                    ]
-                }
-            )
+            side_effect=_pages({"Wishy": _page((123, "Wishy"), (456, "Wishy Washy"))})
         )
 
         results, stats = await resolver.resolve(["Wishy"])
@@ -371,14 +352,7 @@ class TestApiVerdicts:
         """The disambiguator strip is load-bearing: 'Popsicle (2)' collides
         with 'Popsicle' and the family reads as ambiguous — never a guess."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {
-                    "Popsicle": [
-                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
-                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
-                    ]
-                }
-            )
+            side_effect=_pages({"Popsicle": _page((10, "Popsicle"), (20, "Popsicle (2)"))})
         )
 
         results, stats = await resolver.resolve(["Popsicle"])
@@ -397,14 +371,7 @@ class TestApiVerdicts:
         """Same artist id twice on the page is one candidate, not an
         overload — count distinct ids, not rows."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {
-                    "Wishy": [
-                        DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
-                        DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
-                    ]
-                }
-            )
+            side_effect=_pages({"Wishy": _page((123, "Wishy"), (123, "Wishy"))})
         )
 
         results, _ = await resolver.resolve(["Wishy"])
@@ -417,9 +384,7 @@ class TestApiVerdicts:
         self, resolver, entity_store, discogs_service
     ):
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"REZN": [DiscogsArtistSearchResult(artist_id=456, title="Reznor Ensemble")]}
-            )
+            side_effect=_pages({"REZN": _page((456, "Reznor Ensemble"))})
         )
 
         results, stats = await resolver.resolve(["REZN"])
@@ -462,14 +427,7 @@ class TestApiVerdicts:
         posture as search_artists's malformed-item guard): a partially
         filtered family could read false-unique and mint wrong."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {
-                    "Wishy": [
-                        DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
-                        DiscogsArtistSearchResult(artist_id=456, title="Wi\ud800shy"),
-                    ]
-                }
-            )
+            side_effect=_pages({"Wishy": _page((123, "Wishy"), (456, "Wi\ud800shy"))})
         )
 
         results, stats = await resolver.resolve(["Wishy"])
@@ -516,9 +474,7 @@ class TestCacheConflictRule:
             return_value={"popsicle": ArtistEqualityCandidates(exact={11})}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"Popsicle": [DiscogsArtistSearchResult(artist_id=10, title="Popsicle")]}
-            )
+            side_effect=_pages({"Popsicle": _page((10, "Popsicle"))})
         )
 
         results, _ = await resolver.resolve(["Popsicle"])
@@ -539,7 +495,7 @@ class TestCacheConflictRule:
             return_value={"wishy": ArtistEqualityCandidates(exact={123}, name_variation={123})}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
 
         results, _ = await resolver.resolve(["Wishy"])
@@ -554,7 +510,7 @@ class TestCacheConflictRule:
     async def test_trigram_neighbor_never_vetoes(self, resolver, discogs_cache, discogs_service):
         discogs_cache.artist_trigram_candidates = AsyncMock(return_value={"Wishy": {999}})
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
 
         results, _ = await resolver.resolve(["Wishy"])
@@ -594,7 +550,7 @@ class TestEscalationUnavailable:
         short-circuits, and the shed probe stays uncounted."""
         discogs_service.search_artists = AsyncMock(
             side_effect=[
-                [DiscogsArtistSearchResult(artist_id=123, title="Wishy")],
+                _page((123, "Wishy")),
                 DiscogsBreakerOpenError("shed"),
             ]
         )
@@ -617,9 +573,7 @@ class TestEscalationUnavailable:
         """``None`` = couldn't ask (429-exhausted / network / distrusted
         page) for THAT name only; the batch continues — and the probe DID
         consume limiter budget, so it counts as an api_call."""
-        discogs_service.search_artists = AsyncMock(
-            side_effect=[None, [DiscogsArtistSearchResult(artist_id=5, title="REZN")]]
-        )
+        discogs_service.search_artists = AsyncMock(side_effect=[None, _page((5, "REZN"))])
 
         results, stats = await resolver.resolve(["Wishy", "REZN"])
 
@@ -673,15 +627,17 @@ class TestEscalationUnavailable:
 
 
 class TestDedupe:
-    """Inputs dedupe on (identity-match form, "(N)" suffix); verdicts fan
-    back per position; only the first occurrence's verbatim mints."""
+    """Inputs dedupe on (fixed-point identity-match form, canonical
+    trailing qualifier); verdicts fan back per position; the mint keys on
+    the first occurrence's trimmed verbatim unless tier 1 found a
+    Discogs-id-less stored row to fill in place."""
 
     @pytest.mark.asyncio
     async def test_shared_verdict_per_position_verbatim_echo(
         self, resolver, entity_store, discogs_service
     ):
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"WISHY": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"WISHY": _page((123, "Wishy"))})
         )
 
         results, stats = await resolver.resolve(["Wishy", "wishy", "WISHY"])
@@ -707,7 +663,7 @@ class TestWriteBack:
         self, resolver, entity_store, discogs_service
     ):
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
 
         results, stats = await resolver.resolve(["Wishy"], dry_run=True)
@@ -734,7 +690,7 @@ class TestWriteBack:
             return_value={"wishy": _identity("Wishy", spotify_artist_id="4aBc")}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"wishy": _page((123, "Wishy"))})
         )
 
         results, _ = await resolver.resolve(["wishy"])
@@ -752,9 +708,7 @@ class TestWriteBack:
             return_value={"Tubs": _identity("Tubs", spotify_artist_id="7xYz")}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"The Tubs": [DiscogsArtistSearchResult(artist_id=333, title="The Tubs")]}
-            )
+            side_effect=_pages({"The Tubs": _page((333, "The Tubs"))})
         )
 
         results, _ = await resolver.resolve(["The Tubs", "Tubs"])
@@ -775,7 +729,7 @@ class TestWriteBack:
 
         entity_store.upsert_identity = AsyncMock(return_value=None)
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
 
         with caplog.at_level(logging.ERROR, logger="artists.resolver"):
@@ -796,7 +750,7 @@ class TestWriteBack:
 
         entity_store.upsert_identity = AsyncMock(side_effect=PostgresError("connection reset"))
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
 
         with pytest.raises(PostgresError):
@@ -812,9 +766,7 @@ class TestQualifierGeneralization:
     async def test_width_variant_qualifier_groups_with_ascii_twin(self, resolver, discogs_service):
         """NFKC folding keys '（２）' with '(2)': one group, one probe."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"Popsicle (2)": [DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)")]}
-            )
+            side_effect=_pages({"Popsicle (2)": _page((20, "Popsicle (2)"))})
         )
 
         results, stats = await resolver.resolve(["Popsicle (2)", "Popsicle （２）"])
@@ -833,14 +785,7 @@ class TestQualifierGeneralization:
             return_value={"Popsicle": _identity("Popsicle", discogs_artist_id=10)}
         )
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {
-                    "Popsicle [2]": [
-                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
-                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
-                    ]
-                }
-            )
+            side_effect=_pages({"Popsicle [2]": _page((10, "Popsicle"), (20, "Popsicle (2)"))})
         )
 
         results, stats = await resolver.resolve(["Popsicle", "Popsicle [2]"])
@@ -879,9 +824,7 @@ class TestQualifierGeneralization:
         distinguish family members — for qualified groups the evidence is
         skipped, not consulted."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"Popsicle (2)": [DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)")]}
-            )
+            side_effect=_pages({"Popsicle (2)": _page((20, "Popsicle (2)"))})
         )
 
         results, _ = await resolver.resolve(["Popsicle (2)"])
@@ -901,9 +844,7 @@ class TestQualifierGeneralization:
         names — ambiguous, and no mint either way (documented v1 recall
         tradeoff: never a wrong mint)."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"!!! (Chk Chk Chk)": [DiscogsArtistSearchResult(artist_id=77, title="!!!")]}
-            )
+            side_effect=_pages({"!!! (Chk Chk Chk)": _page((77, "!!!"))})
         )
 
         results, _ = await resolver.resolve(["!!! (Chk Chk Chk)"])
@@ -916,50 +857,51 @@ class TestQualifierGeneralization:
 class TestWinnerQualifierRule:
     """The lone exact-form candidate's OWN title qualifier must equal the
     group's — a mismatch in either direction is family evidence, not a
-    resolution (round-2 review)."""
+    resolution (round-2 review). Both directions get the FULL assertion
+    set (round-3 review: asymmetric asserts left each direction only
+    half-pinned)."""
 
     @pytest.mark.asyncio
-    async def test_bare_group_never_mints_suffix_titled_winner(
-        self, resolver, entity_store, discogs_service
+    @pytest.mark.parametrize(
+        ("input_name", "winner_title"),
+        [("Popsicle", "Popsicle (2)"), ("Popsicle (2)", "Popsicle")],
+        ids=["bare-input-qualified-winner", "qualified-input-bare-winner"],
+    )
+    async def test_qualifier_mismatch_is_ambiguous_and_never_mints(
+        self, resolver, entity_store, discogs_service, input_name, winner_title
     ):
-        """Page 1 for 'Popsicle' holding only 'Popsicle (2)' means the
-        bare member missed the page, not that the family is a singleton —
-        minting id 20 under key 'Popsicle' would be the durable wrong mint
-        the whole design exists to prevent."""
+        """A "(N)"-titled singleton answering a bare input means the bare
+        member missed the page; a bare-titled singleton answering a
+        qualified input is by construction not what the qualifier names.
+        Either direction: doubt -> NULL, nothing persisted."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"Popsicle": [DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)")]}
-            )
+            side_effect=_pages({input_name: _page((20, winner_title))})
         )
 
-        results, stats = await resolver.resolve(["Popsicle"])
-
-        (result,) = results
-        assert result.unresolved_reason == "ambiguous"
-        assert result.candidate_count == 1
-        entity_store.upsert_identity.assert_not_awaited()
-        assert stats.minted == 0
-
-    @pytest.mark.asyncio
-    async def test_qualified_group_never_resolves_bare_titled_winner(
-        self, resolver, entity_store, discogs_service
-    ):
-        """'Popsicle (2)' with a page holding only bare 'Popsicle' must not
-        hand the suffixed input the bare artist's id — the suffix exists
-        because the bare name is someone else."""
-        discogs_service.search_artists = AsyncMock(
-            side_effect=_pages(
-                {"Popsicle (2)": [DiscogsArtistSearchResult(artist_id=10, title="Popsicle")]}
-            )
-        )
-
-        results, _ = await resolver.resolve(["Popsicle (2)"])
+        results, stats = await resolver.resolve([input_name])
 
         (result,) = results
         assert result.unresolved_reason == "ambiguous"
         assert result.candidate_count == 1
         assert result.discogs_artist_id is None
+        assert result.method is None
         entity_store.upsert_identity.assert_not_awaited()
+        assert stats.minted == 0
+        assert stats.ambiguous == 1
+
+    @pytest.mark.asyncio
+    async def test_folded_winner_title_qualifier_matches(self, resolver, discogs_service):
+        """Winner-title qualifier extraction uses the same NFKC/lower
+        fold as grouping: a fullwidth-qualified Discogs title satisfies
+        an ASCII-qualified input."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Popsicle (2)": _page((20, "Popsicle （２）"))})
+        )
+
+        results, _ = await resolver.resolve(["Popsicle (2)"])
+
+        assert results[0].discogs_artist_id == 20
+        assert results[0].canonical_name == "Popsicle （２）"
 
 
 class TestStoreConflict:
@@ -986,8 +928,11 @@ class TestStoreConflict:
         results, stats = await resolver.resolve(batch)
 
         assert [r.unresolved_reason for r in results] == ["ambiguous", "ambiguous"]
-        # The API tier never ran — nothing was measured.
+        # The API tier never ran — nothing was measured — and tier 2 was
+        # never consulted, so corroboration is [] (per the contract's
+        # store-conflict arm), not a measured zero-yield.
         assert all(r.candidate_count is None for r in results)
+        assert all(r.cache_corroboration == [] for r in results)
         discogs_service.search_artists.assert_not_awaited()
         assert stats.api_calls == 0
         assert stats.ambiguous == 2
@@ -1003,7 +948,7 @@ class TestInputHygiene:
         store's exact leg would never find — internal work uses the
         trimmed spelling, the response echoes the raw input."""
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
 
         results, _ = await resolver.resolve(["Wishy "])
@@ -1017,7 +962,7 @@ class TestInputHygiene:
     @pytest.mark.asyncio
     async def test_padded_and_clean_spellings_share_one_group(self, resolver, discogs_service):
         discogs_service.search_artists = AsyncMock(
-            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
 
         results, stats = await resolver.resolve(["Wishy", " Wishy "])
@@ -1039,12 +984,9 @@ class TestStatsInvariants:
         discogs_service.search_artists = AsyncMock(
             side_effect=_pages(
                 {
-                    "Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")],
+                    "Wishy": _page((123, "Wishy")),
                     "REZN": [],
-                    "Popsicle": [
-                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
-                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
-                    ],
+                    "Popsicle": _page((10, "Popsicle"), (20, "Popsicle (2)")),
                     "The Tubs": None,  # couldn't ask
                 }
             )
@@ -1065,3 +1007,255 @@ class TestStatsInvariants:
         assert stats.deduped == 5
         assert stats.api_calls == 4
         assert stats.minted == 1
+
+
+class TestQualifierNormalizerParity:
+    """Round-3 pins: qualifier detection must mirror the normalizer's own
+    strip semantics exactly — nested tails, spacing/bracket/case/width
+    spellings, multi-group tails, Cf characters, and the it-IS-the-name
+    refusal all behave as one canonical key or one bare name."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "variant",
+        ["Popsicle ( 2 )", "Popsicle [2]", "Popsicle （２）", "Popsicle (2)​"],
+        ids=["inner-whitespace", "bracket", "fullwidth", "trailing-zwsp"],
+    )
+    async def test_digit_qualifier_spellings_share_one_group(
+        self, resolver, discogs_service, variant
+    ):
+        # One group -> one probe, which is min() of the two spellings;
+        # map both so the test pins the merge, not the probe choice.
+        page = _page((20, "Popsicle (2)"))
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Popsicle (2)": page, variant.strip(): page})
+        )
+
+        results, stats = await resolver.resolve(["Popsicle (2)", variant])
+
+        assert stats.deduped == 1
+        assert [r.discogs_artist_id for r in results] == [20, 20]
+
+    @pytest.mark.asyncio
+    async def test_nested_qualifier_never_joins_bare_group(
+        self, resolver, entity_store, discogs_service
+    ):
+        """The normalizer strips a nested trailing tail whole; a regex
+        that forbids inner brackets missed it and let the spelling rejoin
+        the bare group (round-3 empirical hole)."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Sault": _identity("Sault", discogs_artist_id=40)}
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Sault (feat. Cindy (2))": _page((40, "Sault"))})
+        )
+
+        results, stats = await resolver.resolve(["Sault", "Sault (feat. Cindy (2))"])
+
+        assert stats.deduped == 2
+        assert results[0].discogs_artist_id == 40
+        assert results[0].method == "identity_store"
+        # The nested-qualified position saw a bare-titled winner: mismatch.
+        assert results[1].unresolved_reason == "ambiguous"
+        entity_store.upsert_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_multi_qualifier_input_sees_family_not_false_zero(
+        self, resolver, entity_store, discogs_service
+    ):
+        """'Sault (2) (UK)' has fixed-point form 'sault': the family
+        filter must see 'Sault' and 'Sault (2)' (ambiguous), not measure
+        a false zero (not_found is durably negative-cacheable)."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Sault (2) (UK)": _page((40, "Sault"), (41, "Sault (2)"))})
+        )
+
+        results, _ = await resolver.resolve(["Sault (2) (UK)"])
+
+        (result,) = results
+        assert result.unresolved_reason == "ambiguous"
+        assert result.candidate_count == 2
+        entity_store.upsert_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_qualifier_key_is_case_insensitive(self, resolver, discogs_service):
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Elephant (SWEDEN)": _page((60, "Elephant (Sweden)"))})
+        )
+
+        results, stats = await resolver.resolve(["Elephant (SWEDEN)", "Elephant (sweden)"])
+
+        assert stats.deduped == 1
+        assert [r.discogs_artist_id for r in results] == [60, 60]
+
+    @pytest.mark.asyncio
+    async def test_fully_parenthesized_real_name_resolves_and_mints(
+        self, resolver, entity_store, discogs_service
+    ):
+        """'(Smog)' is a real artist name, not a qualifier: peeling would
+        empty the name, so — like the normalizer — the resolver treats the
+        group as the name. Bare group: resolves AND mints."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"(Smog)": _page((50, "(Smog)"))})
+        )
+
+        results, stats = await resolver.resolve(["(Smog)"])
+
+        assert results[0].discogs_artist_id == 50
+        assert results[0].method == "api_search"
+        entity_store.upsert_identity.assert_awaited_once_with("(Smog)", discogs_artist_id=50)
+        assert stats.minted == 1
+
+    @pytest.mark.asyncio
+    async def test_width_variant_qualified_store_row_decides(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A stored fullwidth-qualified key ('Popsicle （2）') carries the
+        same canonical qualifier as input 'Popsicle (2)' — it IS that
+        artist's row and decides without an API probe."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Popsicle (2)": _identity("Popsicle （2）", discogs_artist_id=20)}
+        )
+
+        results, stats = await resolver.resolve(["Popsicle (2)"])
+
+        assert results[0].discogs_artist_id == 20
+        assert results[0].method == "identity_store"
+        discogs_service.search_artists.assert_not_awaited()
+        assert stats.api_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_cf_characters_sanitized_from_mint_key(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A ZWSP survives str.strip() but the normalizer removes it — a
+        'Wishy\\u200b' mint key would be invisible to every store read
+        leg. Sanitation strips it; the raw spelling still echoes."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
+        )
+
+        results, _ = await resolver.resolve(["Wishy​"])
+
+        assert results[0].name == "Wishy​"
+        (queried,) = entity_store.bulk_resolve_library_names.await_args[0]
+        assert queried == ["Wishy"]
+        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+
+    @pytest.mark.asyncio
+    async def test_cf_padded_bare_number_still_rejected(
+        self, resolver, entity_store, discogs_service
+    ):
+        """'(2)\\u200b' is the bare-disambiguator garbage shape wearing an
+        invisible character — sanitation runs before validation."""
+        with pytest.raises(ValueError, match=r"names\[0\]"):
+            await resolver.resolve(["(2)​"])
+
+        entity_store.bulk_resolve_library_names.assert_not_awaited()
+        discogs_service.search_artists.assert_not_awaited()
+
+
+class TestTierOneRowSelection:
+    """Round-3 pins for the tier-1 scan's row-configuration matrix."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "batch",
+        [["The Tubs", "Tubs"], ["Tubs", "The Tubs"]],
+        ids=["article-first", "bare-first"],
+    )
+    async def test_decided_beats_fillable_in_both_orders(
+        self, resolver, entity_store, discogs_service, batch
+    ):
+        """A group holding both an id-bearing row and an id-less fillable
+        row short-circuits on the id — no API spend, no mint into the
+        fillable — regardless of input order."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={
+                "The Tubs": _identity("The Tubs", spotify_artist_id="7xYz"),
+                "Tubs": _identity("Tubs", discogs_artist_id=999),
+            }
+        )
+
+        results, stats = await resolver.resolve(batch)
+
+        assert [r.discogs_artist_id for r in results] == [999, 999]
+        assert all(r.method == "identity_store" for r in results)
+        discogs_service.search_artists.assert_not_awaited()
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.api_calls == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "batch",
+        [["The Tubs", "Tubs"], ["Tubs", "The Tubs"]],
+        ids=["article-first", "bare-first"],
+    )
+    async def test_multi_fillable_fill_target_is_content_deterministic(
+        self, resolver, entity_store, discogs_service, batch
+    ):
+        """Two id-less rows in one group: the fill target is min() by
+        library_name — the mint key must not flip with input order."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={
+                "The Tubs": _identity("The Tubs", spotify_artist_id="7xYz"),
+                "Tubs": _identity("Tubs", spotify_artist_id="8aBc"),
+            }
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"The Tubs": _page((333, "The Tubs"))})
+        )
+
+        results, _ = await resolver.resolve(batch)
+
+        assert all(r.discogs_artist_id == 333 for r in results)
+        entity_store.upsert_identity.assert_awaited_once_with("The Tubs", discogs_artist_id=333)
+
+    @pytest.mark.asyncio
+    async def test_qualified_store_row_neither_decides_nor_fills_bare_group(
+        self, resolver, entity_store, discogs_service
+    ):
+        """Symmetric guard: a qualified-keyed row handed back for a BARE
+        read must not decide the group nor become its fill target — the
+        mint keys on the trimmed verbatim instead."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Popsicle": _identity("Popsicle (2)", spotify_artist_id="9dEf")}
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Popsicle": _page((10, "Popsicle"))})
+        )
+
+        results, _ = await resolver.resolve(["Popsicle"])
+
+        assert results[0].discogs_artist_id == 10
+        assert results[0].method == "api_search"
+        entity_store.upsert_identity.assert_awaited_once_with("Popsicle", discogs_artist_id=10)
+
+
+class TestPgFailurePropagation:
+    """The resolve() Raises contract: PG-tier failures propagate to the
+    route's 503 — they must never degrade into per-name verdicts (a 200
+    full of retryable verdicts during a PG outage would also bypass the
+    conflict veto on retry)."""
+
+    @pytest.mark.asyncio
+    async def test_tier1_pg_failure_propagates(self, resolver, entity_store):
+        from asyncpg.exceptions import PostgresError
+
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            side_effect=PostgresError("connection reset")
+        )
+
+        with pytest.raises(PostgresError):
+            await resolver.resolve(["Wishy"])
+
+    @pytest.mark.asyncio
+    async def test_tier2_cache_failure_propagates(self, resolver, discogs_cache):
+        from discogs.cache_service import CacheUnavailableError
+
+        discogs_cache.artist_equality_candidates = AsyncMock(
+            side_effect=CacheUnavailableError("PG pool exhausted")
+        )
+
+        with pytest.raises(CacheUnavailableError):
+            await resolver.resolve(["Wishy"])

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -1,4 +1,4 @@
-"""Unit tests for the bare-name artist resolver (LML#759 PR C).
+"""Unit tests for the bare-name artist resolver (LML#759 PR C1).
 
 The full verdict table from the issue's design, against mocked tiers:
 
@@ -9,8 +9,9 @@ The full verdict table from the issue's design, against mocked tiers:
 - tier 3: ``DiscogsService.search_artists`` (the full-universe
   exact-form uniqueness check — the only tier that can decide a mint)
 
-HTTP envelope concerns (auth, 413, span, error-class routing) live in
-``test_artist_resolve_router.py``; this file is resolver semantics only.
+HTTP envelope concerns (auth, 413, span, error-class routing) belong to
+the endpoint PR's router tests (LML#764); this file is resolver
+semantics only.
 """
 
 from __future__ import annotations
@@ -20,33 +21,28 @@ from unittest.mock import AsyncMock
 import pytest
 
 from discogs.breaker import DiscogsBreakerOpenError
-from discogs.cache_service import ArtistEqualityCandidates
+from discogs.cache_service import ArtistEqualityCandidates, DiscogsCacheService
 from discogs.models import DiscogsArtistSearchResult
-from entity.store import Identity
+from discogs.service import DiscogsService
+from entity.store import EntityStore, Identity
 
 
-def _identity(
-    library_name: str,
-    *,
-    discogs_artist_id: int | None = None,
-    spotify_artist_id: str | None = None,
-) -> Identity:
-    return Identity(
-        id=1,
-        library_name=library_name,
-        discogs_artist_id=discogs_artist_id,
-        wikidata_qid=None,
-        musicbrainz_artist_id=None,
-        spotify_artist_id=spotify_artist_id,
-        apple_music_artist_id=None,
-        bandcamp_id=None,
-        reconciliation_status="reconciled",
-    )
+def _identity(library_name: str, **kwargs) -> Identity:
+    return Identity(id=1, library_name=library_name, reconciliation_status="reconciled", **kwargs)
+
+
+def _pages(mapping: dict[str, list[DiscogsArtistSearchResult]]):
+    """search_artists side_effect: canned single-page observations by probe."""
+
+    async def _search(name: str):
+        return mapping.get(name, [])
+
+    return _search
 
 
 @pytest.fixture
 def entity_store():
-    store = AsyncMock()
+    store = AsyncMock(spec=EntityStore)
     store.bulk_resolve_library_names = AsyncMock(return_value={})
     store.upsert_identity = AsyncMock(side_effect=lambda name, **kw: _identity(name, **kw))
     return store
@@ -54,7 +50,7 @@ def entity_store():
 
 @pytest.fixture
 def discogs_cache():
-    cache = AsyncMock()
+    cache = AsyncMock(spec=DiscogsCacheService)
 
     async def _equality(forms):
         return {form: ArtistEqualityCandidates() for form in forms}
@@ -69,12 +65,14 @@ def discogs_cache():
 
 @pytest.fixture
 def discogs_service():
-    service = AsyncMock()
+    service = AsyncMock(spec=DiscogsService)
     service.search_artists = AsyncMock(return_value=[])
     return service
 
 
-def _make_resolver(entity_store, discogs_cache, discogs_service):
+@pytest.fixture
+def resolver(entity_store, discogs_cache, discogs_service):
+    """Subject under test; mock methods rebound per-test still take effect."""
     from artists.resolver import BareNameArtistResolver
 
     return BareNameArtistResolver(
@@ -84,32 +82,70 @@ def _make_resolver(entity_store, discogs_cache, discogs_service):
     )
 
 
+class TestInputValidation:
+    """Garbage input raises ValueError (route → 422) before any tier runs.
+
+    An in-band verdict would lie: ``not_found`` is a measured zero a
+    consumer may durably negative-cache, and a NUL reaching the tier-2 PG
+    binds would 503 the whole batch as a fake cache outage.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_name",
+        ["   ", "\t", "Ol\x00ga", "\x1c", "\ud800"],
+        ids=["spaces", "tab", "embedded-nul", "separator-control", "lone-surrogate"],
+    )
+    async def test_invalid_name_raises_before_any_probe(
+        self, resolver, entity_store, discogs_cache, discogs_service, bad_name
+    ):
+        with pytest.raises(ValueError, match=r"names\[1\]"):
+            await resolver.resolve(["Wishy", bad_name])
+
+        entity_store.bulk_resolve_library_names.assert_not_awaited()
+        discogs_cache.artist_equality_candidates.assert_not_awaited()
+        discogs_cache.artist_trigram_candidates.assert_not_awaited()
+        discogs_service.search_artists.assert_not_awaited()
+        entity_store.upsert_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_punctuation_only_real_band_names_survive_validation(
+        self, resolver, discogs_service
+    ):
+        """'!!!' keeps a non-empty identity-match form — the empty-form
+        rejection is scoped to true garbage, not avant band names."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"!!!": [DiscogsArtistSearchResult(artist_id=77, title="!!!")]})
+        )
+
+        results, stats = await resolver.resolve(["!!!"])
+
+        assert results[0].discogs_artist_id == 77
+        assert stats.resolved == 1
+
+
 class TestIdentityStoreShortCircuit:
     """Tier 1: a pre-existing row with a Discogs id decides before any evidence."""
 
     @pytest.mark.asyncio
-    async def test_hit_resolves_without_cache_or_api(
-        self, entity_store, discogs_cache, discogs_service
-    ):
+    async def test_hit_resolves_without_cache_or_api(self, resolver, entity_store, discogs_service):
         entity_store.bulk_resolve_library_names = AsyncMock(
             return_value={"Juana Molina": _identity("Juana Molina", discogs_artist_id=187553)}
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["Juana Molina"])
 
-        assert len(results) == 1
-        r = results[0]
-        assert r.name == "Juana Molina"
-        assert r.discogs_artist_id == 187553
-        assert r.method == "identity_store"
+        (result,) = results
+        assert result.name == "Juana Molina"
+        assert result.discogs_artist_id == 187553
+        assert result.method == "identity_store"
         # entity.identity stores no Discogs title — identity_store omits it.
-        assert r.canonical_name is None
+        assert result.canonical_name is None
         # The store decides before cache evidence is consulted: always
         # empty corroboration and an unmeasured (null, never 0) count.
-        assert r.cache_corroboration == []
-        assert r.candidate_count is None
-        assert r.unresolved_reason is None
+        assert result.cache_corroboration == []
+        assert result.candidate_count is None
+        assert result.unresolved_reason is None
 
         discogs_service.search_artists.assert_not_awaited()
         entity_store.upsert_identity.assert_not_awaited()
@@ -119,7 +155,7 @@ class TestIdentityStoreShortCircuit:
 
     @pytest.mark.asyncio
     async def test_hit_form_excluded_from_cache_evidence_queries(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_cache, discogs_service
     ):
         """Short-circuited forms must not reach tier 2 — the contract says
         corroboration is always empty there, and each equality query is four
@@ -128,9 +164,8 @@ class TestIdentityStoreShortCircuit:
             return_value={"Juana Molina": _identity("Juana Molina", discogs_artist_id=187553)}
         )
         discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=77, title="Wishy")]
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=77, title="Wishy")]})
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         await resolver.resolve(["Juana Molina", "Wishy"])
 
@@ -141,7 +176,7 @@ class TestIdentityStoreShortCircuit:
 
     @pytest.mark.asyncio
     async def test_row_without_discogs_id_does_not_short_circuit(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_service
     ):
         """A row that exists but has no discogs_artist_id can't answer this
         endpoint's question — the API tier still runs."""
@@ -149,9 +184,8 @@ class TestIdentityStoreShortCircuit:
             return_value={"Wishy": _identity("Wishy", spotify_artist_id="4aBc")}
         )
         discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["Wishy"])
 
@@ -159,73 +193,200 @@ class TestIdentityStoreShortCircuit:
         assert results[0].discogs_artist_id == 123
         assert stats.api_calls == 1
 
+    @pytest.mark.asyncio
+    async def test_every_group_verbatim_is_read(self, resolver, entity_store, discogs_service):
+        """A group-mate's exact stored row must decide even when a different
+        spelling of the same form came first in the batch."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Tubs": _identity("Tubs", discogs_artist_id=999)}
+        )
+
+        results, stats = await resolver.resolve(["The Tubs", "Tubs"])
+
+        (queried,) = entity_store.bulk_resolve_library_names.await_args[0]
+        assert queried == ["The Tubs", "Tubs"]
+        assert [r.discogs_artist_id for r in results] == [999, 999]
+        assert all(r.method == "identity_store" for r in results)
+        discogs_service.search_artists.assert_not_awaited()
+        assert stats.api_calls == 0
+
+
+class TestDisambiguatedInputs:
+    """A raw "(N)" suffix denotes a DIFFERENT artist than the bare name:
+    suffixed inputs get their own group and can never inherit the bare
+    form's verdict — never a guess."""
+
+    @pytest.mark.asyncio
+    async def test_store_hit_never_answers_suffixed_group(
+        self, resolver, entity_store, discogs_service
+    ):
+        """The confirmed round-1 defect: a stored bare 'Popsicle' row must
+        not fan its id onto 'Popsicle (2)' — the suffix exists because the
+        bare name is someone else."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Popsicle": _identity("Popsicle", discogs_artist_id=10)}
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {
+                    "Popsicle (2)": [
+                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
+                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
+                    ]
+                }
+            )
+        )
+
+        results, stats = await resolver.resolve(["Popsicle", "Popsicle (2)"])
+
+        assert stats.deduped == 2
+        assert results[0].discogs_artist_id == 10
+        assert results[0].method == "identity_store"
+        # The suffixed position saw the overloaded family and refused.
+        assert results[1].unresolved_reason == "ambiguous"
+        assert results[1].candidate_count == 2
+        assert results[1].discogs_artist_id is None
+
+    @pytest.mark.asyncio
+    async def test_canonical_leg_bare_row_cannot_decide_suffixed_group(
+        self, resolver, entity_store, discogs_service
+    ):
+        """The store's canonical read leg strips '(N)' too, so it can hand
+        back a bare-form row for a suffixed query — only an exact
+        library_name match may decide a suffixed group."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            # Keyed by the INPUT name; the row itself is the bare form.
+            return_value={"Popsicle (2)": _identity("Popsicle", discogs_artist_id=10)}
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {
+                    "Popsicle (2)": [
+                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
+                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
+                    ]
+                }
+            )
+        )
+
+        results, _ = await resolver.resolve(["Popsicle (2)"])
+
+        assert results[0].unresolved_reason == "ambiguous"
+        assert results[0].discogs_artist_id is None
+
+    @pytest.mark.asyncio
+    async def test_exact_suffixed_store_row_short_circuits(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A stored row keyed exactly 'Popsicle (2)' IS that artist's row
+        and decides its group normally."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Popsicle (2)": _identity("Popsicle (2)", discogs_artist_id=20)}
+        )
+
+        results, stats = await resolver.resolve(["Popsicle (2)"])
+
+        assert results[0].discogs_artist_id == 20
+        assert results[0].method == "identity_store"
+        discogs_service.search_artists.assert_not_awaited()
+        assert stats.api_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_suffixed_singleton_resolves_without_mint(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A suffixed group whose exact-form family is a singleton resolves
+        via the API — but never mints: a '(N)' key is unreachable via the
+        three-leg read and pure pollution in the store."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {"Popsicle (2)": [DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)")]}
+            )
+        )
+
+        results, stats = await resolver.resolve(["Popsicle (2)"])
+
+        assert results[0].discogs_artist_id == 20
+        assert results[0].canonical_name == "Popsicle (2)"
+        assert results[0].method == "api_search"
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.minted == 0
+        assert stats.resolved == 1
+
 
 class TestApiVerdicts:
     """Tier 3: the exact-form uniqueness table."""
 
     @pytest.mark.asyncio
     async def test_unique_exact_form_resolves_and_mints_verbatim(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_service
     ):
         # Page noise whose identity-match form differs must not count.
         discogs_service.search_artists = AsyncMock(
-            return_value=[
-                DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
-                DiscogsArtistSearchResult(artist_id=456, title="Wishy Washy"),
-            ]
+            side_effect=_pages(
+                {
+                    "Wishy": [
+                        DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
+                        DiscogsArtistSearchResult(artist_id=456, title="Wishy Washy"),
+                    ]
+                }
+            )
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["Wishy"])
 
-        r = results[0]
-        assert r.discogs_artist_id == 123
-        assert r.canonical_name == "Wishy"
-        assert r.method == "api_search"
-        assert r.candidate_count == 1
-        assert r.unresolved_reason is None
+        (result,) = results
+        assert result.discogs_artist_id == 123
+        assert result.canonical_name == "Wishy"
+        assert result.method == "api_search"
+        assert result.candidate_count == 1
+        assert result.unresolved_reason is None
         entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
         assert stats.minted == 1
         assert stats.resolved == 1
 
     @pytest.mark.asyncio
     async def test_overloaded_family_is_ambiguous_and_mints_nothing(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_service
     ):
         """The disambiguator strip is load-bearing: 'Popsicle (2)' collides
         with 'Popsicle' and the family reads as ambiguous — never a guess."""
         discogs_service.search_artists = AsyncMock(
-            return_value=[
-                DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
-                DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
-            ]
+            side_effect=_pages(
+                {
+                    "Popsicle": [
+                        DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
+                        DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
+                    ]
+                }
+            )
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["Popsicle"])
 
-        r = results[0]
-        assert r.unresolved_reason == "ambiguous"
-        assert r.candidate_count == 2
-        assert r.discogs_artist_id is None
-        assert r.method is None
+        (result,) = results
+        assert result.unresolved_reason == "ambiguous"
+        assert result.candidate_count == 2
+        assert result.discogs_artist_id is None
+        assert result.method is None
         entity_store.upsert_identity.assert_not_awaited()
         assert stats.ambiguous == 1
         assert stats.minted == 0
 
     @pytest.mark.asyncio
-    async def test_duplicate_api_ids_collapse_to_one_candidate(
-        self, entity_store, discogs_cache, discogs_service
-    ):
+    async def test_duplicate_api_ids_collapse_to_one_candidate(self, resolver, discogs_service):
         """Same artist id twice on the page is one candidate, not an
         overload — count distinct ids, not rows."""
         discogs_service.search_artists = AsyncMock(
-            return_value=[
-                DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
-                DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
-            ]
+            side_effect=_pages(
+                {
+                    "Wishy": [
+                        DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
+                        DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
+                    ]
+                }
+            )
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, _ = await resolver.resolve(["Wishy"])
 
@@ -234,44 +395,91 @@ class TestApiVerdicts:
 
     @pytest.mark.asyncio
     async def test_zero_exact_form_candidates_is_not_found(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_service
     ):
         discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=456, title="Reznor Ensemble")]
+            side_effect=_pages(
+                {"REZN": [DiscogsArtistSearchResult(artist_id=456, title="Reznor Ensemble")]}
+            )
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["REZN"])
 
-        r = results[0]
-        assert r.unresolved_reason == "not_found"
+        (result,) = results
+        assert result.unresolved_reason == "not_found"
         # A measured zero — the API tier ran and testified.
-        assert r.candidate_count == 0
+        assert result.candidate_count == 0
         entity_store.upsert_identity.assert_not_awaited()
         assert stats.not_found == 1
 
     @pytest.mark.asyncio
     async def test_alias_only_cache_evidence_is_not_found_with_corroboration(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_cache, discogs_service
     ):
         """Alias-shaped matches can't be globally uniqueness-checked: v1
         declines to mint but records the leg — the v2 alias-arm sizing
         telemetry rides ``cache_corroboration`` on unresolved verdicts."""
-
-        async def _equality(forms):
-            return {"rezn": ArtistEqualityCandidates(alias={999})}
-
-        discogs_cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
+        discogs_cache.artist_equality_candidates = AsyncMock(
+            return_value={"rezn": ArtistEqualityCandidates(alias={999})}
+        )
         discogs_service.search_artists = AsyncMock(return_value=[])
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, _ = await resolver.resolve(["REZN"])
 
-        r = results[0]
-        assert r.unresolved_reason == "not_found"
-        assert r.cache_corroboration == ["cache_alias"]
-        assert r.candidate_count == 0
+        (result,) = results
+        assert result.unresolved_reason == "not_found"
+        assert result.cache_corroboration == ["cache_alias"]
+        assert result.candidate_count == 0
         entity_store.upsert_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unencodable_api_title_distrusts_whole_page(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A title the normalizer cannot encode distrusts the page (same
+        posture as search_artists's malformed-item guard): a partially
+        filtered family could read false-unique and mint wrong."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {
+                    "Wishy": [
+                        DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
+                        DiscogsArtistSearchResult(artist_id=456, title="Wi\ud800shy"),
+                    ]
+                }
+            )
+        )
+
+        results, stats = await resolver.resolve(["Wishy"])
+
+        (result,) = results
+        assert result.unresolved_reason == "escalation_unavailable"
+        assert result.candidate_count is None
+        entity_store.upsert_identity.assert_not_awaited()
+        # The probe itself was placed and consumed limiter budget.
+        assert stats.api_calls == 1
+
+
+class TestProbeDeterminism:
+    """The tier-3 query string derives from group content, never input
+    order — the single-page observation universe must not vary with the
+    order a caller happens to send names in."""
+
+    @pytest.mark.asyncio
+    async def test_same_group_probes_identically_in_both_orders(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        from artists.resolver import BareNameArtistResolver
+
+        for batch in (["Wishy", "WISHY"], ["WISHY", "Wishy"]):
+            discogs_service.search_artists.reset_mock()
+            resolver = BareNameArtistResolver(
+                entity_store=entity_store,
+                discogs_cache=discogs_cache,
+                discogs_service=discogs_service,
+            )
+            await resolver.resolve(batch)
+            discogs_service.search_artists.assert_awaited_once_with("WISHY")
 
 
 class TestCacheConflictRule:
@@ -280,67 +488,59 @@ class TestCacheConflictRule:
 
     @pytest.mark.asyncio
     async def test_equality_conflict_is_ambiguous_with_count_one(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_cache, discogs_service
     ):
-        async def _equality(forms):
-            return {"popsicle": ArtistEqualityCandidates(exact={11})}
-
-        discogs_cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
-        discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=10, title="Popsicle")]
+        discogs_cache.artist_equality_candidates = AsyncMock(
+            return_value={"popsicle": ArtistEqualityCandidates(exact={11})}
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {"Popsicle": [DiscogsArtistSearchResult(artist_id=10, title="Popsicle")]}
+            )
+        )
 
         results, _ = await resolver.resolve(["Popsicle"])
 
-        r = results[0]
-        assert r.unresolved_reason == "ambiguous"
+        (result,) = results
+        assert result.unresolved_reason == "ambiguous"
         # Exactly 1: the API observed one exact-form candidate; the
         # ambiguity is the cache conflict, not an overload family.
-        assert r.candidate_count == 1
-        assert r.cache_corroboration == ["cache_exact"]
+        assert result.candidate_count == 1
+        assert result.cache_corroboration == ["cache_exact"]
         entity_store.upsert_identity.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_equality_agreement_resolves_with_corroboration(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, discogs_cache, discogs_service
     ):
-        async def _equality(forms):
-            return {"wishy": ArtistEqualityCandidates(exact={123}, name_variation={123})}
-
-        discogs_cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
-        discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+        discogs_cache.artist_equality_candidates = AsyncMock(
+            return_value={"wishy": ArtistEqualityCandidates(exact={123}, name_variation={123})}
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+        )
 
         results, _ = await resolver.resolve(["Wishy"])
 
-        r = results[0]
-        assert r.discogs_artist_id == 123
-        assert r.method == "api_search"
-        # Enum order, only legs with candidates.
-        assert r.cache_corroboration == ["cache_exact", "cache_name_variation"]
+        (result,) = results
+        assert result.discogs_artist_id == 123
+        assert result.method == "api_search"
+        # Leg field-declaration order, only legs with candidates.
+        assert result.cache_corroboration == ["cache_exact", "cache_name_variation"]
 
     @pytest.mark.asyncio
-    async def test_trigram_neighbor_never_vetoes(
-        self, entity_store, discogs_cache, discogs_service
-    ):
-        async def _trigram(names, **kwargs):
-            return {"Wishy": {999}}
-
-        discogs_cache.artist_trigram_candidates = AsyncMock(side_effect=_trigram)
+    async def test_trigram_neighbor_never_vetoes(self, resolver, discogs_cache, discogs_service):
+        discogs_cache.artist_trigram_candidates = AsyncMock(return_value={"Wishy": {999}})
         discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, _ = await resolver.resolve(["Wishy"])
 
-        r = results[0]
-        assert r.discogs_artist_id == 123
-        assert r.unresolved_reason is None
-        assert r.cache_corroboration == ["cache_trigram"]
+        (result,) = results
+        assert result.discogs_artist_id == 123
+        assert result.unresolved_reason is None
+        assert result.cache_corroboration == ["cache_trigram"]
 
 
 class TestEscalationUnavailable:
@@ -348,30 +548,56 @@ class TestEscalationUnavailable:
 
     @pytest.mark.asyncio
     async def test_breaker_trip_short_circuits_remaining_batch(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_service
     ):
         discogs_service.search_artists = AsyncMock(side_effect=DiscogsBreakerOpenError("shed"))
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["Wishy", "REZN", "The Tubs"])
 
         assert [r.unresolved_reason for r in results] == ["escalation_unavailable"] * 3
         assert all(r.candidate_count is None for r in results)
-        # One shed, not one per remaining name.
+        # One shed, not one per remaining name — and a shed probe never
+        # reached the API, so it must not count as an api_call.
         assert discogs_service.search_artists.await_count == 1
+        assert stats.api_calls == 0
         assert stats.escalation_unavailable == 3
         entity_store.upsert_identity.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_single_none_response_does_not_short_circuit(
-        self, entity_store, discogs_cache, discogs_service
+    async def test_mid_batch_breaker_preserves_earlier_verdicts_and_mints(
+        self, resolver, entity_store, discogs_service
     ):
+        """The order production hits: an earlier name resolves and mints,
+        THEN the breaker trips — pre-shed work must survive, the remainder
+        short-circuits, and the shed probe stays uncounted."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=[
+                [DiscogsArtistSearchResult(artist_id=123, title="Wishy")],
+                DiscogsBreakerOpenError("shed"),
+            ]
+        )
+
+        results, stats = await resolver.resolve(["Wishy", "REZN", "The Tubs"])
+
+        assert results[0].discogs_artist_id == 123
+        assert results[0].method == "api_search"
+        assert [r.unresolved_reason for r in results[1:]] == ["escalation_unavailable"] * 2
+        # Two probes placed (one measured, one shed), third short-circuited.
+        assert discogs_service.search_artists.await_count == 2
+        assert stats.api_calls == 1
+        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        assert stats.minted == 1
+        assert stats.resolved == 1
+        assert stats.escalation_unavailable == 2
+
+    @pytest.mark.asyncio
+    async def test_single_none_response_does_not_short_circuit(self, resolver, discogs_service):
         """``None`` = couldn't ask (429-exhausted / network / distrusted
-        page) for THAT name only; the batch continues."""
+        page) for THAT name only; the batch continues — and the probe DID
+        consume limiter budget, so it counts as an api_call."""
         discogs_service.search_artists = AsyncMock(
             side_effect=[None, [DiscogsArtistSearchResult(artist_id=5, title="REZN")]]
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["Wishy", "REZN"])
 
@@ -379,19 +605,24 @@ class TestEscalationUnavailable:
         assert results[0].candidate_count is None
         assert results[1].discogs_artist_id == 5
         assert discogs_service.search_artists.await_count == 2
+        assert stats.api_calls == 2
         assert stats.escalation_unavailable == 1
         assert stats.resolved == 1
 
     @pytest.mark.asyncio
-    async def test_no_discogs_service_sheds_api_tier_only(
-        self, entity_store, discogs_cache, discogs_service
-    ):
+    async def test_no_discogs_service_sheds_api_tier_only(self, entity_store, discogs_cache):
         """No DISCOGS_TOKEN → PG tiers keep answering; API-needing names
         report escalation_unavailable, identity_store hits still resolve."""
+        from artists.resolver import BareNameArtistResolver
+
         entity_store.bulk_resolve_library_names = AsyncMock(
             return_value={"Juana Molina": _identity("Juana Molina", discogs_artist_id=187553)}
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service=None)
+        resolver = BareNameArtistResolver(
+            entity_store=entity_store,
+            discogs_cache=discogs_cache,
+            discogs_service=None,
+        )
 
         results, stats = await resolver.resolve(["Juana Molina", "Wishy"])
 
@@ -399,69 +630,51 @@ class TestEscalationUnavailable:
         assert results[1].unresolved_reason == "escalation_unavailable"
         assert stats.resolved == 1
         assert stats.escalation_unavailable == 1
+        assert stats.api_calls == 0
 
     @pytest.mark.asyncio
     async def test_escalation_unavailable_still_carries_cache_corroboration(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, discogs_cache, discogs_service
     ):
         """Cache evidence gathered before the shed is telemetry we already
         paid for — it rides the unresolved verdict."""
-
-        async def _equality(forms):
-            return {"wishy": ArtistEqualityCandidates(member={42})}
-
-        discogs_cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
+        discogs_cache.artist_equality_candidates = AsyncMock(
+            return_value={"wishy": ArtistEqualityCandidates(member={42})}
+        )
         discogs_service.search_artists = AsyncMock(side_effect=DiscogsBreakerOpenError("shed"))
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, _ = await resolver.resolve(["Wishy"])
 
-        r = results[0]
-        assert r.unresolved_reason == "escalation_unavailable"
-        assert r.cache_corroboration == ["cache_member"]
+        (result,) = results
+        assert result.unresolved_reason == "escalation_unavailable"
+        assert result.cache_corroboration == ["cache_member"]
 
 
 class TestDedupe:
-    """Inputs dedupe on identity-match form; verdicts fan back per position;
-    only the first occurrence's verbatim mints."""
+    """Inputs dedupe on (identity-match form, "(N)" suffix); verdicts fan
+    back per position; only the first occurrence's verbatim mints."""
 
     @pytest.mark.asyncio
     async def test_shared_verdict_per_position_verbatim_echo(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_service
     ):
         discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+            side_effect=_pages({"WISHY": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["Wishy", "wishy", "WISHY"])
 
         assert [r.name for r in results] == ["Wishy", "wishy", "WISHY"]
         assert all(r.discogs_artist_id == 123 for r in results)
-        # One unique form → one API probe, one mint, keyed on the first
-        # occurrence's verbatim (two rows for one Discogs id is how the
-        # store accretes near-duplicate keys).
-        assert discogs_service.search_artists.await_count == 1
+        # One unique group → one API probe (the deterministic min()
+        # representative), one mint, keyed on the FIRST occurrence's
+        # verbatim (two rows for one Discogs id is how the store accretes
+        # near-duplicate keys).
+        discogs_service.search_artists.assert_awaited_once_with("WISHY")
         entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
         assert stats.names == 3
         assert stats.deduped == 1
         assert stats.resolved == 3
-
-    @pytest.mark.asyncio
-    async def test_disambiguated_input_collides_with_bare_form(
-        self, entity_store, discogs_cache, discogs_service
-    ):
-        """'Popsicle (2)' normalizes to the same form as 'Popsicle' — one
-        work unit, shared verdict."""
-        discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=10, title="Popsicle")]
-        )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
-
-        results, stats = await resolver.resolve(["Popsicle", "Popsicle (2)"])
-
-        assert stats.deduped == 1
-        assert results[0].discogs_artist_id == results[1].discogs_artist_id == 10
 
 
 class TestWriteBack:
@@ -469,20 +682,19 @@ class TestWriteBack:
 
     @pytest.mark.asyncio
     async def test_dry_run_returns_full_verdicts_but_never_upserts(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_service
     ):
         discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, stats = await resolver.resolve(["Wishy"], dry_run=True)
 
-        r = results[0]
+        (result,) = results
         # Everything ran identically — real API verification, full verdict.
-        assert r.discogs_artist_id == 123
-        assert r.method == "api_search"
-        assert r.candidate_count == 1
+        assert result.discogs_artist_id == 123
+        assert result.method == "api_search"
+        assert result.candidate_count == 1
         assert stats.api_calls == 1
         # ...except the persistence.
         entity_store.upsert_identity.assert_not_awaited()
@@ -490,19 +702,18 @@ class TestWriteBack:
 
     @pytest.mark.asyncio
     async def test_partial_row_fills_stored_key_not_verbatim(
-        self, entity_store, discogs_cache, discogs_service
+        self, resolver, entity_store, discogs_service
     ):
         """When tier 1 found a row (via any leg) that lacks a Discogs id,
-        the mint targets the FOUND row's library_name so COALESCE fills it
-        in place — upserting the verbatim input would insert a second row
-        for the same artist (near-duplicate key accretion)."""
+        the mint targets the FOUND row's library_name so the upsert fills
+        it in place — upserting the verbatim input would insert a second
+        row for the same artist (near-duplicate key accretion)."""
         entity_store.bulk_resolve_library_names = AsyncMock(
             return_value={"wishy": _identity("Wishy", spotify_artist_id="4aBc")}
         )
         discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+            side_effect=_pages({"wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         results, _ = await resolver.resolve(["wishy"])
 
@@ -510,19 +721,40 @@ class TestWriteBack:
         entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
 
     @pytest.mark.asyncio
-    async def test_upsert_returning_none_logs_and_keeps_verdict(
-        self, entity_store, discogs_cache, discogs_service, caplog
+    async def test_fillable_row_found_via_group_mate_verbatim(
+        self, resolver, entity_store, discogs_service
     ):
-        """A swallowed persistence failure must be loud in logs but the
-        verdict stands — it reports Discogs truth, not storage state (the
-        dry_run contract already decouples the two)."""
+        """The fill-in-place retarget works when the id-less row matches a
+        NON-first verbatim of the group."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Tubs": _identity("Tubs", spotify_artist_id="7xYz")}
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages(
+                {"The Tubs": [DiscogsArtistSearchResult(artist_id=333, title="The Tubs")]}
+            )
+        )
+
+        results, _ = await resolver.resolve(["The Tubs", "Tubs"])
+
+        assert all(r.discogs_artist_id == 333 for r in results)
+        entity_store.upsert_identity.assert_awaited_once_with("Tubs", discogs_artist_id=333)
+
+    @pytest.mark.asyncio
+    async def test_upsert_returning_none_logs_and_keeps_verdict(
+        self, resolver, entity_store, discogs_service, caplog
+    ):
+        """Pins the DEFENSIVE branch for upsert_identity's declared
+        Optional return (today's PgSource raises instead of returning
+        None — that path is pinned separately below): a swallowed
+        persistence failure must be loud in logs, and the verdict stands
+        (it reports Discogs truth; dry_run already decouples the two)."""
         import logging
 
         entity_store.upsert_identity = AsyncMock(return_value=None)
         discogs_service.search_artists = AsyncMock(
-            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
         )
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
 
         with caplog.at_level(logging.ERROR, logger="artists.resolver"):
             results, stats = await resolver.resolve(["Wishy"])
@@ -531,25 +763,19 @@ class TestWriteBack:
         assert stats.minted == 0
         assert any("write-back failed" in r.getMessage() for r in caplog.records)
 
-
-class TestDegenerateInputs:
     @pytest.mark.asyncio
-    async def test_empty_identity_match_form_is_not_found_without_probes(
-        self, entity_store, discogs_cache, discogs_service
+    async def test_write_back_pg_exception_propagates(
+        self, resolver, entity_store, discogs_service
     ):
-        """A name that normalizes to an empty form ('   ') has no queryable
-        identity — not_found, with candidate_count null (nothing was
-        measured; the API tier never ran) and no cache/API probes."""
-        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+        """The REAL persistence failure mode: PgSource propagates asyncpg
+        errors, resolve() re-raises (route → 503). Pinned so nobody
+        mistakes the Optional-return branch above for this path."""
+        from asyncpg.exceptions import PostgresError
 
-        results, stats = await resolver.resolve(["   "])
+        entity_store.upsert_identity = AsyncMock(side_effect=PostgresError("connection reset"))
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Wishy": [DiscogsArtistSearchResult(artist_id=123, title="Wishy")]})
+        )
 
-        r = results[0]
-        assert r.name == "   "
-        assert r.unresolved_reason == "not_found"
-        assert r.candidate_count is None
-        assert r.cache_corroboration == []
-        discogs_service.search_artists.assert_not_awaited()
-        discogs_cache.artist_equality_candidates.assert_not_awaited()
-        discogs_cache.artist_trigram_candidates.assert_not_awaited()
-        assert stats.not_found == 1
+        with pytest.raises(PostgresError):
+            await resolver.resolve(["Wishy"])

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -1,0 +1,555 @@
+"""Unit tests for the bare-name artist resolver (LML#759 PR C).
+
+The full verdict table from the issue's design, against mocked tiers:
+
+- tier 1: ``EntityStore.bulk_resolve_library_names`` (identity_store
+  short-circuit) + ``upsert_identity`` (write-back)
+- tier 2: ``DiscogsCacheService.artist_equality_candidates`` /
+  ``artist_trigram_candidates`` (evidence, never verdicts)
+- tier 3: ``DiscogsService.search_artists`` (the full-universe
+  exact-form uniqueness check — the only tier that can decide a mint)
+
+HTTP envelope concerns (auth, 413, span, error-class routing) live in
+``test_artist_resolve_router.py``; this file is resolver semantics only.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.breaker import DiscogsBreakerOpenError
+from discogs.cache_service import ArtistEqualityCandidates
+from discogs.models import DiscogsArtistSearchResult
+from entity.store import Identity
+
+
+def _identity(
+    library_name: str,
+    *,
+    discogs_artist_id: int | None = None,
+    spotify_artist_id: str | None = None,
+) -> Identity:
+    return Identity(
+        id=1,
+        library_name=library_name,
+        discogs_artist_id=discogs_artist_id,
+        wikidata_qid=None,
+        musicbrainz_artist_id=None,
+        spotify_artist_id=spotify_artist_id,
+        apple_music_artist_id=None,
+        bandcamp_id=None,
+        reconciliation_status="reconciled",
+    )
+
+
+@pytest.fixture
+def entity_store():
+    store = AsyncMock()
+    store.bulk_resolve_library_names = AsyncMock(return_value={})
+    store.upsert_identity = AsyncMock(side_effect=lambda name, **kw: _identity(name, **kw))
+    return store
+
+
+@pytest.fixture
+def discogs_cache():
+    cache = AsyncMock()
+
+    async def _equality(forms):
+        return {form: ArtistEqualityCandidates() for form in forms}
+
+    async def _trigram(names, **kwargs):
+        return {name: set() for name in names}
+
+    cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
+    cache.artist_trigram_candidates = AsyncMock(side_effect=_trigram)
+    return cache
+
+
+@pytest.fixture
+def discogs_service():
+    service = AsyncMock()
+    service.search_artists = AsyncMock(return_value=[])
+    return service
+
+
+def _make_resolver(entity_store, discogs_cache, discogs_service):
+    from artists.resolver import BareNameArtistResolver
+
+    return BareNameArtistResolver(
+        entity_store=entity_store,
+        discogs_cache=discogs_cache,
+        discogs_service=discogs_service,
+    )
+
+
+class TestIdentityStoreShortCircuit:
+    """Tier 1: a pre-existing row with a Discogs id decides before any evidence."""
+
+    @pytest.mark.asyncio
+    async def test_hit_resolves_without_cache_or_api(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Juana Molina": _identity("Juana Molina", discogs_artist_id=187553)}
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Juana Molina"])
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.name == "Juana Molina"
+        assert r.discogs_artist_id == 187553
+        assert r.method == "identity_store"
+        # entity.identity stores no Discogs title — identity_store omits it.
+        assert r.canonical_name is None
+        # The store decides before cache evidence is consulted: always
+        # empty corroboration and an unmeasured (null, never 0) count.
+        assert r.cache_corroboration == []
+        assert r.candidate_count is None
+        assert r.unresolved_reason is None
+
+        discogs_service.search_artists.assert_not_awaited()
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.api_calls == 0
+        assert stats.minted == 0
+        assert stats.resolved == 1
+
+    @pytest.mark.asyncio
+    async def test_hit_form_excluded_from_cache_evidence_queries(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """Short-circuited forms must not reach tier 2 — the contract says
+        corroboration is always empty there, and each equality query is four
+        seq-scans on the shared PG we shouldn't pay for a decided name."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Juana Molina": _identity("Juana Molina", discogs_artist_id=187553)}
+        )
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=77, title="Wishy")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        await resolver.resolve(["Juana Molina", "Wishy"])
+
+        (equality_forms,) = discogs_cache.artist_equality_candidates.await_args[0]
+        assert equality_forms == ["wishy"]
+        (trigram_names,) = discogs_cache.artist_trigram_candidates.await_args[0]
+        assert trigram_names == ["Wishy"]
+
+    @pytest.mark.asyncio
+    async def test_row_without_discogs_id_does_not_short_circuit(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """A row that exists but has no discogs_artist_id can't answer this
+        endpoint's question — the API tier still runs."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Wishy": _identity("Wishy", spotify_artist_id="4aBc")}
+        )
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Wishy"])
+
+        assert results[0].method == "api_search"
+        assert results[0].discogs_artist_id == 123
+        assert stats.api_calls == 1
+
+
+class TestApiVerdicts:
+    """Tier 3: the exact-form uniqueness table."""
+
+    @pytest.mark.asyncio
+    async def test_unique_exact_form_resolves_and_mints_verbatim(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        # Page noise whose identity-match form differs must not count.
+        discogs_service.search_artists = AsyncMock(
+            return_value=[
+                DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
+                DiscogsArtistSearchResult(artist_id=456, title="Wishy Washy"),
+            ]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Wishy"])
+
+        r = results[0]
+        assert r.discogs_artist_id == 123
+        assert r.canonical_name == "Wishy"
+        assert r.method == "api_search"
+        assert r.candidate_count == 1
+        assert r.unresolved_reason is None
+        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        assert stats.minted == 1
+        assert stats.resolved == 1
+
+    @pytest.mark.asyncio
+    async def test_overloaded_family_is_ambiguous_and_mints_nothing(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """The disambiguator strip is load-bearing: 'Popsicle (2)' collides
+        with 'Popsicle' and the family reads as ambiguous — never a guess."""
+        discogs_service.search_artists = AsyncMock(
+            return_value=[
+                DiscogsArtistSearchResult(artist_id=10, title="Popsicle"),
+                DiscogsArtistSearchResult(artist_id=20, title="Popsicle (2)"),
+            ]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Popsicle"])
+
+        r = results[0]
+        assert r.unresolved_reason == "ambiguous"
+        assert r.candidate_count == 2
+        assert r.discogs_artist_id is None
+        assert r.method is None
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.ambiguous == 1
+        assert stats.minted == 0
+
+    @pytest.mark.asyncio
+    async def test_duplicate_api_ids_collapse_to_one_candidate(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """Same artist id twice on the page is one candidate, not an
+        overload — count distinct ids, not rows."""
+        discogs_service.search_artists = AsyncMock(
+            return_value=[
+                DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
+                DiscogsArtistSearchResult(artist_id=123, title="Wishy"),
+            ]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, _ = await resolver.resolve(["Wishy"])
+
+        assert results[0].candidate_count == 1
+        assert results[0].discogs_artist_id == 123
+
+    @pytest.mark.asyncio
+    async def test_zero_exact_form_candidates_is_not_found(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=456, title="Reznor Ensemble")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["REZN"])
+
+        r = results[0]
+        assert r.unresolved_reason == "not_found"
+        # A measured zero — the API tier ran and testified.
+        assert r.candidate_count == 0
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.not_found == 1
+
+    @pytest.mark.asyncio
+    async def test_alias_only_cache_evidence_is_not_found_with_corroboration(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """Alias-shaped matches can't be globally uniqueness-checked: v1
+        declines to mint but records the leg — the v2 alias-arm sizing
+        telemetry rides ``cache_corroboration`` on unresolved verdicts."""
+
+        async def _equality(forms):
+            return {"rezn": ArtistEqualityCandidates(alias={999})}
+
+        discogs_cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
+        discogs_service.search_artists = AsyncMock(return_value=[])
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, _ = await resolver.resolve(["REZN"])
+
+        r = results[0]
+        assert r.unresolved_reason == "not_found"
+        assert r.cache_corroboration == ["cache_alias"]
+        assert r.candidate_count == 0
+        entity_store.upsert_identity.assert_not_awaited()
+
+
+class TestCacheConflictRule:
+    """Equality-leg cache evidence can veto (conflict → doubt → NULL);
+    trigram evidence never can."""
+
+    @pytest.mark.asyncio
+    async def test_equality_conflict_is_ambiguous_with_count_one(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        async def _equality(forms):
+            return {"popsicle": ArtistEqualityCandidates(exact={11})}
+
+        discogs_cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=10, title="Popsicle")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, _ = await resolver.resolve(["Popsicle"])
+
+        r = results[0]
+        assert r.unresolved_reason == "ambiguous"
+        # Exactly 1: the API observed one exact-form candidate; the
+        # ambiguity is the cache conflict, not an overload family.
+        assert r.candidate_count == 1
+        assert r.cache_corroboration == ["cache_exact"]
+        entity_store.upsert_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_equality_agreement_resolves_with_corroboration(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        async def _equality(forms):
+            return {"wishy": ArtistEqualityCandidates(exact={123}, name_variation={123})}
+
+        discogs_cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, _ = await resolver.resolve(["Wishy"])
+
+        r = results[0]
+        assert r.discogs_artist_id == 123
+        assert r.method == "api_search"
+        # Enum order, only legs with candidates.
+        assert r.cache_corroboration == ["cache_exact", "cache_name_variation"]
+
+    @pytest.mark.asyncio
+    async def test_trigram_neighbor_never_vetoes(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        async def _trigram(names, **kwargs):
+            return {"Wishy": {999}}
+
+        discogs_cache.artist_trigram_candidates = AsyncMock(side_effect=_trigram)
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, _ = await resolver.resolve(["Wishy"])
+
+        r = results[0]
+        assert r.discogs_artist_id == 123
+        assert r.unresolved_reason is None
+        assert r.cache_corroboration == ["cache_trigram"]
+
+
+class TestEscalationUnavailable:
+    """'Couldn't ask' is retryable and distinct from 'asked and missed'."""
+
+    @pytest.mark.asyncio
+    async def test_breaker_trip_short_circuits_remaining_batch(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        discogs_service.search_artists = AsyncMock(side_effect=DiscogsBreakerOpenError("shed"))
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Wishy", "REZN", "The Tubs"])
+
+        assert [r.unresolved_reason for r in results] == ["escalation_unavailable"] * 3
+        assert all(r.candidate_count is None for r in results)
+        # One shed, not one per remaining name.
+        assert discogs_service.search_artists.await_count == 1
+        assert stats.escalation_unavailable == 3
+        entity_store.upsert_identity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_single_none_response_does_not_short_circuit(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """``None`` = couldn't ask (429-exhausted / network / distrusted
+        page) for THAT name only; the batch continues."""
+        discogs_service.search_artists = AsyncMock(
+            side_effect=[None, [DiscogsArtistSearchResult(artist_id=5, title="REZN")]]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Wishy", "REZN"])
+
+        assert results[0].unresolved_reason == "escalation_unavailable"
+        assert results[0].candidate_count is None
+        assert results[1].discogs_artist_id == 5
+        assert discogs_service.search_artists.await_count == 2
+        assert stats.escalation_unavailable == 1
+        assert stats.resolved == 1
+
+    @pytest.mark.asyncio
+    async def test_no_discogs_service_sheds_api_tier_only(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """No DISCOGS_TOKEN → PG tiers keep answering; API-needing names
+        report escalation_unavailable, identity_store hits still resolve."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"Juana Molina": _identity("Juana Molina", discogs_artist_id=187553)}
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service=None)
+
+        results, stats = await resolver.resolve(["Juana Molina", "Wishy"])
+
+        assert results[0].discogs_artist_id == 187553
+        assert results[1].unresolved_reason == "escalation_unavailable"
+        assert stats.resolved == 1
+        assert stats.escalation_unavailable == 1
+
+    @pytest.mark.asyncio
+    async def test_escalation_unavailable_still_carries_cache_corroboration(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """Cache evidence gathered before the shed is telemetry we already
+        paid for — it rides the unresolved verdict."""
+
+        async def _equality(forms):
+            return {"wishy": ArtistEqualityCandidates(member={42})}
+
+        discogs_cache.artist_equality_candidates = AsyncMock(side_effect=_equality)
+        discogs_service.search_artists = AsyncMock(side_effect=DiscogsBreakerOpenError("shed"))
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, _ = await resolver.resolve(["Wishy"])
+
+        r = results[0]
+        assert r.unresolved_reason == "escalation_unavailable"
+        assert r.cache_corroboration == ["cache_member"]
+
+
+class TestDedupe:
+    """Inputs dedupe on identity-match form; verdicts fan back per position;
+    only the first occurrence's verbatim mints."""
+
+    @pytest.mark.asyncio
+    async def test_shared_verdict_per_position_verbatim_echo(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Wishy", "wishy", "WISHY"])
+
+        assert [r.name for r in results] == ["Wishy", "wishy", "WISHY"]
+        assert all(r.discogs_artist_id == 123 for r in results)
+        # One unique form → one API probe, one mint, keyed on the first
+        # occurrence's verbatim (two rows for one Discogs id is how the
+        # store accretes near-duplicate keys).
+        assert discogs_service.search_artists.await_count == 1
+        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        assert stats.names == 3
+        assert stats.deduped == 1
+        assert stats.resolved == 3
+
+    @pytest.mark.asyncio
+    async def test_disambiguated_input_collides_with_bare_form(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """'Popsicle (2)' normalizes to the same form as 'Popsicle' — one
+        work unit, shared verdict."""
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=10, title="Popsicle")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Popsicle", "Popsicle (2)"])
+
+        assert stats.deduped == 1
+        assert results[0].discogs_artist_id == results[1].discogs_artist_id == 10
+
+
+class TestWriteBack:
+    """Mint rules: verbatim key, discogs_artist_id only, dry_run inverse."""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_full_verdicts_but_never_upserts(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["Wishy"], dry_run=True)
+
+        r = results[0]
+        # Everything ran identically — real API verification, full verdict.
+        assert r.discogs_artist_id == 123
+        assert r.method == "api_search"
+        assert r.candidate_count == 1
+        assert stats.api_calls == 1
+        # ...except the persistence.
+        entity_store.upsert_identity.assert_not_awaited()
+        assert stats.minted == 0
+
+    @pytest.mark.asyncio
+    async def test_partial_row_fills_stored_key_not_verbatim(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """When tier 1 found a row (via any leg) that lacks a Discogs id,
+        the mint targets the FOUND row's library_name so COALESCE fills it
+        in place — upserting the verbatim input would insert a second row
+        for the same artist (near-duplicate key accretion)."""
+        entity_store.bulk_resolve_library_names = AsyncMock(
+            return_value={"wishy": _identity("Wishy", spotify_artist_id="4aBc")}
+        )
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, _ = await resolver.resolve(["wishy"])
+
+        assert results[0].discogs_artist_id == 123
+        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+
+    @pytest.mark.asyncio
+    async def test_upsert_returning_none_logs_and_keeps_verdict(
+        self, entity_store, discogs_cache, discogs_service, caplog
+    ):
+        """A swallowed persistence failure must be loud in logs but the
+        verdict stands — it reports Discogs truth, not storage state (the
+        dry_run contract already decouples the two)."""
+        import logging
+
+        entity_store.upsert_identity = AsyncMock(return_value=None)
+        discogs_service.search_artists = AsyncMock(
+            return_value=[DiscogsArtistSearchResult(artist_id=123, title="Wishy")]
+        )
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        with caplog.at_level(logging.ERROR, logger="artists.resolver"):
+            results, stats = await resolver.resolve(["Wishy"])
+
+        assert results[0].discogs_artist_id == 123
+        assert stats.minted == 0
+        assert any("write-back failed" in r.getMessage() for r in caplog.records)
+
+
+class TestDegenerateInputs:
+    @pytest.mark.asyncio
+    async def test_empty_identity_match_form_is_not_found_without_probes(
+        self, entity_store, discogs_cache, discogs_service
+    ):
+        """A name that normalizes to an empty form ('   ') has no queryable
+        identity — not_found, with candidate_count null (nothing was
+        measured; the API tier never ran) and no cache/API probes."""
+        resolver = _make_resolver(entity_store, discogs_cache, discogs_service)
+
+        results, stats = await resolver.resolve(["   "])
+
+        r = results[0]
+        assert r.name == "   "
+        assert r.unresolved_reason == "not_found"
+        assert r.candidate_count is None
+        assert r.cache_corroboration == []
+        discogs_service.search_artists.assert_not_awaited()
+        discogs_cache.artist_equality_candidates.assert_not_awaited()
+        discogs_cache.artist_trigram_candidates.assert_not_awaited()
+        assert stats.not_found == 1

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -2345,6 +2345,80 @@ class TestArtistEqualityCandidates:
 # ---------------------------------------------------------------------------
 
 
+class TestArtistEqualityCandidatesLegIteration:
+    """The dataclass owns its leg enumeration (LML#759 review round 1):
+    consumers derive corroboration and the conflict-rule union from ONE
+    field list, so a leg added to the dataclass cannot be silently absent
+    from either — a missing leg in the union weakens the veto and lets an
+    ambiguous name mint."""
+
+    def test_nonempty_legs_in_field_declaration_order(self):
+        candidates = ArtistEqualityCandidates(
+            exact={1},
+            alias={3},
+            name_variation={4},
+        )
+        assert candidates.nonempty_legs() == ["exact", "alias", "name_variation"]
+
+    def test_nonempty_legs_empty_when_all_legs_measured_zero(self):
+        assert ArtistEqualityCandidates().nonempty_legs() == []
+
+    def test_leg_names_match_wire_enum_values(self):
+        """Field names are contractually tied to ArtistResolveCacheLeg
+        (each wire value is "cache_" + field name); a rename on either
+        side must fail here, not silently desynchronize telemetry."""
+        from dataclasses import fields
+
+        from generated.api_models import ArtistResolveCacheLeg
+
+        wire_values = {leg.value for leg in ArtistResolveCacheLeg}
+        for f in fields(ArtistEqualityCandidates):
+            assert f"cache_{f.name}" in wire_values
+
+    def test_all_candidate_ids_unions_every_leg(self):
+        candidates = ArtistEqualityCandidates(
+            exact={1, 2},
+            member={2, 3},
+            alias={4},
+            name_variation={5},
+        )
+        assert candidates.all_candidate_ids() == {1, 2, 3, 4, 5}
+
+    def test_all_candidate_ids_empty_on_measured_zero(self):
+        assert ArtistEqualityCandidates().all_candidate_ids() == set()
+
+    def test_field_order_matches_wire_enum_declaration_order(self):
+        """nonempty_legs() promises field order == wire enum order — a
+        reorder on either side silently changes cache_corroboration
+        ordering that downstream consumers treat as deterministic."""
+        from dataclasses import fields
+
+        from generated.api_models import ArtistResolveCacheLeg
+
+        equality_enum_values = [
+            leg.value
+            for leg in ArtistResolveCacheLeg
+            if leg is not ArtistResolveCacheLeg.cache_trigram
+        ]
+        assert [f"cache_{f.name}" for f in fields(ArtistEqualityCandidates)] == (
+            equality_enum_values
+        )
+
+    def test_every_equality_enum_value_has_a_dataclass_field(self):
+        """Reverse parity: a wire enum leg added without its dataclass
+        field would silently never corroborate NOR veto — the exact
+        missing-leg failure the leg-iteration methods exist to prevent."""
+        from dataclasses import fields
+
+        from generated.api_models import ArtistResolveCacheLeg
+
+        field_names = {f.name for f in fields(ArtistEqualityCandidates)}
+        for leg in ArtistResolveCacheLeg:
+            if leg is ArtistResolveCacheLeg.cache_trigram:
+                continue
+            assert leg.value.removeprefix("cache_") in field_names
+
+
 class TestArtistTrigramCandidates:
     """The trigram query runs on an acquired connection inside a transaction
     so ``SET LOCAL pg_trgm.similarity_threshold`` can pin the ``%``
@@ -2455,46 +2529,3 @@ class TestArtistTrigramCandidates:
         conn.fetch = AsyncMock(return_value=[{"input": "not in batch", "artist_ids": [1]}])
         with pytest.raises(CacheUnavailableError):
             await cache_service.artist_trigram_candidates(["Stereolab"])
-
-
-class TestArtistEqualityCandidatesLegIteration:
-    """The dataclass owns its leg enumeration (LML#759 review round 1):
-    consumers derive corroboration and the conflict-rule union from ONE
-    field list, so a leg added to the dataclass cannot be silently absent
-    from either — a missing leg in the union weakens the veto and lets an
-    ambiguous name mint."""
-
-    def test_nonempty_legs_in_field_declaration_order(self):
-        candidates = ArtistEqualityCandidates(
-            exact={1},
-            alias={3},
-            name_variation={4},
-        )
-        assert candidates.nonempty_legs() == ["exact", "alias", "name_variation"]
-
-    def test_nonempty_legs_empty_when_all_legs_measured_zero(self):
-        assert ArtistEqualityCandidates().nonempty_legs() == []
-
-    def test_leg_names_match_wire_enum_values(self):
-        """Field names are contractually tied to ArtistResolveCacheLeg
-        (each wire value is "cache_" + field name); a rename on either
-        side must fail here, not silently desynchronize telemetry."""
-        from dataclasses import fields
-
-        from generated.api_models import ArtistResolveCacheLeg
-
-        wire_values = {leg.value for leg in ArtistResolveCacheLeg}
-        for f in fields(ArtistEqualityCandidates):
-            assert f"cache_{f.name}" in wire_values
-
-    def test_all_candidate_ids_unions_every_leg(self):
-        candidates = ArtistEqualityCandidates(
-            exact={1, 2},
-            member={2, 3},
-            alias={4},
-            name_variation={5},
-        )
-        assert candidates.all_candidate_ids() == {1, 2, 3, 4, 5}
-
-    def test_all_candidate_ids_empty_on_measured_zero(self):
-        assert ArtistEqualityCandidates().all_candidate_ids() == set()

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -1,6 +1,7 @@
 """Unit tests for discogs/cache_service.py."""
 
 import asyncio
+from dataclasses import fields
 from datetime import UTC
 from unittest.mock import AsyncMock
 
@@ -21,6 +22,7 @@ from discogs.models import (
     ReleaseVideo,
     TrackItem,
 )
+from generated.api_models import ArtistResolveCacheLeg
 
 
 def make_fetch_router(**table_results):
@@ -2367,10 +2369,6 @@ class TestArtistEqualityCandidatesLegIteration:
         """Field names are contractually tied to ArtistResolveCacheLeg
         (each wire value is "cache_" + field name); a rename on either
         side must fail here, not silently desynchronize telemetry."""
-        from dataclasses import fields
-
-        from generated.api_models import ArtistResolveCacheLeg
-
         wire_values = {leg.value for leg in ArtistResolveCacheLeg}
         for f in fields(ArtistEqualityCandidates):
             assert f"cache_{f.name}" in wire_values
@@ -2391,10 +2389,6 @@ class TestArtistEqualityCandidatesLegIteration:
         """nonempty_legs() promises field order == wire enum order — a
         reorder on either side silently changes cache_corroboration
         ordering that downstream consumers treat as deterministic."""
-        from dataclasses import fields
-
-        from generated.api_models import ArtistResolveCacheLeg
-
         equality_enum_values = [
             leg.value
             for leg in ArtistResolveCacheLeg
@@ -2408,10 +2402,6 @@ class TestArtistEqualityCandidatesLegIteration:
         """Reverse parity: a wire enum leg added without its dataclass
         field would silently never corroborate NOR veto — the exact
         missing-leg failure the leg-iteration methods exist to prevent."""
-        from dataclasses import fields
-
-        from generated.api_models import ArtistResolveCacheLeg
-
         field_names = {f.name for f in fields(ArtistEqualityCandidates)}
         for leg in ArtistResolveCacheLeg:
             if leg is ArtistResolveCacheLeg.cache_trigram:

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
+from discogs.cache_service import (
+    ArtistEqualityCandidates,
+    CacheUnavailableError,
+    DiscogsCacheService,
+)
 from discogs.models import (
     ArtistCredit,
     ArtistDetails,
@@ -2451,3 +2455,46 @@ class TestArtistTrigramCandidates:
         conn.fetch = AsyncMock(return_value=[{"input": "not in batch", "artist_ids": [1]}])
         with pytest.raises(CacheUnavailableError):
             await cache_service.artist_trigram_candidates(["Stereolab"])
+
+
+class TestArtistEqualityCandidatesLegIteration:
+    """The dataclass owns its leg enumeration (LML#759 review round 1):
+    consumers derive corroboration and the conflict-rule union from ONE
+    field list, so a leg added to the dataclass cannot be silently absent
+    from either — a missing leg in the union weakens the veto and lets an
+    ambiguous name mint."""
+
+    def test_nonempty_legs_in_field_declaration_order(self):
+        candidates = ArtistEqualityCandidates(
+            exact={1},
+            alias={3},
+            name_variation={4},
+        )
+        assert candidates.nonempty_legs() == ["exact", "alias", "name_variation"]
+
+    def test_nonempty_legs_empty_when_all_legs_measured_zero(self):
+        assert ArtistEqualityCandidates().nonempty_legs() == []
+
+    def test_leg_names_match_wire_enum_values(self):
+        """Field names are contractually tied to ArtistResolveCacheLeg
+        (each wire value is "cache_" + field name); a rename on either
+        side must fail here, not silently desynchronize telemetry."""
+        from dataclasses import fields
+
+        from generated.api_models import ArtistResolveCacheLeg
+
+        wire_values = {leg.value for leg in ArtistResolveCacheLeg}
+        for f in fields(ArtistEqualityCandidates):
+            assert f"cache_{f.name}" in wire_values
+
+    def test_all_candidate_ids_unions_every_leg(self):
+        candidates = ArtistEqualityCandidates(
+            exact={1, 2},
+            member={2, 3},
+            alias={4},
+            name_variation={5},
+        )
+        assert candidates.all_candidate_ids() == {1, 2, 3, 4, 5}
+
+    def test_all_candidate_ids_empty_on_measured_zero(self):
+        assert ArtistEqualityCandidates().all_candidate_ids() == set()


### PR DESCRIPTION
Part of #759 (PR C1 — the endpoint PR C was split into a stacked pair for reviewability; PR C2 is #764, retargeted onto this branch). PR A is WXYC/wxyc-shared#218, PR B is #761 + #762, all merged.

## `artists/resolver.py` — tier orchestration + verdict assembly

The verify-before-mint engine the `POST /api/v1/artists/resolve/bulk` endpoint (PR C2 / #764) mounts. **Inert until C2 lands** — nothing calls `BareNameArtistResolver` yet, so this is a zero-behavior-change PR in the PR-B mold.

Per unique identity-match form (`to_identity_match_form`; duplicate positions share the verdict, per-position verbatim echo):

1. **`entity.identity` three-leg read** (batched `bulk_resolve_library_names`) — true short-circuit (`method: identity_store`) only when the row carries a `discogs_artist_id`. A row holding other ids falls through, and its **stored key** becomes the mint target so COALESCE fills the row in place instead of accreting a near-duplicate key.
2. **Cache candidate evidence** (`artist_equality_candidates` + `artist_trigram_candidates`, batched, skipped for tier-1-decided forms) — reported in `cache_corroboration` on both verdict kinds; equality legs can veto (conflict → `ambiguous`), trigram never does.
3. **Serial Discogs exact-form uniqueness check** (`search_artists`) — exact-form family counted by **distinct artist id** after the "(N)"-stripping normalizer (so "Popsicle (2)" collides with "Popsicle"). 1 candidate + no conflict → resolved + mint (`discogs_artist_id` only, verbatim key, skipped on `dry_run`); ≥2 → `ambiguous`; 0 → `not_found` (measured zero) even when alias-shaped cache evidence exists (counted for the v2 alias-arm sizing instead). `None` (couldn't ask) → `escalation_unavailable` for that name; `DiscogsBreakerOpenError` → `escalation_unavailable` **and short-circuits the rest of the batch** (one shed, not one per name). A missing Discogs service (no token) degrades the API tier the same way — PG tiers keep answering.

`candidate_count` null-vs-zero is enforced throughout (null = not measured: identity_store, escalation_unavailable, empty-form inputs). `ResolveStats` carries the per-request aggregates C2's Sentry span + PostHog event consume.

## Tests

**21 resolver unit tests** (`tests/unit/test_artist_resolver.py`) — the full verdict table: identity-store short-circuit (zero cache/API probes, empty corroboration), unique-resolves-and-mints, overload → ambiguous, distinct-id collapse, measured-zero not_found, alias-only-evidence not_found + corroboration, equality conflict vs agreement vs trigram-never-vetoes, breaker mid-batch short-circuit, single-None non-fatal, service-None degradation, corroboration on unresolved verdicts, dedupe/first-verbatim-mint, dry_run inverse, stored-key fill, loud write-back failure, empty-form degenerate.

Local checks: ruff + mypy clean, 21/21 unit tests green on this slice alone.

## Related

- #759 (parent) — WXYC/wxyc-shared#218 (PR A), #761 / #762 (PR B), #764 (PR C2, stacked on this), WXYC/Backend-Service#1614 (consumer)
