### PR TITLE
perf(lookup): lean /lookup-only hydration read path (L4a)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -1076,106 +1076,148 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
-            release_row = await self.pool.fetchrow(
-                "SELECT id, title, release_year, artwork_url, released, "
-                "artwork_checked_at, not_found, master_id "
-                "FROM release WHERE id = $1",
-                release_id,
+            return await self._hydrate_release(release_id, include_videos=True)
+        except Exception as e:
+            logger.error(f"Cache get_release failed: {e}")
+            raise CacheUnavailableError(f"Cache get_release failed: {e}") from e
+
+    async def get_release_lean(self, release_id: int) -> ReleaseMetadataResponse | None:
+        """Lean ``/lookup``-only release hydration (LML#894, lever L4a).
+
+        Identical to :meth:`get_release` except it does NOT read the
+        ``release_video`` child table — ``/lookup`` never surfaces release
+        videos, so skipping that leg trims one PG round-trip per release
+        hydration (9 → 8). ``release_track_artist`` (both legs, incl. the
+        LML#699 ``extra = 1`` writer credits) is still read.
+
+        The shared :meth:`get_release` is deliberately left untouched so the
+        public ``/api/v1/discogs/release`` response keeps returning ``videos``
+        on BOTH warm and cold cache paths (the ``plans/lookup-latency-plan.md``
+        §6.3 fence: a field-drop must never mutate the shared cached read the
+        ``/discogs/*`` surface serves from).
+        """
+        try:
+            return await self._hydrate_release(release_id, include_videos=False)
+        except Exception as e:
+            logger.error(f"Cache get_release_lean failed: {e}")
+            raise CacheUnavailableError(f"Cache get_release_lean failed: {e}") from e
+
+    async def _hydrate_release(
+        self, release_id: int, *, include_videos: bool
+    ) -> ReleaseMetadataResponse | None:
+        """Shared hydration core for :meth:`get_release` / :meth:`get_release_lean`.
+
+        ``include_videos`` toggles only the ``release_video`` read: the full
+        path passes ``True``; the lean ``/lookup`` path passes ``False`` and
+        returns an empty ``videos`` list. Every other child read — including
+        both ``release_track_artist`` legs (LML#699) — is identical across the
+        two callers. Exceptions propagate to the public wrappers, which log and
+        translate them to :class:`CacheUnavailableError`.
+        """
+        release_row = await self.pool.fetchrow(
+            "SELECT id, title, release_year, artwork_url, released, "
+            "artwork_checked_at, not_found, master_id "
+            "FROM release WHERE id = $1",
+            release_id,
+        )
+
+        if release_row is None:
+            return None
+
+        # LML#510: tombstone short-circuit. The parent row's `not_found`
+        # flag is authoritative — there are no child rows for a
+        # tombstone (the tombstone branch in write_release skips the
+        # cascade), so the 4-7 PG round-trips below would all be empty
+        # selects. Returning a tombstone-shaped model keeps the
+        # `is_pg_hit` predicate at the public boundary happy (the
+        # `artwork_checked_at` stamp is set, so the seam treats it as
+        # a hit) and the public method's tombstone translation
+        # converts it back to None for the caller.
+        if release_row["not_found"]:
+            return ReleaseMetadataResponse(
+                release_id=release_id,
+                title="",
+                artist="",
+                release_url=f"https://www.discogs.com/release/{release_id}",
+                not_found=True,
+                artwork_checked_at=release_row["artwork_checked_at"],
+                cached=True,
             )
 
-            if release_row is None:
-                return None
-
-            # LML#510: tombstone short-circuit. The parent row's `not_found`
-            # flag is authoritative — there are no child rows for a
-            # tombstone (the tombstone branch in write_release skips the
-            # cascade), so the 4-7 PG round-trips below would all be empty
-            # selects. Returning a tombstone-shaped model keeps the
-            # `is_pg_hit` predicate at the public boundary happy (the
-            # `artwork_checked_at` stamp is set, so the seam treats it as
-            # a hit) and the public method's tombstone translation
-            # converts it back to None for the caller.
-            if release_row["not_found"]:
-                return ReleaseMetadataResponse(
-                    release_id=release_id,
-                    title="",
-                    artist="",
-                    release_url=f"https://www.discogs.com/release/{release_id}",
-                    not_found=True,
-                    artwork_checked_at=release_row["artwork_checked_at"],
-                    cached=True,
-                )
-
-            # Fetch all child tables in parallel (independent queries)
-            (
-                artist_rows,
-                label_rows,
-                track_rows,
-                track_artist_rows,
-                track_writer_rows,
-            ) = await asyncio.gather(
-                self.pool.fetch(
-                    """
+        # Fetch all child tables in parallel (independent queries)
+        (
+            artist_rows,
+            label_rows,
+            track_rows,
+            track_artist_rows,
+            track_writer_rows,
+        ) = await asyncio.gather(
+            self.pool.fetch(
+                """
                     SELECT artist_id, artist_name, extra, role
                     FROM release_artist
                     WHERE release_id = $1
                     ORDER BY extra, artist_name
                     """,
-                    release_id,
-                ),
-                self.pool.fetch(
-                    "SELECT label_id, label_name, catno FROM release_label WHERE release_id = $1",
-                    release_id,
-                ),
-                self.pool.fetch(
-                    """
+                release_id,
+            ),
+            self.pool.fetch(
+                "SELECT label_id, label_name, catno FROM release_label WHERE release_id = $1",
+                release_id,
+            ),
+            self.pool.fetch(
+                """
                     SELECT position, title, duration, sequence
                     FROM release_track
                     WHERE release_id = $1
                     ORDER BY sequence
                     """,
-                    release_id,
-                ),
-                self.pool.fetch(
-                    # `extra = 0` keeps TrackItem.artists tight on main-performer
-                    # credits; extras (writer/producer/remixer) live with
-                    # `extra = 1` and would otherwise cross-pollinate the
-                    # `(artist, track)` validation `_scan_tracklist_for_match`
-                    # runs over this list in `discogs/service.py`. Mirrors the
-                    # filter `validate_track_on_release` already applies; see
-                    # #333 for the precision/recall trade-off and #588 for this
-                    # call site.
-                    """
+                release_id,
+            ),
+            self.pool.fetch(
+                # `extra = 0` keeps TrackItem.artists tight on main-performer
+                # credits; extras (writer/producer/remixer) live with
+                # `extra = 1` and would otherwise cross-pollinate the
+                # `(artist, track)` validation `_scan_tracklist_for_match`
+                # runs over this list in `discogs/service.py`. Mirrors the
+                # filter `validate_track_on_release` already applies; see
+                # #333 for the precision/recall trade-off and #588 for this
+                # call site.
+                """
                     SELECT track_sequence, artist_name
                     FROM release_track_artist
                     WHERE release_id = $1
                       AND extra = 0
                     ORDER BY track_sequence
                     """,
-                    release_id,
-                ),
-                self.pool.fetch(
-                    # LML#699 Phase 2: the `extra = 1` companion read — per-track
-                    # writer/producer/remixer credits carrying `role`. Kept as a
-                    # SEPARATE query (not a widening of the `extra = 0` read
-                    # above) so `TrackItem.artists` stays performers-only for the
-                    # validation scan; the writer-role subset is keyed by track
-                    # position into `track_writers` below for BMI composer
-                    # credits. `release_track_artist` has no `artist_id` column,
-                    # so only `artist_name` + `role` are selected.
-                    """
+                release_id,
+            ),
+            self.pool.fetch(
+                # LML#699 Phase 2: the `extra = 1` companion read — per-track
+                # writer/producer/remixer credits carrying `role`. Kept as a
+                # SEPARATE query (not a widening of the `extra = 0` read
+                # above) so `TrackItem.artists` stays performers-only for the
+                # validation scan; the writer-role subset is keyed by track
+                # position into `track_writers` below for BMI composer
+                # credits. `release_track_artist` has no `artist_id` column,
+                # so only `artist_name` + `role` are selected.
+                """
                     SELECT track_sequence, artist_name, role
                     FROM release_track_artist
                     WHERE release_id = $1
                       AND extra = 1
                     ORDER BY track_sequence
                     """,
-                    release_id,
-                ),
-            )
+                release_id,
+            ),
+        )
 
