### PR TITLE
fix(#767): align bulk-route request envelope + transient-error classification

### DIFF
--- a/artists/router.py
+++ b/artists/router.py
@@ -23,14 +23,12 @@ import logging
 from typing import TYPE_CHECKING
 
 import sentry_sdk
-from asyncpg.exceptions import InterfaceError, PostgresError
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, ValidationError
-from starlette.requests import ClientDisconnect
 from wxyc_fastapi.observability import RequestTelemetry, init_cache_stats
 
 from artists.composer import ArtistSearchAliasesComposer
 from artists.resolver import BareNameArtistResolver, InvalidNameError
+from core.bulk_body import TRANSIENT_PG_ERRORS, parse_bulk_body, resolve_input_cap
 from core.dependencies import (
     get_artist_resolve_posthog_client,
     get_discogs_cache_service_from_pool,
@@ -53,43 +51,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _resolve_input_cap(request_model: type[BaseModel]) -> int:
-    """Read the names array `maxItems` from a generated model's JSON schema.
-
-    Drift guard: api.yaml's `maxItems` for `names` drives the generated
-    request model's constraint. The routes enforce the cap as 413 before
-    Pydantic validation; sourcing the literal from the model means a
-    future api.yaml change that regenerates the model automatically
-    updates the manual 413 gate.
-
-    Uses `model_json_schema()` rather than the lower-level
-    `model_fields[...].metadata` introspection because the JSON-schema
-    export is Pydantic's documented public API (it's tied to OpenAPI
-    generation and unlikely to drift across minor versions), whereas the
-    metadata shape is implementation detail that has changed before.
-    `pydantic` is pinned only as a lower bound (`>=2.0.0`) so this
-    distinction matters across deploys.
-
-    Raises at module import time if `maxItems` is missing — fail loud, so
-    a regenerated model that drops the constraint can't silently widen
-    the 413 gate and produce 422 responses for cap-exceeded requests.
-    """
-    schema = request_model.model_json_schema()
-    names_schema = schema.get("properties", {}).get("names", {})
-    max_items = names_schema.get("maxItems")
-    if isinstance(max_items, int) and max_items > 0:
-        return max_items
-    raise RuntimeError(
-        f"Cannot resolve `maxItems` for {request_model.__name__}.names "
-        "from its JSON schema. The route's 413 gate must agree with the "
-        "generated model; fix or regenerate the model before this module "
-        f"can import (schema fragment: {names_schema!r})."
-    )
-
-
 # Per api.yaml: max names per request; over-cap returns 413.
-_BULK_INPUT_CAP = _resolve_input_cap(ArtistSearchAliasesBulkRequest)
-_RESOLVE_INPUT_CAP = _resolve_input_cap(ArtistResolveBulkRequest)
+_BULK_INPUT_CAP = resolve_input_cap(ArtistSearchAliasesBulkRequest, "names")
+_RESOLVE_INPUT_CAP = resolve_input_cap(ArtistResolveBulkRequest, "names")
 
 _ROUTE_PATH = "/api/v1/artists/search-aliases/bulk"
 _RESOLVE_ROUTE_PATH = "/api/v1/artists/resolve/bulk"
@@ -113,48 +77,6 @@ _ENTITY_STORE_QUERY_FAILED_DETAIL = (
 _DISCOGS_CACHE_QUERY_FAILED_DETAIL = (
     "Discogs cache query failed — likely a transient connection loss; retrying may succeed."
 )
-
-
-async def _parse_bulk_names_body[RequestT: BaseModel](
-    http_request: Request,
-    model: type[RequestT],
-    cap: int,
-) -> RequestT:
-    """Shared request envelope for the bulk `names` routes in this router.
-
-    Manual 413 check before Pydantic validation (mirrors `bulk-resolve-
-    libraries`): the generated request models carry api.yaml's `maxItems`,
-    but Pydantic's enforcement is 422. The api.yaml contract documents 413
-    for cap exceedance, so the raw count is read first and 413 raised;
-    only then does the model validate.
-    """
-    try:
-        body = await http_request.json()
-    except (ValueError, TypeError) as e:
-        raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
-    except ClientDisconnect:
-        # Client closed the connection before the body completed. There is
-        # no point sending a 5xx — the client is gone — but we want this to
-        # land as a 4xx in logs (the route did its job; the failure is the
-        # client's). Treat as 400 to keep error-class accounting clean.
-        raise HTTPException(
-            status_code=400,
-            detail="Client disconnected before request body completed.",
-        ) from None
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
-    names_raw = body.get("names")
-    if not isinstance(names_raw, list):
-        raise HTTPException(status_code=422, detail="`names` must be a JSON array.")
-    if len(names_raw) > cap:
-        raise HTTPException(
-            status_code=413,
-            detail=f"Batch exceeded the {cap}-name cap (received {len(names_raw)}).",
-        )
-    try:
-        return model.model_validate(body)
-    except ValidationError as e:
-        raise HTTPException(status_code=422, detail=e.errors()) from None
 
 
 router = APIRouter(tags=["artists"])
@@ -187,8 +109,8 @@ async def search_aliases_bulk(
     `asyncio.gather` over per-name leaves (LML#370/#372 cascade-cascade
     avoidance).
     """
-    request = await _parse_bulk_names_body(
-        http_request, ArtistSearchAliasesBulkRequest, _BULK_INPUT_CAP
+    request = await parse_bulk_body(
+        http_request, ArtistSearchAliasesBulkRequest, _BULK_INPUT_CAP, field="names"
     )
 
     if entity_store is None:
@@ -245,7 +167,7 @@ async def search_aliases_bulk(
             raise HTTPException(
                 status_code=503, detail=_DISCOGS_CACHE_QUERY_FAILED_DETAIL
             ) from None
-        except (PostgresError, InterfaceError, OSError):
+        except TRANSIENT_PG_ERRORS:
             # Phase 1: entity-store PG failure (raw asyncpg error — not
             # wrapped). Phase 2 errors are wrapped above; if a PostgresError
             # reaches here, it came from `bulk_resolve_library_names`.
@@ -342,8 +264,8 @@ async def resolve_bulk(
     LML#755 breaker shed degrades per-name to `escalation_unavailable` —
     the PG tiers keep answering, never a batch-level 503.
     """
-    request = await _parse_bulk_names_body(
-        http_request, ArtistResolveBulkRequest, _RESOLVE_INPUT_CAP
+    request = await parse_bulk_body(
+        http_request, ArtistResolveBulkRequest, _RESOLVE_INPUT_CAP, field="names"
     )
 
     if entity_store is None:
@@ -410,7 +332,7 @@ async def resolve_bulk(
             raise HTTPException(
                 status_code=503, detail=_DISCOGS_CACHE_QUERY_FAILED_DETAIL
             ) from None
-        except (PostgresError, InterfaceError, OSError):
+        except TRANSIENT_PG_ERRORS:
             # Tier-1 read or write-back: raw entity-store PG failure.
             # InterfaceError (asyncpg's client-side pool/connection
             # lifecycle errors) subclasses neither PostgresError nor

--- a/cache/router.py
+++ b/cache/router.py
@@ -36,9 +36,7 @@ from collections import Counter
 from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
-from asyncpg.exceptions import PostgresError
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import ValidationError
 
 from cache.dispatch import refresh_identity
 from cache.models import (
@@ -46,6 +44,7 @@ from cache.models import (
     BulkCacheRefreshResponse,
     CacheRefreshResultItem,
 )
+from core.bulk_body import TRANSIENT_PG_ERRORS, parse_bulk_body
 from core.bulk_concurrency import (
     acquire_bulk_global_permit,
     cancel_and_drain,
@@ -151,27 +150,18 @@ async def handle_refresh_for_identities(
     bandcamp_client: BandcampClient | None = Depends(get_bandcamp_client),
 ) -> BulkCacheRefreshResponse:
     """Bulk cache refresh. See route docstring for protocol."""
-    # Manual 400-on-overflow before Pydantic so oversize doesn't get 422'd.
-    # Same precedent as `/api/v1/lookup/bulk` (lookup/router.py:301-322).
-    try:
-        body = await http_request.json()
-    except (ValueError, TypeError) as e:
-        raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
-    ids_raw = body.get("identity_ids")
-    if not isinstance(ids_raw, list):
-        raise HTTPException(status_code=422, detail="`identity_ids` must be a JSON array.")
-    if len(ids_raw) > _REFRESH_INPUT_CAP:
-        raise HTTPException(
-            status_code=400,
-            detail=(f"Batch exceeded the {_REFRESH_INPUT_CAP}-id cap (received {len(ids_raw)})."),
-        )
-
-    try:
-        request = BulkCacheRefreshRequest.model_validate(body)
-    except ValidationError as e:
-        raise HTTPException(status_code=422, detail=e.errors()) from None
+    # Shared bulk envelope (LML#767): raw-JSON parse, ClientDisconnect -> 400,
+    # non-object -> 400, manual over-cap before Pydantic, then model_validate.
+    # `cap_status=400` preserves this route's LML#525 over-cap contract (400,
+    # not the family's default 413). An absent/wrong-type `identity_ids` field
+    # falls through to Pydantic's structured errors() rather than a bare 422.
+    request = await parse_bulk_body(
+        http_request,
+        BulkCacheRefreshRequest,
+        _REFRESH_INPUT_CAP,
+        field="identity_ids",
+        cap_status=400,
+    )
 
     store = _require_entity_store(entity_store)
     discogs = _require_discogs_service(discogs_service)
@@ -187,7 +177,7 @@ async def handle_refresh_for_identities(
         provenance = await store.get_release_identity_provenance_bulk(
             list(dict.fromkeys(identity_ids))
         )
-    except (PostgresError, OSError) as e:
+    except TRANSIENT_PG_ERRORS as e:
         logger.exception("cache refresh: provenance bulk read failed for %d ids", len(identity_ids))
         raise HTTPException(
             status_code=503,

--- a/core/bulk_body.py
+++ b/core/bulk_body.py
@@ -1,0 +1,141 @@
+"""Shared request envelope for the bulk-route family (LML#767).
+
+Every bulk route that hand-parses its body (rather than taking a typed body
+parameter) needs the same envelope: raw-JSON parse, client-disconnect
+handling, a manual over-cap check that raises 413 *before* Pydantic (whose
+`max_length` enforcement would otherwise 422 an oversize batch), then full
+model validation. The api.yaml contract documents 413 for cap exceedance,
+so the raw count is read first.
+
+The artists routes (LML#764) were the first to consolidate their two copies
+into a private helper; the older bulk routes each carried a drifted copy
+(missing `InterfaceError` in the transient tuple, missing the
+`ClientDisconnect` arm, and treating an absent batch field as a bare-string
+422). This module is the one source of truth they all now share.
+
+Two pieces:
+
+- ``TRANSIENT_PG_ERRORS`` — the exception tuple a bulk route catches around
+  its PG work to return a transient 503 (retry may succeed) rather than an
+  application 500. Includes asyncpg's client-side ``InterfaceError``
+  alongside the server-side ``PostgresError`` and socket-level ``OSError``:
+  asyncpg raises pool-lifecycle errors ("pool is closing", "connection is
+  closed") as the base ``InterfaceError``, which subclasses neither of the
+  other two, so a deploy-window pool teardown would otherwise read as a 500.
+  The same class ``discogs/fallthrough.py`` pins in ``_ARMING_EXCEPTIONS`` as
+  its test-asserted "DB unreachable" set.
+
+- ``parse_bulk_body(request, model, cap, field)`` — the envelope itself,
+  generalized over the batch field name (``names`` / ``inputs`` /
+  ``identity_ids`` / ``items``).
+"""
+
+from __future__ import annotations
+
+from asyncpg.exceptions import InterfaceError, PostgresError
+from fastapi import HTTPException, Request
+from pydantic import BaseModel, ValidationError
+from starlette.requests import ClientDisconnect
+
+# The transient DB-unreachable set. A bulk route catches this around its PG
+# work and returns 503; anything else is an application bug and stays a 500.
+# InterfaceError is asyncpg's client-side pool/connection lifecycle class,
+# which subclasses neither PostgresError (server-side) nor OSError
+# (socket-level) — without it a pool teardown during a deploy reads as a 500.
+TRANSIENT_PG_ERRORS: tuple[type[BaseException], ...] = (
+    PostgresError,
+    InterfaceError,
+    OSError,
+)
+
+
+async def parse_bulk_body[RequestT: BaseModel](
+    request: Request,
+    model: type[RequestT],
+    cap: int,
+    field: str,
+    cap_status: int = 413,
+) -> RequestT:
+    """Parse + cap-check a bulk route's raw JSON body, then validate.
+
+    The manual 413 check runs before Pydantic validation: the generated
+    request models carry api.yaml's ``maxItems`` as ``max_length``, but
+    Pydantic's enforcement is 422. The api.yaml contract documents 413 for
+    cap exceedance, so the raw count of ``field`` is read first and 413
+    raised; only then does the model validate.
+
+    An absent or wrong-type ``field`` is deliberately NOT special-cased here:
+    the cap guard is ``isinstance(x, list) and len(x) > cap``, so a non-list
+    value falls straight through to ``model_validate``, which produces
+    Pydantic's structured ``missing`` / ``list_type`` error rather than a
+    bare-string 422. Every other field already gets that structured shape;
+    the batch field now matches.
+
+    ``cap_status`` is the over-cap status: 413 by default (the api.yaml
+    contract for the identity/artists routes), overridable to 400 for the
+    lookup/bulk and cache-refresh routes, which document 400 for oversize
+    batches. Passing it preserves each route's existing wire contract.
+
+    Status codes: 400 (malformed JSON / client disconnect / non-object body),
+    ``cap_status`` (over cap), 422 (Pydantic validation).
+    """
+    try:
+        body = await request.json()
+    except (ValueError, TypeError) as e:
+        raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
+    except ClientDisconnect:
+        # Client closed the connection before the body completed. There is no
+        # point sending a 5xx — the client is gone — but we want this to land
+        # as a 4xx in logs (the route did its job; the failure is the
+        # client's). Treat as 400 to keep error-class accounting clean; a
+        # dropped arm would surface these as unhandled 500-shaped noise.
+        raise HTTPException(
+            status_code=400,
+            detail="Client disconnected before request body completed.",
+        ) from None
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
+    batch = body.get(field)
+    if isinstance(batch, list) and len(batch) > cap:
+        raise HTTPException(
+            status_code=cap_status,
+            detail=f"Batch exceeded the {cap}-item cap (received {len(batch)}).",
+        )
+    try:
+        return model.model_validate(body)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from None
+
+
+def resolve_input_cap(request_model: type[BaseModel], field: str) -> int:
+    """Read a batch field's ``maxItems`` from a generated model's JSON schema.
+
+    Drift guard: api.yaml's ``maxItems`` for the batch field drives the
+    generated request model's constraint. The routes enforce the cap as 413
+    before Pydantic validation; sourcing the literal from the model means a
+    future api.yaml change that regenerates the model automatically updates
+    the manual 413 gate.
+
+    Uses ``model_json_schema()`` rather than the lower-level
+    ``model_fields[...].metadata`` introspection because the JSON-schema
+    export is Pydantic's documented public API (it's tied to OpenAPI
+    generation and unlikely to drift across minor versions), whereas the
+    metadata shape is implementation detail that has changed before.
+    ``pydantic`` is pinned only as a lower bound (``>=2.0.0``) so this
+    distinction matters across deploys.
+
+    Raises at module import time if ``maxItems`` is missing — fail loud, so a
+    regenerated model that drops the constraint can't silently widen the 413
+    gate and produce 422 responses for cap-exceeded requests.
+    """
+    schema = request_model.model_json_schema()
+    field_schema = schema.get("properties", {}).get(field, {})
+    max_items = field_schema.get("maxItems")
+    if isinstance(max_items, int) and max_items > 0:
+        return max_items
+    raise RuntimeError(
+        f"Cannot resolve `maxItems` for {request_model.__name__}.{field} "
+        "from its JSON schema. The route's 413 gate must agree with the "
+        "generated model; fix or regenerate the model before this module "
+        f"can import (schema fragment: {field_schema!r})."
+    )

--- a/identity/dependencies.py
+++ b/identity/dependencies.py
@@ -3,10 +3,10 @@
 import asyncio
 import logging
 
-from asyncpg.exceptions import PostgresError
 from fastapi import Depends
 
 from config.settings import Settings, get_settings
+from core.bulk_body import TRANSIENT_PG_ERRORS
 from core.dependencies import get_discogs_pool
 from entity.sources import PgSource
 from entity.store import EntityStore
@@ -78,7 +78,7 @@ async def get_entity_store(
         pg = PgSource(pool=pool)
         try:
             await pg.fetchone(_PROBE_SQL)
-        except (PostgresError, OSError) as e:
+        except TRANSIENT_PG_ERRORS as e:
             logger.warning(
                 "Entity store probe failed; disabling identity routes: %s: %s",
                 type(e).__name__,

--- a/identity/router.py
+++ b/identity/router.py
@@ -19,10 +19,13 @@ from collections import Counter
 from typing import Any
 
 import sentry_sdk
-from asyncpg.exceptions import PostgresError
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import ValidationError
 
+from core.bulk_body import (
+    TRANSIENT_PG_ERRORS,
+    parse_bulk_body,
+    resolve_input_cap,
+)
 from core.bulk_concurrency import (
     acquire_bulk_global_permit,
     cancel_and_drain,
@@ -54,8 +57,10 @@ from identity.release_validation import (
 # Lazy imports inside the handler:
 #   wxyc_etl.text.is_compilation_artist — required at handler scope only.
 
-# Per api.yaml: max 1,000 inputs per request; over-cap returns 413.
-_BULK_RESOLVE_INPUT_CAP = 1000
+# Per api.yaml: max inputs per request; over-cap returns 413. Read from the
+# generated model's JSON schema so a regenerated `maxItems` moves the 413
+# gate in lockstep (LML#767 drift guard — the artists routes' pattern).
+_BULK_RESOLVE_INPUT_CAP = resolve_input_cap(BulkResolveLibrariesRequest, "inputs")
 
 
 def _bulk_resolve_default_concurrency() -> int:
@@ -129,7 +134,7 @@ async def resolve_identity(
     store = _require_entity_store(entity_store)
     try:
         identity = await store.get_identity(name)
-    except (PostgresError, OSError):
+    except TRANSIENT_PG_ERRORS:
         logger.exception("Entity store query failed for name=%r", name)
         raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
     if identity is None:
@@ -163,7 +168,7 @@ async def bulk_resolve_identities(
     for name in request.names:
         try:
             identity = await store.get_identity(name)
-        except (PostgresError, OSError):
+        except TRANSIENT_PG_ERRORS:
             # Fail closed on partial PG failure: the caller cannot distinguish
             # "name had no identity" from "PG died before this name was tried".
             logger.exception("Entity store query failed mid-bulk for name=%r", name)
@@ -218,35 +223,14 @@ async def bulk_resolve_libraries(
     # don't touch this endpoint) to the wxyc_etl ABI.
     from wxyc_etl.text import is_compilation_artist
 
-    # Parse + cap-check manually rather than via a typed body parameter:
-    # the codegen-derived `BulkResolveLibrariesRequest` carries
-    # `max_length=1000` (extracted from api.yaml's `maxItems: 1000`), which
-    # would let Pydantic short-circuit over-cap requests as 422. The
-    # api.yaml contract documents 413 explicitly for cap exceedance, so we
-    # check the raw input count first and raise 413; only then do we run
-    # full per-input validation.
-    try:
-        body = await http_request.json()
-    except (ValueError, TypeError) as e:
-        raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
-    inputs_raw = body.get("inputs")
-    if not isinstance(inputs_raw, list):
-        raise HTTPException(status_code=422, detail="`inputs` must be a JSON array.")
-    if len(inputs_raw) > _BULK_RESOLVE_INPUT_CAP:
-        raise HTTPException(
-            status_code=413,
-            detail=(
-                f"Batch exceeded the {_BULK_RESOLVE_INPUT_CAP}-input cap "
-                f"(received {len(inputs_raw)})."
-            ),
-        )
-
-    try:
-        request = BulkResolveLibrariesRequest.model_validate(body)
-    except ValidationError as e:
-        raise HTTPException(status_code=422, detail=e.errors()) from None
+    # Shared bulk envelope (LML#767): raw-JSON parse, ClientDisconnect -> 400,
+    # non-object -> 400, manual over-cap -> 413 before Pydantic (whose
+    # `max_length` would 422 an oversize batch, but api.yaml documents 413),
+    # then model_validate. An absent/wrong-type `inputs` field falls through
+    # to Pydantic's structured errors() rather than a bare-string 422.
+    request = await parse_bulk_body(
+        http_request, BulkResolveLibrariesRequest, _BULK_RESOLVE_INPUT_CAP, field="inputs"
+    )
 
     store = _require_entity_store(entity_store)
 
@@ -306,7 +290,7 @@ async def bulk_resolve_libraries(
                 # / etc. divergence when storage happens to be canonical).
                 # Strictly ≥ legacy `get_identity()` hit rate.
                 identity: Identity | None = await store.resolve_library_name(input_row.artist_name)
-            except (PostgresError, OSError):
+            except TRANSIENT_PG_ERRORS:
                 logger.exception(
                     "Entity store query failed mid-bulk-resolve for library_id=%d artist_name=%r",
                     input_row.library_id,
@@ -322,7 +306,7 @@ async def bulk_resolve_libraries(
                 # is covered by the same permit, so a resolved input never holds
                 # two pool connections at once.
                 return await compose_for_identity(input_row.library_id, identity, store)
-            except (PostgresError, OSError):
+            except TRANSIENT_PG_ERRORS:
                 logger.exception(
                     "Provenance fetch failed mid-bulk-resolve for library_id=%d",
                     input_row.library_id,
@@ -494,7 +478,7 @@ async def resolve_release_identity(
             identity_id, minted = await store.mint_or_get_release_identity(
                 source=source_value, external_id=canonical_external_id
             )
-        except (PostgresError, OSError):
+        except TRANSIENT_PG_ERRORS:
             logger.exception(
                 "release-identity resolve failed for source=%r external_id=%r",
                 source_value,

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
-from pydantic import ValidationError
 from wxyc_fastapi.observability import (
     RequestTelemetry,
     get_cache_stats,
@@ -22,6 +21,7 @@ from clients.bandcamp import BandcampClient
 from clients.streaming.apple_music import AppleMusicClient
 from clients.streaming.spotify import SpotifyClient
 from config.settings import get_settings
+from core.bulk_body import parse_bulk_body
 from core.bulk_concurrency import (
     acquire_bulk_global_permit,
     cancel_and_drain,
@@ -480,28 +480,14 @@ async def handle_bulk_lookup(
     ),
 ) -> BulkLookupResponse:
     """Bulk lookup. See route docstring for protocol."""
-    # Manual cap-check: 400 (not Pydantic's 422) for oversize batches.
-    try:
-        body = await http_request.json()
-    except (ValueError, TypeError) as e:
-        raise HTTPException(status_code=400, detail=f"Malformed JSON body: {e}") from None
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
-    items_raw = body.get("items")
-    if not isinstance(items_raw, list):
-        raise HTTPException(status_code=422, detail="`items` must be a JSON array.")
-    if len(items_raw) > _BULK_LOOKUP_INPUT_CAP:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Batch exceeded the {_BULK_LOOKUP_INPUT_CAP}-item cap (received {len(items_raw)})."
-            ),
-        )
-
-    try:
-        request = BulkLookupRequest.model_validate(body)
-    except ValidationError as e:
-        raise HTTPException(status_code=422, detail=e.errors()) from None
+    # Shared bulk envelope (LML#767): raw-JSON parse, ClientDisconnect -> 400,
+    # non-object -> 400, manual over-cap before Pydantic, then model_validate.
+    # `cap_status=400` preserves this route's LML#368 over-cap contract (400,
+    # not the family's default 413). An absent/wrong-type `items` field falls
+    # through to Pydantic's structured errors() rather than a bare 422.
+    request = await parse_bulk_body(
+        http_request, BulkLookupRequest, _BULK_LOOKUP_INPUT_CAP, field="items", cap_status=400
+    )
 
     # Entry signal (LML#371). Fires synchronously before any awaits, so a
     # handler that later hangs past the caller's AbortController still leaves

--- a/tests/integration/test_cache_refresh_for_identities.py
+++ b/tests/integration/test_cache_refresh_for_identities.py
@@ -368,7 +368,9 @@ class TestCacheRefreshInputValidation:
         ids = list(range(1, 52))  # 51 ids > 50 cap
         resp = await app_client.post(_ROUTE, json={"identity_ids": ids})
         assert resp.status_code == 400
-        assert "50-id cap" in resp.text
+        # Shared bulk envelope (LML#767) emits a generic "{cap}-item cap"
+        # message; the 400 status is the load-bearing contract, not the noun.
+        assert "50-item cap" in resp.text
 
     @pytest.mark.asyncio
     async def test_empty_identity_ids_returns_422(self, app_client):

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -1110,3 +1110,50 @@ class TestBulkLookupClientAbort:
         assert captured_tags.get("lml.client_aborted") == "true", (
             f"Expected lml.client_aborted=true tag; got {captured_tags!r}"
         )
+
+
+class TestBulkLookupFamilyAlignment:
+    """LML#767: the bulk-lookup route joins the shared envelope. It has no
+    batch-level transient-PG arm (per-item failures are isolated in
+    `_run_one`), so only the ClientDisconnect and structured-422 arms apply.
+    The 400 over-cap contract (LML#368) is preserved."""
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_during_body_read_returns_400(self, app_client, monkeypatch):
+        """A mid-body client abort maps to 400, not an unhandled 500."""
+        from starlette.requests import ClientDisconnect, Request
+
+        async def _gone(self):
+            raise ClientDisconnect()
+
+        monkeypatch.setattr(Request, "json", _gone)
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup/bulk", json={"items": [{"artist": "x", "album": "y"}]}
+                )
+
+        assert resp.status_code == 400
+        assert "disconnected" in resp.json()["detail"].lower()
+        mock_lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_absent_items_field_returns_structured_422(self, app_client):
+        """A missing `items` field falls through to model_validate, so the
+        detail is Pydantic's structured errors() list, not a bare
+        "`items` must be a JSON array" string."""
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post("/api/v1/lookup/bulk", json={})
+
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert isinstance(detail, list)
+        assert detail[0]["loc"] == ["items"]
+        assert detail[0]["type"] == "missing"
+        mock_lookup.assert_not_awaited()

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -1079,3 +1079,90 @@ class TestBulkResolveDefaultConcurrencyTracksPool:
 
         monkeypatch.setenv("LML_DISCOGS_POOL_MAX_SIZE", "8")
         assert _bulk_resolve_default_concurrency() == 8
+
+
+class TestBulkResolveFamilyAlignment:
+    """LML#767: the manual-parse route joins the shared envelope + transient
+    tuple. InterfaceError -> 503, ClientDisconnect -> 400, and an absent
+    batch field -> Pydantic's structured 422 (not the old bare-string)."""
+
+    @pytest.mark.asyncio
+    async def test_interface_error_mid_batch_returns_503(self, app_client, mock_entity_store):
+        """asyncpg's client-side InterfaceError (pool teardown) fails the
+        whole batch closed with 503, same as PostgresError/OSError."""
+        from asyncpg.exceptions import InterfaceError
+
+        async def maybe_fail(name: str):
+            if name == "Boom":
+                raise InterfaceError("pool is closing")
+            return None
+
+        mock_entity_store.resolve_library_name.side_effect = maybe_fail
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={
+                    "inputs": [
+                        {"library_id": 1, "artist_name": "Fine One", "album_title": "x"},
+                        {"library_id": 2, "artist_name": "Boom", "album_title": "x"},
+                    ]
+                },
+            )
+
+        assert resp.status_code == 503
+        assert "results" not in resp.json()
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_during_body_read_returns_400(
+        self, app_client, mock_entity_store, monkeypatch
+    ):
+        """A mid-body client abort maps to 400, not an unhandled 500 — the
+        arm keeps error-class accounting clean."""
+        from starlette.requests import ClientDisconnect, Request
+
+        async def _gone(self):
+            raise ClientDisconnect()
+
+        monkeypatch.setattr(Request, "json", _gone)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/bulk-resolve-libraries",
+                json={"inputs": [{"library_id": 1, "artist_name": "x", "album_title": "y"}]},
+            )
+
+        assert resp.status_code == 400
+        assert "disconnected" in resp.json()["detail"].lower()
+        mock_entity_store.resolve_library_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_absent_inputs_field_returns_structured_422(self, app_client, mock_entity_store):
+        """A missing `inputs` field falls through to model_validate, so the
+        detail is Pydantic's structured errors() list (missing/list_type),
+        not a bare "`inputs` must be a JSON array" string."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/api/v1/identity/bulk-resolve-libraries", json={})
+
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert isinstance(detail, list)
+        assert detail[0]["loc"] == ["inputs"]
+        assert detail[0]["type"] == "missing"
+        mock_entity_store.resolve_library_name.assert_not_awaited()
+
+    def test_input_cap_reads_from_generated_model_schema(self):
+        """Item 5: the 413 gate cap is schema-derived, not a hardcoded 1000
+        — a regenerated model with a different maxItems moves the gate."""
+        from generated.api_models import BulkResolveLibrariesRequest
+        from identity.router import _BULK_RESOLVE_INPUT_CAP
+
+        schema = BulkResolveLibrariesRequest.model_json_schema()
+        assert schema["properties"]["inputs"]["maxItems"] == _BULK_RESOLVE_INPUT_CAP
+        assert _BULK_RESOLVE_INPUT_CAP == 1000

--- a/tests/unit/test_cache_refresh_endpoint.py
+++ b/tests/unit/test_cache_refresh_endpoint.py
@@ -91,3 +91,86 @@ class TestCacheRefreshGlobalBound:
         assert peak <= 2, (
             f"Peak cross-request concurrency was {peak}; global permit did not bound it"
         )
+
+
+class TestCacheRefreshFamilyAlignment:
+    """LML#767: the cache-refresh route joins the shared envelope + transient
+    tuple. InterfaceError -> 503, ClientDisconnect -> 400, absent batch field
+    -> Pydantic's structured 422. The 400 over-cap contract is preserved."""
+
+    @pytest.mark.asyncio
+    async def test_interface_error_on_provenance_read_returns_503(
+        self, app_client, mock_entity_store
+    ):
+        """asyncpg's client-side InterfaceError on the batch provenance read
+        maps to 503, same transient class as PostgresError/OSError."""
+        from asyncpg.exceptions import InterfaceError
+
+        mock_entity_store.get_release_identity_provenance_bulk.side_effect = InterfaceError(
+            "pool is closing"
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/cache/refresh-for-identities", json={"identity_ids": [42]}
+            )
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_during_body_read_returns_400(
+        self, app_client, mock_entity_store, monkeypatch
+    ):
+        """A mid-body client abort maps to 400, not an unhandled 500."""
+        from starlette.requests import ClientDisconnect, Request
+
+        async def _gone(self):
+            raise ClientDisconnect()
+
+        monkeypatch.setattr(Request, "json", _gone)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/cache/refresh-for-identities", json={"identity_ids": [42]}
+            )
+
+        assert resp.status_code == 400
+        assert "disconnected" in resp.json()["detail"].lower()
+        mock_entity_store.get_release_identity_provenance_bulk.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_absent_identity_ids_field_returns_structured_422(
+        self, app_client, mock_entity_store
+    ):
+        """A missing `identity_ids` field falls through to model_validate, so
+        the detail is Pydantic's structured errors() list, not a bare
+        "`identity_ids` must be a JSON array" string."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/api/v1/cache/refresh-for-identities", json={})
+
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert isinstance(detail, list)
+        assert detail[0]["loc"] == ["identity_ids"]
+        assert detail[0]["type"] == "missing"
+
+    @pytest.mark.asyncio
+    async def test_over_cap_still_returns_400(self, app_client, mock_entity_store):
+        """The 400 over-cap contract (LML#525, not 413) survives adoption of
+        the shared envelope."""
+        oversized = list(range(51))
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/cache/refresh-for-identities", json={"identity_ids": oversized}
+            )
+
+        assert resp.status_code == 400
+        mock_entity_store.get_release_identity_provenance_bulk.assert_not_awaited()

--- a/tests/unit/test_core_bulk_body.py
+++ b/tests/unit/test_core_bulk_body.py
@@ -1,0 +1,154 @@
+"""Unit tests for the shared bulk-route request envelope (`core/bulk_body.py`).
+
+The envelope helper (`parse_bulk_body`) and the transient-PG-error tuple
+(`TRANSIENT_PG_ERRORS`) are the single source of truth the whole bulk-route
+family shares (LML#767). The artists routes (LML#764) were the template; this
+module pins the generalized behavior directly, independent of any one route:
+
+- the `field` parameter generalizes what was a hardcoded `names`;
+- absent/wrong-type batch fields fall through to `model_validate` so
+  Pydantic produces its structured `errors()` array (not a bare-string 422);
+- `TRANSIENT_PG_ERRORS` includes asyncpg's client-side `InterfaceError`
+  alongside `PostgresError` and `OSError`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from asyncpg.exceptions import InterfaceError, PostgresError
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+from starlette.requests import ClientDisconnect
+
+from core.bulk_body import TRANSIENT_PG_ERRORS, parse_bulk_body
+
+
+class _NamesModel(BaseModel):
+    names: list[str] = Field(..., min_length=1, max_length=3)
+
+
+class _InputsModel(BaseModel):
+    inputs: list[int] = Field(..., min_length=1, max_length=3)
+
+
+class _FakeRequest:
+    """Minimal stand-in for starlette.Request — only `.json()` is exercised."""
+
+    def __init__(self, *, body=None, raises=None):
+        self._body = body
+        self._raises = raises
+
+    async def json(self):
+        if self._raises is not None:
+            raise self._raises
+        return self._body
+
+
+class TestTransientPgErrors:
+    def test_includes_interface_error(self):
+        """asyncpg's client-side pool-lifecycle errors subclass neither
+        PostgresError nor OSError; the tuple must name InterfaceError so a
+        deploy-window pool teardown reads as a transient 503, not a 500."""
+        assert InterfaceError in TRANSIENT_PG_ERRORS
+
+    def test_includes_postgres_error_and_oserror(self):
+        assert PostgresError in TRANSIENT_PG_ERRORS
+        assert OSError in TRANSIENT_PG_ERRORS
+
+
+class TestParseBulkBody:
+    @pytest.mark.asyncio
+    async def test_valid_body_returns_model(self):
+        req = _FakeRequest(body={"names": ["Wishy"]})
+        result = await parse_bulk_body(req, _NamesModel, cap=3, field="names")
+        assert isinstance(result, _NamesModel)
+        assert result.names == ["Wishy"]
+
+    @pytest.mark.asyncio
+    async def test_field_parameter_is_honored(self):
+        """The helper is generalized over the batch field name — `inputs`
+        here, not the artists routes' hardcoded `names`."""
+        req = _FakeRequest(body={"inputs": [1, 2]})
+        result = await parse_bulk_body(req, _InputsModel, cap=3, field="inputs")
+        assert result.inputs == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_400(self):
+        req = _FakeRequest(raises=ValueError("bad json"))
+        with pytest.raises(HTTPException) as exc:
+            await parse_bulk_body(req, _NamesModel, cap=3, field="names")
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_returns_400(self):
+        req = _FakeRequest(raises=ClientDisconnect())
+        with pytest.raises(HTTPException) as exc:
+            await parse_bulk_body(req, _NamesModel, cap=3, field="names")
+        assert exc.value.status_code == 400
+        assert "disconnected" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_non_dict_body_returns_400(self):
+        req = _FakeRequest(body=["not", "a", "dict"])
+        with pytest.raises(HTTPException) as exc:
+            await parse_bulk_body(req, _NamesModel, cap=3, field="names")
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_over_cap_returns_413(self):
+        req = _FakeRequest(body={"names": ["a", "b", "c", "d"]})
+        with pytest.raises(HTTPException) as exc:
+            await parse_bulk_body(req, _NamesModel, cap=3, field="names")
+        assert exc.value.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_cap_status_is_parameterized(self):
+        """Some routes (lookup/bulk, cache-refresh) document 400 for oversize
+        batches, not 413. The helper takes `cap_status` (default 413) so the
+        shared envelope serves both without changing any route's wire
+        contract."""
+        req = _FakeRequest(body={"names": ["a", "b", "c", "d"]})
+        with pytest.raises(HTTPException) as exc:
+            await parse_bulk_body(req, _NamesModel, cap=3, field="names", cap_status=400)
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_absent_field_falls_through_to_structured_422(self):
+        """A missing batch field must NOT be a bare-string "must be a JSON
+        array" 422 — it falls through to `model_validate` so Pydantic emits
+        its structured `errors()` list (the missing/list_type shape every
+        other field gets)."""
+        req = _FakeRequest(body={})
+        with pytest.raises(HTTPException) as exc:
+            await parse_bulk_body(req, _NamesModel, cap=3, field="names")
+        assert exc.value.status_code == 422
+        # Structured detail: a list of Pydantic error dicts, not a string.
+        assert isinstance(exc.value.detail, list)
+        assert exc.value.detail
+        assert exc.value.detail[0]["loc"] == ("names",)
+        assert exc.value.detail[0]["type"] == "missing"
+
+    @pytest.mark.asyncio
+    async def test_wrong_type_field_falls_through_to_structured_422(self):
+        """A wrong-type batch field (string, not list) also falls through to
+        Pydantic's structured list_type error rather than the bare-string
+        type gate — same 422 status, richer detail."""
+        req = _FakeRequest(body={"names": "not a list"})
+        with pytest.raises(HTTPException) as exc:
+            await parse_bulk_body(req, _NamesModel, cap=3, field="names")
+        assert exc.value.status_code == 422
+        assert isinstance(exc.value.detail, list)
+        assert exc.value.detail[0]["loc"] == ("names",)
+        assert exc.value.detail[0]["type"] == "list_type"
+
+    @pytest.mark.asyncio
+    async def test_over_cap_check_tolerates_non_list_field(self):
+        """The cap guard must be `isinstance(x, list) and len(x) > cap` so a
+        non-list field doesn't raise TypeError in `len()` before falling
+        through to structured validation."""
+        # A dict field is neither over-cap nor a list — must not 413, must
+        # reach model_validate and 422 there.
+        req = _FakeRequest(body={"names": {"not": "a list"}})
+        with pytest.raises(HTTPException) as exc:
+            await parse_bulk_body(req, _NamesModel, cap=3, field="names")
+        assert exc.value.status_code == 422

--- a/tests/unit/test_identity_dependencies.py
+++ b/tests/unit/test_identity_dependencies.py
@@ -264,3 +264,28 @@ class TestEntityStoreLazyInitRace:
         )
         # All callers must see the same EntityStore instance.
         assert len({id(r) for r in results}) == 1
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_probe_raises_interface_error(
+    monkeypatch, _fake_discogs_pool, caplog
+):
+    """LML#767: asyncpg's client-side InterfaceError (pool/connection
+    lifecycle) is classified as a transient DB-unreachable probe failure —
+    the same arm as PostgresError/OSError, distinguished from the generic
+    catch-all by the "probe failed; disabling identity routes" log line."""
+    import logging
+
+    async def boom(self, query, *args):
+        raise asyncpg.exceptions.InterfaceError("pool is closing")
+
+    monkeypatch.setattr("entity.sources.PgSource.fetchone", boom)
+    settings = _settings("postgresql://x:y@127.0.0.1:1/z")
+    monkeypatch.setattr("core.dependencies.get_settings", lambda: settings)
+
+    with caplog.at_level(logging.WARNING, logger="identity.dependencies"):
+        result = await deps.get_entity_store(settings)
+
+    assert result is None
+    assert deps._entity_probe_failed is True
+    assert any("probe failed; disabling identity routes" in r.getMessage() for r in caplog.records)

--- a/tests/unit/test_identity_router.py
+++ b/tests/unit/test_identity_router.py
@@ -267,3 +267,58 @@ class TestEntityStoreUnavailable:
 
         assert resp.status_code == 503
         assert "entity store" in resp.json()["detail"].lower()
+
+
+class TestInterfaceErrorMapping:
+    """LML#767 family alignment: asyncpg's client-side ``InterfaceError``
+    (raised for pool-lifecycle events — "pool is closing", "connection is
+    closed") subclasses neither ``PostgresError`` nor ``OSError``, so a
+    deploy-window pool teardown would otherwise surface as an application 500
+    on these routes. The transient tuple must catch it and return 503, the
+    same class the artists routes and ``discogs/fallthrough.py`` pin."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_503_on_interface_error(self, app_client, mock_entity_store):
+        from asyncpg.exceptions import InterfaceError
+
+        mock_entity_store.get_identity.side_effect = InterfaceError("pool is closing")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_bulk_returns_503_on_interface_error(self, app_client, mock_entity_store):
+        from asyncpg.exceptions import InterfaceError
+
+        mock_entity_store.get_identity.side_effect = InterfaceError("connection is closed")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post("/identity/bulk", json={"names": ["Stereolab"]})
+
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_release_identity_resolve_returns_503_on_interface_error(
+        self, app_client, mock_entity_store
+    ):
+        from asyncpg.exceptions import InterfaceError
+
+        mock_entity_store.mint_or_get_release_identity.side_effect = InterfaceError(
+            "pool is closed"
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_client), base_url="http://test"
+        ) as ac:
+            resp = await ac.post(
+                "/api/v1/identity/resolve",
+                json={"kind": "release", "source": "discogs_release", "external_id": "12345"},
+            )
+
+        assert resp.status_code == 503


### PR DESCRIPTION
Closes #767.

## What

The #764 review found the bulk-route request envelope and transient-error classification had forked across the router family. The two artists routes (from #764) carried the correct behavior and shared a private helper; the older identity, cache-refresh, and bulk-lookup routes each missed pieces. This PR generalizes the artists routes' private helpers into `core/` as the single source of truth and adopts them family-wide (items 1-5 of the issue).

### `core/bulk_body.py` (new)

- `parse_bulk_body(request, model, cap, field, cap_status=413)` — the generalized bulk request envelope, hoisted and generalized from `artists/router.py::_parse_bulk_names_body`. The batch-field name is now a parameter (was hardcoded `names`); the over-cap status is parameterized (`cap_status`) so routes that document 400 for oversize batches (lookup/bulk, cache-refresh) keep that contract while sharing the envelope. An absent/wrong-type batch field falls through to `model_validate` (structured Pydantic `errors()`) instead of a bare-string 422.
- `TRANSIENT_PG_ERRORS = (PostgresError, InterfaceError, OSError)` — the shared transient-503 tuple. asyncpg raises its client-side pool-lifecycle errors ("pool is closing", "connection is closed") as the base `InterfaceError`, which subclasses neither `PostgresError` nor `OSError`; the same class `discogs/fallthrough.py` already pins in `_ARMING_EXCEPTIONS`.
- `resolve_input_cap(model, field)` — the schema-introspecting cap reader, generalized from the artists routes' `_resolve_input_cap` to take a `field` parameter.

### Adoption

- **`artists/router.py`** — re-pointed at the `core/` helpers; its private copies are gone (one source of truth).
- **`identity/router.py`** — 5 `except (PostgresError, OSError)` arms → `TRANSIENT_PG_ERRORS`; bulk-resolve-libraries adopts `parse_bulk_body` (brings the ClientDisconnect→400 arm and structured absent-field 422); `_BULK_RESOLVE_INPUT_CAP` now reads `maxItems` from the generated model instead of a hardcoded `1000`.
- **`identity/dependencies.py`** — the entity-store probe arm now classifies `InterfaceError` as a transient DB-unreachable failure (was falling to the generic catch-all with a misleading "Unexpected error" log).
- **`cache/router.py`** — adopts `parse_bulk_body` (`cap_status=400` preserves the LML#525 over-cap contract) and `TRANSIENT_PG_ERRORS`.
- **`lookup/router.py`** — adopts `parse_bulk_body` (`cap_status=400` preserves the LML#368 contract). No batch-level transient-PG arm (per-item failures are isolated), so only the ClientDisconnect + structured-422 arms apply.

## Behavior changes (all pinned by a unit test per route)

- `InterfaceError` → **503** (was 500) on every PG-touching bulk arm.
- Mid-body client abort → **400** uniformly (was unhandled 5xx-shaped noise).
- Absent/wrong-type batch field → **structured 422** (Pydantic `errors()`, was bare-string).
- Wire status codes unchanged throughout: 413 for identity/artists over-cap, 400 for lookup/cache over-cap, 503/400/422 as before.

Tests follow the artists routes' `TestErrorClassRouting` / `TestBodyParse` template.

## Testing

- New `tests/unit/test_core_bulk_body.py` (12 tests) pins the helper + tuple directly.
- Per-route tests added: identity (InterfaceError→503 ×3 routes), identity-deps (InterfaceError probe classification), bulk-resolve-libraries (InterfaceError/ClientDisconnect/structured-422/schema-cap), cache-refresh (InterfaceError/ClientDisconnect/structured-422/400-cap-preserved), bulk-lookup (ClientDisconnect/structured-422).
- Full bulk-route family: 163 passed. Full default suite: 3749 passed (2 pre-existing environmental anomalies unrelated to this change — a local-PG-on-5433 credentials test and a cross-file event-loop teardown artifact, both present on pristine main).
- `ruff check` + `ruff format --check` clean.

## Deferred

Item 6 of #767 — the family-wide `{detail}`-vs-`{message}` wire-contract drift between LML's error payloads and wxyc-shared's `ApiErrorResponse` — is **not** in this PR. It spans wxyc-shared and needs a contract decision (LML-side exception handler emitting `{message}` vs amending `api.yaml`'s `ApiErrorResponse`). Filed as **#771** with both options laid out; decision to be recorded there before implementation.

## Related

- #767 — this PR (items 1-5).
- #771 — deferred item 6 (error-payload wire-contract drift).
- #764 — the artists-routes envelope consolidation this generalizes.
- #759 — the bulk bare-name artist resolution work the envelope family grew out of.
- #766 — the concurrent-writer upsert-guard follow-up from the same #759 cluster.
