### PR TITLE
Serve the /admin streaming-DB endpoints from the object store (volume eviction PR 2)

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -387,13 +387,18 @@ async def upload_streaming_db(
 
     with tempfile.TemporaryDirectory(prefix="lml-streaming-upload-") as td:
         tdir = Path(td)
-        # The upload scratch file keeps the ``.tmp`` suffix the coverage read is
-        # keyed on so a post-validation read fault is still classified 500.
+        # Scratch file for the upload. A post-validation read fault on it is
+        # classified 500 (not 409) by the ``except`` around the
+        # ``_streaming_coverage(upload_tmp)`` call below, since the upload has
+        # already passed albums-count validation -- the suffix is not load-bearing.
         upload_tmp = tdir / "upload.tmp"
 
         try:
             content = await file.read()
             upload_tmp.write_bytes(content)
+            # Free the ~53MB upload buffer before we fetch the baseline object,
+            # which materializes another full copy in memory (LML memory pressure).
+            del content
         except Exception as e:
             logger.error(f"Failed to write uploaded streaming DB: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to write file: {e}") from e
@@ -519,7 +524,7 @@ async def download_streaming_db(
     library-sync pipeline (WXYC/discogs-etl) read the file directly from the
     store instead of round-tripping it through a GitHub Release. The whole
     object (~53MB) is buffered and returned in one response; that egress is
-    negligible at weekly cadence.
+    negligible at the daily sync cadence.
     """
     _validate_auth(settings, authorization)
 

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import sqlite3
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
@@ -11,16 +12,18 @@ from typing import Literal
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, UploadFile
 from fastapi import Path as PathParam
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import JSONResponse, Response
 
 from config.settings import Settings, get_settings
 from core.dependencies import (
     close_library_db,
     get_discogs_cache_service_from_pool,
+    get_object_store,
 )
 from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 from discogs.memory_cache import evict_cached
 from discogs.service import DiscogsService
+from storage.object_store import ObjectNotFoundError, ObjectStore
 
 logger = logging.getLogger(__name__)
 
@@ -44,19 +47,14 @@ _STREAMING_COVERAGE_METRICS = ("apple_url", "spotify_url", "deezer_url", "albums
 _background_tasks: set[asyncio.Task] = set()
 
 
-def _streaming_db_path(settings: Settings) -> Path:
-    """Sibling of library.db on the Railway volume."""
-    return settings.resolved_library_db_path.parent / STREAMING_DB_FILENAME
-
-
 class StreamingCoverageUnreadableError(Exception):
-    """A streaming_availability.db file exists on disk but could not be read.
+    """A streaming_availability.db object exists but could not be read.
 
-    Distinguishes "no prior file" (a legitimate first upload) from "prior file
+    Distinguishes "no prior object" (a legitimate first upload) from "prior object
     present but unreadable" so the upload guard can fail *closed* on the latter:
     waving an upload through because the baseline read failed would re-open the
-    288-Apple-URLs -> 0 hole the guard exists to plug, precisely when the disk is
-    flaky.
+    288-Apple-URLs -> 0 hole the guard exists to plug, precisely when the stored
+    object is corrupt.
     """
 
 
@@ -347,7 +345,7 @@ async def upload_library_db(
         403: {"description": "Invalid or missing token"},
         409: {
             "description": "Refused (use force=true): either a coverage regression vs the "
-            "file on disk, or the on-disk file is present but unreadable. The JSON `detail` "
+            "stored object, or the stored object is present but unreadable. The JSON `detail` "
             "carries an `error` discriminator; the regression variant also includes a "
             "`regressions` list."
         },
@@ -358,112 +356,135 @@ async def upload_streaming_db(
     file: UploadFile,
     force: bool = False,
     settings: Settings = Depends(get_settings),
+    object_store: ObjectStore = Depends(get_object_store),
     authorization: str | None = Header(None),
 ):
-    """Store a streaming_availability.db backup on the Railway volume.
+    """Store a streaming_availability.db backup in the object store.
 
     This is the canonical copy the daily library-sync reads (LML#672), so the
-    upload is a full-file replace guarded against coverage regression. It is first
-    validated as SQLite with an 'albums' table (400 on failure), then the guard
-    runs and rejects the upload with **409** when either:
+    upload is a full-object replace guarded against coverage regression. It is
+    first validated as SQLite with an 'albums' table (400 on failure), then the
+    guard runs and rejects the upload with **409** when either:
 
     * any of {apple_url, spotify_url, deezer_url, albums, track_results} drops
-      below prior * (1 - tolerance) or goes non-zero -> zero versus the file
-      currently on disk -- ``detail`` is ``{error, regressions, hint}``; or
-    * the on-disk file exists but cannot be read, so there is no baseline to
+      below prior * (1 - tolerance) or goes non-zero -> zero versus the object
+      currently stored -- ``detail`` is ``{error, regressions, hint}``; or
+    * the stored object exists but cannot be read, so there is no baseline to
       compare against -- ``detail`` is ``{error, hint}`` (no ``regressions``).
 
     Branch on ``detail['error']``; ``regressions`` is only present for the first
     case. Pass ``?force=true`` to override either rejection (logged loudly).
+
+    The storage backend (:class:`~storage.object_store.ObjectStore`) is
+    selected once per deployment (WXYC#836): a Railway Bucket in prod, a local
+    directory in dev/tests. The coverage guard's semantics are identical in both
+    modes -- a **missing** object (S3 404 / absent file) reads as the all-zero
+    first-upload baseline and is accepted, while a present-but-**unreadable**
+    object fails closed at 409. ``put`` is atomic per object (S3 PUT; the local
+    store does tmp + ``os.replace``), so no replace dance is needed here.
     """
     _validate_auth(settings, authorization)
 
-    db_path = _streaming_db_path(settings)
-    tmp_path = db_path.with_suffix(db_path.suffix + ".tmp")
+    with tempfile.TemporaryDirectory(prefix="lml-streaming-upload-") as td:
+        tdir = Path(td)
+        # The upload scratch file keeps the ``.tmp`` suffix the coverage read is
+        # keyed on so a post-validation read fault is still classified 500.
+        upload_tmp = tdir / "upload.tmp"
 
-    try:
-        content = await file.read()
-        tmp_path.write_bytes(content)
-    except Exception as e:
-        logger.error(f"Failed to write uploaded streaming DB: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to write file: {e}") from e
+        try:
+            content = await file.read()
+            upload_tmp.write_bytes(content)
+        except Exception as e:
+            logger.error(f"Failed to write uploaded streaming DB: {e}")
+            raise HTTPException(status_code=500, detail=f"Failed to write file: {e}") from e
 
-    try:
-        conn = sqlite3.connect(str(tmp_path))
-        row_count = conn.execute("SELECT count(*) FROM albums").fetchone()[0]
-        conn.close()
-    except Exception as e:
-        tmp_path.unlink(missing_ok=True)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid SQLite database: {e}",
-        ) from e
+        try:
+            conn = sqlite3.connect(str(upload_tmp))
+            row_count = conn.execute("SELECT count(*) FROM albums").fetchone()[0]
+            conn.close()
+        except Exception as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid SQLite database: {e}",
+            ) from e
 
-    # Coverage-regression guard (LML#672): compare against the live on-disk file
-    # at replace time (not an uploader-supplied baseline). A stale-content writer
-    # that genuinely lost coverage is rejected on the regression and re-applies on
-    # its next cycle. (This is eventual rejection across cycles, not a lock across
-    # concurrent uploads -- the two writers here, a weekly cron and a rare manual
-    # run, are effectively non-concurrent.)
-    try:
-        old_cov = _streaming_coverage(db_path)
-    except StreamingCoverageUnreadableError:
-        # The existing file is present but unreadable, so there is no baseline to
-        # compare against. Fail closed rather than fail open: treating it as a
-        # first upload would accept any thin replacement. force=true overrides.
-        if force:
-            logger.warning(
-                "On-disk streaming DB unreadable but force=true; "
-                "replacing without a coverage baseline."
-            )
+        # Coverage-regression guard (LML#672): compare against the object currently
+        # stored (not an uploader-supplied baseline). A stale-content writer that
+        # genuinely lost coverage is rejected on the regression and re-applies on
+        # its next cycle. (Eventual rejection across cycles, not a lock across
+        # concurrent uploads -- the two writers here, a weekly cron and a rare
+        # manual run, are effectively non-concurrent.)
+        try:
+            baseline_bytes = await object_store.get(STREAMING_DB_FILENAME)
+        except ObjectNotFoundError:
+            # No stored object -> the first-upload baseline (all-zero coverage);
+            # the regression check skips zero baselines, so the upload is accepted.
             old_cov = dict.fromkeys(_STREAMING_COVERAGE_METRICS, 0)
         else:
-            tmp_path.unlink(missing_ok=True)
-            logger.warning("Rejected streaming upload: on-disk streaming DB unreadable.")
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "error": "existing streaming DB unreadable; refusing to replace blind",
-                    "hint": "retry once the volume is readable, or pass force=true to override",
-                },
-            ) from None
-    try:
-        new_cov = _streaming_coverage(tmp_path)
-    except StreamingCoverageUnreadableError as e:
-        # The upload already passed the albums-count validation above, so this is a
-        # server-side read fault on a file we just wrote and validated, not a bad
-        # client upload -- surface it as 500 so a retry-on-5xx caller retries.
-        tmp_path.unlink(missing_ok=True)
-        raise HTTPException(
-            status_code=500,
-            detail=f"Uploaded streaming DB became unreadable after validation: {e}",
-        ) from e
-    regressions = _check_streaming_regression(old_cov, new_cov)
-    if regressions:
-        if force:
-            logger.warning(
-                "Streaming upload regresses coverage but force=true; replacing anyway. "
-                "Regressions: %s",
-                regressions,
-            )
-        else:
-            tmp_path.unlink(missing_ok=True)
-            logger.warning(
-                "Rejected streaming upload: coverage regression vs on-disk file. %s",
-                regressions,
-            )
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "error": "streaming coverage regression",
-                    "regressions": regressions,
-                    "hint": "re-run as a round-trip (download -> modify -> upload), "
-                    "or pass force=true to override",
-                },
-            )
+            baseline_tmp = tdir / "baseline.db"
+            baseline_tmp.write_bytes(baseline_bytes)
+            try:
+                old_cov = _streaming_coverage(baseline_tmp)
+            except StreamingCoverageUnreadableError:
+                # The stored object is present but unreadable, so there is no
+                # baseline to compare against. Fail closed rather than fail open:
+                # treating it as a first upload would accept any thin replacement.
+                # force=true overrides.
+                if force:
+                    logger.warning(
+                        "Stored streaming DB unreadable but force=true; "
+                        "replacing without a coverage baseline."
+                    )
+                    old_cov = dict.fromkeys(_STREAMING_COVERAGE_METRICS, 0)
+                else:
+                    logger.warning("Rejected streaming upload: stored streaming DB unreadable.")
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "error": "existing streaming DB unreadable; refusing to replace blind",
+                            "hint": "retry once the stored object is readable, "
+                            "or pass force=true to override",
+                        },
+                    ) from None
 
-    os.replace(str(tmp_path), str(db_path))
-    logger.info(f"Streaming database backed up: {db_path} ({row_count} albums)")
+        try:
+            new_cov = _streaming_coverage(upload_tmp)
+        except StreamingCoverageUnreadableError as e:
+            # The upload already passed the albums-count validation above, so this
+            # is a server-side read fault on a file we just wrote and validated, not
+            # a bad client upload -- surface it as 500 so a retry-on-5xx caller
+            # retries.
+            raise HTTPException(
+                status_code=500,
+                detail=f"Uploaded streaming DB became unreadable after validation: {e}",
+            ) from e
+
+        regressions = _check_streaming_regression(old_cov, new_cov)
+        if regressions:
+            if force:
+                logger.warning(
+                    "Streaming upload regresses coverage but force=true; replacing anyway. "
+                    "Regressions: %s",
+                    regressions,
+                )
+            else:
+                logger.warning(
+                    "Rejected streaming upload: coverage regression vs stored object. %s",
+                    regressions,
+                )
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error": "streaming coverage regression",
+                        "regressions": regressions,
+                        "hint": "re-run as a round-trip (download -> modify -> upload), "
+                        "or pass force=true to override",
+                    },
+                )
+
+        await object_store.put(STREAMING_DB_FILENAME, upload_tmp)
+
+    logger.info("Streaming database backed up to the object store (%d albums)", row_count)
 
     return JSONResponse(
         content={
@@ -484,32 +505,36 @@ async def upload_streaming_db(
         },
         401: {"description": "Missing authorization"},
         403: {"description": "Invalid or missing token"},
-        404: {"description": "streaming_availability.db not present on the volume"},
+        404: {"description": "streaming_availability.db not present in the store"},
     },
 )
 async def download_streaming_db(
     settings: Settings = Depends(get_settings),
+    object_store: ObjectStore = Depends(get_object_store),
     authorization: str | None = Header(None),
 ):
-    """Stream the current streaming_availability.db from the Railway volume.
+    """Stream the current streaming_availability.db from the object store.
 
     Symmetric with `POST /admin/upload-streaming-db`. Lets the daily
     library-sync pipeline (WXYC/discogs-etl) read the file directly from the
-    volume instead of round-tripping it through a GitHub Release.
+    store instead of round-tripping it through a GitHub Release. The whole
+    object (~53MB) is buffered and returned in one response; that egress is
+    negligible at weekly cadence.
     """
     _validate_auth(settings, authorization)
 
-    db_path = _streaming_db_path(settings)
-    if not db_path.exists():
+    try:
+        data = await object_store.get(STREAMING_DB_FILENAME)
+    except ObjectNotFoundError:
         raise HTTPException(
             status_code=404,
-            detail=f"{STREAMING_DB_FILENAME} not found on volume",
-        )
+            detail=f"{STREAMING_DB_FILENAME} not found in the store",
+        ) from None
 
-    return FileResponse(
-        path=db_path,
+    return Response(
+        content=data,
         media_type="application/octet-stream",
-        filename=STREAMING_DB_FILENAME,
+        headers={"content-disposition": f'attachment; filename="{STREAMING_DB_FILENAME}"'},
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,30 @@ def _reset_bulk_global_permit():
 
 
 @pytest.fixture(autouse=True)
+def _reset_object_store_singleton():
+    """Suite-wide reset of the WXYC#835 process-global object store.
+
+    ``core.dependencies._object_store`` is a lazily built process-global
+    (:class:`LocalDirStore` or :class:`S3ObjectStore`) cached on first
+    ``get_object_store`` call. The admin streaming-DB endpoints (WXYC#836)
+    resolve it, and each of their tests roots a fresh ``LocalDirStore`` at its
+    own ``tmp_path`` (via an overridden ``get_settings``) or overrides the store
+    outright for bucket mode. Left unreset, the FIRST such test's store would be
+    reused by every later one — a stale ``tmp_path`` baseline read as another
+    test's on-disk file, or a moto-backed S3 store leaking past its
+    ``mock_aws`` context. Autouse at the root (not per-file) because both the
+    unit guard suite and the integration round-trip touch it, and the reset is
+    one attribute write. Nothing to close: neither store holds a persistent
+    connection.
+    """
+    from core import dependencies as _core_deps
+
+    _core_deps._object_store = None
+    yield
+    _core_deps._object_store = None
+
+
+@pytest.fixture(autouse=True)
 def _reset_lookup_inflight_cap():
     """Suite-wide reset of the LML#706 ``/lookup`` in-flight semaphore.
 

--- a/tests/integration/test_admin_streaming_db.py
+++ b/tests/integration/test_admin_streaming_db.py
@@ -1,18 +1,29 @@
 """Integration tests for /admin/upload-streaming-db + /admin/download-streaming-db.
 
-Verifies the volume round-trip: upload bytes, fetch them back, assert byte-equal.
+Verifies the store round-trip: upload bytes, fetch them back, assert byte-equal.
 This is the contract the discogs-etl daily sync depends on once it stops going
-through the GitHub Release transport.
+through the GitHub Release transport. Run against both store backends
+(WXYC#836): ``LocalDirStore`` (the default, rooted at the library.db parent) and
+a moto-backed ``S3ObjectStore`` (Railway Bucket), proving the contract is
+identical in either mode.
 """
 
 import sqlite3
 from unittest.mock import AsyncMock
 
+import boto3
 import pytest
 from httpx import ASGITransport, AsyncClient
+from moto import mock_aws
 
 from config.settings import Settings, get_settings
-from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+from core.dependencies import (
+    get_discogs_service,
+    get_library_db,
+    get_object_store,
+    get_posthog_client,
+)
+from storage.object_store import S3ObjectStore
 from tests.unit.conftest import override_deps
 
 
@@ -92,6 +103,71 @@ class TestUploadDownloadRoundTrip:
                     "/admin/download-streaming-db",
                     headers={"Authorization": "Bearer round-trip-token"},
                 )
+
+        assert download_resp.status_code == 200
+        assert download_resp.content == original_bytes
+        assert download_resp.headers["content-type"] == "application/octet-stream"
+
+
+class TestUploadDownloadRoundTripBucket:
+    @pytest.mark.asyncio
+    async def test_upload_then_download_byte_equal_in_bucket(
+        self, tmp_path, admin_settings, monkeypatch
+    ):
+        """The same round-trip against a moto-backed S3 store (Railway Bucket).
+
+        The store is overridden onto an ``S3ObjectStore`` so the endpoints write to
+        and read from the (in-process) bucket; ``mock_aws`` wraps the whole exchange.
+        """
+        from main import app
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+        source_path = tmp_path / "source_streaming.db"
+        original_bytes = _make_streaming_db(source_path, album_count=5)
+
+        with mock_aws():
+            boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="lml-rt-bucket")
+            store = S3ObjectStore(
+                bucket="lml-rt-bucket",
+                endpoint_url="https://s3.amazonaws.com",
+                region="us-east-1",
+            )
+            with override_deps(
+                app,
+                {
+                    get_library_db: AsyncMock(),
+                    get_discogs_service: None,
+                    get_posthog_client: None,
+                    get_settings: admin_settings,
+                    get_object_store: store,
+                },
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    with open(source_path, "rb") as f:
+                        upload_resp = await client.post(
+                            "/admin/upload-streaming-db",
+                            headers={"Authorization": "Bearer round-trip-token"},
+                            files={
+                                "file": (
+                                    "streaming_availability.db",
+                                    f,
+                                    "application/octet-stream",
+                                )
+                            },
+                        )
+                    assert upload_resp.status_code == 200
+                    assert upload_resp.json()["row_count"] == 5
+
+                    download_resp = await client.get(
+                        "/admin/download-streaming-db",
+                        headers={"Authorization": "Bearer round-trip-token"},
+                    )
 
         assert download_resp.status_code == 200
         assert download_resp.content == original_bytes

--- a/tests/unit/test_admin_streaming_store_bucket.py
+++ b/tests/unit/test_admin_streaming_store_bucket.py
@@ -1,0 +1,245 @@
+"""Bucket-mode tests for the /admin streaming-DB endpoints (WXYC#836).
+
+Pin the LML#672 coverage-guard semantics when the active store is an
+:class:`S3ObjectStore` (Railway Bucket) rather than the local volume: a missing
+object is accepted (first upload), an unreadable object is refused with 409, a
+coverage regression is refused with 409, and ``force=true`` overrides each. The
+download endpoint streams the object and 404s when the key is absent.
+
+moto (``mock_aws``) patches botocore's HTTP layer in-process, so no network or
+real bucket is touched and no pytest marker is needed — the same approach the
+#835 store unit tests use. The existing local-mode suite
+(``test_admin_streaming_guard.py``) proves the identical contract against
+``LocalDirStore``; the two together are the "same behavior in both store modes"
+guarantee the epic's drift-risk mitigation calls for.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import boto3
+import pytest
+from httpx import ASGITransport, AsyncClient
+from moto import mock_aws
+
+from config.settings import Settings, get_settings
+from core.dependencies import (
+    get_discogs_service,
+    get_library_db,
+    get_object_store,
+    get_posthog_client,
+)
+from routers.admin import STREAMING_DB_FILENAME
+from storage.object_store import ObjectNotFoundError, S3ObjectStore
+from tests.unit.conftest import override_deps
+from tests.unit.test_admin_streaming_guard import _make_streaming_db
+
+BUCKET = "lml-streaming-test"
+# moto's decorator only intercepts AWS-recognized endpoints; the store passes
+# endpoint_url straight through to boto3 with no endpoint-specific logic, so an
+# AWS endpoint exercises the same code the Railway Bucket endpoint would in prod.
+ENDPOINT = "https://s3.amazonaws.com"
+
+
+@pytest.fixture
+def admin_settings(tmp_path):
+    return Settings(
+        admin_token="bucket-token",
+        library_db_path=tmp_path / "library.db",
+        discogs_token=None,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+    )
+
+
+@pytest.fixture
+def s3_store(monkeypatch):
+    """An :class:`S3ObjectStore` backed by an in-process moto S3 with the bucket made.
+
+    ``mock_aws`` wraps the ``yield`` so it stays active for the whole test body —
+    the endpoint's own boto3 get/put (run in ``asyncio.to_thread``) is intercepted
+    too, not just fixture setup.
+    """
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+        yield S3ObjectStore(bucket=BUCKET, endpoint_url=ENDPOINT, region="us-east-1")
+
+
+async def _seed(store: S3ObjectStore, tmp_path: Path, **coverage) -> None:
+    """Write a streaming DB with the given coverage into the store under the key."""
+    seed = tmp_path / "seed.db"
+    _make_streaming_db(seed, **coverage)
+    await store.put(STREAMING_DB_FILENAME, seed)
+
+
+async def _apple_count_in_store(store: S3ObjectStore, tmp_path: Path) -> int:
+    """COUNT(apple_url) of the DB currently stored under the streaming key."""
+    data = await store.get(STREAMING_DB_FILENAME)
+    check = tmp_path / "check.db"
+    check.write_bytes(data)
+    conn = sqlite3.connect(str(check))
+    try:
+        return conn.execute("SELECT COUNT(apple_url) FROM albums").fetchone()[0]
+    finally:
+        conn.close()
+
+
+async def _upload(app, settings, store, db_file, *, force=False):
+    url = "/admin/upload-streaming-db" + ("?force=true" if force else "")
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: None,
+            get_posthog_client: None,
+            get_settings: settings,
+            get_object_store: store,
+        },
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            with open(db_file, "rb") as f:
+                return await client.post(
+                    url,
+                    headers={"Authorization": "Bearer bucket-token"},
+                    files={"file": ("streaming_availability.db", f, "application/octet-stream")},
+                )
+
+
+class TestUploadBucketGuard:
+    @pytest.mark.asyncio
+    async def test_first_upload_missing_object_accepted(self, tmp_path, admin_settings, s3_store):
+        """No object under the key -> accepted like a local first upload."""
+        from main import app
+
+        upload = tmp_path / "u.db"
+        _make_streaming_db(upload, albums=10, apple=5, spotify=8, deezer=6, track_results=20)
+
+        resp = await _upload(app, admin_settings, s3_store, upload)
+        assert resp.status_code == 200
+        assert resp.json()["row_count"] == 10
+        assert await s3_store.exists(STREAMING_DB_FILENAME) is True
+
+    @pytest.mark.asyncio
+    async def test_growth_allowed(self, tmp_path, admin_settings, s3_store):
+        from main import app
+
+        await _seed(s3_store, tmp_path, albums=100, apple=50, spotify=80, deezer=60)
+        upload = tmp_path / "u.db"
+        _make_streaming_db(upload, albums=110, apple=60, spotify=90, deezer=70)
+
+        resp = await _upload(app, admin_settings, s3_store, upload)
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_regression_rejected(self, tmp_path, admin_settings, s3_store):
+        """The 288 -> 0 incident against a seeded bucket object -> 409, object untouched."""
+        from main import app
+
+        await _seed(s3_store, tmp_path, albums=300, apple=288, spotify=200, deezer=150)
+        upload = tmp_path / "u.db"
+        _make_streaming_db(upload, albums=300, apple=0, spotify=200, deezer=150)
+
+        resp = await _upload(app, admin_settings, s3_store, upload)
+        assert resp.status_code == 409
+        regs = resp.json()["detail"]["regressions"]
+        assert any(r["metric"] == "apple_url" for r in regs)
+        # The object in the bucket is left untouched.
+        assert await _apple_count_in_store(s3_store, tmp_path) == 288
+
+    @pytest.mark.asyncio
+    async def test_force_overrides_regression(self, tmp_path, admin_settings, s3_store):
+        from main import app
+
+        await _seed(s3_store, tmp_path, albums=300, apple=288, spotify=200, deezer=150)
+        upload = tmp_path / "u.db"
+        _make_streaming_db(upload, albums=300, apple=0, spotify=200, deezer=150)
+
+        resp = await _upload(app, admin_settings, s3_store, upload, force=True)
+        assert resp.status_code == 200
+        assert await _apple_count_in_store(s3_store, tmp_path) == 0
+
+    @pytest.mark.asyncio
+    async def test_unreadable_object_rejected_not_fail_open(
+        self, tmp_path, admin_settings, s3_store
+    ):
+        """A present-but-corrupt object fails closed (409), not accepted as a first upload."""
+        from main import app
+
+        await s3_store.put(STREAMING_DB_FILENAME, b"this is not a sqlite database")
+        upload = tmp_path / "u.db"
+        _make_streaming_db(upload, albums=300, apple=0, spotify=200, deezer=150)
+
+        resp = await _upload(app, admin_settings, s3_store, upload)
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "error" in detail
+        assert "regressions" not in detail
+        # The corrupt object is left untouched.
+        assert await s3_store.get(STREAMING_DB_FILENAME) == b"this is not a sqlite database"
+
+    @pytest.mark.asyncio
+    async def test_force_overrides_unreadable_object(self, tmp_path, admin_settings, s3_store):
+        from main import app
+
+        await s3_store.put(STREAMING_DB_FILENAME, b"this is not a sqlite database")
+        upload = tmp_path / "u.db"
+        _make_streaming_db(upload, albums=300, apple=288, spotify=200, deezer=150)
+
+        resp = await _upload(app, admin_settings, s3_store, upload, force=True)
+        assert resp.status_code == 200
+        assert await _apple_count_in_store(s3_store, tmp_path) == 288
+
+
+class TestDownloadBucket:
+    async def _download(self, app, settings, store):
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: settings,
+                get_object_store: store,
+            },
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                return await client.get(
+                    "/admin/download-streaming-db",
+                    headers={"Authorization": "Bearer bucket-token"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_download_missing_object_404(self, admin_settings, s3_store):
+        from main import app
+
+        resp = await self._download(app, admin_settings, s3_store)
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_download_returns_object_bytes(self, tmp_path, admin_settings, s3_store):
+        from main import app
+
+        seed = tmp_path / "seed.db"
+        _make_streaming_db(seed, albums=5, apple=3)
+        await s3_store.put(STREAMING_DB_FILENAME, seed)
+
+        resp = await self._download(app, admin_settings, s3_store)
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/octet-stream"
+        assert resp.content == seed.read_bytes()
+
+
+def test_object_not_found_error_is_importable():
+    """Guards the symbol the endpoints branch on to map absence -> accept / 404."""
+    assert issubclass(ObjectNotFoundError, Exception)


### PR DESCRIPTION
## Summary

PR 2 of the volume-eviction epic (#834). Routes `POST /admin/upload-streaming-db` and `GET /admin/download-streaming-db` through the #835 `ObjectStore` instead of the Railway `/data` volume, with **zero contract change** — identical URLs, auth, and status codes. Consumers (`refresh-streaming.yml`, the discogs-etl daily sync, manual scripts) change nothing.

## What changed

- **Upload** buffers the upload to a temp file, validates it as SQLite (`albums` probe → 400), fetches the current stored object to a temp file for the LML#672 coverage baseline, runs the unchanged `_streaming_coverage` / `_check_streaming_regression` guard, and `put`s the validated upload.
- **Download** streams the stored object (404 when absent) via a plain `Response`, preserving the `application/octet-stream` content-type and `content-disposition` filename.
- The guard's **missing-vs-unreadable asymmetry** is preserved and made store-agnostic — a **missing** object (S3 404 / absent file) reads as the all-zero first-upload baseline and is accepted; a present-but-**unreadable** object fails closed at **409** with a `force=true` override. These are cleanly distinguishable against the store (S3 404 vs fetched-but-corrupt).
- `put` is atomic per object (S3 PUT; the local store does tmp + `os.replace`), so the endpoint's own `os.replace` dance is gone and temp scratch lives in a `TemporaryDirectory`. The dead `_streaming_db_path` helper and the `FileResponse` import are removed.

## Guard semantics pinned first (the epic's named drift risk)

- New moto-backed bucket suite `tests/unit/test_admin_streaming_store_bucket.py` mirrors the existing `LocalDirStore` guard suite: missing→accept, unreadable→409+force, regression→409+force, plus download 404/bytes.
- The integration round-trip gains a bucket variant; the **existing endpoint suite runs unchanged against `LocalDirStore`**, proving the contract held.
- A root-conftest autouse fixture resets the process-global object store between tests so a cached store can't leak across `tmp_path`s once the endpoints resolve it.

The running app never reads `streaming_availability.db` — it is purely a hosted artifact, so no boot-fetch is needed (that's `library.db`, PR 3 / #837).

## Verification

- Full default suite green locally (4014 passed; the one local `test_pg_source_bad_credentials` failure is pre-existing environmental noise — a local Postgres answering the intentionally-bogus DSN — and skips in CI).
- `ruff check` + `ruff format --check` clean; `mypy .` clean.

Closes #836.

## Related

- #834 (epic), #835 (storage layer, PR 1), #837 (PR 3 — library.db boot-fetch), #672 (coverage guard + volume-canonical history)