### PR TITLE
feat(#759): bulk artist-resolve drain engine (PR D1)

### DIFF
--- a/scripts/artist_resolve_drain/__init__.py
+++ b/scripts/artist_resolve_drain/__init__.py
@@ -1,0 +1,7 @@
+"""Bulk artist-resolve drain (LML#759 PR D).
+
+Drives prod `POST /api/v1/artists/resolve/bulk` over the Backend-Service name set
+(BS#1614) with crash-safe JSONL resume, bounded `escalation_unavailable` retries,
+and a yield report + wrong-mint spot-check gating the `--live` run. Loop logic in
+:mod:`.drain`; report/spot-check in :mod:`.report`; CLI in ``__main__``.
+"""

--- a/scripts/artist_resolve_drain/__main__.py
+++ b/scripts/artist_resolve_drain/__main__.py
@@ -1,0 +1,176 @@
+"""CLI entrypoint for the bulk artist-resolve drain (LML#759 PR D).
+
+Drains a bare-name set — clean touring-artist names Backend-Service exports for
+its concerts pipeline (WXYC/Backend-Service#1614) — through the prod
+`POST /api/v1/artists/resolve/bulk` endpoint, paging 25 at a time and appending
+every verdict to a JSONL log with crash-safe, mode-scoped resume. This module is
+the drain engine's entrypoint; the yield report + wrong-mint spot-check that gate
+the `--live` mint are layered on separately (see
+:mod:`scripts.artist_resolve_drain.report`).
+
+    # dry drain against prod off-peak (outside the 06:00 UTC backfill window)
+    LML_API_KEY=... LML_BASE_URL=https://<prod-lml> \
+        uv run python -m scripts.artist_resolve_drain names.txt --out drain.jsonl
+
+    # after the spot-check review, authorize the live drain (mints
+    # entity.identity — durable, COALESCE never-clobber, so a wrong mint is
+    # un-self-correcting)
+    ... --live --out drain.jsonl
+
+The drain always runs against the **prod** endpoint: it is the only place all
+Discogs traffic coordinates through a single 50/min limiter + LML#755 breaker, so
+a drain there can't 429 live lookups the way a staging drain (shared token,
+uncoordinated limiter) would.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+
+import httpx
+
+from scripts._lib.runtime import set_up_script_runtime
+from scripts._lib.signals import ShutdownFlag
+from scripts.artist_resolve_drain.drain import (
+    DEFAULT_COOLDOWN_SECONDS,
+    DEFAULT_MAX_RETRIES,
+    PAGE_SIZE,
+    make_post_batch,
+    parse_names_file,
+    run_drain,
+)
+
+logger = logging.getLogger("artist_resolve_drain")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = ArgumentParser(
+        prog="python -m scripts.artist_resolve_drain",
+        description="Drain a bare-name set through prod POST /api/v1/artists/resolve/bulk.",
+    )
+    parser.add_argument("names_file", help="Names handoff file (JSON array or newline-delimited).")
+    parser.add_argument(
+        "--out",
+        default="artist_resolve_drain.jsonl",
+        help="JSONL verdict log (append + resume). Default: artist_resolve_drain.jsonl",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="LML base URL. Defaults to $LML_BASE_URL, then $PRODUCTION_URL.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="LML API key (bearer). Defaults to $LML_API_KEY.",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Mint entity.identity rows. Default is a dry run (no write-back).",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=PAGE_SIZE,
+        help=f"Names per request (endpoint cap {PAGE_SIZE}). Default: {PAGE_SIZE}",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=DEFAULT_MAX_RETRIES,
+        help=f"escalation retries. Default: {DEFAULT_MAX_RETRIES}",
+    )
+    parser.add_argument(
+        "--cooldown",
+        type=float,
+        default=float(DEFAULT_COOLDOWN_SECONDS),
+        help=f"Seconds between retry rounds. Default: {DEFAULT_COOLDOWN_SECONDS}",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="Per-request timeout (s). A full escalating page can take ~30s. Default: 120",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args(argv)
+
+
+async def _run(
+    args: argparse.Namespace,
+    base_url: str,
+    api_key: str,
+    dry_run: bool,
+    shutdown: ShutdownFlag,
+) -> None:
+    names = parse_names_file(Path(args.names_file).read_text(encoding="utf-8"))
+    logger.info("loaded %d unique name(s) from %s", len(names), args.names_file)
+    if not names:
+        logger.warning("no names to drain; nothing to do")
+        return
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(args.timeout)) as client:
+        post_batch = make_post_batch(client, base_url, api_key)
+        records = await run_drain(
+            all_names=names,
+            dry_run=dry_run,
+            out_path=args.out,
+            post_batch=post_batch,
+            page_size=args.page_size,
+            max_retries=args.max_retries,
+            cooldown=args.cooldown,
+            shutdown=shutdown,
+        )
+
+    logger.info(
+        "drain complete: %d verdict record(s) for %d name(s) → %s",
+        len(records),
+        len(names),
+        args.out,
+    )
+    print(f"Drain complete: {len(records)} verdict record(s) written to {args.out}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    shutdown = set_up_script_runtime(
+        logger=logger,
+        verbose=args.verbose,
+        shutdown_unit="batch",
+        include_logger_name=False,
+    )
+
+    base_url = args.base_url or os.environ.get("LML_BASE_URL") or os.environ.get("PRODUCTION_URL")
+    if not base_url:
+        logger.error("no base URL: pass --base-url or set $LML_BASE_URL / $PRODUCTION_URL")
+        sys.exit(2)
+    api_key = args.api_key or os.environ.get("LML_API_KEY")
+    if not api_key:
+        logger.error("no API key: pass --api-key or set $LML_API_KEY")
+        sys.exit(2)
+    if args.page_size < 1 or args.page_size > PAGE_SIZE:
+        logger.error("--page-size must be 1..%d (endpoint cap)", PAGE_SIZE)
+        sys.exit(2)
+
+    dry_run = not args.live
+    if dry_run:
+        logger.info("DRY RUN — no entity.identity write-back (pass --live to mint)")
+    else:
+        logger.warning(
+            "LIVE DRAIN against %s — mints DURABLE entity.identity rows (COALESCE "
+            "never-clobber). Ensure the dry-run spot-check was human-reviewed.",
+            base_url,
+        )
+
+    asyncio.run(_run(args, base_url, api_key, dry_run, shutdown))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/artist_resolve_drain/drain.py
+++ b/scripts/artist_resolve_drain/drain.py
@@ -1,0 +1,359 @@
+"""Core drain loop for the bulk artist-resolve endpoint (LML#759 PR D).
+
+Drives prod `POST /api/v1/artists/resolve/bulk` over a Backend-Service-exported
+name set (BS#1614), paging at the endpoint's 25-name cap. Every verdict is
+appended to a JSONL log so a crash mid-drain resumes without re-paying the
+API-verification cost of the batches already settled. The single retryable
+verdict — `escalation_unavailable` (LML#755 breaker open / Discogs outage /
+429 / 5xx-after-retries) — is re-paged after a cool-down, bounded by
+`max_retries`, then reported as residual.
+
+The loop is network- and clock-free at its core: `run_drain` takes an injected
+`post_batch` coroutine (built by `make_post_batch` around an `httpx.AsyncClient`
+in `__main__`) plus injectable `sleep`/`clock`, so the resume/retry logic is
+unit-testable without touching Discogs or waiting out a cool-down.
+
+Report aggregation and the spot-check sampler live in the sibling
+:mod:`scripts.artist_resolve_drain.report`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+import httpx
+
+logger = logging.getLogger("artist_resolve_drain")
+
+# The endpoint's `maxItems` cap; a fully-escalating page of 25 ≈ 25 API calls
+# ≈ 30s at the shared 50/min Discogs budget (LML#759 design).
+PAGE_SIZE = 25
+RESOLVE_PATH = "/api/v1/artists/resolve/bulk"
+
+# `escalation_unavailable` is the retryable verdict; 2 retries (3 attempts total)
+# matches the "bounded retries (2-3)" the design specifies.
+DEFAULT_MAX_RETRIES = 2
+DEFAULT_COOLDOWN_SECONDS = 60
+
+# Verdict kinds that never change on a re-page — the drain settles them once.
+# `escalation_unavailable` is deliberately excluded: it is the one retryable
+# verdict (re-paged after a cool-down, up to max_retries).
+_TERMINAL_REASONS = frozenset({"not_found", "ambiguous"})
+
+# Injected clock/sleep seams (the testable core): `clock` returns the ISO-8601
+# `ts` written to each JSONL record; `sleep` awaits the cool-down between rounds.
+_Clock = Callable[[], str]
+_Sleep = Callable[[float], Awaitable[None]]
+
+
+class DrainError(RuntimeError):
+    """A contract break from the resolve endpoint (bad length / index misalignment)."""
+
+
+class _ShutdownFlag(Protocol):
+    @property
+    def requested(self) -> bool: ...
+
+
+class _PostBatch(Protocol):
+    async def __call__(self, names: list[str], dry_run: bool) -> list[dict[str, Any]]: ...
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Input parsing
+# --------------------------------------------------------------------------- #
+def parse_names_file(text: str) -> list[str]:
+    """Parse a names handoff file into an ordered, de-duplicated name list.
+
+    Accepts either a JSON array of strings or a newline-delimited list. Blank
+    lines are dropped and surrounding whitespace trimmed; exact duplicates are
+    collapsed preserving first-occurrence order (the endpoint dedupes on the
+    identity-match form internally, but collapsing verbatim repeats here avoids
+    wasting page slots).
+    """
+    stripped = text.strip()
+    if stripped:
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list) and all(isinstance(item, str) for item in parsed):
+            return _dedupe([item.strip() for item in parsed])
+    return _dedupe(line.strip() for line in text.splitlines())
+
+
+def _dedupe(names: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for name in names:
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+    return out
+
+
+def chunk(items: Sequence[Any], size: int) -> Iterator[list[Any]]:
+    """Yield successive ``size``-length pages from ``items``."""
+    if size <= 0:
+        raise ValueError("chunk size must be positive")
+    for start in range(0, len(items), size):
+        yield list(items[start : start + size])
+
+
+# --------------------------------------------------------------------------- #
+# Verdict records
+# --------------------------------------------------------------------------- #
+def record_from_verdict(
+    verdict: dict[str, Any], *, dry_run: bool, attempt: int, ts: str
+) -> dict[str, Any]:
+    """Project an ``ArtistResolveResult`` verdict onto a JSONL drain record."""
+    return {
+        "name": verdict["name"],
+        "discogs_artist_id": verdict.get("discogs_artist_id"),
+        "canonical_name": verdict.get("canonical_name"),
+        "method": verdict.get("method"),
+        "cache_corroboration": list(verdict.get("cache_corroboration") or []),
+        "unresolved_reason": verdict.get("unresolved_reason"),
+        "candidate_count": verdict.get("candidate_count"),
+        "dry_run": dry_run,
+        "attempt": attempt,
+        "ts": ts,
+    }
+
+
+def is_terminal(rec: dict[str, Any]) -> bool:
+    """Whether a verdict will not change on a re-page (resolved / not_found / ambiguous)."""
+    if rec.get("discogs_artist_id") is not None:
+        return True
+    return rec.get("unresolved_reason") in _TERMINAL_REASONS
+
+
+def latest_by_name(records: Sequence[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Latest (last-appended) record per name — append order is attempt order."""
+    latest: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        latest[rec["name"]] = rec
+    return latest
+
+
+def attempt_counts(records: Sequence[dict[str, Any]]) -> dict[str, int]:
+    """How many times each name has been paged (one record per attempt)."""
+    counts: dict[str, int] = {}
+    for rec in records:
+        counts[rec["name"]] = counts.get(rec["name"], 0) + 1
+    return counts
+
+
+def filter_records_for_mode(
+    records: Sequence[dict[str, Any]], *, dry_run: bool
+) -> list[dict[str, Any]]:
+    """Keep only records written in the current mode.
+
+    Dry and live records may share one JSONL file; resume and reporting are
+    mode-scoped so a prior dry drain never makes a `--live` run skip the mint.
+    """
+    return [rec for rec in records if bool(rec.get("dry_run")) is dry_run]
+
+
+def compute_pending(
+    all_names: Sequence[str], records: Sequence[dict[str, Any]], max_attempts: int
+) -> list[str]:
+    """The names still needing a page: unseen, plus retryable escalations under cap.
+
+    ``records`` must already be scoped to the current mode
+    (see :func:`filter_records_for_mode`).
+    """
+    latest = latest_by_name(records)
+    counts = attempt_counts(records)
+    pending: list[str] = []
+    seen: set[str] = set()
+    for name in all_names:
+        if name in seen:
+            continue
+        seen.add(name)
+        rec = latest.get(name)
+        if rec is None:
+            pending.append(name)
+        elif is_terminal(rec):
+            continue
+        elif counts.get(name, 0) < max_attempts:
+            # escalation_unavailable, retries remaining
+            pending.append(name)
+    return pending
+
+
+# --------------------------------------------------------------------------- #
+# JSONL persistence
+# --------------------------------------------------------------------------- #
+def load_records(path: str | Path) -> list[dict[str, Any]]:
+    """Load all JSONL drain records; an absent file is an empty run."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    with p.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def append_record(path: str | Path, rec: dict[str, Any]) -> None:
+    """Append one record as a JSON line, flushing so a crash keeps prior lines."""
+    p = Path(path)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        fh.flush()
+
+
+# --------------------------------------------------------------------------- #
+# HTTP envelope
+# --------------------------------------------------------------------------- #
+async def resolve_batch(
+    client: httpx.AsyncClient,
+    base_url: str,
+    api_key: str,
+    names: list[str],
+    dry_run: bool,
+) -> list[dict[str, Any]]:
+    """POST one page to the resolve endpoint and return its index-aligned verdicts.
+
+    Raises :class:`DrainError` on a length or index-alignment break (the endpoint
+    contract is to echo each input ``name`` verbatim, index-aligned), and
+    ``httpx.HTTPStatusError`` on a non-2xx response.
+    """
+    url = base_url.rstrip("/") + RESOLVE_PATH
+    resp = await client.post(
+        url,
+        json={"names": names, "dry_run": dry_run},
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    resp.raise_for_status()
+    results = resp.json()["results"]
+    if len(results) != len(names):
+        raise DrainError(f"resolve returned {len(results)} results for {len(names)} names")
+    for sent, got in zip(names, results, strict=True):
+        if got.get("name") != sent:
+            raise DrainError(f"resolve index misalignment: sent {sent!r}, got {got.get('name')!r}")
+    return results
+
+
+def make_post_batch(
+    client: httpx.AsyncClient,
+    base_url: str,
+    api_key: str,
+    *,
+    max_http_retries: int = 3,
+    backoff: float = 2.0,
+    sleep: _Sleep = asyncio.sleep,
+) -> _PostBatch:
+    """Build a `post_batch` coroutine that retries transient transport/5xx errors.
+
+    Per-name `escalation_unavailable` is a 200-response verdict handled by the
+    drain loop's cool-down, not here; this retry only covers HTTP-layer flakes
+    (timeouts, connection resets, edge 5xx). A 4xx (401/413/400) is a misconfig
+    and is not retried.
+    """
+
+    async def post_batch(names: list[str], dry_run: bool) -> list[dict[str, Any]]:
+        last_exc: Exception | None = None
+        for attempt in range(1, max_http_retries + 1):
+            try:
+                return await resolve_batch(client, base_url, api_key, names, dry_run)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code < 500:
+                    raise  # client error — misconfig, do not retry
+                last_exc = exc
+            except httpx.HTTPError as exc:
+                last_exc = exc
+            if attempt < max_http_retries:
+                wait = backoff * attempt
+                logger.warning(
+                    "batch HTTP error (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt,
+                    max_http_retries,
+                    wait,
+                    last_exc,
+                )
+                await sleep(wait)
+        assert last_exc is not None
+        raise last_exc
+
+    return post_batch
+
+
+# --------------------------------------------------------------------------- #
+# The drain loop
+# --------------------------------------------------------------------------- #
+async def run_drain(
+    *,
+    all_names: Sequence[str],
+    dry_run: bool,
+    out_path: str | Path,
+    post_batch: _PostBatch,
+    page_size: int = PAGE_SIZE,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    cooldown: float = DEFAULT_COOLDOWN_SECONDS,
+    shutdown: _ShutdownFlag | None = None,
+    sleep: _Sleep = asyncio.sleep,
+    clock: _Clock = _utc_now_iso,
+) -> list[dict[str, Any]]:
+    """Drive the drain to completion (or shutdown), returning the mode's records.
+
+    Resumes from any existing JSONL at ``out_path`` (mode-scoped), pages the
+    pending set at ``page_size``, and after each round sleeps ``cooldown`` and
+    re-pages the `escalation_unavailable` residue up to ``max_retries`` times.
+    """
+    max_attempts = max_retries + 1
+    records = filter_records_for_mode(load_records(out_path), dry_run=dry_run)
+    round_idx = 0
+    while True:
+        if shutdown is not None and shutdown.requested:
+            logger.info("shutdown requested; stopping drain")
+            break
+        pending = compute_pending(all_names, records, max_attempts)
+        if not pending:
+            break
+        if round_idx > 0:
+            logger.info(
+                "cool-down %ss before retry round %d over %d escalation_unavailable name(s)",
+                cooldown,
+                round_idx,
+                len(pending),
+            )
+            await sleep(cooldown)
+            if shutdown is not None and shutdown.requested:
+                logger.info("shutdown requested during cool-down; stopping drain")
+                break
+        counts = attempt_counts(records)
+        for batch in chunk(pending, page_size):
+            if shutdown is not None and shutdown.requested:
+                logger.info("shutdown requested; stopping mid-round")
+                return records
+            verdicts = await post_batch(batch, dry_run)
+            ts = clock()
+            for name, verdict in zip(batch, verdicts, strict=True):
+                attempt = counts.get(name, 0) + 1
+                rec = record_from_verdict(verdict, dry_run=dry_run, attempt=attempt, ts=ts)
+                append_record(out_path, rec)
+                records.append(rec)
+            logger.info(
+                "paged %d name(s) [round %d]; %d records total",
+                len(batch),
+                round_idx,
+                len(records),
+            )
+        round_idx += 1
+    return records

--- a/tests/unit/test_artist_resolve_drain.py
+++ b/tests/unit/test_artist_resolve_drain.py
@@ -1,0 +1,501 @@
+"""Unit tests for the bulk artist-resolve drain engine (LML#759 PR D).
+
+The drain drives the prod `POST /api/v1/artists/resolve/bulk` endpoint over a
+name set exported by Backend-Service (BS#1614), paging 25 at a time, appending
+verdicts to a JSONL log with crash-safe resume, and re-paging the retryable
+`escalation_unavailable` verdict after a cool-down with bounded retries.
+
+These tests pin the pure orchestration logic (parse / resume / retry) and the
+HTTP envelope (`resolve_batch`) without touching the network. The yield report +
+spot-check sampler are covered in `test_artist_resolve_drain_report.py`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from scripts.artist_resolve_drain import drain
+from scripts.artist_resolve_drain.drain import (
+    DrainError,
+    attempt_counts,
+    chunk,
+    compute_pending,
+    filter_records_for_mode,
+    is_terminal,
+    latest_by_name,
+    load_records,
+    make_post_batch,
+    parse_names_file,
+    record_from_verdict,
+    resolve_batch,
+    run_drain,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Verdict / record builders mirroring the ArtistResolveResult wire shape.
+# --------------------------------------------------------------------------- #
+def _resolved(name, artist_id, *, method="api_search", corr=None, candidate_count=1):
+    return {
+        "name": name,
+        "discogs_artist_id": artist_id,
+        "canonical_name": f"{name}",
+        "method": method,
+        "cache_corroboration": list(corr or []),
+        "unresolved_reason": None,
+        "candidate_count": candidate_count,
+    }
+
+
+def _unresolved(name, reason, *, corr=None, candidate_count=None):
+    return {
+        "name": name,
+        "discogs_artist_id": None,
+        "canonical_name": None,
+        "method": None,
+        "cache_corroboration": list(corr or []),
+        "unresolved_reason": reason,
+        "candidate_count": candidate_count,
+    }
+
+
+def _rec(verdict, *, dry_run=True, attempt=1, ts="2026-07-12T00:00:00+00:00"):
+    return record_from_verdict(verdict, dry_run=dry_run, attempt=attempt, ts=ts)
+
+
+# --------------------------------------------------------------------------- #
+# parse_names_file
+# --------------------------------------------------------------------------- #
+class TestParseNamesFile:
+    def test_newline_delimited_strips_blanks_and_trims(self):
+        text = "Wishy\n  REZN  \n\nL'Rain\n"
+        assert parse_names_file(text) == ["Wishy", "REZN", "L'Rain"]
+
+    def test_dedupes_preserving_first_occurrence_order(self):
+        text = "glaive\nThe Tubs\nglaive\nSiM\n"
+        assert parse_names_file(text) == ["glaive", "The Tubs", "SiM"]
+
+    def test_json_array_input(self):
+        text = json.dumps(["Popsicle", "Wishy", "Popsicle"])
+        assert parse_names_file(text) == ["Popsicle", "Wishy"]
+
+    def test_json_non_list_falls_back_to_line_mode(self):
+        # A bare JSON object is not a name list; treat the whole thing as lines.
+        text = '{"names": ["a"]}'
+        assert parse_names_file(text) == ['{"names": ["a"]}']
+
+    def test_empty_input_yields_empty_list(self):
+        assert parse_names_file("\n\n   \n") == []
+
+
+# --------------------------------------------------------------------------- #
+# chunk
+# --------------------------------------------------------------------------- #
+class TestChunk:
+    def test_pages_into_fixed_size_batches(self):
+        assert list(chunk(list(range(5)), 2)) == [[0, 1], [2, 3], [4]]
+
+    def test_empty_yields_nothing(self):
+        assert list(chunk([], 25)) == []
+
+    def test_rejects_non_positive_size(self):
+        with pytest.raises(ValueError):
+            list(chunk([1, 2], 0))
+
+
+# --------------------------------------------------------------------------- #
+# is_terminal / record helpers
+# --------------------------------------------------------------------------- #
+class TestIsTerminal:
+    def test_resolved_is_terminal(self):
+        assert is_terminal(_rec(_resolved("Wishy", 111))) is True
+
+    @pytest.mark.parametrize("reason", ["not_found", "ambiguous"])
+    def test_not_found_and_ambiguous_are_terminal(self, reason):
+        assert is_terminal(_rec(_unresolved("x", reason))) is True
+
+    def test_escalation_unavailable_is_not_terminal(self):
+        assert is_terminal(_rec(_unresolved("x", "escalation_unavailable"))) is False
+
+
+class TestRecordFromVerdict:
+    def test_carries_mode_attempt_ts_and_wire_fields(self):
+        rec = record_from_verdict(
+            _resolved("Wishy", 111, corr=["cache_exact"]),
+            dry_run=False,
+            attempt=2,
+            ts="T",
+        )
+        assert rec["name"] == "Wishy"
+        assert rec["discogs_artist_id"] == 111
+        assert rec["cache_corroboration"] == ["cache_exact"]
+        assert rec["dry_run"] is False
+        assert rec["attempt"] == 2
+        assert rec["ts"] == "T"
+
+    def test_missing_corroboration_defaults_to_empty_list(self):
+        verdict = {"name": "x", "unresolved_reason": "not_found"}
+        rec = record_from_verdict(verdict, dry_run=True, attempt=1, ts="T")
+        assert rec["cache_corroboration"] == []
+        assert rec["discogs_artist_id"] is None
+
+
+class TestLatestAndCounts:
+    def test_latest_by_name_keeps_last_append(self):
+        recs = [
+            _rec(_unresolved("a", "escalation_unavailable"), attempt=1),
+            _rec(_resolved("a", 9), attempt=2),
+        ]
+        assert latest_by_name(recs)["a"]["discogs_artist_id"] == 9
+
+    def test_attempt_counts_counts_records_per_name(self):
+        recs = [
+            _rec(_unresolved("a", "escalation_unavailable"), attempt=1),
+            _rec(_unresolved("a", "escalation_unavailable"), attempt=2),
+            _rec(_resolved("b", 1), attempt=1),
+        ]
+        assert attempt_counts(recs) == {"a": 2, "b": 1}
+
+
+# --------------------------------------------------------------------------- #
+# filter_records_for_mode
+# --------------------------------------------------------------------------- #
+class TestFilterRecordsForMode:
+    def test_keeps_only_records_matching_dry_run(self):
+        recs = [
+            _rec(_resolved("a", 1), dry_run=True),
+            _rec(_resolved("b", 2), dry_run=False),
+        ]
+        assert [r["name"] for r in filter_records_for_mode(recs, dry_run=True)] == ["a"]
+        assert [r["name"] for r in filter_records_for_mode(recs, dry_run=False)] == ["b"]
+
+
+# --------------------------------------------------------------------------- #
+# compute_pending — the resume + retry brain
+# --------------------------------------------------------------------------- #
+class TestComputePending:
+    def test_fresh_run_returns_all_names_deduped(self):
+        assert compute_pending(["a", "b", "a"], [], max_attempts=3) == ["a", "b"]
+
+    def test_terminal_names_are_skipped_on_resume(self):
+        recs = [_rec(_resolved("a", 1)), _rec(_unresolved("b", "not_found"))]
+        assert compute_pending(["a", "b", "c"], recs, max_attempts=3) == ["c"]
+
+    def test_escalation_is_repaged_below_max_attempts(self):
+        recs = [_rec(_unresolved("a", "escalation_unavailable"), attempt=1)]
+        assert compute_pending(["a"], recs, max_attempts=3) == ["a"]
+
+    def test_escalation_is_residual_at_max_attempts(self):
+        recs = [
+            _rec(_unresolved("a", "escalation_unavailable"), attempt=1),
+            _rec(_unresolved("a", "escalation_unavailable"), attempt=2),
+            _rec(_unresolved("a", "escalation_unavailable"), attempt=3),
+        ]
+        assert compute_pending(["a"], recs, max_attempts=3) == []
+
+    def test_later_terminal_verdict_wins_over_earlier_escalation(self):
+        recs = [
+            _rec(_unresolved("a", "escalation_unavailable"), attempt=1),
+            _rec(_resolved("a", 7), attempt=2),
+        ]
+        assert compute_pending(["a"], recs, max_attempts=3) == []
+
+
+# --------------------------------------------------------------------------- #
+# JSONL round-trip
+# --------------------------------------------------------------------------- #
+class TestJsonlIo:
+    def test_append_then_load_round_trips(self, tmp_path):
+        path = tmp_path / "drain.jsonl"
+        drain.append_record(path, _rec(_resolved("a", 1)))
+        drain.append_record(path, _rec(_unresolved("b", "not_found")))
+        loaded = load_records(path)
+        assert [r["name"] for r in loaded] == ["a", "b"]
+
+    def test_load_missing_file_returns_empty(self, tmp_path):
+        assert load_records(tmp_path / "nope.jsonl") == []
+
+
+# --------------------------------------------------------------------------- #
+# resolve_batch — HTTP envelope
+# --------------------------------------------------------------------------- #
+class TestResolveBatch:
+    @pytest.mark.asyncio
+    async def test_sends_bearer_auth_and_dry_run_body_and_returns_results(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://lml.example/api/v1/artists/resolve/bulk",
+            json={"results": [_resolved("Wishy", 111), _unresolved("REZN", "not_found")]},
+        )
+        async with httpx.AsyncClient() as client:
+            results = await resolve_batch(
+                client, "https://lml.example", "secret-key", ["Wishy", "REZN"], dry_run=True
+            )
+        assert [r["name"] for r in results] == ["Wishy", "REZN"]
+        req = httpx_mock.get_requests()[0]
+        assert req.headers["Authorization"] == "Bearer secret-key"
+        body = json.loads(req.content)
+        assert body == {"names": ["Wishy", "REZN"], "dry_run": True}
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_base_url_is_normalized(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://lml.example/api/v1/artists/resolve/bulk",
+            json={"results": [_resolved("Wishy", 111)]},
+        )
+        async with httpx.AsyncClient() as client:
+            await resolve_batch(client, "https://lml.example/", "k", ["Wishy"], dry_run=False)
+        # No assertion error from add_response's exact-url match == pass.
+
+    @pytest.mark.asyncio
+    async def test_length_mismatch_raises(self, httpx_mock):
+        httpx_mock.add_response(json={"results": [_resolved("Wishy", 111)]})
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(DrainError):
+                await resolve_batch(client, "https://lml.example", "k", ["Wishy", "REZN"], True)
+
+    @pytest.mark.asyncio
+    async def test_index_misalignment_raises(self, httpx_mock):
+        # Endpoint must echo name verbatim, index-aligned; a mismatch is a contract break.
+        httpx_mock.add_response(json={"results": [_resolved("SOMEONE-ELSE", 111)]})
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(DrainError):
+                await resolve_batch(client, "https://lml.example", "k", ["Wishy"], True)
+
+    @pytest.mark.asyncio
+    async def test_http_error_status_raises(self, httpx_mock):
+        httpx_mock.add_response(status_code=401, json={"detail": "nope"})
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                await resolve_batch(client, "https://lml.example", "k", ["Wishy"], True)
+
+
+# --------------------------------------------------------------------------- #
+# make_post_batch — transient-HTTP retry adapter (retry 5xx/transport, not 4xx)
+# --------------------------------------------------------------------------- #
+class TestMakePostBatch:
+    @pytest.mark.asyncio
+    async def test_retries_transient_5xx_then_succeeds(self, httpx_mock):
+        # A 5xx is a transient server hiccup — retried after a backoff, then the
+        # 200 result is returned.
+        httpx_mock.add_response(status_code=503)
+        httpx_mock.add_response(json={"results": [_resolved("Wishy", 111)]})
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        async with httpx.AsyncClient() as client:
+            post = make_post_batch(client, "https://lml.example", "k", sleep=fake_sleep)
+            results = await post(["Wishy"], True)
+        assert [r["name"] for r in results] == ["Wishy"]
+        assert len(sleeps) == 1  # one backoff between the 503 and the successful retry
+
+    @pytest.mark.asyncio
+    async def test_retries_transport_error_then_succeeds(self, httpx_mock):
+        # A connection-layer failure (no HTTP status) is also transient → retried.
+        httpx_mock.add_exception(httpx.ConnectError("boom"))
+        httpx_mock.add_response(json={"results": [_resolved("Wishy", 111)]})
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        async with httpx.AsyncClient() as client:
+            post = make_post_batch(client, "https://lml.example", "k", sleep=fake_sleep)
+            results = await post(["Wishy"], True)
+        assert [r["name"] for r in results] == ["Wishy"]
+        assert len(sleeps) == 1
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_4xx(self, httpx_mock):
+        # A 4xx is a misconfig (bad key / oversized page / bad request), not a
+        # transient fault — re-raised immediately with no retry.
+        httpx_mock.add_response(status_code=401, json={"detail": "nope"})
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        async with httpx.AsyncClient() as client:
+            post = make_post_batch(client, "https://lml.example", "k", sleep=fake_sleep)
+            with pytest.raises(httpx.HTTPStatusError):
+                await post(["Wishy"], True)
+        assert sleeps == []  # no backoff — failed fast
+        assert len(httpx_mock.get_requests()) == 1  # exactly one attempt
+
+    @pytest.mark.asyncio
+    async def test_reraises_last_error_after_exhausting_retries(self, httpx_mock):
+        # Persistent 5xx: retried up to max_http_retries, then the last error
+        # surfaces (rather than a silent empty result).
+        for _ in range(3):
+            httpx_mock.add_response(status_code=502)
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        async with httpx.AsyncClient() as client:
+            post = make_post_batch(
+                client, "https://lml.example", "k", max_http_retries=3, sleep=fake_sleep
+            )
+            with pytest.raises(httpx.HTTPStatusError):
+                await post(["Wishy"], True)
+        assert len(httpx_mock.get_requests()) == 3  # all attempts made
+        assert len(sleeps) == 2  # slept between each attempt, not after the last
+
+
+# --------------------------------------------------------------------------- #
+# run_drain — the full loop, with an injected post + sleep (no network, no wait)
+# --------------------------------------------------------------------------- #
+class _FakePost:
+    """Records calls and returns scripted verdicts keyed by name.
+
+    `plan[name]` is a list of verdicts consumed one per call; the last entry
+    repeats once exhausted.
+    """
+
+    def __init__(self, plan):
+        self.plan = {k: list(v) for k, v in plan.items()}
+        self.batches: list[list[str]] = []
+
+    async def __call__(self, names, dry_run):
+        self.batches.append(list(names))
+        out = []
+        for name in names:
+            seq = self.plan[name]
+            verdict = seq.pop(0) if len(seq) > 1 else seq[0]
+            out.append(verdict)
+        return out
+
+
+@pytest.mark.asyncio
+class TestRunDrain:
+    async def test_writes_jsonl_verdict_per_name(self, tmp_path):
+        out = tmp_path / "d.jsonl"
+        post = _FakePost({"a": [_resolved("a", 1)], "b": [_unresolved("b", "not_found")]})
+        await run_drain(
+            all_names=["a", "b"],
+            dry_run=True,
+            out_path=out,
+            post_batch=post,
+            page_size=25,
+            max_retries=2,
+            cooldown=0,
+            sleep=_noop_sleep,
+            clock=lambda: "T",
+        )
+        names = [r["name"] for r in load_records(out)]
+        assert sorted(names) == ["a", "b"]
+
+    async def test_pages_at_page_size(self, tmp_path):
+        post = _FakePost({n: [_resolved(n, i)] for i, n in enumerate("abcde")})
+        await run_drain(
+            all_names=list("abcde"),
+            dry_run=True,
+            out_path=tmp_path / "d.jsonl",
+            post_batch=post,
+            page_size=2,
+            max_retries=2,
+            cooldown=0,
+            sleep=_noop_sleep,
+            clock=lambda: "T",
+        )
+        assert [len(b) for b in post.batches] == [2, 2, 1]
+
+    async def test_resume_skips_terminal_names_from_prior_run(self, tmp_path):
+        out = tmp_path / "d.jsonl"
+        drain.append_record(out, _rec(_resolved("a", 1), dry_run=True))
+        post = _FakePost({"b": [_resolved("b", 2)]})
+        await run_drain(
+            all_names=["a", "b"],
+            dry_run=True,
+            out_path=out,
+            post_batch=post,
+            page_size=25,
+            max_retries=2,
+            cooldown=0,
+            sleep=_noop_sleep,
+            clock=lambda: "T",
+        )
+        # "a" was already terminal → never re-posted.
+        assert post.batches == [["b"]]
+
+    async def test_live_run_ignores_prior_dry_run_records(self, tmp_path):
+        out = tmp_path / "d.jsonl"
+        drain.append_record(out, _rec(_resolved("a", 1), dry_run=True))
+        post = _FakePost({"a": [_resolved("a", 1)]})
+        await run_drain(
+            all_names=["a"],
+            dry_run=False,  # live
+            out_path=out,
+            post_batch=post,
+            page_size=25,
+            max_retries=2,
+            cooldown=0,
+            sleep=_noop_sleep,
+            clock=lambda: "T",
+        )
+        # Prior record was dry_run=True; the live run must actually re-post to mint.
+        assert post.batches == [["a"]]
+
+    async def test_escalation_is_repaged_after_cooldown_then_residual(self, tmp_path):
+        out = tmp_path / "d.jsonl"
+        sleeps: list[float] = []
+
+        async def rec_sleep(seconds):
+            sleeps.append(seconds)
+
+        # "a" resolves on 2nd attempt; "b" is escalation forever → residual.
+        post = _FakePost(
+            {
+                "a": [
+                    _unresolved("a", "escalation_unavailable"),
+                    _resolved("a", 5),
+                ],
+                "b": [_unresolved("b", "escalation_unavailable")],
+            }
+        )
+        await run_drain(
+            all_names=["a", "b"],
+            dry_run=True,
+            out_path=out,
+            post_batch=post,
+            page_size=25,
+            max_retries=2,  # 3 attempts total
+            cooldown=42,
+            sleep=rec_sleep,
+            clock=lambda: "T",
+        )
+        latest = latest_by_name(load_records(out))
+        assert latest["a"]["discogs_artist_id"] == 5
+        assert latest["b"]["unresolved_reason"] == "escalation_unavailable"
+        # b tried on 3 attempts total.
+        assert attempt_counts(load_records(out))["b"] == 3
+        # Cool-down slept once per retry round (2 retries), each for `cooldown`.
+        assert sleeps == [42, 42]
+
+    async def test_stops_early_on_shutdown_request(self, tmp_path):
+        class _Flag:
+            requested = True
+
+        post = _FakePost({"a": [_resolved("a", 1)]})
+        await run_drain(
+            all_names=["a"],
+            dry_run=True,
+            out_path=tmp_path / "d.jsonl",
+            post_batch=post,
+            page_size=25,
+            max_retries=2,
+            cooldown=0,
+            sleep=_noop_sleep,
+            clock=lambda: "T",
+            shutdown=_Flag(),
+        )
+        assert post.batches == []
+
+
+async def _noop_sleep(seconds):
+    return None


### PR DESCRIPTION
PR **D1 of #759** — the drain engine. This is the first half of a split of #775 (originally 1.3k lines) into two reviewable PRs; **D2** (`feat/759-pr-d2-report`) stacks the yield report + wrong-mint spot-check on top and closes #759.

PRs A (WXYC/wxyc-shared#218/#219), B (#761/#762), and C (resolver core #765 + endpoint #764) are merged; the four review-loop follow-ups (#770/#772/#773/#774) landed on top. This adds the tool that runs the endpoint over the real Backend-Service name set.

## What

`scripts/artist_resolve_drain/` — the network- and clock-free drain core:

- **`drain.py`** — `parse_names_file`, `compute_pending` (the resume + retry brain), `resolve_batch` (HTTP envelope with length + index-alignment guards), `make_post_batch` (transient-HTTP retry; 4xx left to fail loudly), and `run_drain` (the loop). `run_drain` takes an injected `post_batch`/`sleep`/`clock`, so resume, retry, and paging are unit-tested without touching Discogs or waiting out a cool-down.
- **`__main__.py`** — a runnable CLI that drains a bare-name set to the JSONL verdict log and prints a one-line completion summary. The report/spot-check rendering + the `--report`/`--spot-check`/`--seed` flags are layered on in D2.

## Safety design (per the #759 drain section)

- **Prod endpoint only.** It is the single place all Discogs traffic coordinates through one 50/min limiter + the #755 breaker; a staging drain (shared token, uncoordinated limiter) could 429 live lookups. Run off-peak, outside the 06:00 UTC backfill window.
- **Dry run is the default; `--live` is explicit** — a mint is durable (COALESCE never-clobber), so a wrong mint is un-self-correcting.
- **Crash-safe, mode-scoped resume.** Every verdict is appended to a JSONL log; a restart re-pages nothing already settled, and because resume is scoped by `dry_run`, a prior dry drain never makes a `--live` run skip the mint.
- **Bounded escalation retry.** `escalation_unavailable` is the one retryable verdict — re-paged after a cool-down up to `--max-retries` (default 2), then left as residual for the D2 report.

## Testing

TDD throughout. 39 unit tests (`tests/unit/test_artist_resolve_drain.py`) cover parsing, `compute_pending` resume/retry/mode-filter, the JSONL round-trip, `resolve_batch` (auth header, `dry_run` body, length + index-misalignment guards, HTTP error) via `pytest-httpx`, `make_post_batch` (retry 5xx/transport with backoff, fail-fast on 4xx, re-raise on exhaustion), and the full `run_drain` loop with an injected fake post + fake sleep (resume-skip, escalation re-page with cool-down then residual, dry-vs-live, shutdown). Local gate green: `ruff check` / `ruff format --check` / `mypy` (fully typed — not in the relaxed-scripts override) / the drain test file. No `pg` tests — the drain is a pure HTTP client with no DB access of its own.

## Related

- #759 (parent). D2 (`feat/759-pr-d2-report`) stacks on this branch and closes #759.
- Supersedes #775 (the un-split single PR), which will be closed in favor of D1 + D2.
- WXYC/Backend-Service#1614 — the concerts headliner writer, unblocked once D2's drain report + spot-check land.
- #755 — the Discogs saturation breaker the `escalation_unavailable` retry rides.
