### PR TITLE
perf(lookup): collapse lean hydration into json_agg reads (L4c)

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -11,6 +11,7 @@ The cache uses PostgreSQL's pg_trgm extension for fuzzy text matching.
 
 import asyncio
 import hashlib
+import json
 import logging
 from dataclasses import dataclass, field, fields
 
@@ -356,6 +357,25 @@ ORDER BY mt.sim DESC\
 # ``_WORK_MEM_RE`` (imported from ``config.settings``, the single source of the
 # grammar) before interpolation — defense in depth at the interpolation point,
 # complementing the ``Settings._validate_work_mem`` boot-time gate.
+
+
+def _decode_json_agg(value: object) -> list:
+    """Decode a ``json_agg`` result column into a Python list.
+
+    ``json_agg`` returns SQL ``NULL`` (Python ``None``) when the correlated
+    subquery matches no rows, and a ``json`` value otherwise. asyncpg hands a
+    ``json`` column back as a ``str`` unless a type codec is registered (LML
+    registers none), so this decodes the string. Test doubles pass the already-
+    parsed Python list/dict structure, which is returned as-is. Any other value
+    (an unexpected scalar) is treated as empty.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return json.loads(value)
+    if isinstance(value, list):
+        return value
+    return []
 
 
 def _build_search_bounds_sql(statement_timeout_ms: int, work_mem: str) -> str:
@@ -1076,43 +1096,281 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
-            return await self._hydrate_release(release_id, include_videos=True)
+            return await self._hydrate_release(release_id)
         except Exception as e:
             logger.error(f"Cache get_release failed: {e}")
             raise CacheUnavailableError(f"Cache get_release failed: {e}") from e
 
     async def get_release_lean(self, release_id: int) -> ReleaseMetadataResponse | None:
-        """Lean ``/lookup``-only release hydration (LML#894, lever L4a).
+        """Lean ``/lookup``-only release hydration (LML#894 L4a; LML#895 L4c).
 
-        Identical to :meth:`get_release` except it does NOT read the
-        ``release_video`` child table — ``/lookup`` never surfaces release
-        videos, so skipping that leg trims one PG round-trip per release
-        hydration (9 → 8). ``release_track_artist`` (both legs, incl. the
-        LML#699 ``extra = 1`` writer credits) is still read.
+        Returns a payload **shape-identical** to :meth:`get_release` on the
+        ``/lookup``-visible surface, but reads it in **≤ 2 PG round-trips**
+        instead of the per-child N+1 the shared method issues:
+
+        * one ``json_agg`` SELECT hydrating the release row together with the
+          ``release_artist`` / ``release_label`` / ``release_track`` children
+          and **both** ``release_track_artist`` legs (``extra = 0`` performers
+          and the LML#699 ``extra = 1`` writer credits) in a single read; and
+        * one resilient ``release_genre`` / ``release_style`` read (their tables
+          can be absent on an un-rebuilt cache, so a failure degrades to empty
+          lists rather than failing the lookup — mirroring the shared path).
+
+        ``release_video`` is not read (``/lookup`` never surfaces videos, so
+        ``videos`` is always ``[]``). Collapsing the read burst also subsumes
+        the connection-churn ("L5") win: one acquire per read instead of the
+        ~7.5 acquire/``RESET ALL`` release cycles the per-child loop paid.
 
         The shared :meth:`get_release` is deliberately left untouched so the
         public ``/api/v1/discogs/release`` response keeps returning ``videos``
-        on BOTH warm and cold cache paths (the ``plans/lookup-latency-plan.md``
-        §6.3 fence: a field-drop must never mutate the shared cached read the
-        ``/discogs/*`` surface serves from).
+        (and every other child) on BOTH warm and cold cache paths — the
+        ``plans/lookup-latency-plan.md`` §6.3 fence: a field-drop or read-shape
+        change must never mutate the shared cached read ``/discogs/*`` serves
+        from.
         """
         try:
-            return await self._hydrate_release(release_id, include_videos=False)
+            return await self._hydrate_release_lean(release_id)
         except Exception as e:
             logger.error(f"Cache get_release_lean failed: {e}")
             raise CacheUnavailableError(f"Cache get_release_lean failed: {e}") from e
 
-    async def _hydrate_release(
-        self, release_id: int, *, include_videos: bool
-    ) -> ReleaseMetadataResponse | None:
-        """Shared hydration core for :meth:`get_release` / :meth:`get_release_lean`.
+    # ``json_agg`` single-round-trip release hydration for the lean ``/lookup``
+    # path (LML#895 L4c). Each correlated subquery aggregates one child table
+    # into a JSON array; ordering is applied inside the aggregate so the decoded
+    # lists match the per-child ``ORDER BY`` the shared path uses. ``json_agg``
+    # yields SQL NULL for an empty child, which ``_decode_json_agg`` maps to
+    # ``[]``. ``release_video`` is intentionally absent — ``/lookup`` never
+    # surfaces videos. Genre/style are read separately (see ``_LEAN_GENRE_STYLE_SQL``)
+    # so their optional tables can fail-soft without sinking the core read.
+    _LEAN_RELEASE_SQL = """
+        SELECT
+            r.id,
+            r.title,
+            r.release_year,
+            r.artwork_url,
+            r.released,
+            r.artwork_checked_at,
+            r.not_found,
+            r.master_id,
+            (
+                SELECT json_agg(json_build_object(
+                    'artist_id', ra.artist_id,
+                    'artist_name', ra.artist_name,
+                    'extra', ra.extra,
+                    'role', ra.role
+                ) ORDER BY ra.extra, ra.artist_name)
+                FROM release_artist ra
+                WHERE ra.release_id = r.id
+            ) AS artists,
+            (
+                SELECT json_agg(json_build_object(
+                    'label_id', rl.label_id,
+                    'label_name', rl.label_name,
+                    'catno', rl.catno
+                ))
+                FROM release_label rl
+                WHERE rl.release_id = r.id
+            ) AS labels,
+            (
+                SELECT json_agg(json_build_object(
+                    'position', rt.position,
+                    'title', rt.title,
+                    'duration', rt.duration,
+                    'sequence', rt.sequence
+                ) ORDER BY rt.sequence)
+                FROM release_track rt
+                WHERE rt.release_id = r.id
+            ) AS tracks,
+            (
+                SELECT json_agg(json_build_object(
+                    'track_sequence', rta.track_sequence,
+                    'artist_name', rta.artist_name
+                ) ORDER BY rta.track_sequence)
+                FROM release_track_artist rta
+                WHERE rta.release_id = r.id AND rta.extra = 0
+            ) AS track_artists,
+            (
+                SELECT json_agg(json_build_object(
+                    'track_sequence', rta.track_sequence,
+                    'artist_name', rta.artist_name,
+                    'role', rta.role
+                ) ORDER BY rta.track_sequence)
+                FROM release_track_artist rta
+                WHERE rta.release_id = r.id AND rta.extra = 1
+            ) AS track_writers
+        FROM release r
+        WHERE r.id = $1
+    """
 
-        ``include_videos`` toggles only the ``release_video`` read: the full
-        path passes ``True``; the lean ``/lookup`` path passes ``False`` and
-        returns an empty ``videos`` list. Every other child read — including
-        both ``release_track_artist`` legs (LML#699) — is identical across the
-        two callers. Exceptions propagate to the public wrappers, which log and
-        translate them to :class:`CacheUnavailableError`.
+    # Second (resilient) round-trip: genre + style as two json_agg columns.
+    # Kept out of ``_LEAN_RELEASE_SQL`` so that a missing/absent genre or style
+    # table (possible on an un-rebuilt cache) fails only this read — which the
+    # caller swallows to empty lists — rather than sinking the core hydration.
+    _LEAN_GENRE_STYLE_SQL = """
+        SELECT
+            (SELECT json_agg(genre) FROM release_genre WHERE release_id = $1) AS genres,
+            (SELECT json_agg(style) FROM release_style WHERE release_id = $1) AS styles
+    """
+
+    async def _hydrate_release_lean(self, release_id: int) -> ReleaseMetadataResponse | None:
+        """L4c single-burst hydration backing :meth:`get_release_lean`.
+
+        Round-trip 1 (:attr:`_LEAN_RELEASE_SQL`) hydrates the release row and
+        every ``/lookup`` child in one read; round-trip 2
+        (:attr:`_LEAN_GENRE_STYLE_SQL`) reads genre/style resiliently. No PG
+        connection is held across an HTTP hop — both reads are pure cache reads.
+        Exceptions from the core read propagate to :meth:`get_release_lean`,
+        which translates them to :class:`CacheUnavailableError`.
+        """
+        release_row = await self.pool.fetchrow(self._LEAN_RELEASE_SQL, release_id)
+
+        if release_row is None:
+            return None
+
+        # LML#510: tombstone short-circuit (same contract as the shared path).
+        # The parent's ``not_found`` flag is authoritative; a tombstone has no
+        # child rows, so the aggregated JSON columns are all empty anyway.
+        if release_row["not_found"]:
+            return ReleaseMetadataResponse(
+                release_id=release_id,
+                title="",
+                artist="",
+                release_url=f"https://www.discogs.com/release/{release_id}",
+                not_found=True,
+                artwork_checked_at=release_row["artwork_checked_at"],
+                cached=True,
+            )
+
+        # Round-trip 2: genre/style, fail-soft to empty lists (their tables can
+        # be absent on an un-rebuilt cache) — mirrors the shared path's
+        # ``return_exceptions=True`` gather.
+        try:
+            gs_row = await self.pool.fetchrow(self._LEAN_GENRE_STYLE_SQL, release_id)
+            genre_names = _decode_json_agg(gs_row["genres"]) if gs_row else []
+            style_names = _decode_json_agg(gs_row["styles"]) if gs_row else []
+        except Exception as e:
+            logger.warning(f"Lean genre/style read failed for release {release_id}: {e}")
+            genre_names = []
+            style_names = []
+
+        artist_rows = _decode_json_agg(release_row["artists"])
+        label_rows = _decode_json_agg(release_row["labels"])
+        track_rows = _decode_json_agg(release_row["tracks"])
+        track_artist_rows = _decode_json_agg(release_row["track_artists"])
+        track_writer_rows = _decode_json_agg(release_row["track_writers"])
+
+        primary_artist = ""
+        primary_artist_id = None
+        artist_credits: list[ArtistCredit] = []
+        extra_artist_credits: list[ArtistCredit] = []
+        for row in artist_rows:
+            credit = ArtistCredit(
+                artist_id=row["artist_id"],
+                name=row["artist_name"],
+                role=row["role"],
+            )
+            if row["extra"] == 0:
+                artist_credits.append(credit)
+                if not primary_artist:
+                    primary_artist = row["artist_name"]
+                    primary_artist_id = row["artist_id"]
+            else:
+                extra_artist_credits.append(credit)
+
+        label_credits = [
+            LabelCredit(
+                label_id=row["label_id"],
+                name=row["label_name"],
+                catno=row["catno"],
+            )
+            for row in label_rows
+        ]
+        primary_label = label_credits[0].name if label_credits else None
+        primary_label_id = label_credits[0].label_id if label_credits else None
+
+        track_artists: dict[int, list[str]] = {}
+        for row in track_artist_rows:
+            seq = row["track_sequence"]
+            if seq not in track_artists:
+                track_artists[seq] = []
+            track_artists[seq].append(row["artist_name"])
+
+        # LML#699 Phase 2: per-track writer credits keyed by ``track_sequence``,
+        # pre-filtered to writer roles (``is_writer_role``). Identical
+        # post-processing to the shared path — only the row source (the decoded
+        # ``extra = 1`` json_agg leg) differs.
+        track_writers_by_seq: dict[int, list[ArtistCredit]] = {}
+        for row in track_writer_rows:
+            role = row.get("role")
+            if not is_writer_role(role):
+                continue
+            seq = row["track_sequence"]
+            track_writers_by_seq.setdefault(seq, []).append(
+                ArtistCredit(name=row["artist_name"], role=role)
+            )
+
+        tracklist = []
+        seq_to_position: dict[int, str] = {}
+        for row in track_rows:
+            seq = row["sequence"]
+            position = row["position"] or ""
+            seq_to_position[seq] = position
+            tracklist.append(
+                TrackItem(
+                    position=position,
+                    title=row["title"],
+                    duration=row["duration"],
+                    artists=track_artists.get(seq, []),
+                )
+            )
+
+        # Re-key per-track writer credits by display position. A position shared
+        # by more than one track is ambiguous (non-unique Discogs ``position``
+        # text) and dropped rather than mis-attributed — same fence as the
+        # shared path (see LML#699 rationale there).
+        position_track_counts: dict[str, int] = {}
+        for position in seq_to_position.values():
+            if position:
+                position_track_counts[position] = position_track_counts.get(position, 0) + 1
+        track_writers: dict[str, list[ArtistCredit]] = {}
+        for seq, credits in track_writers_by_seq.items():
+            position = seq_to_position.get(seq)
+            if position and position_track_counts.get(position) == 1:
+                track_writers[position] = credits
+
+        return ReleaseMetadataResponse(
+            release_id=release_id,
+            title=release_row["title"],
+            artist=primary_artist,
+            artist_id=primary_artist_id,
+            year=release_row["release_year"],
+            label=primary_label,
+            label_id=primary_label_id,
+            genres=list(genre_names),
+            styles=list(style_names),
+            artwork_url=release_row["artwork_url"],
+            artwork_checked_at=release_row["artwork_checked_at"],
+            tracklist=tracklist,
+            release_url=f"https://www.discogs.com/release/{release_id}",
+            cached=True,
+            artists=artist_credits,
+            extra_artists=extra_artist_credits,
+            labels=label_credits,
+            released=release_row["released"],
+            master_id=release_row["master_id"],
+            # ``/lookup`` never surfaces videos — always empty on the lean path.
+            videos=[],
+            track_writers=track_writers or None,
+        )
+
+    async def _hydrate_release(self, release_id: int) -> ReleaseMetadataResponse | None:
+        """Full hydration core for the shared, read-through-cached :meth:`get_release`.
+
+        Reads every child table (including ``release_video``) via the per-child
+        N+1 the ``/discogs/*`` surface, the warmer, and genre-agg rely on. The
+        lean ``/lookup`` path does NOT use this method — it uses the collapsed
+        :meth:`_hydrate_release_lean`. Exceptions propagate to :meth:`get_release`,
+        which translates them to :class:`CacheUnavailableError`.
         """
         release_row = await self.pool.fetchrow(
             "SELECT id, title, release_year, artwork_url, released, "
@@ -1212,49 +1470,34 @@ class DiscogsCacheService:
             ),
         )
 
-        # Genre/style tables may not exist if the pipeline hasn't been re-run.
-        # The ``release_video`` leg rides the same resilient gather on the full
-        # path but is skipped entirely on the lean ``/lookup`` path (LML#894):
-        # ``/lookup`` never surfaces videos, so we save the round-trip.
-        if include_videos:
-            gsv = await asyncio.gather(
-                self.pool.fetch(
-                    "SELECT genre FROM release_genre WHERE release_id = $1",
-                    release_id,
-                ),
-                self.pool.fetch(
-                    "SELECT style FROM release_style WHERE release_id = $1",
-                    release_id,
-                ),
-                self.pool.fetch(
-                    """
-                    SELECT sequence, src, title, duration, embed
-                    FROM release_video
-                    WHERE release_id = $1
-                    ORDER BY sequence
-                    """,
-                    release_id,
-                ),
-                return_exceptions=True,
-            )
-            genre_rows = gsv[0] if not isinstance(gsv[0], BaseException) else []
-            style_rows = gsv[1] if not isinstance(gsv[1], BaseException) else []
-            video_rows = gsv[2] if not isinstance(gsv[2], BaseException) else []
-        else:
-            gs = await asyncio.gather(
-                self.pool.fetch(
-                    "SELECT genre FROM release_genre WHERE release_id = $1",
-                    release_id,
-                ),
-                self.pool.fetch(
-                    "SELECT style FROM release_style WHERE release_id = $1",
-                    release_id,
-                ),
-                return_exceptions=True,
-            )
-            genre_rows = gs[0] if not isinstance(gs[0], BaseException) else []
-            style_rows = gs[1] if not isinstance(gs[1], BaseException) else []
-            video_rows = []
+        # Genre/style/video tables may not exist if the pipeline hasn't been
+        # re-run, so this gather is resilient (``return_exceptions=True``). This
+        # is the shared full path serving ``/discogs/*`` — it always reads
+        # ``release_video``; the lean ``/lookup`` path uses
+        # :meth:`_hydrate_release_lean` instead and never touches videos.
+        gsv = await asyncio.gather(
+            self.pool.fetch(
+                "SELECT genre FROM release_genre WHERE release_id = $1",
+                release_id,
+            ),
+            self.pool.fetch(
+                "SELECT style FROM release_style WHERE release_id = $1",
+                release_id,
+            ),
+            self.pool.fetch(
+                """
+                SELECT sequence, src, title, duration, embed
+                FROM release_video
+                WHERE release_id = $1
+                ORDER BY sequence
+                """,
+                release_id,
+            ),
+            return_exceptions=True,
+        )
+        genre_rows = gsv[0] if not isinstance(gsv[0], BaseException) else []
+        style_rows = gsv[1] if not isinstance(gsv[1], BaseException) else []
+        video_rows = gsv[2] if not isinstance(gsv[2], BaseException) else []
 
         primary_artist = ""
         primary_artist_id = None
@@ -1779,21 +2022,42 @@ class DiscogsCacheService:
             CacheUnavailableError: If database is unreachable
         """
         try:
-            return await self._hydrate_artist_details(artist_id, include_related=True)
+            return await self._hydrate_artist_details(artist_id)
         except Exception as e:
             logger.error(f"Cache get_artist_details failed: {e}")
             raise CacheUnavailableError(f"Cache get_artist_details failed: {e}") from e
 
-    async def get_artist_details_lean(self, artist_id: int) -> ArtistDetails | None:
-        """Lean ``/lookup``-only artist hydration (LML#894, lever L4a).
+    # ``json_agg`` single-round-trip artist hydration for the lean ``/lookup``
+    # path (LML#895 L4c). Only ``artist_url`` (the Wikipedia bio link) is
+    # aggregated — ``/lookup`` never reads aliases / name-variations / members —
+    # folding the former second round-trip into the parent read.
+    _LEAN_ARTIST_SQL = """
+        SELECT
+            a.id,
+            a.name,
+            a.profile,
+            a.image_url,
+            a.fetched_at,
+            a.not_found,
+            (
+                SELECT json_agg(au.url)
+                FROM artist_url au
+                WHERE au.artist_id = a.id
+            ) AS urls
+        FROM artist a
+        WHERE a.id = $1
+    """
 
-        Identical to :meth:`get_artist_details` except it does NOT read the
-        ``artist_alias`` / ``artist_name_variation`` / ``artist_member`` child
-        tables — ``/lookup`` only reads ``profile`` (bio) and ``urls`` (the
-        Wikipedia link), never aliases / name-variations / members. Skipping
-        those three legs trims the artist hydration from 5 PG round-trips to 2
-        (``artist`` row + ``artist_url``); the returned model carries empty
-        ``aliases`` / ``name_variations`` / ``members``.
+    async def get_artist_details_lean(self, artist_id: int) -> ArtistDetails | None:
+        """Lean ``/lookup``-only artist hydration (LML#894 L4a; LML#895 L4c).
+
+        Returns the same ``/lookup``-visible surface as :meth:`get_artist_details`
+        (``name`` / ``profile`` / ``image_url`` / ``urls`` / ``fetched_at``) but
+        in a **single** ``json_agg`` PG round-trip (:attr:`_LEAN_ARTIST_SQL`) —
+        the ``artist_url`` leg is folded into the parent read. ``/lookup`` never
+        reads ``artist_alias`` / ``artist_name_variation`` / ``artist_member``,
+        so the returned model carries empty ``aliases`` / ``name_variations`` /
+        ``members``.
 
         The shared :meth:`get_artist_details` is deliberately left untouched so
         the public ``/api/v1/discogs/artist`` response keeps returning those
@@ -1801,22 +2065,54 @@ class DiscogsCacheService:
         ``plans/lookup-latency-plan.md`` §6.3 fence).
         """
         try:
-            return await self._hydrate_artist_details(artist_id, include_related=False)
+            return await self._hydrate_artist_details_lean(artist_id)
         except Exception as e:
             logger.error(f"Cache get_artist_details_lean failed: {e}")
             raise CacheUnavailableError(f"Cache get_artist_details_lean failed: {e}") from e
 
-    async def _hydrate_artist_details(
-        self, artist_id: int, *, include_related: bool
-    ) -> ArtistDetails | None:
-        """Shared core for get_artist_details / get_artist_details_lean.
+    async def _hydrate_artist_details_lean(self, artist_id: int) -> ArtistDetails | None:
+        """L4c single-burst hydration backing :meth:`get_artist_details_lean`.
 
-        ``include_related`` toggles the ``artist_alias`` / ``artist_name_variation``
-        / ``artist_member`` reads: the full path passes ``True``; the lean
-        ``/lookup`` path passes ``False``, reads only ``artist_url``, and returns
-        empty ``aliases`` / ``name_variations`` / ``members``. Exceptions
-        propagate to the public wrappers, which translate them to
-        :class:`CacheUnavailableError`.
+        One :attr:`_LEAN_ARTIST_SQL` read hydrates the artist row and its
+        ``artist_url`` list; no PG connection is held across an HTTP hop.
+        Exceptions propagate to :meth:`get_artist_details_lean`.
+        """
+        artist_row = await self.pool.fetchrow(self._LEAN_ARTIST_SQL, artist_id)
+
+        if artist_row is None:
+            return None
+
+        # LML#510: tombstone short-circuit (same contract as the shared path).
+        if artist_row["not_found"]:
+            return ArtistDetails(
+                artist_id=artist_id,
+                name="",
+                not_found=True,
+                fetched_at=artist_row["fetched_at"],
+                cached=True,
+            )
+
+        return ArtistDetails(
+            artist_id=artist_row["id"],
+            name=artist_row["name"],
+            profile=artist_row["profile"],
+            image_url=artist_row["image_url"],
+            aliases=[],
+            name_variations=[],
+            members=[],
+            urls=list(_decode_json_agg(artist_row["urls"])),
+            fetched_at=artist_row["fetched_at"],
+            cached=True,
+        )
+
+    async def _hydrate_artist_details(self, artist_id: int) -> ArtistDetails | None:
+        """Full hydration core for the shared, read-through-cached :meth:`get_artist_details`.
+
+        Reads every related child (``artist_alias`` / ``artist_name_variation`` /
+        ``artist_member`` / ``artist_url``) the ``/discogs/*`` surface, the
+        warmer, and genre-agg rely on. The lean ``/lookup`` path does NOT use
+        this method — it uses :meth:`_hydrate_artist_details_lean`. Exceptions
+        propagate to :meth:`get_artist_details`.
         """
         # `fetched_at` is projected so the service-layer `is_pg_hit`
         # predicate can distinguish stub rows (rebuild-created, never
@@ -1845,35 +2141,25 @@ class DiscogsCacheService:
                 cached=True,
             )
 
-        if include_related:
-            # Fetch all child tables in parallel (independent queries)
-            alias_rows, nv_rows, member_rows, url_rows = await asyncio.gather(
-                self.pool.fetch(
-                    "SELECT alias_id, alias_name FROM artist_alias WHERE artist_id = $1",
-                    artist_id,
-                ),
-                self.pool.fetch(
-                    "SELECT name FROM artist_name_variation WHERE artist_id = $1",
-                    artist_id,
-                ),
-                self.pool.fetch(
-                    "SELECT member_id, member_name, active FROM artist_member WHERE artist_id = $1",
-                    artist_id,
-                ),
-                self.pool.fetch(
-                    "SELECT url FROM artist_url WHERE artist_id = $1",
-                    artist_id,
-                ),
-            )
-        else:
-            # Lean /lookup path: only the URL leg (Wikipedia bio link) is read.
-            alias_rows = []
-            nv_rows = []
-            member_rows = []
-            url_rows = await self.pool.fetch(
+        # Fetch all child tables in parallel (independent queries)
+        alias_rows, nv_rows, member_rows, url_rows = await asyncio.gather(
+            self.pool.fetch(
+                "SELECT alias_id, alias_name FROM artist_alias WHERE artist_id = $1",
+                artist_id,
+            ),
+            self.pool.fetch(
+                "SELECT name FROM artist_name_variation WHERE artist_id = $1",
+                artist_id,
+            ),
+            self.pool.fetch(
+                "SELECT member_id, member_name, active FROM artist_member WHERE artist_id = $1",
+                artist_id,
+            ),
+            self.pool.fetch(
                 "SELECT url FROM artist_url WHERE artist_id = $1",
                 artist_id,
-            )
+            ),
+        )
 
         return ArtistDetails(
             artist_id=artist_row["id"],

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -1109,10 +1109,12 @@ class DiscogsService:
 
         Args:
             release_id: Discogs release ID
-            lean: LML#894 (lever L4a). When ``True``, route the PG read through
-                the SEPARATE lean cache method (:meth:`DiscogsCacheService.get_release_lean`),
-                which skips the ``release_video`` child ``/lookup`` never uses
-                (9 → 8 PG round-trips). The shared cached read (``lean=False``,
+            lean: LML#894 (lever L4a) / LML#895 (lever L4c). When ``True``, route
+                the PG read through the SEPARATE lean cache method
+                (:meth:`DiscogsCacheService.get_release_lean`), which collapses
+                the per-child hydration into ``json_agg`` reads (≤ 2 PG
+                round-trips) and never surfaces the ``release_video`` child
+                ``/lookup`` never uses. The shared cached read (``lean=False``,
                 the default) is untouched and keeps serving ``/discogs/*``. The
                 ``@async_cached`` key includes ``lean``, so lean and full
                 results occupy disjoint L1 entries — a lean read can never be
@@ -1368,11 +1370,13 @@ class DiscogsService:
 
         Args:
             artist_id: Discogs artist ID
-            lean: LML#894 (lever L4a). When ``True``, route the PG read through
-                the SEPARATE lean cache method (:meth:`DiscogsCacheService.get_artist_details_lean`),
-                which skips the ``artist_alias`` / ``artist_name_variation`` /
-                ``artist_member`` children ``/lookup`` never uses (5 → 2 PG
-                round-trips; ``profile`` + ``urls`` are still read). The shared
+            lean: LML#894 (lever L4a) / LML#895 (lever L4c). When ``True``, route
+                the PG read through the SEPARATE lean cache method
+                (:meth:`DiscogsCacheService.get_artist_details_lean`), which folds
+                ``artist_url`` into the parent row via ``json_agg`` (a single PG
+                round-trip; ``profile`` + ``urls`` are still read) and never reads
+                the ``artist_alias`` / ``artist_name_variation`` /
+                ``artist_member`` children ``/lookup`` never uses. The shared
                 cached read (``lean=False``, the default) is untouched and keeps
                 serving ``/discogs/*``; the ``@async_cached`` key includes
                 ``lean`` so lean and full results occupy disjoint L1 entries.

--- a/tests/integration/test_cache_lean_json_agg_parity.py
+++ b/tests/integration/test_cache_lean_json_agg_parity.py
@@ -374,7 +374,7 @@ async def test_artist_lean_no_urls_returns_empty_list(pg_pool):
 
 @pytest.mark.pg
 @pytest.mark.asyncio
-async def test_release_lean_tombstone_returns_none(pg_pool):
+async def test_release_lean_tombstone_surfaces_not_found(pg_pool):
     async with pg_pool.acquire() as conn:
         await conn.execute(
             "INSERT INTO release (id, title, not_found, artwork_checked_at) "

--- a/tests/integration/test_cache_lean_json_agg_parity.py
+++ b/tests/integration/test_cache_lean_json_agg_parity.py
@@ -1,0 +1,388 @@
+"""Parity test for the L4c ``json_agg`` lean ``/lookup`` read path (LML#895).
+
+L4c collapses the lean ``/lookup`` release/artist hydration into 1-2 ``json_agg``
+round-trips (extending the LML#894 lean path). This suite pins the acceptance
+criterion end-to-end against a real PostgreSQL: for a fixture release and a
+fixture artist, ``get_release_lean`` / ``get_artist_details_lean`` return a
+payload **shape-identical** to the shared per-child ``get_release`` /
+``get_artist_details`` on the ``/lookup``-visible surface. The only deliberate
+divergences are the children ``/lookup`` never consumes — release ``videos`` and
+artist ``aliases`` / ``name_variations`` / ``members`` — which the lean path
+returns empty while the shared (``/discogs/*``) path returns full.
+
+Running against real Postgres also exercises the real driver's ``json`` decode
+(asyncpg hands a ``json`` column back as ``str``), which the mock-based unit
+tests in ``tests/unit/test_cache_service.py`` cannot.
+
+Run with: ``pytest -m pg -v tests/integration/test_cache_lean_json_agg_parity.py``
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from discogs.cache_service import DiscogsCacheService
+
+# ``pg_pool`` (max_size=3) is provided by tests/integration/conftest.py.
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def fresh_schema(pg_pool):
+    """Bring up the parent + child tables the release / artist reads touch."""
+    async with pg_pool.acquire() as conn:
+        for child in (
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+            "release_track",
+            "release_track_artist",
+            "release_video",
+            "artist_alias",
+            "artist_name_variation",
+            "artist_member",
+            "artist_url",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {child} CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS release CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS artist CASCADE")
+
+        await conn.execute("""
+            CREATE TABLE release (
+                id                  integer PRIMARY KEY,
+                title               text NOT NULL,
+                release_year        smallint,
+                country             text,
+                artwork_url         text,
+                released            text,
+                format              text,
+                master_id           integer,
+                artwork_checked_at  timestamptz,
+                not_found           boolean NOT NULL DEFAULT FALSE
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_artist (
+                release_id  integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                artist_id   integer,
+                artist_name text NOT NULL,
+                extra       integer DEFAULT 0,
+                role        text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_label (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                label_id   integer,
+                label_name text NOT NULL,
+                catno      text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_genre (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                genre      text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_style (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                style      text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_track (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                sequence   integer NOT NULL,
+                position   text,
+                title      text NOT NULL,
+                duration   text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_track_artist (
+                release_id     integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                track_sequence integer NOT NULL,
+                artist_name    text NOT NULL,
+                extra          integer DEFAULT 0,
+                role           text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_video (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                sequence   integer NOT NULL,
+                src        text NOT NULL,
+                title      text,
+                duration   integer,
+                embed      boolean DEFAULT true
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist (
+                id         integer PRIMARY KEY,
+                name       text NOT NULL,
+                profile    text,
+                image_url  text,
+                fetched_at timestamptz,
+                not_found  boolean NOT NULL DEFAULT FALSE
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_alias (
+                artist_id  integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                alias_id   integer,
+                alias_name text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_name_variation (
+                artist_id integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                name      text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_member (
+                artist_id   integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                member_id   integer,
+                member_name text NOT NULL,
+                active      boolean DEFAULT true
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE artist_url (
+                artist_id integer NOT NULL REFERENCES artist(id) ON DELETE CASCADE,
+                url       text NOT NULL
+            )
+        """)
+    yield
+    async with pg_pool.acquire() as conn:
+        for t in (
+            "release_artist",
+            "release_label",
+            "release_genre",
+            "release_style",
+            "release_track",
+            "release_track_artist",
+            "release_video",
+            "artist_alias",
+            "artist_name_variation",
+            "artist_member",
+            "artist_url",
+            "release",
+            "artist",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {t} CASCADE")
+
+
+async def _seed_release(pg_pool):
+    """A richly-populated release: Duke Ellington & John Coltrane on Impulse."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO release (id, title, release_year, artwork_url, released, master_id, "
+            "not_found) VALUES (100, 'Duke Ellington & John Coltrane', 1963, "
+            "'https://img.discogs.com/duke.jpg', '1963-01-01', 555, FALSE)"
+        )
+        await conn.executemany(
+            "INSERT INTO release_artist (release_id, artist_id, artist_name, extra, role) "
+            "VALUES (100, $1, $2, $3, $4)",
+            [
+                (10, "Duke Ellington", 0, None),
+                (11, "John Coltrane", 0, None),
+                (12, "Aaron Bell", 1, "Bass"),
+            ],
+        )
+        await conn.execute(
+            "INSERT INTO release_label (release_id, label_id, label_name, catno) "
+            "VALUES (100, 7, 'Impulse Records', 'A-30')"
+        )
+        await conn.executemany(
+            "INSERT INTO release_genre (release_id, genre) VALUES (100, $1)",
+            [("Jazz",), ("Blues",)],
+        )
+        await conn.executemany(
+            "INSERT INTO release_style (release_id, style) VALUES (100, $1)",
+            [("Big Band",), ("Modal",)],
+        )
+        await conn.executemany(
+            "INSERT INTO release_track (release_id, sequence, position, title, duration) "
+            "VALUES (100, $1, $2, $3, $4)",
+            [
+                (1, "A1", "In a Sentimental Mood", "4:17"),
+                (2, "A2", "Take the Coltrane", "4:44"),
+            ],
+        )
+        await conn.executemany(
+            "INSERT INTO release_track_artist "
+            "(release_id, track_sequence, artist_name, extra, role) VALUES (100, $1, $2, $3, $4)",
+            [
+                # extra=0 performer credits (flow to TrackItem.artists)
+                (1, "Duke Ellington", 0, None),
+                (2, "John Coltrane", 0, None),
+                # extra=1 per-track writer + a non-writer credit
+                (1, "Duke Ellington", 1, "Written-By"),
+                (2, "A Producer", 1, "Producer"),
+            ],
+        )
+        await conn.execute(
+            "INSERT INTO release_video (release_id, sequence, src, title, duration, embed) "
+            "VALUES (100, 1, 'https://youtu.be/x', 'A Sentimental Mood (live)', 257, true)"
+        )
+
+
+async def _seed_artist(pg_pool):
+    """A richly-populated artist: Stereolab, with every related child present."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO artist (id, name, profile, image_url, fetched_at, not_found) "
+            "VALUES (77, 'Stereolab', 'Anglo-French avant-pop band.', "
+            "'https://img.discogs.com/stereolab.jpg', now(), FALSE)"
+        )
+        await conn.execute(
+            "INSERT INTO artist_alias (artist_id, alias_id, alias_name) "
+            "VALUES (77, 88, 'Groop Play')"
+        )
+        await conn.executemany(
+            "INSERT INTO artist_name_variation (artist_id, name) VALUES (77, $1)",
+            [("Stereo Lab",), ("Stereolab (2)",)],
+        )
+        await conn.execute(
+            "INSERT INTO artist_member (artist_id, member_id, member_name, active) "
+            "VALUES (77, 99, 'Laetitia Sadier', true)"
+        )
+        await conn.executemany(
+            "INSERT INTO artist_url (artist_id, url) VALUES (77, $1)",
+            [("https://en.wikipedia.org/wiki/Stereolab",), ("https://stereolab.co.uk",)],
+        )
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_release_lean_shape_parity_with_full(pg_pool):
+    await _seed_release(pg_pool)
+    svc = DiscogsCacheService(pg_pool)
+
+    full = await svc.get_release(100)
+    lean = await svc.get_release_lean(100)
+
+    assert full is not None and lean is not None
+
+    # /lookup-visible surface: identical.
+    assert lean.title == full.title
+    assert lean.artist == full.artist == "Duke Ellington"
+    assert lean.artist_id == full.artist_id
+    assert lean.year == full.year == 1963
+    assert lean.label == full.label == "Impulse Records"
+    assert lean.label_id == full.label_id
+    assert lean.genres == full.genres == ["Jazz", "Blues"]
+    assert lean.styles == full.styles == ["Big Band", "Modal"]
+    assert lean.artwork_url == full.artwork_url
+    assert lean.released == full.released
+    assert lean.master_id == full.master_id == 555
+    assert [c.name for c in lean.artists] == [c.name for c in full.artists]
+    assert [c.name for c in lean.extra_artists] == [c.name for c in full.extra_artists]
+    assert [(c.name, c.role) for c in lean.extra_artists] == [("Aaron Bell", "Bass")]
+    assert [(lc.name, lc.catno) for lc in lean.labels] == [
+        (lc.name, lc.catno) for lc in full.labels
+    ]
+    assert [(t.position, t.title, t.duration, t.artists) for t in lean.tracklist] == [
+        (t.position, t.title, t.duration, t.artists) for t in full.tracklist
+    ]
+    # LML#699 per-track writer credits survive on the lean path, position-keyed.
+    assert lean.track_writers == full.track_writers
+    assert lean.track_writers is not None
+    assert [c.name for c in lean.track_writers["A1"]] == ["Duke Ellington"]
+    assert "A2" not in lean.track_writers  # producer-only extra=1 → dropped
+
+    # Deliberate divergence: /lookup never surfaces videos.
+    assert lean.videos == []
+    assert len(full.videos) == 1
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_artist_lean_shape_parity_with_full(pg_pool):
+    await _seed_artist(pg_pool)
+    svc = DiscogsCacheService(pg_pool)
+
+    full = await svc.get_artist_details(77)
+    lean = await svc.get_artist_details_lean(77)
+
+    assert full is not None and lean is not None
+
+    # /lookup-visible surface: identical.
+    assert lean.name == full.name == "Stereolab"
+    assert lean.profile == full.profile
+    assert lean.image_url == full.image_url
+    assert lean.fetched_at == full.fetched_at
+    assert (
+        lean.urls
+        == full.urls
+        == [
+            "https://en.wikipedia.org/wiki/Stereolab",
+            "https://stereolab.co.uk",
+        ]
+    )
+
+    # Deliberate divergence: /lookup never reads related children.
+    assert lean.aliases == []
+    assert lean.name_variations == []
+    assert lean.members == []
+    assert len(full.aliases) == 1
+    assert full.name_variations == ["Stereo Lab", "Stereolab (2)"]
+    assert len(full.members) == 1
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_release_lean_empty_children_return_empty_lists(pg_pool):
+    """A release with no child rows: json_agg NULLs decode to [], not None."""
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO release (id, title, not_found) VALUES (200, 'Bare Release', FALSE)"
+        )
+    svc = DiscogsCacheService(pg_pool)
+    lean = await svc.get_release_lean(200)
+    assert lean is not None
+    assert lean.artist == ""
+    assert lean.artists == []
+    assert lean.extra_artists == []
+    assert lean.labels == []
+    assert lean.tracklist == []
+    assert lean.genres == []
+    assert lean.styles == []
+    assert lean.videos == []
+    assert lean.track_writers is None
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_artist_lean_no_urls_returns_empty_list(pg_pool):
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO artist (id, name, fetched_at, not_found) "
+            "VALUES (300, 'Juana Molina', now(), FALSE)"
+        )
+    svc = DiscogsCacheService(pg_pool)
+    lean = await svc.get_artist_details_lean(300)
+    assert lean is not None
+    assert lean.name == "Juana Molina"
+    assert lean.urls == []
+    assert lean.aliases == []
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+async def test_release_lean_tombstone_returns_none(pg_pool):
+    async with pg_pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO release (id, title, not_found, artwork_checked_at) "
+            "VALUES (400, '', TRUE, now())"
+        )
+    svc = DiscogsCacheService(pg_pool)
+    lean = await svc.get_release_lean(400)
+    # The tombstone-shaped model carries not_found=True; the service boundary
+    # translates it, but the cache method itself surfaces the tombstone.
+    assert lean is not None
+    assert lean.not_found is True

--- a/tests/unit/test_cache_service.py
+++ b/tests/unit/test_cache_service.py
@@ -2865,20 +2865,31 @@ class TestArtistTrigramCandidates:
 
 
 # ---------------------------------------------------------------------------
-# get_release_lean / get_artist_details_lean (LML#894, lever L4a)
+# get_release_lean / get_artist_details_lean (LML#894 L4a; LML#895 L4c)
 #
-# The lean /lookup-only hydration read path omits the 4 children /lookup never
-# consumes (release_video; artist_alias, artist_name_variation, artist_member)
-# to cut PG round-trips 14->10. The shared get_release / get_artist_details
-# MUST keep reading those children so the public /api/v1/discogs/* responses
-# stay full on both warm and cold paths (the plans/lookup-latency-plan.md
-# section 6.3 fence). release_track_artist (LML#699 writer credits) stays on
-# the lean release path.
+# L4a introduced a lean /lookup-only hydration read path that omitted the 4
+# children /lookup never consumes (release_video; artist_alias,
+# artist_name_variation, artist_member). L4c (#895) collapses that same lean
+# path's per-child N+1 into 1-2 json_agg reads: the release lean read is now a
+# single json_agg SELECT (release row + all /lookup children) plus one resilient
+# genre/style read, and the artist lean read is a single json_agg SELECT. The
+# shared get_release / get_artist_details keep their per-child reads unchanged so
+# the public /api/v1/discogs/* responses stay full on both warm and cold paths
+# (the plans/lookup-latency-plan.md section 6.3 fence). release_track_artist
+# (LML#699 writer credits, both extra legs) stays on the lean release path.
 # ---------------------------------------------------------------------------
 
 
-def _capture_release_row():
-    return {
+def _lean_release_row(**overrides):
+    """A parent-release fetchrow result carrying the json_agg child columns.
+
+    Mirrors what the L4c single-round-trip lean SELECT returns: the release
+    columns plus one aggregated JSON column per /lookup child. Child columns are
+    native Python lists/dicts here — the production ``_decode_json_agg`` helper
+    also accepts the raw ``str`` asyncpg hands back for a ``json`` column, which
+    the pg-marked parity test exercises for real.
+    """
+    row = {
         "id": 1,
         "title": "Aluminum Tunes",
         "release_year": 1998,
@@ -2887,120 +2898,154 @@ def _capture_release_row():
         "artwork_checked_at": None,
         "not_found": False,
         "master_id": None,
+        "artists": [{"artist_id": 42, "artist_name": "Stereolab", "extra": 0, "role": None}],
+        "labels": [{"label_id": 7, "label_name": "Duophonic", "catno": "D-1"}],
+        "tracks": [{"position": "1", "title": "Space Moment", "duration": None, "sequence": 1}],
+        "track_artists": [{"track_sequence": 1, "artist_name": "Stereolab"}],
+        "track_writers": [],
+    }
+    row.update(overrides)
+    return row
+
+
+def _lean_genre_style_row(genres=None, styles=None):
+    return {
+        "genres": genres if genres is not None else ["Rock"],
+        "styles": styles if styles is not None else ["Post-Rock"],
     }
 
 
-class TestGetReleaseLean:
+def _route_lean_release(release_row=None, genre_style_row=None):
+    """fetchrow side_effect: routes the genre/style read vs the main json_agg read."""
+    release_row = release_row if release_row is not None else _lean_release_row()
+    genre_style_row = genre_style_row if genre_style_row is not None else _lean_genre_style_row()
+
+    async def route(query, *args):
+        if "release_genre" in query or "release_style" in query:
+            return genre_style_row
+        return release_row
+
+    return route
+
+
+class TestGetReleaseLeanJsonAgg:
     @pytest.mark.asyncio
-    async def test_lean_skips_release_video(self, cache_service, mock_asyncpg_pool):
-        """get_release_lean must NOT query release_video, but MUST still read
-        the tracklist / artist / label / genre / style children AND both the
-        extra=0 and extra=1 release_track_artist legs (LML#699 writer credits).
-        """
-        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
-        captured_queries: list[str] = []
+    async def test_lean_collapses_to_two_read_bursts(self, cache_service, mock_asyncpg_pool):
+        """L4c: the lean release hydration is <=2 PG round-trips (one json_agg
+        release+children read + one genre/style read), never a per-child N+1 of
+        fetch() calls."""
+        captured: list[str] = []
 
-        async def capture_fetch(query, *args):
-            captured_queries.append(query)
-            return []
+        async def capture_fetchrow(query, *args):
+            captured.append(query)
+            if "release_genre" in query or "release_style" in query:
+                return _lean_genre_style_row()
+            return _lean_release_row()
 
-        mock_asyncpg_pool.fetch = AsyncMock(side_effect=capture_fetch)
+        mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=capture_fetchrow)
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
 
         result = await cache_service.get_release_lean(1)
         assert result is not None
+        assert not mock_asyncpg_pool.fetch.called, (
+            "L4c lean release path must not issue per-child pool.fetch() reads"
+        )
+        assert len(captured) <= 2, (
+            f"lean release hydration must be <=2 round-trips; got {len(captured)}: {captured!r}"
+        )
 
-        joined = [" ".join(q.split()) for q in captured_queries]
-        assert not any("release_video" in q for q in joined), (
-            f"lean release path must not read release_video; got: {joined!r}"
+        joined = [" ".join(q.split()) for q in captured]
+        agg = next((q for q in joined if "json_agg" in q and "release_artist" in q), None)
+        assert agg is not None, f"expected a json_agg release read; got: {joined!r}"
+        assert "release_video" not in agg, (
+            f"lean json_agg read must not touch release_video; got: {agg!r}"
         )
-        # Kept children.
-        for table in (
-            "release_artist",
-            "release_label",
-            "release_track",
-            "release_genre",
-            "release_style",
-        ):
-            assert any(table in q for q in joined), (
-                f"lean release path must still read {table}; got: {joined!r}"
-            )
+        for table in ("release_artist", "release_label", "release_track"):
+            assert table in agg, f"lean json_agg read must cover {table}; got: {agg!r}"
         # LML#699: both release_track_artist legs survive on the lean path.
-        rta = [q for q in joined if "release_track_artist" in q]
-        assert any("AND extra = 0" in q for q in rta), (
-            f"lean path must keep the extra=0 release_track_artist read; got: {rta!r}"
-        )
-        assert any("AND extra = 1" in q for q in rta), (
-            f"lean path must keep the extra=1 writer-credit read (LML#699); got: {rta!r}"
+        assert "extra = 0" in agg, f"lean path must keep the extra=0 rta leg; got: {agg!r}"
+        assert "extra = 1" in agg, (
+            f"lean path must keep the extra=1 writer-credit leg (LML#699); got: {agg!r}"
         )
 
     @pytest.mark.asyncio
-    async def test_lean_returns_empty_videos(self, cache_service, mock_asyncpg_pool):
-        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
-        mock_asyncpg_pool.fetch = AsyncMock(
-            side_effect=make_fetch_router(
-                release_track_artist=[],
-                release_track=[
-                    {"position": "1", "title": "Space Moment", "duration": None, "sequence": 1}
-                ],
-                release_artist=[
-                    {"artist_id": 42, "artist_name": "Stereolab", "extra": 0, "role": None}
-                ],
-                release_label=[{"label_id": 7, "label_name": "Duophonic", "catno": "D-1"}],
-                release_genre=[{"genre": "Rock"}],
-                release_style=[{"style": "Post-Rock"}],
-            )
-        )
-
+    async def test_lean_maps_json_agg_children_to_model(self, cache_service, mock_asyncpg_pool):
+        mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=_route_lean_release())
         result = await cache_service.get_release_lean(1)
         assert result is not None
         assert result.videos == []
-        # Core /lookup-consumed fields are intact.
         assert result.title == "Aluminum Tunes"
         assert result.artist == "Stereolab"
         assert result.artist_id == 42
         assert result.genres == ["Rock"]
         assert result.styles == ["Post-Rock"]
         assert result.label == "Duophonic"
+        assert result.label_id == 7
         assert len(result.tracklist) == 1
+        assert result.tracklist[0].title == "Space Moment"
+        assert result.tracklist[0].artists == ["Stereolab"]
         assert result.cached is True
 
     @pytest.mark.asyncio
-    async def test_lean_shape_parity_with_full_for_videoless_release(
+    async def test_lean_maps_track_writers_from_extra1_leg(self, cache_service, mock_asyncpg_pool):
+        """LML#699: the extra=1 json_agg leg is filtered to writer roles and
+        re-keyed by display position, exactly as the shared full path does."""
+        row = _lean_release_row(
+            tracks=[
+                {"position": "A1", "title": "Sol Te Pegou", "duration": None, "sequence": 1},
+                {"position": "A2", "title": "Dor Fodida", "duration": None, "sequence": 2},
+            ],
+            track_artists=[{"track_sequence": 1, "artist_name": "Sessa"}],
+            track_writers=[
+                {"track_sequence": 1, "artist_name": "Track One Writer", "role": "Written-By"},
+                {"track_sequence": 2, "artist_name": "A Producer", "role": "Producer"},
+            ],
+        )
+        mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=_route_lean_release(release_row=row))
+        result = await cache_service.get_release_lean(1)
+        assert result is not None
+        assert result.track_writers is not None
+        assert [c.name for c in result.track_writers["A1"]] == ["Track One Writer"]
+        # A2's only extra=1 credit is a non-writer role and is dropped.
+        assert "A2" not in result.track_writers
+
+    @pytest.mark.asyncio
+    async def test_lean_genre_style_failure_degrades_to_empty(
         self, cache_service, mock_asyncpg_pool
     ):
-        """For a release with no videos, get_release_lean returns the same core
-        payload get_release does (the /lookup-visible surface is unchanged)."""
-        router = make_fetch_router(
-            release_track_artist=[{"track_sequence": 1, "artist_name": "Stereolab"}],
-            release_track=[
-                {"position": "1", "title": "Space Moment", "duration": None, "sequence": 1}
-            ],
-            release_artist=[
-                {"artist_id": 42, "artist_name": "Stereolab", "extra": 0, "role": None}
-            ],
-            release_label=[{"label_id": 7, "label_name": "Duophonic", "catno": "D-1"}],
-            release_genre=[{"genre": "Rock"}],
-            release_style=[{"style": "Post-Rock"}],
-            release_video=[],
-        )
-        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
-        mock_asyncpg_pool.fetch = AsyncMock(side_effect=router)
-        full = await cache_service.get_release(1)
+        """Genre/style tables may be absent on an un-rebuilt cache. A failure of
+        that resilient read degrades to empty lists WITHOUT failing the lookup —
+        the core json_agg read still populated the rest of the payload."""
 
-        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_release_row())
-        mock_asyncpg_pool.fetch = AsyncMock(side_effect=router)
-        lean = await cache_service.get_release_lean(1)
+        async def route(query, *args):
+            if "release_genre" in query or "release_style" in query:
+                raise Exception("relation release_genre does not exist")
+            return _lean_release_row()
 
-        assert full is not None and lean is not None
-        assert lean.title == full.title
-        assert lean.artist == full.artist
-        assert lean.artist_id == full.artist_id
-        assert lean.genres == full.genres
-        assert lean.styles == full.styles
-        assert lean.label == full.label
-        assert [t.title for t in lean.tracklist] == [t.title for t in full.tracklist]
-        assert [t.artists for t in lean.tracklist] == [t.artists for t in full.tracklist]
-        assert lean.videos == full.videos == []
+        mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=route)
+        result = await cache_service.get_release_lean(1)
+        assert result is not None
+        assert result.genres == []
+        assert result.styles == []
+        # Core fields from the main json_agg read still survive.
+        assert result.artist == "Stereolab"
+        assert result.title == "Aluminum Tunes"
+
+    @pytest.mark.asyncio
+    async def test_lean_core_read_failure_raises_cache_unavailable(
+        self, cache_service, mock_asyncpg_pool
+    ):
+        """A failure of the MAIN json_agg read is NOT swallowed by the genre/style
+        resilience — it propagates as CacheUnavailableError."""
+
+        async def route(query, *args):
+            if "release_genre" in query or "release_style" in query:
+                return _lean_genre_style_row()
+            raise Exception("db error")
+
+        mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=route)
+        with pytest.raises(CacheUnavailableError):
+            await cache_service.get_release_lean(1)
 
     @pytest.mark.asyncio
     async def test_shared_get_release_still_reads_release_video(
@@ -3034,6 +3079,19 @@ class TestGetReleaseLean:
             await cache_service.get_release_lean(1)
 
 
+def _capture_release_row():
+    return {
+        "id": 1,
+        "title": "Aluminum Tunes",
+        "release_year": 1998,
+        "artwork_url": "https://img.com/a.jpg",
+        "released": None,
+        "artwork_checked_at": None,
+        "not_found": False,
+        "master_id": None,
+    }
+
+
 def _capture_artist_row():
     from datetime import datetime
 
@@ -3047,41 +3105,55 @@ def _capture_artist_row():
     }
 
 
-class TestGetArtistDetailsLean:
+def _lean_artist_row(**overrides):
+    from datetime import datetime
+
+    row = {
+        "id": 77,
+        "name": "Stereolab",
+        "profile": "Anglo-French band.",
+        "image_url": "https://i.discogs.com/stereolab.jpg",
+        "fetched_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "not_found": False,
+        "urls": [],
+    }
+    row.update(overrides)
+    return row
+
+
+class TestGetArtistDetailsLeanJsonAgg:
     @pytest.mark.asyncio
-    async def test_lean_skips_related_children(self, cache_service, mock_asyncpg_pool):
-        """get_artist_details_lean must NOT query artist_alias /
-        artist_name_variation / artist_member, but MUST still read artist_url
-        (the /lookup wikipedia-URL surface)."""
-        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_artist_row())
-        captured_queries: list[str] = []
+    async def test_lean_single_read_burst(self, cache_service, mock_asyncpg_pool):
+        """L4c: the lean artist hydration is a single json_agg fetchrow — no
+        per-child fetch() reads of artist_alias / artist_name_variation /
+        artist_member, and artist_url is folded into the one read."""
+        captured: list[str] = []
 
-        async def capture_fetch(query, *args):
-            captured_queries.append(query)
-            return []
+        async def capture_fetchrow(query, *args):
+            captured.append(query)
+            return _lean_artist_row()
 
-        mock_asyncpg_pool.fetch = AsyncMock(side_effect=capture_fetch)
+        mock_asyncpg_pool.fetchrow = AsyncMock(side_effect=capture_fetchrow)
+        mock_asyncpg_pool.fetch = AsyncMock(return_value=[])
+
         result = await cache_service.get_artist_details_lean(77)
         assert result is not None
-
-        for table in ("artist_alias", "artist_name_variation", "artist_member"):
-            assert not any(table in q for q in captured_queries), (
-                f"lean artist path must not read {table}; got: {captured_queries!r}"
-            )
-        assert any("artist_url" in q for q in captured_queries), (
-            f"lean artist path must still read artist_url; got: {captured_queries!r}"
+        assert not mock_asyncpg_pool.fetch.called, (
+            "L4c lean artist path must not issue per-child pool.fetch() reads"
         )
+        assert len(captured) == 1, f"lean artist hydration must be 1 round-trip; got {captured!r}"
+        q = " ".join(captured[0].split())
+        for table in ("artist_alias", "artist_name_variation", "artist_member"):
+            assert table not in q, f"lean artist read must not touch {table}; got: {q!r}"
+        assert "artist_url" in q, f"lean artist read must still cover artist_url; got: {q!r}"
+        assert "json_agg" in q, f"lean artist read must aggregate urls via json_agg; got: {q!r}"
 
     @pytest.mark.asyncio
     async def test_lean_returns_empty_related_but_keeps_urls_and_profile(
         self, cache_service, mock_asyncpg_pool
     ):
-        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=_capture_artist_row())
-        mock_asyncpg_pool.fetch = AsyncMock(
-            side_effect=make_fetch_router(
-                artist_url=[{"url": "https://en.wikipedia.org/wiki/Stereolab"}],
-            )
-        )
+        row = _lean_artist_row(urls=["https://en.wikipedia.org/wiki/Stereolab"])
+        mock_asyncpg_pool.fetchrow = AsyncMock(return_value=row)
         result = await cache_service.get_artist_details_lean(77)
         assert result is not None
         assert result.name == "Stereolab"


### PR DESCRIPTION
## What

Lever **L4c** of the July-2026 saturation epic (WXYC/library-metadata-lookup#803). Extends the LML#894 lean `/lookup` read path (it does **not** add a second lean path) so per-lookup hydration collapses from the per-child N+1 into `json_agg` reads:

- **Release lean read → ≤ 2 round-trips.** One `json_agg` SELECT hydrates the release row together with `release_artist` / `release_label` / `release_track` and **both** `release_track_artist` legs (`extra = 0` performers + the LML#699 `extra = 1` writer credits) in a single read; a second resilient read aggregates `release_genre` / `release_style` and fail-softs to empty lists (their tables can be absent on an un-rebuilt cache), mirroring the shared path's `return_exceptions=True` gather.
- **Artist lean read → 1 round-trip.** `artist_url` is folded into the parent row via `json_agg`, dropping the former second round-trip.
- **Subsumes the connection-churn ("L5") win:** one acquire per read instead of the ~7.5 acquire/`RESET ALL` release cycles the loop paid. No PG connection is held across any Apple/Discogs HTTP hop (LML#706 starvation guard).

## Regression safety (the §6.3 fence)

- The shared, read-through-cached `get_release` / `get_artist_details` are **unchanged in shape and behavior** — they keep their per-child reads (including `release_video` and the artist `alias` / `name_variation` / `member` children), so `/discogs/*`, the cache warmer, and genre-agg still get full payloads on both warm and cold paths. The only internal edit to the shared methods is removing the now-dead `include_videos` / `include_related` toggles the lean path no longer routes through; the full read is byte-identical.
- `release_track_artist` (LML#699 writer credits) is never dropped — both legs remain on the lean path.

## Tests (TDD)

- Rewrote the LML#894 lean unit tests to the `json_agg` shape: assert ≤ 2 read bursts (release) / 1 (artist), no per-child `pool.fetch()`, both `extra` legs present, writer-role filtering + position re-keying, genre/style fail-soft vs core-read propagation, and the shared-path fences still hold.
- New **`pg`-marked** parity suite (`tests/integration/test_cache_lean_json_agg_parity.py`): `get_release_lean` / `get_artist_details_lean` are shape-identical to the full path for a fixture release (Duke Ellington & John Coltrane) and artist (Stereolab), with the only deliberate divergence being the children `/lookup` never consumes (`videos`; `aliases` / `name_variations` / `members`). Also exercises the real asyncpg `json` decode the unit mocks cannot.

## Local CI

`pytest` unit suite (4019) + the new `pg` parity suite (5) + related `pg` cache tests (17) green; `mypy` clean on the changed file; `ruff check` + `ruff format --check` clean.

Closes #895