### PR TITLE
fix(#778): degrade a persistently-erroring page to escalation_unavailable

### DIFF
--- a/scripts/artist_resolve_drain/drain.py
+++ b/scripts/artist_resolve_drain/drain.py
@@ -132,6 +132,25 @@ def record_from_verdict(
     }
 
 
+def _escalation_unavailable_verdict(name: str) -> dict[str, Any]:
+    """Synthesize the verdict for a page whose HTTP call failed after retries.
+
+    A persistent transport/5xx failure — "couldn't ask" — is the design's one
+    retryable verdict. Shaped exactly like a 200-level ``escalation_unavailable``
+    result so it flows through :func:`record_from_verdict` and is re-paged by the
+    round loop like any other escalation (see :func:`run_drain`).
+    """
+    return {
+        "name": name,
+        "discogs_artist_id": None,
+        "canonical_name": None,
+        "method": None,
+        "cache_corroboration": [],
+        "unresolved_reason": "escalation_unavailable",
+        "candidate_count": None,
+    }
+
+
 def is_terminal(rec: dict[str, Any]) -> bool:
     """Whether a verdict will not change on a re-page (resolved / not_found / ambiguous)."""
     if rec.get("discogs_artist_id") is not None:
@@ -342,7 +361,26 @@ async def run_drain(
             if shutdown is not None and shutdown.requested:
                 logger.info("shutdown requested; stopping mid-round")
                 return records
-            verdicts = await post_batch(batch, dry_run)
+            try:
+                verdicts = await post_batch(batch, dry_run)
+            except httpx.HTTPError as exc:
+                # `post_batch` exhausted its transport/5xx retries and raised. A
+                # persistent HTTP-layer failure is "couldn't ask" — degrade the
+                # whole page to escalation_unavailable and let the round loop
+                # re-page it (up to max_retries), rather than crash the drain and
+                # skip its report (LML#778). A 4xx is a misconfig (bad key /
+                # oversized page), not a transient fault, so it still surfaces —
+                # mirroring make_post_batch's own 4xx policy.
+                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 500:
+                    raise
+                logger.warning(
+                    "batch HTTP error after retries [round %d]; degrading %d name(s) "
+                    "to escalation_unavailable: %s",
+                    round_idx,
+                    len(batch),
+                    exc,
+                )
+                verdicts = [_escalation_unavailable_verdict(name) for name in batch]
             ts = clock()
             for name, verdict in zip(batch, verdicts, strict=True):
                 attempt = counts.get(name, 0) + 1

--- a/tests/unit/test_artist_resolve_drain.py
+++ b/tests/unit/test_artist_resolve_drain.py
@@ -496,6 +496,119 @@ class TestRunDrain:
         )
         assert post.batches == []
 
+    # --------------------------------------------------------------------- #
+    # LML#778 — a persistent HTTP error out of `post_batch` (after it has
+    # exhausted its own transport/5xx retries) must degrade the whole page to
+    # `escalation_unavailable` and let the round loop re-page it, NOT crash the
+    # drain and skip its report. Surfaced by the 2026-07-13 live drain, which
+    # aborted twice on `httpx.ReadTimeout` (slow-minting pages + LML#755 shed).
+    # --------------------------------------------------------------------- #
+    async def test_http_error_page_degrades_to_escalation_then_completes(self, tmp_path):
+        out = tmp_path / "d.jsonl"
+        calls = {"n": 0}
+
+        async def flaky_post(names, dry_run):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # post_batch gave up after its retries and raised (the #778 case).
+                raise httpx.ReadTimeout("timed out")
+            return [_resolved(name, 100 + i) for i, name in enumerate(names)]
+
+        records = await run_drain(
+            all_names=["Wishy", "REZN"],
+            dry_run=False,
+            out_path=out,
+            post_batch=flaky_post,
+            page_size=25,
+            max_retries=2,
+            cooldown=0,
+            sleep=_noop_sleep,
+            clock=lambda: "T",
+        )
+
+        loaded = load_records(out)
+        # First attempt: the timed-out page is recorded as escalation_unavailable
+        # for every name, shaped like a 200-level escalation verdict — no crash.
+        first = [r for r in loaded if r["attempt"] == 1]
+        assert {r["name"] for r in first} == {"Wishy", "REZN"}
+        assert all(r["unresolved_reason"] == "escalation_unavailable" for r in first)
+        assert all(r["discogs_artist_id"] is None for r in first)
+        assert all(r["method"] is None for r in first)
+        assert all(r["candidate_count"] is None for r in first)
+        assert all(r["cache_corroboration"] == [] for r in first)
+        # The run reached completion: the retry round minted both.
+        latest = latest_by_name(loaded)
+        assert latest["Wishy"]["discogs_artist_id"] == 100
+        assert latest["REZN"]["discogs_artist_id"] == 101
+        assert records is not None  # returned normally; no exception escaped run_drain
+
+    async def test_persistent_http_error_settles_as_residual_without_crashing(self, tmp_path):
+        out = tmp_path / "d.jsonl"
+
+        async def always_timeout(names, dry_run):
+            raise httpx.ReadTimeout("still timing out")
+
+        records = await run_drain(
+            all_names=["Wishy"],
+            dry_run=False,
+            out_path=out,
+            post_batch=always_timeout,
+            page_size=25,
+            max_retries=2,  # 3 attempts total
+            cooldown=7,
+            sleep=_noop_sleep,
+            clock=lambda: "T",
+        )
+
+        loaded = load_records(out)
+        # Paged the full retry budget, every attempt an escalation, then settled
+        # as residual — and the run still returned instead of crashing.
+        assert attempt_counts(loaded)["Wishy"] == 3
+        assert latest_by_name(loaded)["Wishy"]["unresolved_reason"] == "escalation_unavailable"
+        assert records is not None
+
+    async def test_drain_error_still_propagates_not_degraded(self, tmp_path):
+        # A contract break (bad length / index misalignment) is not a transient
+        # "couldn't ask" — it must fail loudly, never degrade to a verdict.
+        async def contract_break(names, dry_run):
+            raise DrainError("index misalignment")
+
+        with pytest.raises(DrainError):
+            await run_drain(
+                all_names=["Wishy"],
+                dry_run=False,
+                out_path=tmp_path / "d.jsonl",
+                post_batch=contract_break,
+                page_size=25,
+                max_retries=2,
+                cooldown=0,
+                sleep=_noop_sleep,
+                clock=lambda: "T",
+            )
+
+    async def test_client_error_4xx_propagates_not_degraded(self, tmp_path):
+        # A 4xx is a misconfig (bad key / oversized page), not "couldn't ask" —
+        # surfacing it beats silently degrading every page to escalation residual,
+        # which would mask e.g. a wrong API key as a transient breaker shed.
+        request = httpx.Request("POST", "https://lml.example/api/v1/artists/resolve/bulk")
+        response = httpx.Response(401, request=request)
+
+        async def unauthorized(names, dry_run):
+            raise httpx.HTTPStatusError("401 Unauthorized", request=request, response=response)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await run_drain(
+                all_names=["Wishy"],
+                dry_run=False,
+                out_path=tmp_path / "d.jsonl",
+                post_batch=unauthorized,
+                page_size=25,
+                max_retries=2,
+                cooldown=0,
+                sleep=_noop_sleep,
+                clock=lambda: "T",
+            )
+
 
 async def _noop_sleep(seconds):
     return None

--- a/tests/unit/test_artist_resolve_drain.py
+++ b/tests/unit/test_artist_resolve_drain.py
@@ -609,6 +609,42 @@ class TestRunDrain:
                 clock=lambda: "T",
             )
 
