### PR TITLE
fix(#782): album-less track retry on album-constrained Apple miss

### DIFF
--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -76,14 +76,16 @@ class AppleMusicTrackMatch:
     needs before clearing a library row's curated streaming URLs. Album-
     less winners and LML#782 album-fallback winners carry False: their
     album axis never passed, so they prove nothing about the requested
-    album. Defaults True because every pre-#782 match was constrained by
-    construction; ``find_track_metadata`` always sets it explicitly.
+    album. Deliberately no default: a silent True would fail open
+    (authorizing the destructive #505 clear), a silent False would fail
+    open the other way (re-admitting the sibling-override leak #505
+    fixed) — every construction site must state its evidence.
     """
 
     url: str
     artwork_url: str | None
     release_year: int | None
-    album_verified: bool = True
+    album_verified: bool
 
 
 logger = logging.getLogger(__name__)
@@ -93,8 +95,10 @@ logger = logging.getLogger(__name__)
 # provider uses inside `clients/streaming/matching.is_acceptable_match` — not a
 # re-declared literal, so the two can't drift (LML#592). Stops the wrong link
 # from freezing onto a flowsheet row when Apple's search ranking is unstable for
-# obscure artists (LML#389) or returns a same-titled track from the wrong
-# album (LML#396).
+# obscure artists (LML#389). On the album axis the floor now gates metadata
+# rather than the link: a same-titled track from the wrong album (LML#396)
+# loses its album-derived fields and `album_verified` status via the LML#782
+# album-less fallback instead of being dropped outright.
 _APPLE_MUSIC_MATCH_FLOOR = SCORE_MATCH_ACCEPTANCE_FLOOR
 
 # Apple Music developer-token lifetime. Apple permits `exp` up to ~6 months;

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -339,7 +339,9 @@ class AppleMusicClient(BaseStreamingClient):
 
     async def find_track_url(self, artist: str, song: str, album: str | None = None) -> str | None:
         """Search for `(artist, song[, album])` and return the Apple Music track
-        URL of the best floor-clearing match, else `None`.
+        URL of the best floor-clearing match, else `None`. The album axis is
+        soft (LML#782): an album-constrained miss re-scores without it, so a
+        supplied album narrows the choice but no longer vetoes the URL.
 
         Thin wrapper around ``find_track_metadata`` (LML#500): both methods
         score against the same ``search_song`` response with the same
@@ -415,7 +417,11 @@ class AppleMusicClient(BaseStreamingClient):
 
         norm_artist = normalize_for_comparison(artist)
         norm_song = normalize_for_comparison(song)
-        norm_album = normalize_for_comparison(album) if album else None
+        # ``or None``: a whitespace-only album normalizes to "" — no
+        # scoreable constraint, so treat it as album-less rather than
+        # running a guaranteed-miss constrained pass whose winner would
+        # be mislabeled ``track_album_fallback`` in LML#592 telemetry.
+        norm_album = (normalize_for_comparison(album) or None) if album else None
 
         best, (artist_axis, track_axis) = _select_best_track_candidate(
             results,
@@ -440,6 +446,13 @@ class AppleMusicClient(BaseStreamingClient):
         # winner is surfaced URL-only (below): its album-derived fields
         # describe an album that just FAILED the floor against the request,
         # so carrying them would be the LML#396/#487 wrong-album leak.
+        # Known recall trade: the fallback URL fills the Apple slot, which
+        # preempts the album-keyed post-process leg (it fires only on a
+        # null slot). For genuine divergence rows that leg could never
+        # succeed anyway; when the requested album DOES exist on Apple but
+        # its track version fell outside this search's top results, the
+        # track deep-link wins over the eventually-warmed album-canonical
+        # URL — the issue's "URL beats null" call, accepted knowingly.
         album_fallback = False
         if best is None and norm_album is not None:
             best, (artist_axis, track_axis) = _select_best_track_candidate(

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -385,6 +385,12 @@ class AppleMusicClient(BaseStreamingClient):
         carries over to ``find_track_url`` (post-collapse): the happy
         path doesn't consume artwork, but the URL it returns now comes
         from a likely-more-canonical record.
+
+        When the album-constrained pass clears nobody, RE-SCORES the same
+        response with the album axis dropped and returns the winner's URL
+        only (LML#782 album-title divergence — see the fallback comment
+        inline). Still a single Apple Music API call: the album constraint
+        was never part of the ``search_song`` query, only of the scoring.
         """
         results = await self.search_song(artist, song)
         if not results:
@@ -394,82 +400,50 @@ class AppleMusicClient(BaseStreamingClient):
         norm_song = normalize_for_comparison(song)
         norm_album = normalize_for_comparison(album) if album else None
 
-        best_overall: dict | None = None
-        best_overall_score = 0.0
-        best_overall_axes: tuple[float, float] = (0.0, 0.0)
-        best_with_artwork: dict | None = None
-        best_with_artwork_score = 0.0
-        best_with_artwork_axes: tuple[float, float] = (0.0, 0.0)
+        best, (artist_axis, track_axis) = _select_best_track_candidate(
+            results,
+            norm_artist=norm_artist,
+            norm_song=norm_song,
+            norm_album=norm_album,
+            raw_song=song,
+        )
 
-        for item in results:
-            attrs = item.get("attributes") or {}
-            url = attrs.get("url")
-            if not url:
-                continue
-            artist_score = fuzz.token_set_ratio(
-                norm_artist, normalize_for_comparison(attrs.get("artistName") or "")
+        # LML#782: album-title divergence. The WXYC catalog album and
+        # Apple's album for the same track can legitimately differ (Friko's
+        # "Get Numb To It!" sits on an Apple album titled "Get Numb to
+        # It!", not the catalog's "RED XEROX"), and the album-keyed
+        # streaming-URL post-process can never rescue such rows — it
+        # searches Apple by the request album, which doesn't exist there.
+        # Returning None here therefore froze these tracks as permanent
+        # nulls once Backend-Service persisted the miss (BS#1192). Re-score
+        # the SAME response with the album axis dropped: the artist/track
+        # 80/80 floors (LML#389) and the LML#719 degenerate-subset guard
+        # still apply, so only the album constraint is relaxed. Zero extra
+        # API calls — the album was only ever a scoring-time filter. The
+        # winner is surfaced URL-only (below): its album-derived fields
+        # describe an album that just FAILED the floor against the request,
+        # so carrying them would be the LML#396/#487 wrong-album leak.
+        album_fallback = False
+        if best is None and norm_album is not None:
+            best, (artist_axis, track_axis) = _select_best_track_candidate(
+                results,
+                norm_artist=norm_artist,
+                norm_song=norm_song,
+                norm_album=None,
+                raw_song=song,
             )
-            track_score = fuzz.token_set_ratio(
-                norm_song, normalize_for_comparison(attrs.get("name") or "")
-            )
-            if artist_score < _APPLE_MUSIC_MATCH_FLOOR or track_score < _APPLE_MUSIC_MATCH_FLOOR:
-                continue
-            # LML#719: token_set_ratio returns 100 for any token-subset, so a
-            # short generic query title buried in a long unrelated candidate
-            # clears the floor with no real signal — fatal on Various-Artists
-            # requests where the artist axis can't disambiguate (a `Various
-            # Artists` request shares the `various artists` token cluster with
-            # any VA-credited catalog spam). Reject the title axis's degenerate
-            # subsets while keeping the legitimate variant subsets the
-            # token_set path exists to admit. Title axis only — the artist axis
-            # keeps token_set for leader->ensemble subsets (Yves -> Yves Tumor).
-            #
-            # Recall cost (accepted): the guard is unconditional, so a genuine
-            # partial/truncated query title that is a NON-suffix token-subset
-            # (`Fade` -> `Fade Into You`, `Motion` -> `Motion Sickness`) now
-            # drops even when the artist axis is an exact match — these scored
-            # token_set 100 pre-LML#719. This is the fail-safe trade: dropping
-            # Apple enrichment (URL/artwork/year) beats caching a wrong one, and
-            # the loss only bites when the track is ALSO absent from the WXYC
-            # library (the synthesis path is the sole find_track_metadata
-            # caller; in-catalog rows source artwork from the library row, not
-            # this probe). Never alters the DJ's typed artist/song text.
-            if title_subset_is_degenerate(song, attrs.get("name") or ""):
-                continue
-            if norm_album is not None:
-                album_score = fuzz.token_set_ratio(
-                    norm_album, normalize_for_comparison(attrs.get("albumName") or "")
-                )
-                if album_score < _APPLE_MUSIC_MATCH_FLOOR:
-                    continue
-                combined = (artist_score + track_score + album_score) / 3
-            else:
-                combined = (artist_score + track_score) / 2
-            if combined > best_overall_score:
-                best_overall_score = combined
-                best_overall = item
-                best_overall_axes = (artist_score, track_score)
-            if (attrs.get("artwork") or {}).get("url") and combined > best_with_artwork_score:
-                best_with_artwork_score = combined
-                best_with_artwork = item
-                best_with_artwork_axes = (artist_score, track_score)
+            album_fallback = True
 
-        best = best_with_artwork or best_overall
         if best is None:
             return None
 
-        # LML#592: emit the CHOSEN winner's axis scores (track surface). Scores
-        # are stashed in lockstep with each candidate so they describe whichever
-        # record `best_with_artwork or best_overall` actually selected — not the
-        # higher-fuzz record that artwork preference may have passed over.
-        artist_axis, track_axis = (
-            best_with_artwork_axes if best is best_with_artwork else best_overall_axes
-        )
         record_match_telemetry(
             artist_score=artist_axis,
             title_score=track_axis,
             service="apple_music",
-            surface="track",
+            # The fallback winner gets its own surface so LML#592 dashboards
+            # can watch the fallback rate separately from ordinary track wins.
+            surface="track_album_fallback" if album_fallback else "track",
             # LML#592 labeling: request values vs the CHOSEN winner's strings
             # (same record the axes were stashed from), for the marginal sample.
             query_artist=artist,
@@ -485,8 +459,10 @@ class AppleMusicClient(BaseStreamingClient):
         # album-derived fields (``artwork_url``, ``release_year``) describe
         # whatever album Apple ranked highest; surfacing them on the
         # synthesized result would be a wrong-album leak. ~40% of
-        # request-o-matic traffic is artist+song-only.
-        if album is None:
+        # request-o-matic traffic is artist+song-only. The LML#782 fallback
+        # winner is the same trade with sharper evidence — its album just
+        # FAILED the floor against the requested one — so it is URL-only too.
+        if album is None or album_fallback:
             return AppleMusicTrackMatch(url=_extract_url(best), artwork_url=None, release_year=None)
 
         return AppleMusicTrackMatch(
@@ -494,6 +470,100 @@ class AppleMusicClient(BaseStreamingClient):
             artwork_url=_extract_artwork_url(best),
             release_year=_extract_release_year(best),
         )
+
+
+def _select_best_track_candidate(
+    results: list[dict],
+    *,
+    norm_artist: str,
+    norm_song: str,
+    norm_album: str | None,
+    raw_song: str,
+) -> tuple[dict | None, tuple[float, float]]:
+    """One scoring pass over a ``search_song`` response.
+
+    Applies the 80/80(/80) ``token_set_ratio`` floor per axis plus the
+    LML#719 degenerate-subset guard on the title axis, and picks the
+    highest-combined-score candidate — PREFERRING floor-clearers that
+    carry ``attributes.artwork`` over higher-scoring ones that lack it
+    (see ``find_track_metadata``'s docstring for why).
+
+    Extracted from ``find_track_metadata`` so the LML#782 album-less
+    fallback can re-score the same in-memory response with
+    ``norm_album=None`` instead of paying a second Apple Music call.
+    ``raw_song`` is the un-normalized request title — the LML#719 guard
+    does its own normalization internally.
+
+    Returns ``(best, (artist_score, track_score))`` — the chosen record
+    (or ``None`` when nothing clears) plus its per-axis scores, stashed
+    in lockstep with the candidate so they describe whichever record
+    ``best_with_artwork or best_overall`` actually selected, not the
+    higher-fuzz record that artwork preference may have passed over
+    (LML#592).
+    """
+    best_overall: dict | None = None
+    best_overall_score = 0.0
+    best_overall_axes: tuple[float, float] = (0.0, 0.0)
+    best_with_artwork: dict | None = None
+    best_with_artwork_score = 0.0
+    best_with_artwork_axes: tuple[float, float] = (0.0, 0.0)
+
+    for item in results:
+        attrs = item.get("attributes") or {}
+        url = attrs.get("url")
+        if not url:
+            continue
+        artist_score = fuzz.token_set_ratio(
+            norm_artist, normalize_for_comparison(attrs.get("artistName") or "")
+        )
+        track_score = fuzz.token_set_ratio(
+            norm_song, normalize_for_comparison(attrs.get("name") or "")
+        )
+        if artist_score < _APPLE_MUSIC_MATCH_FLOOR or track_score < _APPLE_MUSIC_MATCH_FLOOR:
+            continue
+        # LML#719: token_set_ratio returns 100 for any token-subset, so a
+        # short generic query title buried in a long unrelated candidate
+        # clears the floor with no real signal — fatal on Various-Artists
+        # requests where the artist axis can't disambiguate (a `Various
+        # Artists` request shares the `various artists` token cluster with
+        # any VA-credited catalog spam). Reject the title axis's degenerate
+        # subsets while keeping the legitimate variant subsets the
+        # token_set path exists to admit. Title axis only — the artist axis
+        # keeps token_set for leader->ensemble subsets (Yves -> Yves Tumor).
+        #
+        # Recall cost (accepted): the guard is unconditional, so a genuine
+        # partial/truncated query title that is a NON-suffix token-subset
+        # (`Fade` -> `Fade Into You`, `Motion` -> `Motion Sickness`) now
+        # drops even when the artist axis is an exact match — these scored
+        # token_set 100 pre-LML#719. This is the fail-safe trade: dropping
+        # Apple enrichment (URL/artwork/year) beats caching a wrong one, and
+        # the loss only bites when the track is ALSO absent from the WXYC
+        # library (the synthesis path is the sole find_track_metadata
+        # caller; in-catalog rows source artwork from the library row, not
+        # this probe). Never alters the DJ's typed artist/song text.
+        if title_subset_is_degenerate(raw_song, attrs.get("name") or ""):
+            continue
+        if norm_album is not None:
+            album_score = fuzz.token_set_ratio(
+                norm_album, normalize_for_comparison(attrs.get("albumName") or "")
+            )
+            if album_score < _APPLE_MUSIC_MATCH_FLOOR:
+                continue
+            combined = (artist_score + track_score + album_score) / 3
+        else:
+            combined = (artist_score + track_score) / 2
+        if combined > best_overall_score:
+            best_overall_score = combined
+            best_overall = item
+            best_overall_axes = (artist_score, track_score)
+        if (attrs.get("artwork") or {}).get("url") and combined > best_with_artwork_score:
+            best_with_artwork_score = combined
+            best_with_artwork = item
+            best_with_artwork_axes = (artist_score, track_score)
+
+    best = best_with_artwork or best_overall
+    axes = best_with_artwork_axes if best is best_with_artwork else best_overall_axes
+    return best, axes
 
 
 def _extract_artist_name(item: dict) -> str:

--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -27,7 +27,10 @@ Public surface:
   with the URL plus `attributes.artwork.url` (artwork) and
   `attributes.releaseDate` (year) so the synthesized
   `DiscogsSearchResult` surfaces the correct album's cover art instead
-  of leaking a sibling-album library row's Discogs image.
+  of leaking a sibling-album library row's Discogs image. When every
+  candidate fails only the album axis, re-scores the same response
+  without it (LML#782 album-title divergence) and returns a URL-only,
+  `album_verified=False` match.
 """
 
 from __future__ import annotations
@@ -66,11 +69,21 @@ class AppleMusicTrackMatch:
     ``search_song`` response payload — no extra Apple Music API rounds
     over the existing ``find_track_url`` quota. ``url`` is the Apple Music
     song deep-link (same value ``find_track_url`` returns).
+
+    ``album_verified`` is True only when the winner cleared the
+    ``album_score >= 80`` floor against a supplied album — the evidence
+    the LML#505 override invalidation in ``lookup/enrichment/item.py``
+    needs before clearing a library row's curated streaming URLs. Album-
+    less winners and LML#782 album-fallback winners carry False: their
+    album axis never passed, so they prove nothing about the requested
+    album. Defaults True because every pre-#782 match was constrained by
+    construction; ``find_track_metadata`` always sets it explicitly.
     """
 
     url: str
     artwork_url: str | None
     release_year: int | None
+    album_verified: bool = True
 
 
 logger = logging.getLogger(__name__)
@@ -452,23 +465,34 @@ class AppleMusicClient(BaseStreamingClient):
             matched_title=_extract_name(best),
         )
 
-        # When ``album`` was not supplied the 80/80(/80) floor collapses to
-        # 80/80 — any artist+song match clears regardless of album, and
-        # Apple typically returns the most popular album containing this
-        # song title. The match's URL is per-track so it stays, but the
-        # album-derived fields (``artwork_url``, ``release_year``) describe
-        # whatever album Apple ranked highest; surfacing them on the
-        # synthesized result would be a wrong-album leak. ~40% of
-        # request-o-matic traffic is artist+song-only. The LML#782 fallback
-        # winner is the same trade with sharper evidence — its album just
-        # FAILED the floor against the requested one — so it is URL-only too.
-        if album is None or album_fallback:
-            return AppleMusicTrackMatch(url=_extract_url(best), artwork_url=None, release_year=None)
+        # When no album constrained the scoring (``norm_album is None``
+        # covers both ``album=None`` and a falsy/empty album string) the
+        # 80/80(/80) floor collapses to 80/80 — any artist+song match
+        # clears regardless of album, and Apple typically returns the most
+        # popular album containing this song title. The match's URL is
+        # per-track so it stays, but the album-derived fields
+        # (``artwork_url``, ``release_year``) describe whatever album Apple
+        # ranked highest; surfacing them on the synthesized result would be
+        # a wrong-album leak. ~40% of request-o-matic traffic is
+        # artist+song-only. The LML#782 fallback winner is the same trade
+        # with sharper evidence — its album just FAILED the floor against
+        # the requested one — so it is URL-only too. Either way the album
+        # axis never passed, so the match is ``album_verified=False`` and
+        # the LML#505 invalidation downstream must not treat it as proof
+        # the requested album exists on Apple.
+        if norm_album is None or album_fallback:
+            return AppleMusicTrackMatch(
+                url=_extract_url(best),
+                artwork_url=None,
+                release_year=None,
+                album_verified=False,
+            )
 
         return AppleMusicTrackMatch(
             url=_extract_url(best),
             artwork_url=_extract_artwork_url(best),
             release_year=_extract_release_year(best),
+            album_verified=True,
         )
 
 

--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -393,7 +393,8 @@ def record_match_telemetry(
         artist_score: Fuzzy score of the request artist vs the matched artist.
         title_score: Fuzzy score of the request title vs the matched title.
         service: Streaming service that produced the match ("apple_music", ...).
-        surface: Match surface — "album" or "track".
+        surface: Match surface — "album", "track", or "track_album_fallback"
+            (a track winner selected by the LML#782 album-less re-score).
         query_artist: Request artist string (labeling; marginal clears only).
         matched_artist: Matched-candidate artist string (labeling).
         query_title: Request title string (labeling).

--- a/lookup/enrichment/__init__.py
+++ b/lookup/enrichment/__init__.py
@@ -121,6 +121,13 @@ async def enrich_artwork_results(
     None on the synthesized result because they require a verified
     Discogs identity link (no equivalent surfaces from Apple).
 
+    **Behavior change (LML#782):** when Apple titles the album differently
+    than the catalog (album-title divergence), the probe's album-less
+    fallback still supplies the per-track URL, so the synthesized result
+    can also be URL-only — ``artwork_url`` and ``release_year`` stay None
+    because the fallback winner's album axis failed the floor
+    (``AppleMusicTrackMatch.album_verified=False``).
+
     ``extended=True`` additionally populates the new DiscogsMatchResult
     fields LML already loaded during the release+artist fetches:
     ``discogs_artist_id``, ``tracklist``, ``genres``, ``styles``, ``label``,

--- a/lookup/enrichment/item.py
+++ b/lookup/enrichment/item.py
@@ -242,25 +242,39 @@ async def enrich_one(
     # So a library row for the sibling original propagates its five
     # curated streaming URLs through the override block above when
     # the request is for the Deluxe. When Discogs lacks the Deluxe
-    # (synthesis branch, ``not library_row_acceptable``) the Apple
-    # probe fetches the *requested* album — ``find_track_metadata``
-    # enforces ``album_score >= 80`` at
-    # ``clients/streaming/apple_music.py:407-412`` — proving the
-    # row's URLs are for a sibling, not the request. Clear them so
-    # the precedence at the final ``update`` assignment lets the
-    # probe URL win the Apple slot and the other four services
-    # downgrade to ``_build_streaming_search_url`` placeholders
-    # instead of leaking the wrong release to iOS / dj-site.
+    # (synthesis branch, ``not library_row_acceptable``) an
+    # ``album_verified`` Apple probe match proves the *requested*
+    # album exists on Apple — ``find_track_metadata`` sets the flag
+    # only when the winner cleared the ``album_score >= 80`` floor
+    # against the supplied album — so the row's URLs must be for a
+    # sibling, not the request. Clear them so the precedence at the
+    # final ``update`` assignment lets the probe URL win the Apple
+    # slot and the other four services downgrade to
+    # ``_build_streaming_search_url`` placeholders instead of
+    # leaking the wrong release to iOS / dj-site.
     #
-    # The ``album`` and ``item.title`` guards exclude two paths the
-    # collapse-to-``probe_match is not None`` rule mishandles:
-    # artist-only lookups (``album=None`` → probe ran without the
-    # ``album_score`` floor, so a probe match does not imply
-    # override is wrong) and title-less rows (no row title to be
-    # 'wrong' against). Both retain the override; the title-less
-    # branch is a latent leak tracked as an open question on LML#505
-    # and explicitly out of scope here.
-    if not library_row_acceptable and probe_match is not None and ctx.album and item.title:
+    # ``album_verified`` is the load-bearing guard: it excludes the
+    # paths a collapse-to-``probe_match is not None`` rule
+    # mishandles. Artist-only lookups (``album=None``) never ran the
+    # ``album_score`` floor, and LML#782 album-fallback winners
+    # FAILED it — Apple simply titles the album differently than the
+    # catalog (Friko "RED XEROX" vs Apple "Get Numb to It!"), so the
+    # row may well be the requested album and its curated URLs
+    # correct. Both carry ``album_verified=False`` and retain the
+    # override. ``ctx.album`` stays as defense-in-depth for the
+    # artist-only path (a verified match implies an album was
+    # supplied, so the conjunct is redundant when the flag honors
+    # its contract). ``item.title`` excludes title-less rows (no row
+    # title to be 'wrong' against); that branch is a latent leak
+    # tracked as an open question on LML#505 and explicitly out of
+    # scope here.
+    if (
+        not library_row_acceptable
+        and probe_match is not None
+        and probe_match.album_verified
+        and ctx.album
+        and item.title
+    ):
         apple_music_override = None
         spotify_url = None
         youtube_music_url = None

--- a/tests/integration/test_streaming_on_discogs_miss.py
+++ b/tests/integration/test_streaming_on_discogs_miss.py
@@ -68,7 +68,9 @@ class TestStreamingOnDiscogsMiss:
         # find_track_url — AsyncMock(spec=...) would otherwise auto-generate
         # a Mock-returning stub and silently keep the test green.
         apple_music.find_track_metadata = AsyncMock(
-            return_value=AppleMusicTrackMatch(url=apple_url, artwork_url=None, release_year=None)
+            return_value=AppleMusicTrackMatch(
+                url=apple_url, artwork_url=None, release_year=None, album_verified=True
+            )
         )
         apple_music.find_track_url = AsyncMock()
 
@@ -173,4 +175,65 @@ class TestStreamingOnDiscogsMiss:
         assert top.artwork.soundcloud_url is not None
         # Pin the synthesis path — the no-match shape still routes through
         # find_track_metadata, not find_track_url.
+        apple_music.find_track_url.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fallback_shape_apple_url_survives_route(self, library_db):
+        """LML#782 end-to-end: when the probe's winner came from the
+        album-less fallback (``album_verified=False``, URL-only — Apple
+        titles the album differently than the catalog), the synthesized
+        streaming-only result still carries the per-track Apple URL
+        through ``perform_lookup``. This is the whole point of the
+        fallback: divergence rows previously froze as permanent nulls
+        once Backend-Service persisted the miss (BS#1192)."""
+        from wxyc_fastapi.observability import init_cache_stats
+
+        init_cache_stats()
+
+        mock_service = AsyncMock(
+            spec_set=[
+                "search",
+                "search_releases_by_track",
+                "validate_track_on_release",
+                "get_release",
+                "cache_service",
+            ]
+        )
+        mock_service.cache_service = None
+        mock_service.search = AsyncMock(return_value=DiscogsSearchResponse(results=[]))
+        mock_service.get_release = AsyncMock(return_value=None)
+        mock_service.validate_track_on_release = AsyncMock(return_value=False)
+
+        fallback_url = "https://music.apple.com/us/song/cybeles-reverie/999"
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock(
+            return_value=AppleMusicTrackMatch(
+                url=fallback_url, artwork_url=None, release_year=None, album_verified=False
+            )
+        )
+        apple_music.find_track_url = AsyncMock()
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Aluminum Tunes",
+            song="Cybele's Reverie",
+            raw_message="Stereolab - Aluminum Tunes - Cybele's Reverie",
+        )
+        response = await perform_lookup(
+            request,
+            library_db,
+            mock_service,
+            make_lml_telemetry(),
+            apple_music=apple_music,
+        )
+
+        assert len(response.results) >= 1
+        top = response.results[0]
+        assert top.artwork is not None
+        assert top.artwork.release_id == 0
+        # The fallback URL survives the route — no more permanent null.
+        assert top.artwork.apple_music_url == fallback_url
+        # URL-only contract: the fallback winner's album-derived fields
+        # never surface (its album axis failed the floor).
+        assert top.artwork.release_year is None
         apple_music.find_track_url.assert_not_called()

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -208,19 +208,40 @@ class TestFindTrackUrl:
         assert url is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_album_below_floor(self, es256_keypair):
-        """LML#396: same artist + same track title on the wrong album."""
+    async def test_album_below_floor_falls_back_to_url(self, es256_keypair):
+        """LML#782: album-title divergence. The WXYC catalog album and
+        Apple's album for the same track can legitimately differ (Friko's
+        "Get Numb To It!" lives on an Apple album titled "Get Numb to
+        It!", not the catalog's "RED XEROX"), so an album-constrained
+        miss re-scores the same response with the album axis dropped
+        (artist+track 80/80 still enforced) and surfaces the per-track
+        URL instead of returning None.
+
+        This deliberately inverts the LML#396 expectation (album below
+        floor -> None): a link to the verified track on a different
+        release beats the permanent null BS persistence froze these into
+        (BS#1192). The wrong-album *metadata* leak LML#396/#487 guarded
+        against cannot recur — the fallback strips the album-derived
+        fields (pinned by TestFindTrackMetadata.
+        test_album_below_floor_falls_back_to_url_only)."""
         client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
-            return_value=_songs_response([_make_song_data(album_name="Some Unrelated Compilation")])
+            return_value=_songs_response(
+                [
+                    _make_song_data(
+                        name="Get Numb to It!",
+                        artist_name="Friko",
+                        album_name="Get Numb to It!",
+                        url="https://music.apple.com/us/song/get-numb-to-it/1713114815",
+                    )
+                ]
+            )
         )
         client._http = mock_http
 
-        url = await client.find_track_url(
-            "Jessica Pratt", "Back, Baby", album="On Your Own Love Again"
-        )
-        assert url is None
+        url = await client.find_track_url("Friko", "Get Numb To It!", album="RED XEROX")
+        assert url == "https://music.apple.com/us/song/get-numb-to-it/1713114815"
 
     @pytest.mark.asyncio
     async def test_picks_best_scoring_when_multiple_clear_floor(self, es256_keypair):
@@ -594,12 +615,16 @@ class TestFindTrackMetadata:
         assert match is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_album_below_floor(self, es256_keypair):
-        """LML#487 Tzenni-vs-Yenbett shape: when the song appears on the
-        wrong album in Apple's catalog (a compilation, a single-track
-        sampler) the 3-way 80/80/80 floor must reject. Otherwise the
-        synthesized result would carry wrong-album artwork, regressing
-        on the very bug this ticket fixes."""
+    async def test_album_below_floor_falls_back_to_url_only(self, es256_keypair):
+        """LML#782 album-less fallback on the metadata path: when every
+        candidate fails the album axis (Tzenni-vs-Yenbett shape — the
+        song sits on a different Apple album than the one requested),
+        re-score without the album constraint and surface the per-track
+        URL — but STRIP ``artwork_url`` and ``release_year``. The
+        candidate's album-derived fields describe an album that failed
+        the 80 floor against the requested one, so surfacing them would
+        be exactly the wrong-album leak LML#487 fixed. Same contract as
+        ``album=None`` (``test_album_none_strips_album_derived_fields``)."""
         client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
@@ -610,6 +635,56 @@ class TestFindTrackMetadata:
         match = await client.find_track_metadata(
             "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
         )
+        assert match is not None
+        assert match.url == "https://music.apple.com/us/song/hebebeb-zrag/9"
+        assert match.artwork_url is None
+        assert match.release_year is None
+
+    @pytest.mark.asyncio
+    async def test_album_fallback_does_not_rescue_artist_below_floor(self, es256_keypair):
+        """The LML#782 fallback relaxes ONLY the album axis. A candidate
+        that also fails the artist floor stays rejected in the re-score —
+        the LML#389 wrong-artist guard is untouched by the fallback."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response(
+                [
+                    _make_song_data_full(
+                        artist_name="Completely Different Artist",
+                        album_name="Some Unrelated Compilation",
+                    )
+                ]
+            )
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+        assert match is None
+
+    @pytest.mark.asyncio
+    async def test_album_fallback_does_not_rescue_degenerate_title_subset(self, es256_keypair):
+        """The LML#719 degenerate-subset guard applies inside the LML#782
+        fallback re-score too: a buried token-subset title (``Hound Dog``
+        inside ``Black leather (The hound dog mix)``) must stay rejected
+        even with the album axis dropped."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response(
+                [
+                    _make_song_data_full(
+                        name="Black leather (The hound dog mix)",
+                        album_name="Some Unrelated Compilation",
+                    )
+                ]
+            )
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata("Noura Mint Seymali", "Hound Dog", album="Yenbett")
         assert match is None
 
     @pytest.mark.asyncio
@@ -1003,6 +1078,29 @@ class TestFindTrackMetadataEmits:
         # Emitted title score is B's track axis (la paradoja == 100), NOT B's
         # album axis (DOGA vs DOGAS == 88.89) — pins (artist, track) lockstep.
         assert rec.call_args.kwargs["title_score"] >= 95.0
+
+    @pytest.mark.asyncio
+    async def test_fallback_winner_emits_distinct_surface(self, es256_keypair):
+        """LML#782: a winner selected by the album-less fallback re-score
+        emits ``surface="track_album_fallback"`` — exactly one call,
+        because the album-constrained pass chose no winner and so emitted
+        nothing. The distinct surface lets LML#592 dashboards track the
+        fallback rate separately from ordinary track wins."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response([_make_song_data(album_name="Some Unrelated Compilation")])
+        )
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.record_match_telemetry") as rec:
+            match = await client.find_track_metadata(
+                "Jessica Pratt", "Back, Baby", album="On Your Own Love Again"
+            )
+
+        assert match is not None
+        rec.assert_called_once()
+        assert rec.call_args.kwargs["surface"] == "track_album_fallback"
 
 
 class TestRetryBehavior:

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -222,8 +222,8 @@ class TestFindTrackUrl:
         release beats the permanent null BS persistence froze these into
         (BS#1192). The wrong-album *metadata* leak LML#396/#487 guarded
         against cannot recur — the fallback strips the album-derived
-        fields (pinned by TestFindTrackMetadata.
-        test_album_below_floor_falls_back_to_url_only)."""
+        fields, pinned by the metadata-path twin
+        ``test_album_below_floor_falls_back_to_url_only``."""
         client = _client(es256_keypair)
         mock_http = AsyncMock(spec=httpx.AsyncClient)
         mock_http.get = AsyncMock(
@@ -242,6 +242,9 @@ class TestFindTrackUrl:
 
         url = await client.find_track_url("Friko", "Get Numb To It!", album="RED XEROX")
         assert url == "https://music.apple.com/us/song/get-numb-to-it/1713114815"
+        # The fallback is a re-score of the SAME response — never a second
+        # Apple API round (the documented quota invariant).
+        assert mock_http.get.call_count == 1
 
     @pytest.mark.asyncio
     async def test_picks_best_scoring_when_multiple_clear_floor(self, es256_keypair):
@@ -639,6 +642,9 @@ class TestFindTrackMetadata:
         assert match.url == "https://music.apple.com/us/song/hebebeb-zrag/9"
         assert match.artwork_url is None
         assert match.release_year is None
+        # The fallback is a re-score of the SAME response — never a second
+        # Apple API round (the documented quota invariant).
+        assert mock_http.get.call_count == 1
 
     @pytest.mark.asyncio
     async def test_constrained_winner_is_album_verified(self, es256_keypair):
@@ -1139,6 +1145,31 @@ class TestFindTrackMetadataEmits:
         assert kwargs["matched_artist"] == "Wanda"
         assert kwargs["query_title"] == "la paradoja"
         assert kwargs["matched_title"] == "la paradoja"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_album_emits_plain_track_surface(self, es256_keypair):
+        """A whitespace-only album normalizes to ``""`` — no scoreable
+        constraint. It must take the album-less path directly (one scoring
+        pass, ``surface="track"``), not run a guaranteed-miss constrained
+        pass and mislabel the winner ``"track_album_fallback"`` — that
+        would inflate the LML#592 fallback-rate dashboard with requests
+        that were never album-constrained to begin with."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([_make_song_data_full()]))
+        client._http = mock_http
+
+        with patch("clients.streaming.apple_music.record_match_telemetry") as rec:
+            match = await client.find_track_metadata(
+                "Noura Mint Seymali", "Hebebeb (Zrag)", album="   "
+            )
+
+        assert match is not None
+        assert match.artwork_url is None
+        assert match.release_year is None
+        assert match.album_verified is False
+        rec.assert_called_once()
+        assert rec.call_args.kwargs["surface"] == "track"
 
     @pytest.mark.asyncio
     async def test_emits_scores_of_chosen_winner_not_top_fuzz(self, es256_keypair):

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -641,6 +641,60 @@ class TestFindTrackMetadata:
         assert match.release_year is None
 
     @pytest.mark.asyncio
+    async def test_constrained_winner_is_album_verified(self, es256_keypair):
+        """A winner from the album-constrained pass carries
+        ``album_verified=True`` — it cleared the ``album_score >= 80``
+        floor against the requested album, so downstream consumers
+        (the LML#505 override invalidation in ``lookup/enrichment/item.py``)
+        may treat the match as proof the requested album exists on Apple."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([_make_song_data_full()]))
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+        assert match is not None
+        assert match.album_verified is True
+
+    @pytest.mark.asyncio
+    async def test_fallback_winner_is_not_album_verified(self, es256_keypair):
+        """An LML#782 fallback winner carries ``album_verified=False``: its
+        album axis FAILED the floor against the requested album, so the
+        match proves nothing about the requested album's presence on
+        Apple. The LML#505 invalidation in ``lookup/enrichment/item.py``
+        keys off this flag — without it, a fallback match would nuke a
+        correct row's curated streaming overrides in exactly the
+        album-title-divergence shape this fallback exists to fix."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response([_make_song_data_full(album_name="Tzenni")])
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+        assert match is not None
+        assert match.album_verified is False
+
+    @pytest.mark.asyncio
+    async def test_album_none_winner_is_not_album_verified(self, es256_keypair):
+        """With ``album=None`` the album floor never ran, so the match
+        cannot claim album verification (same reason its album-derived
+        fields are stripped)."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([_make_song_data_full()]))
+        client._http = mock_http
+
+        match = await client.find_track_metadata("Noura Mint Seymali", "Hebebeb (Zrag)", album=None)
+        assert match is not None
+        assert match.album_verified is False
+
+    @pytest.mark.asyncio
     async def test_album_fallback_does_not_rescue_artist_below_floor(self, es256_keypair):
         """The LML#782 fallback relaxes ONLY the album axis. A candidate
         that also fails the artist floor stays rejected in the re-score —
@@ -803,6 +857,26 @@ class TestFindTrackMetadata:
         # Album-derived fields stripped when album is None.
         assert match.artwork_url is None
         assert match.release_year is None
+
+    @pytest.mark.asyncio
+    async def test_empty_album_treated_as_unconstrained(self, es256_keypair):
+        """``album=""`` normalizes to no constraint (the constrained pass
+        never runs), so the winner must take the same URL-only,
+        unverified contract as ``album=None``. Previously the URL-only
+        gate tested ``album is None`` literally, letting an empty-string
+        album surface full artwork/release-year that no album floor ever
+        checked — the LML#487 wrong-album leak through a falsy edge."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(return_value=_songs_response([_make_song_data_full()]))
+        client._http = mock_http
+
+        match = await client.find_track_metadata("Noura Mint Seymali", "Hebebeb (Zrag)", album="")
+        assert match is not None
+        assert match.url == "https://music.apple.com/us/song/hebebeb-zrag/9"
+        assert match.artwork_url is None
+        assert match.release_year is None
+        assert match.album_verified is False
 
     @pytest.mark.asyncio
     async def test_prefers_match_with_artwork_over_higher_scoring_without(self, es256_keypair):

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -695,6 +695,31 @@ class TestFindTrackMetadata:
         assert match.album_verified is False
 
     @pytest.mark.asyncio
+    async def test_album_fallback_does_not_rescue_track_below_floor(self, es256_keypair):
+        """The LML#782 fallback relaxes ONLY the album axis. A candidate
+        whose track title fails the 80 floor (a genuinely different,
+        non-subset title) stays rejected in the re-score — dropping the
+        album constraint must not admit wrong-track matches."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response(
+                [
+                    _make_song_data_full(
+                        name="Completely Unrelated Title",
+                        album_name="Tzenni",
+                    )
+                ]
+            )
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Yenbett"
+        )
+        assert match is None
+
+    @pytest.mark.asyncio
     async def test_album_fallback_does_not_rescue_artist_below_floor(self, es256_keypair):
         """The LML#782 fallback relaxes ONLY the album axis. A candidate
         that also fails the artist floor stays rejected in the re-score —

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -3596,16 +3596,18 @@ class TestSiblingOverrideProbeDivergence:
     synthesized result and the user lands on the wrong release in their
     streaming app.
 
-    ``find_track_metadata`` enforces ``album_score >= 80`` against the
-    *requested* album (``clients/streaming/apple_music.py:407-412``), so
-    a probe match on the synthesis branch is, by construction, for the
-    requested album whenever ``album`` was supplied. When both ``album``
-    and ``item.title`` carry signal, the override URLs must therefore
-    have come from a wrong-sibling row — clear them. The artist-only
-    path (``album=None``) and the title-less row path (``item.title is
-    None``) intentionally retain the override: in those branches the
-    probe's album-score filter never ran, so a probe match does not
-    imply the override is wrong.
+    ``find_track_metadata`` sets ``AppleMusicTrackMatch.album_verified``
+    only when the winner cleared the ``album_score >= 80`` floor against
+    the *requested* album, so an ``album_verified`` probe match on the
+    synthesis branch is, by construction, for the requested album. When
+    that flag and ``item.title`` both carry signal, the override URLs
+    must therefore have come from a wrong-sibling row — clear them. The
+    artist-only path (``album=None``), the LML#782 album-fallback path
+    (album axis FAILED — Apple merely titles the album differently), and
+    the title-less row path (``item.title is None``) intentionally
+    retain the override: in those branches the probe's album-score
+    filter never passed, so a probe match does not imply the override
+    is wrong.
     """
 
     @pytest.mark.asyncio
@@ -3683,6 +3685,69 @@ class TestSiblingOverrideProbeDivergence:
         # Spotify's templated fallback is gone (LML#573); nothing fills the
         # slot in this no-Spotify-client / flag-off setup.
         assert enriched.spotify_url is None
+
+    @pytest.mark.asyncio
+    async def test_fallback_probe_match_retains_curated_overrides(self):
+        """LML#782 seam guard: an album-UNVERIFIED probe match must NOT
+        trigger the LML#505 invalidation.
+
+        The #782 album-less fallback makes ``find_track_metadata`` return a
+        match even when the album axis FAILED (Apple titles the album
+        differently than the catalog — Friko's "Get Numb To It!" sits on an
+        Apple album "Get Numb to It!", not the catalog's "RED XEROX"). Such
+        a match proves nothing about the library row's curated URLs: here
+        the row IS the requested album (exact title match), its five
+        curated links are correct, and Apple merely disagrees about album
+        naming. Clearing them would downgrade correct librarian-curated
+        links to search placeholders in exactly the divergence shape the
+        fallback exists to fix. ``AppleMusicTrackMatch.album_verified``
+        carries the distinction; only a verified match may clear."""
+        item = make_library_item(id=77, artist="Friko", title="RED XEROX")
+
+        curated_spotify = "https://open.spotify.com/album/red-xerox-id"
+        curated_apple = "https://music.apple.com/us/album/red-xerox/222"
+        curated_ytm = "https://music.youtube.com/playlist?list=red-xerox"
+        curated_bandcamp = "https://friko.bandcamp.com/album/red-xerox"
+        curated_soundcloud = "https://soundcloud.com/friko/sets/red-xerox"
+
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": curated_spotify,
+                "apple_music_url": curated_apple,
+                "youtube_music_url": curated_ytm,
+                "bandcamp_url": curated_bandcamp,
+                "soundcloud_url": curated_soundcloud,
+            }
+        )
+
+        probe_match = AppleMusicTrackMatch(
+            url="https://music.apple.com/us/song/get-numb-to-it/1713114815",
+            artwork_url=None,
+            release_year=None,
+            album_verified=False,
+        )
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
+
+        results = await enrich_artwork_results(
+            [(item, None)],  # synthesis branch — no Discogs hit
+            AsyncMock(),
+            song="Get Numb To It!",
+            album="RED XEROX",
+            apple_music=apple_music,
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched is not None
+        # All five curated overrides survive the unverified probe match.
+        assert enriched.spotify_url == curated_spotify
+        assert enriched.apple_music_url == curated_apple
+        assert enriched.youtube_music_url == curated_ytm
+        assert enriched.bandcamp_url == curated_bandcamp
+        assert enriched.soundcloud_url == curated_soundcloud
 
     @pytest.mark.asyncio
     async def test_probe_url_wins_precedence_over_override_on_synthesis_branch(self):

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -151,7 +151,9 @@ class TestEnrichArtworkResults:
         apple_url = "https://music.apple.com/us/album/tragic-magic/1843854211"
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(
-            return_value=AppleMusicTrackMatch(url=apple_url, artwork_url=None, release_year=None)
+            return_value=AppleMusicTrackMatch(
+                url=apple_url, artwork_url=None, release_year=None, album_verified=True
+            )
         )
 
         results = await enrich_artwork_results(
@@ -1568,7 +1570,9 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
 
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(
-            return_value=AppleMusicTrackMatch(url=apple_url, artwork_url=None, release_year=None)
+            return_value=AppleMusicTrackMatch(
+                url=apple_url, artwork_url=None, release_year=None, album_verified=True
+            )
         )
 
         results = await enrich_artwork_results(
@@ -1661,7 +1665,9 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         apple_music.find_track_metadata = AsyncMock(
             side_effect=[
                 AttributeError("Apple returned a non-dict item"),
-                AppleMusicTrackMatch(url=item2_url, artwork_url=None, release_year=None),
+                AppleMusicTrackMatch(
+                    url=item2_url, artwork_url=None, release_year=None, album_verified=True
+                ),
             ]
         )
 
@@ -1712,6 +1718,7 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
                 url="https://music.apple.com/should-never-resolve",
                 artwork_url=None,
                 release_year=None,
+                album_verified=True,
             )
 
         apple_music.find_track_metadata = AsyncMock(side_effect=slow_find)
@@ -1764,6 +1771,7 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
                 url="https://music.apple.com/should-never-resolve",
                 artwork_url=None,
                 release_year=None,
+                album_verified=True,
             )
 
         apple_music.find_track_metadata = AsyncMock(side_effect=slow_find)
@@ -1817,6 +1825,7 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
                 url="https://music.apple.com/should-never-resolve",
                 artwork_url=None,
                 release_year=None,
+                album_verified=True,
             )
 
         apple_music.find_track_metadata = AsyncMock(side_effect=slow_find)
@@ -2080,6 +2089,7 @@ class TestExternalArtworkProbe:
             url="https://music.apple.com/us/song/hebebeb-zrag/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/abc/600x600bb.jpg",
             release_year=2025,
+            album_verified=True,
         )
 
         apple_music = AsyncMock(spec=AppleMusicClient)
@@ -2132,6 +2142,7 @@ class TestExternalArtworkProbe:
             url="https://music.apple.com/us/song/hebebeb-zrag/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/abc/600x600bb.jpg",
             release_year=2025,
+            album_verified=True,
         )
 
         apple_music = AsyncMock(spec=AppleMusicClient)
