### PR TITLE
fix(#783): structured-only /lookup (no raw_message) returns 200 instead of 500

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -369,7 +369,13 @@ async def _step_prepare_request(
         artist=request.artist,
         is_request=True,
         message_type=MessageType.REQUEST,
-        raw_message=request.raw_message,
+        # LookupRequest.raw_message is str | None (optional when structured
+        # fields are supplied), but ParsedRequest.raw_message is a non-optional
+        # str whose "no raw text" sentinel is "". Coerce None here so a
+        # structured-only request doesn't fail Pydantic validation and surface
+        # as a 500 (WXYC/library-metadata-lookup#783). The pipeline drives off
+        # artist/album/song regardless; "" is inert for the free-text legs.
+        raw_message=request.raw_message or "",
     )
 
     if parsed.artist:

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -8,7 +8,7 @@ from httpx import ASGITransport, AsyncClient
 from discogs.service import DiscogsService
 from library.db import LibraryDB
 from lookup.models import LookupResponse, LookupResultItem
-from tests.factories import LOOKUP_BODY, make_catalog_item, make_match_result
+from tests.factories import LOOKUP_BODY, make_catalog_item, make_library_item, make_match_result
 from tests.unit.conftest import override_deps
 
 
@@ -120,6 +120,61 @@ class TestHandleLookup:
                 resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
 
         assert resp.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_structured_body_without_raw_message_returns_200(
+        self, mock_library_db, mock_settings
+    ):
+        """Regression (WXYC/library-metadata-lookup#783): a structured-only POST
+        (artist/album/song, no ``raw_message``) must return 200, not 500.
+
+        ``LookupRequest.raw_message`` is ``str | None`` and defaults to None; the
+        internal ``ParsedRequest.raw_message`` is a non-optional ``str``. Copying
+        None across in ``_step_prepare`` raised a Pydantic ValidationError that
+        ``handle_lookup`` wrapped as HTTP 500. This drives the REAL orchestrator
+        (``perform_lookup`` is not patched) so the router→pipeline seam is covered
+        end-to-end. Discogs is None so the pipeline resolves purely from the
+        library hit, isolating the raw_message coercion under test.
+        """
+        from config.settings import get_settings
+        from core.dependencies import (
+            get_discogs_service,
+            get_library_db,
+            get_posthog_client,
+        )
+        from main import app
+
+        mock_library_db.search.return_value = [
+            make_library_item(
+                id=42,
+                artist="Stereolab",
+                title="Aluminum Tunes",
+                call_letters="RO",
+                genre="Rock",
+            )
+        ]
+
+        body = {"artist": "Stereolab", "album": "Aluminum Tunes", "song": "Pop Quiz"}
+        assert "raw_message" not in body
+
+        with override_deps(
+            app,
+            {
+                get_library_db: mock_library_db,
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+            },
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=body)
+
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert len(results) == 1
+        assert results[0]["library_item"]["artist"] == "Stereolab"
 
     @pytest.mark.asyncio
     async def test_http_exception_passthrough(self, app_client):

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -229,6 +229,41 @@ class TestPerformLookupBasic:
         assert response.results[0].artwork is None
 
     @pytest.mark.asyncio
+    async def test_structured_fields_without_raw_message_resolves(self, mock_library_db, telemetry):
+        """Regression (WXYC/library-metadata-lookup#783): a structured-only request
+        (artist/album/song set, ``raw_message`` omitted → None on the public
+        ``LookupRequest``) must resolve normally, not blow up.
+
+        ``ParsedRequest.raw_message`` is a non-optional ``str``; ``_step_prepare``
+        copied the request value straight across, so a ``None`` raw_message raised a
+        Pydantic ValidationError that ``handle_lookup`` surfaced as HTTP 500. The
+        structured path drives the pipeline from artist/album/song regardless of
+        raw_message, so this must return the library hit."""
+        stereolab_aluminum = make_library_item(
+            id=42,
+            artist="Stereolab",
+            title="Aluminum Tunes",
+            call_letters="RO",
+            genre="Rock",
+        )
+        mock_library_db.search.return_value = [stereolab_aluminum]
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Aluminum Tunes",
+            song="Pop Quiz",
+            # raw_message intentionally omitted → None
+        )
+        assert request.raw_message is None
+
+        response = await perform_lookup(request, mock_library_db, None, telemetry)
+
+        assert isinstance(response, LookupResponse)
+        assert len(response.results) == 1
+        assert response.results[0].library_item.artist == "Stereolab"
+        assert response.results[0].library_item.title == "Aluminum Tunes"
+
+    @pytest.mark.asyncio
     async def test_song_as_track_emits_matched_via_on_result_item(
         self, mock_library_db, mock_discogs_service, telemetry
     ):


### PR DESCRIPTION
## Summary

`POST /api/v1/lookup` with structured fields (`artist`/`album`/`song`) but no `raw_message` returned **HTTP 500**. This violated the documented `LookupRequest` contract — `raw_message` is "optional when structured fields are provided."

**Root cause:** the public `LookupRequest.raw_message` is `str | None`, but the internal `ParsedRequest.raw_message` is a non-optional `str` (default `""`). `_step_prepare_request` copied the request value straight across (`lookup/orchestrator.py:366`), so a `None` raw_message failed Pydantic validation; `handle_lookup` caught the `ValidationError` and re-raised it as a generic `{"detail":"Internal server error"}` 500.

Latent, not an active outage: no organic caller hits it (Backend-Service and request-o-matic always send `raw_message`). It was minted by the #782 Apple-null repro.

## Fix

Coerce `None` to the field's own `""` sentinel at the single `ParsedRequest` construction site:

```python
raw_message=request.raw_message or "",
```

`lookup/orchestrator.py:366` is the only production `ParsedRequest` construction site, and every downstream reader takes raw_message via `parsed.raw_message` (the search pipeline, the `.lower()` in `track_on_compilation`, `detect_ambiguous_format` in `swapped_interpretation`), so coercing once at construction covers them all. `""` is the correct "no raw text" value — a structured request drives the pipeline from `artist`/`album`/`song` regardless, and `""` is inert for the free-text legs. `or ""` is a no-op for any real string, so the raw-message path and ambiguous-format detection are unchanged.

## Tests (TDD)

- **Root-cause unit test** (`test_orchestrator.py`): `perform_lookup` with `{artist, album, song}` and no `raw_message` resolves the library hit instead of raising a `ValidationError`.
- **HTTP-surface regression test** (`test_lookup_router.py`): the endpoint returns 200 through the **real** orchestrator (not a patched `perform_lookup`), covering the router→pipeline seam end-to-end.

Both confirmed red before the fix (the router test failed with a 500 wrapping the exact `ParsedRequest` `None` validation error), green after. Full unit suite (3534 tests) passes; `ruff check` + `ruff format --check` clean.

The fix commit auto-resolves the two Sentry issues: `LIBRARY-METADATA-LOOKUP-1Z` (root validation error) and `LIBRARY-METADATA-LOOKUP-1Y` (surfaced 500).

Closes #783