### PR TITLE
feat(scripts): seeder for verified library-release overrides (LML#850)

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -185,3 +185,21 @@ LML_API_KEY=... LML_BASE_URL=https://<prod-lml> \
 ```
 
 `--base-url` defaults to `$LML_BASE_URL` then `$PRODUCTION_URL`; `--api-key` to `$LML_API_KEY`. Other flags: `--page-size` (default/cap 25), `--max-retries` (default 2), `--cooldown` (seconds between retry rounds, default 60), `--spot-check` (sample size, default 20), `--seed` (spot-check RNG seed — the sample is reproducible from the JSONL), `--timeout` (per-request seconds, default 120; a fully-escalating page can take ~30s). The report is printed to stdout and, with `--report`, written to a markdown file for pasting into WXYC/Backend-Service#1614.
+
+## Library-Release Override Seeder (`scripts/seed_library_release_overrides.py`)
+
+Seeds `lml_cache.library_release_override` from WXYC DJ Alex L.'s hand-verified `card_catalog_id -> discogs_release_id` CSV (LML#850). Each pin makes a library-album `/lookup` return the verified Discogs release (and its correct tracklist) instead of the per-request fuzzy pick — gated behind the `LML_LIBRARY_RELEASE_OVERRIDE` flag (see [`env-vars.md`](env-vars.md)). The verified CSV lives in the workspace meta-repo (`plans/alex-discogs-import/data/phase1_release_links.csv`) and is **not** committed here — pass its path via `--input`.
+
+**Safety:** dry-run by default — parses + validates the CSV and reports, making **no DB connection** (so it can't create the schema either); pass `--execute` to bootstrap the schema and write. Every row is stamped `--source` (default `alex-l-2026`) so a run is reversible by `DELETE FROM lml_cache.library_release_override WHERE source = '<source>'`. The upsert is `ON CONFLICT (library_id) DO UPDATE` guarded by `source = EXCLUDED.source`, so a re-run is idempotent **and** never clobbers a pin later hand-corrected under a different `source`. Targets the shared discogs-cache PG via `DATABASE_URL_DISCOGS`. **Prod writes require explicit authorization and run staging-first.**
+
+```bash
+# 1. dry-run (default): parse + validate + report, no DB connection
+uv run python -m scripts.seed_library_release_overrides \
+  --input ../plans/alex-discogs-import/data/phase1_release_links.csv
+
+# 2. perform the upsert (staging first)
+uv run python -m scripts.seed_library_release_overrides \
+  --input <path> --execute
+```
+
+`load_rows` opens the CSV `utf-8-sig` (BOM-tolerant), drops rows with a missing/non-integer/non-positive id, and dedupes by `library_id` (last row wins — a later hand-correction supersedes an earlier automated entry). The seeder writes the override table only; minting `entity.release_identity` for the pinned releases and warming the release cache are separate optional operational steps via the existing HTTP surfaces (`POST /api/v1/identity/resolve`, `POST /api/v1/cache/refresh-for-identities`) against a running service.

--- a/scripts/seed_library_release_overrides.py
+++ b/scripts/seed_library_release_overrides.py
@@ -1,0 +1,218 @@
+"""Seed ``lml_cache.library_release_override`` from a verified CSV (LML#850).
+
+WXYC DJ Alex L. hand-verified the correct Discogs release for each card
+catalog entry. This seeder loads the Phase-1 slice (the rows that are Discogs
+*release* ids) into the LML-owned override table, so a library-album lookup
+returns Alex's pinned release — and its correct tracklist — instead of the
+per-request fuzzy pick.
+
+The verified CSV lives in the workspace meta-repo
+(``plans/alex-discogs-import/data/phase1_release_links.csv``) and is **not**
+committed to this repo — pass its path via ``--input``. Its columns are
+``card_catalog_id, discogs_release_id, artist, title, wxyc_genre, format,
+source_file``; ``card_catalog_id`` == tubafrenzy ``LIBRARY_RELEASE.ID`` ==
+``LibraryItem.id`` (the exact key of the override table).
+
+Safety:
+  * **Dry-run by default** — parses + validates the CSV and reports, and makes
+    **no database connection at all**. Pass ``--execute`` to bootstrap the
+    schema (idempotent ``IF NOT EXISTS``) and perform the upsert.
+  * **Reversible** — every row is stamped ``source`` (default ``alex-l-2026``);
+    rollback is ``DELETE FROM lml_cache.library_release_override WHERE source =
+    '<source>'``.
+  * **Idempotent + non-clobbering** — ``ON CONFLICT (library_id) DO UPDATE``
+    guarded by ``source = EXCLUDED.source``: a re-run refreshes only rows this
+    seeder owns and never overwrites a pin later hand-corrected under a
+    different ``source``.
+  * Targets the shared discogs-cache PG via ``DATABASE_URL_DISCOGS``. **Prod
+    writes require explicit authorization and run staging-first.**
+
+Scope: this seeds the override table only. Minting ``entity.release_identity``
+for the pinned releases and warming the release cache are separate, optional
+operational steps handled by the existing HTTP surfaces
+(``POST /api/v1/identity/resolve`` and ``POST /api/v1/cache/refresh-for-identities``)
+against a running service — they are intentionally not bolted onto this
+table-writer.
+
+Usage:
+    # dry-run (default; no DB connection)
+    uv run python -m scripts.seed_library_release_overrides \\
+        --input ../plans/alex-discogs-import/data/phase1_release_links.csv
+
+    # perform the upsert (staging first)
+    uv run python -m scripts.seed_library_release_overrides \\
+        --input <path> --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("seed_library_release_overrides")
+
+DEFAULT_SOURCE = "alex-l-2026"
+
+_LIBRARY_ID_COL = "card_catalog_id"
+_RELEASE_ID_COL = "discogs_release_id"
+
+# Data safety: the conflict UPDATE is guarded by ``source = EXCLUDED.source`` so a
+# re-run only touches rows THIS seeder owns. A pin later hand-corrected under a
+# different ``source`` (e.g. a Music-Director fix) is left untouched — a
+# re-applied CSV can never silently clobber a newer correction, and the scoped
+# rollback DELETE stays truthful. (Per-CLAUDE.md "never overwrite successfully
+# collected data".)
+_UPSERT_SQL = """\
+INSERT INTO lml_cache.library_release_override
+    (library_id, discogs_release_id, source, updated_at)
+VALUES ($1, $2, $3, now())
+ON CONFLICT (library_id) DO UPDATE
+SET discogs_release_id = EXCLUDED.discogs_release_id,
+    updated_at = now()
+WHERE library_release_override.source = EXCLUDED.source\
+"""
+
+
+@dataclass(frozen=True)
+class OverrideRow:
+    """One verified pin: a WXYC library release id -> a Discogs release id."""
+
+    library_id: int
+    discogs_release_id: int
+
+
+def load_rows(path: Path) -> list[OverrideRow]:
+    """Parse the verified CSV into valid, deduped ``OverrideRow``s.
+
+    Drops rows whose ``card_catalog_id`` / ``discogs_release_id`` is missing,
+    non-integer, or non-positive (a ``discogs_release_id <= 0`` can never be a
+    real release — it maps to the ``release_id=0`` sentinel and the DB CHECK
+    would reject it anyway). Dedupes by ``library_id``, **last row wins** (a
+    later hand-correction supersedes an earlier automated entry). Opens with
+    ``utf-8-sig`` so an Excel "CSV UTF-8" (BOM-prefixed) export still matches
+    the first header. Logs the counts so a run is auditable.
+    """
+    parsed = 0
+    skipped = 0
+    by_library_id: dict[int, int] = {}
+    with path.open(newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for record in reader:
+            parsed += 1
+            library_id = _parse_positive_int(record.get(_LIBRARY_ID_COL))
+            release_id = _parse_positive_int(record.get(_RELEASE_ID_COL))
+            if library_id is None or release_id is None:
+                skipped += 1
+                continue
+            by_library_id[library_id] = release_id  # last wins
+    log.info(
+        "loaded %d CSV rows: %d valid pins (%d distinct library ids), %d skipped",
+        parsed,
+        parsed - skipped,
+        len(by_library_id),
+        skipped,
+    )
+    return [OverrideRow(library_id=k, discogs_release_id=v) for k, v in by_library_id.items()]
+
+
+def _parse_positive_int(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+async def seed_overrides(conn, rows: list[OverrideRow], *, execute: bool, source: str) -> int:
+    """Upsert the override rows. Dry-run (``execute=False``) writes nothing.
+
+    Returns the number of rows sent to the upsert (0 on a dry-run or an empty
+    set). Uses a single ``executemany`` with the source-guarded ``ON CONFLICT
+    (library_id) DO UPDATE`` so a re-run is idempotent and non-clobbering.
+    """
+    if not rows:
+        log.info("no rows to seed")
+        return 0
+    if not execute:
+        log.info("[dry-run] would upsert %d override rows (source=%s)", len(rows), source)
+        return 0
+    params = [(r.library_id, r.discogs_release_id, source) for r in rows]
+    await conn.executemany(_UPSERT_SQL, params)
+    log.info("upserted %d override rows (source=%s)", len(rows), source)
+    return len(rows)
+
+
+async def main(args: argparse.Namespace) -> None:
+    rows = load_rows(Path(args.input))
+    if not rows:
+        log.warning("no valid rows loaded from %s — nothing to do", args.input)
+        return
+
+    if not args.execute:
+        # Truly write-nothing: a dry-run makes no DB connection, so it can't
+        # create the schema/table either. It validates the CSV and reports.
+        log.info(
+            "[dry-run] %d valid pins would be upserted (source=%s). Pass --execute "
+            "to bootstrap the schema and write. No database connection was made.",
+            len(rows),
+            args.source,
+        )
+        return
+
+    from config.settings import get_settings
+    from entity.library_release_override import set_up_library_release_override_schema
+    from entity.sources import PgSource
+
+    db_url = get_settings().database_url_discogs
+    if not db_url:
+        raise SystemExit("DATABASE_URL_DISCOGS is not configured — cannot seed overrides")
+
+    pg = PgSource(dsn=db_url)
+    try:
+        # Bootstrap the schema (idempotent IF NOT EXISTS; a no-op on an already-
+        # migrated prod) so the seeder works against a fresh staging PG too.
+        await set_up_library_release_override_schema(pg)
+        # A bare pooled connection for the multi-row ``executemany`` upsert.
+        async with pg.acquire() as conn:
+            written = await seed_overrides(conn, rows, execute=True, source=args.source)
+        log.info("seed complete: %d rows written (source=%s)", written, args.source)
+    finally:
+        await pg.close()
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to the verified CSV (plans/alex-discogs-import/data/phase1_release_links.csv)",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Perform the upsert (default: dry-run, makes no DB connection)",
+    )
+    parser.add_argument(
+        "--source",
+        default=DEFAULT_SOURCE,
+        help=f"Provenance stamp for rollback (default: {DEFAULT_SOURCE})",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    asyncio.run(main(_build_arg_parser().parse_args()))

--- a/tests/integration/test_seed_library_release_overrides.py
+++ b/tests/integration/test_seed_library_release_overrides.py
@@ -1,0 +1,144 @@
+"""Integration (``@pytest.mark.pg``) tests for the override seeder (LML#850).
+
+Drives the seeder's real ``ON CONFLICT (library_id) DO UPDATE`` upsert against
+an actual PostgreSQL connection and reads back through the production prefetch
+helper. Unit coverage (``tests/unit/test_seed_library_release_overrides.py``)
+mocks PG for the CSV-parse + dry-run logic; this proves the SQL itself.
+
+Concrete risks the unit tests cannot catch:
+
+* Upsert semantics — a re-seed with a corrected release updates in place
+  (idempotent), never duplicates a ``library_id``.
+* The dry-run path truly writes nothing.
+* The reversibility contract: a scoped ``DELETE ... WHERE source = ...`` removes
+  exactly the seeded rows.
+
+Run with: pytest -m pg -v tests/integration/test_seed_library_release_overrides.py
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from entity.library_release_override import (
+    get_library_release_overrides,
+    set_up_library_release_override_schema,
+)
+from entity.sources import PgSource
+from scripts.seed_library_release_overrides import OverrideRow, seed_overrides
+
+_SOURCE = "alex-l-2026"
+
+
+@pytest_asyncio.fixture
+async def pg_source(pg_pool):
+    """A ``PgSource`` borrowing the test pool (no-op close)."""
+    return PgSource(pool=pg_pool)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_override_schema(pg_pool, pg_source):
+    """Reset just the override table, then apply its DDL (surgical — see the
+    read-path integration file for the rationale)."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS lml_cache.library_release_override")
+    await set_up_library_release_override_schema(pg_source)
+    yield
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS lml_cache.library_release_override")
+
+
+@pytest.mark.pg
+class TestSeedRoundTrip:
+    @pytest.mark.asyncio
+    async def test_seed_then_prefetch_returns_pins(self, pg_source, pg_pool):
+        rows = [
+            OverrideRow(library_id=17, discogs_release_id=437503),
+            OverrideRow(library_id=28, discogs_release_id=9590),
+        ]
+        async with pg_pool.acquire() as conn:
+            written = await seed_overrides(conn, rows, execute=True, source=_SOURCE)
+        assert written == 2
+
+        result = await get_library_release_overrides(pg_source, [17, 28, 999])
+        assert result == {17: 437503, 28: 9590}
+
+    @pytest.mark.asyncio
+    async def test_reseed_updates_in_place_and_is_idempotent(self, pg_source, pg_pool):
+        async with pg_pool.acquire() as conn:
+            await seed_overrides(
+                conn,
+                [OverrideRow(library_id=17, discogs_release_id=437503)],
+                execute=True,
+                source=_SOURCE,
+            )
+            # Re-seed the same library id with a CORRECTED release — upsert
+            # updates the existing row in place (one row, new value).
+            await seed_overrides(
+                conn,
+                [OverrideRow(library_id=17, discogs_release_id=111111)],
+                execute=True,
+                source=_SOURCE,
+            )
+            count = await conn.fetchval(
+                "SELECT count(*)::int FROM lml_cache.library_release_override WHERE library_id = 17"
+            )
+        assert count == 1
+        result = await get_library_release_overrides(pg_source, [17])
+        assert result == {17: 111111}
+
+    @pytest.mark.asyncio
+    async def test_reseed_does_not_clobber_a_different_source_pin(self, pg_source, pg_pool):
+        # Data safety: a pin later hand-corrected under a DIFFERENT source (e.g. a
+        # Music-Director fix) must survive a re-applied CSV. The source-guarded
+        # ON CONFLICT ... WHERE keeps it untouched.
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO lml_cache.library_release_override "
+                "(library_id, discogs_release_id, source) VALUES (17, 222222, 'md-fix')"
+            )
+            # Re-run Alex's seeder over the same library_id with a different value.
+            await seed_overrides(
+                conn,
+                [OverrideRow(library_id=17, discogs_release_id=437503)],
+                execute=True,
+                source=_SOURCE,
+            )
+            row = await conn.fetchrow(
+                "SELECT discogs_release_id, source FROM lml_cache.library_release_override "
+                "WHERE library_id = 17"
+            )
+        # The MD fix is preserved — NOT reverted to Alex's value or re-stamped.
+        assert row["discogs_release_id"] == 222222
+        assert row["source"] == "md-fix"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_nothing(self, pg_source, pg_pool):
+        async with pg_pool.acquire() as conn:
+            written = await seed_overrides(
+                conn,
+                [OverrideRow(library_id=17, discogs_release_id=437503)],
+                execute=False,
+                source=_SOURCE,
+            )
+        assert written == 0
+        result = await get_library_release_overrides(pg_source, [17])
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_rollback_delete_by_source(self, pg_source, pg_pool):
+        # The reversibility contract: a scoped DELETE by source removes exactly
+        # the seeded rows.
+        async with pg_pool.acquire() as conn:
+            await seed_overrides(
+                conn,
+                [OverrideRow(library_id=17, discogs_release_id=437503)],
+                execute=True,
+                source=_SOURCE,
+            )
+            await conn.execute(
+                "DELETE FROM lml_cache.library_release_override WHERE source = $1", _SOURCE
+            )
+        result = await get_library_release_overrides(pg_source, [17])
+        assert result == {}

--- a/tests/unit/test_seed_library_release_overrides.py
+++ b/tests/unit/test_seed_library_release_overrides.py
@@ -1,0 +1,99 @@
+"""Unit tests for the library-release override seeder (LML#850).
+
+The seeder's load-bearing, testable core: parse the verified CSV, drop invalid
+pins, dedupe by library id, and upsert with the source-guarded ``ON CONFLICT
+(library_id) DO UPDATE`` — idempotent, dry-run by default. The live DB
+connection is exercised by the ``@pytest.mark.pg`` integration suite; here PG
+is mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scripts.seed_library_release_overrides import (
+    OverrideRow,
+    load_rows,
+    seed_overrides,
+)
+
+_CSV = """card_catalog_id,discogs_release_id,artist,title,wxyc_genre,format,source_file
+17,437503,Above the Law,Murder Rap,Hiphop,vinyl,x.xlsx
+28,9590,John Acquaviva,Mainhatten Sound,Hiphop,cd,x.xlsx
+99,0,Bad Pin,Zero Release,Rock,cd,x.xlsx
+100,,No Release,Empty,Rock,cd,x.xlsx
+28,12345,John Acquaviva,Dup Row Wins,Hiphop,cd,x.xlsx
+"""
+
+
+def _write_csv(tmp_path, text: str = _CSV):
+    p = tmp_path / "phase1.csv"
+    p.write_text(text)
+    return p
+
+
+class TestLoadRows:
+    def test_parses_valid_rows(self, tmp_path):
+        rows = load_rows(_write_csv(tmp_path))
+        by_id = {r.library_id: r.discogs_release_id for r in rows}
+        assert by_id[17] == 437503
+
+    def test_drops_zero_and_empty_release_ids(self, tmp_path):
+        rows = load_rows(_write_csv(tmp_path))
+        ids = {r.library_id for r in rows}
+        # library 99 (release 0) and 100 (empty) are invalid pins — excluded.
+        assert 99 not in ids
+        assert 100 not in ids
+
+    def test_dedupes_by_library_id_last_wins(self, tmp_path):
+        # library 28 appears twice; the last row wins (a later hand-correction
+        # supersedes an earlier one).
+        rows = load_rows(_write_csv(tmp_path))
+        by_id = {r.library_id: r.discogs_release_id for r in rows}
+        assert by_id[28] == 12345
+
+    def test_returns_override_row_instances(self, tmp_path):
+        rows = load_rows(_write_csv(tmp_path))
+        assert all(isinstance(r, OverrideRow) for r in rows)
+
+
+@pytest.mark.asyncio
+class TestSeedOverrides:
+    async def test_dry_run_writes_nothing(self):
+        conn = AsyncMock()
+        rows = [OverrideRow(library_id=17, discogs_release_id=437503)]
+
+        written = await seed_overrides(conn, rows, execute=False, source="alex-l-2026")
+
+        assert written == 0
+        conn.executemany.assert_not_awaited()
+        conn.execute.assert_not_awaited()
+
+    async def test_execute_upserts_on_conflict(self):
+        conn = AsyncMock()
+        rows = [
+            OverrideRow(library_id=17, discogs_release_id=437503),
+            OverrideRow(library_id=28, discogs_release_id=12345),
+        ]
+
+        written = await seed_overrides(conn, rows, execute=True, source="alex-l-2026")
+
+        assert written == 2
+        assert conn.executemany.await_count == 1
+        sql = conn.executemany.await_args.args[0]
+        assert "INSERT INTO lml_cache.library_release_override" in sql
+        assert "ON CONFLICT (library_id) DO UPDATE" in sql
+        # Data-safety guard: the UPDATE only fires for rows this source owns, so a
+        # re-run never clobbers a different-source (e.g. MD) hand-correction.
+        assert "WHERE library_release_override.source = EXCLUDED.source" in sql
+        # The source is stamped for reversibility.
+        params = conn.executemany.await_args.args[1]
+        assert all(p[2] == "alex-l-2026" for p in params)
+
+    async def test_empty_rows_is_noop(self):
+        conn = AsyncMock()
+        written = await seed_overrides(conn, [], execute=True, source="alex-l-2026")
+        assert written == 0
+        conn.executemany.assert_not_awaited()


### PR DESCRIPTION
Seeds `lml_cache.library_release_override` (added in #851, merged) from Alex L.’s hand-verified `card_catalog_id → discogs_release_id` CSV, so library-album lookups return the verified Discogs release + correct tracklist once `LML_LIBRARY_RELEASE_OVERRIDE` is flipped on.

_(Supersedes #852, which GitHub force-closed when its stacked base branch `lml-library-release-override` was deleted on #851’s merge; this is the same seeder commit rebased onto `main`.)_

## What this does

- **`scripts/seed_library_release_overrides.py`**: `--input <csv>`, **dry-run by default** (parses + reports, makes **no DB connection**); `--execute` bootstraps the schema and upserts. The upsert is `ON CONFLICT (library_id) DO UPDATE … WHERE library_release_override.source = EXCLUDED.source` — idempotent **and** it never clobbers a pin later hand-corrected under a different `source` (data-safety). Reversible by a scoped `DELETE … WHERE source = alex-l-2026`. Targets `DATABASE_URL_DISCOGS`. `load_rows` is BOM-tolerant (`utf-8-sig`), drops invalid/non-positive ids, dedupes by `library_id`.
- Scope is the override table only — minting `entity.release_identity` and warming the release cache are separate operational steps via existing endpoints (`/api/v1/identity/resolve`, `/api/v1/cache/refresh-for-identities`), deliberately not bolted onto the table-writer.
- `docs/scripts.md` runbook; unit tests (CSV parse, dry-run/execute, source-guarded upsert SQL) + `@pytest.mark.pg` integration (round-trip, idempotency, **different-source non-clobber**, dry-run, rollback).

## Data handling

The verified CSV (`plans/alex-discogs-import/data/phase1_release_links.csv`, 12,218 rows) lives in the workspace meta-repo and is **not** committed here — passed via `--input`. **No prod writes from this PR** — seeding is a manual, staging-first step gated on separate authorization.

Reviewed via multi-agent `/code-review max` (2 rounds); all findings addressed (removed the buggy optional mint/warm passes, added the data-safety source-guard, made dry-run truly write-nothing).

Closes #850.