@@ -2398,6 +2409,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/hebebeb-zrag/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/abc/600x600bb.jpg",
             release_year=2025,
+            album_verified=True,
         )
 
         apple_music = AsyncMock(spec=AppleMusicClient)
@@ -2480,6 +2492,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/x/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/yenbett.jpg",
             release_year=2025,
+            album_verified=True,
         )
 
         apple_music = AsyncMock(spec=AppleMusicClient)
@@ -2744,6 +2757,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/x/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/right.jpg",
             release_year=1979,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -2800,6 +2814,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/x/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/right.jpg",
             release_year=2010,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -2861,6 +2876,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/x/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/yenbett.jpg",
             release_year=2025,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -2916,6 +2932,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/x/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/yenbett.jpg",
             release_year=2025,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -3192,6 +3209,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/wrong-artwork/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/WRONG/600x600bb.jpg",
             release_year=2025,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -3233,6 +3251,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/wrong-artwork/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/WRONG/600x600bb.jpg",
             release_year=2025,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -3331,6 +3350,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/x/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/yenbett.jpg",
             release_year=2025,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -3404,6 +3424,7 @@ class TestArtistIdentitySplitGate:
             url="https://music.apple.com/us/song/non-top1-track/9",
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/dots-and-loops.jpg",
             release_year=1997,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -3647,6 +3668,7 @@ class TestSiblingOverrideProbeDivergence:
             url=probe_url,
             artwork_url="https://is1-ssl.mzstatic.com/image/thumb/deluxe/600x600bb.jpg",
             release_year=2015,
