### PR TITLE
feat(#824): pin crowd-out bounded-resolve empties as short-TTL misses

### DIFF
--- a/entity/release_resolution_cache.py
+++ b/entity/release_resolution_cache.py
@@ -29,7 +29,8 @@ two-channel decision). ``is_track`` discriminates the two channels: ``True`` for
 a ``(artist, track)`` resolution, ``False`` for ``(artist, album)``.
 
 Staleness is a SQL-side filter (mirroring ``discogs/cache_service.py`` and the
-streaming cache), but with a **dual TTL** that diverges from the streaming
+streaming cache), but with a **tiered TTL** — a positive TTL, a known-miss TTL,
+and (LML#824) a short crowd-out-miss TTL — that diverges from the streaming
 template's eternal-hit policy:
 
 * ``release_id IS NOT NULL`` AND ``resolved_at > now() - positive_ttl`` —
@@ -190,12 +191,14 @@ class ReleaseResolution:
     * ``was_present=True`` and ``release_id`` is an ``int`` — a fresh resolution
       inside ``positive_ttl``. Short-circuit with this ``release_id``.
     * ``was_present=True`` and ``release_id is None`` — a fresh **known miss**
-      inside ``miss_ttl``. Short-circuit: the live probe already came up empty
-      recently, so skip it.
+      inside its TTL (``miss_ttl`` for an exhausted miss, or the shorter
+      ``crowd_out_miss_ttl`` for a LML#824 crowd-out miss). Short-circuit: the
+      live probe already came up empty recently, so skip it.
     * ``was_present=False`` (``release_id`` always ``None``) — no fresh row: the
       entry is absent, the positive hit aged past ``positive_ttl``, or the miss
-      aged past ``miss_ttl``. Run the live probe. The SQL WHERE collapses all
-      three into this shape, so the caller can't (and needn't) tell them apart.
+      aged past its TTL (``miss_ttl``, or ``crowd_out_miss_ttl`` for a crowd-out
+      miss). Run the live probe. The SQL WHERE collapses all these into this
+      shape, so the caller can't (and needn't) tell them apart.
     """
 
     release_id: int | None

--- a/entity/release_resolution_cache.py
+++ b/entity/release_resolution_cache.py
@@ -47,6 +47,14 @@ template's eternal-hit policy:
   Filtered out; the caller falls through to a live probe. The stale row stays
   and the next probe's UPSERT refreshes it in place.
 
+LML#824 adds a third miss flavor via the ``crowd_out`` marker column. A miss
+written with ``crowd_out = true`` (the bounded resolve truncated its candidate
+set, so the release that would resolve may just have sorted past the window) is
+honored on a much shorter ``crowd_out_miss_ttl`` (~1h) instead of the 7-day
+``miss_ttl`` — long enough to absorb a re-add burst, short enough to self-heal a
+transient crowd-out. Normal exhausted misses (``crowd_out = false``, the default)
+and every positive keep their existing TTLs.
+
 ``get_cached_release_id`` therefore returns a three-valued ``ReleaseResolution``:
 ``was_present=True, release_id=<int>`` (fresh hit), ``was_present=True,
 release_id=None`` (fresh known miss — skip the probe), or ``was_present=False,
@@ -97,6 +105,17 @@ DEFAULT_POSITIVE_TTL = timedelta(days=90)
 # enough that a newly-cataloged release becomes resolvable within a week.
 DEFAULT_MISS_TTL = timedelta(days=7)
 
+# LML#824: how long a *crowd-out* miss stays authoritative. A crowd-out empty
+# (the bounded resolve truncated its candidate set at ``max_validations`` — the
+# release that would resolve may simply have sorted past the window, an effect
+# #802's recall amplifies) is neither a confirmed miss (don't pin the full 7d,
+# which would suppress a resolvable release) nor safe to leave unpinned (that
+# re-probes on *every* subsequent add — the daily flowsheet-backfill flood
+# re-adds the same tracks, LML#706 / BS#1591). A short TTL splits the
+# difference: long enough to absorb one flood pass, short enough that a
+# transient crowd-out self-heals within the hour.
+DEFAULT_CROWD_OUT_MISS_TTL = timedelta(hours=1)
+
 _DDL_SCHEMA = "CREATE SCHEMA IF NOT EXISTS lml_cache"
 
 # Named CHECK constraint (``release_id_validity``) avoids reliance on PG
@@ -109,36 +128,54 @@ CREATE TABLE IF NOT EXISTS lml_cache.release_resolution_cache (
     title_normalized TEXT NOT NULL,
     is_track BOOLEAN NOT NULL,
     release_id INTEGER,
+    crowd_out BOOLEAN NOT NULL DEFAULT false,
     resolved_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (artist_normalized, title_normalized, is_track),
     CONSTRAINT release_id_validity CHECK (release_id IS NULL OR release_id > 0)
 )\
 """
 
+# LML#824 additive upgrade for a table that predates the crowd_out column (prod,
+# where the CREATE TABLE IF NOT EXISTS above is a no-op). ADD COLUMN with a
+# constant DEFAULT is a metadata-only, fast operation in modern PostgreSQL, so
+# it's safe to re-issue on every boot even against a populated table. Existing
+# rows backfill to false, keeping their normal 7-day miss TTL.
+_DDL_ADD_CROWD_OUT_COLUMN = (
+    "ALTER TABLE lml_cache.release_resolution_cache "
+    "ADD COLUMN IF NOT EXISTS crowd_out BOOLEAN NOT NULL DEFAULT false"
+)
+
 # Staleness lives in the WHERE clause. ``$1``/``$2`` are the normalized keys,
 # ``$3`` the ``is_track`` discriminator, ``$4`` the positive-hit cutoff
