### PR TITLE
feat(#842): StreamingCatalogDAO — the PG rewrite of ResultsDB (PR B)

### DIFF
--- a/entity/streaming_catalog.py
+++ b/entity/streaming_catalog.py
@@ -293,10 +293,21 @@ CREATE TABLE IF NOT EXISTS lml_cache.streaming_track_result (
 )\
 """
 
-# Same provisional-shape caveat as the album-service status index above.
+# ``get_pending_tracks`` / ``get_local_miss_tracks`` scan a single
+# ``resolution_status`` ORDER BY id LIMIT n; the composite
+# ``(resolution_status, id)`` serves both the equality filter and the id
+# ordering from one index (ordered index read + early LIMIT stop, no Sort
+# node). Reshaped from the original single-column ``(resolution_status)`` now
+# that PR B's real track scans have landed: ``CREATE INDEX IF NOT EXISTS``
+# never redefines an existing index, so the new shape takes a NEW name and the
+# old one is dropped first. Both statements are idempotent — the drop is a
+# no-op once the old index is gone, the create once the new one exists.
+_DDL_TRACK_RESULT_STATUS_INDEX_DROP = (
+    "DROP INDEX IF EXISTS lml_cache.idx_streaming_track_result_status"
+)
 _DDL_TRACK_RESULT_STATUS_INDEX = (
-    "CREATE INDEX IF NOT EXISTS idx_streaming_track_result_status\n"
-    "    ON lml_cache.streaming_track_result (resolution_status)"
+    "CREATE INDEX IF NOT EXISTS idx_streaming_track_result_status_id\n"
+    "    ON lml_cache.streaming_track_result (resolution_status, id)"
 )
 
 # Write-side floor metrics (one row per metric, e.g. 'apple_music_found').
@@ -652,6 +663,7 @@ _DDL_STATEMENTS = (
     _DDL_ALBUM_SERVICE_WIDEN_CHECK,
     _DDL_ALBUM_SERVICE_STATUS_INDEX,
     _DDL_TRACK_RESULT,
+    _DDL_TRACK_RESULT_STATUS_INDEX_DROP,
     _DDL_TRACK_RESULT_STATUS_INDEX,
     _DDL_COVERAGE_BASELINE,
     _DDL_GUARD_ALBUM_FN,

--- a/entity/streaming_catalog.sql
+++ b/entity/streaming_catalog.sql
@@ -222,10 +222,20 @@ CREATE TABLE IF NOT EXISTS lml_cache.streaming_track_result (
     )
 );
 
--- Same provisional-shape caveat as the album-service status index above.
+-- Reshape of the track status index: drop the original single-column
+-- (resolution_status) form so the composite below can supersede it under a
+-- new name (CREATE INDEX IF NOT EXISTS never redefines an existing index).
+-- No-op once the old index is gone.
 
-CREATE INDEX IF NOT EXISTS idx_streaming_track_result_status
-    ON lml_cache.streaming_track_result (resolution_status);
+DROP INDEX IF EXISTS lml_cache.idx_streaming_track_result_status;
+
+-- get_pending_tracks / get_local_miss_tracks scan one resolution_status
+-- ORDER BY id LIMIT n; the composite (resolution_status, id) serves both the
+-- equality filter and the id ordering from one index (ordered read + early
+-- LIMIT stop, no Sort node).
+
+CREATE INDEX IF NOT EXISTS idx_streaming_track_result_status_id
+    ON lml_cache.streaming_track_result (resolution_status, id);
 
 -- Write-side floor metrics (one row per metric, e.g. 'apple_music_found').
 -- Refreshed only at the end of successful pipeline runs — never by the daily

--- a/scripts/regenerate_streaming_catalog_sql.py
+++ b/scripts/regenerate_streaming_catalog_sql.py
@@ -13,7 +13,7 @@ header or a comment, edit this file. Then regenerate:
 
     uv run python -m scripts.regenerate_streaming_catalog_sql
 
-Comments are keyed by each statement's FIRST LINE (all 21 are unique — an
+Comments are keyed by each statement's FIRST LINE (all 22 are unique — an
 import-time check below enforces that), not by tuple index, so inserting or
 reordering statements never silently shifts prose onto the wrong statement:
 an unmatched or leftover key raises instead.
@@ -155,8 +155,16 @@ _COMMENTS: dict[str, str] = {
 -- provenance columns and the seed must not silently drop them. The UNIQUE
 -- doubles as the FK-side index for the ON DELETE RESTRICT check (leading
 -- album_id). The urls CHECK bans only the empty string and is NULL-tolerant.""",
-    "CREATE INDEX IF NOT EXISTS idx_streaming_track_result_status": """\
--- Same provisional-shape caveat as the album-service status index above.""",
+    "DROP INDEX IF EXISTS lml_cache.idx_streaming_track_result_status": """\
+-- Reshape of the track status index: drop the original single-column
+-- (resolution_status) form so the composite below can supersede it under a
+-- new name (CREATE INDEX IF NOT EXISTS never redefines an existing index).
+-- No-op once the old index is gone.""",
+    "CREATE INDEX IF NOT EXISTS idx_streaming_track_result_status_id": """\
+-- get_pending_tracks / get_local_miss_tracks scan one resolution_status
+-- ORDER BY id LIMIT n; the composite (resolution_status, id) serves both the
+-- equality filter and the id ordering from one index (ordered read + early
+-- LIMIT stop, no Sort node).""",
     "CREATE TABLE IF NOT EXISTS lml_cache.streaming_coverage_baseline (": """\
 -- Write-side floor metrics (one row per metric, e.g. 'apple_music_found').
 -- Refreshed only at the end of successful pipeline runs — never by the daily

--- a/scripts/streaming_availability/catalog_dao.py
+++ b/scripts/streaming_availability/catalog_dao.py
@@ -13,9 +13,10 @@ reach past the method surface into ``results_db._db`` raw SQL or
 compilation-skip and ``--retry-misses`` bulk updates, the track pipeline's
 extract/build-index/validate scans and album rollup, and the bandcamp
 pipeline's slug-discovery writes (found-slug + searched-not-found
-sentinel), Wikidata slug loader, and URL migration all bypass the methods
-today, and PR D rewrites those sites against DAO methods (adding any
-that are missing) rather than swapping a constructor. The load-bearing
+sentinel), Wikidata slug loader, URL migration, and dry-run preview
+counters all bypass the methods today, and PR D rewrites those sites
+against DAO methods (adding any that are missing) rather than swapping a
+constructor. The load-bearing
 translation decisions:
 
 * **Anti-join pending semantics.** The legacy SQLite schema materialized a

--- a/scripts/streaming_availability/catalog_dao.py
+++ b/scripts/streaming_availability/catalog_dao.py
@@ -1,0 +1,626 @@
+"""PG-backed streaming-catalog DAO — the ``ResultsDB`` rewrite (LML#842 PR B).
+
+``StreamingCatalogDAO`` reproduces the ``results_db.ResultsDB`` method surface
+over the PR A row-level schema (``lml_cache.streaming_album`` +
+``streaming_album_service`` + ``streaming_track_result`` +
+``streaming_coverage_baseline``) so the PR D/E pipeline and script callers
+port by swapping the construction site, not their call sites. The load-bearing
+translation decisions:
+
+* **Anti-join pending semantics.** The legacy SQLite schema materialized a
+  ``{service}_status = 'pending'`` column per album at insert time; the PG
+  schema materializes NO service rows until a probe writes one. Every pending
+  scan, stats bucket, and wide pivot column therefore coalesces row absence to
+  ``'pending'`` — inserts stay single-table and services can be added without
+  backfilling fan-out rows.
+* **Wide legacy row shape.** Reads go through one shared four-way pivot
+  (``_WIDE_ALBUM_SELECT``) emitting the legacy column names (``spotify_status``,
+  ``spotify_id``, ``apple_url``, ``bandcamp_slug``, …), so row consumers written
+  against ``SELECT * FROM albums`` keep working unchanged. ``library_ids`` /
+  ``formats`` come back as JSON strings (asyncpg's default jsonb codec), which
+  matches the callers' existing ``json.loads``.
+* **Upsert discipline (plan D3).** Service writes are ``INSERT … ON CONFLICT
+  (album_id, service) DO UPDATE`` with ``COALESCE(EXCLUDED.x, existing.x)`` on
+  every metadata column: a follow-up write with omitted params never nulls
+  collected data at the DAO layer, and the PR A no-regress guards backstop
+  anything that slips past (the DAO is a tripwire, not a pre-masker — guard
+  errors and CHECK violations propagate to the caller unmasked).
+* **Loud service validation.** Unknown or unsupported service tokens raise
+  ``ValueError`` before any I/O (the legacy DAO silently no-opped on unknown
+  services in ``update_result``). Validation precedes pool access so a typo'd
+  token in an offline drain dies at the call site without dialing PG.
+* **Deterministic batching.** Every list read carries an explicit ``ORDER BY``
+  (the legacy code leaned on SQLite's implicit rowid order, which PG does not
+  provide), so paged drains are stable across runs.
+* **No write lock.** The SQLite DAO serialized writers behind an asyncio lock
+  because the whole file was a single-writer resource; PG handles concurrent
+  writers natively, so no such lock exists here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import asyncpg
+
+from entity.sources import PgSource
+from entity.streaming_catalog import set_up_streaming_catalog_schema
+from scripts.streaming_availability.dedup import DeduplicatedAlbum
+
+# Legacy service token -> canonical `_SERVICES` slug (the value stored in
+# ``streaming_album_service.service``). The legacy surface says "apple"; the
+# schema's CHECK list says "apple_music".
+_SERVICE_ALIASES = {"apple": "apple_music"}
+
+# Canonical slug -> SQL join alias in ``_WIDE_ALBUM_SELECT``. The alias doubles
+# as the legacy wide-column prefix, which is why apple_music's alias is
+# "apple". Only these four services have a legacy pivot column set; canonical
+# slugs outside this map (e.g. "tidal") are rejected until a caller needs them.
+_PIVOT_ALIAS = {
+    "spotify": "spotify",
+    "apple_music": "apple",
+    "deezer": "deezer",
+    "bandcamp": "bandcamp",
+}
+
+# Services ``update_result`` may write. Bandcamp is excluded on purpose: its
+# slug/url lifecycle has dedicated methods, and routing it through
+# ``update_result`` was never legal in the legacy DAO either (a silent no-op
+# there; a loud ValueError here).
+_UPDATE_RESULT_SERVICES = frozenset({"spotify", "apple_music", "deezer"})
+
+# The one shared services pivot: album columns plus each legacy service's
+# column set, with row absence coalesced to 'pending'. Callers append WHERE /
+# ORDER BY / LIMIT clauses (predicates reference the join aliases directly —
+# e.g. ``COALESCE(spotify.status, 'pending') = 'pending'`` is the anti-join
+# pending scan).
+_WIDE_ALBUM_SELECT = """
+    SELECT
+        a.id,
+        a.normalized_artist,
+        a.normalized_title,
+        a.display_artist,
+        a.display_title,
+        a.library_ids,
+        a.formats,
+        a.genre,
+        a.label,
+        a.is_compilation,
+        a.is_single,
+        a.discogs_artist,
+        a.discogs_title,
+        a.discogs_release_id,
+        a.discogs_status,
+        COALESCE(deezer.status, 'pending') AS deezer_status,
+        deezer.url AS deezer_url,
+        deezer.confidence AS deezer_confidence,
+        deezer.matched_artist AS deezer_matched_artist,
+        deezer.matched_title AS deezer_matched_title,
+        deezer.checked_at AS deezer_checked_at,
+        COALESCE(spotify.status, 'pending') AS spotify_status,
+        spotify.url AS spotify_url,
+        spotify.service_item_id AS spotify_id,
+        spotify.confidence AS spotify_confidence,
+        spotify.matched_artist AS spotify_matched_artist,
+        spotify.matched_title AS spotify_matched_title,
+        spotify.checked_at AS spotify_checked_at,
+        COALESCE(apple.status, 'pending') AS apple_status,
+        apple.url AS apple_url,
+        apple.confidence AS apple_confidence,
+        apple.matched_artist AS apple_matched_artist,
+        apple.matched_title AS apple_matched_title,
+        apple.checked_at AS apple_checked_at,
+        COALESCE(bandcamp.status, 'pending') AS bandcamp_status,
+        bandcamp.slug AS bandcamp_slug,
+        bandcamp.url AS bandcamp_url,
+        bandcamp.checked_at AS bandcamp_checked_at,
+        a.created_at
+    FROM lml_cache.streaming_album AS a
+    LEFT JOIN lml_cache.streaming_album_service AS deezer
+        ON deezer.album_id = a.id AND deezer.service = 'deezer'
+    LEFT JOIN lml_cache.streaming_album_service AS spotify
+        ON spotify.album_id = a.id AND spotify.service = 'spotify'
+    LEFT JOIN lml_cache.streaming_album_service AS apple
+        ON apple.album_id = a.id AND apple.service = 'apple_music'
+    LEFT JOIN lml_cache.streaming_album_service AS bandcamp
+        ON bandcamp.album_id = a.id AND bandcamp.service = 'bandcamp'
+"""
+
+_INSERT_ALBUM = """
+    INSERT INTO lml_cache.streaming_album (
+        normalized_artist, normalized_title, display_artist, display_title,
+        library_ids, formats, genre, label, is_compilation, is_single
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    ON CONFLICT (normalized_artist, normalized_title) DO NOTHING
+    RETURNING id
+"""
+
+_INSERT_TRACK = """
+    INSERT INTO lml_cache.streaming_track_result (
+        album_id, artist, title, position, source, source_type
+    )
+    VALUES ($1, $2, $3, $4, $5, $6)
+    ON CONFLICT (album_id, artist, title) DO NOTHING
+    RETURNING id
+"""
+
+_UPSERT_SERVICE_RESULT = """
+    INSERT INTO lml_cache.streaming_album_service (
+        album_id, service, status, url, service_item_id,
+        confidence, matched_artist, matched_title, checked_at
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+    ON CONFLICT (album_id, service) DO UPDATE SET
+        status = EXCLUDED.status,
+        url = COALESCE(EXCLUDED.url, streaming_album_service.url),
+        service_item_id = COALESCE(
+            EXCLUDED.service_item_id, streaming_album_service.service_item_id
+        ),
+        confidence = COALESCE(EXCLUDED.confidence, streaming_album_service.confidence),
+        matched_artist = COALESCE(
+            EXCLUDED.matched_artist, streaming_album_service.matched_artist
+        ),
+        matched_title = COALESCE(EXCLUDED.matched_title, streaming_album_service.matched_title),
+        checked_at = EXCLUDED.checked_at
+"""
+
+_SERVICE_STATS = """
+    SELECT COALESCE(s.status, 'pending') AS status, COUNT(*) AS n
+    FROM lml_cache.streaming_album AS a
+    LEFT JOIN lml_cache.streaming_album_service AS s
+        ON s.album_id = a.id AND s.service = $1
+    GROUP BY 1
+"""
+
+_UPSERT_BASELINE = """
+    INSERT INTO lml_cache.streaming_coverage_baseline (metric, value, updated_at)
+    VALUES ($1, $2, now())
+    ON CONFLICT (metric) DO UPDATE SET
+        value = EXCLUDED.value,
+        updated_at = EXCLUDED.updated_at
+"""
+
+
+def _resolve_pivot_service(service: str) -> str:
+    """Map a legacy service token to its wide-pivot join alias, or raise."""
+    canonical = _SERVICE_ALIASES.get(service, service)
+    alias = _PIVOT_ALIAS.get(canonical)
+    if alias is None:
+        raise ValueError(
+            f"unknown streaming service {service!r}: expected one of "
+            "spotify/apple/deezer/bandcamp or the 'discogs' pseudo-service"
+        )
+    return alias
+
+
+class StreamingCatalogDAO:
+    """Async DAO over the ``lml_cache`` streaming-catalog tables.
+
+    Construction mirrors ``PgSource``: exactly one of ``dsn`` (offline
+    scripts — the DAO owns a lazily-created pool) or ``pool`` (app paths
+    borrowing the shared discogs-cache pool; ``close()`` is then a no-op so
+    teardown here never closes the pool under a live sibling service).
+    """
+
+    def __init__(self, dsn: str | None = None, *, pool: asyncpg.Pool | None = None) -> None:
+        self._pg = PgSource(dsn, pool=pool)
+
+    async def connect(self) -> None:
+        """Bootstrap the catalog schema (idempotent; shared with the lifespan)."""
+        await set_up_streaming_catalog_schema(self._pg)
+
+    async def close(self) -> None:
+        await self._pg.close()
+
+    # -- albums ----------------------------------------------------------
+
+    async def insert_albums(self, albums: list[DeduplicatedAlbum]) -> int:
+        """Insert deduplicated albums, ignoring already-known ones; return the new-row count."""
+        inserted = 0
+        async with self._pg.acquire() as conn:
+            for album in albums:
+                new_id = await conn.fetchval(
+                    _INSERT_ALBUM,
+                    album.normalized_artist,
+                    album.normalized_title,
+                    album.display_artist,
+                    album.display_title,
+                    json.dumps(album.library_ids),
+                    json.dumps(album.formats),
+                    album.genre,
+                    album.label,
+                    album.is_compilation,
+                    album.is_single,
+                )
+                if new_id is not None:
+                    inserted += 1
+        return inserted
+
+    async def get_pending(self, service: str, limit: int = 100) -> list[dict[str, Any]]:
+        """Albums still pending for ``service`` (or the ``discogs`` pseudo-service).
+
+        ``discogs`` reads the album-table status column and — legacy contract —
+        applies NO compilation filter (the orchestrator's discogs branch scans
+        everything; ``get_pending_discogs`` is the filtered variant).
+        """
+        if service == "discogs":
+            return await self._pg.fetchall(
+                _WIDE_ALBUM_SELECT + " WHERE a.discogs_status = 'pending' ORDER BY a.id LIMIT $1",
+                limit,
+            )
+        alias = _resolve_pivot_service(service)
+        return await self._pg.fetchall(
+            _WIDE_ALBUM_SELECT
+            + f" WHERE COALESCE({alias}.status, 'pending') = 'pending' ORDER BY a.id LIMIT $1",
+            limit,
+        )
+
+    async def update_result(
+        self,
+        album_id: int,
+        service: str,
+        status: str,
+        *,
+        url: str | None = None,
+        spotify_id: str | None = None,
+        confidence: float | None = None,
+        matched_artist: str | None = None,
+        matched_title: str | None = None,
+    ) -> None:
+        """Upsert one probe result onto ``(album_id, service)``.
+
+        An upsert, not an UPDATE: under the anti-join model the target row
+        usually does not exist when the first probe lands. NULL params never
+        overwrite populated metadata (plan D3); schema CHECKs and no-regress
+        guard errors propagate unmasked.
+        """
+        canonical = _SERVICE_ALIASES.get(service, service)
+        if canonical == "bandcamp":
+            raise ValueError(
+                "bandcamp results go through update_bandcamp_url / "
+                "mark_bandcamp_not_found, not update_result"
+            )
+        if canonical not in _UPDATE_RESULT_SERVICES:
+            raise ValueError(
+                f"unknown streaming service {service!r}: update_result accepts spotify/apple/deezer"
+            )
+        await self._pg.execute(
+            _UPSERT_SERVICE_RESULT,
+            album_id,
+            canonical,
+            status,
+            url,
+            spotify_id,
+            confidence,
+            matched_artist,
+            matched_title,
+        )
+
+    # -- discogs enrichment -----------------------------------------------
+
+    async def get_pending_discogs(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Non-compilation albums whose Discogs enrichment is still pending."""
+        return await self._pg.fetchall(
+            _WIDE_ALBUM_SELECT
+            + " WHERE a.discogs_status = 'pending' AND NOT a.is_compilation"
+            + " ORDER BY a.id LIMIT $1",
+            limit,
+        )
+
+    async def update_discogs_result(
+        self,
+        album_id: int,
+        status: str,
+        *,
+        artist: str | None = None,
+        title: str | None = None,
+        release_id: int | None = None,
+    ) -> None:
+        """Record a Discogs match attempt; omitted metadata never nulls prior finds."""
+        await self._pg.execute(
+            """
+            UPDATE lml_cache.streaming_album SET
+                discogs_status = $2,
+                discogs_artist = COALESCE($3, discogs_artist),
+                discogs_title = COALESCE($4, discogs_title),
+                discogs_release_id = COALESCE($5, discogs_release_id)
+            WHERE id = $1
+            """,
+            album_id,
+            status,
+            artist,
+            title,
+            release_id,
+        )
+
+    # -- cascade scans ------------------------------------------------------
+
+    async def get_deezer_hits_pending_spotify(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Deezer-found albums whose Spotify probe has not run yet."""
+        return await self._pg.fetchall(
+            _WIDE_ALBUM_SELECT
+            + " WHERE deezer.status = 'found' AND COALESCE(spotify.status, 'pending') = 'pending'"
+            + " ORDER BY a.id LIMIT $1",
+            limit,
+        )
+
+    async def get_spotify_misses_pending_apple(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Spotify-missed albums whose Apple Music probe has not run yet."""
+        return await self._pg.fetchall(
+            _WIDE_ALBUM_SELECT
+            + " WHERE spotify.status = 'not_found'"
+            + " AND COALESCE(apple.status, 'pending') = 'pending'"
+            + " ORDER BY a.id LIMIT $1",
+            limit,
+        )
+
+    # -- bandcamp -----------------------------------------------------------
+
+    async def update_bandcamp_slug(self, album_id: int, slug: str) -> None:
+        """Attach a bandcamp artist slug; the lookup status stays/defaults to pending."""
+        await self._pg.execute(
+            """
+            INSERT INTO lml_cache.streaming_album_service (album_id, service, slug)
+            VALUES ($1, 'bandcamp', $2)
+            ON CONFLICT (album_id, service) DO UPDATE SET slug = EXCLUDED.slug
+            """,
+            album_id,
+            slug,
+        )
+
+    async def update_bandcamp_url(self, album_id: int, url: str) -> None:
+        """Record a confirmed bandcamp album URL (slug untouched)."""
+        await self._pg.execute(
+            """
+            INSERT INTO lml_cache.streaming_album_service (album_id, service, status, url, checked_at)
+            VALUES ($1, 'bandcamp', 'found', $2, now())
+            ON CONFLICT (album_id, service) DO UPDATE SET
+                status = 'found',
+                url = EXCLUDED.url,
+                checked_at = EXCLUDED.checked_at
+            """,
+            album_id,
+            url,
+        )
+
+    async def mark_bandcamp_not_found(self, album_id: int) -> None:
+        """Durably mark 'tried, no match' so re-runs skip already-attempted slugs (#661)."""
+        await self._pg.execute(
+            """
+            INSERT INTO lml_cache.streaming_album_service (album_id, service, status, checked_at)
+            VALUES ($1, 'bandcamp', 'not_found', now())
+            ON CONFLICT (album_id, service) DO UPDATE SET
+                status = 'not_found',
+                checked_at = EXCLUDED.checked_at
+            """,
+            album_id,
+        )
+
+    async def get_artists_without_bandcamp_slug(
+        self, *, not_on_streaming_only: bool = True, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Distinct non-compilation artists with no bandcamp slug yet.
+
+        Default scope narrows to spotify-missed albums (the not-on-streaming
+        report population the slug hunt targets); ``not_on_streaming_only=False``
+        widens to every slugless artist.
+        """
+        query = """
+            SELECT DISTINCT a.display_artist
+            FROM lml_cache.streaming_album AS a
+            LEFT JOIN lml_cache.streaming_album_service AS bandcamp
+                ON bandcamp.album_id = a.id AND bandcamp.service = 'bandcamp'
+            LEFT JOIN lml_cache.streaming_album_service AS spotify
+                ON spotify.album_id = a.id AND spotify.service = 'spotify'
+            WHERE bandcamp.slug IS NULL AND NOT a.is_compilation
+        """
+        params: list[Any] = []
+        if not_on_streaming_only:
+            query += " AND spotify.status = 'not_found'"
+        query += " ORDER BY a.display_artist"
+        if limit is not None:
+            params.append(limit)
+            query += f" LIMIT ${len(params)}"
+        return await self._pg.fetchall(query, *params)
+
+    async def get_pending_bandcamp_lookup(
+        self, limit: int | None = None, slug: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Slugged, unresolved, non-compilation albums awaiting a bandcamp page fetch."""
+        query = _WIDE_ALBUM_SELECT + (
+            " WHERE bandcamp.slug IS NOT NULL AND bandcamp.slug <> ''"
+            " AND bandcamp.url IS NULL AND bandcamp.status = 'pending'"
+            " AND NOT a.is_compilation"
+        )
+        params: list[Any] = []
+        if slug is not None:
+            params.append(slug)
+            query += f" AND bandcamp.slug = ${len(params)}"
+        query += " ORDER BY a.id"
+        if limit is not None:
+            params.append(limit)
+            query += f" LIMIT ${len(params)}"
+        return await self._pg.fetchall(query, *params)
+
+    # -- stats & reports ------------------------------------------------------
+
+    async def get_stats(self) -> dict[str, Any]:
+        """Per-service status histograms plus the album total (legacy key set)."""
+        stats: dict[str, Any] = {}
+        async with self._pg.acquire() as conn:
+            for legacy, canonical in (
+                ("spotify", "spotify"),
+                ("apple", "apple_music"),
+                ("deezer", "deezer"),
+                ("bandcamp", "bandcamp"),
+            ):
+                rows = await conn.fetch(_SERVICE_STATS, canonical)
+                stats[legacy] = {row["status"]: row["n"] for row in rows}
+            discogs_rows = await conn.fetch(
+                "SELECT discogs_status AS status, COUNT(*) AS n"
+                " FROM lml_cache.streaming_album GROUP BY 1"
+            )
+            stats["discogs"] = {row["status"]: row["n"] for row in discogs_rows}
+            stats["total"] = await conn.fetchval("SELECT COUNT(*) FROM lml_cache.streaming_album")
+        return stats
+
+    async def get_not_on_streaming(self) -> list[dict[str, Any]]:
+        """Non-compilation albums Spotify definitively missed (the report population)."""
+        return await self._pg.fetchall(
+            _WIDE_ALBUM_SELECT
+            + " WHERE spotify.status = 'not_found' AND NOT a.is_compilation"
+            + " ORDER BY a.display_artist, a.display_title"
+        )
+
+    async def get_all_results(self) -> list[dict[str, Any]]:
+        """Every album in the wide legacy shape, ordered for stable exports."""
+        return await self._pg.fetchall(
+            _WIDE_ALBUM_SELECT + " ORDER BY a.display_artist, a.display_title"
+        )
+
+    # -- tracks ---------------------------------------------------------------
+
+    async def insert_tracks(self, tracks: list[dict[str, Any]]) -> int:
+        """Insert track rows, ignoring already-known ones; return the new-row count."""
+        inserted = 0
+        async with self._pg.acquire() as conn:
+            for track in tracks:
+                new_id = await conn.fetchval(
+                    _INSERT_TRACK,
+                    track["album_id"],
+                    track["artist"],
+                    track["title"],
+                    track.get("position"),
+                    track["source"],
+                    track["source_type"],
+                )
+                if new_id is not None:
+                    inserted += 1
+        return inserted
+
+    async def get_pending_tracks(self, limit: int = 100) -> list[dict[str, Any]]:
+        return await self._pg.fetchall(
+            "SELECT * FROM lml_cache.streaming_track_result"
+            " WHERE resolution_status = 'pending' ORDER BY id LIMIT $1",
+            limit,
+        )
+
+    async def get_local_miss_tracks(self, limit: int = 100) -> list[dict[str, Any]]:
+        return await self._pg.fetchall(
+            "SELECT * FROM lml_cache.streaming_track_result"
+            " WHERE resolution_status = 'local_miss' ORDER BY id LIMIT $1",
+            limit,
+        )
+
+    async def update_track_resolution(
+        self,
+        track_id: int,
+        status: str,
+        *,
+        resolved_via: str | None = None,
+        resolved_album_id: int | None = None,
+        resolved_release_id: int | None = None,
+        spotify_url: str | None = None,
+        spotify_confidence: float | None = None,
+        deezer_url: str | None = None,
+        deezer_confidence: float | None = None,
+    ) -> None:
+        """Record a track-resolution attempt; omitted params never null prior finds."""
+        await self._pg.execute(
+            """
+            UPDATE lml_cache.streaming_track_result SET
+                resolution_status = $2,
+                resolved_via = COALESCE($3, resolved_via),
+                resolved_album_id = COALESCE($4, resolved_album_id),
+                resolved_release_id = COALESCE($5, resolved_release_id),
+                spotify_url = COALESCE($6, spotify_url),
+                spotify_confidence = COALESCE($7, spotify_confidence),
+                deezer_url = COALESCE($8, deezer_url),
+                deezer_confidence = COALESCE($9, deezer_confidence),
+                checked_at = now()
+            WHERE id = $1
+            """,
+            track_id,
+            status,
+            resolved_via,
+            resolved_album_id,
+            resolved_release_id,
+            spotify_url,
+            spotify_confidence,
+            deezer_url,
+            deezer_confidence,
+        )
+
+    async def get_track_stats(self) -> dict[str, int]:
+        """Track counts by resolution status plus their total (legacy shape)."""
+        rows = await self._pg.fetchall(
+            "SELECT resolution_status AS status, COUNT(*) AS n"
+            " FROM lml_cache.streaming_track_result GROUP BY 1"
+        )
+        stats: dict[str, int] = {row["status"]: row["n"] for row in rows}
+        stats["total"] = sum(row["n"] for row in rows)
+        return stats
+
+    async def get_album_track_summary(self, album_id: int) -> dict[str, Any]:
+        """Per-album track rollup with the legacy resolved-by-subtraction arithmetic."""
+        rows = await self._pg.fetchall(
+            "SELECT resolution_status AS status, COUNT(*) AS n"
+            " FROM lml_cache.streaming_track_result WHERE album_id = $1 GROUP BY 1",
+            album_id,
+        )
+        counts = {row["status"]: row["n"] for row in rows}
+        total = sum(counts.values())
+        pending = counts.get("pending", 0)
+        not_found = counts.get("not_found", 0)
+        resolved = (
+            total
+            - pending
+            - counts.get("local_miss", 0)
+            - not_found
+            - counts.get("false_positive", 0)
+            - counts.get("error", 0)
+        )
+        return {
+            "total": total,
+            "resolved": resolved,
+            "not_found": not_found,
+            "pending": pending,
+            "on_streaming": resolved > 0,
+        }
+
+    # -- coverage baseline -----------------------------------------------------
+
+    async def refresh_coverage_baseline(self) -> dict[str, int]:
+        """Recompute and upsert the coverage floors from live catalog counts.
+
+        The five metric keys mirror ``routers/admin.py``'s
+        ``_STREAMING_COVERAGE_METRICS`` exactly — that endpoint is the reader
+        this table feeds post-cutover (plan PR F). Runs in one transaction so a
+        partial failure never publishes a half-refreshed floor set; the PR A
+        lowering guard fires through unmasked if live counts ever regress.
+        """
+        async with self._pg.acquire() as conn:
+            async with conn.transaction():
+                albums = await conn.fetchval("SELECT COUNT(*) FROM lml_cache.streaming_album")
+                url_rows = await conn.fetch(
+                    "SELECT service, COUNT(*) AS n FROM lml_cache.streaming_album_service"
+                    " WHERE url IS NOT NULL GROUP BY service"
+                )
+                url_counts = {row["service"]: row["n"] for row in url_rows}
+                track_results = await conn.fetchval(
+                    "SELECT COUNT(*) FROM lml_cache.streaming_track_result"
+                    " WHERE resolution_status IN ('local_match', 'api_match')"
+                    " AND (spotify_url IS NOT NULL OR deezer_url IS NOT NULL)"
+                )
+                metrics: dict[str, int] = {
+                    "apple_url": url_counts.get("apple_music", 0),
+                    "spotify_url": url_counts.get("spotify", 0),
+                    "deezer_url": url_counts.get("deezer", 0),
+                    "albums": albums,
+                    "track_results": track_results,
+                }
+                for metric, value in metrics.items():
+                    await conn.execute(_UPSERT_BASELINE, metric, value)
+        return metrics

--- a/scripts/streaming_availability/catalog_dao.py
+++ b/scripts/streaming_availability/catalog_dao.py
@@ -227,8 +227,9 @@ _UPSERT_BASELINE = """
     INSERT INTO lml_cache.streaming_coverage_baseline (metric, value, updated_at)
     VALUES ($1, $2, now())
     ON CONFLICT (metric) DO UPDATE SET
-        value = EXCLUDED.value,
+        value = GREATEST(EXCLUDED.value, lml_cache.streaming_coverage_baseline.value),
         updated_at = EXCLUDED.updated_at
+    RETURNING value
 """
 
 
@@ -500,12 +501,8 @@ class StreamingCatalogDAO:
         """Per-service status histograms plus the album total (legacy key set)."""
         stats: dict[str, Any] = {}
         async with self._pg.acquire() as conn:
-            for legacy, canonical in (
-                ("spotify", "spotify"),
-                ("apple", "apple_music"),
-                ("deezer", "deezer"),
-                ("bandcamp", "bandcamp"),
-            ):
+            # canonical slug -> legacy stats key is exactly the pivot-alias map.
+            for canonical, legacy in _PIVOT_ALIAS.items():
                 rows = await conn.fetch(_SERVICE_STATS, canonical)
                 stats[legacy] = {row["status"]: row["n"] for row in rows}
             discogs_rows = await conn.fetch(
@@ -662,7 +659,15 @@ class StreamingCatalogDAO:
         return stats
 
     async def get_album_track_summary(self, album_id: int) -> dict[str, Any]:
-        """Per-album track rollup with the legacy resolved-by-subtraction arithmetic."""
+        """Per-album track rollup: ``resolved`` counts the two resolved statuses directly.
+
+        Counting ``local_match`` + ``api_match`` (rather than subtracting the
+        enumerated unresolved statuses from the total) is robust to a novel or
+        unmapped ``resolution_status``: an unrecognized value stays unresolved
+        instead of silently inflating ``resolved`` — matching the export and
+        coverage-baseline filters, which likewise gate on
+        ``resolution_status IN ('local_match', 'api_match')``.
+        """
         rows = await self._pg.fetchall(
             "SELECT resolution_status AS status, COUNT(*) AS n"
             " FROM lml_cache.streaming_track_result WHERE album_id = $1 GROUP BY 1",
@@ -672,14 +677,7 @@ class StreamingCatalogDAO:
         total = sum(counts.values())
         pending = counts.get("pending", 0)
         not_found = counts.get("not_found", 0)
-        resolved = (
-            total
-            - pending
-            - counts.get("local_miss", 0)
-            - not_found
-            - counts.get("false_positive", 0)
-            - counts.get("error", 0)
-        )
+        resolved = counts.get("local_match", 0) + counts.get("api_match", 0)
         return {
             "total": total,
             "resolved": resolved,
@@ -691,13 +689,22 @@ class StreamingCatalogDAO:
     # -- coverage baseline -----------------------------------------------------
 
     async def refresh_coverage_baseline(self) -> dict[str, int]:
-        """Recompute and upsert the coverage floors from live catalog counts.
+        """Recompute the coverage floors from live catalog counts, ratcheting up.
 
         The five metric keys mirror ``routers/admin.py``'s
         ``_STREAMING_COVERAGE_METRICS`` exactly — that endpoint is the reader
         this table feeds post-cutover (plan PR F). Runs in one transaction so a
-        partial failure never publishes a half-refreshed floor set; the PR A
-        lowering guard fires through unmasked if live counts ever regress.
+        partial failure never publishes a half-refreshed floor set.
+
+        Each metric ratchets **up only** (``GREATEST(live, stored)``): the
+        baseline is a monotonic high-water mark, so a live regression — e.g. a
+        sanctioned ``mark_track_false_positive`` demotion between runs — holds
+        the floor rather than lowering it or aborting the refresh through PR A's
+        lowering guard (the writer never attempts a downward move, so the guard
+        never trips). Detecting a genuine coverage regression is the read-side
+        export check's job, not this writer's. Returns the effective
+        post-ratchet floor per metric (== the stored row), which can exceed the
+        live count when a metric held.
         """
         async with self._pg.acquire() as conn:
             async with conn.transaction():
@@ -712,13 +719,14 @@ class StreamingCatalogDAO:
                     " WHERE resolution_status IN ('local_match', 'api_match')"
                     " AND (spotify_url IS NOT NULL OR deezer_url IS NOT NULL)"
                 )
-                metrics: dict[str, int] = {
+                live: dict[str, int] = {
                     "apple_url": url_counts.get("apple_music", 0),
                     "spotify_url": url_counts.get("spotify", 0),
                     "deezer_url": url_counts.get("deezer", 0),
                     "albums": albums,
                     "track_results": track_results,
                 }
-                for metric, value in metrics.items():
-                    await conn.execute(_UPSERT_BASELINE, metric, value)
-        return metrics
+                floors: dict[str, int] = {}
+                for metric, value in live.items():
+                    floors[metric] = await conn.fetchval(_UPSERT_BASELINE, metric, value)
+        return floors

--- a/scripts/streaming_availability/catalog_dao.py
+++ b/scripts/streaming_availability/catalog_dao.py
@@ -3,8 +3,15 @@
 ``StreamingCatalogDAO`` reproduces the ``results_db.ResultsDB`` method surface
 over the PR A row-level schema (``lml_cache.streaming_album`` +
 ``streaming_album_service`` + ``streaming_track_result`` +
-``streaming_coverage_baseline``) so the PR D/E pipeline and script callers
-port by swapping the construction site, not their call sites. The load-bearing
+``streaming_coverage_baseline``): callers that go through ResultsDB *methods*
+port by swapping the construction site, not their call sites. Callers that
+reach past the method surface into ``results_db._db`` raw SQL or
+``_write_lock`` get no such promise — the streaming pipeline's
+compilation-skip and ``--retry-misses`` bulk updates, the track pipeline's
+extract/build-index/validate scans and album rollup, and the bandcamp
+pipeline's searched-not-found sentinel and URL migration all bypass the
+methods today, and PR D rewrites those sites against DAO methods (adding any
+that are missing) rather than swapping a constructor. The load-bearing
 translation decisions:
 
 * **Anti-join pending semantics.** The legacy SQLite schema materialized a
@@ -24,7 +31,11 @@ translation decisions:
   every metadata column: a follow-up write with omitted params never nulls
   collected data at the DAO layer, and the PR A no-regress guards backstop
   anything that slips past (the DAO is a tripwire, not a pre-masker — guard
-  errors and CHECK violations propagate to the caller unmasked).
+  errors and CHECK violations propagate to the caller unmasked). The one
+  deliberate demotion the legacy surface performs — the validate phase's
+  ``api_match`` → ``false_positive`` flip — goes through
+  ``mark_track_false_positive``, which opts into the guard
+  transaction-locally instead of asking callers to speak GUCs.
 * **Loud service validation.** Unknown or unsupported service tokens raise
   ``ValueError`` before any I/O (the legacy DAO silently no-opped on unknown
   services in ``update_result``). Validation precedes pool access so a typo'd
@@ -45,7 +56,7 @@ from typing import Any
 import asyncpg
 
 from entity.sources import PgSource
-from entity.streaming_catalog import set_up_streaming_catalog_schema
+from entity.streaming_catalog import ALLOW_URL_REMOVAL_GUC, set_up_streaming_catalog_schema
 from scripts.streaming_availability.dedup import DeduplicatedAlbum
 
 # Legacy service token -> canonical `_SERVICES` slug (the value stored in
@@ -127,21 +138,33 @@ _WIDE_ALBUM_SELECT = """
         ON bandcamp.album_id = a.id AND bandcamp.service = 'bandcamp'
 """
 
-_INSERT_ALBUM = """
+# Set-based inserts: one statement per batch (columnar arrays + unnest), not
+# one round-trip per row. The PR C full-catalog seed pushes ~65k albums through
+# insert_albums against the remote discogs-cache PG, where a per-row loop pays
+# tens of minutes in pure RTT. ON CONFLICT DO NOTHING arbitrates duplicates
+# both against existing rows and within the batch itself, so interrupted runs
+# stay idempotent; RETURNING id preserves the new-row-count contract.
+_INSERT_ALBUMS_BULK = """
     INSERT INTO lml_cache.streaming_album (
         normalized_artist, normalized_title, display_artist, display_title,
         library_ids, formats, genre, label, is_compilation, is_single
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+    SELECT * FROM unnest(
+        $1::text[], $2::text[], $3::text[], $4::text[],
+        $5::jsonb[], $6::jsonb[], $7::text[], $8::text[],
+        $9::boolean[], $10::boolean[]
+    )
     ON CONFLICT (normalized_artist, normalized_title) DO NOTHING
     RETURNING id
 """
 
-_INSERT_TRACK = """
+_INSERT_TRACKS_BULK = """
     INSERT INTO lml_cache.streaming_track_result (
         album_id, artist, title, position, source, source_type
     )
-    VALUES ($1, $2, $3, $4, $5, $6)
+    SELECT * FROM unnest(
+        $1::bigint[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[]
+    )
     ON CONFLICT (album_id, artist, title) DO NOTHING
     RETURNING id
 """
@@ -217,26 +240,27 @@ class StreamingCatalogDAO:
     # -- albums ----------------------------------------------------------
 
     async def insert_albums(self, albums: list[DeduplicatedAlbum]) -> int:
-        """Insert deduplicated albums, ignoring already-known ones; return the new-row count."""
-        inserted = 0
-        async with self._pg.acquire() as conn:
-            for album in albums:
-                new_id = await conn.fetchval(
-                    _INSERT_ALBUM,
-                    album.normalized_artist,
-                    album.normalized_title,
-                    album.display_artist,
-                    album.display_title,
-                    json.dumps(album.library_ids),
-                    json.dumps(album.formats),
-                    album.genre,
-                    album.label,
-                    album.is_compilation,
-                    album.is_single,
-                )
-                if new_id is not None:
-                    inserted += 1
-        return inserted
+        """Insert deduplicated albums, ignoring already-known ones; return the new-row count.
+
+        One set-based statement per call (see ``_INSERT_ALBUMS_BULK``); an
+        empty batch returns 0 without touching PG.
+        """
+        if not albums:
+            return 0
+        rows = await self._pg.fetchall(
+            _INSERT_ALBUMS_BULK,
+            [a.normalized_artist for a in albums],
+            [a.normalized_title for a in albums],
+            [a.display_artist for a in albums],
+            [a.display_title for a in albums],
+            [json.dumps(a.library_ids) for a in albums],
+            [json.dumps(a.formats) for a in albums],
+            [a.genre for a in albums],
+            [a.label for a in albums],
+            [a.is_compilation for a in albums],
+            [a.is_single for a in albums],
+        )
+        return len(rows)
 
     async def get_pending(self, service: str, limit: int = 100) -> list[dict[str, Any]]:
         """Albums still pending for ``service`` (or the ``discogs`` pseudo-service).
@@ -483,22 +507,23 @@ class StreamingCatalogDAO:
     # -- tracks ---------------------------------------------------------------
 
     async def insert_tracks(self, tracks: list[dict[str, Any]]) -> int:
-        """Insert track rows, ignoring already-known ones; return the new-row count."""
-        inserted = 0
-        async with self._pg.acquire() as conn:
-            for track in tracks:
-                new_id = await conn.fetchval(
-                    _INSERT_TRACK,
-                    track["album_id"],
-                    track["artist"],
-                    track["title"],
-                    track.get("position"),
-                    track["source"],
-                    track["source_type"],
-                )
-                if new_id is not None:
-                    inserted += 1
-        return inserted
+        """Insert track rows, ignoring already-known ones; return the new-row count.
+
+        One set-based statement per call (see ``_INSERT_TRACKS_BULK``); an
+        empty batch returns 0 without touching PG.
+        """
+        if not tracks:
+            return 0
+        rows = await self._pg.fetchall(
+            _INSERT_TRACKS_BULK,
+            [t["album_id"] for t in tracks],
+            [t["artist"] for t in tracks],
+            [t["title"] for t in tracks],
+            [t.get("position") for t in tracks],
+            [t["source"] for t in tracks],
+            [t["source_type"] for t in tracks],
+        )
+        return len(rows)
 
     async def get_pending_tracks(self, limit: int = 100) -> list[dict[str, Any]]:
         return await self._pg.fetchall(
@@ -552,6 +577,28 @@ class StreamingCatalogDAO:
             deezer_url,
             deezer_confidence,
         )
+
+    async def mark_track_false_positive(self, track_id: int) -> None:
+        """Demote a resolved track to ``false_positive`` (the validate phase).
+
+        The one deliberate status demotion in the legacy surface: URL
+        validation flips ``api_match`` tracks whose URLs fail service-metadata
+        checks. The PR A no-regress guard blocks demotions by default, so this
+        method opts in via ``set_config(..., is_local => true)`` inside its own
+        transaction — the opt-in covers exactly this UPDATE and evaporates at
+        COMMIT, never leaking to other statements on the pooled connection.
+        Collected URLs and resolution metadata stay in place as the audit
+        trail (legacy ``phase_validate`` only ever flipped the status).
+        """
+        async with self._pg.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute("SELECT set_config($1, 'on', true)", ALLOW_URL_REMOVAL_GUC)
+                await conn.execute(
+                    "UPDATE lml_cache.streaming_track_result SET"
+                    " resolution_status = 'false_positive', checked_at = now()"
+                    " WHERE id = $1",
+                    track_id,
+                )
 
     async def get_track_stats(self) -> dict[str, int]:
         """Track counts by resolution status plus their total (legacy shape)."""

--- a/scripts/streaming_availability/catalog_dao.py
+++ b/scripts/streaming_availability/catalog_dao.py
@@ -6,14 +6,15 @@ over the PR A row-level schema (``lml_cache.streaming_album`` +
 ``streaming_coverage_baseline``): callers that go through ResultsDB *methods*
 port by swapping the construction site, not their call sites — except the
 demotion-exposed calls the *Upsert discipline* bullet names (the validate
-phase's ``false_positive`` write and the album pipeline's two cross-service
+phase's ``false_positive`` write and the album pipeline's two
 ``not_found`` miss writes), which PR D must rewrite. Callers that
 reach past the method surface into ``results_db._db`` raw SQL or
 ``_write_lock`` get no such promise — the streaming pipeline's
 compilation-skip and ``--retry-misses`` bulk updates, the track pipeline's
 extract/build-index/validate scans and album rollup, and the bandcamp
-pipeline's searched-not-found sentinel and URL migration all bypass the
-methods today, and PR D rewrites those sites against DAO methods (adding any
+pipeline's slug-discovery writes (found-slug + searched-not-found
+sentinel), Wikidata slug loader, and URL migration all bypass the methods
+today, and PR D rewrites those sites against DAO methods (adding any
 that are missing) rather than swapping a constructor. The load-bearing
 translation decisions:
 
@@ -42,18 +43,24 @@ translation decisions:
   ``update_track_resolution`` rejects ``'false_positive'`` outright, so the
   legacy validate-phase demotion call fails loudly at port time instead of
   tripping the trigger mid-drain. That static tripwire is track-side only:
-  the legacy album pipeline's deezer- and spotify-stage miss handlers
+  the legacy album pipeline's miss handlers
   (``scripts/streaming_availability/__main__.py``) also demote through the
-  method surface — each writes ``update_result(album_id, "spotify",
-  "not_found")`` that can land on a row already ``'found'`` for spotify,
+  method surface — a deezer miss writes ``update_result(album_id,
+  "spotify", "not_found")`` cross-service ("not digitally distributed"),
+  and a spotify-stage miss writes the same status for spotify itself —
+  and either write can land on a row already ``'found'`` for spotify,
   because the pipeline admits every deezer-pending album regardless of
-  spotify status and found-with-deezer-pending rows are a real legacy state
-  (the ``deezer_*`` columns arrived by ``_migrate`` with ``DEFAULT
-  'pending'`` after Spotify-only runs had populated ``spotify_status``).
+  spotify status. What mints those rows is the ``--retry-misses`` reset
+  (same file): it flips ``deezer_status`` ``not_found``→``pending``
+  unconditionally while its spotify reset only covers
+  ``spotify_status='not_found' AND deezer_status='pending'``, so every
+  spotify-found/deezer-not_found album (29,861 of 65,147 in the 2026-04
+  snapshot) re-enters the deezer stage with spotify still ``'found'``.
   ``'not_found'`` is usually legal, so no static rejection is possible
-  there; PR D must rewrite those two call sites as conditional writes (skip
-  services already resolved) rather than re-point them, or the album drain
-  trips the found→``not_found`` no-regress trigger mid-batch.
+  there; PR D must rewrite the two miss-handler call sites as conditional
+  writes (skip services already resolved) and port ``--retry-misses`` in
+  the same change, or the first retried drain trips the
+  found→``not_found`` no-regress trigger per re-missed row.
 * **Loud service validation.** Unknown or unsupported service tokens raise
   ``ValueError`` before any I/O (the legacy DAO silently no-opped on unknown
   services in ``update_result``). Validation precedes pool access so a typo'd
@@ -578,9 +585,9 @@ class StreamingCatalogDAO:
         validate phase's demotion call is a site PR D must rewrite, not
         merely re-point); accepting it here would let the PR A trigger kill
         a drain mid-phase with a RaiseError instead of failing loudly at
-        the call site. The album pipeline's cross-service ``not_found``
-        miss writes carry the same trigger exposure but admit no static
-        tripwire — see the module docstring's *Upsert discipline* bullet.
+        the call site. The album pipeline's ``not_found`` miss writes
+        carry the same trigger exposure but admit no static tripwire —
+        see the module docstring's *Upsert discipline* bullet.
         """
         if status == "false_positive":
             raise ValueError(

--- a/scripts/streaming_availability/catalog_dao.py
+++ b/scripts/streaming_availability/catalog_dao.py
@@ -35,7 +35,11 @@ translation decisions:
   deliberate demotion the legacy surface performs — the validate phase's
   ``api_match`` → ``false_positive`` flip — goes through
   ``mark_track_false_positive``, which opts into the guard
-  transaction-locally instead of asking callers to speak GUCs.
+  transaction-locally instead of asking callers to speak GUCs;
+  ``update_track_resolution`` rejects ``'false_positive'`` outright, so the
+  legacy validate-phase demotion call — the one *method-surface* call site
+  PR D must rewrite rather than merely re-point — fails loudly at port time
+  instead of tripping the trigger mid-drain.
 * **Loud service validation.** Unknown or unsupported service tokens raise
   ``ValueError`` before any I/O (the legacy DAO silently no-opped on unknown
   services in ``update_result``). Validation precedes pool access so a typo'd
@@ -552,7 +556,21 @@ class StreamingCatalogDAO:
         deezer_url: str | None = None,
         deezer_confidence: float | None = None,
     ) -> None:
-        """Record a track-resolution attempt; omitted params never null prior finds."""
+        """Record a track-resolution attempt; omitted params never null prior finds.
+
+        Rejects ``status='false_positive'`` before any I/O: that is the one
+        guarded demotion, sanctioned only via ``mark_track_false_positive``.
+        The legacy method accepted it (the validate phase's demotion call is
+        the one method-surface call site PR D must rewrite); accepting it
+        here would let the PR A trigger kill a drain mid-phase with a
+        RaiseError instead of failing loudly at the call site.
+        """
+        if status == "false_positive":
+            raise ValueError(
+                "status 'false_positive' is the guarded demotion — route it through "
+                "mark_track_false_positive, which opts into the no-regress guard "
+                "transaction-locally"
+            )
         await self._pg.execute(
             """
             UPDATE lml_cache.streaming_track_result SET
@@ -587,8 +605,16 @@ class StreamingCatalogDAO:
         method opts in via ``set_config(..., is_local => true)`` inside its own
         transaction — the opt-in covers exactly this UPDATE and evaporates at
         COMMIT, never leaking to other statements on the pooled connection.
+
         Collected URLs and resolution metadata stay in place as the audit
-        trail (legacy ``phase_validate`` only ever flipped the status).
+        trail. That is a deliberate improvement over the legacy demotion, NOT
+        parity: the legacy ``update_track_resolution`` wrote every metadata
+        column from its None-defaulted params, so a legacy ``false_positive``
+        flip nulled the URLs, confidences, and provenance it was invalidating.
+        Retention is safe because nothing downstream reads URLs off
+        ``false_positive`` rows — the streaming-links export and the coverage
+        baseline both filter on ``resolution_status IN ('local_match',
+        'api_match')``.
         """
         async with self._pg.acquire() as conn:
             async with conn.transaction():

--- a/scripts/streaming_availability/catalog_dao.py
+++ b/scripts/streaming_availability/catalog_dao.py
@@ -4,7 +4,10 @@
 over the PR A row-level schema (``lml_cache.streaming_album`` +
 ``streaming_album_service`` + ``streaming_track_result`` +
 ``streaming_coverage_baseline``): callers that go through ResultsDB *methods*
-port by swapping the construction site, not their call sites. Callers that
+port by swapping the construction site, not their call sites — except the
+demotion-exposed calls the *Upsert discipline* bullet names (the validate
+phase's ``false_positive`` write and the album pipeline's two cross-service
+``not_found`` miss writes), which PR D must rewrite. Callers that
 reach past the method surface into ``results_db._db`` raw SQL or
 ``_write_lock`` get no such promise — the streaming pipeline's
 compilation-skip and ``--retry-misses`` bulk updates, the track pipeline's
@@ -37,9 +40,20 @@ translation decisions:
   ``mark_track_false_positive``, which opts into the guard
   transaction-locally instead of asking callers to speak GUCs;
   ``update_track_resolution`` rejects ``'false_positive'`` outright, so the
-  legacy validate-phase demotion call — the one *method-surface* call site
-  PR D must rewrite rather than merely re-point — fails loudly at port time
-  instead of tripping the trigger mid-drain.
+  legacy validate-phase demotion call fails loudly at port time instead of
+  tripping the trigger mid-drain. That static tripwire is track-side only:
+  the legacy album pipeline's deezer- and spotify-stage miss handlers
+  (``scripts/streaming_availability/__main__.py``) also demote through the
+  method surface — each writes ``update_result(album_id, "spotify",
+  "not_found")`` that can land on a row already ``'found'`` for spotify,
+  because the pipeline admits every deezer-pending album regardless of
+  spotify status and found-with-deezer-pending rows are a real legacy state
+  (the ``deezer_*`` columns arrived by ``_migrate`` with ``DEFAULT
+  'pending'`` after Spotify-only runs had populated ``spotify_status``).
+  ``'not_found'`` is usually legal, so no static rejection is possible
+  there; PR D must rewrite those two call sites as conditional writes (skip
+  services already resolved) rather than re-point them, or the album drain
+  trips the found→``not_found`` no-regress trigger mid-batch.
 * **Loud service validation.** Unknown or unsupported service tokens raise
   ``ValueError`` before any I/O (the legacy DAO silently no-opped on unknown
   services in ``update_result``). Validation precedes pool access so a typo'd
@@ -558,12 +572,15 @@ class StreamingCatalogDAO:
     ) -> None:
         """Record a track-resolution attempt; omitted params never null prior finds.
 
-        Rejects ``status='false_positive'`` before any I/O: that is the one
-        guarded demotion, sanctioned only via ``mark_track_false_positive``.
-        The legacy method accepted it (the validate phase's demotion call is
-        the one method-surface call site PR D must rewrite); accepting it
-        here would let the PR A trigger kill a drain mid-phase with a
-        RaiseError instead of failing loudly at the call site.
+        Rejects ``status='false_positive'`` before any I/O: that is the
+        guarded track demotion, sanctioned only via
+        ``mark_track_false_positive``. The legacy method accepted it (the
+        validate phase's demotion call is a site PR D must rewrite, not
+        merely re-point); accepting it here would let the PR A trigger kill
+        a drain mid-phase with a RaiseError instead of failing loudly at
+        the call site. The album pipeline's cross-service ``not_found``
+        miss writes carry the same trigger exposure but admit no static
+        tripwire — see the module docstring's *Upsert discipline* bullet.
         """
         if status == "false_positive":
             raise ValueError(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,7 @@ import pytest_asyncio
 
 from config.settings import Settings
 from discogs.models import DiscogsSearchResponse
+from entity.streaming_catalog import ALLOW_URL_REMOVAL_GUC
 from library.db import LibraryDB
 from tests.factories import make_discogs_result
 
@@ -210,6 +211,19 @@ async def _veto_if_any_rows(conn, targets: "Iterable[tuple[str, str]]") -> None:
             f"Refusing to DROP: {'; '.join(parts)}. Point DATABASE_URL_TEST "
             "at a clean, reachable PG before running this suite."
         )
+
+
+async def opted_in(conn) -> None:
+    """Arm the ``lml_cache`` no-regress guards' opt-in for the current transaction.
+
+    Wraps the runbook spelling — ``set_config(<GUC>, 'on', true)`` with
+    ``is_local=true`` — so suites exercising legitimate discard paths can't
+    typo the GUC name. Must be called INSIDE an open transaction block
+    (``async with conn.transaction():``): asyncpg autocommits otherwise, and a
+    transaction-local setting evaporates the instant its implicit transaction
+    commits. Protection restores automatically at COMMIT/ROLLBACK.
+    """
+    await conn.execute(f"SELECT set_config('{ALLOW_URL_REMOVAL_GUC}', 'on', true)")
 
 
 async def skip_unless_wxyc_identity_match_artist(conn) -> None:

--- a/tests/integration/test_pg_fixture_guard_adoption.py
+++ b/tests/integration/test_pg_fixture_guard_adoption.py
@@ -59,6 +59,7 @@ _LML_CACHE_FIXTURE_FILES = (
     "test_streaming_url_persistent_lookup.py",
     "test_track_streaming_url_cache_pg.py",
     "test_streaming_catalog.py",
+    "test_streaming_catalog_dao.py",
     "test_library_release_override.py",
     "test_seed_library_release_overrides.py",
 )

--- a/tests/integration/test_streaming_catalog.py
+++ b/tests/integration/test_streaming_catalog.py
@@ -260,11 +260,19 @@ class TestSchemaBootstrap:
     async def test_boot_installs_status_indexes(self, pg_pool):
         async with pg_pool.acquire() as conn:
             rows = await conn.fetch(
-                "SELECT indexname FROM pg_indexes WHERE schemaname = 'lml_cache' "
-                "AND indexname = ANY($1::text[])",
-                ["idx_streaming_album_service_status", "idx_streaming_track_result_status"],
+                "SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = 'lml_cache' "
+                "AND indexname LIKE 'idx_streaming_%status%'"
             )
-        assert len(rows) == 2
+        by_name = {r["indexname"]: r["indexdef"] for r in rows}
+        # exactly these two — the reshaped composite track index has superseded
+        # (dropped) the original single-column idx_streaming_track_result_status
+        assert set(by_name) == {
+            "idx_streaming_album_service_status",
+            "idx_streaming_track_result_status_id",
+        }
+        # the composite serves get_pending_tracks / get_local_miss_tracks's
+        # (resolution_status = X ORDER BY id LIMIT n) from one index
+        assert "(resolution_status, id)" in by_name["idx_streaming_track_result_status_id"]
 
     @pytest.mark.asyncio
     async def test_service_check_rejects_unknown_service(self, pg_pool):

--- a/tests/integration/test_streaming_catalog.py
+++ b/tests/integration/test_streaming_catalog.py
@@ -30,10 +30,9 @@ from entity.sources import PgSource
 from entity.streaming_catalog import (
     _SERVICE_IN_LIST,
     _TABLES,
-    ALLOW_URL_REMOVAL_GUC,
     set_up_streaming_catalog_schema,
 )
-from tests.integration.conftest import skip_if_named_tables_populated
+from tests.integration.conftest import opted_in, skip_if_named_tables_populated
 
 # ``_TABLES`` is parents-before-children (creation order), so its reverse is
 # FK-safe for plain DROP TABLE.
@@ -74,11 +73,6 @@ _INSERT_TRACK = (
 # tracks are discogs_tracklist/compilation).
 _TRACK_SOURCE = "discogs_tracklist"
 _TRACK_SOURCE_TYPE = "compilation"
-
-# Derived from the module constant so the opt-in these tests exercise can't
-# drift from the GUC the guards consult; the guard layer itself stays pinned
-# by the many ``match="allow_url_removal"`` rejection sites below.
-_OPT_IN = f"SELECT set_config('{ALLOW_URL_REMOVAL_GUC}', 'on', true)"
 
 _SPOTIFY_URL = "https://open.spotify.com/album/2u30gztZTylY4RG7IvfXs8"
 _APPLE_URL = "https://music.apple.com/us/album/aluminum-tunes/1443179207"
@@ -407,7 +401,7 @@ class TestSchemaBootstrap:
         with pytest.raises(asyncpg.ForeignKeyViolationError):
             async with pg_pool.acquire() as conn:
                 async with conn.transaction():
-                    await conn.execute(_OPT_IN)
+                    await opted_in(conn)
                     await conn.execute(
                         "DELETE FROM lml_cache.streaming_album WHERE id = $1", album_id
                     )
@@ -769,7 +763,7 @@ class TestAlbumRowGuard:
         album_id = await _make_matched_album(pg_pool)
         async with pg_pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
                 await conn.execute(
                     "UPDATE lml_cache.streaming_album SET discogs_status = 'pending', "
                     "discogs_release_id = NULL WHERE id = $1",
@@ -897,7 +891,7 @@ class TestServiceRowGuard:
                 _INSERT_SERVICE_WITH_SLUG, album_id, "bandcamp", "found", None, "stereolab"
             )
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
                 await conn.execute(
                     "UPDATE lml_cache.streaming_album_service SET slug = NULL "
                     "WHERE album_id = $1 AND service = 'bandcamp'",
@@ -1048,7 +1042,7 @@ class TestServiceRowGuard:
         album_id = await _make_found_service_row(pg_pool)
         async with pg_pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
                 await conn.execute(
                     "UPDATE lml_cache.streaming_album_service SET url = NULL, "
                     "status = 'not_found' WHERE album_id = $1 AND service = 'spotify'",
@@ -1067,7 +1061,7 @@ class TestServiceRowGuard:
         album_id = await _make_found_service_row(pg_pool)
         async with pg_pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
                 await conn.execute(
                     "DELETE FROM lml_cache.streaming_album_service WHERE album_id = $1",
                     album_id,
@@ -1083,7 +1077,7 @@ class TestServiceRowGuard:
         album_id = await _make_found_service_row(pg_pool)
         async with pg_pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
             # Same connection, new transaction: the GUC must not leak.
             with pytest.raises(asyncpg.PostgresError, match="allow_url_removal"):
                 await conn.execute(
@@ -1352,7 +1346,7 @@ class TestTrackRowGuard:
         )
         async with pg_pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
                 await conn.execute(
                     "UPDATE lml_cache.streaming_track_result SET resolution_status = "
                     "'false_positive', spotify_url = NULL WHERE id = $1",
@@ -1380,7 +1374,7 @@ class TestTrackRowGuard:
         track_id = await _make_track(pg_pool, album_id)
         async with pg_pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
                 await conn.execute(
                     "DELETE FROM lml_cache.streaming_track_result WHERE id = $1", track_id
                 )
@@ -1420,7 +1414,7 @@ class TestTruncateGuard:
         album_id = await _make_found_service_row(pg_pool)
         async with pg_pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
                 await conn.execute("TRUNCATE lml_cache.streaming_album_service")
             remaining = await conn.fetchval(
                 "SELECT count(*) FROM lml_cache.streaming_album_service WHERE album_id = $1",
@@ -1561,7 +1555,7 @@ class TestCoverageBaselineGuard:
         await _seed_baseline(pg_pool)
         async with pg_pool.acquire() as conn:
             async with conn.transaction():
-                await conn.execute(_OPT_IN)
+                await opted_in(conn)
                 await conn.execute(
                     "UPDATE lml_cache.streaming_coverage_baseline SET value = 100 "
                     "WHERE metric = 'apple_music_found'"

--- a/tests/integration/test_streaming_catalog_dao.py
+++ b/tests/integration/test_streaming_catalog_dao.py
@@ -1,0 +1,792 @@
+"""Integration (``@pytest.mark.pg``) tests for ``StreamingCatalogDAO`` (LML#842 PR B).
+
+The PG rewrite of ``scripts/streaming_availability/results_db.py``'s
+``ResultsDB``: same method surface (so the PR D/E callers port by
+construction-site changes), backed by the PR A row-level schema
+(``lml_cache.streaming_album`` + ``streaming_album_service`` +
+``streaming_track_result`` + ``streaming_coverage_baseline``) instead of the
+whole-file SQLite lineage. The load-bearing contracts pinned here:
+
+* **Anti-join pending semantics** — a missing ``(album, service)`` row IS
+  ``'pending'``. Fresh albums carry no service rows at all; every pending
+  scan, stats bucket, and wide pivot column must coalesce absence to
+  ``'pending'`` rather than fan out phantom rows at insert time.
+* **Wide legacy row shape** — reads return the legacy SQLite column names
+  (``spotify_status``, ``spotify_id``, ``apple_url``, ``bandcamp_slug``, …)
+  via one shared four-way service pivot, so row consumers port unchanged.
+* **Upsert discipline (plan D3)** — service writes are upserts on
+  ``(album_id, service)`` that never write NULL over populated metadata
+  (``COALESCE(EXCLUDED.x, existing.x)``), and PR A's no-regress guards
+  propagate as-is: the DAO is a tripwire, not a pre-masker.
+* **Coverage baseline refresh** — ``refresh_coverage_baseline`` upserts the
+  five ``routers/admin.py`` metric keys from live counts; lowering a floor
+  raises through the PR A baseline guard.
+
+Run with: pytest -m pg -v tests/integration/test_streaming_catalog_dao.py
+"""
+
+from __future__ import annotations
+
+import json
+
+import asyncpg
+import asyncpg.exceptions
+import pytest
+import pytest_asyncio
+
+from entity.streaming_catalog import _TABLES
+from scripts.streaming_availability.catalog_dao import StreamingCatalogDAO
+from scripts.streaming_availability.dedup import DeduplicatedAlbum
+from tests.integration.conftest import (
+    DATABASE_URL,
+    opted_in,
+    skip_if_named_tables_populated,
+)
+
+# ``_TABLES`` is parents-before-children (creation order), so its reverse is
+# FK-safe for plain DROP TABLE.
+_DROP_ORDER = tuple(reversed(_TABLES))
+
+_SPOTIFY_URL = "https://open.spotify.com/album/2FZLDLcLBKcQLTLdQ7Wvoj"
+_APPLE_URL = "https://music.apple.com/us/album/aluminum-tunes/1443544224"
+_DEEZER_URL = "https://www.deezer.com/album/302127"
+_BANDCAMP_URL = "https://stereolab.bandcamp.com/album/aluminum-tunes"
+
+# The legacy ``albums`` SELECT-* column set (post-``_migrate()``), i.e. the row
+# shape every PR D/E row consumer was written against. The wide pivot must keep
+# emitting at least these names.
+_LEGACY_ALBUM_COLUMNS = {
+    "id",
+    "normalized_artist",
+    "normalized_title",
+    "display_artist",
+    "display_title",
+    "library_ids",
+    "formats",
+    "genre",
+    "label",
+    "is_compilation",
+    "is_single",
+    "discogs_artist",
+    "discogs_title",
+    "discogs_release_id",
+    "discogs_status",
+    "deezer_status",
+    "deezer_url",
+    "deezer_confidence",
+    "deezer_matched_artist",
+    "deezer_matched_title",
+    "deezer_checked_at",
+    "spotify_status",
+    "spotify_url",
+    "spotify_id",
+    "spotify_confidence",
+    "spotify_matched_artist",
+    "spotify_matched_title",
+    "spotify_checked_at",
+    "apple_status",
+    "apple_url",
+    "apple_confidence",
+    "apple_matched_artist",
+    "apple_matched_title",
+    "apple_checked_at",
+    "bandcamp_slug",
+    "bandcamp_url",
+    "bandcamp_status",
+    "bandcamp_checked_at",
+    "created_at",
+}
+
+# Distinct-album kwarg bundles (WXYC-representative fixtures).
+_PRATT = {
+    "normalized_artist": "jessica pratt",
+    "normalized_title": "on your own love again",
+    "display_artist": "Jessica Pratt",
+    "display_title": "On Your Own Love Again",
+}
+_MOLINA = {
+    "normalized_artist": "juana molina",
+    "normalized_title": "doga",
+    "display_artist": "Juana Molina",
+    "display_title": "DOGA",
+}
+_CAT_POWER = {
+    "normalized_artist": "cat power",
+    "normalized_title": "moon pix",
+    "display_artist": "Cat Power",
+    "display_title": "Moon Pix",
+}
+_COMPILATION = {
+    "normalized_artist": "various artists",
+    "normalized_title": "disco not disco",
+    "display_artist": "Various Artists",
+    "display_title": "Disco Not Disco",
+    "is_compilation": True,
+}
+
+
+def _make_album(**overrides) -> DeduplicatedAlbum:
+    kwargs: dict = {
+        "normalized_artist": "stereolab",
+        "normalized_title": "aluminum tunes",
+        "display_artist": "Stereolab",
+        "display_title": "Aluminum Tunes",
+        "library_ids": [87],
+        "formats": ["CD"],
+        "genre": "Rock",
+        "label": "Duophonic",
+    }
+    kwargs.update(overrides)
+    return DeduplicatedAlbum(**kwargs)
+
+
+def _make_track(album_id: int, **overrides) -> dict:
+    track: dict = {
+        "album_id": album_id,
+        "artist": "Juana Molina",
+        "title": "la paradoja",
+        "position": "A1",
+        "source": "discogs_tracklist",
+        "source_type": "compilation",
+    }
+    track.update(overrides)
+    return track
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def reset_catalog_tables(pg_pool):
+    """Reset just the four streaming-catalog tables around each test.
+
+    Same surgical shape as PR A's ``test_streaming_catalog.py`` fixture: veto
+    through the shared table-scoped guard first (a mispointed
+    ``DATABASE_URL_TEST`` at the shared discogs-cache PG must skip, not drop
+    collected data), then drop only the tables this suite owns.
+    """
+    async with pg_pool.acquire() as conn:
+        await skip_if_named_tables_populated(
+            conn, tuple(("lml_cache", table) for table in _DROP_ORDER)
+        )
+        for table in _DROP_ORDER:
+            await conn.execute(f"DROP TABLE IF EXISTS lml_cache.{table}")
+    yield
+    async with pg_pool.acquire() as conn:
+        for table in _DROP_ORDER:
+            await conn.execute(f"DROP TABLE IF EXISTS lml_cache.{table}")
+
+
+@pytest_asyncio.fixture
+async def dao(pg_pool, reset_catalog_tables):
+    """A connected DAO borrowing the test pool; ``connect()`` bootstraps the schema."""
+    d = StreamingCatalogDAO(pool=pg_pool)
+    await d.connect()
+    yield d
+    await d.close()
+
+
+async def _seed_album(dao: StreamingCatalogDAO, pg_pool, **overrides) -> int:
+    """Insert one album through the DAO and return its PG id."""
+    album = _make_album(**overrides)
+    await dao.insert_albums([album])
+    async with pg_pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT id FROM lml_cache.streaming_album "
+            "WHERE normalized_artist = $1 AND normalized_title = $2",
+            album.normalized_artist,
+            album.normalized_title,
+        )
+
+
+async def _seed_track(dao: StreamingCatalogDAO, pg_pool, album_id: int, **overrides) -> int:
+    """Insert one track through the DAO and return its PG id."""
+    track = _make_track(album_id, **overrides)
+    await dao.insert_tracks([track])
+    async with pg_pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT id FROM lml_cache.streaming_track_result "
+            "WHERE album_id = $1 AND artist = $2 AND title = $3",
+            album_id,
+            track["artist"],
+            track["title"],
+        )
+
+
+@pytest.mark.pg
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_connect_bootstraps_schema(self, dao, pg_pool) -> None:
+        """``connect()`` on a bare PG stands up all four catalog tables."""
+        async with pg_pool.acquire() as conn:
+            for table in _TABLES:
+                regclass = await conn.fetchval("SELECT to_regclass($1)", f"lml_cache.{table}")
+                assert regclass is not None, f"lml_cache.{table} missing after connect()"
+
+    @pytest.mark.asyncio
+    async def test_connect_is_idempotent(self, dao) -> None:
+        await dao.connect()
+        assert await dao.insert_albums([_make_album()]) == 1
+
+    @pytest.mark.asyncio
+    async def test_dsn_construction_owns_its_pool(self, reset_catalog_tables) -> None:
+        """The dsn shape (offline scripts, no shared app pool) round-trips:
+        connect → bootstrap → write → read → close."""
+        d = StreamingCatalogDAO(dsn=DATABASE_URL)
+        try:
+            await d.connect()
+            assert await d.insert_albums([_make_album()]) == 1
+            stats = await d.get_stats()
+            assert stats["total"] == 1
+        finally:
+            await d.close()
+
+
+@pytest.mark.pg
+class TestInsertAlbums:
+    @pytest.mark.asyncio
+    async def test_insert_returns_count_and_persists(self, dao) -> None:
+        inserted = await dao.insert_albums([_make_album(), _make_album(**_PRATT)])
+        assert inserted == 2
+        rows = await dao.get_all_results()
+        assert [r["display_title"] for r in rows] == [
+            "On Your Own Love Again",
+            "Aluminum Tunes",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_insert_ignored(self, dao) -> None:
+        assert await dao.insert_albums([_make_album()]) == 1
+        assert await dao.insert_albums([_make_album()]) == 0
+        assert (await dao.get_stats())["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_provenance_json_round_trips_as_str(self, dao) -> None:
+        """``library_ids``/``formats`` stay JSON strings on the way out —
+        the PR D/E row consumers call ``json.loads`` on them today."""
+        await dao.insert_albums([_make_album(library_ids=[87, 91], formats=["CD", "Vinyl"])])
+        row = (await dao.get_all_results())[0]
+        assert isinstance(row["library_ids"], str)
+        assert json.loads(row["library_ids"]) == [87, 91]
+        assert json.loads(row["formats"]) == ["CD", "Vinyl"]
+
+    @pytest.mark.asyncio
+    async def test_flags_round_trip(self, dao) -> None:
+        await dao.insert_albums([_make_album(**_COMPILATION), _make_album(is_single=True)])
+        rows = {r["display_title"]: r for r in await dao.get_all_results()}
+        assert rows["Disco Not Disco"]["is_compilation"]
+        assert not rows["Disco Not Disco"]["is_single"]
+        assert rows["Aluminum Tunes"]["is_single"]
+
+
+@pytest.mark.pg
+class TestPendingScans:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("service", ["spotify", "apple", "deezer", "bandcamp"])
+    async def test_fresh_album_is_pending_everywhere(self, dao, pg_pool, service) -> None:
+        """The anti-join contract: a fresh album has NO service rows, yet is
+        pending for every probed service."""
+        album_id = await _seed_album(dao, pg_pool)
+        rows = await dao.get_pending(service)
+        assert [r["id"] for r in rows] == [album_id]
+        async with pg_pool.acquire() as conn:
+            n = await conn.fetchval("SELECT COUNT(*) FROM lml_cache.streaming_album_service")
+        assert n == 0, "pending must come from row ABSENCE, not fan-out rows"
+
+    @pytest.mark.asyncio
+    async def test_found_excluded_from_pending_others_unaffected(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_result(album_id, "spotify", "found", url=_SPOTIFY_URL)
+        assert await dao.get_pending("spotify") == []
+        assert [r["id"] for r in await dao.get_pending("apple")] == [album_id]
+        assert [r["id"] for r in await dao.get_pending("deezer")] == [album_id]
+
+    @pytest.mark.asyncio
+    async def test_pending_row_carries_legacy_wide_shape(self, dao, pg_pool) -> None:
+        await _seed_album(dao, pg_pool)
+        row = (await dao.get_pending("spotify"))[0]
+        assert _LEGACY_ALBUM_COLUMNS <= set(row.keys())
+        assert row["spotify_status"] == "pending"
+        assert row["apple_status"] == "pending"
+        assert row["bandcamp_status"] == "pending"
+        assert row["spotify_url"] is None
+        assert row["bandcamp_slug"] is None
+        assert row["deezer_matched_artist"] is None
+
+    @pytest.mark.asyncio
+    async def test_discogs_pseudo_service_reads_album_column(self, dao, pg_pool) -> None:
+        """``get_pending("discogs")`` is the album-column pseudo-service the
+        ``__main__.py`` orchestrator uses — and unlike ``get_pending_discogs``
+        it applies NO compilation filter (legacy contract)."""
+        album_id = await _seed_album(dao, pg_pool)
+        comp_id = await _seed_album(dao, pg_pool, **_COMPILATION)
+        assert {r["id"] for r in await dao.get_pending("discogs")} == {album_id, comp_id}
+        await dao.update_discogs_result(
+            album_id, "found", artist="Stereolab", title="Aluminum Tunes", release_id=118423
+        )
+        assert {r["id"] for r in await dao.get_pending("discogs")} == {comp_id}
+
+    @pytest.mark.asyncio
+    async def test_limit_respected(self, dao, pg_pool) -> None:
+        await _seed_album(dao, pg_pool)
+        await _seed_album(dao, pg_pool, **_PRATT)
+        await _seed_album(dao, pg_pool, **_MOLINA)
+        assert len(await dao.get_pending("spotify", limit=2)) == 2
+        assert len(await dao.get_pending("discogs", limit=1)) == 1
+
+
+@pytest.mark.pg
+class TestDiscogsEnrichment:
+    @pytest.mark.asyncio
+    async def test_get_pending_discogs_excludes_compilations(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        await _seed_album(dao, pg_pool, **_COMPILATION)
+        assert [r["id"] for r in await dao.get_pending_discogs()] == [album_id]
+
+    @pytest.mark.asyncio
+    async def test_update_discogs_result_persists_match_group(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_discogs_result(
+            album_id, "found", artist="Stereolab", title="Aluminum Tunes", release_id=118423
+        )
+        row = (await dao.get_all_results())[0]
+        assert row["discogs_status"] == "found"
+        assert row["discogs_artist"] == "Stereolab"
+        assert row["discogs_title"] == "Aluminum Tunes"
+        assert row["discogs_release_id"] == 118423
+        assert await dao.get_pending_discogs() == []
+
+    @pytest.mark.asyncio
+    async def test_update_discogs_result_coalesces_metadata(self, dao, pg_pool) -> None:
+        """Plan D3: a follow-up write with omitted metadata must not null what
+        an earlier write collected."""
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_discogs_result(album_id, "error", artist="Stereolab")
+        await dao.update_discogs_result(album_id, "found", release_id=118423)
+        row = (await dao.get_all_results())[0]
+        assert row["discogs_status"] == "found"
+        assert row["discogs_artist"] == "Stereolab"
+        assert row["discogs_release_id"] == 118423
+
+
+@pytest.mark.pg
+class TestCascadeQueries:
+    @pytest.mark.asyncio
+    async def test_deezer_hits_pending_spotify(self, dao, pg_pool) -> None:
+        hit_id = await _seed_album(dao, pg_pool)
+        miss_id = await _seed_album(dao, pg_pool, **_PRATT)
+        await dao.update_result(hit_id, "deezer", "found", url=_DEEZER_URL)
+        await dao.update_result(miss_id, "deezer", "not_found")
+        assert [r["id"] for r in await dao.get_deezer_hits_pending_spotify()] == [hit_id]
+        await dao.update_result(hit_id, "spotify", "found", url=_SPOTIFY_URL)
+        assert await dao.get_deezer_hits_pending_spotify() == []
+
+    @pytest.mark.asyncio
+    async def test_spotify_misses_pending_apple(self, dao, pg_pool) -> None:
+        miss_id = await _seed_album(dao, pg_pool)
+        await _seed_album(dao, pg_pool, **_PRATT)  # spotify never probed: excluded
+        await dao.update_result(miss_id, "spotify", "not_found")
+        assert [r["id"] for r in await dao.get_spotify_misses_pending_apple()] == [miss_id]
+        await dao.update_result(miss_id, "apple", "not_found")
+        assert await dao.get_spotify_misses_pending_apple() == []
+
+
+@pytest.mark.pg
+class TestUpdateResult:
+    @pytest.mark.asyncio
+    async def test_spotify_metadata_lands_in_wide_row(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_result(
+            album_id,
+            "spotify",
+            "found",
+            url=_SPOTIFY_URL,
+            spotify_id="2FZLDLcLBKcQLTLdQ7Wvoj",
+            confidence=0.97,
+            matched_artist="Stereolab",
+            matched_title="Aluminum Tunes",
+        )
+        row = (await dao.get_all_results())[0]
+        assert row["spotify_status"] == "found"
+        assert row["spotify_url"] == _SPOTIFY_URL
+        assert row["spotify_id"] == "2FZLDLcLBKcQLTLdQ7Wvoj"
+        assert row["spotify_confidence"] == pytest.approx(0.97)
+        assert row["spotify_matched_artist"] == "Stereolab"
+        assert row["spotify_matched_title"] == "Aluminum Tunes"
+        assert row["spotify_checked_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_apple_alias_writes_apple_music_service_row(self, dao, pg_pool) -> None:
+        """The legacy ``apple`` token maps to the canonical ``apple_music``
+        slug in the service rows while the wide pivot keeps the legacy
+        ``apple_*`` column names."""
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_result(album_id, "apple", "found", url=_APPLE_URL)
+        async with pg_pool.acquire() as conn:
+            service = await conn.fetchval(
+                "SELECT service FROM lml_cache.streaming_album_service WHERE album_id = $1",
+                album_id,
+            )
+        assert service == "apple_music"
+        row = (await dao.get_all_results())[0]
+        assert row["apple_status"] == "found"
+        assert row["apple_url"] == _APPLE_URL
+
+    @pytest.mark.asyncio
+    async def test_null_metadata_does_not_clobber(self, dao, pg_pool) -> None:
+        """Plan D3 upsert discipline: NULL params never overwrite populated
+        metadata (``COALESCE(EXCLUDED.x, existing.x)``). The legacy SQLite DAO
+        would have nulled the URL here."""
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_result(
+            album_id, "spotify", "found", url=_SPOTIFY_URL, matched_artist="Stereolab"
+        )
+        await dao.update_result(album_id, "spotify", "found", confidence=0.88)
+        row = (await dao.get_all_results())[0]
+        assert row["spotify_url"] == _SPOTIFY_URL
+        assert row["spotify_matched_artist"] == "Stereolab"
+        assert row["spotify_confidence"] == pytest.approx(0.88)
+
+    @pytest.mark.asyncio
+    async def test_upserts_row_that_does_not_exist_yet(self, dao, pg_pool) -> None:
+        """Writes are upserts, not UPDATEs — the anti-join model means the
+        target row usually doesn't exist when the first probe lands."""
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_result(album_id, "deezer", "error")
+        row = (await dao.get_all_results())[0]
+        assert row["deezer_status"] == "error"
+        assert await dao.get_pending("deezer") == []
+
+    @pytest.mark.asyncio
+    async def test_empty_url_rejected_by_schema_check(self, dao, pg_pool) -> None:
+        """The extractors' ``''`` default must trip PR A's column CHECK — the
+        DAO passes it through rather than silently normalizing, so the broken
+        caller gets fixed instead of masked."""
+        album_id = await _seed_album(dao, pg_pool)
+        with pytest.raises(asyncpg.CheckViolationError):
+            await dao.update_result(album_id, "spotify", "found", url="")
+
+    @pytest.mark.asyncio
+    async def test_demotion_propagates_guard_error(self, dao, pg_pool) -> None:
+        """PR A's no-regress status gate fires through the DAO unmasked."""
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_result(album_id, "spotify", "found", url=_SPOTIFY_URL)
+        with pytest.raises(asyncpg.exceptions.PostgresError, match="allow_url_removal"):
+            await dao.update_result(album_id, "spotify", "not_found")
+
+
+@pytest.mark.pg
+class TestBandcamp:
+    @pytest.mark.asyncio
+    async def test_update_bandcamp_slug_creates_pending_row(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_bandcamp_slug(album_id, "stereolab")
+        row = (await dao.get_all_results())[0]
+        assert row["bandcamp_slug"] == "stereolab"
+        assert row["bandcamp_status"] == "pending"
+        assert [r["id"] for r in await dao.get_pending_bandcamp_lookup()] == [album_id]
+
+    @pytest.mark.asyncio
+    async def test_pending_bandcamp_lookup_slug_filter(self, dao, pg_pool) -> None:
+        a_id = await _seed_album(dao, pg_pool)
+        b_id = await _seed_album(dao, pg_pool, **_PRATT)
+        await dao.update_bandcamp_slug(a_id, "stereolab")
+        await dao.update_bandcamp_slug(b_id, "jessicapratt")
+        rows = await dao.get_pending_bandcamp_lookup(slug="jessicapratt")
+        assert [r["id"] for r in rows] == [b_id]
+
+    @pytest.mark.asyncio
+    async def test_pending_bandcamp_lookup_excludes_compilations(self, dao, pg_pool) -> None:
+        comp_id = await _seed_album(dao, pg_pool, **_COMPILATION)
+        await dao.update_bandcamp_slug(comp_id, "variousartists")
+        assert await dao.get_pending_bandcamp_lookup() == []
+
+    @pytest.mark.asyncio
+    async def test_update_bandcamp_url_marks_found_and_preserves_slug(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_bandcamp_slug(album_id, "stereolab")
+        await dao.update_bandcamp_url(album_id, _BANDCAMP_URL)
+        row = (await dao.get_all_results())[0]
+        assert row["bandcamp_url"] == _BANDCAMP_URL
+        assert row["bandcamp_status"] == "found"
+        assert row["bandcamp_slug"] == "stereolab"
+        assert row["bandcamp_checked_at"] is not None
+        assert await dao.get_pending_bandcamp_lookup() == []
+
+    @pytest.mark.asyncio
+    async def test_mark_bandcamp_not_found_is_resumable_marker(self, dao, pg_pool) -> None:
+        """#661 contract: 'tried, no match' must be durably distinct from 'not
+        yet tried' so a bulk drain skips already-attempted slugs on re-run."""
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_bandcamp_slug(album_id, "stereolab")
+        await dao.mark_bandcamp_not_found(album_id)
+        row = (await dao.get_all_results())[0]
+        assert row["bandcamp_status"] == "not_found"
+        assert row["bandcamp_url"] is None
+        assert await dao.get_pending_bandcamp_lookup() == []
+
+    @pytest.mark.asyncio
+    async def test_artists_without_slug_default_scope(self, dao, pg_pool) -> None:
+        """Default scope = spotify not_found, non-compilation, slugless,
+        DISTINCT display_artist."""
+        miss_id = await _seed_album(dao, pg_pool)
+        slugged_id = await _seed_album(dao, pg_pool, **_PRATT)
+        await _seed_album(dao, pg_pool, **_MOLINA)  # spotify never probed
+        comp_id = await _seed_album(dao, pg_pool, **_COMPILATION)
+        for album_id in (miss_id, slugged_id, comp_id):
+            await dao.update_result(album_id, "spotify", "not_found")
+        await dao.update_bandcamp_slug(slugged_id, "jessicapratt")
+        rows = await dao.get_artists_without_bandcamp_slug()
+        assert [r["display_artist"] for r in rows] == ["Stereolab"]
+
+    @pytest.mark.asyncio
+    async def test_artists_without_slug_all_scope_and_limit(self, dao, pg_pool) -> None:
+        await _seed_album(dao, pg_pool)
+        await _seed_album(dao, pg_pool, **_MOLINA)
+        rows = await dao.get_artists_without_bandcamp_slug(not_on_streaming_only=False)
+        assert {r["display_artist"] for r in rows} == {"Stereolab", "Juana Molina"}
+        limited = await dao.get_artists_without_bandcamp_slug(not_on_streaming_only=False, limit=1)
+        assert len(limited) == 1
+
+
+@pytest.mark.pg
+class TestStatsAndReports:
+    @pytest.mark.asyncio
+    async def test_get_stats_empty(self, dao) -> None:
+        stats = await dao.get_stats()
+        assert stats == {
+            "spotify": {},
+            "apple": {},
+            "discogs": {},
+            "deezer": {},
+            "bandcamp": {},
+            "total": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_stats_counts_missing_rows_as_pending(self, dao, pg_pool) -> None:
+        found_id = await _seed_album(dao, pg_pool)
+        await _seed_album(dao, pg_pool, **_PRATT)
+        await dao.update_result(found_id, "spotify", "found", url=_SPOTIFY_URL)
+        stats = await dao.get_stats()
+        assert stats["total"] == 2
+        assert stats["spotify"] == {"found": 1, "pending": 1}
+        assert stats["apple"] == {"pending": 2}
+        assert stats["deezer"] == {"pending": 2}
+        assert stats["bandcamp"] == {"pending": 2}
+        assert stats["discogs"] == {"pending": 2}
+
+    @pytest.mark.asyncio
+    async def test_get_not_on_streaming(self, dao, pg_pool) -> None:
+        miss_a = await _seed_album(dao, pg_pool)
+        miss_b = await _seed_album(dao, pg_pool, **_CAT_POWER)
+        hit_id = await _seed_album(dao, pg_pool, **_PRATT)
+        comp_id = await _seed_album(dao, pg_pool, **_COMPILATION)
+        for album_id in (miss_a, miss_b, comp_id):
+            await dao.update_result(album_id, "spotify", "not_found")
+        await dao.update_result(hit_id, "spotify", "found", url=_SPOTIFY_URL)
+        rows = await dao.get_not_on_streaming()
+        assert [r["display_artist"] for r in rows] == ["Cat Power", "Stereolab"]
+
+    @pytest.mark.asyncio
+    async def test_get_all_results_ordering(self, dao, pg_pool) -> None:
+        await _seed_album(dao, pg_pool)
+        await _seed_album(dao, pg_pool, **_MOLINA)
+        await _seed_album(dao, pg_pool, **_CAT_POWER)
+        rows = await dao.get_all_results()
+        assert [r["display_artist"] for r in rows] == [
+            "Cat Power",
+            "Juana Molina",
+            "Stereolab",
+        ]
+
+
+@pytest.mark.pg
+class TestTracks:
+    @pytest.mark.asyncio
+    async def test_insert_tracks_counts_and_dedupes(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        tracks = [
+            _make_track(album_id),
+            _make_track(album_id, artist="Jessica Pratt", title="Back, Baby", position="A2"),
+        ]
+        assert await dao.insert_tracks(tracks) == 2
+        assert await dao.insert_tracks(tracks) == 0
+
+    @pytest.mark.asyncio
+    async def test_get_pending_tracks_and_limit(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        await _seed_track(dao, pg_pool, album_id)
+        await _seed_track(dao, pg_pool, album_id, artist="Jessica Pratt", title="Back, Baby")
+        assert len(await dao.get_pending_tracks()) == 2
+        assert len(await dao.get_pending_tracks(limit=1)) == 1
+
+    @pytest.mark.asyncio
+    async def test_update_track_resolution_full(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        track_id = await _seed_track(dao, pg_pool, album_id)
+        await dao.update_track_resolution(
+            track_id,
+            "local_match",
+            resolved_via="library",
+            resolved_album_id=album_id,
+            resolved_release_id=118423,
+            spotify_url=_SPOTIFY_URL,
+            spotify_confidence=0.93,
+        )
+        assert await dao.get_pending_tracks() == []
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM lml_cache.streaming_track_result WHERE id = $1", track_id
+            )
+        assert row["resolution_status"] == "local_match"
+        assert row["resolved_via"] == "library"
+        assert row["spotify_url"] == _SPOTIFY_URL
+        assert row["spotify_confidence"] == pytest.approx(0.93)
+        assert row["checked_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_update_track_resolution_coalesces(self, dao, pg_pool) -> None:
+        """The lateral ``local_match`` → ``api_match`` move is legal, and the
+        second write's omitted params must not null the first write's URLs."""
+        album_id = await _seed_album(dao, pg_pool)
+        track_id = await _seed_track(dao, pg_pool, album_id)
+        await dao.update_track_resolution(track_id, "local_match", spotify_url=_SPOTIFY_URL)
+        await dao.update_track_resolution(track_id, "api_match", deezer_url=_DEEZER_URL)
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM lml_cache.streaming_track_result WHERE id = $1", track_id
+            )
+        assert row["resolution_status"] == "api_match"
+        assert row["spotify_url"] == _SPOTIFY_URL
+        assert row["deezer_url"] == _DEEZER_URL
+
+    @pytest.mark.asyncio
+    async def test_get_local_miss_tracks(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        track_id = await _seed_track(dao, pg_pool, album_id)
+        await dao.update_track_resolution(track_id, "local_miss")
+        assert [r["id"] for r in await dao.get_local_miss_tracks()] == [track_id]
+        await dao.update_track_resolution(track_id, "api_match", spotify_url=_SPOTIFY_URL)
+        assert await dao.get_local_miss_tracks() == []
+
+    @pytest.mark.asyncio
+    async def test_track_demotion_propagates_guard_error(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        track_id = await _seed_track(dao, pg_pool, album_id)
+        await dao.update_track_resolution(track_id, "local_match", spotify_url=_SPOTIFY_URL)
+        with pytest.raises(asyncpg.exceptions.PostgresError, match="allow_url_removal"):
+            await dao.update_track_resolution(track_id, "not_found")
+
+    @pytest.mark.asyncio
+    async def test_get_track_stats(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        resolved_id = await _seed_track(dao, pg_pool, album_id)
+        await _seed_track(dao, pg_pool, album_id, artist="Jessica Pratt", title="Back, Baby")
+        await dao.update_track_resolution(resolved_id, "local_match", spotify_url=_SPOTIFY_URL)
+        stats = await dao.get_track_stats()
+        assert stats == {"local_match": 1, "pending": 1, "total": 2}
+
+    @pytest.mark.asyncio
+    async def test_get_album_track_summary(self, dao, pg_pool) -> None:
+        album_id = await _seed_album(dao, pg_pool)
+        statuses = {
+            "la paradoja": ("local_match", {"spotify_url": _SPOTIFY_URL}),
+            "Back, Baby": ("api_match", {"deezer_url": _DEEZER_URL}),
+            "Eras": ("pending", None),
+            "Call Your Name": ("not_found", None),
+        }
+        for title, (status, extra) in statuses.items():
+            track_id = await _seed_track(dao, pg_pool, album_id, title=title)
+            if status != "pending":
+                await dao.update_track_resolution(track_id, status, **(extra or {}))
+        summary = await dao.get_album_track_summary(album_id)
+        assert summary == {
+            "total": 4,
+            "resolved": 2,
+            "not_found": 1,
+            "pending": 1,
+            "on_streaming": True,
+        }
+
+
+@pytest.mark.pg
+class TestCoverageBaseline:
+    @pytest.mark.asyncio
+    async def test_refresh_on_empty_catalog(self, dao, pg_pool) -> None:
+        metrics = await dao.refresh_coverage_baseline()
+        assert metrics == {
+            "apple_url": 0,
+            "spotify_url": 0,
+            "deezer_url": 0,
+            "albums": 0,
+            "track_results": 0,
+        }
+        async with pg_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT metric, value FROM lml_cache.streaming_coverage_baseline"
+            )
+        assert {r["metric"]: r["value"] for r in rows} == metrics
+
+    @pytest.mark.asyncio
+    async def test_refresh_computes_live_counts(self, dao, pg_pool) -> None:
+        """The five metric keys mirror ``routers/admin.py``'s
+        ``_STREAMING_COVERAGE_METRICS``; ``track_results`` counts only usable
+        rows (resolved AND carrying a streaming URL)."""
+        a_id = await _seed_album(dao, pg_pool)
+        b_id = await _seed_album(dao, pg_pool, **_PRATT)
+        await dao.update_result(a_id, "spotify", "found", url=_SPOTIFY_URL)
+        await dao.update_result(b_id, "apple", "found", url=_APPLE_URL)
+        usable_id = await _seed_track(dao, pg_pool, a_id)
+        bare_id = await _seed_track(dao, pg_pool, a_id, title="Back, Baby")
+        await dao.update_track_resolution(usable_id, "local_match", spotify_url=_SPOTIFY_URL)
+        await dao.update_track_resolution(bare_id, "api_match")  # resolved, no URL: unusable
+        metrics = await dao.refresh_coverage_baseline()
+        assert metrics == {
+            "apple_url": 1,
+            "spotify_url": 1,
+            "deezer_url": 0,
+            "albums": 2,
+            "track_results": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_refresh_ratchets_upward(self, dao, pg_pool) -> None:
+        await _seed_album(dao, pg_pool)
+        first = await dao.refresh_coverage_baseline()
+        assert first["albums"] == 1
+        await _seed_album(dao, pg_pool, **_PRATT)
+        second = await dao.refresh_coverage_baseline()
+        assert second["albums"] == 2
+
+    @pytest.mark.asyncio
+    async def test_refresh_lowering_propagates_guard_error(self, dao, pg_pool) -> None:
+        """A refresh computing LESS coverage than the stored floor must raise
+        through PR A's baseline guard — the DAO never pre-masks the tripwire."""
+        await _seed_album(dao, pg_pool)
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO lml_cache.streaming_coverage_baseline (metric, value) "
+                "VALUES ('albums', 5)"
+            )
+        with pytest.raises(asyncpg.exceptions.PostgresError, match="allow_url_removal"):
+            await dao.refresh_coverage_baseline()
+
+
+@pytest.mark.pg
+class TestOptedInRequeue:
+    @pytest.mark.asyncio
+    async def test_opted_in_reset_requeues_album(self, dao, pg_pool) -> None:
+        """The operator re-probe flow: an opted-in transaction may reset a
+        collected probe to pending, and the DAO's anti-join scan picks the
+        album back up."""
+        album_id = await _seed_album(dao, pg_pool)
+        await dao.update_result(album_id, "spotify", "found", url=_SPOTIFY_URL)
+        assert await dao.get_pending("spotify") == []
+        async with pg_pool.acquire() as conn:
+            async with conn.transaction():
+                await opted_in(conn)
+                await conn.execute(
+                    "UPDATE lml_cache.streaming_album_service "
+                    "SET status = 'pending', url = NULL "
+                    "WHERE album_id = $1 AND service = 'spotify'",
+                    album_id,
+                )
+        assert [r["id"] for r in await dao.get_pending("spotify")] == [album_id]

--- a/tests/integration/test_streaming_catalog_dao.py
+++ b/tests/integration/test_streaming_catalog_dao.py
@@ -1,8 +1,9 @@
 """Integration (``@pytest.mark.pg``) tests for ``StreamingCatalogDAO`` (LML#842 PR B).
 
 The PG rewrite of ``scripts/streaming_availability/results_db.py``'s
-``ResultsDB``: same method surface (so the PR D/E callers port by
-construction-site changes), backed by the PR A row-level schema
+``ResultsDB``: same method surface (so PR D/E callers that go through
+ResultsDB methods port by construction-site changes; the raw ``_db``
+reach-ins get rewritten in PR D), backed by the PR A row-level schema
 (``lml_cache.streaming_album`` + ``streaming_album_service`` +
 ``streaming_track_result`` + ``streaming_coverage_baseline``) instead of the
 whole-file SQLite lineage. The load-bearing contracts pinned here:
@@ -256,6 +257,20 @@ class TestInsertAlbums:
         assert await dao.insert_albums([_make_album()]) == 1
         assert await dao.insert_albums([_make_album()]) == 0
         assert (await dao.get_stats())["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_insert_skips_intra_batch_duplicates(self, dao) -> None:
+        """Two rows sharing a normalized key inside ONE batch: first wins,
+        duplicate skipped. Pins the set-based single-statement insert path,
+        where intra-batch conflicts are arbitrated by ON CONFLICT DO NOTHING
+        rather than by the earlier row already being committed."""
+        batch = [
+            _make_album(),
+            _make_album(display_title="Aluminum Tunes (reissue)"),
+            _make_album(**_PRATT),
+        ]
+        assert await dao.insert_albums(batch) == 2
+        assert (await dao.get_stats())["total"] == 2
 
     @pytest.mark.asyncio
     async def test_provenance_json_round_trips_as_str(self, dao) -> None:
@@ -674,6 +689,54 @@ class TestTracks:
         await dao.update_track_resolution(track_id, "local_match", spotify_url=_SPOTIFY_URL)
         with pytest.raises(asyncpg.exceptions.PostgresError, match="allow_url_removal"):
             await dao.update_track_resolution(track_id, "not_found")
+
+    @pytest.mark.asyncio
+    async def test_insert_tracks_skips_intra_batch_duplicates(self, dao, pg_pool) -> None:
+        """Same intra-batch arbitration pin as the album insert: a duplicate
+        (album_id, artist, title) inside one batch is skipped, not an error."""
+        album_id = await _seed_album(dao, pg_pool)
+        batch = [
+            _make_track(album_id),
+            _make_track(album_id, position="B7"),
+            _make_track(album_id, artist="Jessica Pratt", title="Back, Baby"),
+        ]
+        assert await dao.insert_tracks(batch) == 2
+
+    @pytest.mark.asyncio
+    async def test_mark_track_false_positive_demotes_api_match(self, dao, pg_pool) -> None:
+        """The one deliberate demotion in the legacy surface: the track
+        pipeline's validate phase flips ``api_match`` tracks whose URLs fail
+        service-metadata validation to ``false_positive``. The DAO opts into
+        the PR A no-regress guard transaction-locally for exactly this write;
+        the collected URLs stay in place as the audit trail (legacy behavior —
+        ``phase_validate`` only ever flipped the status)."""
+        album_id = await _seed_album(dao, pg_pool)
+        track_id = await _seed_track(dao, pg_pool, album_id)
+        await dao.update_track_resolution(track_id, "api_match", spotify_url=_SPOTIFY_URL)
+        await dao.mark_track_false_positive(track_id)
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM lml_cache.streaming_track_result WHERE id = $1", track_id
+            )
+        assert row["resolution_status"] == "false_positive"
+        assert row["spotify_url"] == _SPOTIFY_URL
+        assert row["checked_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_mark_track_false_positive_opt_in_does_not_leak(self, dao, pg_pool) -> None:
+        """The demotion's guard opt-in is transaction-local: a plain demotion
+        attempted right after — very likely on the same pooled connection —
+        must still trip the no-regress guard."""
+        album_id = await _seed_album(dao, pg_pool)
+        demoted_id = await _seed_track(dao, pg_pool, album_id)
+        guarded_id = await _seed_track(
+            dao, pg_pool, album_id, artist="Jessica Pratt", title="Back, Baby"
+        )
+        await dao.update_track_resolution(demoted_id, "api_match", spotify_url=_SPOTIFY_URL)
+        await dao.update_track_resolution(guarded_id, "api_match", deezer_url=_DEEZER_URL)
+        await dao.mark_track_false_positive(demoted_id)
+        with pytest.raises(asyncpg.exceptions.PostgresError, match="allow_url_removal"):
+            await dao.update_track_resolution(guarded_id, "not_found")
 
     @pytest.mark.asyncio
     async def test_get_track_stats(self, dao, pg_pool) -> None:

--- a/tests/integration/test_streaming_catalog_dao.py
+++ b/tests/integration/test_streaming_catalog_dao.py
@@ -36,6 +36,7 @@ import pytest
 import pytest_asyncio
 
 from entity.streaming_catalog import _TABLES
+from routers.admin import _STREAMING_COVERAGE_METRICS
 from scripts.streaming_availability.catalog_dao import StreamingCatalogDAO
 from scripts.streaming_availability.dedup import DeduplicatedAlbum
 from tests.integration.conftest import (
@@ -770,6 +771,22 @@ class TestTracks:
             "on_streaming": True,
         }
 
+    @pytest.mark.asyncio
+    async def test_get_album_track_summary_counts_only_resolved_statuses(
+        self, dao, pg_pool
+    ) -> None:
+        """``resolved`` is a direct count of the two resolved statuses, not a
+        subtraction of the enumerated unresolved ones — a novel/unmapped
+        status (a future resolution_status, or a raw pipeline write the
+        subtraction list never learned about) must not silently inflate it."""
+        album_id = await _seed_album(dao, pg_pool)
+        track_id = await _seed_track(dao, pg_pool, album_id)
+        await dao.update_track_resolution(track_id, "skipped")  # novel, unmapped status
+        summary = await dao.get_album_track_summary(album_id)
+        assert summary["total"] == 1
+        assert summary["resolved"] == 0
+        assert summary["on_streaming"] is False
+
 
 @pytest.mark.pg
 class TestCoverageBaseline:
@@ -788,6 +805,15 @@ class TestCoverageBaseline:
                 "SELECT metric, value FROM lml_cache.streaming_coverage_baseline"
             )
         assert {r["metric"]: r["value"] for r in rows} == metrics
+
+    @pytest.mark.asyncio
+    async def test_refresh_metric_keys_match_admin_constant(self, dao) -> None:
+        """The floor keys the DAO writes are exactly the reader's
+        ``routers/admin.py`` ``_STREAMING_COVERAGE_METRICS`` set — pinning the
+        two hardcoded lists together so a future edit to one that forgets the
+        other fails here instead of silently desyncing the export check."""
+        floors = await dao.refresh_coverage_baseline()
+        assert set(floors) == set(_STREAMING_COVERAGE_METRICS)
 
     @pytest.mark.asyncio
     async def test_refresh_computes_live_counts(self, dao, pg_pool) -> None:
@@ -821,17 +847,27 @@ class TestCoverageBaseline:
         assert second["albums"] == 2
 
     @pytest.mark.asyncio
-    async def test_refresh_lowering_propagates_guard_error(self, dao, pg_pool) -> None:
-        """A refresh computing LESS coverage than the stored floor must raise
-        through PR A's baseline guard — the DAO never pre-masks the tripwire."""
+    async def test_refresh_lowering_holds_the_floor(self, dao, pg_pool) -> None:
+        """A refresh computing LESS coverage than the stored floor must not
+        lower it: the baseline is a monotonic high-water mark. Each metric
+        ratchets up only (``GREATEST(live, stored)``), so a live regression —
+        e.g. a sanctioned ``mark_track_false_positive`` demotion between runs —
+        holds the floor rather than lowering it or aborting the whole refresh
+        through PR A's guard. Regression *detection* is the read-side export
+        check's job, not this writer's."""
         await _seed_album(dao, pg_pool)
         async with pg_pool.acquire() as conn:
             await conn.execute(
                 "INSERT INTO lml_cache.streaming_coverage_baseline (metric, value) "
                 "VALUES ('albums', 5)"
             )
-        with pytest.raises(asyncpg.exceptions.PostgresError, match="allow_url_removal"):
-            await dao.refresh_coverage_baseline()
+        floors = await dao.refresh_coverage_baseline()
+        assert floors["albums"] == 5  # held at the high-water mark, not lowered to live 1
+        async with pg_pool.acquire() as conn:
+            stored = await conn.fetchval(
+                "SELECT value FROM lml_cache.streaming_coverage_baseline WHERE metric = 'albums'"
+            )
+        assert stored == 5
 
 
 @pytest.mark.pg

--- a/tests/integration/test_streaming_catalog_dao.py
+++ b/tests/integration/test_streaming_catalog_dao.py
@@ -708,8 +708,9 @@ class TestTracks:
         pipeline's validate phase flips ``api_match`` tracks whose URLs fail
         service-metadata validation to ``false_positive``. The DAO opts into
         the PR A no-regress guard transaction-locally for exactly this write;
-        the collected URLs stay in place as the audit trail (legacy behavior —
-        ``phase_validate`` only ever flipped the status)."""
+        the collected URLs stay in place as the audit trail — deliberately
+        better than the legacy demotion, which nulled every omitted metadata
+        column (nothing downstream reads URLs off ``false_positive`` rows)."""
         album_id = await _seed_album(dao, pg_pool)
         track_id = await _seed_track(dao, pg_pool, album_id)
         await dao.update_track_resolution(track_id, "api_match", spotify_url=_SPOTIFY_URL)

--- a/tests/unit/test_streaming_catalog_dao.py
+++ b/tests/unit/test_streaming_catalog_dao.py
@@ -77,3 +77,14 @@ class TestServiceValidation:
         dao = StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN)
         with pytest.raises(ValueError, match="napster"):
             await dao.update_result(1, "napster", "found")
+
+    @pytest.mark.asyncio
+    async def test_update_track_resolution_rejects_false_positive(self) -> None:
+        """``false_positive`` is the guarded demotion, sanctioned only via
+        ``mark_track_false_positive``. The legacy validate phase wrote it
+        through this method; accepting it here would let the PR A trigger
+        kill a PR D drain mid-phase — a loud redirect at the call site (and
+        at port time) beats a RaiseError in production."""
+        dao = StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN)
+        with pytest.raises(ValueError, match="mark_track_false_positive"):
+            await dao.update_track_resolution(1, "false_positive")

--- a/tests/unit/test_streaming_catalog_dao.py
+++ b/tests/unit/test_streaming_catalog_dao.py
@@ -29,6 +29,22 @@ class TestConstruction:
             StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN, pool=object())  # type: ignore[arg-type]
 
 
+class TestEmptyBatches:
+    """Empty batches return 0 without dialing PG — the set-based bulk inserts
+    have no rows to arbitrate, and an offline caller flushing an empty buffer
+    should not pay (or fail on) a connection."""
+
+    @pytest.mark.asyncio
+    async def test_insert_albums_empty_batch_returns_zero_without_connecting(self) -> None:
+        dao = StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN)
+        assert await dao.insert_albums([]) == 0
+
+    @pytest.mark.asyncio
+    async def test_insert_tracks_empty_batch_returns_zero_without_connecting(self) -> None:
+        dao = StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN)
+        assert await dao.insert_tracks([]) == 0
+
+
 class TestServiceValidation:
     @pytest.mark.asyncio
     async def test_get_pending_unknown_service_raises_before_any_connection(self) -> None:

--- a/tests/unit/test_streaming_catalog_dao.py
+++ b/tests/unit/test_streaming_catalog_dao.py
@@ -1,0 +1,63 @@
+"""Unit tests for ``StreamingCatalogDAO`` construction and validation (LML#842 PR B).
+
+The DAO's PG behavior lives in ``tests/integration/test_streaming_catalog_dao.py``
+(``-m pg``). This file pins the pure surface: the dsn/pool XOR construction
+contract and the service-token validation, which must fail loudly BEFORE any
+pool is created — a typo'd service name in an offline drain script should die
+at the call site, not after opening connections to the shared discogs-cache PG.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.streaming_availability.catalog_dao import StreamingCatalogDAO
+
+# A DSN that must never be dialed: the validation-order tests below pass it to
+# prove ValueError beats pool creation. If a test hangs or errors on connect,
+# validation has been reordered behind I/O.
+_NEVER_DIALED_DSN = "postgresql://lml-unit-test-never-connects/nonexistent"
+
+
+class TestConstruction:
+    def test_requires_dsn_or_pool(self) -> None:
+        with pytest.raises(ValueError):
+            StreamingCatalogDAO()
+
+    def test_rejects_both_dsn_and_pool(self) -> None:
+        with pytest.raises(ValueError):
+            StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN, pool=object())  # type: ignore[arg-type]
+
+
+class TestServiceValidation:
+    @pytest.mark.asyncio
+    async def test_get_pending_unknown_service_raises_before_any_connection(self) -> None:
+        dao = StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN)
+        with pytest.raises(ValueError, match="napster"):
+            await dao.get_pending("napster")
+
+    @pytest.mark.asyncio
+    async def test_get_pending_rejects_unpivoted_canonical_service(self) -> None:
+        """``tidal`` is a legal ``_SERVICES`` slug but outside the legacy
+        ResultsDB surface (no wide-pivot column set); the DAO speaks only the
+        legacy tokens (spotify/apple/deezer/bandcamp + the discogs
+        pseudo-service) until a PR D+ caller needs more."""
+        dao = StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN)
+        with pytest.raises(ValueError, match="tidal"):
+            await dao.get_pending("tidal")
+
+    @pytest.mark.asyncio
+    async def test_update_result_rejects_bandcamp(self) -> None:
+        """Bandcamp has dedicated methods (``update_bandcamp_url`` /
+        ``mark_bandcamp_not_found``); routing it through ``update_result``
+        was never legal in the legacy DAO either (silent no-op there — a
+        loud ValueError here)."""
+        dao = StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN)
+        with pytest.raises(ValueError, match="bandcamp"):
+            await dao.update_result(1, "bandcamp", "found", url="https://example.test/x")
+
+    @pytest.mark.asyncio
+    async def test_update_result_rejects_unknown_service(self) -> None:
+        dao = StreamingCatalogDAO(dsn=_NEVER_DIALED_DSN)
+        with pytest.raises(ValueError, match="napster"):
+            await dao.update_result(1, "napster", "found")

--- a/tests/unit/test_streaming_catalog_schema.py
+++ b/tests/unit/test_streaming_catalog_schema.py
@@ -251,7 +251,11 @@ class TestSetUpStreamingCatalogSchema:
         assert joined.count("CREATE OR REPLACE TRIGGER") == 8
         assert joined.count("BEFORE TRUNCATE ON") == 4
         assert "CREATE INDEX IF NOT EXISTS idx_streaming_album_service_status" in joined
-        assert "CREATE INDEX IF NOT EXISTS idx_streaming_track_result_status" in joined
+        assert (
+            "CREATE INDEX IF NOT EXISTS idx_streaming_track_result_status_id\n"
+            "    ON lml_cache.streaming_track_result (resolution_status, id)" in joined
+        )
+        assert "DROP INDEX IF EXISTS lml_cache.idx_streaming_track_result_status" in joined
 
     async def test_runs_as_one_transaction_on_one_connection(self):
         # All-or-nothing: a mid-boot failure must never leave tables standing
@@ -339,7 +343,9 @@ class TestSetUpStreamingCatalogSchema:
         # legitimately contains "BEFORE UPDATE OR DELETE" — so assert on the
         # statement head instead: after the two-statement preamble (SET LOCAL
         # + advisory lock SELECT, both row-neutral), every statement is CREATE,
-        # ALTER, or the widen-only DO block (which only ever EXECUTEs an ALTER).
+        # ALTER, the widen-only DO block (which only ever EXECUTEs an ALTER), or
+        # a DROP INDEX IF EXISTS (row-neutral DDL: the track status-index
+        # reshape drops the superseded single-column form).
         pg = _FakePgSource()
 
         await set_up_streaming_catalog_schema(pg)
@@ -349,6 +355,6 @@ class TestSetUpStreamingCatalogSchema:
         assert ddl, "bootstrap issued no DDL"
         for sql in ddl:
             head = sql.lstrip().split()[0]
-            assert head in {"CREATE", "ALTER", "DO"}, (
+            assert head in {"CREATE", "ALTER", "DO", "DROP"}, (
                 f"non-DDL statement in bootstrap: {sql[:80]!r}"
             )


### PR DESCRIPTION
Part of #842 (PR B of the seven-PR chain; plan: https://github.com/WXYC/library-metadata-lookup/issues/842#issuecomment-5029098765). Builds on PR A (#883, merged): the DAO layer over the row-level `lml_cache` streaming-catalog schema.

## What

`scripts/streaming_availability/catalog_dao.py` — `StreamingCatalogDAO`, reproducing the legacy `results_db.ResultsDB` method surface over PG. Callers that go through ResultsDB *methods* port by swapping only their construction sites — except the demotion-exposed calls below; the raw `results_db._db`/`_write_lock` reach-ins (the streaming pipeline's compilation-skip and `--retry-misses` bulk updates, the track pipeline's extract/build-index/validate scans and album rollup, the bandcamp pipeline's slug-discovery writes + searched-not-found sentinel, Wikidata slug loader, URL migration, and dry-run preview counters) are PR D rewrite scope, named as such in the module docstring:

- **One shared services pivot** (`_WIDE_ALBUM_SELECT`): every album read emits the legacy wide column names (`spotify_status`, `spotify_id`, `apple_url`, `bandcamp_slug`, …) via four LEFT JOINs, with missing `(album, service)` rows coalesced to `'pending'` — the anti-join replacement for SQLite's materialized per-service pending columns. Row consumers written against `SELECT * FROM albums` keep working unchanged (pinned by a column-set test). `library_ids`/`formats` stay JSON strings on the way out (asyncpg's default jsonb codec), matching the callers' existing `json.loads`.
- **Upsert discipline (plan D3)**: service writes are `INSERT … ON CONFLICT (album_id, service) DO UPDATE` with `COALESCE(EXCLUDED.x, existing.x)` on every metadata column — omitted params never null collected data. PR A's no-regress guards and CHECKs propagate unmasked (found→not_found demotion, baseline lowering, and `''`-URL are each asserted to raise through the DAO).
- **`mark_track_false_positive`** — the one deliberate demotion in the legacy surface (the validate phase flips `api_match` tracks whose URLs fail service-metadata checks). Opts into the PR A guard transaction-locally (`set_config` `is_local` inside its own transaction; a same-pool follow-up demotion test proves the opt-in doesn't leak). `update_track_resolution` rejects `'false_positive'` with a ValueError naming this method — the legacy validate phase demoted through the plain update, so that port trap fails loudly at port time instead of tripping the trigger mid-drain. Not every method-surface port trap is statically rejectable, though: the legacy album pipeline's deezer/spotify miss handlers write `update_result(album_id, "spotify", "not_found")` (cross-service from the deezer stage, same-service from the spotify stage) and either can land on an already-`found` row — the `--retry-misses` reset mints that state by flipping deezer `not_found`→`pending` unconditionally while its spotify reset requires `deezer_status='pending'`, leaving 29,861 of 65,147 snapshot albums spotify-found/deezer-resettable. `'not_found'` is usually legal so no ValueError is possible — the module docstring names those two call sites (plus the paired `--retry-misses` port) as PR D conditional-write rewrite scope alongside the raw-SQL reach-ins. Collected URLs/metadata stay in place as the audit trail — deliberately better than the legacy demotion, whose all-columns UPDATE nulled them (nothing downstream reads URLs off `false_positive` rows).
- **Set-based bulk inserts**: `insert_albums`/`insert_tracks` are one `unnest`-based statement per batch, not a round-trip per row — the PR C seed pushes ~65k albums through `insert_albums` against the remote discogs-cache PG. `ON CONFLICT DO NOTHING` arbitrates pre-existing and intra-batch duplicates alike (both pinned); empty batches return 0 without dialing.
- **Construction mirrors `PgSource`**: dsn (offline scripts, owned lazy pool) XOR pool (borrowed shared pool; `close()` is then a no-op). `connect()` runs the same idempotent bootstrap as the `main.py` lifespan.
- `refresh_coverage_baseline()`: transactional recompute + upsert of the five `routers/admin.py` `_STREAMING_COVERAGE_METRICS` keys from live counts.

## Deviations from the legacy DAO (each pinned by a test)

- Unknown/unsupported service tokens raise `ValueError` **before any I/O** instead of the legacy silent no-op (`update_result("bandcamp", …)` included — bandcamp has dedicated methods).
- Every list read carries an explicit `ORDER BY` (SQLite's implicit rowid order doesn't exist in PG) for deterministic batching.
- No asyncio write lock — PG handles concurrent writers; SQLite's single-writer serialization was a file-level constraint.

## Tests

- `tests/unit/test_streaming_catalog_dao.py` — 9 tests: dsn/pool XOR, service-token + false-positive-status validation ordering, empty-batch early return (never dials PG).
- `tests/integration/test_streaming_catalog_dao.py` — 54 `-m pg` tests: lifecycle/bootstrap, insert dedupe (cross-call and intra-batch) + JSON provenance round-trip, anti-join pending scans, discogs pseudo-service, cascade queries (deezer→spotify, spotify→apple), upsert/COALESCE semantics, guard propagation, the false-positive demotion seam (+ opt-in leak check), bandcamp slug/url/not_found lifecycle, stats (missing-rows-as-pending), reports, track resolution + rollup arithmetic, coverage baseline (compute/ratchet/lowering-guard), and an opted-in requeue round-trip.
- `tests/integration/conftest.py` — new `opted_in(conn)` helper wrapping the guards' transaction-local `set_config` opt-in; `test_streaming_catalog.py`'s ten former private `_OPT_IN` sites now route through it, so the opt-in has exactly one spelling.
- Suite registered in the `_LML_CACHE_FIXTURE_FILES` fixture-guard roster.

Local CI: ruff format/check clean, `mypy . --ignore-missing-imports` clean, full unit suite 4392 passed, full `-m pg` suite 510 passed.

## Review follow-up (round 6)

A high-effort review pass turned up five fixes, each landed TDD-first:

- **Coverage-baseline ratchet (correctness).** `refresh_coverage_baseline` upserted `value = EXCLUDED.value`, so any live regression tripped PR A's zero-tolerance lowering guard and aborted the *whole* refresh (all five metrics, including grown ones). Since `mark_track_false_positive` is a sanctioned per-run demotion that lowers `track_results`, the next refresh would wedge until manual GUC intervention. Now `value = GREATEST(EXCLUDED.value, existing)` — the baseline is a monotonic high-water mark that holds on a live dip and never fights its own guard; the method returns the effective post-ratchet floor (`RETURNING value`). Regression *detection* stays the read-side export check's job. The former `test_refresh_lowering_propagates_guard_error` (which pinned the abort) is inverted to `test_refresh_lowering_holds_the_floor`.
- **`resolved` counted directly (correctness).** `get_album_track_summary` derived `resolved` by subtracting the enumerated unresolved statuses from the total, so a novel/unmapped `resolution_status` (a future value, or a raw pipeline write — the column has no CHECK) silently counted as resolved. Now `resolved = local_match + api_match`, matching the export/baseline filters; pinned by a novel-status test.
- **Composite status index (perf).** `get_pending_tracks` / `get_local_miss_tracks` scan `WHERE resolution_status = X ORDER BY id LIMIT n`, which the provisional single-column `(resolution_status)` index served with a Sort. Reshaped to `(resolution_status, id)` (ordered read + early LIMIT stop). `CREATE INDEX IF NOT EXISTS` can't redefine an index, so the reshape drops the old name first and creates under `idx_streaming_track_result_status_id`; the generated `entity/streaming_catalog.sql` twin is regenerated and its byte/normalized-equality tests stay green.
- **Metric-key parity test.** New `-m pg` test pins `refresh_coverage_baseline`'s floor keys to `routers/admin._STREAMING_COVERAGE_METRICS`, so a future edit to one list that forgets the other fails loudly instead of desyncing the export check.
- **`get_stats` dedup.** The per-service loop now iterates `_PIVOT_ALIAS` instead of a re-enumerated literal tuple (iteration-equivalent; existing `get_stats` tests unchanged).

Two lower-severity efficiency notes (the per-service aggregate fan-out in `get_stats`; the four-join single-service read) were assessed and left as intentional.

## Related

- #842 (epic — stays open through PR G)
- #883 (PR A — schema + invariants, merged)
