### PR TITLE
chore(codegen): regenerate api_models for ArtistMetadataResponse.bioTokens

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1907,6 +1907,10 @@ class ArtistMetadataResponse(BaseModel):
     bio: str | None = Field(None, description="Artist biography from Discogs")
     wikipediaUrl: str | None = Field(None, description="Wikipedia URL for the artist")
     imageUrl: str | None = Field(None, description="Artist image URL from Discogs")
+    bioTokens: list[DiscogsResolvedToken] | None = Field(
+        None,
+        description="Pre-parsed structured tokens from the artist's Discogs profile markup. Pass-through of DiscogsArtistDetails.profile_tokens, so clients can share token rendering across the two payloads.\n",
+    )
 
 
 class ArtworkSearchResponse(BaseModel):


### PR DESCRIPTION
wxyc-shared merged `bioTokens` onto `ArtistMetadataResponse` ([wxyc-shared@2318420](https://github.com/WXYC/wxyc-shared/commit/2318420c1fae15b0d0cb244e94168b8d4ae21125), 2026-07-23), which makes the Codegen Freshness job fail on every LML PR until the committed `generated/api_models.py` catches up — first observed on #912. This is the standard paired-regen chore (same shape as the `Concert.station_recommended_rank` regen): a pure additive optional field, regenerated via `scripts/generate_api_models.sh` against a synced wxyc-shared checkout. No LML runtime consumer of `bioTokens` yet.