### PR TITLE
chore(codegen): regenerate api_models for ArtistMetadataResponse.bioTokens

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1907,6 +1907,10 @@ class ArtistMetadataResponse(BaseModel):
     bio: str | None = Field(None, description="Artist biography from Discogs")
     wikipediaUrl: str | None = Field(None, description="Wikipedia URL for the artist")
     imageUrl: str | None = Field(None, description="Artist image URL from Discogs")
+    bioTokens: list[DiscogsResolvedToken] | None = Field(
+        None,
+        description="Pre-parsed structured tokens from the artist's Discogs profile markup. Pass-through of DiscogsArtistDetails.profile_tokens, so clients can share token rendering across the two payloads.\n",
+    )
 
 
 class ArtworkSearchResponse(BaseModel):


### PR DESCRIPTION
wxyc-shared merged `ArtistMetadataResponse.bioTokens` (WXYC/wxyc-shared@2318420, contract pin 291c9cc), which put the committed `generated/api_models.py` behind the contract — the Codegen Freshness job is now red on every open PR (#910, #912). This is the downstream consumer regen: `scripts/generate_api_models.sh` against the synced wxyc-shared `api.yaml`. The diff is the expected four-line `bioTokens` field addition and nothing else (byte-identical to the drift CI reported). Local battery: ruff format/check clean, `mypy .` clean, full unit suite 4381 passed.