### PR TITLE
feat(#862): off-prod Apple-Music-URL resolver for the BS#1631 tail

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -256,3 +256,29 @@ uv run python -m scripts.drain_master_api_tail \
 uv run python -m scripts.seed_library_release_overrides \
   --input phase2_master_links_api.csv --source alex-l-2026-masters-api --execute
 ```
+
+## Apple-Music-URL Resolver (`scripts/resolve_apple_urls.py`)
+
+Off-prod resolver for the [BS#1631](https://github.com/WXYC/Backend-Service/issues/1631) Apple-Music-URL backfill's still-null `album_metadata` tail. The in-service backfill drives LML `/api/v1/lookup`, but almost none of a full lookup's work is needed for `apple_music_url`: the persistent album-level URL comes *solely* from the async warm calling `AppleMusicClient.find_album_match(artist, album)` (`entity/streaming_url_cache.py`). This script calls that exact method directly — **exact match parity** with the album-phase capture path — at a fraction of the cost, and, run off-prod, sidesteps both the LML health watchdog and the synchronous-enrichment latency wall ([LML#706](https://github.com/WXYC/library-metadata-lookup/issues/706)) that make the in-service backfill trip and under-capture.
+
+It is the **resolve** half of a two-phase, clean-ownership design: this script reads a read-only candidate export `(album_id, artist, album)` and emits `(album_id, apple_music_url)` for accepted matches to a TSV; the **apply** half (Backend-Service `jobs/apple-music-url-backfill/resolve.ts::applyUpdate`, fill-only `WHERE apple_music_url IS NULL`) writes it back. LML never writes BS RDS. Scope is **album-level only** — `find_album_match` is the album-phase warm path; the flowsheet phase's track-level probe is out of scope.
+
+**Shared-token safety.** The Apple JWT creds (`APPLE_MUSIC_TEAM_ID`/`KEY_ID`/`PRIVATE_KEY`, from `os.environ`) are prod's and their per-process limiter is not coordinated with the live service's. Run **off-peak**, bound `--concurrency`, and set `--rate-per-min` to stay under Apple's ceiling so the resolver never starves prod's own enrichment (a 403/429 reuses the client's backoff). Progress is checkpointed per album to a JSONL file: terminal states (`matched`, `no_match`) are never retried, while `api_error` (transient) is re-attempted on the next run — so an interrupted or re-run resolve never re-spends Apple budget on a settled candidate. `--limit` caps candidates per run for a smoke batch; `--dry-run` resolves + tallies + checkpoints but emits no output TSV.
+
+```bash
+# dry-run tally first (no TSV emitted); off-peak only
+uv run python -m scripts.resolve_apple_urls \
+  --candidates candidates.tsv \
+  --checkpoint apple_resolve.jsonl \
+  --out apple_urls.tsv \
+  --concurrency 10 --rate-per-min 300 --dry-run
+
+# then the real resolve (writes/updates the checkpoint + the (album_id, url) TSV)
+uv run python -m scripts.resolve_apple_urls \
+  --candidates candidates.tsv \
+  --checkpoint apple_resolve.jsonl \
+  --out apple_urls.tsv \
+  --concurrency 10 --rate-per-min 300
+```
+
+The emitted `apple_urls.tsv` is applied back via the Backend-Service fill-only write (SELECT-before / count-after; never overwrites a non-null URL).

--- a/scripts/resolve_apple_urls.py
+++ b/scripts/resolve_apple_urls.py
@@ -1,0 +1,416 @@
+"""Off-prod Apple-Music-URL resolver for the BS#1631 album-phase tail.
+
+BS#1631 drives LML ``/api/v1/lookup`` over ~27K still-null ``album_metadata``
+rows to fill ``apple_music_url``. Almost none of a full lookup's work is needed
+for that column: the persistent album-level ``apple_music_url`` the backfill
+reads comes *solely* from the async warm calling
+``AppleMusicClient.find_album_match(artist, album)``
+(``entity/streaming_url_cache.py:350``), which uses the shared fuzz-floor
+``find_best_source_match``. So a standalone resolver that calls
+``find_album_match`` directly has **exact match parity** with the album-phase
+capture path, at a fraction of the cost — and, run off-prod, it sidesteps both
+the LML health watchdog and the synchronous-enrichment latency wall (LML#706)
+that make the in-service backfill trip and under-capture.
+
+This is the **resolve** half of a two-phase, clean-ownership design: this script
+(LML repo) reads the still-null candidate set ``(album_id, artist, album)`` and
+emits ``(album_id, apple_music_url)`` for accepted matches to a TSV; the **apply**
+half (Backend-Service ``jobs/apple-music-url-backfill/resolve.ts::applyUpdate``,
+fill-only ``WHERE apple_music_url IS NULL``) writes it back. LML never writes BS
+RDS.
+
+Per candidate:
+
+1. ``find_album_match(artist, album)`` — the exact album-level warm path.
+2. A ``SourceMatch`` -> ``matched`` (emit ``album_id\turl``); ``None`` ->
+   ``no_match``; a raised Apple API error -> ``api_error`` (transient).
+
+Progress is checkpointed per album to a JSONL file, so an interrupted or re-run
+resolve never re-spends Apple API budget on a candidate already in a terminal
+state (``matched`` / ``no_match``). ``api_error`` is transient and retried.
+
+**Safety.** The Apple JWT creds are prod's, and their per-process limiter is not
+coordinated with the live service's. Run **off-peak**, bound ``--concurrency``,
+and set ``--rate-per-min`` to stay under Apple's ceiling so the resolver never
+starves prod's own Apple enrichment. Read-only against BS (candidates are an
+exported TSV, not a live BS read); the only write is the separate fill-only apply.
+
+Usage (dry-run tally first, then the real run)::
+
+    python -m scripts.resolve_apple_urls \\
+        --candidates candidates.tsv \\
+        --checkpoint apple_resolve.jsonl \\
+        --out apple_urls.tsv \\
+        --concurrency 10 --rate-per-min 300 --dry-run
+
+    python -m scripts.resolve_apple_urls \\
+        --candidates candidates.tsv \\
+        --checkpoint apple_resolve.jsonl \\
+        --out apple_urls.tsv \\
+        --concurrency 10 --rate-per-min 300
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import logging
+import os
+import time
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from scripts._lib.csv_ids import parse_positive_int
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("resolve_apple_urls")
+
+# Per-candidate outcome states.
+STATUS_MATCHED = "matched"  # find_album_match returned a SourceMatch -> emit url
+STATUS_NO_MATCH = "no_match"  # find_album_match returned None (no Apple album)
+STATUS_API_ERROR = "api_error"  # find_album_match raised (transient) -> retry
+
+# Terminal states are stable conclusions and are skipped on re-run. ``api_error``
+# is transient and retried until it settles.
+TERMINAL_STATUSES = frozenset({STATUS_MATCHED, STATUS_NO_MATCH})
+
+_TSV_HEADER = ["album_id", "apple_music_url"]
+
+
+@dataclass(frozen=True)
+class AlbumResolveOutcome:
+    """The resolver's terminal-or-retryable decision for one album id."""
+
+    album_id: int
+    apple_music_url: str | None
+    status: str
+
+
+# ---------------------------------------------------------------------------
+# Pure core (no network)
+# ---------------------------------------------------------------------------
+
+
+async def resolve_one(client, album_id: int, artist: str, album: str) -> AlbumResolveOutcome:
+    """Resolve one ``(artist, album)`` to an Apple URL via ``find_album_match``.
+
+    ``client`` needs async ``find_album_match(artist, title) -> SourceMatch|None``
+    (an ``AppleMusicClient``). A raised Apple API error is caught and reported as
+    ``api_error`` so one transient failure never aborts the run — the caller
+    leaves it un-terminal for retry on the next pass.
+    """
+    try:
+        match = await client.find_album_match(artist, album)
+    except Exception as exc:  # noqa: BLE001 — transient Apple error: retryable
+        log.warning("album %d (%s — %s) raised: %s", album_id, artist, album, exc)
+        return AlbumResolveOutcome(album_id, None, STATUS_API_ERROR)
+    url = match.url if match is not None else None
+    if url:
+        return AlbumResolveOutcome(album_id, url, STATUS_MATCHED)
+    return AlbumResolveOutcome(album_id, None, STATUS_NO_MATCH)
+
+
+def min_interval_seconds(rate_per_min: int | None) -> float:
+    """Minimum seconds between call starts for ``rate_per_min``, or 0 (unbounded).
+
+    ``None`` or a non-positive rate disables spacing.
+    """
+    if not rate_per_min or rate_per_min <= 0:
+        return 0.0
+    return 60.0 / rate_per_min
+
+
+class _RateGate:
+    """Serializes call *starts* to at least ``min_interval`` apart (monotonic).
+
+    On top of the concurrency semaphore: the semaphore bounds in-flight calls;
+    this bounds the start rate so a burst of fast Apple responses can't exceed
+    the per-minute budget. ``min_interval == 0`` is a no-op.
+    """
+
+    def __init__(self, min_interval: float):
+        self._min_interval = min_interval
+        self._lock = asyncio.Lock()
+        self._next_allowed = 0.0
+
+    async def wait(self) -> None:
+        if self._min_interval <= 0:
+            return
+        async with self._lock:
+            now = time.monotonic()
+            wait_for = self._next_allowed - now
+            if wait_for > 0:
+                await asyncio.sleep(wait_for)
+                now = time.monotonic()
+            self._next_allowed = now + self._min_interval
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint I/O (JSONL, append-only, last-write-wins)
+# ---------------------------------------------------------------------------
+
+
+def load_checkpoint(path: Path) -> dict[int, AlbumResolveOutcome]:
+    """Read the JSONL checkpoint into ``{album_id: outcome}`` (last line wins).
+
+    A malformed line — a truncated final record from a hard kill mid-append, or a
+    JSON object missing a required field — is skipped with a warning rather than
+    aborting the resume, so a partial write never strands the whole run.
+    """
+    out: dict[int, AlbumResolveOutcome] = {}
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+            outcome = AlbumResolveOutcome(
+                album_id=int(d["album_id"]),
+                apple_music_url=d.get("apple_music_url"),
+                status=d["status"],
+            )
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
+            log.warning("skipping malformed checkpoint line (%s): %.80s", exc, line)
+            continue
+        out[outcome.album_id] = outcome
+    return out
+
+
+def append_checkpoint(path: Path, outcome: AlbumResolveOutcome) -> None:
+    """Append one outcome as a JSON line (creating parent dirs)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(asdict(outcome)) + "\n")
+
+
+def _pending_candidates(
+    candidates: Sequence[tuple[int, str, str]], done: dict[int, AlbumResolveOutcome]
+) -> list[tuple[int, str, str]]:
+    """Candidates not yet in a terminal state, preserving input order."""
+    return [
+        c
+        for c in candidates
+        if (done.get(c[0]) is None or done[c[0]].status not in TERMINAL_STATUSES)
+    ]
+
+
+async def run_resolve(
+    client,
+    candidates: Sequence[tuple[int, str, str]],
+    checkpoint_path: Path,
+    *,
+    concurrency: int = 10,
+    limit: int | None = None,
+    rate_per_min: int | None = None,
+    dry_run: bool = False,
+    out_path: Path | None = None,
+) -> dict[int, AlbumResolveOutcome]:
+    """Resolve all non-terminal candidates, checkpointing each outcome as it lands.
+
+    Bounded to ``concurrency`` in-flight ``find_album_match`` calls and, if
+    ``rate_per_min`` is set, at most that many call-starts per minute. ``limit``
+    caps how many candidates this invocation processes — use it to smoke-test a
+    small batch. Returns the merged ``{album_id: outcome}`` after this pass. When
+    ``dry_run`` and ``out_path`` are given, the run tallies but writes no output
+    TSV (the checkpoint is still updated so a dry-run resume is cheap).
+
+    Raises ``ValueError`` for out-of-range knobs so a typo fails fast: a
+    ``concurrency < 1`` builds an unacquirable ``asyncio.Semaphore(0)`` and hangs;
+    a negative ``limit`` slices ``todo[:-1]`` and would resolve all-but-one of the
+    tail against the prod Apple token instead of a small batch.
+    """
+    if concurrency < 1:
+        raise ValueError(f"concurrency must be >= 1, got {concurrency}")
+    if limit is not None and limit < 1:
+        raise ValueError(f"limit must be >= 1 when set, got {limit}")
+    done = load_checkpoint(checkpoint_path)
+    todo = _pending_candidates(candidates, done)
+    if limit is not None:
+        todo = todo[:limit]
+    log.info(
+        "resolve: %d candidates total, %d already terminal, %d to process this run",
+        len(candidates),
+        len(candidates) - len(_pending_candidates(candidates, done)),
+        len(todo),
+    )
+    if not todo:
+        return done
+
+    sem = asyncio.Semaphore(concurrency)
+    gate = _RateGate(min_interval_seconds(rate_per_min))
+    write_lock = asyncio.Lock()
+    counts: dict[str, int] = {}
+
+    async def worker(album_id: int, artist: str, album: str) -> None:
+        async with sem:
+            await gate.wait()
+            outcome = await resolve_one(client, album_id, artist, album)
+        async with write_lock:
+            append_checkpoint(checkpoint_path, outcome)
+            done[album_id] = outcome
+            counts[outcome.status] = counts.get(outcome.status, 0) + 1
+            processed = sum(counts.values())
+            if processed % 250 == 0:
+                log.info("progress: %d processed — %s", processed, dict(counts))
+
+    await asyncio.gather(*(worker(aid, art, alb) for aid, art, alb in todo))
+    log.info("resolve pass complete: %s", dict(counts))
+
+    if out_path is not None and not dry_run:
+        n = write_url_tsv(out_path, done)
+        log.info("wrote %d matched (album_id, url) rows -> %s", n, out_path)
+    elif dry_run:
+        log.info("dry-run: %d matched (no TSV emitted)", counts.get(STATUS_MATCHED, 0))
+    return done
+
+
+# ---------------------------------------------------------------------------
+# TSV I/O
+# ---------------------------------------------------------------------------
+
+
+def load_candidates(path: Path) -> list[tuple[int, str, str]]:
+    """Read the ``album_id\\tartist\\talbum`` candidate TSV (read-only BS export).
+
+    Ids go through the shared :func:`parse_positive_int`; a blank/non-integer/
+    non-positive id, a blank artist, or a blank album skips the row rather than
+    aborting the whole rate-limited run. Opens ``utf-8-sig`` so a BOM-prefixed
+    export still matches the header.
+    """
+    rows: list[tuple[int, str, str]] = []
+    with path.open(newline="", encoding="utf-8-sig") as f:
+        for r in csv.DictReader(f, delimiter="\t"):
+            album_id = parse_positive_int(r.get("album_id"))
+            artist = (r.get("artist") or "").strip()
+            album = (r.get("album") or "").strip()
+            if album_id is None or not artist or not album:
+                continue
+            rows.append((album_id, artist, album))
+    return rows
+
+
+def write_url_tsv(path: Path, outcomes: dict[int, AlbumResolveOutcome]) -> int:
+    """Write ``album_id\\tapple_music_url`` for matched outcomes only.
+
+    This is the fill payload the BS apply consumes; ``no_match`` / ``api_error``
+    carry no URL and are omitted. Rows are sorted by ``album_id`` for a stable
+    diff-able output.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    matched = sorted(
+        (o for o in outcomes.values() if o.status == STATUS_MATCHED and o.apple_music_url),
+        key=lambda o: o.album_id,
+    )
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f, delimiter="\t")
+        w.writerow(_TSV_HEADER)
+        for o in matched:
+            w.writerow([o.album_id, o.apple_music_url])
+    return len(matched)
+
+
+# ---------------------------------------------------------------------------
+# Apple client construction (off-prod precedent: recheck_streaming_after_mojibake)
+# ---------------------------------------------------------------------------
+
+
+def _build_apple_client():
+    """Construct an ``AppleMusicClient`` from ``os.environ`` Apple JWT creds.
+
+    Modeled on the off-prod precedent
+    ``scripts/recheck_streaming_after_mojibake.py:193-197`` — same
+    ``team_id``/``key_id``/``private_key`` construction and missing-creds skip.
+    Raises ``SystemExit`` if the creds are not all present (nothing to resolve).
+    """
+    from clients.streaming.apple_music import AppleMusicClient
+
+    team = os.environ.get("APPLE_MUSIC_TEAM_ID")
+    key = os.environ.get("APPLE_MUSIC_KEY_ID")
+    priv = os.environ.get("APPLE_MUSIC_PRIVATE_KEY")
+    if not (team and key and priv):
+        raise SystemExit("APPLE_MUSIC_TEAM_ID/KEY_ID/PRIVATE_KEY not all set — cannot resolve")
+    return AppleMusicClient(team_id=team, key_id=key, private_key=priv)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+async def _run(args: argparse.Namespace) -> None:
+    candidates = load_candidates(Path(args.candidates))
+    log.info("loaded %d candidate albums from %s", len(candidates), args.candidates)
+
+    client = _build_apple_client()
+    try:
+        await run_resolve(
+            client,
+            candidates,
+            Path(args.checkpoint),
+            concurrency=args.concurrency,
+            limit=args.limit,
+            rate_per_min=args.rate_per_min,
+            dry_run=args.dry_run,
+            out_path=Path(args.out),
+        )
+    finally:
+        try:
+            await client.close()
+        except Exception:  # noqa: BLE001 — best-effort close
+            log.exception("failed to close Apple Music client")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--candidates",
+        required=True,
+        help="TSV of (album_id, artist, album) — read-only BS still-null export",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        required=True,
+        help="JSONL checkpoint path (resumable; never re-spends Apple budget)",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output TSV (album_id, apple_music_url) for the BS fill-only apply",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=10,
+        help="Max in-flight find_album_match calls (default 10)",
+    )
+    parser.add_argument(
+        "--rate-per-min",
+        type=int,
+        default=None,
+        help="Cap Apple call-starts per minute (default: unbounded; set for shared token)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap candidates processed this run (smoke-test a batch before the full run)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve + tally + checkpoint but emit no output TSV",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    asyncio.run(_run(_build_arg_parser().parse_args()))

--- a/tests/unit/test_resolve_apple_urls.py
+++ b/tests/unit/test_resolve_apple_urls.py
@@ -1,0 +1,240 @@
+"""Unit tests for the BS#1631 off-prod Apple-Music-URL resolver.
+
+The resolver drains the still-null ``album_metadata`` tail by calling LML's exact
+album-level match path — ``AppleMusicClient.find_album_match(artist, album)`` (the
+same call the async warm uses, ``entity/streaming_url_cache.py:350``) — off-prod at
+bounded concurrency, and emits ``(album_id, apple_music_url)`` for accepted matches.
+
+These tests exercise the pure decision core and the resumable checkpoint loop with a
+fake client — no network, no Apple calls.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from scripts.resolve_apple_urls import (
+    STATUS_API_ERROR,
+    STATUS_MATCHED,
+    STATUS_NO_MATCH,
+    TERMINAL_STATUSES,
+    AlbumResolveOutcome,
+    append_checkpoint,
+    load_candidates,
+    load_checkpoint,
+    min_interval_seconds,
+    resolve_one,
+    run_resolve,
+    write_url_tsv,
+)
+
+
+class FakeAppleClient:
+    """Duck-typed stand-in for AppleMusicClient.find_album_match.
+
+    ``matches`` maps ``(artist, title) -> url``; a missing key resolves to a
+    ``None`` match (no Apple album). ``raise_on`` names ``(artist, title)`` pairs
+    that raise (a transient Apple API error).
+    """
+
+    def __init__(self, matches=None, raise_on=None):
+        self.matches = matches or {}
+        self.raise_on = raise_on or set()
+        self.album_match_calls: list[tuple[str, str]] = []
+        self.track_calls: list = []
+
+    async def find_album_match(self, artist, title):
+        self.album_match_calls.append((artist, title))
+        if (artist, title) in self.raise_on:
+            raise RuntimeError("apple api 500")
+        url = self.matches.get((artist, title))
+        return types.SimpleNamespace(url=url) if url else None
+
+    async def find_track_metadata(self, *args, **kwargs):
+        # The album-phase capture path is album-level only. If the resolver ever
+        # reaches for the track path it would diverge from what the warm caches.
+        self.track_calls.append((args, kwargs))
+        raise AssertionError("resolver must call find_album_match, not the track path")
+
+
+class TestResolveOne:
+    @pytest.mark.asyncio
+    async def test_accepted_match_emits_url(self):
+        url = "https://music.apple.com/us/album/doga/1"
+        client = FakeAppleClient(matches={("Juana Molina", "DOGA"): url})
+        oc = await resolve_one(client, 42, "Juana Molina", "DOGA")
+        assert oc == AlbumResolveOutcome(42, url, STATUS_MATCHED)
+
+    @pytest.mark.asyncio
+    async def test_none_match_is_no_match(self):
+        client = FakeAppleClient(matches={})  # no Apple album
+        oc = await resolve_one(client, 42, "Obscure", "Nowhere")
+        assert oc == AlbumResolveOutcome(42, None, STATUS_NO_MATCH)
+
+    @pytest.mark.asyncio
+    async def test_api_error_is_counted_not_raised(self):
+        client = FakeAppleClient(raise_on={("Juana Molina", "DOGA")})
+        oc = await resolve_one(client, 42, "Juana Molina", "DOGA")
+        assert oc == AlbumResolveOutcome(42, None, STATUS_API_ERROR)
+
+    @pytest.mark.asyncio
+    async def test_uses_album_level_match_not_track(self):
+        # Match parity: the album-phase warm captures apple_music_url solely via
+        # find_album_match. Assert the resolver calls exactly that, never the
+        # track path (FakeAppleClient.find_track_metadata raises if touched).
+        client = FakeAppleClient(matches={("Sessa", "Grandeza"): "u"})
+        await resolve_one(client, 1, "Sessa", "Grandeza")
+        assert client.album_match_calls == [("Sessa", "Grandeza")]
+        assert client.track_calls == []
+
+
+class TestCheckpoint:
+    def test_round_trip_and_last_write_wins(self, tmp_path):
+        path = tmp_path / "sub" / "ckpt.jsonl"
+        append_checkpoint(path, AlbumResolveOutcome(10, None, STATUS_API_ERROR))
+        append_checkpoint(path, AlbumResolveOutcome(20, "u20", STATUS_MATCHED))
+        # A retry of 10 that now matches — last line wins.
+        append_checkpoint(path, AlbumResolveOutcome(10, "u10", STATUS_MATCHED))
+        loaded = load_checkpoint(path)
+        assert loaded[10] == AlbumResolveOutcome(10, "u10", STATUS_MATCHED)
+        assert loaded[20] == AlbumResolveOutcome(20, "u20", STATUS_MATCHED)
+
+    def test_missing_file_is_empty(self, tmp_path):
+        assert load_checkpoint(tmp_path / "nope.jsonl") == {}
+
+    def test_corrupt_trailing_line_is_skipped(self, tmp_path):
+        path = tmp_path / "ckpt.jsonl"
+        append_checkpoint(path, AlbumResolveOutcome(10, "u10", STATUS_MATCHED))
+        with path.open("a", encoding="utf-8") as f:
+            f.write('{"album_id": 30, "apple_mus')  # truncated
+        loaded = load_checkpoint(path)  # must not raise
+        assert loaded[10] == AlbumResolveOutcome(10, "u10", STATUS_MATCHED)
+        assert 30 not in loaded
+
+    def test_terminal_statuses_exclude_api_error(self):
+        assert STATUS_MATCHED in TERMINAL_STATUSES
+        assert STATUS_NO_MATCH in TERMINAL_STATUSES
+        # api_error is transient -> retried on re-run.
+        assert STATUS_API_ERROR not in TERMINAL_STATUSES
+
+
+class TestRunResolve:
+    @pytest.mark.asyncio
+    async def test_resolves_and_checkpoints(self, tmp_path):
+        ckpt = tmp_path / "ckpt.jsonl"
+        client = FakeAppleClient(matches={("A", "a1"): "urlA"})
+        candidates = [(100, "A", "a1"), (200, "B", "b1")]
+        done = await run_resolve(client, candidates, ckpt, concurrency=2)
+        assert done[100] == AlbumResolveOutcome(100, "urlA", STATUS_MATCHED)
+        assert done[200] == AlbumResolveOutcome(200, None, STATUS_NO_MATCH)
+        assert set(load_checkpoint(ckpt)) == {100, 200}
+
+    @pytest.mark.asyncio
+    async def test_api_error_does_not_abort_run(self, tmp_path):
+        ckpt = tmp_path / "ckpt.jsonl"
+        client = FakeAppleClient(matches={("C", "c1"): "urlC"}, raise_on={("A", "a1")})
+        candidates = [(100, "A", "a1"), (300, "C", "c1")]
+        done = await run_resolve(client, candidates, ckpt, concurrency=1)
+        # The erroring candidate is recorded transient; the other still resolves.
+        assert done[100].status == STATUS_API_ERROR
+        assert done[300] == AlbumResolveOutcome(300, "urlC", STATUS_MATCHED)
+
+    @pytest.mark.asyncio
+    async def test_resume_skips_terminal_and_retries_api_error(self, tmp_path):
+        ckpt = tmp_path / "ckpt.jsonl"
+        append_checkpoint(ckpt, AlbumResolveOutcome(100, "u100", STATUS_MATCHED))
+        append_checkpoint(ckpt, AlbumResolveOutcome(200, None, STATUS_API_ERROR))
+        client = FakeAppleClient(matches={("B", "b1"): "u200"})
+        candidates = [(100, "A", "a1"), (200, "B", "b1")]
+        done = await run_resolve(client, candidates, ckpt, concurrency=2)
+        # 100 terminal -> never re-called; 200 transient -> retried and now matches.
+        assert client.album_match_calls == [("B", "b1")]
+        assert done[200] == AlbumResolveOutcome(200, "u200", STATUS_MATCHED)
+
+    @pytest.mark.asyncio
+    async def test_dry_run_emits_no_output_but_still_tallies(self, tmp_path):
+        out = tmp_path / "out.tsv"
+        ckpt = tmp_path / "ckpt.jsonl"
+        client = FakeAppleClient(matches={("A", "a1"): "urlA"})
+        done = await run_resolve(
+            client, [(100, "A", "a1")], ckpt, concurrency=1, dry_run=True, out_path=out
+        )
+        assert done[100].status == STATUS_MATCHED  # resolved + tallied
+        assert not out.exists()  # but nothing emitted
+
+    @pytest.mark.asyncio
+    async def test_zero_concurrency_raises_instead_of_hanging(self, tmp_path):
+        client = FakeAppleClient()
+        with pytest.raises(ValueError):
+            await run_resolve(client, [(1, "A", "a")], tmp_path / "c.jsonl", concurrency=0)
+        assert client.album_match_calls == []
+
+    @pytest.mark.asyncio
+    async def test_negative_limit_raises_instead_of_slicing(self, tmp_path):
+        client = FakeAppleClient()
+        candidates = [(n, "A", str(n)) for n in (1, 2, 3)]
+        with pytest.raises(ValueError):
+            await run_resolve(client, candidates, tmp_path / "c.jsonl", limit=-1)
+        assert client.album_match_calls == []
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_candidates_processed(self, tmp_path):
+        ckpt = tmp_path / "ckpt.jsonl"
+        client = FakeAppleClient()
+        candidates = [(n, "A", str(n)) for n in (1, 2, 3)]
+        done = await run_resolve(client, candidates, ckpt, concurrency=1, limit=2)
+        assert len(done) == 2
+
+
+class TestRateGate:
+    def test_min_interval_seconds(self):
+        assert min_interval_seconds(60) == pytest.approx(1.0)
+        assert min_interval_seconds(120) == pytest.approx(0.5)
+
+    def test_min_interval_none_is_zero(self):
+        assert min_interval_seconds(None) == 0.0
+
+    def test_min_interval_nonpositive_is_zero(self):
+        assert min_interval_seconds(0) == 0.0
+        assert min_interval_seconds(-5) == 0.0
+
+
+class TestLoadCandidates:
+    def test_parses_tsv_and_skips_malformed(self, tmp_path):
+        p = tmp_path / "c.tsv"
+        p.write_text(
+            "album_id\tartist\talbum\n"
+            "100\tJuana Molina\tDOGA\n"
+            "\tBlank\tId\n"  # missing id -> skip
+            "300\tSessa\t\n"  # blank album -> skip
+            "0\tZero\tId\n"  # non-positive id -> skip
+            "400\tCat Power\tMoon Pix\n",
+            encoding="utf-8",
+        )
+        assert load_candidates(p) == [
+            (100, "Juana Molina", "DOGA"),
+            (400, "Cat Power", "Moon Pix"),
+        ]
+
+    def test_reads_utf8_sig_bom(self, tmp_path):
+        p = tmp_path / "c.tsv"
+        p.write_text("﻿album_id\tartist\talbum\n5\tStereolab\tDots and Loops\n", encoding="utf-8")
+        assert load_candidates(p) == [(5, "Stereolab", "Dots and Loops")]
+
+
+class TestWriteUrlTsv:
+    def test_writes_only_matched_rows(self, tmp_path):
+        p = tmp_path / "out.tsv"
+        outcomes = {
+            100: AlbumResolveOutcome(100, "u100", STATUS_MATCHED),
+            200: AlbumResolveOutcome(200, None, STATUS_NO_MATCH),
+            300: AlbumResolveOutcome(300, None, STATUS_API_ERROR),
+        }
+        n = write_url_tsv(p, outcomes)
+        assert n == 1
+        lines = p.read_text(encoding="utf-8").splitlines()
+        assert lines[0] == "album_id\tapple_music_url"
+        assert lines[1] == "100\tu100"
+        assert len(lines) == 2  # only the matched row


### PR DESCRIPTION
## What

Adds `scripts/resolve_apple_urls.py` — the **resolve** half of the off-prod Apple-Music-URL resolver for the BS#1631 backfill tail (spec: #862).

The in-service backfill drives LML `/api/v1/lookup` to fill `album_metadata.apple_music_url`, keeps tripping the LML health watchdog, and captures ~29% where the Apple catalog holds ~58% (iTunes ceiling sample, n=475). Almost none of a full lookup is needed for that column: the persistent album-level URL comes *solely* from the async warm calling `AppleMusicClient.find_album_match(artist, album)` (`entity/streaming_url_cache.py`). This script calls that exact method directly — **exact match parity** with the album-phase capture path — at a fraction of the cost, and run off-prod it sidesteps both the watchdog and the synchronous-enrichment latency wall (#706).

Two-phase, clean ownership: this script reads a read-only `(album_id, artist, album)` export and emits `(album_id, apple_music_url)` for accepted matches to a TSV; the **apply** half (Backend-Service `resolve.ts::applyUpdate`, fill-only `WHERE apple_music_url IS NULL`) writes it back — LML never touches BS RDS.

## Design

- Bounded `--concurrency` + `--rate-per-min` protect the shared prod Apple token (off-peak).
- Per-album JSONL checkpoint: terminal `matched`/`no_match` never re-spend budget; transient `api_error` is retried. Interrupted/re-run resolves are cheap.
- `--dry-run` tallies + checkpoints, emits no TSV. `--limit` caps a smoke batch.
- Album-level only (`find_album_match`); the flowsheet track-level probe is out of scope.

## Accept-rate validation

The real `find_album_match` on the 475-album ceiling sample landed **52.0%** (95% CI [47.5%, 56.5%]) vs the backfill's 29% and the 58% iTunes ceiling — confirming most of the capture gap was the async-warm-throttle timing artifact, not matching quality. Recorded on #862.

## Tests

21 unit tests (mock client, no network): emit-on-match, no-emit-on-None, error-tolerance, dry-run no-emit, **album-level parity** (fake `find_track_metadata` raises if touched), resume/skip-terminal, concurrency/limit guards, TSV loaders. ruff + mypy clean.

## Scope / follow-on (gated, not in this PR)

Candidate export (prod BS read), full resolve run, and the BS fill-only apply are separate live/gated steps per the #862 plan.

Closes #862