### PR TITLE
fix(discogs): don't memoize degraded search() failures (LML#918)

### DIFF
--- a/discogs/lookup.py
+++ b/discogs/lookup.py
@@ -235,5 +235,8 @@ async def lookup_releases_by_artist(
 
     request = DiscogsSearchRequest(artist=artist)
     response = await service.search(request, limit=limit)
+    if response is None:
+        # Degraded Discogs call (LML#918): treat like an empty result set.
+        return []
 
     return list(response.results)

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -1584,7 +1584,7 @@ class DiscogsService:
     @async_cached(SEARCH_CACHE)
     async def search(
         self, request: DiscogsSearchRequest, limit: int = 5, skip_pg: bool = False
-    ) -> DiscogsSearchResponse:
+    ) -> DiscogsSearchResponse | None:
         """General release search for artwork discovery.
 
         Read-through via :func:`fallthrough` with ``pg_write=None`` — the PG
@@ -1604,7 +1604,12 @@ class DiscogsService:
                 re-searched API-only or the working API arm stays masked.
 
         Returns:
-            DiscogsSearchResponse with ranked results
+            DiscogsSearchResponse with ranked results (possibly empty on a
+            genuine 200-with-no-results negative), or None when the Discogs
+            call *degraded* — rate-limited / retries exhausted, saturation
+            breaker shed, or a 5xx. None is deliberately propagated so
+            ``@async_cached`` does not memoize a transient failure as a
+            1-hour no-match; the next call retries (LML#918).
         """
         params = self._build_search_params(request, limit=limit)
         if not params:
@@ -1657,8 +1662,12 @@ class DiscogsService:
                     )
 
                 if response is None:
+                    # Degraded (rate-limited / retries exhausted). Return None so
+                    # @async_cached does NOT memoize this transient failure as a
+                    # 1-hour no-match (LML#918). A genuine 200-with-no-results
+                    # below stays a real, cacheable (empty) response.
                     logger.warning("Discogs search failed (rate limited or error)")
-                    return DiscogsSearchResponse(cached=False)
+                    return None
 
                 get_cache_stats_recorder().record_api_call()
                 response.raise_for_status()
@@ -1681,10 +1690,20 @@ class DiscogsService:
                         response = await self._request_with_retry(
                             "GET", "/database/search", params=fallback_params
                         )
-                    if response is not None:
-                        get_cache_stats_recorder().record_api_call()
-                        response.raise_for_status()
-                        data = response.json()
+                    if response is None:
+                        # Degraded fuzzy leg (rate-limited / retries exhausted).
+                        # The strict leg returned 200-empty, but the fuzzy ``q=``
+                        # query is the one that resolves non-library releases, so
+                        # a transient failure here must NOT be cached as a
+                        # no-match — return None like the strict-leg degrade
+                        # above so @async_cached skips it (LML#918). Otherwise
+                        # the strict empty would be memoized for an hour on
+                        # exactly the non-library path this fix targets.
+                        logger.warning("Discogs fuzzy search failed (rate limited or error)")
+                        return None
+                    get_cache_stats_recorder().record_api_call()
+                    response.raise_for_status()
+                    data = response.json()
 
                 results = []
                 for item in data.get("results", []):
@@ -1739,13 +1758,13 @@ class DiscogsService:
                 # search failure — DEBUG, not ERROR, so a sustained OPEN episode
                 # doesn't flood Sentry with per-request error events (#755). The
                 # breaker logs the OPEN/CLOSED transitions; the shed counter
-                # carries the volume. Return the same empty response as the
-                # generic path (this seam is read-only, no negative cache write).
-                logger.debug("Discogs saturation breaker shed search; returning empty (cache-only)")
-                return DiscogsSearchResponse(cached=False)
+                # carries the volume. Return None like the generic degraded
+                # path so the shed isn't memoized as a no-match (LML#918).
+                logger.debug("Discogs saturation breaker shed search; returning None (no-poison)")
+                return None
             except Exception as e:
                 logger.error(f"Discogs search failed: {e}")
-                return DiscogsSearchResponse(cached=False)
+                return None
 
         cache = self.cache_service
         if cache is None or skip_pg:
@@ -1762,10 +1781,10 @@ class DiscogsService:
                 # pg_write=None: read-only by design — see method docstring.
                 breadcrumb_data={"artist": request.artist, "album": request.album},
             )
