### PR TITLE
Fix inverted comment about the streaming-upload scratch-file .tmp suffix

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -387,10 +387,12 @@ async def upload_streaming_db(
 
     with tempfile.TemporaryDirectory(prefix="lml-streaming-upload-") as td:
         tdir = Path(td)
-        # Scratch file for the upload. A post-validation read fault on it is
-        # classified 500 (not 409) by the ``except`` around the
-        # ``_streaming_coverage(upload_tmp)`` call below, since the upload has
-        # already passed albums-count validation -- the suffix is not load-bearing.
+        # The upload scratch file MUST end in ``.tmp`` and the baseline temp below
+        # must NOT: test_unreadable_uploaded_tmp_after_validation_is_500 monkeypatches
+        # ``_streaming_coverage`` to fault only on ``.tmp`` paths, which is how it
+        # exercises a post-validation read fault on the *upload* (classified 500 by
+        # the ``except`` around ``_streaming_coverage(upload_tmp)`` below) without
+        # also faulting the *baseline* read. Don't rename these two temp files.
         upload_tmp = tdir / "upload.tmp"
 
         try:


### PR DESCRIPTION
## Summary

Follow-up correction to #845. While addressing review feedback on that PR, a comment revision (448dd6f) inverted the truth about the upload scratch file's `.tmp` suffix — it claimed the suffix "is not load-bearing." It **is**.

`tests/unit/test_admin_streaming_guard.py::test_unreadable_uploaded_tmp_after_validation_is_500` monkeypatches `_streaming_coverage` to raise **only** on paths ending in `.tmp`. That is precisely how the test drives a post-validation read fault on the *upload* temp (asserting the 500 path) while letting the *baseline* read (`baseline.db`, no `.tmp`) succeed. Renaming either temp file would silently break the test's targeting — the exact trap the misleading comment invited.

## What changed

- Rewrote the comment in `routers/admin.py` to state the real invariant (upload temp **MUST** end in `.tmp`, baseline temp must **NOT**) and name the test that depends on it.
- Comment-only; **no behavior change**. The filenames were already correct, so all tests were and remain green.

## Verification

- `ruff check` + `ruff format --check` clean; `mypy` clean.
- `test_admin_streaming_guard.py` + `test_admin_streaming_store_bucket.py` green (34 passed), including the 500-path test.

## Related

- #845 (the PR whose comment this corrects), #836, #834 (epic)