### PR TITLE
fix(#881): drop the per-request PostHog flush that blocked the event loop

### DIFF
--- a/core/server_timing_middleware.py
+++ b/core/server_timing_middleware.py
@@ -107,11 +107,12 @@ class LmlWallTimingMiddleware:
     """ASGI middleware appending the ``lml_wall`` Server-Timing leg.
 
     Registered via ``app.add_middleware(LmlWallTimingMiddleware)`` in
-    ``main.py``, positioned so it wraps only the routing/handler/serialization
-    layer (see the registration site's comment for the ordering rationale — it
-    deliberately excludes the sibling ``posthog_flush_middleware``'s
-    synchronous flush from the timed window, so ``lml_wall`` isn't inflated by
-    unrelated middleware cost).
+    ``main.py`` as the outermost user middleware, so it wraps CORS and the
+    router — the routing/handler/serialization layer this leg exists to
+    measure (see the registration site's comment for the ordering history:
+    it used to also need to keep the now-removed ``posthog_flush_middleware``
+    outside this window; that middleware blocked the event loop with a
+    synchronous flush and was deleted entirely, LML#881/#949).
 
     The wrapped app (``self.app``) is never called inside a try/except: a
     genuine failure inside routing must still propagate to Starlette's

--- a/main.py
+++ b/main.py
@@ -11,9 +11,9 @@ from typing import Any
 
 import sentry_sdk
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from wxyc_fastapi.observability import flush_posthog, init_sentry, shutdown_posthog
+from wxyc_fastapi.observability import init_sentry, shutdown_posthog
 
 from artists.router import router as artists_router
 from cache.router import router as cache_router
@@ -494,26 +494,18 @@ app.add_middleware(
     allow_headers=["Content-Type"],
 )
 
-# Registered BEFORE `posthog_flush_middleware` below deliberately — Starlette's
-# `add_middleware`/`@app.middleware("http")` prepend to the user-middleware
-# list, so the LAST one registered ends up OUTERMOST (it sees the request
-# first and the response last). Registering the wall-clock timer first makes
-# it the INNER of the two: `posthog_flush_middleware`'s synchronous
-# `flush_posthog()` call then runs OUTSIDE the timed window, so it can't
-# inflate the `lml_wall` Server-Timing leg with unrelated middleware cost. See
-# `core/server_timing_middleware.py` for what the leg measures and why. Pure
-# ASGI middleware (LmlWallTimingMiddleware) still goes through `add_middleware`
-# like any other Starlette middleware, so this ordering rule applies exactly
-# the same as it did for the old `@app.middleware("http")` registration.
+# Registered after CORSMiddleware, so it is the OUTERMOST user middleware —
+# Starlette's `add_middleware` prepends to the user-middleware list, and the
+# LAST one registered ends up outermost (sees the request first, the response
+# last). That used to matter for keeping `posthog_flush_middleware`'s
+# synchronous `flush_posthog()` call OUTSIDE the timed window so it couldn't
+# inflate the `lml_wall` Server-Timing leg; that middleware blocked the event
+# loop for ~2.5s per request and was removed outright (LML#881/#949) rather
+# than reordered around, so there is no longer a sibling middleware this one
+# needs to exclude. It now simply wraps CORS + the router, which is exactly
+# the window `lml_wall` is meant to measure — see
+# `core/server_timing_middleware.py` for what the leg measures and why.
 app.add_middleware(LmlWallTimingMiddleware)
-
-
-@app.middleware("http")
-async def posthog_flush_middleware(request: Request, call_next):
-    """Flush PostHog events after each request to prevent data loss."""
-    response = await call_next(request)
-    flush_posthog()
-    return response
 
 
 # Health and admin keep their own auth posture:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -216,6 +216,46 @@ class TestMiddleware:
             "synchronous queue.join() on every request (LML#881)"
         )
 
+    @pytest.mark.asyncio
+    async def test_request_path_never_calls_flush_posthog(self, mock_settings):
+        """Behavioral companion to the structural guard above (LML#949).
+
+        The structural test only proves ``posthog_flush_middleware`` isn't registered by
+        name; it would stay green even if a future change called ``flush_posthog()`` from
+        somewhere else on the request path (a dependency, a route handler, a different
+        middleware). This test drives an actual request through the ASGI app end to end and
+        asserts ``flush_posthog`` is never invoked while handling it — ``main`` no longer
+        imports ``flush_posthog`` at all post-fix, so the patch target is created on the fly
+        (``create=True``); if a regression reintroduces the import and a call, this starts
+        patching the real bound name and the call would be caught the same way the deleted
+        ``test_posthog_flush_middleware`` used to assert the opposite.
+        """
+        from httpx import ASGITransport, AsyncClient
+
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from main import app
+
+        mock_db = AsyncMock()
+        mock_db.is_available = AsyncMock(return_value=True)
+
+        app.dependency_overrides[get_library_db] = lambda: mock_db
+        app.dependency_overrides[get_discogs_service] = lambda: None
+        app.dependency_overrides[get_posthog_client] = lambda: None
+        app.dependency_overrides[get_settings] = lambda: mock_settings
+
+        try:
+            with patch("main.flush_posthog", create=True) as mock_flush:
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    response = await client.get("/health")
+
+            assert response.status_code == 200
+            mock_flush.assert_not_called()
+        finally:
+            app.dependency_overrides.clear()
+
 
 class TestAppRouterRegistration:
     def test_routes_registered(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -3,7 +3,6 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from httpx import ASGITransport, AsyncClient
 
 
 class _FakeAcquire:
@@ -187,31 +186,35 @@ class TestLifespan:
 
 
 class TestMiddleware:
-    @pytest.mark.asyncio
-    async def test_posthog_flush_middleware(self, mock_settings):
-        """PostHog flush middleware flushes after each request."""
-        from config.settings import get_settings
-        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+    def test_no_per_request_posthog_flush_middleware(self, mock_settings):
+        """The request path must not synchronously flush PostHog (LML#881).
+
+        ``posthog_flush_middleware`` used to call ``flush_posthog()`` on every response.
+        ``flush_posthog()`` is ``Posthog.flush()`` == ``queue.join()`` — a blocking wait on
+        the asyncio event loop until the background consumer drains every queued event, so a
+        PostHog slowdown stalled the loop for tens of seconds once per in-flight request,
+        serializing the whole service behind PostHog delivery. Delivery is instead covered by
+        the consumer thread's periodic flush + the lifespan ``shutdown_posthog()`` + posthog's
+        ``atexit`` join, so the per-request flush is removed. Regression guard: no HTTP
+        middleware named ``posthog_flush_middleware`` may be registered on the app.
+        """
         from main import app
 
-        mock_db = AsyncMock()
-        mock_db.is_available = AsyncMock(return_value=True)
+        dispatch_names = []
+        for mw in app.user_middleware:
+            # ``@app.middleware("http")`` registers ``BaseHTTPMiddleware(dispatch=<func>)``;
+            # Starlette exposes the function in ``.kwargs`` (newer) or positionally in
+            # ``.args`` (older), so check both.
+            dispatch = getattr(mw, "kwargs", {}).get("dispatch")
+            if dispatch is None:
+                dispatch = next((a for a in getattr(mw, "args", ()) if callable(a)), None)
+            if dispatch is not None:
+                dispatch_names.append(getattr(dispatch, "__name__", ""))
 
-        app.dependency_overrides[get_library_db] = lambda: mock_db
-        app.dependency_overrides[get_discogs_service] = lambda: None
-        app.dependency_overrides[get_posthog_client] = lambda: None
-        app.dependency_overrides[get_settings] = lambda: mock_settings
-
-        try:
-            with patch("main.flush_posthog") as mock_flush:
-                async with AsyncClient(
-                    transport=ASGITransport(app=app), base_url="http://test"
-                ) as client:
-                    await client.get("/health")
-
-                mock_flush.assert_called()
-        finally:
-            app.dependency_overrides.clear()
+        assert "posthog_flush_middleware" not in dispatch_names, (
+            "posthog_flush_middleware must be removed — it blocks the event loop with a "
+            "synchronous queue.join() on every request (LML#881)"
+        )
 
 
 class TestAppRouterRegistration:


### PR DESCRIPTION
## Problem

`posthog_flush_middleware` (`main.py`) called `flush_posthog()` on **every** HTTP response. In posthog-python that is `Posthog.flush()` == `queue.join()` — a blocking wait on the asyncio event loop until the background consumer thread drains every queued event. During a PostHog slowdown or outage the consumer's batch POST (15s timeout, up to 10 retries with backoff) could stall the loop for **tens of seconds, once per in-flight request**, serializing the whole service behind PostHog delivery.

The exposure peaks exactly when LML is already under stress: the `discogs_rate_gate_fail_open` counter (PR #880) is emitted per fail-open acquire during the discogs-cache floods, so the worst-case flush pressure coincides with the highest-load failure mode (the 06:00 UTC backfill floods).

Staging measurement (#949, 2026-07-27) quantified the steady-state cost: isolating the flush via a `/health`-vs-`/lookup` TTFB delta (same middleware stack, same network path; `/health` enqueues no PostHog event so its flush drains an empty queue) showed quiescent single-request `/lookup` paying **~2.5s of client-observed TTFB** attributable to the synchronous flush alone, on top of the ~0.5s `lml_wall` pipeline the Server-Timing header already accounted for. Under concurrency the same flush serializes requests behind each other: warm C=10 burst measured p50 15.3s / p95 27.4s. This was invisible to prior `Server-Timing` instrumentation because the flush was deliberately placed outside the `lml_wall` timed window (see the "Rebase" section below).

## Fix

Remove the middleware. Delivery is unaffected:
- the posthog consumer thread batch-delivers on its own `flush_interval` cadence;
- LML calls `shutdown_posthog()` from the FastAPI lifespan;
- posthog-python registers `atexit.register(self.join)`, so the queue drains on clean shutdown.

The now-unused `Request` and `flush_posthog` imports are dropped.

## Test

The old `TestMiddleware` asserted the middleware *did* flush per request — inverted into a regression guard asserting no `posthog_flush_middleware` is registered on the app (confirmed red before the removal, green after). A second, behavioral test (`test_request_path_never_calls_flush_posthog`, #949) drives an actual request through the ASGI app end to end and asserts `flush_posthog` is never invoked while handling it, so the guard doesn't depend on the fix staying implemented as a specifically-named middleware. Lifespan-shutdown coverage for `shutdown_posthog` was already in place via `TestLifespan.test_shutdown_calls_cleanup`. `docs/observability-rowless-flag.md`'s delivery-semantics wording is unchanged and still holds.

Local CI: full unit suite (excl. pg/external_api) **4551 passed**; ruff, ruff format, mypy clean.

## Rebase

This branch was rebased onto current `main` to pick up the intervening Server-Timing work (#941/#942/#946), which touched the same region of `main.py`. The rebase applied cleanly with no textual conflicts, but left one piece of semantic drift: the comment above `app.add_middleware(LmlWallTimingMiddleware)` existed solely to document registration order relative to `posthog_flush_middleware` — keeping the flush outside the `lml_wall` timed window. With the flush middleware gone, that comment referenced a name that no longer exists in the file, so it's rewritten to describe the current, simpler state: `LmlWallTimingMiddleware` is now the sole (and outermost) user middleware, wrapping only CORS and the router. The matching stale cross-reference in `core/server_timing_middleware.py`'s class docstring is updated the same way.

## Follow-up

The post-merge staging re-measure (quiescent `/lookup` TTFB and warm C=10 p95, to confirm the ~2.5s floor is gone) is tracked on #949, not blocking this PR.

Closes #881
Closes #949
