### PR TITLE
fix(#747): multi-worker-safe boot-fetch atomic write (unique temp per writer)

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -186,11 +187,23 @@ _BOOT_FETCH_DEADLINE_SECONDS = 60.0
 
 
 def _atomic_write_bytes(dest: Path, data: bytes) -> None:
-    """Write ``data`` to ``dest`` via a temp file + ``os.replace`` (no torn reads)."""
+    """Write ``data`` to ``dest`` via a unique temp file + ``os.replace`` (no torn reads).
+
+    Safe under concurrent writers to the same ``dest`` (LML#747): each call lands
+    the bytes in a distinct ``mkstemp`` file in ``dest``'s directory, so N uvicorn
+    workers boot-fetching ``library.db`` in parallel never share one temp path.
+    The pre-fix fixed name (``dest + ".boot.tmp"``) let one worker's ``os.replace``
+    consume the temp out from under another, whose ``os.replace`` then raised
+    ``FileNotFoundError`` — fatal to a uvicorn child, crash-looping the process
+    group (observed on the ``UVICORN_WORKERS=3`` staging soak). The temp shares
+    ``dest``'s directory so the replace stays a same-filesystem atomic rename.
+    """
     dest.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dest.with_name(dest.name + ".boot.tmp")
+    fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=dest.name + ".", suffix=".boot.tmp")
+    tmp = Path(tmp_name)
     try:
-        tmp.write_bytes(data)
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
         os.replace(tmp, dest)
     except BaseException:
         tmp.unlink(missing_ok=True)

--- a/main.py
+++ b/main.py
@@ -197,16 +197,29 @@ def _atomic_write_bytes(dest: Path, data: bytes) -> None:
     ``FileNotFoundError`` — fatal to a uvicorn child, crash-looping the process
     group (observed on the ``UVICORN_WORKERS=3`` staging soak). The temp shares
     ``dest``'s directory so the replace stays a same-filesystem atomic rename.
+
+    ``mkstemp`` creates its temp 0600; we ``chmod`` it back to the umask-022
+    default (0644) the pre-fix ``Path.write_bytes`` produced, so ``dest``'s mode
+    is unchanged. The temp fd/file are created inside the ``try`` and tracked so
+    any failure — including one raised by ``os.fdopen`` before it takes ownership
+    of the descriptor — closes the fd and unlinks the temp rather than leaking it.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=dest.name + ".", suffix=".boot.tmp")
-    tmp = Path(tmp_name)
+    fd: int | None = None
+    tmp: Path | None = None
     try:
+        fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=dest.name + ".", suffix=".boot.tmp")
+        tmp = Path(tmp_name)
         with os.fdopen(fd, "wb") as f:
+            fd = None  # fdopen owns the descriptor now; the ``with`` closes it
             f.write(data)
+        os.chmod(tmp, 0o644)
         os.replace(tmp, dest)
     except BaseException:
-        tmp.unlink(missing_ok=True)
+        if fd is not None:
+            os.close(fd)
+        if tmp is not None:
+            tmp.unlink(missing_ok=True)
         raise
 
 

--- a/tests/unit/test_main_boot_fetch.py
+++ b/tests/unit/test_main_boot_fetch.py
@@ -172,6 +172,51 @@ class TestBootFetchHelper:
         assert not settings.resolved_library_db_path.exists()
 
 
+class TestAtomicWriteConcurrency:
+    """LML#747: N uvicorn workers boot-fetch library.db in parallel, each calling
+    ``_atomic_write_bytes`` against the SAME dest. The pre-fix fixed temp name
+    (``dest + ".boot.tmp"``) made every worker share one temp path, so one
+    worker's ``os.replace`` consumed the temp out from under another — whose own
+    ``os.replace`` then raised ``FileNotFoundError``, and because uvicorn treats a
+    child that fails startup as fatal, the whole process group crash-looped
+    (observed on the staging ``UVICORN_WORKERS=3`` soak). Concurrent writers to
+    one dest must each use a distinct temp and all land the bytes atomically.
+    """
+
+    def test_concurrent_writers_do_not_collide(self, tmp_path):
+        import threading
+
+        from main import _atomic_write_bytes
+
+        dest = tmp_path / "library.db"
+        # Identical bytes across writers (every worker fetches the same object),
+        # long enough that the write/replace window is non-trivial.
+        payload = b"SQLite format 3\x00" + b"x" * (256 * 1024)
+        n = 16
+        barrier = threading.Barrier(n)
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+
+        def _writer() -> None:
+            barrier.wait()  # release all writers together to maximize overlap
+            try:
+                _atomic_write_bytes(dest, payload)
+            except BaseException as exc:  # noqa: BLE001 - collected for assertion
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=_writer) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent boot-fetch writers collided: {errors!r}"
+        assert dest.read_bytes() == payload  # atomic: never torn or partial
+        # No temp file leaks: dest is the only artifact in the directory.
+        assert list(tmp_path.iterdir()) == [dest]
+
+
 class TestLifespanWiring:
     @pytest.mark.asyncio
     async def test_bucket_mode_invokes_boot_fetch(self, tmp_path, monkeypatch):

--- a/tests/unit/test_main_boot_fetch.py
+++ b/tests/unit/test_main_boot_fetch.py
@@ -16,6 +16,8 @@ store tests use.
 from __future__ import annotations
 
 import asyncio
+import os
+import stat
 from unittest.mock import AsyncMock
 
 import boto3
