### PR TITLE
fix(#816): don't pin a durable known-miss on a truncated (crowd-out) bounded resolve

### DIFF
--- a/lookup/release_resolution.py
+++ b/lookup/release_resolution.py
@@ -243,6 +243,7 @@ async def resolve_release_for_track(
     *,
     also_probe_album_title: bool = False,
     max_validations: int | None = None,
+    truncated_out: list[bool] | None = None,
 ) -> list[ResolvedRelease]:
     """Find and validate the Discogs release(s) a track sits on.
 
@@ -268,6 +269,17 @@ async def resolve_release_for_track(
       case. Sequential (not concurrent) to minimize Discogs quota — the binding
       constraint — and degrade gently under the fallthrough seam's rate-limit
       cool-down. (See the #625 decision record.)
+
+    ``truncated_out`` is an optional out-parameter for the bounded path (LML#816).
+    When a list is passed, the resolver appends a single ``bool`` recording whether
+    the id-having candidate set exceeded ``max_validations`` — i.e. whether some
+    surfaced candidates were never validated. An empty result with ``truncated_out
+    == [True]`` may be a *crowd-out* (a resolvable release sorted outside the
+    window) rather than a true exhaustion; the row-less kernel reads this to avoid
+    pinning a durable known-miss over a release it never actually ruled out. It is
+    only populated in bounded mode (``max_validations is not None``); the default
+    validate-all path leaves it untouched, since it validates every candidate and
+    can never truncate.
 
     When ``also_probe_album_title`` is set and ``album`` is non-empty, a third
     album-title probe (``search_releases_by_album_title``) joins the Wave A/B
@@ -376,6 +388,12 @@ async def resolve_release_for_track(
         # Falsy-id rows can never be validated, so drop them before counting the
         # budget — they must not consume an attempt slot.
         ranked = prerank_candidates_for_validation([r for r in candidates if r.release_id], album)
+        if truncated_out is not None:
+            # LML#816: record whether the window was smaller than the candidate
+            # set — an empty result under truncation is a possible crowd-out, not
+            # a confirmed exhaustion. Recorded before the loop so it is set on
+            # every bounded outcome (empty or hit), keeping the sink single-valued.
+            truncated_out.append(len(ranked) > max_validations)
         for release in ranked[:max_validations]:
             resolved = await _validate_one(release)
             if resolved is not None:

--- a/lookup/rowless.py
+++ b/lookup/rowless.py
@@ -222,7 +222,11 @@ async def _resolve_nonlibrary_release(
        coalesce with a default ``[]`` (the #633 landmine). Cold-cache
        durability comes from the #632 PG cache here instead.
     3. **#632 cache write-back** — the resolved id, or ``None`` to record a known
-       miss so the next identical add short-circuits.
+       miss so the next identical add short-circuits. A known miss is pinned only
+       when the empty resolve was *exhaustive*; an empty from a candidate set
+       truncated at the ``max_validations`` cap (a possible #802-amplified
+       crowd-out) is left unpinned so a resolvable release is not durably
+       suppressed for the miss TTL (LML#816).
 
     ``pg`` is best-effort: ``None`` (or a PG failure, swallowed inside the cache
     helpers) degrades to an uncached bounded resolve. ``album`` (often absent on
@@ -250,6 +254,12 @@ async def _resolve_nonlibrary_release(
             # demote it on a transient outage.
             cached_positive_unhydrated = True
 
+    # LML#816: ``truncated_out`` reports whether the bounded resolve validated
+    # fewer candidates than it surfaced (the id-having set exceeded the cap). An
+    # empty result under truncation may be a *crowd-out* — a resolvable release
+    # sorted outside the 5-candidate window, an effect #802's improved recall
+    # amplifies — rather than a confirmed miss.
+    truncated_out: list[bool] = []
     candidates = await resolve_release_for_track(
         song,
         artist,
@@ -257,15 +267,34 @@ async def _resolve_nonlibrary_release(
         discogs_service,
         also_probe_album_title=bool(album),
         max_validations=5,
+        truncated_out=truncated_out,
     )
     best = candidates[0] if candidates else None
+    # Default to "not truncated" when the sink was left unpopulated (a monkeypatched
+    # resolver in tests, or any non-bounded path), so the pin policy is unchanged
+    # for every case that can't be a crowd-out.
+    bounded_resolve_truncated = bool(truncated_out and truncated_out[0])
 
-    # Never overwrite a known-good cached id with a miss: if we already held a
-    # positive entry that merely failed to re-hydrate (transient get_release /
-    # validate outage) and the live resolve also came up empty, leave the
-    # positive entry intact so it self-heals once the outage clears — rather
-    # than pinning a 7-day miss over good data.
-    if pg is not None and not (cached_positive_unhydrated and best is None):
+    # Two guards protect against pinning a durable known-miss over a release that
+    # is actually resolvable:
+    #
+    # * self-heal (LML#628): if we already held a positive entry that merely
+    #   failed to re-hydrate (transient get_release / validate outage) and the
+    #   live resolve also came up empty, leave the positive intact so it heals
+    #   once the outage clears — never demote good data to a 7-day miss.
+    # * crowd-out (LML#816): if the empty came from a *truncated* candidate set,
+    #   the correct release may simply have sorted past the validation window;
+    #   pinning here would durably suppress it for the miss TTL. Skip the write so
+    #   the next add re-probes; a genuine exhaustion (candidate set NOT truncated,
+    #   so every candidate was tried and failed) still pins below. A positive
+    #   (``best is not None``) is always written — both guards gate on
+    #   ``best is None`` and so never suppress a real resolution.
+    suppress_crowd_out_miss = best is None and bounded_resolve_truncated
+    if (
+        pg is not None
+        and not (cached_positive_unhydrated and best is None)
+        and not suppress_crowd_out_miss
+    ):
         await set_cached_release_id(
             pg,
             artist=artist,

--- a/tests/unit/test_nonlibrary_release_resolution.py
+++ b/tests/unit/test_nonlibrary_release_resolution.py
@@ -234,6 +234,145 @@ async def test_cold_miss_writes_known_miss_to_cache(monkeypatch):
     assert pg.store[(ARTIST.lower(), TRACK.lower(), True)] is None
 
 
+# ---------------------------------------------------------------------------
+# LML#816: a bounded-resolve empty that is a crowd-out (candidate set truncated
+# at the max_validations cap) must NOT pin a durable 7-day known-miss.
+# ---------------------------------------------------------------------------
+
+# A resolvable non-library release whose Discogs id sorts *after* the crowd-out
+# distractors. The bounded no-album prerank orders by ``release_id`` ascending,
+# so a large id lands last — outside the 5-candidate validation window once six
+# lower-id distractors precede it.
+CROWDOUT_CORRECT_ID = RELEASE_ID  # 36907527, far above the distractor ids
+
+
+def _crowdout_distractor(release_id: int) -> ReleaseInfo:
+    """A candidate Discogs surfaces for the artist+track query that does NOT
+    actually carry the track's per-track credit (fails validation). Non-comp so
+    the no-album prerank keys purely on ``release_id``."""
+    return ReleaseInfo(
+        album=f"Unrelated Release {release_id}",
+        artist=ARTIST,
+        release_id=release_id,
+        release_url=f"https://www.discogs.com/release/{release_id}",
+        is_compilation=False,
+    )
+
+
+def _crowdout_correct() -> ReleaseInfo:
+    return ReleaseInfo(
+        album=ALBUM,
+        artist=ARTIST,
+        release_id=CROWDOUT_CORRECT_ID,
+        release_url=RELEASE_URL,
+        is_compilation=False,
+    )
+
+
+def _crowdout_service() -> AsyncMock:
+    """A Discogs service whose track probe first returns six distractors ahead of
+    the correct release (a transient crowd-out), then — once ``cleared`` — returns
+    only the correct release. ``validate_track_on_release`` passes solely for the
+    correct id, so on the crowd-out pass the top-5 pre-ranked candidates all fail
+    and the correct release (sorted 7th by id) never enters the window."""
+    svc = AsyncMock()
+    svc.cache_service = None
+    svc.validate_track_on_release = AsyncMock(
+        side_effect=lambda rid, song, artist: rid == CROWDOUT_CORRECT_ID
+    )
+    svc.search_releases_by_album_title = AsyncMock(return_value=_empty_track_releases())
+    svc.get_release = AsyncMock(
+        return_value=ReleaseMetadataResponse(
+            release_id=CROWDOUT_CORRECT_ID,
+            title=ALBUM,
+            artist=ARTIST,
+            release_url=RELEASE_URL,
+            artwork_url="https://i.discogs.com/sun.jpg",
+        )
+    )
+
+    correct = _crowdout_correct()
+    distractors = [_crowdout_distractor(i) for i in range(1, 7)]  # ids 1..6
+    state = {"cleared": False}
+
+    def _search(track, artist, *_a, **_k):
+        releases = [correct] if state["cleared"] else [*distractors, correct]
+        return TrackReleasesResponse(
+            track=track, artist=artist, releases=list(releases), total=len(releases), cached=False
+        )
+
+    svc.search_releases_by_track = AsyncMock(side_effect=_search)
+    svc._crowdout_state = state
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_crowdout_empty_does_not_durably_suppress_resolvable_release():
+    """A bounded-resolve empty produced by a *transient* crowd-out (more true
+    candidates surfaced than the max_validations=5 window validates, per #802's
+    improved recall) must NOT be pinned as a 7-day known-miss.
+
+    Otherwise the durable negative short-circuits the very next add — turning a
+    one-off truncation into a week-long suppression of a release that is actually
+    resolvable once the crowd-out clears. This is finding C1 of the #807 review.
+    """
+    svc = _crowdout_service()
+    pg = _RecordingPg()
+
+    # First add: six distractors sort ahead of the correct release (id 36907527)
+    # and all fail per-track validation, so the bounded resolve exhausts its
+    # 5-attempt budget without ever reaching the correct release → empty.
+    first = await _resolve_nonlibrary_release(
+        svc, pg, song=TRACK, artist=ARTIST, album=None, is_track=True
+    )
+    assert first is None
+    # The empty came from a TRUNCATED candidate set (7 surfaced > cap 5), so it
+    # must NOT be pinned as a durable known-miss.
+    assert (ARTIST.lower(), TRACK.lower(), True) not in pg.store
+
+    # The transient clears: the distractors are gone and the correct release is
+    # now the sole, resolvable candidate.
+    svc._crowdout_state["cleared"] = True
+
+    # A second identical add must surface the correct release — not be suppressed
+    # by a negative pinned on the first (crowd-out) attempt.
+    second = await _resolve_nonlibrary_release(
+        svc, pg, song=TRACK, artist=ARTIST, album=None, is_track=True
+    )
+    assert second is not None
+    assert second.release_id == CROWDOUT_CORRECT_ID
+    # And now that it genuinely resolved, a POSITIVE is cached.
+    assert pg.store[(ARTIST.lower(), TRACK.lower(), True)] == CROWDOUT_CORRECT_ID
+
+
+@pytest.mark.asyncio
+async def test_exhausted_empty_within_cap_still_pins_known_miss():
+    """The #816 fix is surgical: an empty whose whole candidate set fit inside the
+    cap (every candidate validated and failed) is a genuine exhaustion, so the
+    durable known-miss is still pinned — preserving the #632 amortization contract
+    for truly-unresolvable adds."""
+    svc = _crowdout_service()
+    # Only three distractors this time (≤ cap), none of which validate, and no
+    # correct release — a genuinely exhaustive empty.
+    three = [_crowdout_distractor(i) for i in range(1, 4)]
+    svc.search_releases_by_track = AsyncMock(
+        return_value=TrackReleasesResponse(
+            track=TRACK, artist=ARTIST, releases=three, total=3, cached=False
+        )
+    )
+    svc.validate_track_on_release = AsyncMock(return_value=False)
+    pg = _RecordingPg()
+
+    result = await _resolve_nonlibrary_release(
+        svc, pg, song=TRACK, artist=ARTIST, album=None, is_track=True
+    )
+
+    assert result is None
+    # 3 candidates ≤ cap 5 → exhaustive, not truncated → known-miss pinned.
+    assert pg.execute_calls == 1
+    assert pg.store[(ARTIST.lower(), TRACK.lower(), True)] is None
+
+
 @pytest.mark.asyncio
 async def test_breaker_shed_does_not_pin_a_known_miss(monkeypatch):
     """LML#755 FIX 1: when the bounded resolve is shed by an OPEN breaker

--- a/tests/unit/test_release_resolution.py
+++ b/tests/unit/test_release_resolution.py
@@ -548,6 +548,67 @@ class TestBoundedEarlyExit:
         assert [r.release_id for r in resolved] == [30]
         assert svc.validate_track_on_release.await_args.args[0] == 30
 
+    @pytest.mark.asyncio
+    async def test_bounded_reports_truncation_when_candidates_exceed_cap(self):
+        """LML#816: the bounded path reports (via ``truncated_out``) that its
+        candidate set was truncated at the cap — 8 id-having candidates surfaced,
+        only 5 validated — so an empty result may be a crowd-out (a resolvable
+        release sorted outside the window) rather than a true exhaustion. The
+        row-less kernel uses this to decide whether to pin a durable known-miss."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(return_value=_track_response(*_eight_candidates()))
+        svc.validate_track_on_release = AsyncMock(return_value=False)
+
+        truncated: list[bool] = []
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+            max_validations=5,
+            truncated_out=truncated,
+        )
+
+        assert resolved == []
+        assert svc.validate_track_on_release.await_count == 5
+        # 8 candidates > cap of 5 → the empty came from a truncated set.
+        assert truncated == [True]
+
+    @pytest.mark.asyncio
+    async def test_bounded_reports_no_truncation_when_within_cap(self):
+        """LML#816: when the whole candidate set fits inside the cap and still
+        validates nothing, the empty is a genuine exhaustion — every candidate was
+        tried — so ``truncated_out`` reports ``False`` and the kernel is free to
+        pin the durable known-miss."""
+        from lookup.release_resolution import resolve_release_for_track
+
+        svc = AsyncMock()
+        svc.search_releases_by_track = AsyncMock(
+            return_value=_track_response(
+                _va_comp(release_id=10, album="Comp A"),
+                _va_comp(release_id=20, album="Comp B"),
+                _va_comp(release_id=30, album="Comp C"),
+            )
+        )
+        svc.validate_track_on_release = AsyncMock(return_value=False)
+
+        truncated: list[bool] = []
+        resolved = await resolve_release_for_track(
+            song="Message to Black Youth",
+            artist="A Guy Called Gerald",
+            album="When There Is No Sun",
+            discogs_service=svc,
+            max_validations=5,
+            truncated_out=truncated,
+        )
+
+        assert resolved == []
+        assert svc.validate_track_on_release.await_count == 3
+        # 3 candidates ≤ cap of 5 → nothing was skipped → exhaustive empty.
+        assert truncated == [False]
+
 
 class TestValidateReleaseForTrack:
     """The shared validate+telemetry primitive both strategies delegate to."""


### PR DESCRIPTION
## Summary

Finding **C1** from the max-effort review of the #802 artist-prefilter fix (#807). Classified PLAUSIBLE (real mechanism, uncertain trigger) — this is a reproduce-or-refute. **Verdict: REAL.** A transient crowd-out at the `max_validations=5` cap reproduces, and the current write-back pins it as a durable ~7-day known-miss.

### The mechanism

`_resolve_nonlibrary_release` (`lookup/rowless.py`) runs a **bounded** validate — `resolve_release_for_track(..., max_validations=5)` — on a cold cache, and on an empty result writes a durable `set_cached_release_id(..., release_id=None)`. Layer 1 then short-circuits (`was_present=True, release_id=None` → return `None`, no live probe) for the ~7-day miss TTL.

An empty bounded resolve has two very different causes:
- **Exhaustion** — every surfaced candidate was validated and failed (a real "no release").
- **Crowd-out** — more candidates were surfaced than the 5-attempt window could validate, so the correct release sorted *outside* the window and was never tried. The #802 recall improvement admits more true candidates ahead of the truncation, making this shape more likely.

Pinning a full-TTL known-miss on a crowd-out turns a *one-off* truncation (a transient distractor burst, a validate hiccup) into a **week-long suppression** of a release that is actually resolvable. The pre-existing self-heal guard only protected a previously-cached *positive* that failed to re-hydrate; a genuinely-empty bounded resolve still pinned the negative.

### The fix (option 3: skip the negative write on a truncated candidate set)

- `resolve_release_for_track` gains an optional `truncated_out: list[bool]` out-parameter. In bounded mode it appends a single bool recording whether the id-having candidate set exceeded the cap (some candidates were never validated). Default `None` → the validate-all path and its callers (`resolve_release_for_track_cached`, `lookup/artwork.py`) are byte-for-byte unchanged.
- The kernel reads that flag and **skips the negative write when the empty came from a truncated set**, so the next identical add re-probes instead of returning a stale miss. A genuine exhaustion (candidate set at or below the cap, every candidate tried) still pins the known-miss, preserving the #632 amortization contract.

### Constraints honored

- **Self-heal guard preserved** — a positive that failed to re-hydrate is still never demoted; both guards gate on `best is None`, so a real resolution is never suppressed.
- **#633 landmine not regressed** — still the uncached bounded resolver, never `resolve_release_for_track_cached`.
- **Hot path** — the truncation flag is read from the already-computed ranked-candidate length; no extra Discogs calls, and the positive early-exit path is unchanged.
- **#632 positive-cache read semantics** — unchanged.

### Tests (TDD: RED → GREEN)

- `test_crowdout_empty_does_not_durably_suppress_resolvable_release` (kernel) — seeds six distractors that fail validation ahead of the correct release (sorted 7th by id, outside the window). Asserts the first resolve is empty but pins **no** durable miss, and a second add (transient cleared) returns the correct release and caches the positive. RED before the fix (the durable `release_id=None` was pinned and short-circuited the second add).
- `test_exhausted_empty_within_cap_still_pins_known_miss` (kernel) — three distractors (≤ cap), all fail, no correct release → still pins the known-miss. Proves the fix is surgical.
- `test_bounded_reports_truncation_when_candidates_exceed_cap` / `test_bounded_reports_no_truncation_when_within_cap` (resolver) — pin the `truncated_out` signal (8 > 5 → `[True]`; 3 ≤ 5 → `[False]`).

Full unit suite (3652) + kernel integration tests green; `ruff check` / `ruff format --check` clean.

## Scope note

The durable-negative POLICY change lives in `lookup/rowless.py`'s write-back. The `truncated_out` plumbing in `lookup/release_resolution.py` is the minimal additive signal the write-back needs (options 2/3 in the ticket both reference "the returned candidate count"). No sibling-owned files touched.

Closes #816

## Related

- #818 (C3) — the same durable-negative shape at the `discogs/fallthrough.py` seam. Owned by a parallel change; deliberately untouched here.
- #817 (C2) — the V/A-comp prune in `track_on_compilation.py` / `cache_service.py`. Untouched here.
- Surfaced by the #807 review of the #802 artist-prefilter fix.