### PR TITLE
chore(codegen): regenerate api_models against wxyc-shared main (criticReviews)

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1842,6 +1842,25 @@ class TrackListItem(BaseModel):
     duration: str | None = Field(None, description='Track duration (e.g. "5:23")')
 
 
+class CriticReviewItem(BaseModel):
+    source: str = Field(..., description='Publication name (e.g. "The Quietus")')
+    url: str = Field(
+        ...,
+        description="Link to the original review on the publisher's site (mandatory link-out)",
+    )
+    snippet: str = Field(
+        ...,
+        description="Short attributed excerpt (<= ~300 chars); never the full review body",
+    )
+    author: str | None = Field(None, description="Review author, when available")
+    publishedDate: str | None = Field(
+        None, description='Review publication date when available (e.g. "2024-03-15")'
+    )
+    rating: str | None = Field(
+        None, description='Source-native rating string when available (e.g. "8.0")'
+    )
+
+
 class AlbumMetadataResponse(BaseModel):
     discogsReleaseId: int | None = Field(None, description="Discogs release ID")
     discogsUrl: str | None = Field(None, description="Discogs release page URL")
@@ -1859,6 +1878,10 @@ class AlbumMetadataResponse(BaseModel):
         None, description='Full release date when available (e.g. "2024-03-15")'
     )
     tracklist: list[TrackListItem] | None = Field(None, description="Release tracklist")
+    criticReviews: list[CriticReviewItem] | None = Field(
+        None,
+        description="Attributed external critic-review snippets, each linking out to the original",
+    )
     spotifyUrl: str | None = Field(None, description="Spotify URL for the album or track")
     appleMusicUrl: str | None = Field(None, description="Apple Music URL for the album or track")
     youtubeMusicUrl: str | None = Field(None, description="YouTube Music search URL")


### PR DESCRIPTION
Mechanical codegen sync. Regenerates `generated/api_models.py` from the current `WXYC/wxyc-shared` `main` `api.yaml` to pick up the `AlbumMetadataResponse.criticReviews` field and its new `CriticReviewItem` model (attributed external critic-review snippets, each linking out to the original publisher).

No hand edits — output of `bash scripts/generate_api_models.sh` against wxyc-shared `main`, verified byte-identical to a fresh run against the live spec.

Unblocks the **Codegen Freshness** CI gate, which fails on every LML PR branch whose committed generated model predates a merged wxyc-shared `api.yaml` change (this drift was surfaced by the gate on the #841 PR, orthogonal to that change and packaged separately here per the standing chore(codegen) convention).

Diff is +23 lines, generated-only.