### PR TITLE
Cache-first Apple track probe via a track-scoped cache (LML#893, L1)

### DIFF
--- a/entity/track_streaming_url_cache.py
+++ b/entity/track_streaming_url_cache.py
@@ -1,0 +1,194 @@
+"""Persistent (service, artist, album, song) -> track-URL cache (LML#893, L1).
+
+LML's ``/api/v1/lookup`` happy path (an acceptable library row) probes Apple
+Music with ``find_track_url`` to surface the *played track's* deep-link — a
+~4.8s synchronous call on the hot path. This module caches that per-track URL
+so a repeat lookup of the same ``(artist, album, played-track)`` skips the live
+probe and returns the cached exact-track deep-link.
+
+**Why a SEPARATE table from ``album_streaming_url_cache``.** The album cache
+(``entity/streaming_url_cache.py``) is keyed on ``(service, artist, album)`` —
+no song axis — and is filled with *album* URLs by the streaming post-process.
+Writing a per-track deep-link into it (the closed PR #898 approach) poisoned it:
+wrong-track URLs on repeat lookups, permanent cross-seam contamination, and
+warm-vs-cold divergence on the public ``apple_music_url`` field. The played
+track needs a track-granular URL, so L1 gets its own table with a real song
+axis in the PK. **This module never touches the album cache.**
+
+Keys: ``(service, artist_normalized, album_normalized, song_normalized)`` where
+normalization applies ``wxyc_etl.text.to_match_form`` (NFC + diacritic
+stripping + lowercasing + whitespace collapse). A ``None`` album normalizes to
+the empty string so album-absent lookups still key stably.
+
+Hit/miss semantics are hit-only. Unlike the album cache, this table records NO
+known-miss rows: the ``url`` column is ``NOT NULL`` so a null can never be
+persisted (the #782 / BS#1192 "don't persist a null on first lookup" guard is
+enforced at the schema level, not just by the caller). A SELECT returns the
+durable hit or nothing.
+
+PG failures degrade to a no-op: ``get`` returns ``None``, ``set`` swallows the
+exception. The caller (``lookup/enrichment/item.py``) then falls through to the
+live probe as if no cache were configured. Schema bootstrap
+(``set_up_track_streaming_url_cache_schema``) is called from ``main.py``
+lifespan; the DDL is ``IF NOT EXISTS`` so re-running on every boot is safe.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from wxyc_etl.text import to_match_form
+
+from entity.sources import PgSource
+
+logger = logging.getLogger(__name__)
+
+# The single service L1 ships. The named CHECK constraint pins this set at the
+# DB level; a future PR (e.g. a Spotify track deep-link) extends this tuple and
+# the ALTER below picks it up. Kept as a module constant so the bootstrap DDL
+# and the parity test can both reference it without re-typing the literal.
+APPLE_MUSIC_TRACK_SERVICE = "apple_music_track"
+_SERVICES = (APPLE_MUSIC_TRACK_SERVICE,)
+
+# Shared IN-list literal so the CREATE-time CHECK and the idempotent ALTER are
+# generated from the same source — they can never drift.
+_SERVICE_IN_LIST = ", ".join(f"'{s}'" for s in _SERVICES)
+
+_DDL_SCHEMA = "CREATE SCHEMA IF NOT EXISTS lml_cache"
+
+# ``url TEXT NOT NULL`` enforces the #782/BS#1192 guard structurally: this
+# cache stores only resolved track deep-links, never a "checked, not found"
+# sentinel. The named CHECK constraint uses a name distinct from the album
+# cache's so the two tables' idempotent ALTERs never collide.
+_DDL_TABLE = f"""\
+CREATE TABLE IF NOT EXISTS lml_cache.track_streaming_url_cache (
+    service TEXT NOT NULL,
+    artist_normalized TEXT NOT NULL,
+    album_normalized TEXT NOT NULL,
+    song_normalized TEXT NOT NULL,
+    url TEXT NOT NULL,
+    last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (service, artist_normalized, album_normalized, song_normalized),
+    CONSTRAINT track_streaming_url_cache_service_valid CHECK (
+        service IN ({_SERVICE_IN_LIST})
+    )
+)\
+"""
+
+# Idempotent widen of the named CHECK. ``CREATE TABLE IF NOT EXISTS`` is a
+# no-op on an already-created prod table, so a new service value added to
+# ``_SERVICES`` would never reach an existing table without this ALTER. The
+# DROP-IF-EXISTS + ADD pair is byte-stable across boots and runs atomically
+# within the single statement. Driven from the same ``_SERVICE_IN_LIST`` as the
+# CREATE so the two can't drift.
+_DDL_ALTER_CHECK = f"""\
+ALTER TABLE lml_cache.track_streaming_url_cache
+    DROP CONSTRAINT IF EXISTS track_streaming_url_cache_service_valid,
+    ADD CONSTRAINT track_streaming_url_cache_service_valid CHECK (
+        service IN ({_SERVICE_IN_LIST})
+    )\
+"""
+
+# Hit-only SELECT: the ``url NOT NULL`` schema means any present row is a
+# durable hit. Keyed on the full ``(service, artist, album, song)`` composite —
+# ``song_normalized`` is the axis that makes a DIFFERENT song of the same album
+# a MISS.
+_SELECT_SQL = """\
+SELECT url
+FROM lml_cache.track_streaming_url_cache
+WHERE service = $1 AND artist_normalized = $2
+  AND album_normalized = $3 AND song_normalized = $4\
+"""
+
+# UPSERT: keep the latest URL and refresh ``last_checked_at`` on conflict.
+_UPSERT_SQL = """\
+INSERT INTO lml_cache.track_streaming_url_cache
+    (service, artist_normalized, album_normalized, song_normalized, url, last_checked_at)
+VALUES ($1, $2, $3, $4, $5, now())
+ON CONFLICT (service, artist_normalized, album_normalized, song_normalized) DO UPDATE
+SET url = EXCLUDED.url,
+    last_checked_at = EXCLUDED.last_checked_at\
+"""
+
+
+async def set_up_track_streaming_url_cache_schema(pg: PgSource) -> None:
+    """Apply the idempotent track-cache-schema DDL.
+
+    Called once from ``main.py`` lifespan. Schema and table creation are both
+    ``IF NOT EXISTS`` so re-running on every boot is safe. The final ALTER
+    widens the named CHECK to the current ``_SERVICES`` set so a prod table
+    frozen at an older service set still accepts a newly-added service.
+    """
+    await pg.execute(_DDL_SCHEMA)
+    await pg.execute(_DDL_TABLE)
+    await pg.execute(_DDL_ALTER_CHECK)
+
+
+def _album_key(album: str | None) -> str:
+    """Normalize the album key; ``None`` -> ``""`` for album-absent lookups."""
+    return to_match_form(album) if album else ""
+
+
+async def get_cached_track_streaming_url(
+    pg: PgSource,
+    *,
+    service: str,
+    artist: str,
+    album: str | None,
+    song: str,
+) -> str | None:
+    """Return the cached track deep-link for ``(service, artist, album, song)``.
+
+    Returns the URL on a hit, or ``None`` when no row exists. Keyed on the song
+    so a DIFFERENT song of the same album is a miss. PG failures return
+    ``None`` (same posture as the album cache's negative-cache helper).
+    """
+    artist_key = to_match_form(artist)
+    album_key = _album_key(album)
+    song_key = to_match_form(song)
+    try:
+        row = await pg.fetchone(_SELECT_SQL, service, artist_key, album_key, song_key)
+    except Exception:
+        logger.exception(
+            "track_streaming_url_cache get failed for %s / %s / %s / %s",
+            service,
+            artist_key,
+            album_key,
+            song_key,
+        )
+        return None
+    if row is None:
+        return None
+    return row["url"]
+
+
+async def set_cached_track_streaming_url(
+    pg: PgSource,
+    *,
+    service: str,
+    artist: str,
+    album: str | None,
+    song: str,
+    url: str,
+) -> None:
+    """UPSERT a resolved track deep-link for ``(service, artist, album, song)``.
+
+    Only non-null URLs are ever written — the schema's ``url NOT NULL`` column
+    makes persisting a null impossible, enforcing the #782/BS#1192 guard.
+
+    Write failures are logged and swallowed: cache writes are best-effort. A
+    request that produced a real URL still returns it even if the write fails.
+    """
+    artist_key = to_match_form(artist)
+    album_key = _album_key(album)
+    song_key = to_match_form(song)
+    try:
+        await pg.execute(_UPSERT_SQL, service, artist_key, album_key, song_key, url)
+    except Exception:
+        logger.exception(
+            "track_streaming_url_cache set failed for %s / %s / %s / %s",
+            service,
+            artist_key,
+            album_key,
+            song_key,
+        )

--- a/entity/track_streaming_url_cache.sql
+++ b/entity/track_streaming_url_cache.sql
@@ -1,0 +1,60 @@
+-- Track-scoped streaming-URL cache schema for LML#893 (lever L1).
+--
+-- Canonical DDL reference for the `lml_cache.track_streaming_url_cache` table.
+-- Like `lml_cache.album_streaming_url_cache`, this table lives in the LML-owned
+-- `lml_cache.*` schema (per WXYC/discogs-etl#288, Option 3) and is bootstrapped
+-- from LML's own FastAPI lifespan — no discogs-cache coordination.
+--
+-- It is a SEPARATE table from the album cache on purpose (see the closed PR
+-- #898 poisoning bug): it carries a real `song_normalized` axis in the PK so a
+-- per-track Apple Music deep-link is keyed to the played track and a DIFFERENT
+-- song of the same album is a MISS. The runtime never writes track deep-links
+-- into `album_streaming_url_cache`.
+--
+-- This file exists so:
+--
+--   1. The LML PR's reviewer has the DDL inline for comparison.
+--   2. An operator can apply the schema directly to a non-discogs-cache PG
+--      (e.g. local dev) without booting the full LML app.
+--
+-- The runtime source of truth is `entity/track_streaming_url_cache.py`
+-- (`set_up_track_streaming_url_cache_schema`), which issues these statements via
+-- the `IF NOT EXISTS` forms on every boot. If the canonical shape changes,
+-- update both places (and the parity assertions in
+-- tests/unit/test_track_streaming_url_cache_schema.py).
+
+CREATE SCHEMA IF NOT EXISTS lml_cache;
+
+CREATE TABLE IF NOT EXISTS lml_cache.track_streaming_url_cache (
+    -- Service discriminator. The named CHECK constraint pins the allowed set so
+    -- a typo'd service key fails loudly at write time. A new service is added by
+    -- extending this list AND the idempotent ALTER below (the runtime drives
+    -- both from `_SERVICES`).
+    service TEXT NOT NULL,
+    artist_normalized TEXT NOT NULL,
+    album_normalized TEXT NOT NULL,
+    -- The song axis: what makes this table track-granular. A different song of
+    -- the same album keys to a different row (a MISS), so a cached hit always
+    -- deep-links to the played track.
+    song_normalized TEXT NOT NULL,
+    -- `url` is NOT NULL: this cache stores only resolved track deep-links, never
+    -- a "checked, not found" sentinel. That structurally enforces the
+    -- #782/BS#1192 guard — a null can never be persisted on a first lookup.
+    url TEXT NOT NULL,
+    last_checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (service, artist_normalized, album_normalized, song_normalized),
+    CONSTRAINT track_streaming_url_cache_service_valid CHECK (
+        service IN ('apple_music_track')
+    )
+);
+
+-- Idempotent widen of the named CHECK so an already-created table (where
+-- `CREATE TABLE IF NOT EXISTS` is a no-op) picks up service values added after
+-- its creation. Byte-stable across boots; runs atomically within the one
+-- statement. The runtime (`set_up_track_streaming_url_cache_schema`) issues this
+-- on every boot, generated from `_SERVICES`.
+ALTER TABLE lml_cache.track_streaming_url_cache
+    DROP CONSTRAINT IF EXISTS track_streaming_url_cache_service_valid,
+    ADD CONSTRAINT track_streaming_url_cache_service_valid CHECK (
+        service IN ('apple_music_track')
+    );

--- a/lookup/enrichment/item.py
+++ b/lookup/enrichment/item.py
@@ -33,6 +33,11 @@ from discogs.models import (
 )
 from discogs.service import find_track_position
 from discogs.writer_roles import writer_credits_from_release
+from entity.track_streaming_url_cache import (
+    APPLE_MUSIC_TRACK_SERVICE,
+    get_cached_track_streaming_url,
+    set_cached_track_streaming_url,
+)
 from library.models import LibraryItem
 from lookup.artist_resolution import (
     _artist_pair_verified,
@@ -194,13 +199,76 @@ async def enrich_one(
     probe_release_year: int | None = None
     probe_method = "find_track_metadata" if not library_row_acceptable else "find_track_url"
     skip_happy_probe = library_row_acceptable and apple_music_override
-    if ctx.apple_music is not None and row_artist and search_term and not skip_happy_probe:
+
+    # L1 (LML#893): cache-first Apple track probe on the happy path. When the
+    # lookup carries a played track (``ctx.song``), peek a track-scoped cache
+    # (``lml_cache.track_streaming_url_cache``, keyed on
+    # ``(service, artist, album, song)``) before paying the ~4.8s live
+    # ``find_track_url``. A HIT returns the cached exact-track deep-link and
+    # skips the probe; a MISS runs the probe live (first-lookup URL preserved)
+    # and writes the resolved deep-link back to the TRACK cache. Both the peek
+    # and the write are gated on the kill-switch flags — an incident flip
+    # disables L1's cache read/write. Track deep-links live ONLY in this table:
+    # never the album-keyed cache (the PR #898 poisoning bug). The synthesis
+    # path (``find_track_metadata``) is untouched — track-absent lookups fall
+    # back to today's album/post-process behavior.
+    settings = get_settings()
+    track_cache_enabled = (
+        settings.lml_persist_streaming_urls and settings.lml_persist_streaming_url_apple_music
+    )
+    l1_eligible = bool(
+        library_row_acceptable
+        and ctx.apple_music is not None
+        and row_artist
+        and ctx.song
+        and ctx.discogs_cache_pg is not None
+        and track_cache_enabled
+        and not skip_happy_probe
+    )
+    track_cache_hit = False
+    if l1_eligible:
+        # Narrowed by ``l1_eligible``; asserted for mypy + as a runtime contract.
+        assert ctx.discogs_cache_pg is not None
+        assert ctx.song is not None
+        cached_track_url = await get_cached_track_streaming_url(
+            ctx.discogs_cache_pg,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist=row_artist,
+            album=ctx.album,
+            song=ctx.song,
+        )
+        if cached_track_url is not None:
+            apple_music_url = cached_track_url
+            track_cache_hit = True
+
+    if (
+        ctx.apple_music is not None
+        and row_artist
+        and search_term
+        and not skip_happy_probe
+        and not track_cache_hit
+    ):
         try:
             if library_row_acceptable:
                 apple_music_url = await asyncio.wait_for(
                     ctx.apple_music.find_track_url(row_artist, search_term, album=ctx.album),
                     timeout=apple_music_lookup_timeout_s(),
                 )
+                # L1 write-back: persist a freshly-resolved track deep-link so
+                # the next lookup of this ``(artist, album, song)`` is a HIT.
+                # Never persist a null (#782/BS#1192) — guarded on a non-null
+                # URL and the same kill-switch flags as the peek.
+                if l1_eligible and apple_music_url is not None:
+                    assert ctx.discogs_cache_pg is not None
+                    assert ctx.song is not None
+                    await set_cached_track_streaming_url(
+                        ctx.discogs_cache_pg,
+                        service=APPLE_MUSIC_TRACK_SERVICE,
+                        artist=row_artist,
+                        album=ctx.album,
+                        song=ctx.song,
+                        url=apple_music_url,
+                    )
             else:
                 probe_match = await asyncio.wait_for(
                     ctx.apple_music.find_track_metadata(row_artist, search_term, album=ctx.album),
@@ -461,7 +529,7 @@ async def enrich_one(
         entity_store=ctx.entity_store,
         request_artist=ctx.artist,
         request_album=ctx.album,
-        settings=get_settings(),
+        settings=settings,
     )
 
     # Bandcamp's templated search-URL fallback, deferred past the

--- a/main.py
+++ b/main.py
@@ -214,6 +214,9 @@ async def lifespan(app: FastAPI):
         from entity.sources import PgSource
         from entity.streaming_catalog import set_up_streaming_catalog_schema
         from entity.streaming_url_cache import set_up_streaming_url_cache_schema
+        from entity.track_streaming_url_cache import (
+            set_up_track_streaming_url_cache_schema,
+        )
 
         pool = None
         try:
@@ -233,6 +236,15 @@ async def lifespan(app: FastAPI):
                 (
                     "Streaming-URL cache",
                     lambda: set_up_streaming_url_cache_schema(source),
+                ),
+                # Track-scoped streaming-URL cache (LML#893, lever L1), a
+                # SEPARATE LML-owned ``lml_cache.*`` table keyed on the played
+                # song so the /lookup happy path can skip the ~4.8s live Apple
+                # track probe on a repeat lookup. Never bends the album cache
+                # (the PR #898 poisoning bug). Same pool, same best-effort posture.
+                (
+                    "Track streaming-URL cache",
+                    lambda: set_up_track_streaming_url_cache_schema(source),
                 ),
                 # Positive release-resolution cache (LML#632), another LML-owned
                 # ``lml_cache.*`` application cache. Same pool, same best-effort

--- a/tests/integration/test_pg_fixture_guard_adoption.py
+++ b/tests/integration/test_pg_fixture_guard_adoption.py
@@ -57,6 +57,7 @@ _INLINE_IDENTITY_DDL = re.compile(r"CREATE\s+TABLE\s+entity\.identity", re.IGNOR
 _LML_CACHE_FIXTURE_FILES = (
     "test_release_resolution_cache.py",
     "test_streaming_url_persistent_lookup.py",
+    "test_track_streaming_url_cache_pg.py",
     "test_streaming_catalog.py",
     "test_library_release_override.py",
     "test_seed_library_release_overrides.py",

--- a/tests/integration/test_track_streaming_url_cache_pg.py
+++ b/tests/integration/test_track_streaming_url_cache_pg.py
@@ -1,0 +1,204 @@
+"""Integration tests for the track-scoped streaming-URL cache (LML#893, L1).
+
+The unit tests mock ``PgSource``; this is the matching ``@pytest.mark.pg`` layer
+that drives the real schema, the real UPSERT, and — critically — the
+different-song-same-album MISS against an actual PostgreSQL connection.
+
+Concrete production risks the unit tests cannot catch:
+
+* The named CHECK constraint actually rejects an unknown ``service`` value.
+* The composite PK carries the song axis, so a DIFFERENT song of the same
+  album is a genuine MISS (a wrong-track hit would ship the first song's URL).
+* ``url NOT NULL`` structurally rejects a null write (the #782/BS#1192 guard).
+* ``to_match_form`` normalization parity between SELECT and UPSERT.
+
+Run with: pytest -m pg -v tests/integration/test_track_streaming_url_cache_pg.py
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from entity.sources import PgSource
+from entity.track_streaming_url_cache import (
+    APPLE_MUSIC_TRACK_SERVICE,
+    get_cached_track_streaming_url,
+    set_cached_track_streaming_url,
+    set_up_track_streaming_url_cache_schema,
+)
+from tests.integration.conftest import skip_if_named_tables_populated
+
+_ARTIST = "Juana Molina"
+_ALBUM = "DOGA"
+_SONG = "la paradoja"
+_OTHER_SONG = "eras"
+_TRACK_URL = "https://music.apple.com/us/song/la-paradoja/1234567890"
+
+
+@pytest_asyncio.fixture
+async def pg_source(pg_pool):
+    """A ``PgSource`` borrowing the test pool (no-op close)."""
+    return PgSource(pool=pg_pool)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_cache_schema(pg_pool, pg_source):
+    """Reset just ``lml_cache.track_streaming_url_cache``, then apply the DDL.
+
+    Surgical: drops only the one table this suite owns — not the whole
+    ``lml_cache`` schema — and refuses to run if that table already holds rows
+    (a mispointed ``DATABASE_URL_TEST`` would otherwise drop real cached URLs).
+    """
+    async with pg_pool.acquire() as conn:
+        await skip_if_named_tables_populated(conn, (("lml_cache", "track_streaming_url_cache"),))
+        await conn.execute("DROP TABLE IF EXISTS lml_cache.track_streaming_url_cache")
+    await set_up_track_streaming_url_cache_schema(pg_source)
+    yield
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS lml_cache.track_streaming_url_cache")
+
+
+@pytest.mark.pg
+class TestSchemaBootstrap:
+    @pytest.mark.asyncio
+    async def test_table_created_with_song_axis(self, pg_pool):
+        async with pg_pool.acquire() as conn:
+            cols = await conn.fetch(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'lml_cache' "
+                "AND table_name = 'track_streaming_url_cache'"
+            )
+        names = {r["column_name"] for r in cols}
+        assert {"service", "artist_normalized", "album_normalized", "song_normalized", "url"} <= (
+            names
+        )
+
+    @pytest.mark.asyncio
+    async def test_named_check_constraint_rejects_unknown_service(self, pg_pool):
+        with pytest.raises(asyncpg.PostgresError):
+            async with pg_pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO lml_cache.track_streaming_url_cache "
+                    "(service, artist_normalized, album_normalized, song_normalized, url) "
+                    "VALUES ('spotify_track', 'x', 'y', 'z', 'https://example.test')"
+                )
+
+    @pytest.mark.asyncio
+    async def test_url_column_rejects_null(self, pg_pool):
+        # The #782/BS#1192 guard is enforced at the schema level.
+        with pytest.raises(asyncpg.PostgresError):
+            async with pg_pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO lml_cache.track_streaming_url_cache "
+                    "(service, artist_normalized, album_normalized, song_normalized, url) "
+                    "VALUES ($1, 'x', 'y', 'z', NULL)",
+                    APPLE_MUSIC_TRACK_SERVICE,
+                )
+
+
+@pytest.mark.pg
+class TestCacheReadWrite:
+    @pytest.mark.asyncio
+    async def test_write_then_read_is_a_hit(self, pg_source):
+        await set_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist=_ARTIST,
+            album=_ALBUM,
+            song=_SONG,
+            url=_TRACK_URL,
+        )
+        got = await get_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist=_ARTIST,
+            album=_ALBUM,
+            song=_SONG,
+        )
+        assert got == _TRACK_URL
+
+    @pytest.mark.asyncio
+    async def test_different_song_same_album_is_a_miss(self, pg_source):
+        # The acceptance-critical case: caching one song's deep-link must NOT
+        # serve it for a different song of the same album.
+        await set_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist=_ARTIST,
+            album=_ALBUM,
+            song=_SONG,
+            url=_TRACK_URL,
+        )
+        got = await get_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist=_ARTIST,
+            album=_ALBUM,
+            song=_OTHER_SONG,
+        )
+        assert got is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_updates_in_place(self, pg_source, pg_pool):
+        for url in (_TRACK_URL, _TRACK_URL + "-v2"):
+            await set_cached_track_streaming_url(
+                pg_source,
+                service=APPLE_MUSIC_TRACK_SERVICE,
+                artist=_ARTIST,
+                album=_ALBUM,
+                song=_SONG,
+                url=url,
+            )
+        got = await get_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist=_ARTIST,
+            album=_ALBUM,
+            song=_SONG,
+        )
+        assert got == _TRACK_URL + "-v2"
+        async with pg_pool.acquire() as conn:
+            n = await conn.fetchval("SELECT count(*)::int FROM lml_cache.track_streaming_url_cache")
+        assert n == 1
+
+    @pytest.mark.asyncio
+    async def test_normalization_parity_between_write_and_read(self, pg_source):
+        # Diacritics/case/whitespace differ between write and read; the shared
+        # ``to_match_form`` normalization must still resolve the same row.
+        await set_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="Hermanos Gutiérrez",
+            album="El Bueno Y El Malo",
+            song="Thunderbird",
+            url=_TRACK_URL,
+        )
+        got = await get_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="  hermanos gutierrez ",
+            album="el bueno y el malo",
+            song="THUNDERBIRD",
+        )
+        assert got == _TRACK_URL
+
+    @pytest.mark.asyncio
+    async def test_none_album_keys_stably(self, pg_source):
+        await set_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist=_ARTIST,
+            album=None,
+            song=_SONG,
+            url=_TRACK_URL,
+        )
+        got = await get_cached_track_streaming_url(
+            pg_source,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist=_ARTIST,
+            album=None,
+            song=_SONG,
+        )
+        assert got == _TRACK_URL