+            album_verified=True,
         )
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(return_value=probe_match)
@@ -3771,7 +3793,9 @@ class TestSiblingOverrideProbeDivergence:
 
         apple_music = AsyncMock(spec=AppleMusicClient)
         apple_music.find_track_metadata = AsyncMock(
-            return_value=AppleMusicTrackMatch(url=probe_url, artwork_url=None, release_year=None)
+            return_value=AppleMusicTrackMatch(
+                url=probe_url, artwork_url=None, release_year=None, album_verified=True
+            )
         )
         apple_music.find_track_url = AsyncMock(return_value=probe_url)
 
@@ -3898,6 +3922,7 @@ class TestSiblingOverrideProbeDivergence:
                 url="https://music.apple.com/us/song/doga/888",
                 artwork_url=None,
                 release_year=None,
+                album_verified=False,
             )
         )
         apple_music.find_track_url = AsyncMock(
@@ -3957,6 +3982,7 @@ class TestSiblingOverrideProbeDivergence:
                 url="https://music.apple.com/us/album/aluminum-tunes/999",
                 artwork_url="https://example.com/aluminum-tunes.jpg",
                 release_year=1998,
+                album_verified=True,
             )
         )
         apple_music.find_track_url = AsyncMock(return_value=None)


### PR DESCRIPTION
Part of #782 — implements the **album-less track retry** acceptance criterion ("Album-less track retry on album-constrained miss implemented or deferred with rationale"). Does not close the issue; the latency, prevalence, and BS#1631 backfill criteria remain open.