-        # ``api_fetch`` returns a non-None DiscogsSearchResponse on every path
-        # (parses or constructs a cached=False empty), so the seam's `T | None`
-        # never narrows to None here in practice.
-        assert result is not None
+        # ``result`` is None when the API leg degraded (rate-limited / breaker
+        # shed / 5xx): LML#918 propagates that None so @async_cached skips
+        # memoizing the transient failure. A PG hit or a genuine (possibly
+        # empty) API parse is a real response and is cached as before.
         return result
 
     def _build_search_params(self, request: DiscogsSearchRequest, limit: int = 5) -> dict:

--- a/lookup/artwork.py
+++ b/lookup/artwork.py
@@ -299,7 +299,9 @@ async def fetch_artwork_for_items(
             if item.title and item.title != album and not is_self_titled(item.title):
                 album_variants.append(item.title)
             result = find_best_typed_match(
-                response.results,
+                # None = degraded Discogs call (LML#918); score an empty set,
+                # which falls into the same "no match" path as an empty response.
+                response.results if response is not None else [],
                 query_artist=artist_variants,
                 query_title=album_variants,
                 artist_fn=lambda r: r.artist_variants(),

--- a/lookup/strategies/library_miss.py
+++ b/lookup/strategies/library_miss.py
@@ -112,7 +112,7 @@ async def _library_miss_discogs_search(
         try:
             retry = await discogs_service.search(request, skip_pg=True)
         except Exception:
-            # A raised (or, below, empty) retry keeps the PG-served
+            # A raised (or, below, empty/None) retry keeps the PG-served
             # candidates: the rescue works during an API outage (segments
             # are pure CPU; the tracklist fetch reads the PG tier first).
             logger.warning(
@@ -120,10 +120,11 @@ async def _library_miss_discogs_search(
             )
         else:
             best = _floor_best(retry)
-            if retry.results:
+            if retry is not None and retry.results:
                 # A non-empty retry supersedes even when it floor-fails: the
                 # fuzzy API arm's retrieval is category 2's own premise. Only
-                # an empty retry keeps the PG-served candidates.
+                # an empty (or degraded None, LML#918) retry keeps the
+                # PG-served candidates.
                 response = retry
 
     if best is None and response is not None and response.results:

--- a/lookup/validation.py
+++ b/lookup/validation.py
@@ -60,7 +60,8 @@ async def filter_results_by_track_validation(
             response = await discogs_service.search(
                 DiscogsSearchRequest(album=album_for_search, artist=artist)
             )
-            if not response.results:
+            if response is None or not response.results:
+                # None = degraded Discogs call (LML#918); treat like no results.
                 return None
 
             best_result = response.results[0]

--- a/scripts/benchmark_cache.py
+++ b/scripts/benchmark_cache.py
@@ -160,7 +160,8 @@ async def time_search(service: DiscogsService, query: dict[str, str | None]) -> 
     result = await service.search(request)
     elapsed_ms = (time.perf_counter() - start) * 1000
 
-    return elapsed_ms, result.cached
+    # None = degraded Discogs call (LML#918); count it as an uncached miss.
+    return elapsed_ms, (result.cached if result is not None else False)
 
 
 async def run_benchmark(iterations: int) -> None:

--- a/scripts/measure_artwork_match_floor.py
+++ b/scripts/measure_artwork_match_floor.py
@@ -268,7 +268,9 @@ async def run(args: argparse.Namespace) -> None:
                     )
                     continue
 
-                old_pick, new_pick, a_score, t_score, best = classify(response.results, query)
+                # None = degraded Discogs call (LML#918); classify an empty set.
+                results = response.results if response is not None else []
+                old_pick, new_pick, a_score, t_score, best = classify(results, query)
 
                 if old_pick is None:
                     no_results += 1

--- a/tests/integration/test_error_resilience.py
+++ b/tests/integration/test_error_resilience.py
@@ -335,14 +335,17 @@ class TestSourceTransportFailures:
 
     @pytest.mark.asyncio
     async def test_discogs_service_search_with_http_error_degrades(self):
-        """DiscogsService.search returns empty results on HTTP transport failure."""
+        """DiscogsService.search degrades to None (not an exception) on HTTP
+        transport failure. Post-LML#918 the degraded result is None rather than
+        an empty response, so @async_cached does not memoize the transient
+        failure as an hour-long no-match; callers treat None like an empty."""
         from discogs.models import DiscogsSearchRequest
         from discogs.service import DiscogsService
 
         service = DiscogsService(token="test_token", cache_service=None)
 
         # Mock the httpx client to simulate a connection error.
-        # DiscogsService catches exceptions internally and returns empty results.
+        # DiscogsService catches exceptions internally and degrades to None.
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=Exception("simulated HTTP connection failure"))
         service._client = mock_client
@@ -351,9 +354,8 @@ class TestSourceTransportFailures:
 
         result = await service.search(request)
 
-        # The service gracefully degrades -- returns empty results, not an exception
-        assert result is not None
-        assert result.results == []
+        # Graceful degrade: None, not an exception and not a cacheable empty.
+        assert result is None
 
         # Clean up (avoid real close calls)
         service._client = None

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -3556,3 +3556,113 @@ class TestLeanHydrationRouting:
         assert result is not None and result.name == "FULL"
         cache.get_artist_details.assert_awaited_once_with(77)
         cache.get_artist_details_lean.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# search — no-poison contract (LML#918)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchNoPoison:
+    """LML#918: a *degraded* Discogs ``search()`` (rate-limited/None, breaker
+    shed, or 5xx) must return ``None`` rather than a cacheable empty response —
+    otherwise ``@async_cached`` memoizes the transient failure for an hour and
+    a real album (a new rotation release) sticks as a false no-match. A genuine
+    200-with-zero-results is a real negative and stays a (cacheable) response.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["none_response", "breaker_shed", "server_error"])
+    async def test_degraded_search_returns_none(self, service, mode):
+        req = DiscogsSearchRequest(artist="Chuquimamani-Condori", album="DJ E")
+
+        if mode == "none_response":
+            # _request_with_retry exhausted retries / was rate-limited.
+            rr = AsyncMock(return_value=None)
+        elif mode == "breaker_shed":
+            rr = AsyncMock(side_effect=DiscogsBreakerOpenError("saturation shed"))
+        else:  # server_error: raise_for_status() raises inside _api_fetch
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock(
+                side_effect=httpx.HTTPStatusError("502", request=MagicMock(), response=MagicMock())
+            )
+            rr = AsyncMock(return_value=resp)
+
+        with patch.object(service, "_request_with_retry", rr):
+            result = await service.search(req)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_degraded_result_not_cached_and_recovers(self, service):
+        """Headline guarantee: the degraded result is not memoized, so the very
+        next call re-hits the API and recovers once Discogs returns."""
+        req = DiscogsSearchRequest(artist="Jessica Pratt", album="On Your Own Love Again")
+
+        good = MagicMock()
+        good.raise_for_status = MagicMock()
+        good.json.return_value = {
+            "results": [{"title": "Jessica Pratt - On Your Own Love Again", "id": 7, "thumb": ""}]
+        }
+        rr = AsyncMock(side_effect=[None, good])
+
+        with patch.object(service, "_request_with_retry", rr):
+            first = await service.search(req)
+            second = await service.search(req)
+
+        assert first is None
+        # Not cached → the second call had to hit the API again (would be 1 if poisoned).
+        assert rr.await_count == 2
+        assert second is not None
+        assert second.results and second.results[0].release_id == 7
+
+    @pytest.mark.asyncio
+    async def test_degraded_fuzzy_fallback_is_not_cached_and_recovers(self, service):
+        """When the strict leg returns 200-empty and the fuzzy ``q=`` leg
+        degrades (None), the whole search degrades to None — the strict empty
+        must NOT be cached, because the fuzzy leg is the one that resolves
+        non-library releases (the exact path this fix targets)."""
+        strict_empty = MagicMock()
+        strict_empty.raise_for_status = MagicMock()
+        strict_empty.json.return_value = {"results": []}
+
+        good = MagicMock()
+        good.raise_for_status = MagicMock()
+        good.json.return_value = {
+            "results": [{"title": "Boards of Canada - Inferno", "id": 9, "thumb": ""}]
+        }
+        # 1st search: strict 200-empty -> fuzzy None -> degrade. 2nd search: strict good.
+        rr = AsyncMock(side_effect=[strict_empty, None, good])
+
+        with patch.object(service, "_request_with_retry", rr):
+            first = await service.search(
+                DiscogsSearchRequest(artist="Boards of Canada", album="Inferno")
+            )
+            second = await service.search(
+                DiscogsSearchRequest(artist="Boards of Canada", album="Inferno")
+            )
+
+        assert first is None
+        # Both legs of call 1 (strict + fuzzy) plus the single strict leg of
+        # call 2 — proves the degraded empty was not cached (else count == 2).
+        assert rr.await_count == 3
+        assert second is not None
+        assert second.results and second.results[0].release_id == 9
+
+    @pytest.mark.asyncio
+    async def test_genuine_empty_is_still_a_response(self, service):
+        """A real 200-with-no-results is a legitimate negative — a response
+        (cacheable), not the degraded ``None``."""
+        empty = MagicMock()
+        empty.raise_for_status = MagicMock()
+        empty.json.return_value = {"results": []}
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=empty
+        ):
+            result = await service.search(
+                DiscogsSearchRequest(artist="Nonexistent Act", album="No Such Album")
+            )
+
+        assert result is not None
+        assert result.results == []

--- a/tests/unit/test_library_miss_discogs.py
+++ b/tests/unit/test_library_miss_discogs.py
@@ -1377,3 +1377,46 @@ class TestVaRescueWiring:
             discogs_service=mock_discogs_service,
         )
         assert result is None
+
+
+class TestLibraryMissNoPoison:
+    """LML#918: under the no-poison contract ``discogs_service.search()`` can
+    now return ``None`` on a degraded/shed/5xx Discogs call (instead of a
+    cacheable empty). The library-miss probe must treat ``None`` exactly like
+    an empty result — no crash — on both the primary and the LML#784 skip_pg
+    retry."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_primary_search_returns_none(self, mock_discogs_service):
+        mock_discogs_service.search.return_value = None
+        result = await _library_miss_discogs_search(
+            _parsed("My New Band Believe", "My New Band Believe"),
+            discogs_service=mock_discogs_service,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_skip_pg_retry_returning_none_does_not_crash(
+        self, mock_discogs_service, monkeypatch
+    ):
+        """PG-served candidates that all floor-fail trigger the skip_pg retry;
+        if that retry degrades to ``None``, the caller must not raise on
+        ``retry.results`` — it keeps the PG-served candidates and returns None
+        once nothing clears."""
+        floor_fail = make_discogs_result(
+            release_id=1, artist="Totally Unrelated Act", album="Nothing Alike"
+        )
+        primary = DiscogsSearchResponse(results=[floor_fail], pg_served=True)
+        # primary floor-fails (pg_served) → skip_pg retry fires → retry degrades to None.
+        mock_discogs_service.search.side_effect = [primary, None]
+        # Neutralize the category-2 VA rescue so the assertion isolates the None guard.
+        monkeypatch.setattr(
+            "lookup.strategies.library_miss.find_va_comp_match",
+            AsyncMock(return_value=None),
+        )
+        result = await _library_miss_discogs_search(
+            _parsed("My New Band Believe", "My New Band Believe"),
+            discogs_service=mock_discogs_service,
+        )
+        assert result is None
+        assert mock_discogs_service.search.call_count == 2


### PR DESCRIPTION
Part of the rotation / new-release metadata epic WXYC/Backend-Service#1810 (workstream **W1**). Independent — ships first.

## Problem

`DiscogsService.search()` returned a non-`None` empty `DiscogsSearchResponse` on every degraded path — rate-limited/`None`, saturation-breaker shed, or 5xx — which `@async_cached` then memoized for the full `discogs_search_cache_ttl` (1h). A transient Discogs blip therefore stuck as a **false no-match per worker** even after Discogs recovered, turning real albums into hour-long blanks. This is most visible for new rotation releases: they're absent from the library-filtered discogs-cache, so they depend entirely on the live `search()` call. Unlike `search_releases_by_track` / `get_release`, `search()` laundered the shed/error into a non-`None` empty *inside* `_api_fetch`, so the breaker's no-poison guarantee never covered it.

## Fix

`search()` now returns `DiscogsSearchResponse | None` and returns `None` on the three degraded paths, so the decorator's existing "None results are not cached" contract skips them and the next call retries. A genuine 200-with-no-results stays a real, cacheable (empty) response — only transient failures stop being cached.

Every non-`search_*` caller now treats `None` **exactly like the previous empty response**, so local behavior is unchanged and only the erroneous caching is removed:
- `lookup/artwork.py`, `lookup/validation.py`, `discogs/lookup.py`
- `lookup/strategies/library_miss.py` — incl. the LML#784 `skip_pg` retry (the one genuinely-new crash path: `if retry.results` → guarded)
- `scripts/measure_artwork_match_floor.py`, `scripts/benchmark_cache.py`

## Testing

- New `TestSearchNoPoison`: degraded (None-response / breaker shed / 5xx) → `None`; degraded result is **not cached and recovers** on the next call; a genuine empty stays a response.
- New `TestLibraryMissNoPoison`: primary `None` handled gracefully; the `skip_pg` retry returning `None` no longer raises.
- Full unit suite (4159 passed), `mypy . --ignore-missing-imports` (clean, 465 files), `ruff check`/`format` clean.

Closes #918
