### PR TITLE
entity.identity fill-if-null mint primitive: no-clobber, provenance, minted-row status, case-sibling awareness

### DIFF
--- a/artists/resolver.py
+++ b/artists/resolver.py
@@ -86,13 +86,16 @@ Tiers, per group:
    intra-request concurrency can't beat it and only starves interleaved
    live-lookup traffic of semaphore slots (LML#370/#372).
 
-Write-back: ``upsert_identity``'s ON CONFLICT arm is
-``COALESCE(EXCLUDED.discogs_artist_id, existing)`` — **new wins when
-non-null**; COALESCE only refuses to overwrite with NULL. Not
-overwriting an existing id therefore rests on the tier-1 read gate,
-which is up to ~30s stale at mint time under the serial API pacing — a
-concurrent writer in that window is silently overwritten (LML#766
-tracks the store-level fill-if-null primitive that closes this).
+Write-back: the mint uses ``EntityStore.fill_identity_discogs_id``
+(LML#766), whose ON CONFLICT arm is guarded ``WHERE discogs_artist_id
+IS NULL`` — the id is written ONLY when the stored value is NULL. The
+tier-1 read gate is up to ~30s stale at mint time under the serial API
+pacing, so a concurrent higher-evidence writer (release-derived
+``_writeback_identity``) can set an id in that window; the fill-if-null
+guard means that id is never silently overwritten — the resolver's
+attempt is rejected and counted as ``mint_lost_race`` instead. Minted
+rows are stamped ``reconciliation_status='reconciled'`` so a later
+reconciler campaign can't reprocess (and clobber) the API-verified id.
 Qualifier-bearing groups never mint: a qualified key is unreachable via
 the bare-name reads Backend actually issues (only an exact-leg read of
 the same qualified string finds it — which is also why such a stored row
@@ -270,8 +273,16 @@ class ResolveStats:
     (an upsert that returned None — the store's swallowed-failure
     contract — is logged but not counted, so ``minted`` tracks rows
     actually persisted, not write attempts).
-    ``discogs_api_calls`` counts ``search_artists`` probes that returned
-    to the resolver — including ``None`` returns (a 429-exhausted or
+    ``mint_lost_race`` counts fill-if-null mints (LML#766) the resolver
+    LOST: the store already held a non-null ``discogs_artist_id`` different
+    from this batch's winner, so the store rejected the write and the
+    higher-evidence stored id survived. A non-zero value is not an error —
+    it is the (benign, expected-rare) concurrent-writer signal the #766
+    primitive exists to surface instead of silently clobbering — but a
+    sustained rate is worth alerting on. Only the api_search mint path can
+    lose a race; a lost race is NOT counted in ``minted`` (nothing was
+    persisted by us). ``discogs_api_calls`` counts ``search_artists`` probes
+    that returned to the resolver — including ``None`` returns (a 429-exhausted or
     distrusted probe still consumed shared-limiter budget). A probe shed
     by the breaker is not counted: usually it was refused at entry before
     any HTTP left the building, though a mid-flight open may have spent
@@ -290,6 +301,7 @@ class ResolveStats:
     escalation_unavailable: int = 0
     discogs_api_calls: int = 0
     minted: int = 0
+    mint_lost_race: int = 0
 
 
 @dataclass
@@ -689,26 +701,34 @@ class BareNameArtistResolver:
         mint_key = group.mint_key or group.probe
         if not dry_run and group.qualifier is None:
             # discogs_artist_id only — other id columns belong to their own
-            # enrichment flows. COALESCE guards NULL-overwrites only; not
-            # clobbering an EXISTING id rests on the tier-1 gate, which is
-            # a stale read by mint time (LML#766 tracks the store-level
-            # fill-if-null fix). Qualifier-bearing groups skip the mint
+            # enrichment flows. The fill-if-null primitive (LML#766) writes
+            # the id ONLY when the stored value is NULL, so a concurrent
+            # higher-evidence writer (e.g. release/orchestrator._writeback_
+            # identity) that set an id in the tier-1 read-to-mint window is
+            # never silently clobbered — that race lands as mint_lost_race,
+            # not a bad overwrite. Minted rows are stamped 'reconciled' by
+            # the store so a later reconciler campaign can't reprocess this
+            # API-verified id. Qualifier-bearing groups skip the mint
             # entirely: a qualified key is unreachable via the bare-name
             # reads Backend issues, i.e. pure pollution.
-            upserted = await self._entity_store.upsert_identity(
-                mint_key, discogs_artist_id=winner_id
-            )
-            if upserted is None:
-                # upsert_identity's contract allows a None return for a
-                # swallowed failure; today's PgSource raises instead (the
-                # route 503s), so this branch is belt-and-braces.
+            outcome = await self._entity_store.fill_identity_discogs_id(mint_key, winner_id)
+            if outcome.lost_race:
+                # A concurrent writer already set a DIFFERENT id; the store
+                # kept it (and logged loudly). Count the (benign) race, do
+                # not count a mint — nothing was persisted by us.
+                stats.mint_lost_race += 1
+            elif outcome.identity is None:
+                # Swallowed store failure (today's PgSource raises instead,
+                # so the route 503s); belt-and-braces.
                 logger.error(
-                    "entity.identity write-back failed for '%s' (discogs_artist_id=%d)",
+                    "entity.identity fill-if-null failed for '%s' (discogs_artist_id=%d)",
                     mint_key,
                     winner_id,
                 )
-            else:
+            elif outcome.filled:
                 stats.minted += 1
+            # else: a pre-existing row already held our exact id (idempotent
+            # re-fill / case sibling) — resolved, but nothing minted by us.
         return group.resolved(
             discogs_artist_id=winner_id,
             method=ArtistResolveMethod.api_search,

--- a/entity/store.py
+++ b/entity/store.py
@@ -72,6 +72,43 @@ RETURNING id, library_name, discogs_artist_id, wikidata_qid,
           apple_music_artist_id, bandcamp_id, reconciliation_status\
 """
 
+# --- fill-if-null mint primitive (LML#766) ----------------------------------
+#
+# Unlike `_UPSERT_IDENTITY_SQL`'s COALESCE-new-wins arm, this arm sets
+# `discogs_artist_id` ONLY when the stored value is NULL (the
+# `WHERE ... IS NULL` guard on the DO UPDATE). A concurrent writer that has
+# already set a non-null id in the tier-1 read-to-mint window (up to ~30s
+# stale under the resolver's 50/min serial API pacing) is therefore never
+# silently overwritten — the guard makes the DO UPDATE a no-op, RETURNING
+# comes back empty, and the caller detects the lost race.
+#
+# Row-status decision (LML#766): minted / filled rows are stamped
+# `reconciliation_status = 'reconciled'`, NOT the table default
+# `'unreconciled'`. `scripts/entity_resolution/__main__.py:run_discogs_stage`
+# reprocesses `'unreconciled'` rows through the first-match-wins Discogs
+# cascade and unconditionally `upsert_identity(discogs_artist_id=...)` — i.e.
+# COALESCE-new-wins would clobber this API-verified id with a cascade guess.
+# 'reconciled' excludes the row from that stage's `get_identities_by_status
+# ('unreconciled')` scan. The Wikidata/MusicBrainz enrichment stages DO read
+# 'reconciled' rows, but they only fill `wikidata_qid` / streaming ids and
+# never touch `discogs_artist_id`, so picking the API-verified row up for
+# QID bridging is desirable, not a clobber. `reconciliation_status` is a
+# free-text `TEXT NOT NULL DEFAULT 'unreconciled'` column (no CHECK / enum
+# in the discogs-cache alembic schema), so 'reconciled' — already written by
+# the reconciler — needs no cross-repo enum change.
+_FILL_IDENTITY_DISCOGS_ID_SQL = """\
+INSERT INTO entity.identity (library_name, discogs_artist_id, reconciliation_status)
+VALUES ($1, $2, 'reconciled')
+ON CONFLICT (library_name) DO UPDATE SET
+    discogs_artist_id = EXCLUDED.discogs_artist_id,
+    reconciliation_status = 'reconciled',
+    updated_at = now()
+WHERE entity.identity.discogs_artist_id IS NULL
+RETURNING id, library_name, discogs_artist_id, wikidata_qid,
+          musicbrainz_artist_id, spotify_artist_id,
+          apple_music_artist_id, bandcamp_id, reconciliation_status\
+"""
+
 _GET_IDENTITY_SQL = """\
 SELECT id, library_name, discogs_artist_id, wikidata_qid,
        musicbrainz_artist_id, spotify_artist_id,
@@ -283,6 +320,31 @@ class ProvenanceRow:
     method: str
 
 
+@dataclass
+class FillOutcome:
+    """Result of a fill-if-null ``discogs_artist_id`` mint (LML#766).
+
+    Attributes:
+        identity: The row after the attempt (the winner's state on a lost
+            race), or ``None`` only if the store swallowed a failure.
+        filled: True iff THIS call wrote the ``discogs_artist_id`` — either
+            by inserting a new row or by filling a previously-NULL column.
+        lost_race: True iff the row already held a non-null id DIFFERENT from
+            the one we tried to write. The stored id is preserved; our value
+            was rejected by the ``IS NULL`` guard. Callers should treat this
+            as a real (if benign) conflict worth counting, not an error.
+        previous_discogs_artist_id: The id already stored before our attempt
+            (``None`` when we minted a fresh row or filled a NULL column).
+            Equals ``identity.discogs_artist_id`` on both the idempotent
+            same-id re-fill and the lost race.
+    """
+
+    identity: Identity | None
+    filled: bool
+    lost_race: bool
+    previous_discogs_artist_id: int | None
+
+
 class EntityStore:
     """CRUD interface for the entity identity store.
 
@@ -305,10 +367,18 @@ class EntityStore:
         apple_music_artist_id: str | None = None,
         bandcamp_id: str | None = None,
     ) -> Identity | None:
-        """Insert or update an identity row.
+        """Insert or update an identity row (NEW-WINS-when-non-null).
 
         Uses ``ON CONFLICT ... DO UPDATE`` with ``COALESCE`` so that populated
-        fields are never overwritten with NULL.
+        fields are never overwritten with NULL. **But a non-null EXCLUDED
+        value overwrites a non-null stored value** — this is the new-wins
+        arm, correct for flows that legitimately UPDATE an id (the reconciler
+        campaigns, the streaming/QID enrichment stages). It is NOT safe as a
+        first-write-wins mint: two writers racing to set ``discogs_artist_id``
+        for the same ``library_name`` will clobber each other. Mint call
+        sites that must never overwrite an existing id use
+        ``fill_identity_discogs_id`` (LML#766) instead, whose ON CONFLICT arm
+        is guarded ``WHERE discogs_artist_id IS NULL``.
 
         Every TEXT-bound argument is passed through
         ``wxyc_etl.pg.to_pg_text_form`` before the query — same WX-3.B
@@ -341,6 +411,133 @@ class EntityStore:
         if record is None:
             return None
         return _record_to_identity(record)
+
+    async def fill_identity_discogs_id(
+        self, library_name: str, discogs_artist_id: int
+    ) -> FillOutcome:
+        """Fill ``discogs_artist_id`` only when the stored value is NULL.
+
+        The concurrency-safe mint primitive (LML#766). Unlike
+        ``upsert_identity``'s new-wins arm, this can never silently overwrite
+        a non-null ``discogs_artist_id`` set by a concurrent writer — the ON
+        CONFLICT arm is guarded ``WHERE entity.identity.discogs_artist_id IS
+        NULL``, so a row that already carries an id makes the DO UPDATE a
+        no-op and RETURNING comes back empty. The loser then reads the
+        winner's row back and reports ``lost_race=True`` with a loud WARNING,
+        so a clobbered write leaves a trail rather than vanishing.
+
+        Case-sibling awareness (LML#766 point 4): before the atomic fill, the
+        existing case-insensitive read leg (``_GET_IDENTITY_LOWER_SQL``) is
+        consulted. When an id-bearing row exists under a different casing
+        (e.g. a ``WISHY`` sibling for a ``wishy`` fill), that row answers
+        directly — the fill is short-circuited so the store does not accrete
+        a conflicting case-variant row. A sibling holding a DIFFERENT id is a
+        lost race. This reuses the leg the resolver's tier-1 read already
+        runs, so it adds one sub-millisecond seq-scan on the ~24K-row table
+        and needs no schema change. A sibling with a NULL id does NOT
+        short-circuit: the verbatim key is minted/filled normally (matching
+        the resolver's in-place fill-target choice, which keys on the stored
+        ``library_name``).
+
+        Minted / filled rows are stamped ``reconciliation_status =
+        'reconciled'`` so the reconciler's first-match-wins Discogs cascade
+        (which reprocesses ``'unreconciled'`` rows) can't later clobber this
+        API-verified id. See ``_FILL_IDENTITY_DISCOGS_ID_SQL``.
+
+        Args:
+            library_name: Verbatim artist name (NUL-stripped at the boundary).
+            discogs_artist_id: The id to write if the column is NULL.
+
+        Returns:
+            A ``FillOutcome``. ``filled`` marks the writer that actually set
+            the id; ``lost_race`` marks a writer whose non-null-different
+            conflict was rejected; ``previous_discogs_artist_id`` carries the
+            value that was already stored (``None`` on a fresh mint / NULL
+            fill). ``identity`` is ``None`` only if the store swallowed a
+            failure (today's ``PgSource`` raises instead).
+        """
+        verbatim = to_pg_text_form(library_name)
+
+        # --- Case-sibling short-circuit (LML#766 point 4). ---------------
+        # An id-bearing row under a different casing already answers reads;
+        # filling a verbatim near-duplicate would accrete a conflicting
+        # case-variant. Reuse the existing LOWER leg (lowest id wins, same
+        # rule as the resolver's tier-1 read).
+        sibling_row = await self._pg.fetchone(_GET_IDENTITY_LOWER_SQL, verbatim)
+        if sibling_row is not None and sibling_row["discogs_artist_id"] is not None:
+            sibling = _record_to_identity(sibling_row)
+            existing = sibling.discogs_artist_id
+            if existing == discogs_artist_id:
+                # The sibling already holds our id — idempotent, no-op.
+                return FillOutcome(
+                    identity=sibling,
+                    filled=False,
+                    lost_race=False,
+                    previous_discogs_artist_id=existing,
+                )
+            # A DIFFERENT id under a case-variant: lost race, never mint a
+            # second row. Loud so the rejected attempt leaves a trail.
+            logger.warning(
+                "fill_identity_discogs_id lost race for %r (case sibling %r): "
+                "stored discogs_artist_id=%s, attempted=%s — attempted value NOT written",
+                library_name,
+                sibling.library_name,
+                existing,
+                discogs_artist_id,
+            )
+            return FillOutcome(
+                identity=sibling,
+                filled=False,
+                lost_race=True,
+                previous_discogs_artist_id=existing,
+            )
+
+        # --- Atomic fill-if-null. ----------------------------------------
+        record = await self._pg.fetchone(_FILL_IDENTITY_DISCOGS_ID_SQL, verbatim, discogs_artist_id)
+        if record is not None:
+            # We inserted a fresh row, or filled a previously-NULL column.
+            return FillOutcome(
+                identity=_record_to_identity(record),
+                filled=True,
+                lost_race=False,
+                previous_discogs_artist_id=None,
+            )
+
+        # RETURNING was empty: the row exists and already held a non-null id,
+        # so the `IS NULL` guard blocked the DO UPDATE. Read it back to
+        # distinguish an idempotent same-id re-fill from a genuine lost race.
+        existing_row = await self._pg.fetchone(_GET_IDENTITY_SQL, verbatim)
+        if existing_row is None:
+            # The row vanished between the blocked upsert and this read — a
+            # concurrent delete (orphan pass). Nothing to report as filled.
+            return FillOutcome(
+                identity=None,
+                filled=False,
+                lost_race=False,
+                previous_discogs_artist_id=None,
+            )
+        existing_identity = _record_to_identity(existing_row)
+        existing = existing_identity.discogs_artist_id
+        if existing == discogs_artist_id:
+            return FillOutcome(
+                identity=existing_identity,
+                filled=False,
+                lost_race=False,
+                previous_discogs_artist_id=existing,
+            )
+        logger.warning(
+            "fill_identity_discogs_id lost race for %r: stored discogs_artist_id=%s, "
+            "attempted=%s — attempted value NOT written",
+            library_name,
+            existing,
+            discogs_artist_id,
+        )
+        return FillOutcome(
+            identity=existing_identity,
+            filled=False,
+            lost_race=True,
+            previous_discogs_artist_id=existing,
+        )
 
     async def get_identity(self, library_name: str) -> Identity | None:
         """Look up an identity by library name.

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -277,7 +277,22 @@ async def _writeback_identity(
         # discogs_artist_id: fill-if-null so we never clobber a concurrent
         # writer's id (LML#766). Only write when we actually learned one.
         if identifiers.discogs_artist_id is not None:
-            await store.fill_identity_discogs_id(canonical.artist, identifiers.discogs_artist_id)
+            outcome = await store.fill_identity_discogs_id(
+                canonical.artist, identifiers.discogs_artist_id
+            )
+            # identity=None means the row vanished between the blocked upsert
+            # and the read-back — a concurrent orphan-pass delete (or a
+            # swallowed store failure). The learned id is not re-stamped (and
+            # re-creating a row the orphan pass just deleted would only
+            # re-orphan it), but the drop must not be silent.
+            if outcome.identity is None:
+                logger.warning(
+                    "entity.identity fill-if-null found no row to stamp for "
+                    "'%s' (discogs_artist_id=%d) — concurrent delete or "
+                    "swallowed store failure; id not recorded",
+                    canonical.artist,
+                    identifiers.discogs_artist_id,
+                )
         # bandcamp_id (and the first-sight row creation when no Discogs id was
         # learned): COALESCE-additive upsert. Skipping this entirely when both
         # ids are absent avoids an empty no-op write.

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -128,7 +128,9 @@ async def resolve_release(
     identifiers = _merge_streaming_identifiers(identifiers, streaming)
 
     # Identity write-back: any newly-discovered IDs land in entity.identity
-    # for the artist. Idempotent + COALESCE-based — never clobbers existing data.
+    # for the artist. The discogs_artist_id write is fill-if-null (LML#766) so
+    # a concurrent writer's id is never clobbered; bandcamp_id is COALESCE-
+    # additive. Idempotent.
     # Require a non-empty, non-compilation artist name so we never insert
     # library_name="" or pollute the matcher's lookup space with V/A rows
     # (read-side handlers like identity/router.py already skip these, but the
@@ -249,9 +251,19 @@ async def _writeback_identity(
 ) -> None:
     """Push newly-learned IDs into ``entity.identity`` keyed on the artist name.
 
-    Reuses the existing ``upsert_identity`` SQL pattern (``ON CONFLICT ... DO
-    UPDATE`` with ``COALESCE``) so populated fields are never clobbered. The
-    artist row is created on first sight.
+    The ``discogs_artist_id`` is written via ``EntityStore.
+    fill_identity_discogs_id`` (LML#766): fill-if-null, so a non-null id set
+    by a concurrent writer — the bare-name resolver's ``artists/resolver.py``
+    mint is the realistic contender, and this release-derived id is the
+    HIGHER-evidence of the two — is never silently clobbered. A lost race is
+    logged by the store; there is nothing to surface to the DJ (either id is
+    a valid Discogs artist for this release), so no warning is appended.
+
+    ``bandcamp_id`` is written separately via ``upsert_identity`` (COALESCE-
+    additive: it only fills a NULL, never overwrites). It is not the
+    TOCTOU-contested column, so new-wins-when-non-null is not a hazard for it;
+    the resolver never writes it. The artist row is created on first sight by
+    whichever write runs first.
     """
     # Bandcamp doesn't expose an integer artist ID, so we use the album URL's
     # subdomain as the bandcamp_id placeholder. This matches existing
@@ -262,11 +274,18 @@ async def _writeback_identity(
     )
 
     try:
-        await store.upsert_identity(
-            canonical.artist,
-            discogs_artist_id=identifiers.discogs_artist_id,
-            bandcamp_id=bandcamp_id,
-        )
+        # discogs_artist_id: fill-if-null so we never clobber a concurrent
+        # writer's id (LML#766). Only write when we actually learned one.
+        if identifiers.discogs_artist_id is not None:
+            await store.fill_identity_discogs_id(canonical.artist, identifiers.discogs_artist_id)
+        # bandcamp_id (and the first-sight row creation when no Discogs id was
+        # learned): COALESCE-additive upsert. Skipping this entirely when both
+        # ids are absent avoids an empty no-op write.
+        if bandcamp_id is not None or identifiers.discogs_artist_id is None:
+            await store.upsert_identity(
+                canonical.artist,
+                bandcamp_id=bandcamp_id,
+            )
     except Exception:
         logger.exception("Identity write-back failed for %s", canonical.artist)
         warnings.append(

--- a/scripts/entity_resolution/__main__.py
+++ b/scripts/entity_resolution/__main__.py
@@ -294,7 +294,18 @@ async def run_discogs_stage(
     reconciler: DiscogsReconciler,
     batch_size: int,
 ) -> tuple[int, int]:
-    """Run Discogs reconciliation for unreconciled identities. Returns (matched, no_match)."""
+    """Run Discogs reconciliation for unreconciled identities. Returns (matched, no_match).
+
+    Scans ONLY ``reconciliation_status = 'unreconciled'`` rows, then runs each
+    through the first-match-wins Discogs cascade and ``upsert_identity
+    (discogs_artist_id=...)`` (new-wins-when-non-null). That is exactly the
+    clobber LML#766 guards against: a resolver / release-writeback mint carries
+    an API-VERIFIED ``discogs_artist_id``, so those mints are stamped
+    ``reconciliation_status = 'reconciled'`` by ``fill_identity_discogs_id`` and
+    are therefore EXCLUDED from this scan. Do not widen this to reprocess
+    'reconciled' rows through the cascade, or the campaign will overwrite
+    API-verified ids with first-match-wins guesses.
+    """
     identities = await store.get_identities_by_status("unreconciled")
     if not identities:
         logger.info("No unreconciled identities for Discogs stage")

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -894,6 +894,52 @@ class TestDiscogsStageConfidencePersisted:
 
 
 @pytest.mark.pg
+class TestMintedRowExcludedFromReconciler:
+    """LML#766: a fill-if-null mint carries an API-verified ``discogs_artist_id``
+    and is stamped ``reconciliation_status = 'reconciled'``, so the Discogs
+    reconciliation stage never reprocesses it through the first-match-wins
+    cascade (which would clobber the verified id with a guess)."""
+
+    @pytest.mark.asyncio
+    async def test_fill_minted_row_not_reprocessed_by_discogs_stage(self, pg_source):
+        store = EntityStore(pg_source)
+        # The resolver mints an API-verified id via the fill primitive.
+        outcome = await store.fill_identity_discogs_id("Wishy", 123)
+        assert outcome.filled is True
+        assert outcome.identity.reconciliation_status == "reconciled"
+
+        # A reconciler campaign runs. Its cascade would (wrongly) credit a
+        # DIFFERENT id to "Wishy" if it saw the row — but it must not see it.
+        reconciler = AsyncMock()
+        reconciler.reconcile_batch = AsyncMock(
+            return_value={"Wishy": ReconciliationMatch(discogs_artist_id=999, method="exact_match")}
+        )
+        matched, no_match = await run_discogs_stage(store, reconciler, batch_size=1000)
+
+        # The stage scans only 'unreconciled' rows; the minted row is absent.
+        reconciler.reconcile_batch.assert_not_awaited()
+        assert (matched, no_match) == (0, 0)
+        identity = await store.get_identity("Wishy")
+        assert identity is not None
+        # The API-verified id survives untouched.
+        assert identity.discogs_artist_id == 123
+
+    @pytest.mark.asyncio
+    async def test_reseed_preserves_minted_reconciled_status(self, pg_source):
+        """``seed_identities`` re-upserting a library artist must not reset a
+        minted row's 'reconciled' status back to 'unreconciled' (which would
+        re-expose it to the cascade)."""
+        store = EntityStore(pg_source)
+        await store.fill_identity_discogs_id("Wishy", 123)
+        # Re-seed (no id) — COALESCE preserves the id AND leaves status alone.
+        await store.upsert_identity(library_name="Wishy")
+        identity = await store.get_identity("Wishy")
+        assert identity is not None
+        assert identity.discogs_artist_id == 123
+        assert identity.reconciliation_status == "reconciled"
+
+
+@pytest.mark.pg
 class TestLatestProvenanceTiebreak:
     """LML#233: identical `created_at` rows resolve deterministically by id."""
 

--- a/tests/integration/test_fill_identity_discogs_id.py
+++ b/tests/integration/test_fill_identity_discogs_id.py
@@ -1,0 +1,225 @@
+"""Integration tests for ``EntityStore.fill_identity_discogs_id`` (LML#766).
+
+The fill-if-null mint primitive: sets ``entity.identity.discogs_artist_id``
+only when the stored value is NULL, so a concurrent writer's non-null id can
+never be silently clobbered. The loser observes the loss via RETURNING and the
+store logs it loudly.
+
+Run with: pytest -m pg -v
+Requires: DATABASE_URL_TEST env var or Docker postgres on port 5433.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+import pytest_asyncio
+
+from entity.sources import PgSource
+from entity.store import EntityStore
+from tests.integration.conftest import DATABASE_URL
+
+
+def _source(pg_pool) -> PgSource:
+    source = PgSource.__new__(PgSource)
+    source._dsn = DATABASE_URL
+    source._pool = pg_pool
+    return source
+
+
+@pytest_asyncio.fixture
+async def pg_source(pg_pool):
+    """PgSource wrapping the test pool."""
+    return _source(pg_pool)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_entity_schema(pg_pool):
+    """Create (or re-create) the entity schema for each test.
+
+    Mirrors ``test_entity_resolution.py``'s fixture -- the discogs-cache
+    alembic shape (``reconciliation_status TEXT NOT NULL DEFAULT
+    'unreconciled'``, case-sensitive UNIQUE on ``library_name``).
+    """
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+        await conn.execute("CREATE SCHEMA entity")
+        await conn.execute("""
+            CREATE TABLE entity.identity (
+                id SERIAL PRIMARY KEY,
+                library_name TEXT NOT NULL UNIQUE,
+                discogs_artist_id INTEGER,
+                wikidata_qid TEXT,
+                musicbrainz_artist_id TEXT,
+                spotify_artist_id TEXT,
+                apple_music_artist_id TEXT,
+                bandcamp_id TEXT,
+                reconciliation_status TEXT NOT NULL DEFAULT 'unreconciled',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """)
+        await conn.execute(
+            "CREATE INDEX idx_entity_identity_status ON entity.identity(reconciliation_status)"
+        )
+    yield
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
+
+
+@pytest.mark.pg
+class TestFillIdentityDiscogsId:
+    """Fill-if-null semantics, lost-race detection, minted status."""
+
+    @pytest.mark.asyncio
+    async def test_insert_on_absent_row_fills_and_marks_reconciled(self, pg_source):
+        """First sight: the row is minted with our id and a reconciled
+        status so reconciler campaigns don't reprocess it."""
+        store = EntityStore(pg_source)
+        outcome = await store.fill_identity_discogs_id("Wishy", 123)
+        assert outcome.filled is True
+        assert outcome.lost_race is False
+        assert outcome.identity is not None
+        assert outcome.identity.discogs_artist_id == 123
+        assert outcome.identity.reconciliation_status == "reconciled"
+        assert outcome.previous_discogs_artist_id is None
+
+    @pytest.mark.asyncio
+    async def test_fill_null_column_on_existing_row(self, pg_source):
+        """An existing row with a NULL discogs id and other columns
+        populated gets its id filled without clobbering siblings."""
+        store = EntityStore(pg_source)
+        await store.upsert_identity(library_name="Cat Power", spotify_artist_id="spotify-cat-power")
+        outcome = await store.fill_identity_discogs_id("Cat Power", 3081)
+        assert outcome.filled is True
+        assert outcome.identity is not None
+        assert outcome.identity.discogs_artist_id == 3081
+        assert outcome.identity.spotify_artist_id == "spotify-cat-power"
+        assert outcome.previous_discogs_artist_id is None
+
+    @pytest.mark.asyncio
+    async def test_no_clobber_when_id_already_present_same(self, pg_source):
+        """Idempotent re-fill with the SAME id: not a lost race, the row
+        already holds our value."""
+        store = EntityStore(pg_source)
+        await store.fill_identity_discogs_id("Stereolab", 99)
+        outcome = await store.fill_identity_discogs_id("Stereolab", 99)
+        assert outcome.filled is False
+        assert outcome.lost_race is False
+        assert outcome.identity is not None
+        assert outcome.identity.discogs_artist_id == 99
+        assert outcome.previous_discogs_artist_id == 99
+
+    @pytest.mark.asyncio
+    async def test_lost_race_when_id_already_present_different(self, pg_source, caplog):
+        """A non-null id different from ours is NEVER overwritten; the
+        caller observes the loss via RETURNING and the store logs loudly."""
+        store = EntityStore(pg_source)
+        # A concurrent writer already set a (higher-evidence) id.
+        await store.upsert_identity(library_name="Popsicle", discogs_artist_id=111)
+        with caplog.at_level(logging.WARNING, logger="entity.store"):
+            outcome = await store.fill_identity_discogs_id("Popsicle", 222)
+        assert outcome.filled is False
+        assert outcome.lost_race is True
+        assert outcome.identity is not None
+        # The winner's id survives -- our 222 did NOT overwrite 111.
+        assert outcome.identity.discogs_artist_id == 111
+        assert outcome.previous_discogs_artist_id == 111
+        # Loud log names both values so the clobbered attempt leaves a trail.
+        assert any(
+            "111" in rec.getMessage() and "222" in rec.getMessage() for rec in caplog.records
+        ), caplog.text
+
+    @pytest.mark.asyncio
+    async def test_concurrent_fill_cannot_clobber_non_null_id(self, pg_pool):
+        """Two-writer interleave: even racing, the non-null id survives and
+        at most one writer reports ``filled`` -- a losing writer sees
+        ``lost_race``, never a silent overwrite.
+
+        Each writer runs on its own pool connection (its own EntityStore) so
+        the two ``INSERT ... ON CONFLICT`` statements genuinely contend on the
+        UNIQUE index lock rather than serialising on a shared connection.
+        """
+        store_a = EntityStore(_source(pg_pool))
+        store_b = EntityStore(_source(pg_pool))
+
+        # No pre-existing row: both writers race to create it with DIFFERENT
+        # ids. The UNIQUE index serialises them; whoever inserts first wins,
+        # and the fill-if-null guard blocks the loser's DO UPDATE.
+        results = await asyncio.gather(
+            store_a.fill_identity_discogs_id("Sault", 1001),
+            store_b.fill_identity_discogs_id("Sault", 2002),
+        )
+        filled = [r for r in results if r.filled]
+        lost = [r for r in results if r.lost_race]
+        assert len(filled) == 1, "exactly one writer may fill"
+        assert len(lost) == 1, "the other writer must observe the loss"
+
+        # The stored id is whichever writer won; the loser's id is absent.
+        winner_id = filled[0].identity.discogs_artist_id
+        assert winner_id in (1001, 2002)
+        async with pg_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT discogs_artist_id FROM entity.identity WHERE library_name = $1",
+                "Sault",
+            )
+        assert len(rows) == 1
+        assert rows[0]["discogs_artist_id"] == winner_id
+        # The loser saw the winner's id, not its own.
+        assert lost[0].previous_discogs_artist_id == winner_id
+
+    @pytest.mark.asyncio
+    async def test_upsert_new_wins_semantics_still_available(self, pg_source):
+        """``upsert_identity`` keeps its new-wins-when-non-null contract for
+        flows that legitimately UPDATE an id -- the fill primitive does not
+        replace it."""
+        store = EntityStore(pg_source)
+        await store.upsert_identity(library_name="Grimes", discogs_artist_id=10)
+        # upsert overwrites a non-null id with a new non-null id.
+        await store.upsert_identity(library_name="Grimes", discogs_artist_id=20)
+        identity = await store.get_identity("Grimes")
+        assert identity is not None
+        assert identity.discogs_artist_id == 20
+
+
+@pytest.mark.pg
+class TestFillIdentityCaseSibling:
+    """The case-sibling awareness leg (#766 point 4)."""
+
+    @pytest.mark.asyncio
+    async def test_fills_id_bearing_case_sibling_instead_of_new_variant(self, pg_source):
+        """An id-bearing ``WISHY`` sibling short-circuits a ``wishy`` fill:
+        no new case-variant row is accreted, and the existing id is
+        returned rather than a conflicting second row minted."""
+        store = EntityStore(pg_source)
+        # Existing id-bearing row under a different casing.
+        await store.upsert_identity(library_name="WISHY", discogs_artist_id=123)
+        outcome = await store.fill_identity_discogs_id("wishy", 123)
+        # No new row: the case sibling already answers.
+        async with pg_source.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT library_name FROM entity.identity WHERE LOWER(library_name) = LOWER($1)",
+                "wishy",
+            )
+        assert len(rows) == 1, "must not accrete a case-variant row"
+        assert rows[0]["library_name"] == "WISHY"
+        assert outcome.filled is False
+        assert outcome.identity is not None
+        assert outcome.identity.discogs_artist_id == 123
+
+    @pytest.mark.asyncio
+    async def test_case_sibling_conflict_is_lost_race(self, pg_source):
+        """An id-bearing case sibling holding a DIFFERENT id is a lost race,
+        not a silent second-row mint."""
+        store = EntityStore(pg_source)
+        await store.upsert_identity(library_name="WISHY", discogs_artist_id=123)
+        outcome = await store.fill_identity_discogs_id("wishy", 999)
+        assert outcome.filled is False
+        assert outcome.lost_race is True
+        assert outcome.identity is not None
+        assert outcome.identity.discogs_artist_id == 123
+        async with pg_source.acquire() as conn:
+            count = await conn.fetchval("SELECT count(*) FROM entity.identity")
+        assert count == 1, "no case-variant row minted on conflict"

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -410,6 +410,73 @@ class TestIdentityWriteBack:
         assert not any("identifiers" in w.lower() for w in response.warnings)
 
     @pytest.mark.asyncio
+    async def test_writes_both_ids_when_discogs_and_bandcamp_present(self):
+        """LML#766: when the release carries BOTH a discogs_artist_id and a
+        bandcamp id, the two writes fire — fill-if-null for the contested
+        discogs_artist_id, COALESCE-additive upsert for the bandcamp_id."""
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        store = AsyncMock()
+        deps = _deps(discogs=discogs, entity_store=store)
+
+        # A bandcamp source promoted by the streaming check gives the release a
+        # bandcamp_album_url alongside the Discogs artist id.
+        streaming = _stream()
+        streaming.sources.bandcamp = SourceMatch(
+            url="https://juana-molina.bandcamp.com/album/doga", confidence=100.0
+        )
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=streaming),
+        ):
+            await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        # Contested id → fill-if-null; bandcamp id → additive upsert. Both run.
+        store.fill_identity_discogs_id.assert_awaited_once_with("Juana Molina", 999)
+        store.upsert_identity.assert_awaited_once()
+        assert store.upsert_identity.call_args.kwargs["bandcamp_id"] == "juana-molina"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_delete_of_row_is_logged_not_silent(self, caplog):
+        """LML#766: the fill primitive's concurrent-delete path returns
+        ``identity=None`` (the row vanished between the blocked upsert and the
+        read-back). With no bandcamp id the additive upsert is skipped, so the
+        learned id is not re-stamped — but the drop must not be silent."""
+        import logging
+
+        from entity.store import FillOutcome
+
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        store = AsyncMock()
+        store.fill_identity_discogs_id.return_value = FillOutcome(
+            identity=None, filled=False, lost_race=False, previous_discogs_artist_id=None
+        )
+        deps = _deps(discogs=discogs, entity_store=store)
+
+        with (
+            patch(
+                "release.orchestrator.check_streaming_availability",
+                new=AsyncMock(return_value=_stream()),
+            ),
+            caplog.at_level(logging.WARNING, logger="release.orchestrator"),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        # No bandcamp id and a discogs id present → additive upsert skipped.
+        store.upsert_identity.assert_not_called()
+        # Response is unaffected, but the vanished-row drop left a trail.
+        assert response.canonical.artist == "Juana Molina"
+        assert any(
+            "Juana Molina" in rec.getMessage() and "999" in rec.getMessage()
+            for rec in caplog.records
+        ), caplog.text
+
+    @pytest.mark.asyncio
     async def test_skips_when_store_unavailable(self):
         discogs = AsyncMock()
         discogs.get_release.return_value = _make_release()

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -365,10 +365,49 @@ class TestIdentityWriteBack:
                 ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
             )
 
-        store.upsert_identity.assert_awaited_once()
-        args, kwargs = store.upsert_identity.call_args
-        assert args[0] == "Juana Molina"
-        assert kwargs["discogs_artist_id"] == 999
+        # LML#766: the discogs_artist_id write is fill-if-null so a concurrent
+        # (bare-name resolver) id is never clobbered. No bandcamp id + a
+        # discogs id present means the COALESCE-additive upsert is skipped.
+        store.fill_identity_discogs_id.assert_awaited_once_with("Juana Molina", 999)
+        store.upsert_identity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lost_race_does_not_surface_a_warning(self):
+        """LML#766: the release-derived write is higher-evidence than a
+        bare-name search win, but if a concurrent writer already set a
+        different id the fill primitive keeps the stored value. The store
+        logs it; the DJ sees no warning (either id is a valid Discogs artist
+        for the release), and the response is unaffected."""
+        from entity.store import FillOutcome, Identity
+
+        discogs = AsyncMock()
+        discogs.get_release.return_value = _make_release()
+        store = AsyncMock()
+        store.fill_identity_discogs_id.return_value = FillOutcome(
+            identity=Identity(
+                id=1,
+                library_name="Juana Molina",
+                discogs_artist_id=42,
+                reconciliation_status="reconciled",
+            ),
+            filled=False,
+            lost_race=True,
+            previous_discogs_artist_id=42,
+        )
+        deps = _deps(discogs=discogs, entity_store=store)
+
+        with patch(
+            "release.orchestrator.check_streaming_availability",
+            new=AsyncMock(return_value=_stream()),
+        ):
+            response = await resolve_release(
+                ReleaseResolveRequest(url="https://www.discogs.com/release/12345"), deps
+            )
+
+        store.fill_identity_discogs_id.assert_awaited_once_with("Juana Molina", 999)
+        assert response.canonical.artist == "Juana Molina"
+        # A lost race is not an error condition — no warning to the caller.
+        assert not any("identifiers" in w.lower() for w in response.warnings)
 
     @pytest.mark.asyncio
     async def test_skips_when_store_unavailable(self):
@@ -392,7 +431,7 @@ class TestIdentityWriteBack:
         discogs = AsyncMock()
         discogs.get_release.return_value = _make_release()
         store = AsyncMock()
-        store.upsert_identity.side_effect = RuntimeError("PG down")
+        store.fill_identity_discogs_id.side_effect = RuntimeError("PG down")
         deps = _deps(discogs=discogs, entity_store=store)
 
         with patch(
@@ -425,6 +464,7 @@ class TestIdentityWriteBack:
             )
 
         store.upsert_identity.assert_not_called()
+        store.fill_identity_discogs_id.assert_not_called()
 
     @pytest.mark.parametrize(
         "va_artist",
@@ -457,3 +497,4 @@ class TestIdentityWriteBack:
             )
 
         store.upsert_identity.assert_not_called()
+        store.fill_identity_discogs_id.assert_not_called()

--- a/tests/unit/test_artist_resolve_router.py
+++ b/tests/unit/test_artist_resolve_router.py
@@ -22,7 +22,7 @@ from discogs.cache_service import (
 )
 from discogs.models import DiscogsArtistSearchResult
 from discogs.service import DiscogsService
-from entity.store import EntityStore
+from entity.store import EntityStore, FillOutcome, Identity
 from generated.api_models import ArtistResolveBulkRequest
 from tests.unit.conftest import override_deps
 
@@ -37,6 +37,20 @@ def mock_entity_store():
     store = AsyncMock(spec=EntityStore)
     store.bulk_resolve_library_names = AsyncMock(return_value={})
     store.upsert_identity = AsyncMock(return_value=MagicMock())
+    # LML#766: the mint site uses the fill-if-null primitive; a clean win.
+    store.fill_identity_discogs_id = AsyncMock(
+        return_value=FillOutcome(
+            identity=Identity(
+                id=1,
+                library_name="Wishy",
+                discogs_artist_id=123,
+                reconciliation_status="reconciled",
+            ),
+            filled=True,
+            lost_race=False,
+            previous_discogs_artist_id=None,
+        )
+    )
     return store
 
 
@@ -147,7 +161,7 @@ class TestHappyPath:
         assert result["unresolved_reason"] is None
         # Always serialized — never omitted (null means "not measured").
         assert result["candidate_count"] == 1
-        mock_entity_store.upsert_identity.assert_awaited_once()
+        mock_entity_store.fill_identity_discogs_id.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_dry_run_skips_write_back(self, make_app, mock_entity_store):
@@ -157,7 +171,7 @@ class TestHappyPath:
 
         assert resp.status_code == 200
         assert resp.json()["results"][0]["discogs_artist_id"] == 123
-        mock_entity_store.upsert_identity.assert_not_awaited()
+        mock_entity_store.fill_identity_discogs_id.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_no_discogs_service_degrades_to_200_not_503(self, make_app):
@@ -502,7 +516,7 @@ class TestRouteEnvelopeGaps:
         with ctx:
             resp = await _post(app, {"names": ["Wishy"], "dry_run": False})
         assert resp.status_code == 200
-        mock_entity_store.upsert_identity.assert_awaited_once()
+        mock_entity_store.fill_identity_discogs_id.assert_awaited_once()
 
 
 class TestSentrySpanContract:

--- a/tests/unit/test_artist_resolver.py
+++ b/tests/unit/test_artist_resolver.py
@@ -3,7 +3,8 @@
 The full verdict table from the issue's design, against mocked tiers:
 
 - tier 1: ``EntityStore.bulk_resolve_library_names`` (identity_store
-  short-circuit) + ``upsert_identity`` (write-back)
+  short-circuit) + ``fill_identity_discogs_id`` (fill-if-null write-back,
+  LML#766)
 - tier 2: ``DiscogsCacheService.artist_equality_candidates`` /
   ``artist_trigram_candidates`` (evidence, never verdicts)
 - tier 3: ``DiscogsService.search_artists`` (the full-universe
@@ -25,11 +26,21 @@ from discogs.breaker import DiscogsBreakerOpenError
 from discogs.cache_service import ArtistEqualityCandidates, DiscogsCacheService
 from discogs.models import DiscogsArtistSearchResult
 from discogs.service import DiscogsService
-from entity.store import EntityStore, Identity
+from entity.store import EntityStore, FillOutcome, Identity
 
 
 def _identity(library_name: str, **kwargs) -> Identity:
     return Identity(id=1, library_name=library_name, reconciliation_status="reconciled", **kwargs)
+
+
+def _fill_win(name: str, discogs_artist_id: int) -> FillOutcome:
+    """Default ``fill_identity_discogs_id`` result: a fresh successful mint."""
+    return FillOutcome(
+        identity=_identity(name, discogs_artist_id=discogs_artist_id),
+        filled=True,
+        lost_race=False,
+        previous_discogs_artist_id=None,
+    )
 
 
 def _pages(mapping: dict[str, list[DiscogsArtistSearchResult] | None]):
@@ -69,6 +80,12 @@ def entity_store():
     store = AsyncMock(spec=EntityStore)
     store.bulk_resolve_library_names = AsyncMock(return_value={})
     store.upsert_identity = AsyncMock(side_effect=lambda name, **kw: _identity(name, **kw))
+    # LML#766: the mint site now uses the fill-if-null primitive. Default to a
+    # clean win (fresh mint); tests exercising a lost race / idempotent re-fill
+    # rebind this per-test.
+    store.fill_identity_discogs_id = AsyncMock(
+        side_effect=lambda name, discogs_artist_id: _fill_win(name, discogs_artist_id)
+    )
     return store
 
 
@@ -140,7 +157,7 @@ class TestInputValidation:
         discogs_cache.artist_equality_candidates.assert_not_awaited()
         discogs_cache.artist_trigram_candidates.assert_not_awaited()
         discogs_service.search_artists.assert_not_awaited()
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_punctuation_only_real_band_names_survive_validation(
@@ -180,7 +197,7 @@ class TestIdentityStoreShortCircuit:
         assert result.unresolved_reason is None
 
         discogs_service.search_artists.assert_not_awaited()
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.discogs_api_calls == 0
         assert stats.minted == 0
         assert stats.resolved == 1
@@ -326,7 +343,7 @@ class TestDisambiguatedInputs:
         assert results[0].discogs_artist_id == 20
         assert results[0].canonical_name == "Popsicle (2)"
         assert results[0].method == "api_search"
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.minted == 0
         assert stats.resolved == 1
 
@@ -351,8 +368,63 @@ class TestApiVerdicts:
         assert result.method == "api_search"
         assert result.candidate_count == 1
         assert result.unresolved_reason is None
-        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("Wishy", 123)
         assert stats.minted == 1
+        assert stats.resolved == 1
+
+    @pytest.mark.asyncio
+    async def test_lost_race_counted_not_minted(self, resolver, entity_store, discogs_service):
+        """LML#766: when the store rejects the fill (a concurrent writer
+        already set a different id), the resolver counts mint_lost_race, not
+        minted, and the verdict still reports Discogs truth."""
+        entity_store.fill_identity_discogs_id = AsyncMock(
+            return_value=FillOutcome(
+                identity=_identity("Wishy", discogs_artist_id=999),
+                filled=False,
+                lost_race=True,
+                previous_discogs_artist_id=999,
+            )
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
+        )
+
+        results, stats = await resolver.resolve(["Wishy"])
+
+        (result,) = results
+        # The API verdict is unchanged — the resolver reports what Discogs
+        # returned; the store just declined to overwrite the stored id.
+        assert result.discogs_artist_id == 123
+        assert result.method == "api_search"
+        assert result.unresolved_reason is None
+        assert stats.minted == 0
+        assert stats.mint_lost_race == 1
+        assert stats.resolved == 1
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("Wishy", 123)
+
+    @pytest.mark.asyncio
+    async def test_idempotent_refill_resolves_without_counting_mint(
+        self, resolver, entity_store, discogs_service
+    ):
+        """A pre-existing row already holding our exact id (idempotent
+        re-fill / case sibling): resolved, but nothing minted by us."""
+        entity_store.fill_identity_discogs_id = AsyncMock(
+            return_value=FillOutcome(
+                identity=_identity("Wishy", discogs_artist_id=123),
+                filled=False,
+                lost_race=False,
+                previous_discogs_artist_id=123,
+            )
+        )
+        discogs_service.search_artists = AsyncMock(
+            side_effect=_pages({"Wishy": _page((123, "Wishy"))})
+        )
+
+        results, stats = await resolver.resolve(["Wishy"])
+
+        assert results[0].discogs_artist_id == 123
+        assert stats.minted == 0
+        assert stats.mint_lost_race == 0
         assert stats.resolved == 1
 
     @pytest.mark.asyncio
@@ -372,7 +444,7 @@ class TestApiVerdicts:
         assert result.candidate_count == 2
         assert result.discogs_artist_id is None
         assert result.method is None
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.ambiguous == 1
         assert stats.minted == 0
 
@@ -406,7 +478,7 @@ class TestApiVerdicts:
         # (_pages also raises on unmapped probes).
         assert result.candidate_count == 0
         discogs_service.search_artists.assert_awaited_once_with("REZN")
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.not_found == 1
 
     @pytest.mark.asyncio
@@ -427,7 +499,7 @@ class TestApiVerdicts:
         assert result.unresolved_reason == "not_found"
         assert result.cache_corroboration == ["cache_alias"]
         assert result.candidate_count == 0
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_unencodable_api_title_distrusts_whole_page(
@@ -445,7 +517,7 @@ class TestApiVerdicts:
         (result,) = results
         assert result.unresolved_reason == "escalation_unavailable"
         assert result.candidate_count is None
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         # The probe itself was placed and consumed limiter budget.
         assert stats.discogs_api_calls == 1
 
@@ -495,7 +567,7 @@ class TestCacheConflictRule:
         # ambiguity is the cache conflict, not an overload family.
         assert result.candidate_count == 1
         assert result.cache_corroboration == ["cache_exact"]
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_equality_agreement_resolves_with_corroboration(
@@ -549,7 +621,7 @@ class TestEscalationUnavailable:
         assert discogs_service.search_artists.await_count == 1
         assert stats.discogs_api_calls == 0
         assert stats.escalation_unavailable == 3
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_mid_batch_breaker_preserves_earlier_verdicts_and_mints(
@@ -573,7 +645,7 @@ class TestEscalationUnavailable:
         # Two probes placed (one measured, one shed), third short-circuited.
         assert discogs_service.search_artists.await_count == 2
         assert stats.discogs_api_calls == 1
-        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("Wishy", 123)
         assert stats.minted == 1
         assert stats.resolved == 1
         assert stats.escalation_unavailable == 2
@@ -660,7 +732,7 @@ class TestDedupe:
         # store accretes near-duplicate keys, and the read legs are
         # case-insensitive so any spelling stays findable).
         discogs_service.search_artists.assert_awaited_once_with("WISHY")
-        entity_store.upsert_identity.assert_awaited_once_with("WISHY", discogs_artist_id=123)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("WISHY", 123)
         assert stats.names == 3
         assert stats.deduped == 1
         assert stats.resolved == 3
@@ -688,7 +760,7 @@ class TestWriteBack:
         assert result.candidate_count == 1
         assert stats.discogs_api_calls == 1
         # ...except the persistence.
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.minted == 0
 
     @pytest.mark.asyncio
@@ -709,7 +781,7 @@ class TestWriteBack:
         results, _ = await resolver.resolve(["wishy"])
 
         assert results[0].discogs_artist_id == 123
-        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("Wishy", 123)
 
     @pytest.mark.asyncio
     async def test_fillable_row_found_via_group_mate_verbatim(
@@ -727,20 +799,24 @@ class TestWriteBack:
         results, _ = await resolver.resolve(["The Tubs", "Tubs"])
 
         assert all(r.discogs_artist_id == 333 for r in results)
-        entity_store.upsert_identity.assert_awaited_once_with("Tubs", discogs_artist_id=333)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("Tubs", 333)
 
     @pytest.mark.asyncio
     async def test_upsert_returning_none_logs_and_keeps_verdict(
         self, resolver, entity_store, discogs_service, caplog
     ):
-        """Pins the DEFENSIVE branch for upsert_identity's declared
-        Optional return (today's PgSource raises instead of returning
-        None — that path is pinned separately below): a swallowed
+        """Pins the DEFENSIVE branch for fill_identity_discogs_id's
+        swallowed-failure contract (``identity=None``; today's PgSource
+        raises instead — that path is pinned separately below): a swallowed
         persistence failure must be loud in logs, and the verdict stands
         (it reports Discogs truth; dry_run already decouples the two)."""
         import logging
 
-        entity_store.upsert_identity = AsyncMock(return_value=None)
+        entity_store.fill_identity_discogs_id = AsyncMock(
+            return_value=FillOutcome(
+                identity=None, filled=False, lost_race=False, previous_discogs_artist_id=None
+            )
+        )
         discogs_service.search_artists = AsyncMock(
             side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
@@ -750,7 +826,7 @@ class TestWriteBack:
 
         assert results[0].discogs_artist_id == 123
         assert stats.minted == 0
-        assert any("write-back failed" in r.getMessage() for r in caplog.records)
+        assert any("fill-if-null failed" in r.getMessage() for r in caplog.records)
 
     @pytest.mark.asyncio
     async def test_write_back_pg_exception_propagates(
@@ -761,7 +837,9 @@ class TestWriteBack:
         mistakes the Optional-return branch above for this path."""
         from asyncpg.exceptions import PostgresError
 
-        entity_store.upsert_identity = AsyncMock(side_effect=PostgresError("connection reset"))
+        entity_store.fill_identity_discogs_id = AsyncMock(
+            side_effect=PostgresError("connection reset")
+        )
         discogs_service.search_artists = AsyncMock(
             side_effect=_pages({"Wishy": _page((123, "Wishy"))})
         )
@@ -796,7 +874,7 @@ class TestQualifierGeneralization:
         assert results[0].method == "identity_store"
         assert results[1].unresolved_reason == "ambiguous"
         assert results[1].discogs_artist_id is None
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -861,7 +939,7 @@ class TestQualifierGeneralization:
 
         assert results[0].unresolved_reason == "ambiguous"
         assert results[0].candidate_count == 1
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
 
 class TestWinnerQualifierRule:
@@ -895,7 +973,7 @@ class TestWinnerQualifierRule:
         assert result.candidate_count == 1
         assert result.discogs_artist_id is None
         assert result.method is None
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.minted == 0
         assert stats.ambiguous == 1
 
@@ -942,7 +1020,7 @@ class TestStoreConflict:
         discogs_service.search_artists.assert_not_awaited()
         assert stats.discogs_api_calls == 0
         assert stats.ambiguous == 2
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
 
 class TestInputHygiene:
@@ -963,7 +1041,7 @@ class TestInputHygiene:
         assert results[0].discogs_artist_id == 123
         (queried,) = entity_store.bulk_resolve_library_names.await_args[0]
         assert queried == ["Wishy"]
-        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("Wishy", 123)
 
     @pytest.mark.asyncio
     async def test_padded_and_clean_spellings_share_one_group(self, resolver, discogs_service):
@@ -1063,7 +1141,7 @@ class TestQualifierNormalizerParity:
         assert results[0].method == "identity_store"
         # The nested-qualified position saw a bare-titled winner: mismatch.
         assert results[1].unresolved_reason == "ambiguous"
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_multi_qualifier_input_sees_family_not_false_zero(
@@ -1081,7 +1159,7 @@ class TestQualifierNormalizerParity:
         (result,) = results
         assert result.unresolved_reason == "ambiguous"
         assert result.candidate_count == 2
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_qualifier_key_is_case_insensitive(self, resolver, discogs_service):
@@ -1109,7 +1187,7 @@ class TestQualifierNormalizerParity:
 
         assert results[0].discogs_artist_id == 50
         assert results[0].method == "api_search"
-        entity_store.upsert_identity.assert_awaited_once_with("(Smog)", discogs_artist_id=50)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("(Smog)", 50)
         assert stats.minted == 1
 
     @pytest.mark.asyncio
@@ -1128,7 +1206,7 @@ class TestQualifierNormalizerParity:
         assert results[0].name == "Wishy​"
         (queried,) = entity_store.bulk_resolve_library_names.await_args[0]
         assert queried == ["Wishy"]
-        entity_store.upsert_identity.assert_awaited_once_with("Wishy", discogs_artist_id=123)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("Wishy", 123)
 
     @pytest.mark.asyncio
     async def test_cf_padded_bare_number_still_rejected(
@@ -1166,7 +1244,7 @@ class TestTierOneRowSelection:
         assert [r.discogs_artist_id for r in results] == [999, 999]
         assert all(r.method == "identity_store" for r in results)
         discogs_service.search_artists.assert_not_awaited()
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.discogs_api_calls == 0
 
     @pytest.mark.asyncio
@@ -1189,7 +1267,7 @@ class TestTierOneRowSelection:
         results, _ = await resolver.resolve(batch)
 
         assert all(r.discogs_artist_id == 333 for r in results)
-        entity_store.upsert_identity.assert_awaited_once_with("The Tubs", discogs_artist_id=333)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("The Tubs", 333)
 
     @pytest.mark.asyncio
     async def test_qualified_store_row_neither_decides_nor_fills_bare_group(
@@ -1209,7 +1287,7 @@ class TestTierOneRowSelection:
 
         assert results[0].discogs_artist_id == 10
         assert results[0].method == "api_search"
-        entity_store.upsert_identity.assert_awaited_once_with("Popsicle", discogs_artist_id=10)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("Popsicle", 10)
 
 
 class TestPgFailurePropagation:
@@ -1264,7 +1342,7 @@ class TestRoundFourPins:
         assert result.discogs_artist_id == 42
         assert result.canonical_name == "Sault (2) (UK)"
         assert result.method == "api_search"
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.minted == 0
 
     @pytest.mark.asyncio
@@ -1283,7 +1361,7 @@ class TestRoundFourPins:
         (result,) = results
         assert result.unresolved_reason == "ambiguous"
         assert result.candidate_count == 2
-        entity_store.upsert_identity.assert_not_awaited()
+        entity_store.fill_identity_discogs_id.assert_not_awaited()
         assert stats.minted == 0
 
     @pytest.mark.asyncio
@@ -1346,7 +1424,7 @@ class TestRoundFourPins:
         results, _ = await resolver.resolve(batch)
 
         assert all(r.discogs_artist_id == 333 for r in results)
-        entity_store.upsert_identity.assert_awaited_once_with("The Tubs", discogs_artist_id=333)
+        entity_store.fill_identity_discogs_id.assert_awaited_once_with("The Tubs", 333)
 
     @pytest.mark.asyncio
     async def test_zero_padded_qualifier_stays_distinct(self, resolver, discogs_service):


### PR DESCRIPTION
## Summary

Adds a store-level fill-if-null mint primitive, `EntityStore.fill_identity_discogs_id`, and adopts it at both `entity.identity.discogs_artist_id` mint sites so a concurrent writer's non-null id can never be silently clobbered. Closes the TOCTOU window that `#765`'s resolver and `release/orchestrator._writeback_identity` both had, where the no-overwrite property rested entirely on an up-to-~30s-stale tier-1 read.

Closes #766

## The primitive

`fill_identity_discogs_id(library_name, discogs_artist_id) -> FillOutcome`

- ON CONFLICT arm guarded `WHERE entity.identity.discogs_artist_id IS NULL` — the id is written only when the stored value is NULL. A row already carrying an id makes the `DO UPDATE` a no-op, `RETURNING` comes back empty, and the caller detects the loss.
- The loser reads the winner's row back and returns `FillOutcome(filled=False, lost_race=True, previous_discogs_artist_id=<winner>)`, logging a loud WARNING that names both the stored and the rejected id — a clobbered attempt now leaves a trail.
- `upsert_identity` keeps its **new-wins-when-non-null** semantics for flows that legitimately update an id (reconciler campaigns, QID/streaming enrichment). Docstrings on both methods now spell out which is which; the false "never clobbers existing data" comment on `_writeback_identity` is corrected.

`FillOutcome` distinguishes: fresh mint / NULL fill (`filled=True`), idempotent same-id re-fill (`filled=False, lost_race=False`), and lost race (`lost_race=True`).

## Adoption

- **`artists/resolver.py`** — the api_search mint switches to the primitive. A rejected fill increments the new `ResolveStats.mint_lost_race` counter (which flows automatically to the Sentry span, PostHog event, and log line via the existing `dataclasses.asdict(stats)` fan-out in `artists/router.py`) instead of overwriting. `minted` still counts only actual fills.
- **`release/orchestrator._writeback_identity`** — the release-derived `discogs_artist_id` (the *higher-evidence* of the two racing writers) is written fill-if-null; `bandcamp_id` stays on the COALESCE-additive `upsert_identity` (it is not the TOCTOU-contested column and the resolver never writes it). A lost race is not surfaced as a DJ-facing warning — either id is a valid Discogs artist for the release.

## Judgment call 1 — reconciliation_status for minted rows: **`'reconciled'`**

The reconciler's `run_discogs_stage` scans `get_identities_by_status("unreconciled")`, runs each row through the first-match-wins Discogs cascade, then `upsert_identity(discogs_artist_id=...)` (new-wins) — i.e. it would clobber an API-verified id with a cascade guess. The fix: minted/filled rows are stamped `reconciliation_status = 'reconciled'`, which excludes them from that scan. The Wikidata/MusicBrainz enrichment stages *do* read `'reconciled'` rows, but they only fill `wikidata_qid`/streaming ids and never touch `discogs_artist_id`, so picking an API-verified row up for QID bridging is desirable, not a clobber.

**No cross-repo change:** `reconciliation_status` is `TEXT NOT NULL DEFAULT 'unreconciled'` in the discogs-cache alembic schema — free-text, no CHECK/enum — and `'reconciled'` is a value the reconciler already writes. So this needs no wxyc-shared enum bump / discogs-cache migration (which the issue said to defer to a log marker if it did). `run_discogs_stage`'s docstring gains a guard note; a re-seed via `upsert_identity(library_name=...)` preserves the status (the upsert SQL never touches `reconciliation_status`), covered by an integration test.

## Judgment call 2 — case-sibling: **fill / short-circuit the id-bearing sibling**

Cheaply detectable via the existing LOWER read leg (`_GET_IDENTITY_LOWER_SQL`), so no schema change and no extra cost beyond the one sub-millisecond seq-scan the resolver's tier-1 already runs. Before the atomic fill, an id-bearing sibling under a different casing (e.g. a `WISHY` row for a `wishy` fill) answers directly — same id short-circuits (no accretion of a `wishy` variant), different id is a lost race (no second row minted). A NULL-id sibling does *not* short-circuit: the verbatim key is filled normally, matching the resolver's in-place fill-target choice which already keys on the stored `library_name`.

## Deferred / cross-repo

Nothing deferred as cross-repo — both judgment calls landed within LML because `reconciliation_status` is free-text and the case-sibling scan rides an existing leg.

## Tests

New `pg` integration file `tests/integration/test_fill_identity_discogs_id.py` covers: fresh-mint reconciled status, NULL-column fill, idempotent same-id re-fill, the lost-race log+RETURNING path, a **two-writer `asyncio.gather` interleave** (exactly one filler, the other observes the loss, the stored id is the winner's), `upsert_identity` new-wins still available, and both case-sibling scenarios. `test_entity_resolution.py` gains a reconciler-exclusion invariant (a fill-minted `'reconciled'` row is never reprocessed by `run_discogs_stage`; a re-seed preserves the status). Unit tests in `test_artist_resolver.py` / `test_artist_resolve_router.py` / `release/test_orchestrator.py` are updated to the new mint site and add lost-race / idempotent-re-fill coverage.

Ran locally against a throwaway empty postgres@16 on 5433: the new pg file (10 tests) and `test_entity_resolution.py` all pass; full unit suite green (3438) apart from two pre-existing environment artifacts unrelated to this change (a cross-test event-loop-teardown flake in `test_dependencies.py` that passes in isolation, and `test_error_resilience::test_pg_source_bad_credentials` which expects no PG on 5433). mypy + ruff clean.

## Related

- Builds on #759 (bare-name resolver) and #765 (PR C1, which corrected its own COALESCE docstrings).
- Companion to #276 (the case-insensitive read leg this reuses).
