### PR TITLE
chore(codegen): regenerate api_models against wxyc-shared main (Album Reviews)

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -816,6 +816,53 @@ class ConcertsResponse(BaseModel):
     pagination: PaginationInfo
 
 
+class AlbumReview(BaseModel):
+    id: int
+    album_id: int = Field(
+        ...,
+        description="WXYC library album id when the free-text artist/album resolved to exactly one catalog row; null otherwise.",
+    )
+    artist_name: str = Field(..., description="Artist name exactly as the reviewer entered it.")
+    album_title: str = Field(..., description="Album title exactly as the reviewer entered it.")
+    record_label: str
+    artist_blurb: str = Field(..., description="Short reviewer-written background on the artist.")
+    review: str = Field(..., description="The review body.")
+    recommended_tracks: str = Field(
+        ...,
+        description='Raw recommended-tracks text, including the form\'s `!`-rating notation (1–5 exclamation marks) and "Play All" shorthand.',
+    )
+    buzzwords: str = Field(..., description="Comma-separated reviewer-chosen descriptors.")
+    fcc_violations: str = Field(
+        ...,
+        description='Verbatim reviewer answer listing FCC-violating track numbers. Blank (unanswered) is distinct from "None"/"N/A" (affirmatively clean); values are not normalized.',
+    )
+    review_purpose: str = Field(
+        ...,
+        description='Raw multi-select of "Rotation", "New DJ Assignment", "Album in the Library"; comma-joined when multiple were selected.',
+    )
+    rotated: bool = Field(
+        ...,
+        description='Curator-maintained "was this album rotated" flag; null when the sheet cell is blank or unparseable.',
+    )
+    released_within_six_months: bool = Field(
+        ...,
+        description="Whether the album was released within 6 months of the review; null when unanswered (question added mid-2024).",
+    )
+    social_consent: bool = Field(
+        ...,
+        description="Whether the reviewer consented to the review being shared on station social media (always anonymously); null when unanswered.",
+    )
+    submitted_at: AwareDatetime = Field(
+        ...,
+        description="Form submission instant. Null only for the rare row whose sheet timestamp is missing.",
+    )
+
+
+class AlbumReviewsResponse(BaseModel):
+    album_reviews: list[AlbumReview]
+    pagination: PaginationInfo
+
+
 class DeviceAuthCodeRequest(BaseModel):
     client_id: str = Field(
         ..., description="The client ID of the application requesting authorization."


### PR DESCRIPTION
## What

Regenerates `generated/api_models.py` from the current wxyc-shared `main` `api.yaml`, adding the `AlbumReview` and `AlbumReviewsResponse` Pydantic models.

## Why

wxyc-shared `main` added the album-reviews schemas after LML's last regen (`65a9ed0`), so the committed generated models drifted. The **Codegen Freshness** CI job (`git diff --exit-code generated/` after a regen) therefore fails on **every** branch cut from `main` — e.g. #843 — even when the PR touches nothing under `generated/`. This is the routine catch-up regen; it restores drift-freeness and unblocks the open PRs.

## Notes

- Generated with the pinned toolchain (`datamodel-code-generator==0.56.1`, `ruff==0.15.6`) via `scripts/generate_api_models.sh`, so the output is byte-identical to what CI computes.
- Diff is **only** the two new models — no reordering, no other model changes.
- `ruff check` / `ruff format --check` / `mypy` clean.