-# (``now - positive_ttl``) and ``$5`` the miss cutoff (``now - miss_ttl``). A
-# fresh positive hit passes the first OR branch; a fresh known miss passes the
-# second. A stale hit, a stale miss, and an absent row all return no row.
+# (``now - positive_ttl``), ``$5`` the normal-miss cutoff (``now - miss_ttl``)
+# and ``$6`` the crowd-out-miss cutoff (``now - crowd_out_miss_ttl``, LML#824). A
+# fresh positive hit passes the first OR branch; a fresh normal known miss
+# (``crowd_out = false``) the second; a fresh crowd-out miss (``crowd_out =
+# true``) the third, on its own shorter TTL. A stale row of any kind and an
+# absent row all return no row.
 _SELECT_SQL = """\
 SELECT release_id
 FROM lml_cache.release_resolution_cache
 WHERE artist_normalized = $1 AND title_normalized = $2 AND is_track = $3
   AND (
     (release_id IS NOT NULL AND resolved_at > $4)
-    OR (release_id IS NULL AND resolved_at > $5)
+    OR (release_id IS NULL AND crowd_out = false AND resolved_at > $5)
+    OR (release_id IS NULL AND crowd_out = true AND resolved_at > $6)
   )\
 """
 
 # UPSERT: keep the latest resolution and refresh ``resolved_at`` on conflict.
 # The ``release_id=None`` write path records "resolved to a miss at time T" so
-# subsequent adds inside the miss TTL short-circuit the probe.
+# subsequent adds inside the miss TTL short-circuit the probe. ``$5`` is the
+# ``crowd_out`` marker (LML#824); a later positive or normal-miss write clears it
+# via ``EXCLUDED.crowd_out``, so a self-healed row ages on the right TTL.
 _UPSERT_SQL = """\
 INSERT INTO lml_cache.release_resolution_cache
-    (artist_normalized, title_normalized, is_track, release_id, resolved_at)
-VALUES ($1, $2, $3, $4, now())
+    (artist_normalized, title_normalized, is_track, release_id, crowd_out, resolved_at)
+VALUES ($1, $2, $3, $4, $5, now())
 ON CONFLICT (artist_normalized, title_normalized, is_track) DO UPDATE
 SET release_id = EXCLUDED.release_id,
+    crowd_out = EXCLUDED.crowd_out,
     resolved_at = EXCLUDED.resolved_at\
 """
 
@@ -175,9 +212,15 @@ async def set_up_release_resolution_cache_schema(pg: PgSource) -> None:
     fixtures, future docker-compose stacks) boot LML cleanly. If the
     discogs-cache PG is unreachable at startup, the caller logs and continues;
     the cache layer degrades to a no-op until the next deploy.