-            # Genre/style/video tables may not exist if the pipeline hasn't been re-run
-            genre_style_results = await asyncio.gather(
+        # Genre/style tables may not exist if the pipeline hasn't been re-run.
+        # The ``release_video`` leg rides the same resilient gather on the full
+        # path but is skipped entirely on the lean ``/lookup`` path (LML#894):
+        # ``/lookup`` never surfaces videos, so we save the round-trip.
+        if include_videos:
+            gsv = await asyncio.gather(
                 self.pool.fetch(
                     "SELECT genre FROM release_genre WHERE release_id = $1",
                     release_id,
@@ -1195,152 +1237,151 @@ class DiscogsCacheService:
                 ),
                 return_exceptions=True,
             )
-            genre_rows = (
-                genre_style_results[0]
-                if not isinstance(genre_style_results[0], BaseException)
-                else []
+            genre_rows = gsv[0] if not isinstance(gsv[0], BaseException) else []
+            style_rows = gsv[1] if not isinstance(gsv[1], BaseException) else []
+            video_rows = gsv[2] if not isinstance(gsv[2], BaseException) else []
+        else:
+            gs = await asyncio.gather(
+                self.pool.fetch(
+                    "SELECT genre FROM release_genre WHERE release_id = $1",
+                    release_id,
+                ),
+                self.pool.fetch(
+                    "SELECT style FROM release_style WHERE release_id = $1",
+                    release_id,
+                ),
+                return_exceptions=True,
             )
-            style_rows = (
-                genre_style_results[1]
-                if not isinstance(genre_style_results[1], BaseException)
-                else []
+            genre_rows = gs[0] if not isinstance(gs[0], BaseException) else []
+            style_rows = gs[1] if not isinstance(gs[1], BaseException) else []
+            video_rows = []
+
+        primary_artist = ""
+        primary_artist_id = None
+        artist_credits: list[ArtistCredit] = []
+        extra_artist_credits: list[ArtistCredit] = []
+        for row in artist_rows:
+            credit = ArtistCredit(
+                artist_id=row["artist_id"],
+                name=row["artist_name"],
+                role=row["role"],
             )
-            video_rows = (
-                genre_style_results[2]
-                if not isinstance(genre_style_results[2], BaseException)
-                else []
+            if row["extra"] == 0:
+                artist_credits.append(credit)
+                if not primary_artist:
+                    primary_artist = row["artist_name"]
+                    primary_artist_id = row["artist_id"]
+            else:
+                extra_artist_credits.append(credit)
+
+        label_credits = [
+            LabelCredit(
+                label_id=row["label_id"],
+                name=row["label_name"],
+                catno=row["catno"],
+            )
+            for row in label_rows
+        ]
+        primary_label = label_credits[0].name if label_credits else None
+        primary_label_id = label_credits[0].label_id if label_credits else None
+
+        track_artists: dict[int, list[str]] = {}
+        for row in track_artist_rows:
+            seq = row["track_sequence"]
+            if seq not in track_artists:
+                track_artists[seq] = []
+            track_artists[seq].append(row["artist_name"])
+
+        # LML#699 Phase 2: per-track writer credits, keyed by `track_sequence`
+        # first, then translated to the display `position` via the tracklist
+        # build below. Pre-filtered to writer roles (`is_writer_role`, pure)
+        # so the carried map is a true writer map; `role` is read defensively
+        # (`.get`) because partial test doubles route extra=0-shaped rows here
+        # without a `role` column.
+        track_writers_by_seq: dict[int, list[ArtistCredit]] = {}
+        for row in track_writer_rows:
+            role = row.get("role")
+            if not is_writer_role(role):
+                continue
+            seq = row["track_sequence"]
+            track_writers_by_seq.setdefault(seq, []).append(
+                ArtistCredit(name=row["artist_name"], role=role)
             )
 
-            primary_artist = ""
-            primary_artist_id = None
-            artist_credits: list[ArtistCredit] = []
-            extra_artist_credits: list[ArtistCredit] = []
-            for row in artist_rows:
-                credit = ArtistCredit(
-                    artist_id=row["artist_id"],
-                    name=row["artist_name"],
-                    role=row["role"],
-                )
-                if row["extra"] == 0:
-                    artist_credits.append(credit)
-                    if not primary_artist:
-                        primary_artist = row["artist_name"]
-                        primary_artist_id = row["artist_id"]
-                else:
-                    extra_artist_credits.append(credit)
-
-            label_credits = [
-                LabelCredit(
-                    label_id=row["label_id"],
-                    name=row["label_name"],
-                    catno=row["catno"],
-                )
-                for row in label_rows
-            ]
-            primary_label = label_credits[0].name if label_credits else None
-            primary_label_id = label_credits[0].label_id if label_credits else None
-
-            track_artists: dict[int, list[str]] = {}
-            for row in track_artist_rows:
-                seq = row["track_sequence"]
-                if seq not in track_artists:
-                    track_artists[seq] = []
-                track_artists[seq].append(row["artist_name"])
-
-            # LML#699 Phase 2: per-track writer credits, keyed by `track_sequence`
-            # first, then translated to the display `position` via the tracklist
-            # build below. Pre-filtered to writer roles (`is_writer_role`, pure)
-            # so the carried map is a true writer map; `role` is read defensively
-            # (`.get`) because partial test doubles route extra=0-shaped rows here
-            # without a `role` column.
-            track_writers_by_seq: dict[int, list[ArtistCredit]] = {}
-            for row in track_writer_rows:
-                role = row.get("role")
-                if not is_writer_role(role):
-                    continue
-                seq = row["track_sequence"]
-                track_writers_by_seq.setdefault(seq, []).append(
-                    ArtistCredit(name=row["artist_name"], role=role)
-                )
-
-            tracklist = []
-            seq_to_position: dict[int, str] = {}
-            for row in track_rows:
-                seq = row["sequence"]
-                position = row["position"] or ""
-                seq_to_position[seq] = position
-                tracklist.append(
-                    TrackItem(
-                        position=position,
-                        title=row["title"],
-                        duration=row["duration"],
-                        artists=track_artists.get(seq, []),
-                    )
-                )
-
-            # Re-key the per-track writer credits by display position (the only
-            # track identifier `TrackItem` carries downstream). A writer row
-            # whose `track_sequence` has no tracklist row, or whose position is
-            # empty, is dropped — it can't be looked up by position anyway. A
-            # position shared by more than one track is AMBIGUOUS (Discogs
-            # `position` is non-unique text; multi-disc / mispressed releases
-            # repeat the bare position) and is dropped rather than merged, so the
-            # track-level path falls back to the release-level credit instead of
-            # attributing one track's composers to a co-positioned sibling — a
-            # wrong-attribution we must never make on a BMI royalty field.
-            position_track_counts: dict[str, int] = {}
-            for position in seq_to_position.values():
-                if position:
-                    position_track_counts[position] = position_track_counts.get(position, 0) + 1
-            track_writers: dict[str, list[ArtistCredit]] = {}
-            for seq, credits in track_writers_by_seq.items():
-                position = seq_to_position.get(seq)
-                if position and position_track_counts.get(position) == 1:
-                    track_writers[position] = credits
-
-            videos = [
-                ReleaseVideo(
-                    src=row["src"],
+        tracklist = []
+        seq_to_position: dict[int, str] = {}
+        for row in track_rows:
+            seq = row["sequence"]
+            position = row["position"] or ""
+            seq_to_position[seq] = position
+            tracklist.append(
+                TrackItem(
+                    position=position,
                     title=row["title"],
                     duration=row["duration"],
-                    embed=row["embed"] if row["embed"] is not None else True,
+                    artists=track_artists.get(seq, []),
                 )
-                for row in video_rows
-            ]
-
-            return ReleaseMetadataResponse(
-                release_id=release_id,
-                title=release_row["title"],
-                artist=primary_artist,
-                artist_id=primary_artist_id,
-                year=release_row["release_year"],
-                label=primary_label,
-                label_id=primary_label_id,
-                genres=[row["genre"] for row in genre_rows],
-                styles=[row["style"] for row in style_rows],
-                artwork_url=release_row["artwork_url"],
-                artwork_checked_at=release_row["artwork_checked_at"],
-                tracklist=tracklist,
-                release_url=f"https://www.discogs.com/release/{release_id}",
-                cached=True,
-                artists=artist_credits,
-                extra_artists=extra_artist_credits,
-                labels=label_credits,
-                released=release_row["released"],
-                # LML#688: nullable, recently-added column. ``.get`` tolerates
-                # cache rows written before master_id was plumbed (and partial
-                # test doubles); a real ``SELECT … master_id`` row always carries
-                # the key, None when Discogs has no master for the release.
-                master_id=release_row.get("master_id"),
-                videos=videos,
-                # LML#699 Phase 2: per-track writer credits keyed by display
-                # position; None (not {}) when the release has none.
-                track_writers=track_writers or None,
             )
 
-        except Exception as e:
-            logger.error(f"Cache get_release failed: {e}")
-            raise CacheUnavailableError(f"Cache get_release failed: {e}") from e
+        # Re-key the per-track writer credits by display position (the only
+        # track identifier `TrackItem` carries downstream). A writer row
+        # whose `track_sequence` has no tracklist row, or whose position is
+        # empty, is dropped — it can't be looked up by position anyway. A
+        # position shared by more than one track is AMBIGUOUS (Discogs
+        # `position` is non-unique text; multi-disc / mispressed releases
+        # repeat the bare position) and is dropped rather than merged, so the
+        # track-level path falls back to the release-level credit instead of
+        # attributing one track's composers to a co-positioned sibling — a
+        # wrong-attribution we must never make on a BMI royalty field.
+        position_track_counts: dict[str, int] = {}
+        for position in seq_to_position.values():
+            if position:
+                position_track_counts[position] = position_track_counts.get(position, 0) + 1
+        track_writers: dict[str, list[ArtistCredit]] = {}
+        for seq, credits in track_writers_by_seq.items():
+            position = seq_to_position.get(seq)
+            if position and position_track_counts.get(position) == 1:
+                track_writers[position] = credits
+
+        videos = [
+            ReleaseVideo(
+                src=row["src"],
+                title=row["title"],
+                duration=row["duration"],
+                embed=row["embed"] if row["embed"] is not None else True,
+            )
+            for row in video_rows
+        ]
+
+        return ReleaseMetadataResponse(
+            release_id=release_id,
+            title=release_row["title"],
+            artist=primary_artist,
+            artist_id=primary_artist_id,
+            year=release_row["release_year"],
+            label=primary_label,
+            label_id=primary_label_id,
+            genres=[row["genre"] for row in genre_rows],
+            styles=[row["style"] for row in style_rows],
+            artwork_url=release_row["artwork_url"],
+            artwork_checked_at=release_row["artwork_checked_at"],
+            tracklist=tracklist,
+            release_url=f"https://www.discogs.com/release/{release_id}",
+            cached=True,
+            artists=artist_credits,
+            extra_artists=extra_artist_credits,
+            labels=label_credits,
+            released=release_row["released"],
+            # LML#688: nullable, recently-added column. ``.get`` tolerates
+            # cache rows written before master_id was plumbed (and partial
+            # test doubles); a real ``SELECT … master_id`` row always carries
+            # the key, None when Discogs has no master for the release.
+            master_id=release_row.get("master_id"),
+            videos=videos,
+            # LML#699 Phase 2: per-track writer credits keyed by display
+            # position; None (not {}) when the release has none.
+            track_writers=track_writers or None,
+        )
 
     async def write_release(self, release: ReleaseMetadataResponse) -> None:
         """Write or update a release in the cache.
@@ -1738,34 +1779,73 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
-            # `fetched_at` is projected so the service-layer `is_pg_hit`
-            # predicate can distinguish stub rows (rebuild-created, never
-            # hydrated from Discogs) from rows we've actually fetched. See
-            # `DiscogsService.get_artist_details` and WXYC#502.
-            #
-            # `not_found` (LML#510) is the tombstone discriminator — see
-            # the short-circuit just below.
-            artist_row = await self.pool.fetchrow(
-                "SELECT id, name, profile, image_url, fetched_at, not_found "
-                "FROM artist WHERE id = $1",
-                artist_id,
+            return await self._hydrate_artist_details(artist_id, include_related=True)
+        except Exception as e:
+            logger.error(f"Cache get_artist_details failed: {e}")
+            raise CacheUnavailableError(f"Cache get_artist_details failed: {e}") from e
+
+    async def get_artist_details_lean(self, artist_id: int) -> ArtistDetails | None:
+        """Lean ``/lookup``-only artist hydration (LML#894, lever L4a).
+
+        Identical to :meth:`get_artist_details` except it does NOT read the
+        ``artist_alias`` / ``artist_name_variation`` / ``artist_member`` child
+        tables — ``/lookup`` only reads ``profile`` (bio) and ``urls`` (the
+        Wikipedia link), never aliases / name-variations / members. Skipping
+        those three legs trims the artist hydration from 5 PG round-trips to 2
+        (``artist`` row + ``artist_url``); the returned model carries empty
+        ``aliases`` / ``name_variations`` / ``members``.
+
+        The shared :meth:`get_artist_details` is deliberately left untouched so
+        the public ``/api/v1/discogs/artist`` response keeps returning those
+        children on BOTH warm and cold cache paths (the
+        ``plans/lookup-latency-plan.md`` §6.3 fence).
+        """
+        try:
+            return await self._hydrate_artist_details(artist_id, include_related=False)
+        except Exception as e:
+            logger.error(f"Cache get_artist_details_lean failed: {e}")
+            raise CacheUnavailableError(f"Cache get_artist_details_lean failed: {e}") from e
+
+    async def _hydrate_artist_details(
+        self, artist_id: int, *, include_related: bool
+    ) -> ArtistDetails | None:
+        """Shared core for get_artist_details / get_artist_details_lean.
+
+        ``include_related`` toggles the ``artist_alias`` / ``artist_name_variation``
+        / ``artist_member`` reads: the full path passes ``True``; the lean
+        ``/lookup`` path passes ``False``, reads only ``artist_url``, and returns
+        empty ``aliases`` / ``name_variations`` / ``members``. Exceptions
+        propagate to the public wrappers, which translate them to
+        :class:`CacheUnavailableError`.
+        """
+        # `fetched_at` is projected so the service-layer `is_pg_hit`
+        # predicate can distinguish stub rows (rebuild-created, never
+        # hydrated from Discogs) from rows we've actually fetched. See
+        # `DiscogsService.get_artist_details` and WXYC#502.
+        #
+        # `not_found` (LML#510) is the tombstone discriminator — see
+        # the short-circuit just below.
+        artist_row = await self.pool.fetchrow(
+            "SELECT id, name, profile, image_url, fetched_at, not_found FROM artist WHERE id = $1",
+            artist_id,
+        )
+
+        if artist_row is None:
+            return None
+
+        # LML#510: tombstone short-circuit. Same rationale as the
+        # release path — no child rows exist for a tombstone, so
+        # the asyncio.gather below would just be empty selects.
+        if artist_row["not_found"]:
+            return ArtistDetails(
+                artist_id=artist_id,
+                name="",
+                not_found=True,
+                fetched_at=artist_row["fetched_at"],
+                cached=True,
             )
 
-            if artist_row is None:
-                return None
-
-            # LML#510: tombstone short-circuit. Same rationale as the
-            # release path — no child rows exist for a tombstone, so
-            # the asyncio.gather below would just be empty selects.
-            if artist_row["not_found"]:
-                return ArtistDetails(
-                    artist_id=artist_id,
-                    name="",
-                    not_found=True,
-                    fetched_at=artist_row["fetched_at"],
-                    cached=True,
-                )
-
+        if include_related:
             # Fetch all child tables in parallel (independent queries)
             alias_rows, nv_rows, member_rows, url_rows = await asyncio.gather(
                 self.pool.fetch(
@@ -1785,30 +1865,35 @@ class DiscogsCacheService:
                     artist_id,
                 ),
             )
-
-            return ArtistDetails(
-                artist_id=artist_row["id"],
-                name=artist_row["name"],
-                profile=artist_row["profile"],
-                image_url=artist_row["image_url"],
-                aliases=[
-                    ArtistRef(id=r["alias_id"], name=r["alias_name"])
-                    for r in alias_rows
-                    if r["alias_id"] is not None
-                ],
-                name_variations=[r["name"] for r in nv_rows],
-                members=[
-                    MemberRef(id=r["member_id"], name=r["member_name"], active=r["active"])
-                    for r in member_rows
-                ],
-                urls=[r["url"] for r in url_rows],
-                fetched_at=artist_row["fetched_at"],
-                cached=True,
+        else:
+            # Lean /lookup path: only the URL leg (Wikipedia bio link) is read.
+            alias_rows = []
+            nv_rows = []
+            member_rows = []
+            url_rows = await self.pool.fetch(
+                "SELECT url FROM artist_url WHERE artist_id = $1",
+                artist_id,
             )
 
-        except Exception as e:
-            logger.error(f"Cache get_artist_details failed: {e}")
-            raise CacheUnavailableError(f"Cache get_artist_details failed: {e}") from e
+        return ArtistDetails(
+            artist_id=artist_row["id"],
+            name=artist_row["name"],
+            profile=artist_row["profile"],
+            image_url=artist_row["image_url"],
+            aliases=[
+                ArtistRef(id=r["alias_id"], name=r["alias_name"])
+                for r in alias_rows
+                if r["alias_id"] is not None
+            ],
+            name_variations=[r["name"] for r in nv_rows],
+            members=[
+                MemberRef(id=r["member_id"], name=r["member_name"], active=r["active"])
+                for r in member_rows
+            ],
+            urls=[r["url"] for r in url_rows],
+            fetched_at=artist_row["fetched_at"],
+            cached=True,
+        )
 
     async def get_artist_details_bulk(self, artist_ids: list[int]) -> dict[int, ArtistDetails]:
         """Batched cache-only read of full artist details across many ids.

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -1097,7 +1097,9 @@ class DiscogsService:
         )
 
     @async_cached(RELEASE_CACHE)
-    async def get_release(self, release_id: int) -> ReleaseMetadataResponse | None:
+    async def get_release(
+        self, release_id: int, *, lean: bool = False
+    ) -> ReleaseMetadataResponse | None:
         """Get full release metadata by ID.
 
         Read-through via :func:`fallthrough`: in-memory (decorator) → PG → API
@@ -1107,6 +1109,14 @@ class DiscogsService:
 
         Args:
             release_id: Discogs release ID
+            lean: LML#894 (lever L4a). When ``True``, route the PG read through
+                the SEPARATE lean cache method (:meth:`DiscogsCacheService.get_release_lean`),
+                which skips the ``release_video`` child ``/lookup`` never uses
+                (9 → 8 PG round-trips). The shared cached read (``lean=False``,
+                the default) is untouched and keeps serving ``/discogs/*``. The
+                ``@async_cached`` key includes ``lean``, so lean and full
+                results occupy disjoint L1 entries — a lean read can never be
+                served to (or poison) the ``/discogs/*`` full-object surface.
 
         Returns:
             ReleaseMetadataResponse with full metadata, or None on error
@@ -1290,7 +1300,7 @@ class DiscogsService:
         else:
             value = await fallthrough(
                 label="get_release",
-                pg_read=lambda: cache.get_release(release_id),
+                pg_read=lambda: (cache.get_release_lean if lean else cache.get_release)(release_id),
                 api_fetch=_api_fetch,
                 # LML#510: mypy widens fallthrough's generic `T` to
                 # `T | None` when the result is assigned to a variable
@@ -1346,7 +1356,9 @@ class DiscogsService:
         return value
 
     @async_cached(ARTIST_CACHE)
-    async def get_artist_details(self, artist_id: int) -> ArtistDetails | None:
+    async def get_artist_details(
+        self, artist_id: int, *, lean: bool = False
+    ) -> ArtistDetails | None:
         """Fetch full artist details from Discogs.
 
         Read-through via :func:`fallthrough`: in-memory (decorator) → PG → API
@@ -1356,6 +1368,14 @@ class DiscogsService:
 
         Args:
             artist_id: Discogs artist ID
+            lean: LML#894 (lever L4a). When ``True``, route the PG read through
+                the SEPARATE lean cache method (:meth:`DiscogsCacheService.get_artist_details_lean`),
+                which skips the ``artist_alias`` / ``artist_name_variation`` /
+                ``artist_member`` children ``/lookup`` never uses (5 → 2 PG
+                round-trips; ``profile`` + ``urls`` are still read). The shared
+                cached read (``lean=False``, the default) is untouched and keeps
+                serving ``/discogs/*``; the ``@async_cached`` key includes
+                ``lean`` so lean and full results occupy disjoint L1 entries.
 
         Returns:
             ArtistDetails with full metadata, or None on error
@@ -1451,7 +1471,9 @@ class DiscogsService:
         else:
             value = await fallthrough(
                 label="get_artist_details",
-                pg_read=lambda: cache.get_artist_details(artist_id),
+                pg_read=lambda: (
+                    cache.get_artist_details_lean if lean else cache.get_artist_details
+                )(artist_id),
                 api_fetch=_api_fetch,
                 # LML#510: see the note on `get_release` above.
                 pg_write=cache.write_artist_details,  # type: ignore[arg-type]

--- a/lookup/enrichment/top1.py
+++ b/lookup/enrichment/top1.py
@@ -39,7 +39,13 @@ async def fetch_top1_release_details(
     if top_artwork is None or top_artwork.release_id <= 0:
         return None, None, None, None, None
     try:
-        release = await discogs_service.get_release(top_artwork.release_id)
+        # LML#894 (lever L4a): the /lookup hydration path uses the lean cache
+        # read, which skips the 4 children /lookup never surfaces
+        # (release_video; artist_alias / artist_name_variation / artist_member).
+        # This stage reads only year / artist_id / artist bio + Wikipedia URL,
+        # so the lean shape is byte-identical for what it consumes while cutting
+        # the top-1 hydration from 14 PG round-trips to 10.
+        release = await discogs_service.get_release(top_artwork.release_id, lean=True)
         if not release:
             return None, None, None, None, None
 
@@ -48,7 +54,7 @@ async def fetch_top1_release_details(
         if not isinstance(artist_id, int) or artist_id <= 0:
             return year, None, None, release, None
 
-        details = await discogs_service.get_artist_details(artist_id)
+        details = await discogs_service.get_artist_details(artist_id, lean=True)
         if not details:
             return year, None, None, release, None
 

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -2862,3 +2862,264 @@ class TestArtistTrigramCandidates:
         conn.fetch = AsyncMock(return_value=[{"input": "not in batch", "artist_ids": [1]}])
         with pytest.raises(CacheUnavailableError):
             await cache_service.artist_trigram_candidates(["Stereolab"])
+
+
+# ---------------------------------------------------------------------------
+# get_release_lean / get_artist_details_lean (LML#894, lever L4a)
+#
+# The lean /lookup-only hydration read path omits the 4 children /lookup never
+# consumes (release_video; artist_alias, artist_name_variation, artist_member)
+# to cut PG round-trips 14->10. The shared get_release / get_artist_details
+# MUST keep reading those children so the public /api/v1/discogs/* responses
+# stay full on both warm and cold paths (the plans/lookup-latency-plan.md
+# section 6.3 fence). release_track_artist (LML#699 writer credits) stays on
+# the lean release path.
+# ---------------------------------------------------------------------------
+
+
+def _capture_release_row():
+    return {
+        "id": 1,
+        "title": "Aluminum Tunes",
+        "release_year": 1998,
+        "artwork_url": "https://img.com/a.jpg",
+        "released": None,
+        "artwork_checked_at": None,
+        "not_found": False,
+        "master_id": None,
+    }
+
+
+class TestGetReleaseLean:
+    @pytest.mark.asyncio
+    async def test_lean_skips_release_video(self, cache_service, mock_asyncpg_pool):
+        """get_release_lean must NOT query release_video, but MUST still read
+        the tracklist / artist / label / genre / style children AND both the
+        extra=0 and extra=1 release_track_artist legs (LML#699 writer credits).
+        """
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
+        captured_queries: list[str] = []
+
+        async def capture_fetch(query, *args):
+            captured_queries.append(query)
+            return []
+
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=capture_fetch)
+
+        result = await cache_service.get_release_lean(1)
+        assert result is not None
+
+        joined = [" ".join(q.split()) for q in captured_queries]
+        assert not any("release_video" in q for q in joined), (
+            f"lean release path must not read release_video; got: {joined!r}"
+        )
+        # Kept children.
+        for table in (
+            "release_artist",
+            "release_label",
+            "release_track",
+            "release_genre",
+            "release_style",
+        ):
+            assert any(table in q for q in joined), (
+                f"lean release path must still read {table}; got: {joined!r}"
+            )
+        # LML#699: both release_track_artist legs survive on the lean path.
+        rta = [q for q in joined if "release_track_artist" in q]
+        assert any("AND extra = 0" in q for q in rta), (
+            f"lean path must keep the extra=0 release_track_artist read; got: {rta!r}"
+        )
+        assert any("AND extra = 1" in q for q in rta), (
+            f"lean path must keep the extra=1 writer-credit read (LML#699); got: {rta!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lean_returns_empty_videos(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                release_track_artist=[],
+                release_track=[
+                    {"position": "1", "title": "Space Moment", "duration": None, "sequence": 1}
+                ],
+                release_artist=[
+                    {"artist_id": 42, "artist_name": "Stereolab", "extra": 0, "role": None}
+                ],
+                release_label=[{"label_id": 7, "label_name": "Duophonic", "catno": "D-1"}],
+                release_genre=[{"genre": "Rock"}],
+                release_style=[{"style": "Post-Rock"}],
+            )
+        )
+
+        result = await cache_service.get_release_lean(1)
+        assert result is not None
+        assert result.videos == []
+        # Core /lookup-consumed fields are intact.
+        assert result.title == "Aluminum Tunes"
+        assert result.artist == "Stereolab"
+        assert result.artist_id == 42
+        assert result.genres == ["Rock"]
+        assert result.styles == ["Post-Rock"]
+        assert result.label == "Duophonic"
+        assert len(result.tracklist) == 1
+        assert result.cached is True
+
+    @pytest.mark.asyncio
+    async def test_lean_shape_parity_with_full_for_videoless_release(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """For a release with no videos, get_release_lean returns the same core
+        payload get_release does (the /lookup-visible surface is unchanged)."""
+        router = make_fetch_router(
+            release_track_artist=[{"track_sequence": 1, "artist_name": "Stereolab"}],
+            release_track=[
+                {"position": "1", "title": "Space Moment", "duration": None, "sequence": 1}
+            ],
+            release_artist=[
+                {"artist_id": 42, "artist_name": "Stereolab", "extra": 0, "role": None}
+            ],
+            release_label=[{"label_id": 7, "label_name": "Duophonic", "catno": "D-1"}],
+            release_genre=[{"genre": "Rock"}],
+            release_style=[{"style": "Post-Rock"}],
+            release_video=[],
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=router)
+        full = await cache_service.get_release(1)
+
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=router)
+        lean = await cache_service.get_release_lean(1)
+
+        assert full is not None and lean is not None
+        assert lean.title == full.title
+        assert lean.artist == full.artist
+        assert lean.artist_id == full.artist_id
+        assert lean.genres == full.genres
+        assert lean.styles == full.styles
+        assert lean.label == full.label
+        assert [t.title for t in lean.tracklist] == [t.title for t in full.tracklist]
+        assert [t.artists for t in lean.tracklist] == [t.artists for t in full.tracklist]
+        assert lean.videos == full.videos == []
+
+    @pytest.mark.asyncio
+    async def test_shared_get_release_still_reads_release_video(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Regression fence: the shared get_release path (serves /discogs/*) must
+        keep querying release_video so warm hits are not empty vs cold full."""
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
+        captured_queries: list[str] = []
+
+        async def capture_fetch(query, *args):
+            captured_queries.append(query)
+            return []
+
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=capture_fetch)
+        await cache_service.get_release(1)
+        assert any("release_video" in q for q in captured_queries), (
+            "shared get_release must still read release_video (LML#894 fence); "
+            f"got: {captured_queries!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lean_not_found_returns_none(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=None)
+        assert await cache_service.get_release_lean(999) is None
+
+    @pytest.mark.asyncio
+    async def test_lean_error_raises_cache_unavailable(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=Exception("db error"))
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.get_release_lean(1)
+
+
+def _capture_artist_row():
+    from datetime import datetime
+
+    return {
+        "id": 77,
+        "name": "Stereolab",
+        "profile": "Anglo-French band.",
+        "image_url": "https://i.discogs.com/stereolab.jpg",
+        "fetched_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "not_found": False,
+    }
+
+
+class TestGetArtistDetailsLean:
+    @pytest.mark.asyncio
+    async def test_lean_skips_related_children(self, cache_service, mock_asyncpg_pool):
+        """get_artist_details_lean must NOT query artist_alias /
+        artist_name_variation / artist_member, but MUST still read artist_url
+        (the /lookup wikipedia-URL surface)."""
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_artist_row())
+        captured_queries: list[str] = []
+
+        async def capture_fetch(query, *args):
+            captured_queries.append(query)
+            return []
+
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=capture_fetch)
+        result = await cache_service.get_artist_details_lean(77)
+        assert result is not None
+
+        for table in ("artist_alias", "artist_name_variation", "artist_member"):
+            assert not any(table in q for q in captured_queries), (
+                f"lean artist path must not read {table}; got: {captured_queries!r}"
+            )
+        assert any("artist_url" in q for q in captured_queries), (
+            f"lean artist path must still read artist_url; got: {captured_queries!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lean_returns_empty_related_but_keeps_urls_and_profile(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_artist_row())
+        mock_asyncpg_pool.fetch = AsyncMock(
+            side_effect=make_fetch_router(
+                artist_url=[{"url": "https://en.wikipedia.org/wiki/Stereolab"}],
+            )
+        )
+        result = await cache_service.get_artist_details_lean(77)
+        assert result is not None
+        assert result.name == "Stereolab"
+        assert result.profile == "Anglo-French band."
+        assert result.aliases == []
+        assert result.name_variations == []
+        assert result.members == []
+        assert result.urls == ["https://en.wikipedia.org/wiki/Stereolab"]
+        assert result.cached is True
+
+    @pytest.mark.asyncio
+    async def test_shared_get_artist_details_still_reads_children(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """Regression fence: the shared get_artist_details path (serves
+        /discogs/*) must keep reading all three related-child tables."""
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_artist_row())
+        captured_queries: list[str] = []
+
+        async def capture_fetch(query, *args):
+            captured_queries.append(query)
+            return []
+
+        mock_asyncpg_pool.fetch = AsyncMock(side_effect=capture_fetch)
+        await cache_service.get_artist_details(77)
+        for table in ("artist_alias", "artist_name_variation", "artist_member", "artist_url"):
+            assert any(table in q for q in captured_queries), (
+                f"shared get_artist_details must still read {table} (LML#894 fence); "
+                f"got: {captured_queries!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_lean_not_found_returns_none(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=None)
+        assert await cache_service.get_artist_details_lean(999) is None
+
+    @pytest.mark.asyncio
+    async def test_lean_error_raises_cache_unavailable(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=Exception("db error"))
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.get_artist_details_lean(77)

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -3428,3 +3428,131 @@ class TestDiscogsSearchResultArtistVariants:
 
         r = make_discogs_result(artist="Juana Molina")
         assert r.artist_variants() == ["Juana Molina"]
+
+
+# ---------------------------------------------------------------------------
+# Lean /lookup hydration routing (LML#894, lever L4a)
+#
+# DiscogsService.get_release / get_artist_details gain a keyword-only ``lean``
+# flag that routes the read-through PG read to the SEPARATE lean cache method
+# (cache.get_release_lean / cache.get_artist_details_lean). The shared cached
+# path (lean=False, the default) is unchanged and keeps serving /discogs/*.
+# The @async_cached key includes the ``lean`` kwarg, so lean and full results
+# live in disjoint L1 entries — /discogs/* never reads a lean object.
+# ---------------------------------------------------------------------------
+
+
+class TestLeanHydrationRouting:
+    @pytest.mark.asyncio
+    async def test_get_release_lean_routes_to_lean_cache_read(self, mock_asyncpg_pool):
+        from discogs.cache_service import DiscogsCacheService
+
+        cache = DiscogsCacheService(mock_asyncpg_pool)
+        full = ReleaseMetadataResponse(
+            release_id=123,
+            title="FULL",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/123",
+            artwork_checked_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        lean = ReleaseMetadataResponse(
+            release_id=123,
+            title="LEAN",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/123",
+            artwork_checked_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        cache.get_release = AsyncMock(return_value=full)
+        cache.get_release_lean = AsyncMock(return_value=lean)
+        svc = DiscogsService(token="test-token", cache_service=cache)
+
+        result = await svc.get_release(123, lean=True)
+        assert result is not None and result.title == "LEAN"
+        cache.get_release_lean.assert_awaited_once_with(123)
+        cache.get_release.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_release_default_routes_to_full_cache_read(self, mock_asyncpg_pool):
+        from discogs.cache_service import DiscogsCacheService
+
+        cache = DiscogsCacheService(mock_asyncpg_pool)
+        full = ReleaseMetadataResponse(
+            release_id=123,
+            title="FULL",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/123",
+            artwork_checked_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        cache.get_release = AsyncMock(return_value=full)
+        cache.get_release_lean = AsyncMock(return_value=None)
+        svc = DiscogsService(token="test-token", cache_service=cache)
+
+        result = await svc.get_release(123)
+        assert result is not None and result.title == "FULL"
+        cache.get_release.assert_awaited_once_with(123)
+        cache.get_release_lean.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_lean_and_full_l1_entries_are_disjoint(self, mock_asyncpg_pool):
+        """A lean read must not be served from (or poison) the full L1 entry:
+        /discogs/* (full) and /lookup (lean) hit disjoint cache keys."""
+        from discogs.cache_service import DiscogsCacheService
+
+        cache = DiscogsCacheService(mock_asyncpg_pool)
+        full = ReleaseMetadataResponse(
+            release_id=123,
+            title="FULL",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/123",
+            artwork_checked_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        lean = ReleaseMetadataResponse(
+            release_id=123,
+            title="LEAN",
+            artist="Stereolab",
+            release_url="https://discogs.com/release/123",
+            artwork_checked_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        cache.get_release = AsyncMock(return_value=full)
+        cache.get_release_lean = AsyncMock(return_value=lean)
+        svc = DiscogsService(token="test-token", cache_service=cache)
+
+        # Prime the lean L1 entry, then a full read must still hit the full
+        # cache method (not be served the cached lean object).
+        assert (await svc.get_release(123, lean=True)).title == "LEAN"
+        assert (await svc.get_release(123)).title == "FULL"
+        cache.get_release_lean.assert_awaited_once_with(123)
+        cache.get_release.assert_awaited_once_with(123)
+
+    @pytest.mark.asyncio
+    async def test_get_artist_details_lean_routes_to_lean_cache_read(self, mock_asyncpg_pool):
+        from discogs.cache_service import DiscogsCacheService
+        from discogs.models import ArtistDetails
+
+        cache = DiscogsCacheService(mock_asyncpg_pool)
+        full = ArtistDetails(artist_id=77, name="FULL", fetched_at=datetime(2026, 1, 1, tzinfo=UTC))
+        lean = ArtistDetails(artist_id=77, name="LEAN", fetched_at=datetime(2026, 1, 1, tzinfo=UTC))
+        cache.get_artist_details = AsyncMock(return_value=full)
+        cache.get_artist_details_lean = AsyncMock(return_value=lean)
+        svc = DiscogsService(token="test-token", cache_service=cache)
+
+        result = await svc.get_artist_details(77, lean=True)
+        assert result is not None and result.name == "LEAN"
+        cache.get_artist_details_lean.assert_awaited_once_with(77)
+        cache.get_artist_details.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_artist_details_default_routes_to_full_cache_read(self, mock_asyncpg_pool):
+        from discogs.cache_service import DiscogsCacheService
+        from discogs.models import ArtistDetails
+
+        cache = DiscogsCacheService(mock_asyncpg_pool)
+        full = ArtistDetails(artist_id=77, name="FULL", fetched_at=datetime(2026, 1, 1, tzinfo=UTC))
+        cache.get_artist_details = AsyncMock(return_value=full)
+        cache.get_artist_details_lean = AsyncMock(return_value=None)
+        svc = DiscogsService(token="test-token", cache_service=cache)
+
+        result = await svc.get_artist_details(77)
+        assert result is not None and result.name == "FULL"
+        cache.get_artist_details.assert_awaited_once_with(77)
+        cache.get_artist_details_lean.assert_not_awaited()

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -281,7 +281,8 @@ class TestEnrichArtworkResults:
                 release_url=f"https://discogs.com/release/{release_id}",
             )
 
-        discogs_service.get_release.side_effect = lambda rid: make_release(rid)
+        # ``make_release`` accepts the LML#894 ``lean=`` kwarg the /lookup path passes.
+        discogs_service.get_release.side_effect = make_release
 
         results = await enrich_artwork_results(items_with_artwork, discogs_service, song="Song")
         assert len(results) == 3
@@ -346,7 +347,44 @@ class TestTop1SentinelGuard:
 
         await enrich_artwork_results([(item, artwork)], discogs_service, song="Cross Bones Style")
 
-        discogs_service.get_release.assert_called_once_with(12345)
+        # LML#894: the /lookup hydration path reads the lean cache variant.
+        discogs_service.get_release.assert_called_once_with(12345, lean=True)
+
+
+class TestTop1LeanHydration:
+    """LML#894 (lever L4a): the top-1 hydration N+1 — the 14-round-trip
+    ``get_release`` + ``get_artist_details`` pair — must use the lean read
+    path so ``/lookup`` skips the 4 children it never surfaces."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_top1_uses_lean_release_and_artist_reads(self):
+        from lookup.enrichment.top1 import fetch_top1_release_details
+
+        artwork = make_discogs_result(
+            release_id=555,
+            artist="Duke Ellington & John Coltrane",
+            album="Duke Ellington & John Coltrane",
+        )
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=555,
+            title="Duke Ellington & John Coltrane",
+            artist="Duke Ellington & John Coltrane",
+            year=1963,
+            artist_id=99,
+            release_url="https://discogs.com/release/555",
+        )
+        discogs_service.get_artist_details.return_value = ArtistDetails(
+            artist_id=99,
+            name="Duke Ellington",
+            profile="American composer and bandleader.",
+            urls=["https://en.wikipedia.org/wiki/Duke_Ellington"],
+        )
+
+        await fetch_top1_release_details(discogs_service, artwork)
+
+        discogs_service.get_release.assert_awaited_once_with(555, lean=True)
+        discogs_service.get_artist_details.assert_awaited_once_with(99, lean=True)
 
 
 class TestEnrichArtworkResultsExtended:


### PR DESCRIPTION
## What

Lever **L4a** (parent epic WXYC/library-metadata-lookup#803). Introduces a **lean `/lookup`-only hydration read path** that omits the 4 children `/lookup` never surfaces, cutting the top-1 hydration N+1 from **14 PG round-trips to 10** — *without* mutating the shared cached reads that serve `/api/v1/discogs/*`.

- New `DiscogsCacheService.get_release_lean` / `get_artist_details_lean` skip `release_video` (release) and `artist_alias` / `artist_name_variation` / `artist_member` (artist). `release_track_artist` (#699 writer credits, both `extra` legs) stays on the lean release path. `get_release` 9→8, `get_artist_details` 5→2.
- The shared `get_release` / `get_artist_details` are **unchanged** — they still read all four children on both warm and cold paths, so `/api/v1/discogs/release|artist` keep returning `videos` / `aliases` / `name_variations` / `members` with no warm-vs-cold divergence (the [`plans/lookup-latency-plan.md`](../blob/main/plans/lookup-latency-plan.md) §6.3 fence). The full and lean cache reads share a single `_hydrate_release` / `_hydrate_artist_details` core, so the full path is byte-identical.
- `DiscogsService.get_release` / `get_artist_details` gain a keyword-only `lean` flag that routes the read-through PG read to the lean cache method. The `@async_cached` key includes `lean`, so **lean and full results occupy disjoint L1 entries** — a lean object can never be served to (or poison) the `/discogs/*` full-object surface.
- `top1.fetch_top1_release_details` — the canonical hydration N+1 and the exact 14→10 site — switches to the lean reads. It consumes only `year` / `artist_id` / bio / Wikipedia URL, so the response shape is unchanged.

First, safe structural step; **#895 (L4c)** then collapses this lean path's per-child reads into `json_agg` / `LATERAL` (10→~2).

## Acceptance criteria

- [x] `/lookup` uses a lean hydration path that does NOT read the 4 unused children; round-trips drop 14→10.
- [x] Shared cached `get_release` / `get_artist_details` unchanged — `/discogs/*` still return all children on warm+cold (regression-fenced by spy tests).
- [x] `release_track_artist` (#699) still read on the lean path.
- [x] `/lookup` response shape unchanged for a fixture release and artist.
- [x] TDD: failing spy tests written first (lean path skips the 4 children; shared path still reads them).

## Tests / local CI

TDD throughout (red confirmed before each implementation). Added: cache-layer spy + shape-parity tests (`TestGetReleaseLean`, `TestGetArtistDetailsLean`), service-layer routing + disjoint-L1 tests (`TestLeanHydrationRouting`), and a top-1 lean-usage test (`TestTop1LeanHydration`).

Local CI all green: full default suite (4330 passed), `-m pg` (441 passed, local postgres@16 on :5433), `mypy --ignore-missing-imports` (clean), `ruff check` + `ruff format --check` (clean).

Closes #894