## Problem

When the WXYC catalog album title and Apple's album title for the same track legitimately diverge (Friko's *Get Numb To It!* sits on an Apple album titled *Get Numb to It!*, not the catalog's *RED XEROX*), every candidate fails the `album_score >= 80` axis of the 80/80/80 floor and `find_track_metadata` returns `None`. Backend-Service persists that null permanently (BS#1192), and the album-keyed streaming-URL post-process can never rescue these rows — it searches Apple by the request album, which doesn't exist there. So album-title-divergence rows were permanent nulls on both legs.

## Fix

When the album-constrained scoring pass selects no candidate and an album was supplied, re-score the **same in-memory `search_song` response** with the album axis dropped and surface the winner's per-track URL only:

- **Zero extra Apple quota/latency** — the album was never part of the `search_song` HTTP query, only a scoring-time filter, so the fallback is a pure re-score (the scoring loop is extracted into `_select_best_track_candidate` and called twice). Both fallback tests pin `call_count == 1`.
- **Only the album axis is relaxed** — the LML#389 artist floor, the track floor, and the LML#719 degenerate-subset guard apply unchanged inside the re-score (each pinned by a dedicated negative test).
- **URL-only surface** — the fallback winner's `artwork_url`/`release_year` are stripped (same contract as `album=None`), so the wrong-album metadata leak LML#396/#487 guarded against cannot recur. Empty and whitespace-only albums now take the same unconstrained URL-only path (previously an empty-string album slipped past the literal `album is None` gate and surfaced artwork/year no album floor ever checked).
- **`AppleMusicTrackMatch.album_verified` (new, required)** — `True` iff the winner cleared the album floor against a supplied album. The LML#505 override invalidation in `lookup/enrichment/item.py` cleared all five curated streaming links on any probe match, relying on "a match proves the album floor passed" — which the fallback breaks. The clear now requires `album_verified`; a fallback match retains curated overrides (in the divergence shape the library row IS the requested album — Apple just titles it differently). The field has no default: a silent `True` fails open on the destructive clear, a silent `False` fails open on the sibling-override leak #505 fixed, so every construction site states its evidence.
- **Observable** — the fallback winner emits `surface="track_album_fallback"` match telemetry so LML#592 dashboards can watch the fallback rate separately from ordinary track wins (whitespace-only albums emit plain `"track"` — they were never album-constrained).