+
+    The trailing ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS crowd_out`` (LML#824)
+    upgrades a table created before that column existed: ``CREATE TABLE IF NOT
+    EXISTS`` cannot add a column to an already-present table, so prod needs the
+    idempotent ALTER to gain the marker. It's a no-op once the column exists.
     """
     await pg.execute(_DDL_SCHEMA)
     await pg.execute(_DDL_TABLE)
+    await pg.execute(_DDL_ADD_CROWD_OUT_COLUMN)
 
 
 async def get_cached_release_id(
@@ -188,6 +231,7 @@ async def get_cached_release_id(
     is_track: bool,
     positive_ttl: timedelta = DEFAULT_POSITIVE_TTL,
     miss_ttl: timedelta = DEFAULT_MISS_TTL,
+    crowd_out_miss_ttl: timedelta = DEFAULT_CROWD_OUT_MISS_TTL,
     now: datetime | None = None,
 ) -> ReleaseResolution:
     """Look up a cached resolution for ``(artist, title, is_track)``.
@@ -207,9 +251,16 @@ async def get_cached_release_id(
     reference_now = now or datetime.now(UTC)
     positive_cutoff = reference_now - positive_ttl
     miss_cutoff = reference_now - miss_ttl
+    crowd_out_cutoff = reference_now - crowd_out_miss_ttl
     try:
         row = await pg.fetchone(
-            _SELECT_SQL, artist_key, title_key, is_track, positive_cutoff, miss_cutoff
+            _SELECT_SQL,
+            artist_key,
+            title_key,
+            is_track,
+            positive_cutoff,
+            miss_cutoff,
+            crowd_out_cutoff,
         )
     except Exception:
         logger.exception(
@@ -246,6 +297,7 @@ async def set_cached_release_id(
     title: str,
     is_track: bool,
     release_id: int | None,
+    crowd_out: bool = False,
 ) -> None:
     """UPSERT a cache row for ``(artist, title, is_track)``.
 
@@ -253,14 +305,21 @@ async def set_cached_release_id(
     known miss. ``resolved_at`` is set to ``now()`` server-side on both insert
     and conflict-update.
 
+    ``crowd_out`` (LML#824) marks a *miss* as a short-TTL crowd-out (the bounded
+    resolve truncated its candidate set) rather than a full-7-day exhausted miss.
+    It is a miss-only marker: it is coerced to false alongside a real
+    ``release_id`` so a positive is never mis-marked. A later positive or
+    normal-miss write clears the marker via the UPSERT.
+
     Write failures are logged and swallowed: cache writes are best-effort. A
     request that produced a real resolution still uses it even if the write
     fails.
     """
     artist_key = to_match_form(artist)
     title_key = to_match_form(title)
+    crowd_out_flag = crowd_out and release_id is None
     try:
-        await pg.execute(_UPSERT_SQL, artist_key, title_key, is_track, release_id)
+        await pg.execute(_UPSERT_SQL, artist_key, title_key, is_track, release_id, crowd_out_flag)
     except Exception:
         logger.exception(
             "release_resolution_cache set failed for %s / %s / is_track=%s",

--- a/entity/release_resolution_cache.sql
+++ b/entity/release_resolution_cache.sql
@@ -28,7 +28,17 @@ CREATE TABLE IF NOT EXISTS lml_cache.release_resolution_cache (
     title_normalized TEXT NOT NULL,
     is_track BOOLEAN NOT NULL,
     release_id INTEGER,
+    crowd_out BOOLEAN NOT NULL DEFAULT false,
     resolved_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (artist_normalized, title_normalized, is_track),
     CONSTRAINT release_id_validity CHECK (release_id IS NULL OR release_id > 0)
 );
+
+-- LML#824: `crowd_out` marks a short-TTL crowd-out miss (bounded resolve
+-- truncated its candidate set) apart from a full-7-day exhausted miss. The
+-- runtime bootstrap additionally issues this idempotent ALTER so a table that
+-- predates the column gains it in place (a fresh install already has it from the
+-- CREATE TABLE above, making the ALTER a no-op):
+--
+--   ALTER TABLE lml_cache.release_resolution_cache
+--       ADD COLUMN IF NOT EXISTS crowd_out BOOLEAN NOT NULL DEFAULT false;

--- a/lookup/rowless.py
+++ b/lookup/rowless.py
@@ -222,11 +222,13 @@ async def _resolve_nonlibrary_release(
        coalesce with a default ``[]`` (the #633 landmine). Cold-cache
        durability comes from the #632 PG cache here instead.
     3. **#632 cache write-back** — the resolved id, or ``None`` to record a known
-       miss so the next identical add short-circuits. A known miss is pinned only
-       when the empty resolve was *exhaustive*; an empty from a candidate set
-       truncated at the ``max_validations`` cap (a possible #802-amplified
-       crowd-out) is left unpinned so a resolvable release is not durably
-       suppressed for the miss TTL (LML#816).
+       miss so the next identical add short-circuits. An *exhaustive* empty pins
+       the full 7-day miss; an empty from a candidate set truncated at the
+       ``max_validations`` cap (a possible #802-amplified crowd-out) pins a
+       *short-TTL* crowd-out miss instead (LML#816 → LML#824) — long enough to
+       absorb a re-add burst (the daily backfill flood), short enough that a
+       resolvable release sorted past the window is not suppressed for the full
+       miss TTL, and self-heals within the hour.
 
     ``pg`` is best-effort: ``None`` (or a PG failure, swallowed inside the cache
     helpers) degrades to an uncached bounded resolve. ``album`` (often absent on
@@ -254,7 +256,7 @@ async def _resolve_nonlibrary_release(
             # demote it on a transient outage.
             cached_positive_unhydrated = True
 
-    # LML#816: ``truncated_out`` reports whether the bounded resolve validated
+    # LML#816/#824: ``truncated_out`` reports whether the bounded resolve validated
     # fewer candidates than it surfaced (the id-having set exceeded the cap). An
     # empty result under truncation may be a *crowd-out* — a resolvable release
     # sorted outside the 5-candidate window, an effect #802's improved recall
@@ -275,32 +277,28 @@ async def _resolve_nonlibrary_release(
     # for every case that can't be a crowd-out.
     bounded_resolve_truncated = bool(truncated_out and truncated_out[0])
 
-    # Two guards protect against pinning a durable known-miss over a release that
-    # is actually resolvable:
+    # self-heal guard (LML#628): if we already held a positive entry that merely
+    # failed to re-hydrate (transient get_release / validate outage) and the live
+    # resolve also came up empty, leave the positive intact so it heals once the
+    # outage clears — never demote good data to a miss (short-TTL or long). This
+    # is the one case that skips the write entirely; it gates on ``best is None``
+    # so a real resolution is never suppressed.
     #
-    # * self-heal (LML#628): if we already held a positive entry that merely
-    #   failed to re-hydrate (transient get_release / validate outage) and the
-    #   live resolve also came up empty, leave the positive intact so it heals
-    #   once the outage clears — never demote good data to a 7-day miss.
-    # * crowd-out (LML#816): if the empty came from a *truncated* candidate set,
-    #   the correct release may simply have sorted past the validation window;
-    #   pinning here would durably suppress it for the miss TTL. Skip the write so
-    #   the next add re-probes; a genuine exhaustion (candidate set NOT truncated,
-    #   so every candidate was tried and failed) still pins below. A positive
-    #   (``best is not None``) is always written — both guards gate on
-    #   ``best is None`` and so never suppress a real resolution.
-    suppress_crowd_out_miss = best is None and bounded_resolve_truncated
-    if (
-        pg is not None
-        and not (cached_positive_unhydrated and best is None)
-        and not suppress_crowd_out_miss
-    ):
+    # Otherwise write the outcome. A positive (``best is not None``) is written
+    # with the marker cleared. A miss is marked ``crowd_out`` when the empty came
+    # from a *truncated* candidate set (LML#824) — the correct release may just
+    # have sorted past the validation window, so it earns a short TTL (self-heals
+    # within the hour) rather than the full 7-day miss a genuine exhaustion
+    # (candidate set NOT truncated, every candidate tried and failed) gets.
+    crowd_out_miss = best is None and bounded_resolve_truncated
+    if pg is not None and not (cached_positive_unhydrated and best is None):
         await set_cached_release_id(
             pg,
             artist=artist,
             title=song,
             is_track=is_track,
             release_id=best.release_id if best is not None else None,
+            crowd_out=crowd_out_miss,
         )
 
     return best

--- a/tests/integration/test_release_resolution_cache.py
+++ b/tests/integration/test_release_resolution_cache.py
@@ -4,7 +4,7 @@ Mirrors ``tests/integration/test_streaming_url_persistent_lookup.py``. LML#632
 adds the LML-owned ``lml_cache.release_resolution_cache`` table plus the cache
 module ``entity/release_resolution_cache.py`` (read/write helpers). All unit
 coverage mocks ``PgSource``; this file is the matching ``@pytest.mark.pg`` layer
-driving the real schema, the real UPSERT, and the real dual-TTL math against an
+driving the real schema, the real UPSERT, and the real triple-TTL math against an
 actual PostgreSQL connection.
 
 Concrete production risks the unit tests cannot catch:
@@ -14,8 +14,10 @@ Concrete production risks the unit tests cannot catch:
   would break the ``resolved_at`` cutoff comparison.
 * UPSERT semantics — the composite-PK ``ON CONFLICT`` updates in place.
 * ``to_match_form`` normalization parity between SELECT and UPSERT.
-* The dual TTL: a positive hit reads stale after 90 days; a miss reads fresh
-  inside 7 days and stale after.
+* The triple TTL (LML#824): a positive hit reads stale after 90 days; a normal
+  miss reads fresh inside 7 days and stale after; a crowd-out miss reads fresh
+  inside 1 hour and stale after, on its own shorter cutoff.
+* The additive ``crowd_out`` column ALTER backfills a pre-#824 table in place.
 
 Run with: pytest -m pg -v tests/integration/test_release_resolution_cache.py
 """
@@ -233,3 +235,161 @@ class TestDualTTL:
         )
         assert result.was_present is False
         assert result.release_id is None
+
+
+@pytest.mark.pg
+class TestCrowdOutMissTTL:
+    """LML#824: a crowd-out empty pins a short-TTL miss (``crowd_out=true``), so it
+    self-heals within the hour instead of being suppressed for the full 7 days —
+    while a genuine exhausted miss (``crowd_out=false``) keeps the 7-day TTL."""
+
+    @pytest.mark.asyncio
+    async def test_crowd_out_miss_within_1h_is_returned(self, pg_source):
+        await set_cached_release_id(
+            pg_source,
+            artist="Juana Molina",
+            title="Paraguaya",
+            is_track=True,
+            release_id=None,
+            crowd_out=True,
+        )
+        # A fresh crowd-out miss is honored exactly like any known miss inside its
+        # TTL: present row, null release_id — the caller skips the live probe.
+        result = await get_cached_release_id(
+            pg_source, artist="Juana Molina", title="Paraguaya", is_track=True
+        )
+        assert result.was_present is True
+        assert result.release_id is None
+
+    @pytest.mark.asyncio
+    async def test_crowd_out_miss_past_1h_reads_stale(self, pg_source, pg_pool):
+        await set_cached_release_id(
+            pg_source,
+            artist="Juana Molina",
+            title="Paraguaya",
+            is_track=True,
+            release_id=None,
+            crowd_out=True,
+        )
+        now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+        past = now - timedelta(hours=2)
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE lml_cache.release_resolution_cache SET resolved_at = $1 "
+                "WHERE artist_normalized = 'juana molina' AND title_normalized = 'paraguaya' "
+                "AND is_track = true",
+                past,
+            )
+        # 2h old crowd-out miss is past the 1h crowd-out TTL: filtered by the SQL,
+        # reads as absent so the caller re-probes (the self-heal).
+        result = await get_cached_release_id(
+            pg_source, artist="Juana Molina", title="Paraguaya", is_track=True, now=now
+        )
+        assert result.was_present is False
+        assert result.release_id is None
+
+    @pytest.mark.asyncio
+    async def test_normal_miss_same_age_as_a_stale_crowd_out_is_still_fresh(
+        self, pg_source, pg_pool
+    ):
+        # The discriminating case: at exactly the same 2h age, a crowd-out miss
+        # (short TTL) is stale but a normal exhausted miss (7-day TTL) is fresh.
+        # Proves the marker column selects a distinct cutoff, not just a shared one.
+        await set_cached_release_id(
+            pg_source,
+            artist="Sessa",
+            title="Sonho Da Maçã",
+            is_track=True,
+            release_id=None,
+            crowd_out=False,
+        )
+        now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+        past = now - timedelta(hours=2)
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE lml_cache.release_resolution_cache SET resolved_at = $1 "
+                "WHERE artist_normalized = 'sessa' AND title_normalized = 'sonho da maca' "
+                "AND is_track = true",
+                past,
+            )
+        result = await get_cached_release_id(
+            pg_source, artist="Sessa", title="Sonho Da Maçã", is_track=True, now=now
+        )
+        assert result.was_present is True
+        assert result.release_id is None
+
+    @pytest.mark.asyncio
+    async def test_positive_reresolve_clears_the_crowd_out_marker(self, pg_source, pg_pool):
+        # A crowd-out miss that later resolves must have its marker cleared, so it
+        # ages on the 90-day positive TTL, not the 1h crowd-out TTL.
+        key = ("chuquimamani-condori", "call your name", True)
+        await set_cached_release_id(
+            pg_source,
+            artist="Chuquimamani-Condori",
+            title="Call Your Name",
+            is_track=True,
+            release_id=None,
+            crowd_out=True,
+        )
+        await set_cached_release_id(
+            pg_source,
+            artist="Chuquimamani-Condori",
+            title="Call Your Name",
+            is_track=True,
+            release_id=555,
+        )
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT release_id, crowd_out FROM lml_cache.release_resolution_cache "
+                "WHERE artist_normalized = $1 AND title_normalized = $2 AND is_track = $3",
+                *key,
+            )
+        assert row["release_id"] == 555
+        assert row["crowd_out"] is False
+
+    @pytest.mark.asyncio
+    async def test_positive_write_is_never_marked_crowd_out(self, pg_source, pg_pool):
+        # crowd_out is a miss-only marker: passing crowd_out=True alongside a real
+        # release_id must be coerced to false (a positive is never a crowd-out).
+        await set_cached_release_id(
+            pg_source,
+            artist="Duke Ellington & John Coltrane",
+            title="In a Sentimental Mood",
+            is_track=True,
+            release_id=777,
+            crowd_out=True,
+        )
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT release_id, crowd_out FROM lml_cache.release_resolution_cache "
+                "WHERE artist_normalized = 'duke ellington & john coltrane' "
+                "AND title_normalized = 'in a sentimental mood' AND is_track = true"
+            )
+        assert row["release_id"] == 777
+        assert row["crowd_out"] is False
+
+    @pytest.mark.asyncio
+    async def test_alter_backfills_pre_existing_rows_to_false(self, pg_source, pg_pool):
+        # The prod-upgrade path: an existing table (rows written before #824) gets
+        # the crowd_out column added in place with DEFAULT false, so legacy misses
+        # keep the 7-day TTL rather than being reclassified as short-lived.
+        await set_cached_release_id(
+            pg_source,
+            artist="Stereolab",
+            title="Metronomic Underground",
+            is_track=True,
+            release_id=None,
+        )
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "ALTER TABLE lml_cache.release_resolution_cache DROP COLUMN crowd_out"
+            )
+        # Re-running the bootstrap issues the idempotent ALTER that re-adds it.
+        await set_up_release_resolution_cache_schema(pg_source)
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT crowd_out FROM lml_cache.release_resolution_cache "
+                "WHERE artist_normalized = 'stereolab' "
+                "AND title_normalized = 'metronomic underground' AND is_track = true"
+            )
+        assert row["crowd_out"] is False

--- a/tests/unit/test_nonlibrary_release_resolution.py
+++ b/tests/unit/test_nonlibrary_release_resolution.py
@@ -19,6 +19,7 @@ cache and does NOT re-probe Discogs.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -79,31 +80,69 @@ def _resolving_service() -> AsyncMock:
 class _RecordingPg:
     """A minimal PgSource stand-in backed by a dict, recording read/write calls.
 
-    Stores by ``(artist_normalized, title_normalized, is_track)``. Mirrors the
-    SELECT/UPSERT shape ``release_resolution_cache`` uses closely enough that
+    Stores by ``(artist_normalized, title_normalized, is_track)`` a dict of
+    ``{"release_id", "crowd_out", "resolved_at"}`` and mirrors the SELECT/UPSERT
+    shape ``release_resolution_cache`` uses closely enough that
     ``get_cached_release_id`` / ``set_cached_release_id`` exercise their real
     normalization + three-valued logic against it.
+
+    ``fetchone`` faithfully re-implements the triple-TTL WHERE clause (positive
+    90d / normal-miss 7d / crowd-out 1h) using the cutoffs the reader passes as
+    ``$4``/``$5``/``$6``, so a test can age a stored row (:meth:`age`) to drive a
+    real staleness transition — the LML#824 self-heal. The authoritative SQL
+    version of the same math lives in the ``-m pg`` integration suite.
     """
 
     def __init__(self):
-        self.store: dict[tuple[str, str, bool], int | None] = {}
+        self.store: dict[tuple[str, str, bool], dict] = {}
         self.fetchone_calls = 0
         self.execute_calls = 0
+
+    def seed(self, key: tuple[str, str, bool], release_id: int | None, *, crowd_out: bool = False):
+        """Pre-place a fresh row (resolved_at = now)."""
+        self.store[key] = {
+            "release_id": release_id,
+            "crowd_out": crowd_out,
+            "resolved_at": datetime.now(UTC),
+        }
+
+    def age(self, key: tuple[str, str, bool], delta: timedelta):
+        """Back-date a stored row's ``resolved_at`` to simulate elapsed time."""
+        self.store[key]["resolved_at"] -= delta
 
     async def fetchone(self, query: str, *args):
         self.fetchone_calls += 1
         artist_key, title_key, is_track = args[0], args[1], args[2]
-        key = (artist_key, title_key, is_track)
-        if key not in self.store:
+        positive_cutoff, miss_cutoff, crowd_out_cutoff = args[3], args[4], args[5]
+        row = self.store.get((artist_key, title_key, is_track))
+        if row is None:
             return None
-        # Present rows are always "fresh" in this stand-in (the staleness
-        # cutoffs are real cutoffs but the row's resolved_at is now()).
-        return {"release_id": self.store[key]}
+        resolved_at = row["resolved_at"]
+        release_id = row["release_id"]
+        # Mirror the three-branch WHERE of _SELECT_SQL: a positive uses the 90d
+        # cutoff, a normal miss the 7d cutoff, a crowd-out miss the 1h cutoff.
+        if release_id is not None:
+            fresh = resolved_at > positive_cutoff
+        elif row["crowd_out"]:
+            fresh = resolved_at > crowd_out_cutoff
+        else:
+            fresh = resolved_at > miss_cutoff
+        return {"release_id": release_id} if fresh else None
 
     async def execute(self, query: str, *args):
         self.execute_calls += 1
-        artist_key, title_key, is_track, release_id = args[0], args[1], args[2], args[3]
-        self.store[(artist_key, title_key, is_track)] = release_id
+        artist_key, title_key, is_track, release_id, crowd_out = (
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            args[4],
+        )
+        self.store[(artist_key, title_key, is_track)] = {
+            "release_id": release_id,
+            "crowd_out": crowd_out,
+            "resolved_at": datetime.now(UTC),
+        }
         return "INSERT 0 1"
 
 
@@ -122,9 +161,11 @@ async def test_cold_resolve_then_cache_hit_skips_second_probe():
     assert first.release_url == RELEASE_URL
     assert svc.search_releases_by_track.await_count >= 1
     probes_after_first = svc.search_releases_by_track.await_count
-    # A positive resolution was written to the #632 cache.
+    # A positive resolution was written to the #632 cache, never crowd-out marked.
     assert pg.execute_calls == 1
-    assert pg.store[(ARTIST.lower(), TRACK.lower(), True)] == RELEASE_ID
+    row = pg.store[(ARTIST.lower(), TRACK.lower(), True)]
+    assert row["release_id"] == RELEASE_ID
+    assert row["crowd_out"] is False
 
     second = await _resolve_nonlibrary_release(
         svc, pg, song=TRACK, artist=ARTIST, album=ALBUM, is_track=True
@@ -150,7 +191,7 @@ async def test_transient_rehydrate_failure_does_not_demote_positive_to_miss():
 
     pg = _RecordingPg()
     # Pre-seed a known-good positive entry (a prior successful resolve).
-    pg.store[(ARTIST.lower(), TRACK.lower(), True)] = RELEASE_ID
+    pg.seed((ARTIST.lower(), TRACK.lower(), True), RELEASE_ID)
 
     result = await _resolve_nonlibrary_release(
         svc, pg, song=TRACK, artist=ARTIST, album=ALBUM, is_track=True
@@ -159,7 +200,7 @@ async def test_transient_rehydrate_failure_does_not_demote_positive_to_miss():
     # Nothing surfaces this add, but the cache is NOT demoted to a miss.
     assert result is None
     assert pg.execute_calls == 0
-    assert pg.store[(ARTIST.lower(), TRACK.lower(), True)] == RELEASE_ID
+    assert pg.store[(ARTIST.lower(), TRACK.lower(), True)]["release_id"] == RELEASE_ID
 
 
 @pytest.mark.asyncio
@@ -181,7 +222,7 @@ async def test_empty_title_rehydrate_falls_through_to_live_resolve():
         )
     )
     pg = _RecordingPg()
-    pg.store[(ARTIST.lower(), TRACK.lower(), True)] = RELEASE_ID  # known-good positive
+    pg.seed((ARTIST.lower(), TRACK.lower(), True), RELEASE_ID)  # known-good positive
 
     result = await _resolve_nonlibrary_release(
         svc, pg, song=TRACK, artist=ARTIST, album=ALBUM, is_track=True
@@ -229,14 +270,20 @@ async def test_cold_miss_writes_known_miss_to_cache(monkeypatch):
     )
 
     assert result is None
-    # Known miss recorded (release_id None).
+    # Known miss recorded (release_id None). The candidate set fit inside the cap
+    # (empty is exhaustive, not truncated), so it is a normal 7-day miss.
     assert pg.execute_calls == 1
-    assert pg.store[(ARTIST.lower(), TRACK.lower(), True)] is None
+    row = pg.store[(ARTIST.lower(), TRACK.lower(), True)]
+    assert row["release_id"] is None
+    assert row["crowd_out"] is False
 
 
 # ---------------------------------------------------------------------------
-# LML#816: a bounded-resolve empty that is a crowd-out (candidate set truncated
-# at the max_validations cap) must NOT pin a durable 7-day known-miss.
+# LML#816 / LML#824: a bounded-resolve empty that is a crowd-out (candidate set
+# truncated at the max_validations cap) must NOT pin a durable 7-day known-miss.
+# #816 skipped the write entirely; #824 pins a *short-TTL* crowd-out miss instead
+# — honored long enough to absorb one backfill flood pass, stale within the hour
+# so a transient crowd-out self-heals.
 # ---------------------------------------------------------------------------
 
 # A resolvable non-library release whose Discogs id sorts *after* the crowd-out
@@ -307,17 +354,20 @@ def _crowdout_service() -> AsyncMock:
 
 
 @pytest.mark.asyncio
-async def test_crowdout_empty_does_not_durably_suppress_resolvable_release():
+async def test_crowdout_empty_pins_short_ttl_miss_and_self_heals():
     """A bounded-resolve empty produced by a *transient* crowd-out (more true
     candidates surfaced than the max_validations=5 window validates, per #802's
-    improved recall) must NOT be pinned as a 7-day known-miss.
+    improved recall) pins a SHORT-TTL crowd-out miss, not a durable 7-day one.
 
-    Otherwise the durable negative short-circuits the very next add — turning a
-    one-off truncation into a week-long suppression of a release that is actually
-    resolvable once the crowd-out clears. This is finding C1 of the #807 review.
+    The short TTL absorbs a burst (a re-add inside the hour short-circuits without
+    re-probing) yet still self-heals: once the crowd-out clears AND the short TTL
+    lapses, the next add re-probes and surfaces the now-resolvable release. #816
+    got the non-suppression by skipping the write; #824 bounds the re-probe cost
+    while keeping it.
     """
     svc = _crowdout_service()
     pg = _RecordingPg()
+    key = (ARTIST.lower(), TRACK.lower(), True)
 
     # First add: six distractors sort ahead of the correct release (id 36907527)
     # and all fail per-track validation, so the bounded resolve exhausts its
@@ -326,23 +376,34 @@ async def test_crowdout_empty_does_not_durably_suppress_resolvable_release():
         svc, pg, song=TRACK, artist=ARTIST, album=None, is_track=True
     )
     assert first is None
-    # The empty came from a TRUNCATED candidate set (7 surfaced > cap 5), so it
-    # must NOT be pinned as a durable known-miss.
-    assert (ARTIST.lower(), TRACK.lower(), True) not in pg.store
+    # The empty came from a TRUNCATED candidate set (7 surfaced > cap 5): it is
+    # pinned as a crowd-out miss (short TTL), NOT a durable 7-day known-miss.
+    assert pg.store[key]["release_id"] is None
+    assert pg.store[key]["crowd_out"] is True
 
-    # The transient clears: the distractors are gone and the correct release is
-    # now the sole, resolvable candidate.
+    # Within the short TTL, a re-add short-circuits on the crowd-out miss — no
+    # re-probe (this is the flood-absorbing property #816's no-pin lacked).
+    probes = svc.search_releases_by_track.await_count
+    short_circuit = await _resolve_nonlibrary_release(
+        svc, pg, song=TRACK, artist=ARTIST, album=None, is_track=True
+    )
+    assert short_circuit is None
+    assert svc.search_releases_by_track.await_count == probes
+
+    # The transient clears AND the short TTL lapses (age the crowd-out row past 1h).
     svc._crowdout_state["cleared"] = True
+    pg.age(key, timedelta(hours=2))
 
-    # A second identical add must surface the correct release — not be suppressed
-    # by a negative pinned on the first (crowd-out) attempt.
+    # A second identical add now re-probes and surfaces the correct release — the
+    # crowd-out miss self-healed rather than suppressing it for a week.
     second = await _resolve_nonlibrary_release(
         svc, pg, song=TRACK, artist=ARTIST, album=None, is_track=True
     )
     assert second is not None
     assert second.release_id == CROWDOUT_CORRECT_ID
-    # And now that it genuinely resolved, a POSITIVE is cached.
-    assert pg.store[(ARTIST.lower(), TRACK.lower(), True)] == CROWDOUT_CORRECT_ID
+    # And now that it genuinely resolved, a POSITIVE is cached (marker cleared).
+    assert pg.store[key]["release_id"] == CROWDOUT_CORRECT_ID
+    assert pg.store[key]["crowd_out"] is False
 
 
 @pytest.mark.asyncio
@@ -368,9 +429,12 @@ async def test_exhausted_empty_within_cap_still_pins_known_miss():
     )
 
     assert result is None
-    # 3 candidates ≤ cap 5 → exhaustive, not truncated → known-miss pinned.
+    # 3 candidates ≤ cap 5 → exhaustive, not truncated → full 7-day known-miss
+    # pinned (crowd_out=False), distinct from the short-TTL crowd-out miss above.
     assert pg.execute_calls == 1
-    assert pg.store[(ARTIST.lower(), TRACK.lower(), True)] is None
+    row = pg.store[(ARTIST.lower(), TRACK.lower(), True)]
+    assert row["release_id"] is None
+    assert row["crowd_out"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_release_resolution_cache_schema.py
+++ b/tests/unit/test_release_resolution_cache_schema.py
@@ -7,8 +7,9 @@ Mirrors ``tests/unit/test_streaming_url_cache_schema.py``. Two surfaces:
   ``lml_cache.release_resolution_cache`` table with the named CHECK constraint
   and composite PK, so a reviewer / operator has the DDL inline.
 * ``set_up_release_resolution_cache_schema`` — the lifespan bootstrap helper.
-  It must issue ``CREATE SCHEMA`` then ``CREATE TABLE`` (named CHECK) and
-  nothing else.
+  It must issue ``CREATE SCHEMA`` then ``CREATE TABLE`` (named CHECK) then the
+  idempotent ``ALTER TABLE ... ADD COLUMN IF NOT EXISTS crowd_out`` (LML#824)
+  and nothing else.
 
 The parity assertion pins the module's runtime ``CREATE TABLE`` text to the
 ``.sql`` reference so the two cannot silently drift. PG is mocked; the

--- a/tests/unit/test_release_resolution_cache_schema.py
+++ b/tests/unit/test_release_resolution_cache_schema.py
@@ -54,6 +54,13 @@ class TestCanonicalDDLReference:
         ddl = _SQL_REFERENCE.read_text()
         assert "PRIMARY KEY (artist_normalized, title_normalized, is_track)" in ddl
 
+    def test_has_crowd_out_marker_column(self):
+        # LML#824: the crowd-out marker distinguishes a short-TTL crowd-out miss
+        # from a full-7-day exhausted miss. NOT NULL DEFAULT false so a
+        # pre-existing row (and every positive) reads as a normal miss.
+        ddl = _SQL_REFERENCE.read_text()
+        assert "crowd_out BOOLEAN NOT NULL DEFAULT false" in ddl
+
     def test_module_create_table_matches_sql_reference(self):
         # The .sql file is the hand-maintained mirror of the runtime DDL. Pin
         # the module's ``CREATE TABLE ...`` statement (modulo SQL comments and
@@ -94,23 +101,29 @@ def _extract_create_table(ddl: str) -> str:
 class TestSetUpReleaseResolutionCacheSchema:
     """``set_up_release_resolution_cache_schema`` runs exactly the idempotent DDL."""
 
-    async def test_creates_schema_then_table(self):
+    async def test_creates_schema_then_table_then_alters(self):
         pg = AsyncMock(spec=PgSource)
         pg.execute = AsyncMock(return_value="CREATE")
 
         await set_up_release_resolution_cache_schema(pg)
 
-        # Exactly two executes — schema, then table. No backfill.
-        assert pg.execute.await_count == 2
+        # Three executes — schema, then table, then the additive crowd_out column
+        # ALTER (LML#824) that upgrades a pre-existing prod table in place (the
+        # CREATE TABLE IF NOT EXISTS above is a no-op there). All idempotent.
+        assert pg.execute.await_count == 3
         schema_sql = pg.execute.await_args_list[0].args[0]
         table_sql = pg.execute.await_args_list[1].args[0]
+        alter_sql = pg.execute.await_args_list[2].args[0]
         assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in schema_sql
         assert "CREATE TABLE IF NOT EXISTS lml_cache.release_resolution_cache" in table_sql
         assert "CONSTRAINT release_id_validity CHECK" in table_sql
         assert "PRIMARY KEY (artist_normalized, title_normalized, is_track)" in table_sql
+        assert "ALTER TABLE lml_cache.release_resolution_cache" in alter_sql
+        assert "ADD COLUMN IF NOT EXISTS crowd_out BOOLEAN NOT NULL DEFAULT false" in alter_sql
 
     async def test_does_not_read_or_backfill(self):
-        # The bootstrap is pure DDL: no probe, no INSERT.
+        # The bootstrap is pure DDL: no probe, no data INSERT. The crowd_out
+        # ALTER (LML#824) is an idempotent DDL column add, not a row backfill.
         pg = AsyncMock(spec=PgSource)
         pg.execute = AsyncMock(return_value="CREATE")
 


### PR DESCRIPTION
## Problem

LML#816 stopped a *truncated* (crowd-out) bounded-resolve empty from pinning a durable 7-day known-miss by **skipping the negative write entirely**. That is correct for not suppressing a resolvable release, but it converts every crowd-out empty into a *permanent re-probe*: a track that consistently surfaces more than `max_validations=5` candidates re-runs the full two-wave `search_releases_by_track` probe plus up to five `validate_track_on_release` calls on **every** subsequent add, forever. That steady-state Discogs load lands on exactly the repeatedly-re-added population the daily `flowsheet-metadata-backfill` flood (#706, WXYC/Backend-Service#1591) drives at 06:00 UTC — the cold-probe surface the #706 cold-tail work is trying to shrink.

## Change

Pin a **short-TTL crowd-out miss** instead of nothing:

- **Honored** long enough to absorb one flood pass — a re-add inside the hour short-circuits without re-probing.
- **Stale within the hour** so a transient crowd-out self-heals; a genuinely-resolvable release is never suppressed for the full miss TTL.
- A **genuine exhaustion** (candidate set NOT truncated — every candidate tried and failed) still pins the full 7-day `DEFAULT_MISS_TTL`.
- A **positive** is written unconditionally, marker cleared.

The read-time miss TTL keys off `resolved_at` with no per-row kind, so a distinct crowd-out cutoff needs a marker column:

- `crowd_out BOOLEAN NOT NULL DEFAULT false` on `lml_cache.release_resolution_cache` — LML-owned, lifespan-bootstrapped, **no discogs-cache alembic / three-repo dance**.
- `get_cached_release_id` gains a third SELECT branch on a shorter `crowd_out_miss_ttl` (1h default).
- `set_cached_release_id` gains a `crowd_out` flag — coerced off alongside a real `release_id` so a positive is never mis-marked, and cleared by any later positive/normal-miss UPSERT so a self-healed row ages on the right TTL.
- The bootstrap issues an additive **idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`** so a pre-existing prod table gains the column in place (fast metadata-only add; existing rows backfill to `false`, keeping their 7-day TTL).

## Invariants preserved

- **#628 self-heal guard** — a positive that failed to re-hydrate is never demoted, not even to a short miss (the one path that still skips the write).
- **#633 landmine** — the kernel keeps using the uncached bounded resolver.
- No extra Discogs API call on the happy path.

## Tests

- **Unit** (`test_nonlibrary_release_resolution.py`): the `PgSource` stand-in now models the triple TTL, proving crowd-out empty → short-TTL pin → short-circuit-within-TTL → self-heal-after-TTL; exhausted empty and cold miss stay full-7-day; positive clears the marker.
- **`-m pg`** (`test_release_resolution_cache.py`): drives the real SQL cutoffs — crowd-out fresh <1h / stale >1h, a same-age (2h) normal miss still fresh (the discriminating case), positive re-resolve clears the marker, positive never marked crowd-out, and the ALTER backfills a pre-#824 table in place.
- `test_release_resolution_cache_schema.py`: schema bootstrap now issues three idempotent statements (schema, table, ALTER); `.sql` parity gains the column.

Full unit suite (3665) + touched `-m pg` suites green; `ruff check` / `ruff format --check` clean.

Closes #824.

## Related

- #816 (the fix this refines), #807 / #802 (origin), #817 / #818 (sibling C-series follow-ups), #706 (cold /lookup tail latency the re-probe load intersects).