### PR TITLE
fix(#798): demote hot-path search-fallback + cache-hit logs to DEBUG

### DIFF
--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -310,7 +310,7 @@ async def fallthrough[T](
             if is_pg_hit(cached):
                 _add_discogs_breadcrumb("cache_hit", bc_data)
                 get_cache_stats_recorder().record_pg_cache_hit()
-                logger.info("Cache hit (%s)", label)
+                logger.debug("Cache hit (%s)", label)
                 # ``cached`` may be ``T`` (single-value) or ``False`` (tri-state).
                 # Either way ``is_pg_hit`` said it's a hit, so return it.
                 return cached  # type: ignore[return-value]

--- a/library/db.py
+++ b/library/db.py
@@ -251,26 +251,26 @@ class LibraryDB:
 
                 # If no results and fallback enabled, try LIKE search
                 if not rows and fallback_to_like:
-                    logger.info(
+                    logger.debug(
                         f"FTS search for '{query}' returned no results, trying LIKE fallback"
                     )
                     rows = await self._fallback_like_search(query, limit)
 
                 # If still no results, try fuzzy search
                 if not rows and fallback_to_fuzzy:
-                    logger.info(
+                    logger.debug(
                         f"LIKE search for '{query}' returned no results, trying fuzzy fallback"
                     )
                     return await self._fuzzy_search(query, limit)
             except Exception as e:
                 # FTS syntax errors (e.g., special characters) - fall back to LIKE
                 if fallback_to_like:
-                    logger.info(f"FTS search for '{query}' failed ({e}), trying LIKE fallback")
+                    logger.debug(f"FTS search for '{query}' failed ({e}), trying LIKE fallback")
                     rows = await self._fallback_like_search(query, limit)
 
                     # If still no results, try fuzzy search
                     if not rows and fallback_to_fuzzy:
-                        logger.info(
+                        logger.debug(
                             f"LIKE search for '{query}' returned no results, trying fuzzy fallback"
                         )
                         return await self._fuzzy_search(query, limit)
@@ -495,7 +495,7 @@ class LibraryDB:
         results = [item for _, item in scored_results[:limit]]
 
         if results:
-            logger.info(f"Fuzzy search for '{query}' found {len(results)} results")
+            logger.debug(f"Fuzzy search for '{query}' found {len(results)} results")
 
         return results
 

--- a/lookup/strategies/track_release_matching.py
+++ b/lookup/strategies/track_release_matching.py
@@ -357,7 +357,7 @@ async def search_album_fuzzy(db: LibraryDB, album_title: str) -> list[LibraryIte
             max_words = min(4, len(significant_words))
             for n_words in range(max_words, 1, -1):
                 fuzzy_query = " ".join(significant_words[:n_words])
-                logger.info(
+                logger.debug(
                     f"Exact match failed for '{album_title}', trying fuzzy: '{fuzzy_query}'"
                 )
                 raw_results = await db.search(query=fuzzy_query, limit=MAX_SEARCH_RESULTS)

--- a/tests/unit/test_fallthrough.py
+++ b/tests/unit/test_fallthrough.py
@@ -21,6 +21,7 @@ Tests cover, in order:
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock
 
 import asyncpg.exceptions
@@ -69,6 +70,27 @@ class TestBasicReadThrough:
         assert result == "cached-value"
         pg_read.assert_awaited_once()
         api_fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pg_hit_logs_at_debug_not_info(self, caplog):
+        """#798: the per-call ``Cache hit`` breadcrumb fires once per Discogs
+        fallthrough on the lookup hot path, so it logs at DEBUG (matching the
+        sibling ``Cache miss`` line) rather than flooding INFO under a
+        saturation storm."""
+        pg_read = AsyncMock(return_value="cached-value")
+
+        with caplog.at_level(logging.DEBUG, logger="discogs.fallthrough"):
+            await fallthrough(
+                label="get_thing",
+                pg_read=pg_read,
+                api_fetch=AsyncMock(),
+            )
+
+        hits = [r for r in caplog.records if "Cache hit" in r.getMessage()]
+        assert hits, "expected a cache-hit breadcrumb"
+        assert all(r.levelno == logging.DEBUG for r in hits), [
+            (r.levelname, r.getMessage()) for r in hits
+        ]
 
     @pytest.mark.asyncio
     async def test_pg_miss_calls_api_returns_api_result(self):

--- a/tests/unit/test_library_db.py
+++ b/tests/unit/test_library_db.py
@@ -1,5 +1,6 @@
 """Unit tests for library/db.py."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -363,6 +364,70 @@ class TestLibraryDBSearch:
 
         results = await db.search(query="nothing", fallback_to_like=False, fallback_to_fuzzy=False)
         assert results == []
+
+
+class TestSearchFallbackLogLevels:
+    """#798: the per-candidate search-fallback breadcrumbs log at DEBUG, not
+    INFO, so a single VA-compilation ``/lookup`` doesn't emit one INFO line per
+    token and flood Railway's 500/sec replica cap during saturation storms.
+
+    Capture at DEBUG and assert every fallback breadcrumb is recorded there and
+    none at INFO.
+    """
+
+    @staticmethod
+    def _fallback_records(caplog):
+        markers = ("LIKE fallback", "fuzzy fallback", "Fuzzy search for")
+        return [
+            r
+            for r in caplog.records
+            if r.name == "library.db" and any(m in r.getMessage() for m in markers)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_empty_fts_fallback_chain_logs_at_debug(self, caplog):
+        db = LibraryDB()
+        fts_cursor = AsyncMock()
+        fts_cursor.fetchall = AsyncMock(return_value=[])  # FTS empty
+        like_cursor = AsyncMock()
+        like_cursor.fetchall = AsyncMock(return_value=[])  # LIKE empty
+        row = _make_row(id=1, artist="Stereolab", title="Aluminum Tunes")
+        fuzzy_cursor = AsyncMock()
+        fuzzy_cursor.fetchall = AsyncMock(return_value=[row])
+        db._conn = AsyncMock()
+        db._conn.execute = AsyncMock(side_effect=[fts_cursor, like_cursor, fuzzy_cursor])
+
+        with caplog.at_level(logging.DEBUG, logger="library.db"):
+            await db.search(query="Stereolab Aluminum")
+
+        records = self._fallback_records(caplog)
+        assert records, "expected FTS/LIKE/fuzzy fallback breadcrumbs to be emitted"
+        assert all(r.levelno == logging.DEBUG for r in records), [
+            (r.levelname, r.getMessage()) for r in records
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fts_error_fallback_chain_logs_at_debug(self, caplog):
+        db = LibraryDB()
+        like_cursor = AsyncMock()
+        like_cursor.fetchall = AsyncMock(return_value=[])  # LIKE empty
+        row = _make_row(id=1, artist="Juana Molina", title="DOGA")
+        fuzzy_cursor = AsyncMock()
+        fuzzy_cursor.fetchall = AsyncMock(return_value=[row])
+        db._conn = AsyncMock()
+        # First call (FTS) raises, then LIKE (empty), then fuzzy (row).
+        db._conn.execute = AsyncMock(
+            side_effect=[Exception("FTS syntax error"), like_cursor, fuzzy_cursor]
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="library.db"):
+            await db.search(query="Juana Molina DOGA")
+
+        records = self._fallback_records(caplog)
+        assert records, "expected error-path FTS/LIKE/fuzzy fallback breadcrumbs to be emitted"
+        assert all(r.levelno == logging.DEBUG for r in records), [
+            (r.levelname, r.getMessage()) for r in records
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_search_album_fuzzy.py
+++ b/tests/unit/test_search_album_fuzzy.py
@@ -21,6 +21,7 @@ real fixture library so the actual SQLite/FTS5 ordering quirk participates in
 the trace.
 """
 
+import logging
 import sqlite3
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -424,3 +425,29 @@ class TestPerformLookupRecoversTenantOnKaleidoscope:
         assert response.song_not_found is False, (
             "A confirmed track-bearing album should clear song_not_found"
         )
+
+
+class TestSearchAlbumFuzzyLogLevel:
+    """#798: the progressive-shorter-query breadcrumb in ``search_album_fuzzy``
+    fires once per word-length attempt inside the fuzzy loop — a real per-lookup
+    multiplier on the hot path. It must log at DEBUG, not INFO, so a VA
+    compilation doesn't flood Railway's 500/sec replica cap during a storm.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_query_breadcrumb_logs_at_debug(self, tmp_path, caplog):
+        # A title with no exact/LIKE match in the library forces the
+        # significant-words fuzzy loop, which emits the "trying fuzzy" line.
+        db = LibraryDB(db_path=_create_kaleidoscope_library(tmp_path))
+        await db.connect()
+        try:
+            with caplog.at_level(logging.DEBUG, logger="lookup.strategies.track_release_matching"):
+                await search_album_fuzzy(db, "Nonexistent Compilation Zither")
+        finally:
+            await db.close()
+
+        breadcrumbs = [r for r in caplog.records if "trying fuzzy" in r.getMessage()]
+        assert breadcrumbs, "expected the progressive-fuzzy breadcrumb to be emitted"
+        assert all(r.levelno == logging.DEBUG for r in breadcrumbs), [
+            (r.levelname, r.getMessage()) for r in breadcrumbs
+        ]


### PR DESCRIPTION
## Problem

During Discogs-saturation storms (the 06:00 UTC backfill flood and any latched-breaker episode), LML's per-request INFO logging exceeds Railway's **500 logs/sec** replica cap and Railway starts dropping messages — including the error/warning lines needed for incident triage. Observed in the #779 outage window, where the `@level:error` stream was nothing but Railway drop notices (`Messages dropped: 1396`, …).

The flood is per-candidate INFO churn on the lookup hot path. A single VA-compilation `/lookup` can emit dozens of lines; hundreds of concurrent lookups multiply that past the cap. The logs then drop during *exactly* the windows we most need them.

## Change

Demote all seven hot-path call sites from `INFO` to `DEBUG`:

- `library/db.py` — the four FTS/LIKE/fuzzy fallback breadcrumbs + the per-fuzzy "found N results" line.
- `lookup/strategies/track_release_matching.py` — the "trying fuzzy" breadcrumb (fires inside the progressive-shorter-query loop, so it multiplies per candidate).
- `discogs/fallthrough.py` — the per-call `Cache hit` line. This also restores symmetry with the sibling `Cache miss` line right below it, which was already `DEBUG`.

Prod `LOG_LEVEL=INFO` (verified via Railway CLI), so this genuinely suppresses them in prod while keeping them available at `DEBUG` for single-lookup reproduction.

**Untouched:** the `discogs.breaker` OPEN/degradation `WARNING`/`ERROR` lines — they fire once per state change and stay above the demoted floor as load-bearing incident signals.

## Testing

Pure log-hygiene change — no behavior change to matching or lookup results. Adds `caplog` regression tests asserting the moved lines are recorded at `DEBUG`, not `INFO`, across all three files. Full unit suite green (3630 passed); `ruff check`/`ruff format --check`/`mypy` clean locally.

## Acceptance criteria

- [x] Per-candidate FTS/LIKE/fuzzy fallback lines and per-call `Cache hit` lines log at DEBUG, not INFO.
- [x] A representative VA-compilation `/lookup` emits a small bounded number of INFO lines, not one-per-token.
- [x] `discogs.breaker` OPEN/degradation WARNING/ERROR lines are unaffected.
- [x] Confirmed prod default log level is INFO so the demotion takes effect.
- [x] Tests added asserting the moved lines are DEBUG.

Closes #798