+    async def test_server_error_5xx_degrades_to_escalation_not_propagated(self, tmp_path):
+        out = tmp_path / "d.jsonl"
+        # A 5xx `HTTPStatusError` is "couldn't ask" — repeated 5xx is the issue's
+        # canonical degradable case, so it must degrade like a transport timeout,
+        # not re-raise like a 4xx. Guards the `< 500` boundary's false branch.
+        request = httpx.Request("POST", "https://lml.example/api/v1/artists/resolve/bulk")
+        calls = {"n": 0}
+
+        async def flaky_5xx(names, dry_run):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                response = httpx.Response(503, request=request)
+                raise httpx.HTTPStatusError(
+                    "503 Service Unavailable", request=request, response=response
+                )
+            return [_resolved(name, 100 + i) for i, name in enumerate(names)]
+
+        records = await run_drain(
+            all_names=["Wishy"],
+            dry_run=False,
+            out_path=out,
+            post_batch=flaky_5xx,
+            page_size=25,
+            max_retries=2,
+            cooldown=0,
+            sleep=_noop_sleep,
+            clock=lambda: "T",
+        )
+
+        loaded = load_records(out)
+        first = [r for r in loaded if r["attempt"] == 1]
+        assert first and all(r["unresolved_reason"] == "escalation_unavailable" for r in first)
+        # The run completed instead of crashing; the retry round minted the name.
+        assert latest_by_name(loaded)["Wishy"]["discogs_artist_id"] == 100
+        assert records is not None
+
 
 async def _noop_sleep(seconds):
     return None