This deliberately inverts the LML#396/#487 "album below floor → None" expectation: a verified-track URL on a different release beats a permanent null. The two tests encoding the old expectation are rewritten with the rationale inline.

**Known recall trade (accepted):** a fallback URL fills the Apple slot, which preempts the album-keyed post-process leg (it fires only on a null slot). For genuine divergence rows that leg could never succeed anyway; when the requested album does exist on Apple but its track version fell outside the search's top results, the track deep-link wins over the eventually-warmed album-canonical URL — the issue's "URL beats null" call.

## Tests

- `test_album_below_floor_falls_back_to_url` (Friko shape, `find_track_url`) and `test_album_below_floor_falls_back_to_url_only` (Tzenni shape, metadata path, artwork/year stripped) — the behavior change.
- `test_album_fallback_does_not_rescue_artist_below_floor`, `test_album_fallback_does_not_rescue_track_below_floor`, and `test_album_fallback_does_not_rescue_degenerate_title_subset` — pin that only the album axis is relaxed (#389/#719 non-regression).
- `test_fallback_probe_match_retains_curated_overrides` (enrichment) and `test_fallback_shape_apple_url_survives_route` (integration, through `perform_lookup`) — the #505 seam and the end-to-end fallback shape.
- `album_verified` semantics pinned on all three paths (constrained/fallback/album-less), plus `test_empty_album_treated_as_unconstrained`, `test_whitespace_album_emits_plain_track_surface`, and `test_fallback_winner_emits_distinct_surface`.
- Full unit suite passes (3,542) plus the integration tier. Mocked-unit-only follows the established convention for this client — no real-API Apple Music tests exist in the repo (the `external_api` marker provisions Discogs credentials only).

Verified against prod during the #782 repro: dropping the album constraint resolves the Friko pair live.