--- a/tests/unit/test_enrichment_track_cache.py
+++ b/tests/unit/test_enrichment_track_cache.py
@@ -1,0 +1,257 @@
+"""L1 cache-first Apple track probe on the /lookup happy path (LML#893).
+
+The happy path (an acceptable library row — Discogs artwork present AND the row
+title clears the LML#477 gate) probes Apple Music with ``find_track_url`` to
+surface the played track's deep-link. L1 peeks a NEW track-scoped cache
+(``lml_cache.track_streaming_url_cache``, keyed on
+``(service, artist, album, song)``) before that ~4.8s live probe:
+
+* HIT   -> skip the live probe, return the cached exact-track deep-link.
+* MISS  -> run ``find_track_url`` live (first-lookup URL preserved) AND write
+           the resolved deep-link to the TRACK cache. Never a null write.
+
+Both the peek and the write are gated on the kill-switch flags
+``lml_persist_streaming_urls`` (master) AND
+``lml_persist_streaming_url_apple_music`` (per-service), so flipping either off
+during an incident fully disables L1's cache read/write.
+
+The album-keyed ``lml_cache.album_streaming_url_cache`` is NEVER written by L1
+(the closed PR #898 poisoning bug). These tests pin that boundary.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from clients.streaming.apple_music import AppleMusicClient
+from discogs.models import ReleaseMetadataResponse
+from entity.sources import PgSource
+from entity.track_streaming_url_cache import APPLE_MUSIC_TRACK_SERVICE
+from lookup.enrichment import enrich_artwork_results
+from tests.factories import make_discogs_result, make_library_item
+
+# Jessica Pratt happy-path fixture: artwork present + album == row title, so
+# ``library_row_acceptable`` is True and ``find_track_url`` is the probe.
+_ARTIST = "Jessica Pratt"
+_ALBUM = "On Your Own Love Again"
+_SONG = "Back, Baby"
+_TRACK_URL = "https://music.apple.com/us/song/back-baby/123"
+
+
+def _flags(*, master: bool = True, apple: bool = True) -> SimpleNamespace:
+    """A Settings-like stub carrying only the flags L1 reads."""
+    return SimpleNamespace(
+        lml_persist_streaming_urls=master,
+        lml_persist_streaming_url_apple_music=apple,
+        lml_persist_streaming_url_spotify=False,
+        lml_persist_streaming_url_bandcamp=False,
+    )
+
+
+def _happy_discogs_service() -> AsyncMock:
+    svc = AsyncMock()
+    svc.get_release.return_value = ReleaseMetadataResponse(
+        release_id=1,
+        title=_ALBUM,
+        artist=_ARTIST,
+        year=2015,
+        artist_id=None,
+        release_url="https://discogs.com/release/1",
+    )
+    return svc
+
+
+def _happy_inputs():
+    item = make_library_item(id=42, artist=_ARTIST, title=_ALBUM)
+    artwork = make_discogs_result(
+        release_id=1, artist=_ARTIST, album=_ALBUM, artwork_url="https://example.com/oyola.jpg"
+    )
+    apple_music = AsyncMock(spec=AppleMusicClient)
+    apple_music.find_track_metadata = AsyncMock()
+    apple_music.find_track_url = AsyncMock(return_value=_TRACK_URL)
+    return item, artwork, apple_music
+
+
+async def _run(apple_music, pg, item, artwork, discogs_service):
+    return await enrich_artwork_results(
+        [(item, artwork)],
+        discogs_service,
+        song=_SONG,
+        album=_ALBUM,
+        artist=_ARTIST,
+        apple_music=apple_music,
+        discogs_cache_pg=pg,
+    )
+
+
+@pytest.mark.asyncio
+class TestL1TrackCache:
+    async def test_cache_hit_skips_live_probe_and_returns_cached_url(self):
+        item, artwork, apple_music = _happy_inputs()
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value={"url": _TRACK_URL})
+
+        with patch("lookup.enrichment.item.get_settings", return_value=_flags()):
+            results = await _run(apple_music, pg, item, artwork, _happy_discogs_service())
+
+        _, enriched = results[0]
+        assert enriched.apple_music_url == _TRACK_URL
+        # HIT: the ~4.8s live probe was skipped entirely.
+        apple_music.find_track_url.assert_not_called()
+
+    async def test_cache_miss_runs_live_probe_and_writes_track_cache(self):
+        item, artwork, apple_music = _happy_inputs()
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value=None)  # miss
+        pg.execute = AsyncMock(return_value="INSERT 0 1")
+
+        with (
+            patch("lookup.enrichment.item.get_settings", return_value=_flags()),
+            patch(
+                "lookup.enrichment.item.set_cached_track_streaming_url",
+                new=AsyncMock(),
+            ) as write_mock,
+        ):
+            results = await _run(apple_music, pg, item, artwork, _happy_discogs_service())
+
+        _, enriched = results[0]
+        # First-lookup URL is present (no #782 null) from the live probe.
+        assert enriched.apple_music_url == _TRACK_URL
+        apple_music.find_track_url.assert_awaited_once()
+        # Write-back to the TRACK cache with the resolved deep-link.
+        write_mock.assert_awaited_once()
+        kwargs = write_mock.await_args.kwargs
+        assert kwargs["service"] == APPLE_MUSIC_TRACK_SERVICE
+        assert kwargs["song"] == _SONG
+        assert kwargs["url"] == _TRACK_URL
+
+    async def test_live_miss_returning_none_does_not_persist_null(self):
+        item, artwork, apple_music = _happy_inputs()
+        apple_music.find_track_url = AsyncMock(return_value=None)
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value=None)
+
+        with (
+            patch("lookup.enrichment.item.get_settings", return_value=_flags()),
+            patch(
+                "lookup.enrichment.item.set_cached_track_streaming_url",
+                new=AsyncMock(),
+            ) as write_mock,
+        ):
+            results = await _run(apple_music, pg, item, artwork, _happy_discogs_service())
+
+        _, enriched = results[0]
+        assert enriched.apple_music_url is None
+        # No null persisted on a first-lookup miss (#782 / BS#1192).
+        write_mock.assert_not_awaited()
+
+    async def test_flags_off_disable_peek_and_write(self):
+        item, artwork, apple_music = _happy_inputs()
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value={"url": "https://music.apple.com/SHOULD-NOT-READ"})
+        pg.execute = AsyncMock(return_value="INSERT 0 1")
+
+        with (
+            patch(
+                "lookup.enrichment.item.get_settings",
+                return_value=_flags(apple=False),
+            ),
+            patch(
+                "lookup.enrichment.item.get_cached_track_streaming_url",
+                new=AsyncMock(),
+            ) as read_mock,
+            patch(
+                "lookup.enrichment.item.set_cached_track_streaming_url",
+                new=AsyncMock(),
+            ) as write_mock,
+        ):
+            results = await _run(apple_music, pg, item, artwork, _happy_discogs_service())
+
+        _, enriched = results[0]
+        # Flag off: the cache is not read; the live probe runs and its URL wins.
+        read_mock.assert_not_awaited()
+        write_mock.assert_not_awaited()
+        apple_music.find_track_url.assert_awaited_once()
+        assert enriched.apple_music_url == _TRACK_URL
+
+    async def test_master_flag_off_disables_l1(self):
+        item, artwork, apple_music = _happy_inputs()
+        pg = AsyncMock(spec=PgSource)
+
+        with (
+            patch(
+                "lookup.enrichment.item.get_settings",
+                return_value=_flags(master=False),
+            ),
+            patch(
+                "lookup.enrichment.item.get_cached_track_streaming_url",
+                new=AsyncMock(),
+            ) as read_mock,
+        ):
+            results = await _run(apple_music, pg, item, artwork, _happy_discogs_service())
+
+        _, enriched = results[0]
+        read_mock.assert_not_awaited()
+        apple_music.find_track_url.assert_awaited_once()
+        assert enriched.apple_music_url == _TRACK_URL
+
+    async def test_l1_never_writes_the_album_cache(self):
+        # Regression guard for the PR #898 poisoning bug: the album-keyed cache
+        # must never be written on the L1 track path.
+        item, artwork, apple_music = _happy_inputs()
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value=None)  # track-cache miss
+        pg.execute = AsyncMock(return_value="INSERT 0 1")
+
+        with (
+            patch("lookup.enrichment.item.get_settings", return_value=_flags()),
+            patch(
+                "entity.streaming_url_cache.set_cached_streaming_url",
+                new=AsyncMock(),
+            ) as album_write_mock,
+        ):
+            await _run(apple_music, pg, item, artwork, _happy_discogs_service())
+
+        album_write_mock.assert_not_awaited()
+
+    async def test_track_absent_lookup_does_not_touch_track_cache(self):
+        # No played track (song=None): L1 falls back to today's behavior — the
+        # track cache is neither read nor written.
+        item = make_library_item(id=42, artist=_ARTIST, title=_ALBUM)
+        artwork = make_discogs_result(
+            release_id=1, artist=_ARTIST, album=_ALBUM, artwork_url="https://example.com/o.jpg"
+        )
+        apple_music = AsyncMock(spec=AppleMusicClient)
+        apple_music.find_track_metadata = AsyncMock()
+        apple_music.find_track_url = AsyncMock(return_value=_TRACK_URL)
+        pg = AsyncMock(spec=PgSource)
+
+        with (
+            patch("lookup.enrichment.item.get_settings", return_value=_flags()),
+            patch(
+                "lookup.enrichment.item.get_cached_track_streaming_url",
+                new=AsyncMock(),
+            ) as read_mock,
+            patch(
+                "lookup.enrichment.item.set_cached_track_streaming_url",
+                new=AsyncMock(),
+            ) as write_mock,
+        ):
+            results = await enrich_artwork_results(
+                [(item, artwork)],
+                _happy_discogs_service(),
+                song=None,
+                album=_ALBUM,
+                artist=_ARTIST,
+                apple_music=apple_music,
+                discogs_cache_pg=pg,
+            )
+
+        _, enriched = results[0]
+        read_mock.assert_not_awaited()
+        write_mock.assert_not_awaited()
+        # The row title is the album, so find_track_url still runs on item.title.
+        assert enriched.apple_music_url == _TRACK_URL

--- a/tests/unit/test_track_streaming_url_cache.py
+++ b/tests/unit/test_track_streaming_url_cache.py
@@ -1,0 +1,153 @@
+"""Unit tests for ``entity.track_streaming_url_cache`` (get / set helpers).
+
+The track-scoped streaming-URL cache (LML#893, lever L1) is a NEW LML-owned
+table ``lml_cache.track_streaming_url_cache`` keyed on
+``(service, artist_normalized, album_normalized, song_normalized)`` — a real
+song axis, unlike the album-keyed ``lml_cache.album_streaming_url_cache``. It
+caches the per-track Apple Music deep-link the ~4.8s ``find_track_url`` probe
+resolves on the ``/lookup`` happy path so a repeat lookup of the same
+``(artist, album, played-track)`` skips the live probe.
+
+The cache module owns normalization via ``wxyc_etl.text.to_match_form`` so
+callers pass raw request strings; the ``service`` key distinguishes the row.
+A ``None`` album normalizes to the empty string so album-absent lookups have a
+stable key. PG interaction is mocked with ``AsyncMock(spec=PgSource)``;
+``tests/integration/test_track_streaming_url_cache_pg.py`` covers the real SQL
+behavior end-to-end (including the different-song-same-album MISS).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from wxyc_etl.text import to_match_form
+
+from entity.sources import PgSource
+from entity.track_streaming_url_cache import (
+    APPLE_MUSIC_TRACK_SERVICE,
+    get_cached_track_streaming_url,
+    set_cached_track_streaming_url,
+)
+
+_SAMPLE_URL = "https://music.apple.com/us/song/la-paradoja/1234567890"
+
+
+@pytest.mark.asyncio
+class TestGetCachedTrackStreamingURL:
+    async def test_returns_none_when_row_absent(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value=None)
+
+        result = await get_cached_track_streaming_url(
+            pg,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="Juana Molina",
+            album="DOGA",
+            song="la paradoja",
+        )
+        assert result is None
+
+    async def test_returns_url_on_hit(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value={"url": _SAMPLE_URL})
+
+        result = await get_cached_track_streaming_url(
+            pg,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="Juana Molina",
+            album="DOGA",
+            song="la paradoja",
+        )
+        assert result == _SAMPLE_URL
+
+    async def test_select_is_keyed_on_the_song_axis(self):
+        # The SELECT must bind the normalized song as the fourth key so a
+        # DIFFERENT song of the same album cannot match (no wrong-track).
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value=None)
+
+        await get_cached_track_streaming_url(
+            pg,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="Juana Molina",
+            album="DOGA",
+            song="la paradoja",
+        )
+
+        sql, *binds = pg.fetchone.await_args.args
+        assert "song_normalized" in sql
+        assert binds == [
+            APPLE_MUSIC_TRACK_SERVICE,
+            to_match_form("Juana Molina"),
+            to_match_form("DOGA"),
+            to_match_form("la paradoja"),
+        ]
+
+    async def test_none_album_normalizes_to_empty_string(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value=None)
+
+        await get_cached_track_streaming_url(
+            pg,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="Juana Molina",
+            album=None,
+            song="la paradoja",
+        )
+        _, _service, _artist, album_key, _song = pg.fetchone.await_args.args
+        assert album_key == ""
+
+    async def test_pg_error_degrades_to_none(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(side_effect=RuntimeError("pg down"))
+
+        result = await get_cached_track_streaming_url(
+            pg,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="Juana Molina",
+            album="DOGA",
+            song="la paradoja",
+        )
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestSetCachedTrackStreamingURL:
+    async def test_upserts_with_normalized_keys(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="INSERT 0 1")
+
+        await set_cached_track_streaming_url(
+            pg,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="Juana Molina",
+            album="DOGA",
+            song="la paradoja",
+            url=_SAMPLE_URL,
+        )
+
+        sql, *binds = pg.execute.await_args.args
+        assert "INSERT INTO lml_cache.track_streaming_url_cache" in sql
+        assert "ON CONFLICT" in sql
+        assert binds == [
+            APPLE_MUSIC_TRACK_SERVICE,
+            to_match_form("Juana Molina"),
+            to_match_form("DOGA"),
+            to_match_form("la paradoja"),
+            _SAMPLE_URL,
+        ]
+
+    async def test_write_failure_is_swallowed(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(side_effect=RuntimeError("pg down"))
+
+        # Best-effort: a write failure must not propagate.
+        await set_cached_track_streaming_url(
+            pg,
+            service=APPLE_MUSIC_TRACK_SERVICE,
+            artist="Juana Molina",
+            album="DOGA",
+            song="la paradoja",
+            url=_SAMPLE_URL,
+        )

--- a/tests/unit/test_track_streaming_url_cache_schema.py
+++ b/tests/unit/test_track_streaming_url_cache_schema.py
@@ -1,0 +1,105 @@
+"""Unit tests for the track-scoped streaming-URL cache schema (LML#893, L1).
+
+Two surfaces, mirroring ``test_streaming_url_cache_schema.py``:
+
+* ``entity/track_streaming_url_cache.sql`` — the canonical-DDL reference file.
+  It must describe the ``lml_cache.track_streaming_url_cache`` table with the
+  named CHECK constraint and the composite PK carrying the song axis.
+* ``set_up_track_streaming_url_cache_schema`` — the lifespan bootstrap helper.
+  It must issue ``CREATE SCHEMA`` then ``CREATE TABLE`` (named CHECK) then the
+  idempotent ALTER, and nothing else.
+
+PG is mocked; ``tests/integration/test_track_streaming_url_cache_pg.py`` drives
+the real DDL against PostgreSQL.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from entity.sources import PgSource
+from entity.track_streaming_url_cache import (
+    _SERVICES,
+    set_up_track_streaming_url_cache_schema,
+)
+
+_SQL_REFERENCE = (
+    Path(__file__).resolve().parent.parent.parent / "entity" / "track_streaming_url_cache.sql"
+)
+
+
+class TestCanonicalDDLReference:
+    def test_reference_file_exists(self):
+        assert _SQL_REFERENCE.is_file()
+
+    def test_targets_lml_cache_schema_and_track_table(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in ddl
+        assert "lml_cache.track_streaming_url_cache" in ddl
+
+    def test_has_named_check_constraint_with_track_service(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "CONSTRAINT track_streaming_url_cache_service_valid CHECK" in ddl
+        assert "'apple_music_track'" in ddl
+
+    def test_check_constraint_allowlist_matches_services(self):
+        ddl = _SQL_REFERENCE.read_text()
+        match = re.search(r"service\s+IN\s*\(([^)]*)\)", ddl)
+        assert match is not None, "CHECK constraint IN-list not found in the .sql reference"
+        sql_services = set(re.findall(r"'([^']+)'", match.group(1)))
+        assert sql_services == set(_SERVICES)
+
+    def test_has_composite_primary_key_with_song_axis(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "PRIMARY KEY (service, artist_normalized, album_normalized, song_normalized)" in ddl
+
+
+@pytest.mark.asyncio
+class TestSetUpTrackStreamingUrlCacheSchema:
+    async def test_creates_schema_table_then_alters_check(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="CREATE")
+
+        await set_up_track_streaming_url_cache_schema(pg)
+
+        assert pg.execute.await_count == 3
+        schema_sql = pg.execute.await_args_list[0].args[0]
+        table_sql = pg.execute.await_args_list[1].args[0]
+        alter_sql = pg.execute.await_args_list[2].args[0]
+        assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in schema_sql
+        assert "CREATE TABLE IF NOT EXISTS lml_cache.track_streaming_url_cache" in table_sql
+        assert "CONSTRAINT track_streaming_url_cache_service_valid CHECK" in table_sql
+        assert (
+            "PRIMARY KEY (service, artist_normalized, album_normalized, song_normalized)"
+            in table_sql
+        )
+        assert "ALTER TABLE lml_cache.track_streaming_url_cache" in alter_sql
+        assert "DROP CONSTRAINT IF EXISTS track_streaming_url_cache_service_valid" in alter_sql
+        assert "ADD CONSTRAINT track_streaming_url_cache_service_valid CHECK" in alter_sql
+
+    async def test_bootstrap_is_idempotent(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="ALTER")
+
+        await set_up_track_streaming_url_cache_schema(pg)
+        first = [call.args[0] for call in pg.execute.await_args_list]
+        pg.execute.reset_mock()
+        await set_up_track_streaming_url_cache_schema(pg)
+        second = [call.args[0] for call in pg.execute.await_args_list]
+
+        assert first == second
+
+    async def test_does_not_touch_the_album_cache_table(self):
+        # Regression guard (PR #898): L1's own schema bootstrap must not touch
+        # the album-keyed cache table at all.
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="CREATE")
+
+        await set_up_track_streaming_url_cache_schema(pg)
+
+        executed = [call.args[0] for call in pg.execute.await_args_list]
+        assert not any("album_streaming_url_cache" in sql for sql in executed)


### PR DESCRIPTION
## Summary

Lever **L1** of the July-2026 saturation-era epic (#803). The `/lookup` happy path (an acceptable library row) probes Apple Music with `find_track_url` to surface the played track's deep-link — a ~4.8s synchronous call on the hot path that repeats verbatim on every re-lookup of the same played track. This makes that probe **cache-first**: when a lookup carries a played track, peek a new track-scoped cache before the live probe.

- **HIT** → skip the ~4.8s live `find_track_url` and return the cached exact-track deep-link.
- **MISS** → run `find_track_url` live (first-lookup URL preserved — no #782 null) AND write the resolved deep-link back to the TRACK cache.
- Track-absent lookups fall back to today's album/post-process behavior.

## New table (LML-owned, `lml_cache.*`)

`lml_cache.track_streaming_url_cache`, PK `(service, artist_normalized, album_normalized, song_normalized)` — a real **song axis**. Lifespan-bootstrapped from `main.py` via `CREATE SCHEMA/TABLE IF NOT EXISTS` alongside the other `lml_cache.*` caches, with `entity/track_streaming_url_cache.sql` as the canonical DDL reference. `url` is `NOT NULL`, so a null can never be persisted on a first-lookup miss (the #782/BS#1192 guard, enforced at the schema level).

## Regression safety (supersedes closed PR #898)

- **Never** writes track deep-links into the album-keyed `lml_cache.album_streaming_url_cache` — that was the PR #898 poisoning bug (wrong-track URLs, cross-seam contamination, warm/cold divergence on the public `apple_music_url`). Track URLs live **only** in the new table.
- The peek is keyed on the **song**, so a DIFFERENT song of the same album is a MISS (never served the first song's URL).
- The kill-switch flags `lml_persist_streaming_urls` (master) + `lml_persist_streaming_url_apple_music` (per-service) gate **both** the peek and the write — an incident flip fully disables L1's cache read/write.
- The synthesis-path artwork probe (`find_track_metadata`) stays synchronous and untouched.

## Tests (TDD, red first)

- `tests/unit/test_track_streaming_url_cache.py` — get/set helpers, song-axis key binding, `None`-album normalization, PG-error degrade.
- `tests/unit/test_track_streaming_url_cache_schema.py` — `.sql` reference + bootstrap DDL parity (never touches the album table).
- `tests/unit/test_enrichment_track_cache.py` — hit skips the probe; miss probes + writes back; live-null persists nothing; flags-off disables peek and write; album cache never written; track-absent no-ops.
- `tests/integration/test_track_streaming_url_cache_pg.py` (`@pytest.mark.pg`) — real UPSERT, **different-song-same-album MISS**, `NOT NULL` guard, CHECK constraint, normalization parity.

## Local CI

Unit suite (4022 passed), mypy (clean on changed files), ruff check + format (clean), and the `pg` suite (8 new + 21 album-cache regression) all green locally against a throwaway PostgreSQL 16.

Closes #893