### PR DESCRIPTION
## What

`run_drain` called `post_batch` unguarded, so once `make_post_batch` exhausted its transport/5xx retries and re-raised, the exception propagated out of `run_drain` and crashed the whole drain — skipping report generation and leaving the run incomplete. This wraps the call and degrades a persistently-erroring page to `escalation_unavailable`, letting the existing round / cool-down / `max_retries` loop re-page it; persistently-failing names settle as residual instead of aborting the run.

## Why

The design's verdict taxonomy already has the right bucket for "couldn't ask" — `escalation_unavailable`, the one retryable verdict. A page whose HTTP layer keeps timing out or 5xx-ing after retries is exactly that. This surfaced in the 2026-07-13 live drain over the BS#1614 touring-name set, which aborted twice on `httpx.ReadTimeout` (slow-minting live pages exceeding the per-request timeout while the LML#755 breaker shed under minting load), stranding 18 names and forcing the report to be regenerated by hand from the JSONL.

## How

- Wrap the `post_batch` call in `try / except httpx.HTTPError`. On a persistent failure, synthesize a per-name `escalation_unavailable` verdict (new `_escalation_unavailable_verdict` helper, shaped identically to a 200-level escalation result), record it through the existing `record_from_verdict` → `append_record` path, log a WARNING with the round + page size + error, and `continue`. The round/retry loop re-pages those names; ones that keep failing settle as residual.
- A 4xx is treated as a misconfig (bad key / oversized page), not "couldn't ask", so it is re-raised rather than degraded — otherwise a wrong API key would masquerade as retryable residual across every page. This mirrors `make_post_batch`'s own 4xx policy, and is a deliberate refinement of the issue's `except httpx.HTTPError` shorthand consistent with its "timeout / breaker / repeated 5xx" framing.
- `DrainError` (length / index-alignment contract break) is unaffected: it is not an `httpx.HTTPError`, so it still fails loudly.

## Testing

TDD. Two failing-first repro tests — a `ReadTimeout` page degrades to `escalation_unavailable` and the run completes (the retry round mints), and a persistently-timing-out page settles as residual without crashing — plus two invariant guards (`DrainError` still propagates; a 4xx still propagates). `ruff check` / `ruff format --check` / `mypy` clean (the `scripts/artist_resolve_drain/` package is fully typed); full unit suite green (3531 passed).

## Related

- Closes #778.
- The drain engine landed in #776 (PR D1); this fixes a robustness gap that engine's live run surfaced.
- WXYC/Backend-Service#1614 — the consumer; the 18 `escalation_unavailable` residual can be finished by a clean drain pass once this lands.
