### PR TITLE
Rename "Touring Soon" → "On Tour" in generated api_models description

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -752,6 +752,17 @@ class ConcertStatus(StrEnum):
     rescheduled = "rescheduled"
 
 
+class SimilarArtist(BaseModel):
+    artist_id: int = Field(
+        ...,
+        description="WXYC catalog artist id, same keyspace as `Concert.headlining_artist_id`.",
+    )
+    weight: float = Field(
+        ...,
+        description="semantic-index affinity score, used for client-side ranking and the similar-tier noise cap. Higher is closer.",
+    )
+
+
 class Concert(BaseModel):
     id: int
     venue: Venue
@@ -790,6 +801,14 @@ class Concert(BaseModel):
         ..., description='Source-displayed age restriction (e.g. "18+", "All Ages").'
     )
     status: ConcertStatus
+    genres: list[str] | None = Field(
+        None,
+        description="Discogs genre tags for the resolved headlining artist, aggregated across their releases (LML discogs-cache, majority-take). Null when the headliner is unresolved or enrichment has not run. Optional (not in `required`) so the field can land ahead of the Backend-Service emitter and older clients decode forward-compatibly — same discipline as `FlowsheetV2TrackEntry.upcoming_show`. Same taxonomy as `FlowsheetV2TrackEntry.genres`.",
+    )
+    similar_artists: list[SimilarArtist] | None = Field(
+        None,
+        description="Top-K affinity neighbors of the resolved headliner, computed nightly from the semantic-index graph and ordered by `weight` descending. Null when the headliner is unresolved or enrichment has not run. Powers on-device For You matching (set intersection against liked-artist ids). Optional (not in `required`) so it can land ahead of the Backend-Service emitter and older clients decode forward-compatibly — same discipline as `Concert.genres`.",
+    )
 
 
 class ConcertsResponse(BaseModel):
@@ -2135,7 +2154,7 @@ class FlowsheetV2TrackEntry(FlowsheetV2Base):
     )
     upcoming_show: Concert | None = Field(
         None,
-        description="An optional embedded upcoming Triangle-area concert whose headliner is this track's resolved catalog artist, attached server-side at feed-assembly time so the iOS \"Touring Soon\" Box Office CTA renders inline with no second round-trip.\n\nMatch rule (mirrors `GET /concerts?curated=true`): the track's resolved artist — `flowsheet.album_id → library.artist_id` — is matched against `concerts.headlining_artist_id` on curated, non-tombstoned, upcoming rows (`headlining_artist_id IS NOT NULL`, `removed_at IS NULL`, `starts_on >= today` America/New_York). When an artist has several upcoming dates the **soonest** wins (`ORDER BY starts_on ASC LIMIT 1`), so at most one concert rides each playcut.\n\nAbsent/null when the track has no resolved artist (free-form entries with no `album_id`, or an `album_id` whose library row has no matched artist) or when that artist has no curated upcoming date. The field is additive and optional — older app builds that don't decode it are unaffected. Reuses the `Concert` schema verbatim so iOS decodes one type across the Touring Soon tab and the playcut CTA; the `BoxOfficeTicketPresenter` reads `id`, `title` / `headlining_artist_raw`, `venue` (name + city), `starts_on`, `doors_at`, `status`, `price_min` / `price_max`, `ticket_url`, and `image_url` off it.\n",
+        description="An optional embedded upcoming Triangle-area concert whose headliner is this track's resolved catalog artist, attached server-side at feed-assembly time so the iOS \"On Tour\" Box Office CTA renders inline with no second round-trip.\n\nMatch rule (mirrors `GET /concerts?curated=true`): the track's resolved artist — `flowsheet.album_id → library.artist_id` — is matched against `concerts.headlining_artist_id` on curated, non-tombstoned, upcoming rows (`headlining_artist_id IS NOT NULL`, `removed_at IS NULL`, `starts_on >= today` America/New_York). When an artist has several upcoming dates the **soonest** wins (`ORDER BY starts_on ASC LIMIT 1`), so at most one concert rides each playcut.\n\nAbsent/null when the track has no resolved artist (free-form entries with no `album_id`, or an `album_id` whose library row has no matched artist) or when that artist has no curated upcoming date. The field is additive and optional — older app builds that don't decode it are unaffected. Reuses the `Concert` schema verbatim so iOS decodes one type across the On Tour tab and the playcut CTA; the `BoxOfficeTicketPresenter` reads `id`, `title` / `headlining_artist_raw`, `venue` (name + city), `starts_on`, `doors_at`, `status`, `price_min` / `price_max`, `ticket_url`, and `image_url` off it.\n",
     )
 
 


### PR DESCRIPTION
Regenerates `generated/api_models.py` from the current **wxyc-shared main** api.yaml via `scripts/generate_api_models.sh`, restoring the file's "do not edit manually" contract (an earlier revision of this branch carried a manual two-word hand-edit, made while the wxyc-shared rename PR was still unmerged).

## What the regen picks up

Two already-merged wxyc-shared changes land here together:

- **"Touring Soon" → "On Tour" rename** (wxyc-shared #227) — the two user-facing references in the embedded-concert field description. The iOS Box Office CTA feature is now "On Tour"; org GitHub Project [#37](https://github.com/orgs/WXYC/projects/37) is already named "On Tour".
- **Catch-up to the #221/#222 contract additions** (wxyc-shared #224/#225, merged earlier) that lml's generated file was stale against — this stale-drift, not the rename, was what turned the `Codegen Freshness` check red:
  - new `SimilarArtist` model
  - `Concert.genres: list[str] | None`
  - `Concert.similar_artists: list[SimilarArtist] | None`

  Both new `Concert` fields are optional/nullable and forward-compatible; older clients that don't decode them are unaffected.

## Provenance

Pure regen output from the OpenAPI spec — no wire/contract identifiers are hand-authored. This supersedes the earlier manual edit on this branch; the "do not edit manually" contract is fully restored.

## Verification

- `grep -rniE "touring[ _-]?soon"` → no remaining hits; both "On Tour" references present.
- Regenerated file contains `SimilarArtist`, `Concert.genres`, `Concert.similar_artists`.
- `ruff check` + `ruff format --check` + `mypy` pass on the changed file.

Closes #796
