### PR TITLE
fix(#802): prefilter search_releases_by_track by artist inside the CTE

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -224,6 +224,101 @@ _ARTIST_TRIGRAM_CANDIDATE_THRESHOLD = 0.85
 _PG_TRGM_FLOOR = 0.3
 _SET_PG_TRGM_FLOOR_SQL = f"SET LOCAL pg_trgm.similarity_threshold = {_PG_TRGM_FLOOR}"
 
+# ``search_releases_by_track`` picks one of these two strings on whether an
+# artist was supplied. Two strings, not one ``$3 IS NULL OR ...`` guard, so the
+# artist=None path (the VA / SONG_AS_TRACK hot path, under #706 perf scrutiny)
+# keeps the exact parse tree it runs today — same pg_stat_statements entry, same
+# generic plan. A single guarded string would force the planner to build one
+# generic plan spanning both branches (it can't constant-fold the unknown ``$3``
+# bind at plan time), so the common None path could inherit a worse plan than
+# today's. See LML#802.
+#
+# ``rta.extra = 0`` constrains the credit legs to main-artist credits (mirrors
+# validate_track_on_release after #333). Neither string has a Python-side
+# release-level fuzz fallback: a release whose only matching credit is
+# ``extra = 1`` (featuring guest, composer, remixer) drops from the candidate
+# ranking; the fallthrough seam's API leg surfaces it at the cost of Discogs
+# quota. See #333 for the recall trade-off; #472-#475 track the parallel filters
+# in sibling read sites. Keep this rationale here (not in ``--`` comments inside
+# the SQL) so it stays out of pg_stat_statements and PG logs.
+_SEARCH_BY_TRACK_SQL = """\
+WITH matching_tracks AS (
+    SELECT DISTINCT rt.release_id, rt.sequence,
+           rt.title as track_title,
+           similarity(lower(f_unaccent(rt.title)), lower(f_unaccent($1))) as sim
+    FROM release_track rt
+    WHERE lower(f_unaccent(rt.title)) % lower(f_unaccent($1))
+    ORDER BY sim DESC
+    LIMIT $2
+)
+SELECT r.id as release_id, r.title, ra.artist_name,
+       mt.track_title,
+       CASE WHEN lower(ra.artist_name) LIKE '%various%' THEN true ELSE false END as is_compilation
+FROM matching_tracks mt
+JOIN release r ON r.id = mt.release_id
+JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+LEFT JOIN release_track_artist rta
+    ON rta.release_id = mt.release_id
+    AND rta.track_sequence = mt.sequence
+    AND rta.extra = 0
+WHERE (
+    $3::text IS NULL
+    OR lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3))
+    OR lower(f_unaccent(rta.artist_name)) % lower(f_unaccent($3))
+)
+ORDER BY mt.sim DESC\
+"""
+
+# Artist-supplied variant: the artist predicate is pushed INTO the CTE ``WHERE``
+# (before the ``LIMIT``), via two correlated ``EXISTS`` legs, so the sim-ordered
+# ``LIMIT`` truncates the already-artist-filtered set instead of pruning the
+# artist's own release out from under it (LML#802 / #801). ``EXISTS`` not
+# ``JOIN`` so the CTE can't multiply ``release_track`` rows -- the ``SELECT
+# DISTINCT`` / ``LIMIT`` still counts distinct candidate tracks. The ``rta`` leg
+# is correlated to ``rt.sequence`` so a release credited to the artist only as a
+# track-level featured credit still matches on its matching track. The outer
+# ``SELECT`` / JOIN / ``WHERE`` are kept identical to ``_SEARCH_BY_TRACK_SQL``:
+# redundant with the CTE here (a pure subtractive backstop that can only remove
+# rows the CTE kept, never admit a wrong one) but it preserves the existing
+# display-artist / is_compilation selection for multi-credit releases.
+_SEARCH_BY_TRACK_ARTIST_SQL = """\
+WITH matching_tracks AS (
+    SELECT DISTINCT rt.release_id, rt.sequence,
+           rt.title as track_title,
+           similarity(lower(f_unaccent(rt.title)), lower(f_unaccent($1))) as sim
+    FROM release_track rt
+    WHERE lower(f_unaccent(rt.title)) % lower(f_unaccent($1))
+      AND (
+          EXISTS (SELECT 1 FROM release_artist ra
+                  WHERE ra.release_id = rt.release_id AND ra.extra = 0
+                    AND lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3)))
+          OR
+          EXISTS (SELECT 1 FROM release_track_artist rta
+                  WHERE rta.release_id = rt.release_id
+                    AND rta.track_sequence = rt.sequence AND rta.extra = 0
+                    AND lower(f_unaccent(rta.artist_name)) % lower(f_unaccent($3)))
+      )
+    ORDER BY sim DESC
+    LIMIT $2
+)
+SELECT r.id as release_id, r.title, ra.artist_name,
+       mt.track_title,
+       CASE WHEN lower(ra.artist_name) LIKE '%various%' THEN true ELSE false END as is_compilation
+FROM matching_tracks mt
+JOIN release r ON r.id = mt.release_id
+JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
+LEFT JOIN release_track_artist rta
+    ON rta.release_id = mt.release_id
+    AND rta.track_sequence = mt.sequence
+    AND rta.extra = 0
+WHERE (
+    $3::text IS NULL
+    OR lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3))
+    OR lower(f_unaccent(rta.artist_name)) % lower(f_unaccent($3))
+)
+ORDER BY mt.sim DESC\
+"""
+
 
 def _negative_cache_key_hash(artist: str | None, track: str, artist_as_keyword: bool) -> bytes:
     """Hash the (artist, track, artist_as_keyword) tuple into a stable 32-byte key.
@@ -372,48 +467,17 @@ class DiscogsCacheService:
         Raises:
             CacheUnavailableError: If database is unreachable
         """
-        # `rta.extra = 0` constrains the LEFT JOIN to main-artist credits
-        # (mirrors validate_track_on_release after #333). Unlike
-        # validate_track_on_release, this query has no Python-side release-
-        # level fuzz fallback — a release where the only matching credit is
-        # `extra = 1` (featuring guest, composer, remixer) drops from the
-        # candidate ranking. The fallthrough seam's API leg will surface it
-        # at the cost of Discogs quota. See #333 for the documented recall
-        # trade-off; #472-#475 track the parallel filters in sibling read
-        # sites (get_release_metadata, va_disambiguate, match_compilations,
-        # track_streaming). Keep the rationale here (not in `--` comments
-        # inside the SQL) so it stays out of pg_stat_statements and PG
-        # logs.
+        # Two query strings selected on whether an artist was supplied: the
+        # artist=None path runs `_SEARCH_BY_TRACK_SQL` unchanged (the VA /
+        # SONG_AS_TRACK hot path — its plan must stay frozen, #706); an artist
+        # runs `_SEARCH_BY_TRACK_ARTIST_SQL`, which pushes the predicate into
+        # the CTE so the LIMIT can't prune the artist's own release (#802). Full
+        # rationale (the split, the #333 extra=0 trade-off) sits above the two
+        # module-level constants.
         try:
-            query = """
-                WITH matching_tracks AS (
-                    SELECT DISTINCT rt.release_id, rt.sequence,
-                           rt.title as track_title,
-                           similarity(lower(f_unaccent(rt.title)), lower(f_unaccent($1))) as sim
-                    FROM release_track rt
-                    WHERE lower(f_unaccent(rt.title)) % lower(f_unaccent($1))
-                    ORDER BY sim DESC
-                    LIMIT $2
-                )
-                SELECT r.id as release_id, r.title, ra.artist_name,
-                       mt.track_title,
-                       CASE WHEN lower(ra.artist_name) LIKE '%various%' THEN true ELSE false END as is_compilation
-                FROM matching_tracks mt
-                JOIN release r ON r.id = mt.release_id
-                JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0
-                LEFT JOIN release_track_artist rta
-                    ON rta.release_id = mt.release_id
-                    AND rta.track_sequence = mt.sequence
-                    AND rta.extra = 0
-                WHERE (
-                    $3::text IS NULL
-                    OR lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3))
-                    OR lower(f_unaccent(rta.artist_name)) % lower(f_unaccent($3))
-                )
-                ORDER BY mt.sim DESC
-            """
+            sql = _SEARCH_BY_TRACK_SQL if artist is None else _SEARCH_BY_TRACK_ARTIST_SQL
 
-            rows = await self.pool.fetch(query, track, limit * 2, artist)
+            rows = await self.pool.fetch(sql, track, limit * 2, artist)
 
             results = []
             seen_albums = set()

--- a/tests/integration/test_search_by_track_artist_prefilter.py
+++ b/tests/integration/test_search_by_track_artist_prefilter.py
@@ -1,0 +1,298 @@
+"""Integration tests for the LML#802 artist-prefilter fix in ``search_releases_by_track``.
+
+Reproduces the CTE truncation-before-filter prune: ``matching_tracks`` orders
+by track-title similarity and truncates with ``LIMIT limit*2`` **before** the
+artist predicate runs (the artist bind ``$3`` is referenced only in the outer
+``WHERE``). So an artist's own release is pruned when more than ``limit*2``
+other releases share the (common) track title. The fix pushes the artist
+predicate into the CTE via two correlated ``EXISTS`` legs (release-level
+``release_artist`` + track-level ``release_track_artist``) so the ``LIMIT``
+truncates the already-artist-filtered set.
+
+Determinism (the crux of the RED reproduction): the ``N = 42`` distractor
+releases (> ``limit*2 = 40``) carry a track titled **exactly** like the query
+-> ``sim = 1.0``. The single target release carries a fuzzier title
+(query + ``" (Reprise)"``) -> ``0.3 < sim < 1.0`` (measured 0.619), so it
+deterministically sorts **below** all 42 and is reliably pruned by
+``LIMIT 40`` on current code, regardless of tie ordering. A target that shared
+the exact title would tie at 1.0 with the distractors and prune
+non-deterministically -> flaky RED. See the "trigram floor" pin test which
+asserts that ``sim`` stays in ``(0.3, 1.0)`` so a server-default or title tweak
+that moves it out of range fails loudly instead of silently going flaky.
+
+Run with:
+    pytest -m pg -v tests/integration/test_search_by_track_artist_prefilter.py
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from discogs.cache_service import DiscogsCacheService
+from tests.integration.conftest import (
+    F_UNACCENT_WRAPPER_SQL,
+    skip_if_drop_targets_populated,
+)
+
+pytestmark = pytest.mark.pg
+
+# > limit*2 (= 40 at the default limit=20): enough same-title decoys to fill the
+# CTE's LIMIT before the target (which sorts last on its fuzzier title) can enter.
+N_DISTRACTORS = 42
+COMMON_TITLE = "Common Track"
+FUZZY_TITLE = "Common Track (Reprise)"  # measured similarity vs COMMON_TITLE = 0.619
+
+
+async def _create_schema(conn) -> None:
+    """DROP/CREATE the four discogs-cache tables ``search_releases_by_track`` reads."""
+    await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    await conn.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+    await conn.execute(F_UNACCENT_WRAPPER_SQL)
+
+    await conn.execute("DROP TABLE IF EXISTS release_track_artist CASCADE")
+    await conn.execute("DROP TABLE IF EXISTS release_track CASCADE")
+    await conn.execute("DROP TABLE IF EXISTS release_artist CASCADE")
+    await conn.execute("DROP TABLE IF EXISTS release CASCADE")
+    await conn.execute("""
+        CREATE TABLE release (
+            id    integer PRIMARY KEY,
+            title text NOT NULL
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE release_track (
+            release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+            sequence   integer NOT NULL,
+            title      text NOT NULL
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE release_artist (
+            release_id  integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+            artist_id   integer,
+            artist_name text NOT NULL,
+            extra       integer DEFAULT 0
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE release_track_artist (
+            release_id     integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+            track_sequence integer NOT NULL,
+            artist_name    text NOT NULL,
+            extra          integer DEFAULT 0
+        )
+    """)
+
+
+async def _seed_distractors(conn, *, track_title: str = COMMON_TITLE) -> None:
+    """Seed ``N_DISTRACTORS`` releases by distinct decoy artists, one track each.
+
+    Each distractor track is titled ``track_title`` (exact-match, sim 1.0 when
+    that equals the query) so they flood the ``ORDER BY sim DESC LIMIT`` ahead
+    of a fuzzier-titled target.
+    """
+    await conn.executemany(
+        "INSERT INTO release (id, title) VALUES ($1, $2)",
+        [(i, f"Decoy Album {i}") for i in range(1, N_DISTRACTORS + 1)],
+    )
+    await conn.executemany(
+        "INSERT INTO release_track (release_id, sequence, title) VALUES ($1, 1, $2)",
+        [(i, track_title) for i in range(1, N_DISTRACTORS + 1)],
+    )
+    await conn.executemany(
+        "INSERT INTO release_artist (release_id, artist_name, extra) VALUES ($1, $2, 0)",
+        [(i, f"Decoy Artist {i}") for i in range(1, N_DISTRACTORS + 1)],
+    )
+
+
+@pytest_asyncio.fixture
+async def cache(pg_pool):
+    """Empty four-table discogs-cache schema; yields a service, drops on teardown.
+
+    Each test seeds its own rows so the distractor/target shapes stay local to
+    the behaviour under test.
+    """
+    async with pg_pool.acquire() as conn:
+        await skip_if_drop_targets_populated(
+            conn,
+            ("release", "release_track", "release_artist", "release_track_artist"),
+        )
+        try:
+            await _create_schema(conn)
+        except Exception as e:
+            pytest.skip(f"pg_trgm/unaccent extensions unavailable: {e}")
+
+    yield DiscogsCacheService(pg_pool)
+
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS release_track_artist CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS release_track CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS release_artist CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS release CASCADE")
+
+
+class TestTrigramFloorPin:
+    """Pin the boundary the RED reproductions depend on, so it fails loudly."""
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_title_similarity_in_range(self, cache):
+        async with cache.pool.acquire() as conn:
+            sim = await conn.fetchval(
+                "SELECT similarity(lower(f_unaccent($1)), lower(f_unaccent($2)))",
+                FUZZY_TITLE,
+                COMMON_TITLE,
+            )
+            matches = await conn.fetchval(
+                "SELECT lower(f_unaccent($1)) % lower(f_unaccent($2))",
+                FUZZY_TITLE,
+                COMMON_TITLE,
+            )
+        # Below 1.0 -> the target sorts under the exact-title distractors (RED
+        # prune is deterministic). Above the 0.3 default threshold -> it still
+        # passes the `%` track filter, so the fix can surface it (GREEN).
+        assert 0.3 < sim < 1.0, f"target sim {sim} out of the (0.3, 1.0) window the RED test needs"
+        assert matches is True
+
+
+class TestReleaseLevelArtistPrefilter:
+    """AC#1 -- artist's own release survives despite N > limit*2 same-title others."""
+
+    @pytest.mark.asyncio
+    async def test_target_release_returned_despite_distractor_flood(self, cache):
+        async with cache.pool.acquire() as conn:
+            await _seed_distractors(conn)
+            await conn.execute("INSERT INTO release (id, title) VALUES (1000, 'DOGA')")
+            await conn.execute(
+                "INSERT INTO release_track (release_id, sequence, title) VALUES (1000, 1, $1)",
+                FUZZY_TITLE,
+            )
+            await conn.execute(
+                "INSERT INTO release_artist (release_id, artist_name, extra) "
+                "VALUES (1000, 'Juana Molina', 0)"
+            )
+
+        results = await cache.search_releases_by_track(COMMON_TITLE, "Juana Molina", 20)
+
+        assert [r.release_id for r in results] == [1000]
+        assert results[0].album == "DOGA"
+        assert results[0].artist == "Juana Molina"
+
+
+class TestArtistNoneBranchUnchanged:
+    """AC#2 -- the artist=None (VA / SONG_AS_TRACK) hot path is untouched."""
+
+    @pytest.mark.asyncio
+    async def test_none_branch_still_truncates_by_similarity(self, cache):
+        """With no artist, the query keeps its today-behaviour: the fuzzier
+        target sorts last and is dropped by the sim-ordered ``LIMIT``, exactly
+        as on current code. The artist prefilter must not leak into this path."""
+        async with cache.pool.acquire() as conn:
+            await _seed_distractors(conn)
+            await conn.execute("INSERT INTO release (id, title) VALUES (1000, 'DOGA')")
+            await conn.execute(
+                "INSERT INTO release_track (release_id, sequence, title) VALUES (1000, 1, $1)",
+                FUZZY_TITLE,
+            )
+            await conn.execute(
+                "INSERT INTO release_artist (release_id, artist_name, extra) "
+                "VALUES (1000, 'Juana Molina', 0)"
+            )
+
+        results = await cache.search_releases_by_track(COMMON_TITLE, None, 20)
+
+        # 20 distractors (all sim 1.0) fill the limit; the fuzzier target sorts
+        # last and never enters the top-40 CTE window -> absent, as today.
+        assert len(results) == 20
+        assert 1000 not in {r.release_id for r in results}
+        assert all(r.artist.startswith("Decoy Artist") for r in results)
+
+
+class TestTrackLevelFeaturedCredit:
+    """AC#3 -- the track-level ``rta`` EXISTS leg (featured credit) still matches."""
+
+    @pytest.mark.asyncio
+    async def test_featured_credit_release_returned(self, cache):
+        """release_artist = 'Various' (extra 0); the queried artist appears only
+        as a track-level ``release_track_artist`` credit (extra 0) on the
+        matched track's sequence. The ``rta`` EXISTS leg must keep it in the CTE."""
+        async with cache.pool.acquire() as conn:
+            await _seed_distractors(conn)
+            await conn.execute("INSERT INTO release (id, title) VALUES (2000, 'Nao Wave')")
+            await conn.execute(
+                "INSERT INTO release_track (release_id, sequence, title) VALUES (2000, 7, $1)",
+                FUZZY_TITLE,
+            )
+            await conn.execute(
+                "INSERT INTO release_artist (release_id, artist_name, extra) "
+                "VALUES (2000, 'Various', 0)"
+            )
+            await conn.execute(
+                "INSERT INTO release_track_artist "
+                "(release_id, track_sequence, artist_name, extra) VALUES (2000, 7, $1, 0)",
+                "Azul 29",
+            )
+
+        results = await cache.search_releases_by_track(COMMON_TITLE, "Azul 29", 20)
+
+        assert [r.release_id for r in results] == [2000]
+        assert results[0].is_compilation is True
+
+    @pytest.mark.asyncio
+    async def test_extra_one_featured_credit_excluded(self, cache):
+        """Precision guard: an ``extra = 1`` track credit (guest/remixer/writer)
+        must NOT recall the release -- mirrors the #333 trade-off. The fix keeps
+        ``rta.extra = 0`` in the CTE leg, so the target stays out."""
+        async with cache.pool.acquire() as conn:
+            await _seed_distractors(conn)
+            await conn.execute("INSERT INTO release (id, title) VALUES (2001, 'Nao Wave')")
+            await conn.execute(
+                "INSERT INTO release_track (release_id, sequence, title) VALUES (2001, 7, $1)",
+                FUZZY_TITLE,
+            )
+            await conn.execute(
+                "INSERT INTO release_artist (release_id, artist_name, extra) "
+                "VALUES (2001, 'Various', 0)"
+            )
+            await conn.execute(
+                "INSERT INTO release_track_artist "
+                "(release_id, track_sequence, artist_name, extra) VALUES (2001, 7, $1, 1)",
+                "Azul 29",
+            )
+
+        results = await cache.search_releases_by_track(COMMON_TITLE, "Azul 29", 20)
+
+        assert results == []
+
+
+class TestIssue801ConcretePin:
+    """AC#4 (cache-retrieval half) -- the #801 Milkman / Aphex Twin shape.
+
+    Deterministic stand-in for the live #801 tie: many releases carry a track
+    titled exactly "Milkman", all tying at sim 1.0, so ``ORDER BY sim DESC
+    LIMIT 40`` keeps an arbitrary 40 and Richard D. James Album is pruned before
+    the artist filter. To make the reproduction deterministic (not flaky on the
+    tie), the target's matching track carries a qualifier so it sorts strictly
+    below the exact-title distractors -- the pruning mechanism is identical.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rdj_album_returned_for_milkman_aphex_twin(self, cache):
+        async with cache.pool.acquire() as conn:
+            await _seed_distractors(conn, track_title="Milkman")
+            await conn.execute(
+                "INSERT INTO release (id, title) VALUES (972, 'Richard D. James Album')"
+            )
+            await conn.execute(
+                "INSERT INTO release_track (release_id, sequence, title) "
+                "VALUES (972, 10, 'Milkman (Reprise)')"
+            )
+            await conn.execute(
+                "INSERT INTO release_artist (release_id, artist_name, extra) "
+                "VALUES (972, 'Aphex Twin', 0)"
+            )
+
+        results = await cache.search_releases_by_track("Milkman", "Aphex Twin", 20)
+
+        assert [r.release_id for r in results] == [972]
+        assert results[0].album == "Richard D. James Album"

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from discogs.cache_service import (
+    _SEARCH_BY_TRACK_ARTIST_SQL,
+    _SEARCH_BY_TRACK_SQL,
     ArtistEqualityCandidates,
     CacheUnavailableError,
     DiscogsCacheService,
@@ -214,6 +216,76 @@ class TestSearchReleasesByTrack:
 
         with pytest.raises(CacheUnavailableError):
             await cache_service.search_releases_by_track("S")
+
+    @pytest.mark.asyncio
+    async def test_none_artist_uses_frozen_hot_path_sql(self, cache_service, mock_asyncpg_pool):
+        """The artist=None branch runs `_SEARCH_BY_TRACK_SQL` verbatim.
+
+        This is the VA / SONG_AS_TRACK hot path (#706): its plan and
+        pg_stat_statements entry must stay frozen, so the None branch must
+        dispatch to the unchanged string, never the artist variant.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+
+        await cache_service.search_releases_by_track("Song", None)
+
+        sql = mock_asyncpg_pool.fetch.call_args[0][0]
+        assert sql is _SEARCH_BY_TRACK_SQL
+
+    def test_hot_path_sql_matches_snapshot(self):
+        """Change-detector for the frozen artist=None SQL (LML#802 AC#2).
+
+        Whitespace-normalized, not byte-for-byte: hoisting the string to a
+        module constant de-indents it and pg_stat_statements normalizes
+        whitespace away regardless. What must not drift is the *structure* --
+        any semantic edit to the hot-path query trips this and forces a
+        deliberate re-freeze (and a fresh EXPLAIN).
+        """
+        snapshot = (
+            "WITH matching_tracks AS ( SELECT DISTINCT rt.release_id, rt.sequence, "
+            "rt.title as track_title, "
+            "similarity(lower(f_unaccent(rt.title)), lower(f_unaccent($1))) as sim "
+            "FROM release_track rt WHERE lower(f_unaccent(rt.title)) % lower(f_unaccent($1)) "
+            "ORDER BY sim DESC LIMIT $2 ) "
+            "SELECT r.id as release_id, r.title, ra.artist_name, mt.track_title, "
+            "CASE WHEN lower(ra.artist_name) LIKE '%various%' THEN true ELSE false END "
+            "as is_compilation FROM matching_tracks mt JOIN release r ON r.id = mt.release_id "
+            "JOIN release_artist ra ON ra.release_id = r.id AND ra.extra = 0 "
+            "LEFT JOIN release_track_artist rta ON rta.release_id = mt.release_id "
+            "AND rta.track_sequence = mt.sequence AND rta.extra = 0 "
+            "WHERE ( $3::text IS NULL "
+            "OR lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3)) "
+            "OR lower(f_unaccent(rta.artist_name)) % lower(f_unaccent($3)) ) "
+            "ORDER BY mt.sim DESC"
+        )
+        assert " ".join(_SEARCH_BY_TRACK_SQL.split()) == snapshot
+
+    @pytest.mark.asyncio
+    async def test_artist_predicate_pushed_into_cte_before_limit(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Bug-fix-protocol structural analog (LML#802 AC#1).
+
+        The prune is a SQL-execution artifact -- it can't be reproduced against
+        a mock pool (no SQL runs; behavioural repro lives in the `pg` suite).
+        This pins the *mechanism*: with an artist supplied, the emitted SQL must
+        evaluate an artist EXISTS predicate on `$3` INSIDE the CTE, before the
+        `LIMIT $2` truncates -- otherwise the LIMIT can prune the artist's own
+        release out again.
+        """
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+
+        await cache_service.search_releases_by_track("Song", "Artist")
+
+        sql = mock_asyncpg_pool.fetch.call_args[0][0]
+        assert sql is _SEARCH_BY_TRACK_ARTIST_SQL
+        limit_at = sql.index("LIMIT $2")
+        cte_predicate = "EXISTS (SELECT 1 FROM release_artist ra"
+        assert cte_predicate in sql
+        assert sql.index(cte_predicate) < limit_at, (
+            "artist EXISTS leg must appear inside the CTE, before LIMIT $2"
+        )
+        assert "lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3))" in sql[:limit_at]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`DiscogsCacheService.search_releases_by_track`'s `matching_tracks` CTE ranked releases by track-title trigram similarity and truncated with `ORDER BY sim DESC LIMIT limit*2`, but the artist bind (`$3`) was referenced only in the **outer** `WHERE` — so the `LIMIT` ran before the artist filter. For a common track title, dozens of releases tie at `sim = 1.0` and an arbitrary `limit*2` survive truncation; if the queried artist's own release wasn't in that set it was pruned before the artist predicate ever ran, and the query returned **zero rows for a release that is in the cache**. This is the upstream cause of the #801 "Milkman" / Aphex Twin → *Richard D. James Album* recall miss, and it starves both the Step-2 compilation probe and the #267 cache-only rescue.

## Fix

Split the single query into two module-level SQL strings selected on whether an artist was supplied:

- **`_SEARCH_BY_TRACK_SQL` (artist absent)** — the VA / SONG_AS_TRACK hot path (under #706 perf scrutiny). Structurally unchanged, so its parse tree, `pg_stat_statements` entry, and generic plan stay frozen. Two strings, not one `$3 IS NULL OR …` guard, precisely so the planner doesn't build one generic plan spanning both branches.
- **`_SEARCH_BY_TRACK_ARTIST_SQL` (artist supplied)** — the artist predicate is pushed **into the CTE `WHERE`, before the `LIMIT`**, via two correlated `EXISTS` legs (release-level `release_artist` + track-level `release_track_artist`, the latter correlated to the matched track's `sequence`). `EXISTS` (not `JOIN`) so the CTE can't multiply `release_track` rows — the `SELECT DISTINCT` / `LIMIT` still counts distinct candidate tracks. The outer `SELECT`/JOIN/`WHERE` is kept as a pure subtractive backstop, preserving the existing display-artist / `is_compilation` selection.

`rta.extra = 0` main-artist-credit semantics and the #333 recall trade-off are unchanged; query rationale lives in Python comments (out of `pg_stat_statements` / PG logs).

## Tests

Six `pg`-marked integration reproductions (release-level prefilter, `artist=None` no-regression, track-level featured credit, `extra=1` precision guard, the #801 Milkman/Aphex pin, and a trigram-floor boundary pin) + three unit tests (frozen hot-path dispatch, a whitespace-normalized snapshot change-detector for the None-branch SQL, and a structural pin that the artist `EXISTS` leg lands inside the CTE before `LIMIT`).

**Bug-fix-protocol note:** the prune is a SQL-execution artifact that can't reproduce against a mock pool, so the behavioral repros are the `pg` tests and the structural unit test is the protocol analog. RED was re-confirmed by restoring the pre-fix `cache_service.py`: the 3 behavioral repros fail returning `[]` (the prune), and the Milkman/Aphex pin returns `[]` on old code vs. the target release id with the fix.

## Verification

Local CI green: `ruff check .`, `ruff format --check .`, `mypy . --ignore-missing-imports` (no issues, 399 files), full non-pg suite (3931 passed), and `pytest -m pg` (all 6 new tests + the existing cache_service SQL-substring tests pass).

**Pre-merge gate — satisfied** (full numbers in [this comment](https://github.com/WXYC/library-metadata-lookup/pull/807#issuecomment-4988269885)): `EXPLAIN (ANALYZE, BUFFERS)` on the prod discogs-cache confirms all three trigram GIN indexes exist (`idx_release_track_title_trgm`, `idx_release_artist_name_trgm`, `idx_release_track_artist_name_trgm`) and the artist legs ride them as hashed SubPlans. Realistic `Milkman` + `Aphex Twin` = 264 ms; pathological `Intro` (3,629 matches) = 1.3 s — both dominated by the `title % $1` bitmap-heap-recheck that today's query pays identically, the fix adding only ~25–95 ms of index-driven hashed SubPlan work. No index gap, no regression vs. today's plan for the common-title case.

## Scope

Necessary-but-not-sufficient for the parent class #801 (the end-to-end assertion is a healthy-cache orchestrator replay, tracked on #801). Distinct from #237's trigram-vs-`token_set` mechanism.

Closes #802



---

## Performance analysis

**`artist=None` hot path (VA / SONG_AS_TRACK): zero change.** `_SEARCH_BY_TRACK_SQL` is structurally identical to the pre-split query — same parse tree, plan, and `pg_stat_statements` entry. This is the path the backfill flood mostly exercises, so the #706-sensitive surface is untouched.

**artist-supplied path: neutral-to-slightly-positive, gated on one index.** The artist predicate moves from post-`LIMIT` (40 rows, outer `WHERE`) to pre-`LIMIT` (the full title-match candidate set, inside the CTE via two `EXISTS` legs). `EXPLAIN (ANALYZE, BUFFERS)` on a synthetic 20k-release set (2,000 sharing a common "Milkman" title + one Aphex target; warm cache — plan shape transfers to prod, absolute ms does not):

| Query variant | Result | Exec time | Why |
|---|---|---|---|
| OLD (artist in outer `WHERE`) | **0 rows** (the bug) | 2.99 ms | prunes the artist's release before the filter |
| NEW, **no** `artist_name` trgm index | 1 row (correct) | 18.9 ms (~6×) | seq-scans `release_artist` to evaluate the predicate |
| NEW, **with** `artist_name` trgm index | 1 row (correct) | **2.14 ms** (≈ old, a hair faster) | index probe resolves the `EXISTS` cheaply |

The whole outcome hinges on the `gin_trgm_ops` index on `release_artist.artist_name` (and `release_track_artist.artist_name`). Both are defined in the discogs-etl schema that builds the prod cache — `discogs-etl/schema/create_indexes.sql:17` (`idx_release_artist_name_trgm`) and `create_track_indexes.sql:51` (`idx_release_track_artist_name_trgm`) — so prod is the "with index" row: **perf-neutral-to-positive on the artist branch, zero on the hot path**, while fixing the correctness bug.

**Outstanding verification (was not recorded pre-merge).** Those indexes use `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, which can leave an `INVALID` index if a build/rebuild was interrupted (see the cache-rebuild history behind #706). If either is missing or `indisvalid = false`, the artist branch degrades to a full `release_artist` seq-scan per common-title lookup — far worse than the synthetic 6× under buffer-thrash, competing for the already-starved pool. Confirm on the prod cache:

```sql
SELECT indexrelid::regclass, indisvalid FROM pg_index
WHERE indexrelid::regclass::text
  IN ('idx_release_artist_name_trgm','idx_release_track_artist_name_trgm');
```

Valid → no action (perf-neutral). Missing/invalid → reindex in **discogs-etl** (schema-owned); do not `CREATE INDEX` from LML. Even a no-index regression lands on **organic** artist+track traffic (the #267 rescue, TRACK_ON_COMPILATION artist probe), not the backfill flood (which is artist+album/VA → hits the unchanged hot path).
