### PR TITLE
feat(deploy): honor UVICORN_WORKERS in the entrypoint (LML#747)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,17 @@
 #!/bin/sh
-# Drop to non-root user and start the application
-exec su -s /bin/sh appuser -c "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"
+# Drop to non-root user and start the application.
+#
+# UVICORN_WORKERS wires horizontal scaling (LML#747): the ${UVICORN_WORKERS:-1}
+# default is 1, so today's single-worker behavior is unchanged until the var is
+# set in Railway. Setting it >1 spawns N worker processes, parallelizing the
+# per-request synchronous work across event loops and draining the single-worker
+# starvation tax (plans/lookup-latency-event-loop-starvation.md §3).
+#
+# DO NOT set >1 before the shared-Discogs-60/min-token prereqs are in place, or N
+# uncoordinated per-process limiters will over-issue and 429-trip the LML#755
+# breaker: enable DISCOGS_RATE_BUCKET_ENABLED (LML#841) AND divide
+# DISCOGS_RATE_LIMIT down to floor(50/N) (the bucket fails open to the local
+# limiter on a PG blip), then re-size the breaker/concurrency knobs and confirm
+# the discogs-cache PG connection budget + container RAM. See the horizontal-
+# scaling runbook in docs/deployment.md.
+exec su -s /bin/sh appuser -c "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${UVICORN_WORKERS:-1}"

--- a/tests/unit/test_entrypoint_workers.py
+++ b/tests/unit/test_entrypoint_workers.py
@@ -1,0 +1,22 @@
+"""LML#747: the container entrypoint must honor ``UVICORN_WORKERS`` (default 1).
+
+Wiring the worker count as a Railway env var makes horizontal scaling a
+no-redeploy lever, while the ``:-1`` default keeps today's single-worker behavior
+byte-for-byte until the var is set. The prereqs for setting it >1 (the shared
+Discogs 60/min token: enable ``DISCOGS_RATE_BUCKET_ENABLED`` + divide
+``DISCOGS_RATE_LIMIT`` to ``floor(50/N)``) live in the horizontal-scaling runbook
+(``docs/deployment.md``); this test only guards that the wiring itself exists and
+defaults to 1, so a future edit can't silently drop it or change the default.
+"""
+
+from pathlib import Path
+
+_ENTRYPOINT = Path(__file__).resolve().parents[2] / "entrypoint.sh"
+
+
+def test_entrypoint_honors_uvicorn_workers_defaulting_to_one():
+    script = _ENTRYPOINT.read_text()
+    # uvicorn's worker count is driven by UVICORN_WORKERS, defaulting to 1 —
+    # the exact expansion is load-bearing: a blank/absent default would change
+    # single-worker behavior on merge.
+    assert "--workers ${UVICORN_WORKERS:-1}" in script


### PR DESCRIPTION
## What

Wires `--workers ${UVICORN_WORKERS:-1}` into `entrypoint.sh` so the uvicorn worker count is a Railway env-var lever. Today the entrypoint execs bare `uvicorn main:app` with no `--workers`, and uvicorn doesn't read `UVICORN_WORKERS`/`WEB_CONCURRENCY` on its own — so setting the var did nothing. This is the missing **code enabler** for multi-worker.

## Why

LML runs a single worker → every request's synchronous work serializes on one event loop, and each in-flight request pays a multi-second **starvation tax** under load (`plans/lookup-latency-event-loop-starvation.md` §3; measured as a ~5 s no-span tail after the last await). Multi-worker parallelizes that across processes.

## Zero behavior change

The `:-1` default is **1**, so single-worker behavior is byte-for-byte unchanged until `UVICORN_WORKERS` is set. A guard test asserts the exact `--workers ${UVICORN_WORKERS:-1}` expansion so the wiring and its default can't be silently dropped.

## Does NOT close #747

Setting `UVICORN_WORKERS>1` is gated on the shared-Discogs-60/min-token prereqs — enable `DISCOGS_RATE_BUCKET_ENABLED` (LML#841) **and** divide `DISCOGS_RATE_LIMIT` to `floor(50/N)` (the bucket fails open to the local limiter on a PG blip), re-size the #755 breaker + concurrency knobs, and confirm the discogs-cache PG connection budget + container RAM — per the horizontal-scaling runbook in `docs/deployment.md` (which the entrypoint comment references). Those ops-config + verification steps stay on #747.

Part of #747.