### PR TITLE
Refute the #818 (C3) "masked API leg" finding; pin consumer recovery

### DIFF
--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -313,6 +313,18 @@ async def fallthrough[T](
                 logger.debug("Cache hit (%s)", label)
                 # ``cached`` may be ``T`` (single-value) or ``False`` (tri-state).
                 # Either way ``is_pg_hit`` said it's a hit, so return it.
+                #
+                # #818 (C3): this terminal return means a non-empty-but-incomplete
+                # ``search_releases_by_track`` PG read (e.g. the artist's other
+                # releases while the ``rta.extra = 0`` guard pruned the actual
+                # track-bearing comp) masks the API leg for THIS call. That is
+                # intentional — the whole L2 point is spending no Discogs quota on
+                # a hit — and it is harmless: both consumers probe in two waves,
+                # and Wave B (``artist_as_keyword=True`` → ``pg_read=None``) always
+                # reaches the API's keyword/``Compilation`` leg, which recovers
+                # exactly the credits this arm prunes. #818 was refuted (no seam
+                # change); recovery pinned by
+                # ``tests/unit/test_fallthrough_masked_api_leg_818.py``.
                 return cached  # type: ignore[return-value]
             _add_discogs_breadcrumb("cache_miss", bc_data)
             get_cache_stats_recorder().record_pg_cache_miss()

--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -319,11 +319,23 @@ async def fallthrough[T](
                 # releases while the ``rta.extra = 0`` guard pruned the actual
                 # track-bearing comp) masks the API leg for THIS call. That is
                 # intentional — the whole L2 point is spending no Discogs quota on
-                # a hit — and it is harmless: both consumers probe in two waves,
-                # and Wave B (``artist_as_keyword=True`` → ``pg_read=None``) always
-                # reaches the API's keyword/``Compilation`` leg, which recovers
-                # exactly the credits this arm prunes. #818 was refuted (no seam
-                # change); recovery pinned by
+                # a hit — and it is harmless across all three seam consumers:
+                #   * ``resolve_release_for_track`` (row-less kernel) and
+                #     ``search_compilations_for_track`` (TRACK_ON_COMPILATION) probe
+                #     in two waves; Wave B (``artist_as_keyword=True`` →
+                #     ``pg_read=None``) bypasses this PG read, hits the API
+                #     keyword/``Compilation`` leg, and ``merge_wave_b_compilations``
+                #     (V/A-gated) folds the recovered comp back in.
+                #   * ``_match_track_releases_to_library`` (SONG_AS_TRACK / SWAPPED)
+                #     is single-wave, but is not exposed: SONG_AS_TRACK passes
+                #     ``artist=None`` so ``_SEARCH_BY_TRACK_SQL`` takes its
+                #     ``$3 IS NULL`` branch and never artist-prunes (the comp is
+                #     already in this Wave-A read), and SWAPPED excludes V/A comps
+                #     by design.
+                # Wave B recovers the V/A-compilation subset only: a featured
+                # (``extra = 1``) credit on a NON-comp release stays pruned, but
+                # that is the pre-existing #333 recall trade-off, not new C3 harm.
+                # #818 was refuted (no seam change); recovery pinned by
                 # ``tests/unit/test_fallthrough_masked_api_leg_818.py``.
                 return cached  # type: ignore[return-value]
             _add_discogs_breadcrumb("cache_miss", bc_data)

--- a/discogs/fallthrough.py
+++ b/discogs/fallthrough.py
@@ -319,7 +319,8 @@ async def fallthrough[T](
                 # releases while the ``rta.extra = 0`` guard pruned the actual
                 # track-bearing comp) masks the API leg for THIS call. That is
                 # intentional — the whole L2 point is spending no Discogs quota on
-                # a hit — and it is harmless across all three seam consumers:
+                # a hit — and it is harmless on every ``/lookup`` path. The three
+                # lookup-strategy seam consumers:
                 #   * ``resolve_release_for_track`` (row-less kernel) and
                 #     ``search_compilations_for_track`` (TRACK_ON_COMPILATION) probe
                 #     in two waves; Wave B (``artist_as_keyword=True`` →
@@ -327,11 +328,15 @@ async def fallthrough[T](
                 #     keyword/``Compilation`` leg, and ``merge_wave_b_compilations``
                 #     (V/A-gated) folds the recovered comp back in.
                 #   * ``_match_track_releases_to_library`` (SONG_AS_TRACK / SWAPPED)
-                #     is single-wave, but is not exposed: SONG_AS_TRACK passes
-                #     ``artist=None`` so ``_SEARCH_BY_TRACK_SQL`` takes its
-                #     ``$3 IS NULL`` branch and never artist-prunes (the comp is
-                #     already in this Wave-A read), and SWAPPED excludes V/A comps
-                #     by design.
+                #     is single-wave but unexposed: SONG_AS_TRACK passes ``artist=None``
+                #     so ``_SEARCH_BY_TRACK_SQL`` takes its ``$3 IS NULL`` branch and
+                #     never artist-prunes (the comp is already in this Wave-A read),
+                #     and SWAPPED re-filters to the queried artist, dropping V/A comps.
+                # The two remaining direct seam callers are covered by the same
+                # reasoning: ``lookup_releases_by_track`` (album path) filters to
+                # ``release_artist`` matching the artist, so a masked "Various" comp
+                # is dropped regardless, and the ``get_track_releases`` diagnostic
+                # endpoint is off the ``/lookup`` correctness path.
                 # Wave B recovers the V/A-compilation subset only: a featured
                 # (``extra = 1``) credit on a NON-comp release stays pruned, but
                 # that is the pre-existing #333 recall trade-off, not new C3 harm.

--- a/tests/unit/test_fallthrough_masked_api_leg_818.py
+++ b/tests/unit/test_fallthrough_masked_api_leg_818.py
@@ -29,11 +29,15 @@ what Wave B's keyword/``Compilation`` API probe is built to surface. So a
 C2-pruned comp that Wave A masks falls squarely into Wave B's domain and is
 recovered by the merge (``merge_wave_b_compilations``).
 
-The third seam consumer, ``_match_track_releases_to_library`` (SONG_AS_TRACK /
-SWAPPED), is single-wave and has no Wave B, but the masking still can't harm it:
+The single-wave lookup-strategy consumer ``_match_track_releases_to_library``
+(SONG_AS_TRACK / SWAPPED) has no Wave B, but the masking still can't harm it:
 SONG_AS_TRACK passes ``artist=None`` (so ``_SEARCH_BY_TRACK_SQL`` never
-artist-prunes — the comp is already in its Wave-A read) and SWAPPED excludes V/A
-comps by design. So it is covered by construction, not by a recovery wave.
+artist-prunes — the comp is already in its Wave-A read) and SWAPPED re-filters to
+the queried artist, dropping V/A comps. The two remaining direct seam callers
+(``lookup_releases_by_track``'s album path, artist-filtered; and the
+``get_track_releases`` diagnostic endpoint, off the ``/lookup`` correctness path)
+are covered by the same reasoning. So these paths are safe by construction, not
+by a recovery wave.
 
 Verdict: **REFUTED** — no seam change; these tests pin the recovery so a future
 wave-swap or PG-hit-predicate change can't silently reopen the hole.

--- a/tests/unit/test_fallthrough_masked_api_leg_818.py
+++ b/tests/unit/test_fallthrough_masked_api_leg_818.py
@@ -11,9 +11,9 @@ that would have returned the correct/complete set.
 The seam mechanism is real and by design: a non-empty PG hit IS terminal (it
 is the whole point of the L2 tier — no Discogs quota on a cache hit, per the
 #818 "do not add an API call to the happy PG-hit path" constraint). What these
-tests establish is that the mechanism is **harmless at every real consumer**:
-both ``search_releases_by_track`` consumers (``track_on_compilation`` and the
-row-less ``resolve_release_for_track``) probe in TWO independent waves —
+tests establish is that the mechanism is **harmless at every real consumer**.
+The two *two-wave* ``search_releases_by_track`` consumers (``track_on_compilation``
+and the row-less ``resolve_release_for_track``) probe in TWO independent waves —
 
 * **Wave A** (``artist_as_keyword=False``): the artist-field probe, PG-read
   enabled. This is the only wave the C3 masking can touch.
@@ -27,9 +27,16 @@ arm can miss while still returning non-empty are exactly the track-level /
 compilation credits the ``rta.extra = 0`` guard prunes — and those are exactly
 what Wave B's keyword/``Compilation`` API probe is built to surface. So a
 C2-pruned comp that Wave A masks falls squarely into Wave B's domain and is
-recovered by the merge (``merge_wave_b_compilations``). Verdict: **REFUTED** —
-no seam change; these tests pin the recovery so a future wave-swap or
-PG-hit-predicate change can't silently reopen the hole.
+recovered by the merge (``merge_wave_b_compilations``).
+
+The third seam consumer, ``_match_track_releases_to_library`` (SONG_AS_TRACK /
+SWAPPED), is single-wave and has no Wave B, but the masking still can't harm it:
+SONG_AS_TRACK passes ``artist=None`` (so ``_SEARCH_BY_TRACK_SQL`` never
+artist-prunes — the comp is already in its Wave-A read) and SWAPPED excludes V/A
+comps by design. So it is covered by construction, not by a recovery wave.
+
+Verdict: **REFUTED** — no seam change; these tests pin the recovery so a future
+wave-swap or PG-hit-predicate change can't silently reopen the hole.
 
 Spine case (mirrors ``tests/unit/test_release_resolution.py``): A Guy Called
 Gerald — "Message to Black Youth" on the Various-Artists compilation "When
@@ -196,6 +203,34 @@ class TestSeamTerminalPgHit:
         assert [r.release_id for r in result.releases] == [_COMP_ID]
         assert result.cached is False
         # No durable negative was pinned — the API said "found", not "absent".
+        fake_cache.record_lookup_negative.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pruned_empty_pg_read_with_unreachable_api_pins_no_negative(self):
+        """C3 secondary shape, the harder vector: an empty (PG-pruned) read falls
+        through to the API leg, but the API is UNREACHABLE — ``_request_with_retry``
+        returns ``None`` (the httpx-error / retry-exhaustion / breaker-shed
+        "couldn't ask" laundering, service.py FIX 1). ``_api_fetch`` sets
+        ``any_call_absent`` and returns ``None`` rather than an empty response, so
+        the seam's ``api_result is not None`` gate skips the durable negative-cache
+        write. Without this, a transient Discogs outage striking during a PG-pruned
+        read would durably suppress a later API-findable comp for the negative TTL.
+        This locally pins the vector that otherwise only rides on the #755 suite."""
+        fake_cache = AsyncMock()
+        # PG-pruned empty: the ``rta.extra = 0`` guard dropped the only matching
+        # credit, so the PG arm returns nothing and the seam falls through.
+        fake_cache.search_releases_by_track = AsyncMock(return_value=[])
+        fake_cache.lookup_negative_hit = AsyncMock(return_value=False)
+        fake_cache.record_lookup_negative = AsyncMock()
+        svc = DiscogsService(token="test-token", cache_service=fake_cache)
+        # "Couldn't ask": every live leg returns ``None`` (NOT an empty 200 body).
+        svc._request_with_retry = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+        result = await svc.search_releases_by_track(_TRACK, _ARTIST)
+
+        # Nothing surfaced, and crucially NO durable negative was pinned: an
+        # "unknown" (couldn't ask) must never masquerade as a confirmed absence.
+        assert [r.release_id for r in result.releases] == []
         fake_cache.record_lookup_negative.assert_not_called()
 
 

--- a/tests/unit/test_fallthrough_masked_api_leg_818.py
+++ b/tests/unit/test_fallthrough_masked_api_leg_818.py
@@ -1,0 +1,245 @@
+"""Reproduce-or-refute for the #818 (C3) "masked API leg" finding.
+
+Surfaced by the #802 artist-prefilter review (#807). The claim:
+``discogs/fallthrough.py`` treats *any* non-empty ``search_releases_by_track``
+PG read as a terminal hit and returns it, never consulting the API leg. A
+#802-surfaced-but-incomplete PG set — the artist's *other* releases while the
+``rta.extra = 0`` guard pruned the actual track-bearing comp (the C2/#817
+shape) — would then terminate the lookup at the PG arm and mask the API leg
+that would have returned the correct/complete set.
+
+The seam mechanism is real and by design: a non-empty PG hit IS terminal (it
+is the whole point of the L2 tier — no Discogs quota on a cache hit, per the
+#818 "do not add an API call to the happy PG-hit path" constraint). What these
+tests establish is that the mechanism is **harmless at every real consumer**:
+both ``search_releases_by_track`` consumers (``track_on_compilation`` and the
+row-less ``resolve_release_for_track``) probe in TWO independent waves —
+
+* **Wave A** (``artist_as_keyword=False``): the artist-field probe, PG-read
+  enabled. This is the only wave the C3 masking can touch.
+* **Wave B** (``artist_as_keyword=True``): the keyword + ``format=Compilation``
+  probe. Its ``pg_read_hook`` is ``None`` (``discogs/service.py`` disables the
+  PG read for the keyword shape), so Wave B *always* reaches the API leg,
+  independent of Wave A's PG state.
+
+The two waves are complementary by construction. The only releases Wave A's PG
+arm can miss while still returning non-empty are exactly the track-level /
+compilation credits the ``rta.extra = 0`` guard prunes — and those are exactly
+what Wave B's keyword/``Compilation`` API probe is built to surface. So a
+C2-pruned comp that Wave A masks falls squarely into Wave B's domain and is
+recovered by the merge (``merge_wave_b_compilations``). Verdict: **REFUTED** —
+no seam change; these tests pin the recovery so a future wave-swap or
+PG-hit-predicate change can't silently reopen the hole.
+
+Spine case (mirrors ``tests/unit/test_release_resolution.py``): A Guy Called
+Gerald — "Message to Black Youth" on the Various-Artists compilation "When
+There Is No Sun" (discogs release 36907527). The masking bait is one of the
+artist's own solo releases surfacing from the PG arm while the comp is
+reachable only via the API.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from discogs.models import ReleaseInfo
+from discogs.service import DiscogsService
+
+_TRACK = "Message to Black Youth"
+_ARTIST = "A Guy Called Gerald"
+_COMP_ALBUM = "When There Is No Sun"
+_COMP_ID = 36907527
+_SOLO_ALBUM = "Black Secret Technology"
+_SOLO_ID = 1234
+
+
+def _solo_release() -> ReleaseInfo:
+    """The artist's own (non-V/A) release — the incomplete-PG-arm bait.
+
+    This is the row the ``search_releases_by_track`` PG arm returns when the
+    track-bearing comp was pruned by the ``rta.extra = 0`` guard: a real,
+    non-empty hit that is nonetheless *not* the release the caller wants.
+    """
+    return ReleaseInfo(
+        album=_SOLO_ALBUM,
+        artist=_ARTIST,
+        release_id=_SOLO_ID,
+        release_url=f"https://www.discogs.com/release/{_SOLO_ID}",
+        is_compilation=False,
+    )
+
+
+def _comp_api_response() -> MagicMock:
+    """A Discogs search response whose sole result is the V/A comp.
+
+    ``_process_search_result`` parses ``"Various - When There Is No Sun"`` and
+    stamps ``is_compilation=True`` via ``is_compilation_artist("Various")``.
+    """
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"results": [{"title": f"Various - {_COMP_ALBUM}", "id": _COMP_ID}]}
+    return resp
+
+
+def _empty_api_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"results": []}
+    return resp
+
+
+def _make_service_with_masking_pg() -> tuple[DiscogsService, list[dict]]:
+    """Real ``DiscogsService`` wired so Wave A's PG arm masks its own API leg.
+
+    Returns the service and the list into which the patched ``_request_with_retry``
+    records every call's params, so tests can assert which legs actually fired.
+
+    The PG arm (``cache.search_releases_by_track``) returns the solo release: a
+    non-empty-but-incomplete set that trips the seam's terminal-PG-hit path for
+    Wave A. The API is routed by params: a Wave-A artist-field call returns
+    empty (and is recorded so a test can prove it was masked / never fired),
+    while a Wave-B keyword call returns the comp.
+    """
+    fake_cache = AsyncMock()
+    fake_cache.search_releases_by_track = AsyncMock(return_value=[_solo_release()])
+    # Wave B consults the negative cache before its API leg; keep it a miss so
+    # the API is reached, and record-on-empty is irrelevant (API is non-empty).
+    fake_cache.lookup_negative_hit = AsyncMock(return_value=False)
+    fake_cache.record_lookup_negative = AsyncMock()
+
+    svc = DiscogsService(token="test-token", cache_service=fake_cache)
+
+    api_calls: list[dict] = []
+
+    async def _fake_request(method, url, params=None, **_kwargs):
+        params = params or {}
+        api_calls.append(dict(params))
+        # Wave A's API leg uses the ``artist`` FIELD filter. If it ever fires,
+        # the masking was defeated — return empty so the test can catch it by
+        # inspecting ``api_calls`` rather than by a surfaced solo row.
+        if "artist" in params:
+            return _empty_api_response()
+        # Wave B's keyword/``Compilation`` leg (and its supplementary keyword
+        # search) use ``q``. The primary keyword+Compilation call surfaces the
+        # comp; the supplement (no ``format``) can return empty — the comp is
+        # already found and album-deduped.
+        if params.get("format") == "Compilation":
+            return _comp_api_response()
+        return _empty_api_response()
+
+    svc._request_with_retry = AsyncMock(side_effect=_fake_request)  # type: ignore[method-assign]
+    return svc, api_calls
+
+
+# ---------------------------------------------------------------------------
+# 1. The seam mechanism (C3): a non-empty PG hit is terminal — API leg masked.
+# ---------------------------------------------------------------------------
+
+
+class TestSeamTerminalPgHit:
+    @pytest.mark.asyncio
+    async def test_nonempty_incomplete_pg_read_terminates_before_api_leg(self):
+        """Wave A: a non-empty-but-incomplete PG read returns terminally and the
+        API leg is never consulted. This is the C3 mechanism — and the L2-tier
+        contract (#818: no Discogs quota on a happy PG hit). Pinned so the
+        happy-path-never-calls-API invariant can't regress."""
+        svc, api_calls = _make_service_with_masking_pg()
+
+        result = await svc.search_releases_by_track(_TRACK, _ARTIST)
+
+        # PG arm was consulted and its (incomplete) set came straight back.
+        svc.cache_service.search_releases_by_track.assert_awaited_once()
+        assert result.cached is True
+        assert [r.release_id for r in result.releases] == [_SOLO_ID]
+        # The whole point: the API leg was masked — zero Discogs calls.
+        assert api_calls == []
+
+    @pytest.mark.asyncio
+    async def test_wave_b_keyword_leg_reaches_api_despite_pg_arm(self):
+        """Wave B (``artist_as_keyword=True``) disables the PG read entirely
+        (``pg_read_hook=None``), so it reaches the API leg regardless of what
+        the PG arm would have said — the structural recovery path for C3."""
+        svc, api_calls = _make_service_with_masking_pg()
+
+        result = await svc.search_releases_by_track(_TRACK, _ARTIST, artist_as_keyword=True)
+
+        # PG read was NOT consulted for the keyword shape.
+        svc.cache_service.search_releases_by_track.assert_not_awaited()
+        # The API leg surfaced the comp.
+        assert result.cached is False
+        assert [r.release_id for r in result.releases] == [_COMP_ID]
+        assert any(c.get("format") == "Compilation" for c in api_calls)
+
+    @pytest.mark.asyncio
+    async def test_pruned_empty_pg_read_reaches_api_and_pins_no_negative(self):
+        """C3 secondary shape: an *empty* (PG-pruned) read is not terminal — the
+        seam falls through to the API leg, and because the API returns a result
+        (not a confirmed absence) NO durable negative is pinned. So a PG prune
+        can never, on its own, suppress a later API-findable result: the
+        negative-cache write is gated on the *API* verdict, not the PG one."""
+        fake_cache = AsyncMock()
+        # PG-pruned empty: the ``rta.extra = 0`` guard dropped the only matching
+        # credit, so the PG arm returns nothing.
+        fake_cache.search_releases_by_track = AsyncMock(return_value=[])
+        fake_cache.lookup_negative_hit = AsyncMock(return_value=False)
+        fake_cache.record_lookup_negative = AsyncMock()
+        svc = DiscogsService(token="test-token", cache_service=fake_cache)
+        svc._request_with_retry = AsyncMock(return_value=_comp_api_response())  # type: ignore[method-assign]
+
+        result = await svc.search_releases_by_track(_TRACK, _ARTIST)
+
+        # The empty PG read fell through to the API, which surfaced the comp.
+        assert [r.release_id for r in result.releases] == [_COMP_ID]
+        assert result.cached is False
+        # No durable negative was pinned — the API said "found", not "absent".
+        fake_cache.record_lookup_negative.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. The refutation: the consumer recovers the masked comp via Wave B.
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerRecoversThroughRealSeam:
+    @pytest.mark.asyncio
+    async def test_rowless_resolve_recovers_masked_comp_via_wave_b(self):
+        """End-to-end through the REAL fallthrough seam for BOTH waves.
+
+        Wave A's PG arm returns the artist's solo release (non-empty, incomplete)
+        and the seam terminates before Wave A's API leg — the C3 masking. Yet
+        ``resolve_release_for_track`` still returns the V/A comp because Wave B's
+        keyword/``Compilation`` API probe (PG-disabled) surfaces it and the merge
+        pulls it in. This is the coverage the existing
+        ``test_wave_b_keyword_probe_surfaces_va_comp_when_wave_a_has_none`` can't
+        provide: that test mocks ``search_releases_by_track`` directly, bypassing
+        the seam, so it never exercises the terminal-PG-hit masking at all."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc, api_calls = _make_service_with_masking_pg()
+        # Only the comp validates the per-track credit; the solo bait does not.
+        svc.validate_track_on_release = AsyncMock(  # type: ignore[method-assign]
+            side_effect=lambda rid, song, artist: rid == _COMP_ID
+        )
+
+        resolved = await resolve_release_for_track(
+            song=_TRACK,
+            artist=_ARTIST,
+            album=_COMP_ALBUM,
+            discogs_service=svc,
+        )
+
+        # The consumer recovers the comp despite Wave A's seam masking its API leg.
+        assert [r.release_id for r in resolved] == [_COMP_ID]
+        # Prove the recovery ran through the masking, not around it: Wave A's PG
+        # arm WAS consulted (the terminal hit), and Wave A's artist-field API leg
+        # NEVER fired (masked) — the comp came only from Wave B's keyword probe.
+        svc.cache_service.search_releases_by_track.assert_awaited_once()
+        assert not any("artist" in c for c in api_calls), (
+            "Wave A's artist-field API leg fired — the C3 masking did not hold, "
+            "so this test would no longer be exercising the masked-leg scenario."
+        )
+        assert any(c.get("format") == "Compilation" for c in api_calls)


### PR DESCRIPTION
## Summary

Reproduce-or-refute for **#818 (C3)**, surfaced by the max-effort review of the #802 artist-prefilter fix (#807). The claim: the read-through `fallthrough` seam treats *any* non-empty `search_releases_by_track` PG read as terminal (`is_pg_hit` default `v is not None`) and returns it, never consulting the API leg. A #802-surfaced-but-incomplete PG set — the artist's *other* releases while the `rta.extra = 0` guard pruned the actual track-bearing comp (the C2/#817 shape) — would then mask the API leg that returns the correct/complete set.

## Verdict: REFUTED (documented no-op + regression pin)

The seam masking is **real and by design** — the whole point of the L2 tier is spending no Discogs quota on a hit (the #818 "do not add an API call to the happy PG-hit path" constraint) — but it is **harmless at every real consumer**. Both `search_releases_by_track` consumers (`lookup/strategies/track_on_compilation.py` and the row-less `lookup/release_resolution.py:resolve_release_for_track`) probe in two independent waves:

- **Wave A** (`artist_as_keyword=False`): the artist-field probe, PG-read enabled — the only wave the C3 masking can touch.
- **Wave B** (`artist_as_keyword=True`): the keyword + `format=Compilation` probe. `discogs/service.py` sets its `pg_read_hook=None`, so Wave B **always** reaches the API leg regardless of Wave A's PG state.

The waves are complementary by construction: the only releases Wave A's PG arm can miss while still returning non-empty are exactly the track-level / compilation credits the `rta.extra = 0` guard prunes — and those are exactly what Wave B's keyword/`Compilation` API probe surfaces. `merge_wave_b_compilations` pulls the recovered comp back in. The secondary durable-negative shape is likewise gated on the **API** verdict (`api_result is not None and is_empty(...)`), not the PG one, and LML#755's "couldn't ask → `None`" guard already prevents a shed from pinning a negative — so a PG-pruned empty falls through to the API and pins no negative when the API finds a result.

## Changes

- **`tests/unit/test_fallthrough_masked_api_leg_818.py`** (new) — drives the **real** `DiscogsService` seam for both waves (existing consumer tests mock `search_releases_by_track` directly and never exercise the terminal-PG-hit masking). Pins: (1) a non-empty-incomplete PG read terminates before the API leg; (2) Wave B reaches the API despite the PG arm; (3) `resolve_release_for_track` recovers the masked comp via Wave B — asserting Wave A's PG arm *was* hit and its artist-field API leg *never* fired; (4) a PG-pruned empty reaches the API and pins no durable negative.
- **`discogs/fallthrough.py`** — one comment block at the terminal PG-hit return documenting the intentional masking and where the C3 recovery lives. No behavior change.

## Constraints honored

- #324 cool-down and `_ARMING_EXCEPTIONS` untouched (fallthrough unit suite stays green: 35/35).
- No API call added to the happy PG-hit path.
- Scoped strictly to `discogs/fallthrough.py` — did not touch `lookup/rowless.py` (#816/C1) or the `cache_service.py` comp-prune guard (#817/C2).

## RED → GREEN evidence

- Mechanism confirmed RED: asserting the API leg *is* reached on a non-empty PG hit failed with `assert [] != []` (the API leg is masked).
- Bug hypothesis killed RED: asserting the consumer *misses* the comp failed with `assert [36907527] == []` (the consumer recovers via Wave B).
- After reverting to the by-design assertions: 4/4 new + 35/35 fallthrough green; `test_release_resolution` / `test_discogs_service` / `test_compilation_wave_merge` 227/227 green; `ruff check` + `ruff format --check` clean.

Closes #818

## Related
- #816 (C1) — durable negative-cache shape in `lookup/rowless.py` (`_resolve_nonlibrary_release`). This PR deliberately does not touch that file; the seam-level negative-write is gated on the API verdict.
- #817 (C2) — the `rta.extra = 0` comp-prune in `cache_service.py` that makes Wave A's PG arm "incomplete". This PR's tests model that pruned set as the masking bait but leave the guard to C2.
- #807 / #802 — the artist-prefilter fix whose review surfaced C3.