### PR TITLE
feat(#837): boot-fetch library.db from the object store + upload write-through

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
 """Main application entry point for the Library Metadata Lookup service."""
 
+import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import sentry_sdk
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -11,12 +14,13 @@ from wxyc_fastapi.observability import flush_posthog, init_sentry, shutdown_post
 
 from artists.router import router as artists_router
 from cache.router import router as cache_router
-from config.settings import get_settings
+from config.settings import Settings, get_settings
 from core.auth import require_lml_key
 from core.dependencies import (
     close_discogs_service,
     close_library_db,
     close_musicbrainz_pg,
+    get_object_store,
 )
 from core.logging import setup_logging
 from discogs.router import router as discogs_router
@@ -26,8 +30,10 @@ from identity.router import router as identity_router
 from library.router import router as library_router
 from lookup.router import router as lookup_router
 from release.router import router as release_router
+from routers.admin import LIBRARY_DB_FILENAME
 from routers.admin import router as admin_router
 from routers.health import router as health_router
+from storage.object_store import ObjectNotFoundError, ObjectStore
 from streaming.dependencies import close_streaming_clients
 from streaming.router import router as streaming_router
 
@@ -59,12 +65,82 @@ setup_logging(level=settings.log_level, log_file=log_file)
 logger = logging.getLogger(__name__)
 
 
+def _atomic_write_bytes(dest: Path, data: bytes) -> None:
+    """Write ``data`` to ``dest`` via a temp file + ``os.replace`` (no torn reads)."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(dest.name + ".boot.tmp")
+    try:
+        tmp.write_bytes(data)
+        os.replace(tmp, dest)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+async def _boot_fetch_library_db(
+    settings: Settings,
+    store: ObjectStore,
+    *,
+    attempts: int = 3,
+    base_delay: float = 1.0,
+) -> bool:
+    """Fetch library.db from the object store to the local path before serving.
+
+    Bucket-mode boot step (WXYC#837): populates ``LIBRARY_DB_PATH`` from the
+    durable canonical copy so the process serves the current catalog after a
+    restart with no volume. **Non-fatal** by design (epic #834 decision 2): on a
+    missing object or an exhausted transient-error retry it logs + Sentry-captures
+    and returns ``False``, leaving the app to boot degraded (``/health`` 503 via
+    the missing-DB path) with ``POST /admin/upload-library-db`` still available as
+    the recovery path. A missing object is not retried (a 404 will not resolve on
+    retry); transient errors back off linearly. Returns ``True`` once the local
+    file is written.
+    """
+    dest = settings.resolved_library_db_path
+    for attempt in range(1, attempts + 1):
+        try:
+            data = await store.get(LIBRARY_DB_FILENAME)
+        except ObjectNotFoundError:
+            logger.error(
+                "library.db absent from the object store at boot (key=%s); serving degraded",
+                LIBRARY_DB_FILENAME,
+            )
+            sentry_sdk.capture_message(
+                "library.db missing from object store at boot", level="error"
+            )
+            return False
+        except Exception as exc:  # transient (connection / 5xx): retry then degrade
+            if attempt < attempts:
+                await asyncio.sleep(base_delay * attempt)
+                continue
+            logger.exception(
+                "Boot-fetch of library.db failed after %d attempts; serving degraded", attempts
+            )
+            sentry_sdk.capture_exception(exc)
+            return False
+        # Success: land the bytes atomically off the event loop.
+        await asyncio.to_thread(_atomic_write_bytes, dest, data)
+        logger.info(
+            "Boot-fetched library.db from the object store (%d bytes) -> %s", len(data), dest
+        )
+        return True
+    return False  # unreachable: the loop returns on success or on the final attempt
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifespan with proper startup and shutdown."""
     logger.info(f"Starting {settings.app_name} v{settings.app_version}")
     logger.info(f"Log level: {settings.log_level}")
     logger.info(f"Discogs cache: {'configured' if settings.database_url_discogs else 'disabled'}")
+
+    # Boot-fetch library.db from the object store before serving (WXYC#837).
+    # Bucket mode only and non-fatal — on failure the app boots degraded rather
+    # than crash-looping (see ``_boot_fetch_library_db``). Local mode reads the
+    # file already on disk, so this is skipped there (current behavior).
+    if settings.bucket_mode:
+        store = await get_object_store(settings)
+        await _boot_fetch_library_db(settings, store)
 
     # Bootstrap the persistent streaming-URL cache table directly off the
     # discogs-cache pool. Going through ``get_entity_store`` (and its

--- a/main.py
+++ b/main.py
@@ -65,6 +65,17 @@ setup_logging(level=settings.log_level, log_file=log_file)
 logger = logging.getLogger(__name__)
 
 
+# Wall-clock ceiling on the whole bucket-mode boot fetch (retries included). A
+# partial S3 outage that accepts the connection but hangs on the read would
+# otherwise compound this helper's outer retry loop with boto3's own
+# ``read_timeout`` x ``max_attempts`` and block startup for minutes — long enough
+# for Railway's deploy healthcheck to fail the release, i.e. the slow-motion
+# crash-loop the non-fatal design exists to avoid. 60s comfortably clears any
+# healthy fetch of the tens-of-MB library.db while capping the pathological case
+# well under the healthcheck window (WXYC#837 review).
+_BOOT_FETCH_DEADLINE_SECONDS = 60.0
+
+
 def _atomic_write_bytes(dest: Path, data: bytes) -> None:
     """Write ``data`` to ``dest`` via a temp file + ``os.replace`` (no torn reads)."""
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -77,24 +88,23 @@ def _atomic_write_bytes(dest: Path, data: bytes) -> None:
         raise
 
 
-async def _boot_fetch_library_db(
+async def _fetch_library_db_with_retry(
     settings: Settings,
     store: ObjectStore,
     *,
-    attempts: int = 3,
-    base_delay: float = 1.0,
+    attempts: int,
+    base_delay: float,
 ) -> bool:
-    """Fetch library.db from the object store to the local path before serving.
+    """Fetch library.db to the local path, retrying transient errors.
 
-    Bucket-mode boot step (WXYC#837): populates ``LIBRARY_DB_PATH`` from the
-    durable canonical copy so the process serves the current catalog after a
-    restart with no volume. **Non-fatal** by design (epic #834 decision 2): on a
-    missing object or an exhausted transient-error retry it logs + Sentry-captures
-    and returns ``False``, leaving the app to boot degraded (``/health`` 503 via
-    the missing-DB path) with ``POST /admin/upload-library-db`` still available as
-    the recovery path. A missing object is not retried (a 404 will not resolve on
-    retry); transient errors back off linearly. Returns ``True`` once the local
-    file is written.
+    The retry core of :func:`_boot_fetch_library_db` (which wraps it in the
+    overall deadline). A missing object is **not** retried (a 404 will not resolve
+    on retry) and degrades immediately; transient errors (connection / 5xx) back
+    off linearly and degrade once ``attempts`` is exhausted. The fetched bytes are
+    trusted as-is — the ``POST /admin/upload-library-db`` write path validates the
+    SQLite before it ``put``s, so the store never holds an unvalidated object; no
+    second integrity check is done here. Returns ``True`` once the local file is
+    written, ``False`` on any degrade path.
     """
     dest = settings.resolved_library_db_path
     for attempt in range(1, attempts + 1):
@@ -124,7 +134,43 @@ async def _boot_fetch_library_db(
             "Boot-fetched library.db from the object store (%d bytes) -> %s", len(data), dest
         )
         return True
-    return False  # unreachable: the loop returns on success or on the final attempt
+    return False  # attempts <= 0: nothing tried, degrade by default
+
+
+async def _boot_fetch_library_db(
+    settings: Settings,
+    store: ObjectStore,
+    *,
+    attempts: int = 3,
+    base_delay: float = 1.0,
+    deadline: float = _BOOT_FETCH_DEADLINE_SECONDS,
+) -> bool:
+    """Fetch library.db from the object store to the local path before serving.
+
+    Bucket-mode boot step (WXYC#837): populates ``LIBRARY_DB_PATH`` from the
+    durable canonical copy so the process serves the current catalog after a
+    restart with no volume. **Non-fatal** by design (epic #834 decision 2): on a
+    missing object, an exhausted transient-error retry, or the overall ``deadline``
+    being exceeded, it logs + Sentry-captures and returns ``False``, leaving the
+    app to boot degraded (``/health`` 503 via the missing-DB path) with
+    ``POST /admin/upload-library-db`` still available as the recovery path.
+
+    The retry loop (:func:`_fetch_library_db_with_retry`) is bounded by ``deadline``
+    seconds of total wall-clock so a hung read cannot stall startup — see
+    ``_BOOT_FETCH_DEADLINE_SECONDS``. Returns ``True`` once the local file is
+    written.
+    """
+    try:
+        return await asyncio.wait_for(
+            _fetch_library_db_with_retry(settings, store, attempts=attempts, base_delay=base_delay),
+            timeout=deadline,
+        )
+    except TimeoutError:
+        logger.error(
+            "Boot-fetch of library.db exceeded the %.0fs deadline; serving degraded", deadline
+        )
+        sentry_sdk.capture_message("library.db boot-fetch exceeded deadline", level="error")
+        return False
 
 
 @asynccontextmanager

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["admin"])
 
 STREAMING_DB_FILENAME = "streaming_availability.db"
+LIBRARY_DB_FILENAME = "library.db"
 
 # Coverage-regression guard tolerance for /admin/upload-streaming-db (LML#672).
 # An upload is rejected if any guarded metric drops below prior * (1 - tolerance)
@@ -266,18 +267,37 @@ def _validate_auth(
 async def upload_library_db(
     file: UploadFile,
     settings: Settings = Depends(get_settings),
+    object_store: ObjectStore = Depends(get_object_store),
     authorization: str | None = Header(None),
 ):
     """Replace the library.db file with an uploaded SQLite database.
 
-    The uploaded file is validated before replacing the existing database.
-    The current database connection is closed so the next request picks up
-    the new file.
+    The uploaded file is validated, written to the durable object store (the
+    canonical copy other replicas and the next boot's lifespan fetch read —
+    WXYC#837), and then hot-swapped into the serving replica's local file: the
+    current DB connection is closed (clearing the TTL caches) and the file is
+    atomically replaced so the next request picks up the new catalog.
+
+    The storage backend (:class:`~storage.object_store.ObjectStore`) is selected
+    once per deployment: a Railway Bucket in prod, a local directory in dev/tests.
+    The endpoint is mode-agnostic — it always both ``put``s to the store and does
+    the local hot-swap. In local mode the store's directory *is* the DB's parent,
+    so the ``put`` and the ``os.replace`` land the same file (idempotent); in
+    bucket mode the ``put`` is the remote canonical write and the ``os.replace``
+    is this replica's local refresh. The N>=2 caveat (a hot-swap only refreshes
+    the replica that served the request; others refresh at next restart) is a
+    runbook note, not code (epic #834, PR 4).
     """
     _validate_auth(settings, authorization)
 
     db_path = settings.resolved_library_db_path
-    tmp_path = db_path.parent / f"{db_path.name}.tmp"
+    # ``.upload.tmp`` (not ``.tmp``) so this scratch file never collides with
+    # ``LocalDirStore.put``'s own internal ``<name>.tmp`` in local mode, where the
+    # store's directory is the DB's parent: a shared name would let the store's
+    # os.replace rename this file out from under the local hot-swap below (#837).
+    # Kept in ``db_path.parent`` so the final os.replace is a same-filesystem
+    # atomic rename.
+    tmp_path = db_path.parent / f"{db_path.name}.upload.tmp"
 
     # Write uploaded file to temp location
     try:
@@ -306,10 +326,21 @@ async def upload_library_db(
         new_ids = _get_streaming_ids(tmp_path)
         changes = _compute_streaming_diff(old_ids, new_ids)
 
-    # Close current database connection
+    # Durable canonical write first (WXYC#837). Put-first so a store failure
+    # aborts with 500 *before* we mutate the serving replica's on-disk DB — no
+    # half-applied swap that would leave this replica ahead of the bucket (and of
+    # the next boot / other replicas).
+    try:
+        await object_store.put(LIBRARY_DB_FILENAME, tmp_path)
+    except Exception as e:
+        tmp_path.unlink(missing_ok=True)
+        logger.error(f"Failed to store library.db in the object store: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to store library.db: {e}") from e
+
+    # Close current database connection (clears the TTL caches via LibraryDB.close)
     await close_library_db()
 
-    # Atomic replace
+    # Atomic local hot-swap so this replica serves the new file immediately.
     os.replace(str(tmp_path), str(db_path))
     logger.info(f"Library database replaced: {db_path} ({row_count} rows)")
 

--- a/tests/unit/test_admin_library_store_bucket.py
+++ b/tests/unit/test_admin_library_store_bucket.py
@@ -1,0 +1,146 @@
+"""Bucket-mode tests for POST /admin/upload-library-db (WXYC#837, volume-eviction PR 3).
+
+The upload endpoint is mode-agnostic: it writes the validated file to the active
+:class:`~storage.object_store.ObjectStore` (the durable canonical copy) and then
+performs today's local hot-swap (``close_library_db()`` then ``os.replace``) so
+the replica that served the request also picks up the new file. These tests pin
+the bucket-mode leg against a moto-backed :class:`S3ObjectStore`; the existing
+``test_admin_router.py`` suite proves the identical contract against the default
+``LocalDirStore`` (local mode unchanged).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import boto3
+import pytest
+from httpx import ASGITransport, AsyncClient
+from moto import mock_aws
+
+from config.settings import Settings, get_settings
+from core.dependencies import (
+    get_discogs_service,
+    get_library_db,
+    get_object_store,
+    get_posthog_client,
+)
+from routers.admin import LIBRARY_DB_FILENAME
+from storage.object_store import S3ObjectStore
+from tests.unit.conftest import override_deps
+from tests.unit.test_admin_router import _make_valid_sqlite_db
+
+BUCKET = "lml-library-upload-test"
+ENDPOINT = "https://s3.amazonaws.com"
+
+
+@pytest.fixture
+def admin_settings(tmp_path):
+    return Settings(
+        admin_token="bucket-token",
+        library_db_path=tmp_path / "library.db",
+        discogs_token=None,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+    )
+
+
+@pytest.fixture
+def s3_store(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    with mock_aws():
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+        yield S3ObjectStore(bucket=BUCKET, endpoint_url=ENDPOINT, region="us-east-1")
+
+
+async def _upload(app, settings, store, db_file):
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(),
+            get_discogs_service: None,
+            get_posthog_client: None,
+            get_settings: settings,
+            get_object_store: store,
+        },
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            with open(db_file, "rb") as f:
+                return await client.post(
+                    "/admin/upload-library-db",
+                    headers={"Authorization": "Bearer bucket-token"},
+                    files={"file": ("library.db", f, "application/octet-stream")},
+                )
+
+
+class TestUploadLibraryBucket:
+    @pytest.mark.asyncio
+    async def test_upload_puts_to_bucket(self, tmp_path, admin_settings, s3_store):
+        """A valid upload lands in the bucket under the library.db key."""
+        from main import app
+
+        db_file = tmp_path / "upload.db"
+        _make_valid_sqlite_db(db_file)
+
+        resp = await _upload(app, admin_settings, s3_store, db_file)
+
+        assert resp.status_code == 200
+        assert resp.json()["row_count"] == 1
+        assert await s3_store.exists(LIBRARY_DB_FILENAME) is True
+        data = await s3_store.get(LIBRARY_DB_FILENAME)
+        check = tmp_path / "from_bucket.db"
+        check.write_bytes(data)
+        conn = sqlite3.connect(str(check))
+        try:
+            assert conn.execute("SELECT count(*) FROM library").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    @pytest.mark.asyncio
+    async def test_upload_hotswaps_local_file(self, tmp_path, admin_settings, s3_store):
+        """The serving replica's on-disk library.db is replaced with the upload."""
+        from main import app
+
+        # Pre-existing stale local file to be replaced by the hot-swap.
+        db_path: Path = admin_settings.resolved_library_db_path
+        db_path.write_bytes(b"stale")
+
+        db_file = tmp_path / "upload.db"
+        _make_valid_sqlite_db(db_file)
+
+        resp = await _upload(app, admin_settings, s3_store, db_file)
+
+        assert resp.status_code == 200
+        # Local file now a valid SQLite library DB, not the stale bytes.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            assert conn.execute("SELECT count(*) FROM library").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+    @pytest.mark.asyncio
+    async def test_bucket_put_failure_does_not_hotswap(self, tmp_path, admin_settings):
+        """If the durable put fails, the local file is left intact (put-first ordering)."""
+        from main import app
+
+        db_path: Path = admin_settings.resolved_library_db_path
+        db_path.write_bytes(b"stale-but-canonical")
+
+        db_file = tmp_path / "upload.db"
+        _make_valid_sqlite_db(db_file)
+
+        failing_store = AsyncMock()
+        failing_store.put = AsyncMock(side_effect=RuntimeError("bucket down"))
+
+        resp = await _upload(app, admin_settings, failing_store, db_file)
+
+        assert resp.status_code == 500
+        # Local file untouched — no half-applied swap after a failed durable write.
+        assert db_path.read_bytes() == b"stale-but-canonical"

--- a/tests/unit/test_main_boot_fetch.py
+++ b/tests/unit/test_main_boot_fetch.py
@@ -1,11 +1,12 @@
 """Boot-fetch of library.db from the object store (WXYC#837, volume-eviction PR 3).
 
 In bucket mode the FastAPI lifespan fetches ``library.db`` from the store to the
-local ``LIBRARY_DB_PATH`` before serving, with a small bounded retry. The fetch
-is **non-fatal**: on final failure (transient error exhausted, or the object
-absent) the app logs + Sentry-captures and boots degraded — ``/health`` then
-503s via the missing-DB path while the ``POST /admin/upload-library-db`` recovery
-endpoint stays available (epic #834 decision 2). Local mode never fetches.
+local ``LIBRARY_DB_PATH`` before serving, with a small bounded retry under an
+overall wall-clock deadline. The fetch is **non-fatal**: on final failure
+(transient error exhausted, the object absent, or the deadline exceeded) the app
+logs + Sentry-captures and boots degraded — ``/health`` then 503s via the
+missing-DB path while the ``POST /admin/upload-library-db`` recovery endpoint
+stays available (epic #834 decision 2). Local mode never fetches.
 
 moto (``mock_aws``) intercepts botocore in-process, so no network or real bucket
 is touched and no pytest marker is needed — the same approach the #835/#836
@@ -14,6 +15,7 @@ store tests use.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import boto3
@@ -62,6 +64,20 @@ class _RaisingStore:
         raise self._exc
 
 
+class _HangingStore:
+    """Stub store whose ``get`` blocks longer than the boot-fetch deadline.
+
+    Models a partial S3 outage where the connection is accepted but the read
+    hangs — the failure mode that, without a wall-clock bound, compounds with
+    boto3's own ``read_timeout`` x ``max_attempts`` and can stall startup for
+    minutes.
+    """
+
+    async def get(self, key: str) -> bytes:
+        await asyncio.sleep(3600)
+        raise AssertionError("unreachable: the deadline must fire first")
+
+
 class TestBootFetchHelper:
     @pytest.mark.asyncio
     async def test_success_writes_local_file(self, tmp_path, aws_creds):
@@ -78,6 +94,46 @@ class TestBootFetchHelper:
 
         assert ok is True
         assert settings.resolved_library_db_path.read_bytes() == PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_success_overwrites_existing_local_file(self, tmp_path, aws_creds):
+        """A stale local file (e.g. an old volume copy) is replaced by the bucket copy."""
+        from main import _boot_fetch_library_db
+
+        settings = _bucket_settings(tmp_path)
+        # A pre-existing local library.db — the realistic transition-window state
+        # where a volume still holds an older copy the boot-fetch must supersede.
+        settings.resolved_library_db_path.write_bytes(b"stale-local-library-db")
+
+        with mock_aws():
+            boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+            store = S3ObjectStore(bucket=BUCKET, endpoint_url=ENDPOINT, region="us-east-1")
+            await store.put(LIBRARY_DB_FILENAME, PAYLOAD)
+
+            ok = await _boot_fetch_library_db(settings, store, base_delay=0)
+
+        assert ok is True
+        assert settings.resolved_library_db_path.read_bytes() == PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_deadline_exceeded_degrades(self, tmp_path):
+        """A hung fetch is bounded by the deadline and degrades (non-fatal)."""
+        from main import _boot_fetch_library_db
+
+        settings = _bucket_settings(tmp_path)
+        store = _HangingStore()
+
+        with pytest.MonkeyPatch.context() as mp:
+            captured = []
+            mp.setattr("sentry_sdk.capture_message", lambda *a, **k: captured.append(a))
+            ok = await asyncio.wait_for(
+                _boot_fetch_library_db(settings, store, base_delay=0, deadline=0.05),
+                timeout=5,  # test-level guard: the 0.05s deadline must fire well before this
+            )
+
+        assert ok is False
+        assert captured, "a deadline-exceeded boot-fetch must be Sentry-captured"
+        assert not settings.resolved_library_db_path.exists()
 
     @pytest.mark.asyncio
     async def test_transient_failure_retries_then_degrades(self, tmp_path):

--- a/tests/unit/test_main_boot_fetch.py
+++ b/tests/unit/test_main_boot_fetch.py
@@ -1,0 +1,170 @@
+"""Boot-fetch of library.db from the object store (WXYC#837, volume-eviction PR 3).
+
+In bucket mode the FastAPI lifespan fetches ``library.db`` from the store to the
+local ``LIBRARY_DB_PATH`` before serving, with a small bounded retry. The fetch
+is **non-fatal**: on final failure (transient error exhausted, or the object
+absent) the app logs + Sentry-captures and boots degraded — ``/health`` then
+503s via the missing-DB path while the ``POST /admin/upload-library-db`` recovery
+endpoint stays available (epic #834 decision 2). Local mode never fetches.
+
+moto (``mock_aws``) intercepts botocore in-process, so no network or real bucket
+is touched and no pytest marker is needed — the same approach the #835/#836
+store tests use.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from config.settings import Settings
+from routers.admin import LIBRARY_DB_FILENAME
+from storage.object_store import ObjectNotFoundError, S3ObjectStore
+
+BUCKET = "lml-library-test"
+ENDPOINT = "https://s3.amazonaws.com"
+PAYLOAD = b"SQLite format 3\x00-boot-fetched-library-db-bytes"
+
+
+@pytest.fixture
+def aws_creds(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+
+def _bucket_settings(tmp_path) -> Settings:
+    return Settings(
+        library_db_path=tmp_path / "library.db",
+        lml_bucket_name=BUCKET,
+        lml_bucket_endpoint=ENDPOINT,
+        discogs_token=None,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+    )
+
+
+class _RaisingStore:
+    """Stub store whose ``get`` always raises the given exception."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.calls = 0
+
+    async def get(self, key: str) -> bytes:
+        self.calls += 1
+        raise self._exc
+
+
+class TestBootFetchHelper:
+    @pytest.mark.asyncio
+    async def test_success_writes_local_file(self, tmp_path, aws_creds):
+        """A present object is fetched and written atomically to the local path."""
+        from main import _boot_fetch_library_db
+
+        settings = _bucket_settings(tmp_path)
+        with mock_aws():
+            boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=BUCKET)
+            store = S3ObjectStore(bucket=BUCKET, endpoint_url=ENDPOINT, region="us-east-1")
+            await store.put(LIBRARY_DB_FILENAME, PAYLOAD)
+
+            ok = await _boot_fetch_library_db(settings, store, base_delay=0)
+
+        assert ok is True
+        assert settings.resolved_library_db_path.read_bytes() == PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_transient_failure_retries_then_degrades(self, tmp_path):
+        """A transient error is retried up to ``attempts`` times, then non-fatal."""
+        from main import _boot_fetch_library_db
+
+        settings = _bucket_settings(tmp_path)
+        store = _RaisingStore(RuntimeError("connection reset"))
+
+        with pytest.MonkeyPatch.context() as mp:
+            captured = []
+            mp.setattr("sentry_sdk.capture_exception", lambda *a, **k: captured.append(a))
+            ok = await _boot_fetch_library_db(settings, store, attempts=3, base_delay=0)
+
+        assert ok is False
+        assert store.calls == 3  # retried, not one-shot
+        assert captured, "final failure must be Sentry-captured"
+        assert not settings.resolved_library_db_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_missing_object_degrades_without_retry(self, tmp_path):
+        """A 404 (ObjectNotFoundError) is non-fatal and not retried (retry can't help)."""
+        from main import _boot_fetch_library_db
+
+        settings = _bucket_settings(tmp_path)
+        store = _RaisingStore(ObjectNotFoundError(LIBRARY_DB_FILENAME))
+
+        with pytest.MonkeyPatch.context() as mp:
+            captured = []
+            mp.setattr("sentry_sdk.capture_message", lambda *a, **k: captured.append(a))
+            ok = await _boot_fetch_library_db(settings, store, attempts=3, base_delay=0)
+
+        assert ok is False
+        assert store.calls == 1
+        assert captured, "a missing object at boot must be Sentry-captured"
+        assert not settings.resolved_library_db_path.exists()
+
+
+class TestLifespanWiring:
+    @pytest.mark.asyncio
+    async def test_bucket_mode_invokes_boot_fetch(self, tmp_path, monkeypatch):
+        """In bucket mode the lifespan builds the store and calls the boot-fetch."""
+        import main
+
+        monkeypatch.setattr(main, "settings", _bucket_settings(tmp_path))
+        sentinel_store = object()
+        monkeypatch.setattr(main, "get_object_store", AsyncMock(return_value=sentinel_store))
+
+        seen = {}
+
+        async def _fake_fetch(settings, store, **kwargs):
+            seen["settings"] = settings
+            seen["store"] = store
+            return True
+
+        monkeypatch.setattr(main, "_boot_fetch_library_db", _fake_fetch)
+
+        async with main.lifespan(main.app):
+            pass
+
+        assert seen.get("store") is sentinel_store
+
+    @pytest.mark.asyncio
+    async def test_local_mode_skips_boot_fetch(self, tmp_path, monkeypatch):
+        """Without bucket vars the lifespan does not fetch (current behavior)."""
+        import main
+
+        local_settings = Settings(
+            library_db_path=tmp_path / "library.db",
+            discogs_token=None,
+            database_url_discogs=None,
+            sentry_dsn=None,
+            posthog_api_key=None,
+            enable_telemetry=False,
+        )
+        monkeypatch.setattr(main, "settings", local_settings)
+
+        called = False
+
+        async def _fake_fetch(settings, store, **kwargs):
+            nonlocal called
+            called = True
+            return True
+
+        monkeypatch.setattr(main, "_boot_fetch_library_db", _fake_fetch)
+
+        async with main.lifespan(main.app):
+            pass
+
+        assert called is False


### PR DESCRIPTION
Closes #837. PR 3 of the volume-eviction epic #834 (the last code PR before the operator cutover; #838/#839 are HITL, #840 is docs).

Makes `library.db` bucket-resident, consuming the `ObjectStore` from #835 — the change that lets the volume be removed (zero-downtime deploys) and clears one of the remaining blockers for replicas.

## Changes

**1. Lifespan boot-fetch (`main.py`).** In bucket mode the FastAPI lifespan fetches `library.db` from the store to `LIBRARY_DB_PATH` before serving, with a small bounded retry (3 attempts, linear backoff). It is **non-fatal** by design (epic decision 2): a missing object or an exhausted transient-error retry logs + Sentry-captures and boots degraded — `/health` 503s via the existing missing-DB path while `POST /admin/upload-library-db` stays available as the recovery path — rather than raising and crash-looping into the `railway.toml` restart cap. A 404 is not retried (retry cannot resolve absence); transient errors back off. Local mode never fetches (current behavior). *(This pins the non-fatal path; the plan draft's "fetch failure raises" bullet was a stale contradiction, called out in the issue.)*

**2. Upload write-through (`POST /admin/upload-library-db`).** Validate → `put` to the store (the durable canonical copy the next boot and any future replica read) → today's local hot-swap (`close_library_db` → `os.replace`). **Put-first**, so a store failure aborts with 500 *before* the serving replica's on-disk DB is mutated — no half-applied swap that diverges from the bucket. Mode-agnostic: in local mode the store's directory is the DB's parent so `put` and `os.replace` land the same file; in bucket mode `put` is the remote write and `os.replace` the local refresh.

One bug surfaced while going green: in local mode `LocalDirStore.put`'s own internal `<name>.tmp` collided with the endpoint's `library.db.tmp` scratch file and renamed it out from under the hot-swap (`FileNotFoundError`). Fixed by giving the scratch a distinct `.upload.tmp` suffix, kept in the DB's parent dir so the final `os.replace` stays a same-filesystem atomic rename.

## Tests

moto-backed, mirroring the #836 harness:
- boot-fetch success, transient-failure-retries-then-degrades, missing-object-degrades-without-retry, lifespan wiring (bucket invokes / local skips) — `tests/unit/test_main_boot_fetch.py`
- upload-puts-to-bucket, upload-hotswaps-local-file, put-failure-does-not-hotswap — `tests/unit/test_admin_library_store_bucket.py`
- existing local-mode `tests/unit/test_admin_router.py` unchanged, proving the contract holds in both store modes.

Local CI green: `ruff check` / `ruff format --check`, `mypy . --ignore-missing-imports` (422 files, no issues), unit suite 3801 passed.

## Not in scope

Docs (deployment rewrite + runbooks) and the `entrypoint.sh` chown removal are PR 4 (#840), after the cutover. Enabling N>=2 replicas remains gated on discogs-etl#313 and Backend-Service#1591 per the runbook.