### PR TITLE
chore: regenerate api_models.py (sync FlowsheetV2TrackEntry.artist_id)

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -2207,6 +2207,10 @@ class FlowsheetV2TrackEntry(FlowsheetV2Base):
     entry_type: Literal["track"]
     album_id: int | None = None
     rotation_id: int | None = None
+    artist_id: int | None = Field(
+        None,
+        description="The played release's resolved WXYC catalog artist id (`flowsheet.album_id → library.artist_id`), computed server-side on the same join that powers `upcoming_show`. Shares the catalog artist-id keyspace with `Concert.headlining_artist_id` and `SimilarArtist.artist_id`, so on-device features — the On Tour likes match — can intersect a liked playcut's artist against concert headliners and their affinity neighbors in one id space.\n\nNull for free-form entries (no `album_id`) and for library rows whose album has no linked artist. Additive and optional: older app builds that don't decode it are unaffected.\n",
+    )
     artist_name: str | None = None
     album_title: str | None = None
     track_title: str | None = None


### PR DESCRIPTION
Mechanical catch-up regeneration of `generated/api_models.py` to clear pre-existing, repo-wide **Codegen Freshness** drift.

## Why

The Codegen Freshness CI job re-runs `scripts/generate_api_models.sh` and does `git diff --exit-code generated/`. It was failing on **every** open LML PR (including #859) because `wxyc-shared` main added a field to the OpenAPI contract that had never been regenerated into LML's committed models:

- `FlowsheetV2TrackEntry.artist_id` — an additive, optional, nullable integer added under the [On Tour](https://github.com/orgs/WXYC/projects/37) initiative (wxyc-shared `feat(api): add FlowsheetV2TrackEntry.artist_id`, contract bump 1.18.0 → 1.19.0). It is the played release's resolved WXYC catalog artist id, surfaced so iOS can match liked playcuts against concert headliners in one id space.

This drift was not introduced by any single PR; it is the committed generated file lagging the merged upstream contract. This regen is the catch-up so the check goes green for everyone.

## Change

Purely additive; touches only `generated/`:

```
 generated/api_models.py | 4 ++++
 1 file changed, 4 insertions(+)
```

Adds the `artist_id: int | None` field to `FlowsheetV2TrackEntry`. No deletions, renames, or unrelated model changes.

## Verification

- `scripts/generate_api_models.sh` run against current `wxyc-shared` main; `git diff --exit-code generated/` is clean (identical to what the CI check runs).
- `ruff check`, `ruff format --check`, `mypy`, and `import generated.api_models` all pass.
- Default (unmarked) test suite: 4119 passed.

Unblocks the failing Codegen Freshness check on all open LML PRs, including #859.