### PR TITLE
test(#802): pin the CTE credit guards, outer-block parity, and trigram floor

### DIFF
--- a/tests/integration/test_search_by_track_artist_prefilter.py
+++ b/tests/integration/test_search_by_track_artist_prefilter.py
@@ -43,6 +43,15 @@ N_DISTRACTORS = 42
 COMMON_TITLE = "Common Track"
 FUZZY_TITLE = "Common Track (Reprise)"  # measured similarity vs COMMON_TITLE = 0.619
 
+# The #801 concrete pin (``TestIssue801ConcretePin``) reuses the same
+# fuzzier-than-1.0 mechanism with the real "Milkman" / "Milkman (Reprise)" pair.
+# Pin its similarity in the floor test too, so a cluster whose
+# ``pg_trgm.similarity_threshold`` was raised above this pair's score fails
+# loudly at the boundary instead of silently returning ``[]`` from the #801
+# reproduction (LML#802 review).
+ISSUE_801_QUERY_TITLE = "Milkman"
+ISSUE_801_TARGET_TITLE = "Milkman (Reprise)"
+
 
 async def _create_schema(conn) -> None:
     """DROP/CREATE the four discogs-cache tables ``search_releases_by_track`` reads."""
@@ -136,22 +145,32 @@ class TestTrigramFloorPin:
     """Pin the boundary the RED reproductions depend on, so it fails loudly."""
 
     @pytest.mark.asyncio
-    async def test_fuzzy_title_similarity_in_range(self, cache):
+    @pytest.mark.parametrize(
+        ("target_title", "query_title"),
+        [
+            (FUZZY_TITLE, COMMON_TITLE),
+            (ISSUE_801_TARGET_TITLE, ISSUE_801_QUERY_TITLE),
+        ],
+    )
+    async def test_fuzzy_title_similarity_in_range(self, cache, target_title, query_title):
         async with cache.pool.acquire() as conn:
             sim = await conn.fetchval(
                 "SELECT similarity(lower(f_unaccent($1)), lower(f_unaccent($2)))",
-                FUZZY_TITLE,
-                COMMON_TITLE,
+                target_title,
+                query_title,
             )
             matches = await conn.fetchval(
                 "SELECT lower(f_unaccent($1)) % lower(f_unaccent($2))",
-                FUZZY_TITLE,
-                COMMON_TITLE,
+                target_title,
+                query_title,
             )
         # Below 1.0 -> the target sorts under the exact-title distractors (RED
         # prune is deterministic). Above the 0.3 default threshold -> it still
         # passes the `%` track filter, so the fix can surface it (GREEN).
-        assert 0.3 < sim < 1.0, f"target sim {sim} out of the (0.3, 1.0) window the RED test needs"
+        assert 0.3 < sim < 1.0, (
+            f"target sim {sim} for {target_title!r} vs {query_title!r} "
+            "out of the (0.3, 1.0) window the RED test needs"
+        )
         assert matches is True
 
 
@@ -279,20 +298,20 @@ class TestIssue801ConcretePin:
     @pytest.mark.asyncio
     async def test_rdj_album_returned_for_milkman_aphex_twin(self, cache):
         async with cache.pool.acquire() as conn:
-            await _seed_distractors(conn, track_title="Milkman")
+            await _seed_distractors(conn, track_title=ISSUE_801_QUERY_TITLE)
             await conn.execute(
                 "INSERT INTO release (id, title) VALUES (972, 'Richard D. James Album')"
             )
             await conn.execute(
-                "INSERT INTO release_track (release_id, sequence, title) "
-                "VALUES (972, 10, 'Milkman (Reprise)')"
+                "INSERT INTO release_track (release_id, sequence, title) VALUES (972, 10, $1)",
+                ISSUE_801_TARGET_TITLE,
             )
             await conn.execute(
                 "INSERT INTO release_artist (release_id, artist_name, extra) "
                 "VALUES (972, 'Aphex Twin', 0)"
             )
 
-        results = await cache.search_releases_by_track("Milkman", "Aphex Twin", 20)
+        results = await cache.search_releases_by_track(ISSUE_801_QUERY_TITLE, "Aphex Twin", 20)
 
         assert [r.release_id for r in results] == [972]
         assert results[0].album == "Richard D. James Album"

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -167,7 +167,7 @@ class TestSearchReleasesByTrack:
 
     @pytest.mark.asyncio
     async def test_query_filters_rta_to_extra_zero(self, cache_service, mock_asyncpg_pool):
-        """The rta join must restrict to main-artist credits.
+        """The CTE ``rta`` credit prefilter must restrict to main-artist credits.
 
         Mirrors the per-track filter in ``validate_track_on_release``: the
         candidate-release ranking should not surface a release just because
@@ -175,14 +175,25 @@ class TestSearchReleasesByTrack:
         requested artist. ``release_track_artist`` rows with ``extra = 1``
         are extra credits (writer / producer / performer) and must not
         participate in the candidate-artist match. See #333.
+
+        The guard is pinned on the ``rta`` EXISTS leg *inside the CTE* (before
+        ``LIMIT $2``) -- the leg that governs which releases survive truncation.
+        A bare ``"rta.extra = 0" in sql`` check would be satisfied by the outer
+        LEFT JOIN's copy of the same clause and pass even if the CTE leg's guard
+        were deleted, which is the failure the prefilter exists to prevent
+        (LML#802 review).
         """
         mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
 
         await cache_service.search_releases_by_track("Song", "Artist")
 
         sql = mock_asyncpg_pool.fetch.call_args[0][0]
-        assert "rta.extra = 0" in sql, (
-            f"Expected `rta.extra = 0` constraint in rta join; got: {sql!r}"
+        cte = sql[: sql.index("LIMIT $2")]
+        rta_leg = "EXISTS (SELECT 1 FROM release_track_artist rta"
+        assert rta_leg in cte, f"Expected the rta EXISTS leg inside the CTE; got: {cte!r}"
+        assert "rta.extra = 0" in cte[cte.index(rta_leg) :], (
+            "The CTE rta EXISTS leg must carry `rta.extra = 0`; the outer LEFT "
+            f"JOIN copy does not protect the truncation set. Got: {cte!r}"
         )
 
     @pytest.mark.asyncio
@@ -286,6 +297,32 @@ class TestSearchReleasesByTrack:
             "artist EXISTS leg must appear inside the CTE, before LIMIT $2"
         )
         assert "lower(f_unaccent(ra.artist_name)) % lower(f_unaccent($3))" in sql[:limit_at]
+        # Companion to the rta.extra = 0 pin: the release-level leg is also
+        # precision-guarded to main-artist credits inside the CTE.
+        assert "ra.extra = 0" in sql[:limit_at], (
+            "the release-level EXISTS leg must carry `ra.extra = 0` before LIMIT $2"
+        )
+
+    def test_artist_variant_outer_block_identical_to_hot_path(self):
+        """The two search strings must share a byte-identical outer block.
+
+        ``_SEARCH_BY_TRACK_ARTIST_SQL`` only adds the artist prefilter inside
+        the CTE; everything from the outer ``SELECT`` onward is copied verbatim
+        from ``_SEARCH_BY_TRACK_SQL`` as a pure subtractive backstop (the
+        display-artist / ``is_compilation`` selection). Nothing else pins them
+        equal -- the snapshot test covers only the None branch -- so if the two
+        outer blocks drift, the artist branch could select or classify a release
+        differently from the hot path with no test noticing (LML#802 review).
+        """
+        anchor = "SELECT r.id as release_id"
+        assert _SEARCH_BY_TRACK_SQL.count(anchor) == 1
+        assert _SEARCH_BY_TRACK_ARTIST_SQL.count(anchor) == 1
+        hot_outer = _SEARCH_BY_TRACK_SQL[_SEARCH_BY_TRACK_SQL.index(anchor) :]
+        artist_outer = _SEARCH_BY_TRACK_ARTIST_SQL[_SEARCH_BY_TRACK_ARTIST_SQL.index(anchor) :]
+        assert hot_outer == artist_outer, (
+            "the artist variant's outer block drifted from the hot path; mirror "
+            "any edit across both SQL strings"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Test-only hardening for the #802 artist-prefilter fix (`search_releases_by_track`), closing three gaps the max-effort review found where a test could stay green while the invariant it names was broken. No production change.

## Changes

**1. Pin the CTE `extra = 0` guard on the leg that matters.** `test_query_filters_rta_to_extra_zero` asserted only `"rta.extra = 0" in sql` — satisfied by the outer `LEFT JOIN`'s copy, so it passed even when the guard on the CTE `rta` EXISTS leg (the leg that decides which releases survive `LIMIT $2`) was deleted. It now slices to the pre-`LIMIT` CTE region and pins the guard there; the push-down test gains a companion `ra.extra = 0` assertion.

**2. Pin outer-block parity.** The two SQL constants share a ~16-line outer block kept byte-identical by hand, but only the None-branch snapshot was pinned. A new test asserts the artist variant's outer block equals the hot path's, so any edit to one must be mirrored.

**3. Floor-pin the real Milkman pair.** The #801 reproduction and the trigram floor-pin both depend on the server `pg_trgm.similarity_threshold`, but only the synthetic `Common Track` pair was pinned. The floor test is now parameterized over the real `Milkman` / `Milkman (Reprise)` pair (measured sim 0.50), and `TestIssue801ConcretePin` reuses the same module constants — so a raised-threshold cluster fails loudly at the boundary instead of the #801 test silently returning `[]`.

## Verification

Both strengthened unit assertions were demonstrated RED against targeted mutations before landing (dropping the CTE `rta.extra = 0` while keeping the outer copy → the strengthened test fails while the old bare-substring check still passes; drifting the artist variant's outer block → the parity test fails). Locally: `ruff check` / `ruff format --check` clean, the full `test_cache_service.py` unit suite (123) green, and `pytest -m pg tests/integration/test_search_by_track_artist_prefilter.py` green (7, incl. both floor-pin parametrizations).

Closes #812