@@ -215,6 +217,66 @@ class TestAtomicWriteConcurrency:
         assert dest.read_bytes() == payload  # atomic: never torn or partial
         # No temp file leaks: dest is the only artifact in the directory.
         assert list(tmp_path.iterdir()) == [dest]
+
+
+class TestAtomicWriteBytes:
+    """Single-writer behavior of ``_atomic_write_bytes`` (LML#933 review hardening)."""
+
+    def test_dest_keeps_default_mode_not_mkstemp_0600(self, tmp_path):
+        # ``tempfile.mkstemp`` creates its temp 0600; the pre-fix ``Path.write_bytes``
+        # produced the umask-022 default (0644). The destination mode must match the
+        # pre-fix behavior, not silently tighten to 0600.
+        from main import _atomic_write_bytes
+
+        dest = tmp_path / "library.db"
+        _atomic_write_bytes(dest, b"SQLite format 3\x00data")
+
+        assert dest.read_bytes() == b"SQLite format 3\x00data"
+        assert stat.S_IMODE(dest.stat().st_mode) == 0o644
+
+    def test_replace_failure_leaves_no_temp_and_no_dest(self, tmp_path, monkeypatch):
+        # A failure after the temp exists (here: ``os.replace`` raising) must unlink
+        # the unique temp rather than leak it, and must not create ``dest``.
+        from main import _atomic_write_bytes
+
+        dest = tmp_path / "library.db"
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(os, "replace", _boom)
+
+        with pytest.raises(OSError, match="simulated replace failure"):
+            _atomic_write_bytes(dest, b"payload")
+
+        assert not dest.exists()
+        assert list(tmp_path.iterdir()) == []  # temp cleaned up, nothing leaked
+
+    def test_fdopen_failure_closes_fd_and_removes_temp(self, tmp_path, monkeypatch):
+        # If ``os.fdopen`` raises before taking ownership of the mkstemp descriptor,
+        # the raw fd must still be closed (pre-fix it leaked) and the temp removed.
+        from main import _atomic_write_bytes
+
+        dest = tmp_path / "library.db"
+        closed: list[int] = []
+        real_close = os.close
+
+        def _recording_close(fd):
+            closed.append(fd)
+            real_close(fd)
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("simulated fdopen failure")
+
+        monkeypatch.setattr(os, "fdopen", _boom)
+        monkeypatch.setattr(os, "close", _recording_close)
+
+        with pytest.raises(OSError, match="simulated fdopen failure"):
+            _atomic_write_bytes(dest, b"payload")
+
+        assert closed, "raw mkstemp fd was leaked (never closed) on fdopen failure"
+        assert not dest.exists()
+        assert list(tmp_path.iterdir()) == []  # temp cleaned up, nothing leaked
 
 
 class TestLifespanWiring:


### PR DESCRIPTION
## Summary

`_atomic_write_bytes` (the `#837` boot-fetch atomic write) used a **fixed** temp filename shared by every worker — `dest.with_name(dest.name + ".boot.tmp")`. Under `UVICORN_WORKERS>1`, all workers boot-fetch `library.db` to that same path concurrently; one worker's `os.replace` renames the temp away, then another worker's `os.replace` hits a missing source and raises `FileNotFoundError`. uvicorn treats a child that fails startup as fatal and stops the parent, so the whole process group crash-loops under Railway's `restartPolicyType=ON_FAILURE`.

This was **observed directly** on a staging `UVICORN_WORKERS=3` soak (2026-07-26): the deploy flashed `SUCCESS` (one worker answered `/health` before the parent noticed the failed child), then the group exited.

```
File "/app/main.py", line 194, in _atomic_write_bytes
    os.replace(tmp, dest)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/library.db.boot.tmp' -> '/tmp/library.db'
ERROR:    Child process [6] failed to start, stopping the parent process.
```

## Fix

Each writer now lands its bytes in a **distinct** `tempfile.mkstemp` file in `dest`'s own directory (same filesystem → the `os.replace` stays an atomic rename), and only unlinks its unique temp on the failure path. Because all workers fetch identical bytes, whichever `os.replace` lands last leaves `dest` correct. No behavior change at `UVICORN_WORKERS=1`; the non-fatal degrade semantics of `_boot_fetch_library_db` are untouched.

## Test (TDD)

Adds `TestAtomicWriteConcurrency::test_concurrent_writers_do_not_collide` — 16 barrier-synchronized threads write the same `dest`. **Red:** 15/16 raise `FileNotFoundError` on the shared-path version. **Green:** all succeed, `dest` is byte-exact, no temp leaks. 5/5 non-flaky.

## Verification

- `ruff check .` / `ruff format --check .` clean repo-wide
- `mypy main.py --ignore-missing-imports` clean
- Full non-infra suite: **4496 passed**, 1 skipped, 2 xfailed

## Context

This is a previously-unrecognized **fifth multi-worker prerequisite** for #747 — introduced by #837's boot-fetch after that issue's original three-prerequisite analysis, so the "ops-only, no code left" re-scope missed it. It **blocks** the #747 `UVICORN_WORKERS>1` rollout: without it, a bare `UVICORN_WORKERS=N` (N>1) cannot boot. Staging has been reverted to `UVICORN_WORKERS=1` (healthy) pending this merge → staging deploy → re-attempt.

Closes #932

## Related

- WXYC/library-metadata-lookup#747 — multi-worker rollout this unblocks
- WXYC/library-metadata-lookup#837 — introduced the shared temp path
- WXYC/library-metadata-lookup#834 — volume-eviction epic
