### PR TITLE
test(#768): adopt the shared data-safety guard + entity DDL in the four unguarded pg fixtures

### DIFF
--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -15,57 +15,63 @@ import pytest_asyncio
 
 # ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
 # there for the ``monkeypatch.setenv("DATABASE_URL_DISCOGS", ...)`` wiring below.
-from tests.integration.conftest import DATABASE_URL
+from tests.integration.conftest import (
+    DATABASE_URL,
+    ENTITY_IDENTITY_DDL,
+    skip_if_drop_targets_populated,
+)
 
 
 @pytest_asyncio.fixture(autouse=True)
 async def set_up_entity_schema(pg_pool):
-    """Create + seed a fresh `entity` schema for each test."""
+    """Create + seed a fresh `entity` schema for each test.
+
+    SAFETY: refuses to run when anything this fixture would drop already
+    holds rows — the default ``DATABASE_URL_TEST`` may point at a real
+    discogs-cache whose ``entity.*`` took hours of rate-limited
+    reconciliation to build. The guard sweeps the entity schema dynamically
+    from ``pg_class`` (see ``skip_if_drop_targets_populated``); this fixture
+    drops no public tables, so its public-table list is empty.
+    """
     async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
-        await conn.execute("CREATE SCHEMA entity")
-        await conn.execute("""
-            CREATE TABLE entity.identity (
-                id SERIAL PRIMARY KEY,
-                library_name TEXT NOT NULL UNIQUE,
-                discogs_artist_id INTEGER,
-                wikidata_qid TEXT,
-                musicbrainz_artist_id TEXT,
-                spotify_artist_id TEXT,
-                apple_music_artist_id TEXT,
-                bandcamp_id TEXT,
-                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        await skip_if_drop_targets_populated(conn, ())
+
+    # Creation and seeding inside the try: a mid-seed failure must still
+    # drop whatever was created instead of stranding rows that veto the
+    # next run (same posture as the artists-route siblings).
+    try:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            await conn.execute("CREATE SCHEMA entity")
+            await conn.execute(ENTITY_IDENTITY_DDL)
+            await conn.execute("""
+                CREATE TABLE entity.reconciliation_log (
+                    id SERIAL PRIMARY KEY,
+                    identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
+                    source TEXT NOT NULL,
+                    external_id TEXT NOT NULL,
+                    confidence REAL,
+                    method TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            # Seed in verbatim Backend casing — matches the production shape
+            # surfaced by the #276 audit (99.8% of entity.identity rows are
+            # mixed-case verbatim, not canonical). The handler's three-leg
+            # fall-through (#276) handles both verbatim hits and canonical-form
+            # divergence on top of this shape.
+            await conn.execute(
+                """
+                INSERT INTO entity.identity (library_name, discogs_artist_id, wikidata_qid)
+                VALUES
+                    ('Stereolab', 2154, 'Q484464'),
+                    ('Juana Molina', 305253, 'Q272615')
+                """
             )
-        """)
-        await conn.execute("""
-            CREATE TABLE entity.reconciliation_log (
-                id SERIAL PRIMARY KEY,
-                identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
-                source TEXT NOT NULL,
-                external_id TEXT NOT NULL,
-                confidence REAL,
-                method TEXT NOT NULL,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-        # Seed in verbatim Backend casing — matches the production shape
-        # surfaced by the #276 audit (99.8% of entity.identity rows are
-        # mixed-case verbatim, not canonical). The handler's three-leg
-        # fall-through (#276) handles both verbatim hits and canonical-form
-        # divergence on top of this shape.
-        await conn.execute(
-            """
-            INSERT INTO entity.identity (library_name, discogs_artist_id, wikidata_qid)
-            VALUES
-                ('Stereolab', 2154, 'Q484464'),
-                ('Juana Molina', 305253, 'Q272615')
-            """
-        )
-    yield
-    async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        yield
+    finally:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_cache_refresh_for_identities.py
+++ b/tests/integration/test_cache_refresh_for_identities.py
@@ -29,7 +29,11 @@ from entity.store import EntityStore
 
 # ``DATABASE_URL`` (and the conftest ``pg_pool_large``) come from conftest;
 # imported here for the ``source._dsn`` wiring and ``monkeypatch.setenv`` below.
-from tests.integration.conftest import DATABASE_URL
+from tests.integration.conftest import (
+    DATABASE_URL,
+    ENTITY_IDENTITY_DDL,
+    skip_if_drop_targets_populated,
+)
 
 
 @pytest_asyncio.fixture
@@ -53,64 +57,66 @@ async def pg_source(pg_pool):
 
 @pytest_asyncio.fixture(autouse=True)
 async def set_up_entity_schema(pg_pool):
-    """Drop + recreate the entity schema (artist + release tables)."""
+    """Drop + recreate the entity schema (artist + release tables).
+
+    SAFETY: refuses to run when anything this fixture would drop already
+    holds rows — the default ``DATABASE_URL_TEST`` may point at a real
+    discogs-cache whose ``entity.*`` took hours of rate-limited
+    reconciliation to build. The guard sweeps the entity schema dynamically
+    from ``pg_class`` (see ``skip_if_drop_targets_populated``); this fixture
+    drops no public tables, so its public-table list is empty.
+    """
     async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
-        await conn.execute("CREATE SCHEMA entity")
-        await conn.execute("""
-            CREATE TABLE entity.identity (
-                id SERIAL PRIMARY KEY,
-                library_name TEXT NOT NULL UNIQUE,
-                discogs_artist_id INTEGER,
-                wikidata_qid TEXT,
-                musicbrainz_artist_id TEXT,
-                spotify_artist_id TEXT,
-                apple_music_artist_id TEXT,
-                bandcamp_id TEXT,
-                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-        await conn.execute("""
-            CREATE TABLE entity.reconciliation_log (
-                id SERIAL PRIMARY KEY,
-                identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
-                source TEXT NOT NULL,
-                external_id TEXT NOT NULL,
-                confidence REAL,
-                method TEXT NOT NULL,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-        await conn.execute("""
-            CREATE TABLE entity.release_identity (
-                id SERIAL PRIMARY KEY,
-                discogs_release_id INTEGER UNIQUE,
-                discogs_master_id INTEGER UNIQUE,
-                musicbrainz_release_id TEXT UNIQUE,
-                spotify_album_id TEXT UNIQUE,
-                apple_music_album_id TEXT UNIQUE,
-                bandcamp_album_url TEXT UNIQUE,
-                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-        await conn.execute("""
-            CREATE TABLE entity.release_reconciliation_log (
-                id SERIAL PRIMARY KEY,
-                identity_id INTEGER NOT NULL REFERENCES entity.release_identity(id),
-                source TEXT NOT NULL,
-                external_id TEXT NOT NULL,
-                confidence REAL,
-                method TEXT NOT NULL,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-    yield
-    async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        await skip_if_drop_targets_populated(conn, ())
+
+    # Creation inside the try: a mid-setup failure must still drop whatever
+    # was created instead of stranding rows that veto the next run (same
+    # posture as the artists-route siblings).
+    try:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            await conn.execute("CREATE SCHEMA entity")
+            await conn.execute(ENTITY_IDENTITY_DDL)
+            await conn.execute("""
+                CREATE TABLE entity.reconciliation_log (
+                    id SERIAL PRIMARY KEY,
+                    identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
+                    source TEXT NOT NULL,
+                    external_id TEXT NOT NULL,
+                    confidence REAL,
+                    method TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE entity.release_identity (
+                    id SERIAL PRIMARY KEY,
+                    discogs_release_id INTEGER UNIQUE,
+                    discogs_master_id INTEGER UNIQUE,
+                    musicbrainz_release_id TEXT UNIQUE,
+                    spotify_album_id TEXT UNIQUE,
+                    apple_music_album_id TEXT UNIQUE,
+                    bandcamp_album_url TEXT UNIQUE,
+                    reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE entity.release_reconciliation_log (
+                    id SERIAL PRIMARY KEY,
+                    identity_id INTEGER NOT NULL REFERENCES entity.release_identity(id),
+                    source TEXT NOT NULL,
+                    external_id TEXT NOT NULL,
+                    confidence REAL,
+                    method TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+        yield
+    finally:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/test_charset_torture_entity_identity.py
+++ b/tests/integration/test_charset_torture_entity_identity.py
@@ -24,7 +24,11 @@ from tests.charset_torture import CharsetTortureEntry, entry_id, iter_entries
 
 # ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
 # there for the ``source._dsn`` wiring below.
-from tests.integration.conftest import DATABASE_URL
+from tests.integration.conftest import (
+    DATABASE_URL,
+    ENTITY_IDENTITY_DDL,
+    skip_if_drop_targets_populated,
+)
 
 CORPUS_ENTRIES = list(iter_entries())
 
@@ -43,31 +47,33 @@ PG_TEXT_STRIP_OVERRIDES: dict[tuple[str, str], str] = {
 
 @pytest_asyncio.fixture
 async def entity_store(pg_pool):
-    """EntityStore over a freshly-created entity schema."""
+    """EntityStore over a freshly-created entity schema.
+
+    SAFETY: refuses to run when anything this fixture would drop already
+    holds rows — the default ``DATABASE_URL_TEST`` may point at a real
+    discogs-cache whose ``entity.*`` took hours of rate-limited
+    reconciliation to build. The guard sweeps the entity schema dynamically
+    from ``pg_class`` (see ``skip_if_drop_targets_populated``); this fixture
+    drops no public tables, so its public-table list is empty.
+    """
     async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
-        await conn.execute("CREATE SCHEMA entity")
-        await conn.execute("""
-            CREATE TABLE entity.identity (
-                id SERIAL PRIMARY KEY,
-                library_name TEXT NOT NULL UNIQUE,
-                discogs_artist_id INTEGER,
-                wikidata_qid TEXT,
-                musicbrainz_artist_id TEXT,
-                spotify_artist_id TEXT,
-                apple_music_artist_id TEXT,
-                bandcamp_id TEXT,
-                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-    source = PgSource.__new__(PgSource)
-    source._dsn = DATABASE_URL
-    source._pool = pg_pool
-    yield EntityStore(source)
-    async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        await skip_if_drop_targets_populated(conn, ())
+
+    # Creation inside the try: a mid-setup failure must still drop whatever
+    # was created instead of stranding rows that veto the next run (same
+    # posture as the artists-route siblings).
+    try:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            await conn.execute("CREATE SCHEMA entity")
+            await conn.execute(ENTITY_IDENTITY_DDL)
+        source = PgSource.__new__(PgSource)
+        source._dsn = DATABASE_URL
+        source._pool = pg_pool
+        yield EntityStore(source)
+    finally:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
 
 
 @pytest.mark.pg

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -31,8 +31,10 @@ from scripts.entity_resolution.discogs import DiscogsReconciler, ReconciliationM
 # the discogs-cache mirrors can't drift per-file.
 from tests.integration.conftest import (
     DATABASE_URL,
+    ENTITY_IDENTITY_DDL,
     F_UNACCENT_WRAPPER_SQL,
     RECONCILER_TABLE_DDL,
+    skip_if_drop_targets_populated,
     skip_unless_wxyc_identity_match_artist,
 )
 
@@ -48,42 +50,44 @@ async def pg_source(pg_pool):
 
 @pytest_asyncio.fixture(autouse=True)
 async def set_up_entity_schema(pg_pool):
-    """Create (or re-create) the entity schema for each test."""
+    """Create (or re-create) the entity schema for each test.
+
+    SAFETY: refuses to run when anything this fixture would drop already
+    holds rows — the default ``DATABASE_URL_TEST`` may point at a real
+    discogs-cache whose ``entity.*`` took hours of rate-limited
+    reconciliation to build. The guard sweeps the entity schema dynamically
+    from ``pg_class`` (see ``skip_if_drop_targets_populated``); this fixture
+    drops no public tables, so its public-table list is empty.
+    """
     async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
-        await conn.execute("CREATE SCHEMA entity")
-        await conn.execute("""
-            CREATE TABLE entity.identity (
-                id SERIAL PRIMARY KEY,
-                library_name TEXT NOT NULL UNIQUE,
-                discogs_artist_id INTEGER,
-                wikidata_qid TEXT,
-                musicbrainz_artist_id TEXT,
-                spotify_artist_id TEXT,
-                apple_music_artist_id TEXT,
-                bandcamp_id TEXT,
-                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        await skip_if_drop_targets_populated(conn, ())
+
+    # Creation inside the try: a mid-setup failure must still drop whatever
+    # was created instead of stranding rows that veto the next run (same
+    # posture as the artists-route siblings).
+    try:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            await conn.execute("CREATE SCHEMA entity")
+            await conn.execute(ENTITY_IDENTITY_DDL)
+            await conn.execute(
+                "CREATE INDEX idx_entity_identity_status ON entity.identity(reconciliation_status)"
             )
-        """)
-        await conn.execute(
-            "CREATE INDEX idx_entity_identity_status ON entity.identity(reconciliation_status)"
-        )
-        await conn.execute("""
-            CREATE TABLE entity.reconciliation_log (
-                id SERIAL PRIMARY KEY,
-                identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
-                source TEXT NOT NULL,
-                external_id TEXT NOT NULL,
-                confidence REAL,
-                method TEXT NOT NULL,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-    yield
-    async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            await conn.execute("""
+                CREATE TABLE entity.reconciliation_log (
+                    id SERIAL PRIMARY KEY,
+                    identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
+                    source TEXT NOT NULL,
+                    external_id TEXT NOT NULL,
+                    confidence REAL,
+                    method TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+        yield
+    finally:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
 
 
 @pytest.mark.pg
@@ -358,15 +362,13 @@ class TestTrigramFallbackSQLIntegration:
             except Exception as e:  # locked-down Postgres without contrib
                 pytest.skip(f"pg_trgm/unaccent extensions unavailable: {e}")
 
-            release_artist_exists = await conn.fetchval(
-                "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
-                "WHERE table_schema = current_schema() AND table_name = 'release_artist')"
-            )
-            if release_artist_exists:
-                pytest.skip(
-                    "release_artist already present -- refusing to stub over real "
-                    "discogs-cache data (run the cascade test against a live cache instead)"
-                )
+            # Reconciled onto the shared data-safety guard (LML#768): the
+            # bespoke "release_artist already present" check this fixture
+            # carried was a per-file variant of the same veto. Route it
+            # through ``skip_if_drop_targets_populated`` so a populated
+            # ``release_artist`` (a real discogs-cache) skips rather than
+            # gets stubbed over — and the entity sweep rides along for free.
+            await skip_if_drop_targets_populated(conn, ("release_artist",))
 
             # IMMUTABLE f_unaccent wrapper mirroring discogs-cache, so the
             # trigram operator can ride a functional GIN index. Idempotent.
@@ -458,12 +460,22 @@ class TestIdentityRouterEntityStoreUnavailable:
 
     @pytest_asyncio.fixture(autouse=True)
     async def set_up_entity_schema(self, pg_pool):
-        """Override the module-level autouse fixture: keep the schema *missing*."""
+        """Override the module-level autouse fixture: keep the schema *missing*.
+
+        SAFETY: still guards the drop even though it creates nothing — a
+        mispointed ``DATABASE_URL_TEST`` -> a real discogs-cache must veto
+        here too, never wipe ``entity.*`` (see
+        ``skip_if_drop_targets_populated``). No public tables dropped.
+        """
         async with pg_pool.acquire() as conn:
-            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
-        yield
-        async with pg_pool.acquire() as conn:
-            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            await skip_if_drop_targets_populated(conn, ())
+        try:
+            async with pg_pool.acquire() as conn:
+                await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            yield
+        finally:
+            async with pg_pool.acquire() as conn:
+                await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
 
     @pytest_asyncio.fixture
     async def app_with_pg_dsn(self, monkeypatch):

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -373,6 +373,14 @@ class TestTrigramFallbackSQLIntegration:
             # IMMUTABLE f_unaccent wrapper mirroring discogs-cache, so the
             # trigram operator can ride a functional GIN index. Idempotent.
             await conn.execute(F_UNACCENT_WRAPPER_SQL)
+            # Drop-before-create keeps setup idempotent against an *empty*
+            # residual ``release_artist`` (e.g. a prior run SIGKILLed after the
+            # CREATE but before its teardown's DROP): the guard above only
+            # vetoes when the table holds rows, so an empty residue would reach
+            # a bare ``CREATE TABLE`` and raise DuplicateTableError. Mirrors the
+            # sibling entity fixtures' idempotent ``DROP ... CASCADE`` + CREATE
+            # and this fixture's own teardown.
+            await conn.execute("DROP TABLE IF EXISTS release_artist")
             await conn.execute(
                 f"CREATE TABLE release_artist ({RECONCILER_TABLE_DDL['release_artist']})"
             )

--- a/tests/integration/test_pg_fixture_guard_adoption.py
+++ b/tests/integration/test_pg_fixture_guard_adoption.py
@@ -1,0 +1,107 @@
+"""Regression net for LML#768 — the entity-dropping pg fixtures adopt the
+shared data-safety guard and the hoisted ``ENTITY_IDENTITY_DDL``.
+
+#764 landed ``skip_if_drop_targets_populated`` + ``ENTITY_IDENTITY_DDL`` in
+``conftest.py`` and adopted them in the two artists-route suites. The rest
+of the pg suite predated both: four fixtures ran ``DROP SCHEMA entity
+CASCADE`` with no populated-DB veto (a mispointed ``DATABASE_URL_TEST`` ->
+the local discogs-cache would wipe hours of rate-limited reconciliation),
+and five files carried verbatim ``entity.identity`` DDL copies that a
+discogs-cache alembic column-add (WXYC/wiki#83) would silently skip.
+
+Two nets here:
+
+* A **static** check (no PG) that every migrated file imports the shared
+  guard + DDL constant and carries no inline ``CREATE TABLE entity.identity``
+  — this is what would have flagged a missed file during the hoist.
+* A **behavioral** ``pg`` check that ``skip_if_drop_targets_populated``
+  actually vetoes (with the promised message) when a scratch
+  ``entity.identity`` holds a row — the live half of the AC's spot-check,
+  automated so a future refactor can't quietly defang the guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.integration.conftest import (
+    ENTITY_IDENTITY_DDL,
+    skip_if_drop_targets_populated,
+)
+
+# Every file the #768 hoist touches: the four previously-unguarded fixtures
+# plus ``test_entity_resolution.py`` (fifth DDL copy + its near-variant
+# guard). All must route ``entity.identity`` creation through the shared
+# constant and gate their drops on the shared guard.
+_MIGRATED_FILES = (
+    "test_bulk_resolve_libraries.py",
+    "test_release_identity.py",
+    "test_cache_refresh_for_identities.py",
+    "test_charset_torture_entity_identity.py",
+    "test_entity_resolution.py",
+)
+
+_INLINE_IDENTITY_DDL = re.compile(r"CREATE\s+TABLE\s+entity\.identity", re.IGNORECASE)
+
+
+def _source(name: str) -> str:
+    return (Path(__file__).parent / name).read_text()
+
+
+@pytest.mark.parametrize("name", _MIGRATED_FILES)
+def test_migrated_file_has_no_inline_identity_ddl(name: str) -> None:
+    """No file recreates ``entity.identity`` by hand — a stale copy would
+    stay green against a schema the shared constant has since grown."""
+    assert not _INLINE_IDENTITY_DDL.search(_source(name)), (
+        f"{name} still carries an inline `CREATE TABLE entity.identity` — "
+        "use conftest.ENTITY_IDENTITY_DDL so a discogs-cache column-add "
+        "can't leave this suite green against a stale shape."
+    )
+
+
+@pytest.mark.parametrize("name", _MIGRATED_FILES)
+def test_migrated_file_imports_shared_guard_and_ddl(name: str) -> None:
+    """Every entity-dropping fixture file pulls the shared helpers in, so
+    its drops are veto-gated and its stub matches prod."""
+    src = _source(name)
+    assert "skip_if_drop_targets_populated" in src, (
+        f"{name} does not reference the shared data-safety guard."
+    )
+    assert "ENTITY_IDENTITY_DDL" in src, f"{name} does not reference the shared entity DDL."
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_guard_vetoes_when_scratch_identity_holds_a_row(pg_pool) -> None:
+    """Live half of the AC spot-check: one seeded ``entity.identity`` row
+    makes the shared guard skip with the promised veto message.
+
+    Builds the scratch schema through ``ENTITY_IDENTITY_DDL`` (the exact
+    stub the migrated fixtures now use), seeds a single row, and asserts
+    the guard the fixtures call FIRST raises ``Skipped`` naming the table.
+    Teardown drops the whole schema so the next test's sweep sees zero
+    entity relations — the no-false-veto invariant the issue calls out.
+    """
+    async with pg_pool.acquire() as conn:
+        # Pre-condition: a mispointed real cache would already fail here; on
+        # the clean test DB this is a no-op guard that must NOT veto.
+        await skip_if_drop_targets_populated(conn, ())
+        try:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            await conn.execute("CREATE SCHEMA entity")
+            await conn.execute(ENTITY_IDENTITY_DDL)
+            await conn.execute(
+                "INSERT INTO entity.identity (library_name, discogs_artist_id) "
+                "VALUES ('Stereolab', 2154)"
+            )
+
+            with pytest.raises(pytest.skip.Exception) as excinfo:
+                await skip_if_drop_targets_populated(conn, ())
+            message = str(excinfo.value)
+            assert "Refusing to DROP" in message
+            assert "entity.identity" in message
+        finally:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")

--- a/tests/integration/test_pg_fixture_guard_adoption.py
+++ b/tests/integration/test_pg_fixture_guard_adoption.py
@@ -25,10 +25,12 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import asyncpg
 import pytest
 
 from tests.integration.conftest import (
     ENTITY_IDENTITY_DDL,
+    RECONCILER_TABLE_DDL,
     skip_if_drop_targets_populated,
 )
 
@@ -105,3 +107,48 @@ async def test_guard_vetoes_when_scratch_identity_holds_a_row(pg_pool) -> None:
             assert "entity.identity" in message
         finally:
             await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_trigram_fixture_setup_survives_empty_release_artist_residue(pg_pool) -> None:
+    """An *empty* residual ``release_artist`` must not error the trigram setup.
+
+    ``skip_if_drop_targets_populated`` only vetoes when the target holds rows,
+    so an empty ``release_artist`` left by a crash-interrupted prior run (SIGKILL
+    after the fixture's ``CREATE TABLE`` but before its teardown ``DROP``) sails
+    past the guard. Before the drop-before-create fix, the fixture's bare
+    ``CREATE TABLE release_artist`` then raised ``DuplicateTableError`` — where
+    the pre-#768 existence check would have skipped. This reproduces that
+    residue and asserts the migrated setup sequence (guard, then
+    drop-before-create) is idempotent instead.
+    """
+    async with pg_pool.acquire() as conn:
+        try:
+            # Simulate crash residue: an empty release_artist from an
+            # interrupted prior run whose teardown never ran.
+            await conn.execute("DROP TABLE IF EXISTS release_artist")
+            await conn.execute(
+                f"CREATE TABLE release_artist ({RECONCILER_TABLE_DDL['release_artist']})"
+            )
+
+            # Empty table → guard must NOT veto (it only vetoes on rows). If it
+            # raised Skipped here the test would report skipped, not passed.
+            await skip_if_drop_targets_populated(conn, ("release_artist",))
+
+            # The divergence this fix closes: a *bare* CREATE over the residue
+            # raises (the pre-fix fixture path), which is why the migrated setup
+            # must drop first.
+            with pytest.raises(asyncpg.exceptions.DuplicateTableError):
+                await conn.execute(
+                    f"CREATE TABLE release_artist ({RECONCILER_TABLE_DDL['release_artist']})"
+                )
+
+            # The migrated setup drops before creating, so re-running it over
+            # the empty residue is a no-op recreate rather than a duplicate.
+            await conn.execute("DROP TABLE IF EXISTS release_artist")
+            await conn.execute(
+                f"CREATE TABLE release_artist ({RECONCILER_TABLE_DDL['release_artist']})"
+            )
+        finally:
+            await conn.execute("DROP TABLE IF EXISTS release_artist")

--- a/tests/integration/test_release_identity.py
+++ b/tests/integration/test_release_identity.py
@@ -31,7 +31,11 @@ from entity.store import EntityStore
 
 # ``DATABASE_URL`` (and the conftest ``pg_pool_large``) come from conftest;
 # imported here for the ``source._dsn`` wiring and ``monkeypatch.setenv`` below.
-from tests.integration.conftest import DATABASE_URL
+from tests.integration.conftest import (
+    DATABASE_URL,
+    ENTITY_IDENTITY_DDL,
+    skip_if_drop_targets_populated,
+)
 
 
 @pytest_asyncio.fixture
@@ -55,72 +59,74 @@ async def pg_source(pg_pool):
 
 @pytest_asyncio.fixture(autouse=True)
 async def set_up_entity_schema(pg_pool):
-    """Drop + recreate the entity schema, including the new release tables."""
+    """Drop + recreate the entity schema, including the new release tables.
+
+    SAFETY: refuses to run when anything this fixture would drop already
+    holds rows — the default ``DATABASE_URL_TEST`` may point at a real
+    discogs-cache whose ``entity.*`` took hours of rate-limited
+    reconciliation to build. The guard sweeps the entity schema dynamically
+    from ``pg_class`` (see ``skip_if_drop_targets_populated``); this fixture
+    drops no public tables, so its public-table list is empty.
+    """
     async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
-        await conn.execute("CREATE SCHEMA entity")
-        # Artist-side tables — required so the entity store probe passes.
-        await conn.execute("""
-            CREATE TABLE entity.identity (
-                id SERIAL PRIMARY KEY,
-                library_name TEXT NOT NULL UNIQUE,
-                discogs_artist_id INTEGER,
-                wikidata_qid TEXT,
-                musicbrainz_artist_id TEXT,
-                spotify_artist_id TEXT,
-                apple_music_artist_id TEXT,
-                bandcamp_id TEXT,
-                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        await skip_if_drop_targets_populated(conn, ())
+
+    # Creation inside the try: a mid-setup failure must still drop whatever
+    # was created instead of stranding rows that veto the next run (same
+    # posture as the artists-route siblings).
+    try:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+            await conn.execute("CREATE SCHEMA entity")
+            # Artist-side tables — required so the entity store probe passes.
+            await conn.execute(ENTITY_IDENTITY_DDL)
+            await conn.execute("""
+                CREATE TABLE entity.reconciliation_log (
+                    id SERIAL PRIMARY KEY,
+                    identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
+                    source TEXT NOT NULL,
+                    external_id TEXT NOT NULL,
+                    confidence REAL,
+                    method TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            # Release-side tables — added by LML#526.
+            await conn.execute("""
+                CREATE TABLE entity.release_identity (
+                    id SERIAL PRIMARY KEY,
+                    discogs_release_id INTEGER UNIQUE,
+                    discogs_master_id INTEGER UNIQUE,
+                    musicbrainz_release_id TEXT UNIQUE,
+                    spotify_album_id TEXT UNIQUE,
+                    apple_music_album_id TEXT UNIQUE,
+                    bandcamp_album_url TEXT UNIQUE,
+                    reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            await conn.execute("""
+                CREATE TABLE entity.release_reconciliation_log (
+                    id SERIAL PRIMARY KEY,
+                    identity_id INTEGER NOT NULL REFERENCES entity.release_identity(id),
+                    source TEXT NOT NULL,
+                    external_id TEXT NOT NULL,
+                    confidence REAL,
+                    method TEXT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+            """)
+            # Mirrors the production DDL in entity/release_identity.sql so the
+            # fixture has the same query-plan shape as prod.
+            await conn.execute(
+                "CREATE INDEX idx_release_reconciliation_log_identity_id "
+                "ON entity.release_reconciliation_log(identity_id)"
             )
-        """)
-        await conn.execute("""
-            CREATE TABLE entity.reconciliation_log (
-                id SERIAL PRIMARY KEY,
-                identity_id INTEGER NOT NULL REFERENCES entity.identity(id),
-                source TEXT NOT NULL,
-                external_id TEXT NOT NULL,
-                confidence REAL,
-                method TEXT NOT NULL,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-        # Release-side tables — added by LML#526.
-        await conn.execute("""
-            CREATE TABLE entity.release_identity (
-                id SERIAL PRIMARY KEY,
-                discogs_release_id INTEGER UNIQUE,
-                discogs_master_id INTEGER UNIQUE,
-                musicbrainz_release_id TEXT UNIQUE,
-                spotify_album_id TEXT UNIQUE,
-                apple_music_album_id TEXT UNIQUE,
-                bandcamp_album_url TEXT UNIQUE,
-                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-        await conn.execute("""
-            CREATE TABLE entity.release_reconciliation_log (
-                id SERIAL PRIMARY KEY,
-                identity_id INTEGER NOT NULL REFERENCES entity.release_identity(id),
-                source TEXT NOT NULL,
-                external_id TEXT NOT NULL,
-                confidence REAL,
-                method TEXT NOT NULL,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-        """)
-        # Mirrors the production DDL in entity/release_identity.sql so the
-        # fixture has the same query-plan shape as prod.
-        await conn.execute(
-            "CREATE INDEX idx_release_reconciliation_log_identity_id "
-            "ON entity.release_reconciliation_log(identity_id)"
-        )
-    yield
-    async with pg_pool.acquire() as conn:
-        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        yield
+    finally:
+        async with pg_pool.acquire() as conn:
+            await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
 
 
 @pytest.mark.pg


### PR DESCRIPTION
## What

Adopts the #764 shared data-safety guard (`skip_if_drop_targets_populated`) and the hoisted `ENTITY_IDENTITY_DDL` constant across the five entity-dropping pg fixtures that predated both. Pure test-infrastructure change — no production code.

Before this, four fixtures ran `DROP SCHEMA entity CASCADE` with no populated-DB veto — a developer whose `DATABASE_URL_TEST` points at a real local discogs-cache (the default DSN `postgresql://discogs:discogs@localhost:5433/discogs` is exactly that port) who ran `pytest -m pg` would wipe hours of rate-limited reconciliation data with no veto. Five files also carried verbatim `entity.identity` DDL copies, so a discogs-cache alembic column-add (WXYC/wiki#83) could leave a suite green against a stale schema shape.

## Changes

Each migrated fixture now:
- calls `skip_if_drop_targets_populated(conn, <public-table drop list>)` **before any DROP** (the guard vetoes; it doesn't clean up), inside its own acquire block;
- restructures setup into `try` / `finally` so a mid-seed crash still drops the whole `entity` schema in teardown (preserving the invariant that the next test's sweep sees zero entity relations — no false veto);
- builds `entity.identity` through `ENTITY_IDENTITY_DDL` instead of an inline copy.

Files:
- `test_bulk_resolve_libraries.py` — `set_up_entity_schema` (entity-only; empty public list)
- `test_release_identity.py` — `set_up_entity_schema` (entity-only)
- `test_cache_refresh_for_identities.py` — `set_up_entity_schema` (entity-only)
- `test_charset_torture_entity_identity.py` — `entity_store` (entity-only; yields `EntityStore`)
- `test_entity_resolution.py` — module-level `set_up_entity_schema` (DDL copy + guard), the `TestIdentityRouterEntityStoreUnavailable` class fixture (also drops the entity schema → guarded), and the `TestTrigramFallbackSQLIntegration` near-variant `release_artist`-existence check reconciled onto the shared helper (`public_tables=("release_artist",)`)
- `test_pg_fixture_guard_adoption.py` (new) — regression net: a static check that no migrated file carries inline `CREATE TABLE entity.identity` and each imports the shared guard + DDL, plus a `pg` behavioral check that a seeded scratch `entity.identity` vetoes with the promised message.

## Verification

- Full `pytest -m pg` green against a clean local PG (239 passed, 9 skipped — the skips are the `wxyc_identity_match_artist`- and empty-`release_artist`-gated ones, unchanged from baseline). Stress-ran the five migrated files together 8× with no flakes.
- Default suite green. (`ruff check` / `ruff format --check` clean.)
- **Manual spot-check (AC):** seeded one `entity.identity` row into a scratch schema, ran `test_bulk_resolve_libraries.py` — every test skipped with `Refusing to DROP: tables that hold data (entity.identity). Point DATABASE_URL_TEST at a clean, reachable PG before running this suite.`, and the seeded row survived untouched (guard vetoed before any DROP). Repeated the equivalent for the reconciled `release_artist` near-variant guard.

## Related

- Closes #768
- Builds on #764 (the guard + DDL constant + adoption template)
- Part of the #759 artists-route work that landed the guard
