### PR TITLE
test(#879): consolidate the PostHog env scrub into the root tests conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,41 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from wxyc_fastapi.observability import RequestTelemetry
 
+from config.settings import get_settings
 from discogs.service import DiscogsApiCheckResult
 from lookup import streaming_url_postprocess as _streaming_mod
 from lookup.streaming_url_postprocess import set_suppress_streaming_warm
 from services.parser import MessageType, ParsedRequest
 from tests.factories import make_library_item
+
+
+@pytest.fixture(scope="session", autouse=True)
+def scrub_posthog_env():
+    """Blank ``POSTHOG_API_KEY`` for the whole pytest session (LML#879).
+
+    The integration and e2e tiers' hermeticity convention is FastAPI
+    ``dependency_overrides`` (``get_posthog_client -> None``), but the
+    rate-gate fail-open emitter (``discogs/ratelimit._capture_fail_open``)
+    bypasses DI by design — it reads ``get_posthog_client()`` (which builds a
+    real singleton client straight from ``os.environ``) and the cached real
+    ``Settings`` (telemetry default-on). Without this scrub, the first test
+    that drives the gate into fail-open on a host whose shell or ``.env``
+    carries a live key would send real ``discogs_rate_gate_fail_open`` events
+    to the production PostHog project. E2E is the most exposed tier (it
+    module-skips without a real ``DISCOGS_TOKEN``, so it runs precisely on
+    hosts with a populated ``.env``); the unit tier is already covered by its
+    own ``scrub_credential_env``, for which the extra blank here is a no-op.
+    One session fixture in this root conftest rather than per-tier copies so
+    the scrub can't drift between tiers. Blank rather than delete, mirroring
+    ``tests/unit/conftest.py``'s ``scrub_credential_env``: env vars outrank
+    the ``.env`` source, and empty behaves like unset throughout the codebase.
+    """
+    mp = pytest.MonkeyPatch()
+    mp.setenv("POSTHOG_API_KEY", "")
+    get_settings.cache_clear()
+    yield
+    mp.undo()
+    get_settings.cache_clear()
 
 
 def reset_streaming_warm_state() -> None:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,7 +11,7 @@ import aiosqlite
 import pytest
 import pytest_asyncio
 
-from config.settings import Settings, get_settings
+from config.settings import Settings
 from discogs.models import (
     DiscogsSearchResponse,
     ReleaseInfo,
@@ -21,31 +21,6 @@ from discogs.models import (
 )
 from library.db import LibraryDB
 from tests.factories import make_discogs_result
-
-
-@pytest.fixture(scope="session", autouse=True)
-def scrub_posthog_env():
-    """Blank ``POSTHOG_API_KEY`` for the whole e2e session (LML#879).
-
-    Same rationale as the identically-named integration-tier scrub
-    (``tests/integration/conftest.py``): this tier's hermeticity rests on
-    ``dependency_overrides`` (``get_posthog_client -> None`` in
-    :func:`e2e_client`), but the rate-gate fail-open emitter
-    (``discogs/ratelimit._capture_fail_open``) bypasses DI by design. E2E is
-    the tier most likely to run with a real populated shell/``.env`` (it
-    module-skips without a real ``DISCOGS_TOKEN``), so an operator with
-    ``DISCOGS_RATE_BUCKET_ENABLED=true`` and a live key ambient would
-    otherwise send real ``discogs_rate_gate_fail_open`` events to production
-    PostHog. Blank rather than delete: env vars outrank the ``.env`` source,
-    and empty behaves like unset throughout the codebase.
-    """
-    mp = pytest.MonkeyPatch()
-    mp.setenv("POSTHOG_API_KEY", "")
-    get_settings.cache_clear()
-    yield
-    mp.undo()
-    get_settings.cache_clear()
-
 
 # ---------------------------------------------------------------------------
 # Seed data: WXYC example artists for full-pipeline E2E

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,34 +13,10 @@ import asyncpg
 import pytest
 import pytest_asyncio
 
-from config.settings import Settings, get_settings
+from config.settings import Settings
 from discogs.models import DiscogsSearchResponse
 from library.db import LibraryDB
 from tests.factories import make_discogs_result
-
-
-@pytest.fixture(scope="session", autouse=True)
-def scrub_posthog_env():
-    """Blank ``POSTHOG_API_KEY`` for the whole integration session (LML#879).
-
-    This tier's hermeticity convention is FastAPI ``dependency_overrides``, but
-    the rate-gate fail-open emitter (``discogs/ratelimit._capture_fail_open``)
-    bypasses DI by design — it reads ``get_posthog_client()`` (which builds a
-    real singleton client straight from ``os.environ``) and the cached real
-    ``Settings`` (telemetry default-on). Without this scrub, the first
-    integration test that drives the gate into fail-open on a host whose shell
-    or ``.env`` carries a live key would send real events to the production
-    PostHog project. Blank rather than delete, mirroring
-    ``tests/unit/conftest.py``'s ``scrub_credential_env``: env vars outrank the
-    ``.env`` source, and empty behaves like unset throughout the codebase.
-    """
-    mp = pytest.MonkeyPatch()
-    mp.setenv("POSTHOG_API_KEY", "")
-    get_settings.cache_clear()
-    yield
-    mp.undo()
-    get_settings.cache_clear()
-
 
 # ---------------------------------------------------------------------------
 # PostgreSQL test pool (shared by the ``@pytest.mark.pg`` integration suite)


### PR DESCRIPTION
Re-lands the final nit sweep from the #880 review loop, which missed the merge: PR #880 was merged at head fba8dc8 while the consolidation commit was pushed to its branch about an hour later, so the change never entered main.

The medium-effort review round flagged the near-verbatim duplication of the session-scoped `scrub_posthog_env` fixture across `tests/integration/conftest.py` and `tests/e2e/conftest.py` as a drift hazard — a future change to the scrub landing in one tier but not the other would silently leave the unpatched tier able to send real `discogs_rate_gate_fail_open` events from a developer machine. `tests/conftest.py` is already the shared cross-tier fixture home, so the two copies collapse into one session-scoped autouse fixture there; the unit tier's own `scrub_credential_env` already blanks the key, for which the extra blank is a no-op.

Test-only change (3 files, +32/−51). Verified locally: ruff format/check clean, mypy clean, 3,984 unit+e2e tests passed, integration collection unaffected.

Refs #879, #880.