### PR TITLE
fix(#934): split racy fast-refill assertion out of test_tokens_refill_over_time

### DIFF
--- a/tests/integration/test_discogs_rate_bucket.py
+++ b/tests/integration/test_discogs_rate_bucket.py
@@ -130,11 +130,31 @@ async def test_burst_exhausts_then_denies_with_retry_after(pg_source, bucket_key
     assert denied.retry_after_s > 0.0
 
 
-async def test_tokens_refill_over_time(pg_source, bucket_key):
-    # Fast refill (100/s => a token every 10ms), capacity 1.
-    bucket = await _seed(pg_source, bucket_key, capacity=1, refill=100.0)
+async def test_stays_drained_immediately_after_burst(pg_source, bucket_key):
+    """No meaningful refill happens between two back-to-back acquires.
+
+    Uses ``_TINY_REFILL`` (like the concurrency tests below) so the "still
+    drained" claim never races the wall clock against real PG round-trip
+    latency -- see ``test_tokens_refill_over_time`` for the fast-refill,
+    accrual-over-a-real-sleep counterpart.
+    """
+    bucket = await _seed(pg_source, bucket_key, capacity=1, refill=_TINY_REFILL)
     assert (await bucket.try_acquire()).allowed is True
     assert (await bucket.try_acquire()).allowed is False  # drained
+
+
+async def test_tokens_refill_over_time(pg_source, bucket_key):
+    """A token becomes available again once enough wall-clock time has passed.
+
+    Fast refill (100/s => a token every 10ms), capacity 1. Deliberately does
+    NOT assert "still drained immediately after draining" -- with a 10ms
+    token width, two real PG round-trips (``try_acquire`` is a `FOR UPDATE`
+    select + update) can exceed that window under CI load, so that assertion
+    is racy against the fast refill rate (LML#934). The 50ms sleep here is
+    far larger than any round-trip jitter, so it stays deterministic.
+    """
+    bucket = await _seed(pg_source, bucket_key, capacity=1, refill=100.0)
+    assert (await bucket.try_acquire()).allowed is True  # drains the seeded token
     await asyncio.sleep(0.05)  # 0.05 * 100 = 5 tokens accrue, capped at capacity 1
     assert (await bucket.try_acquire()).allowed is True
 


### PR DESCRIPTION
## Summary
- `test_tokens_refill_over_time` seeded a 100/s refill (a token every 10ms) and asserted the bucket was still drained immediately after draining it — but that only holds if two real PG round-trips (`try_acquire` is a `FOR UPDATE` select + update) complete inside a 10ms window. Under CI load the gap can exceed 10ms, a token refills, and `assert True is False` flakes.
- Split the "stays drained" claim into its own test seeded with `_TINY_REFILL`, matching the pattern `test_concurrent_acquires_never_over_issue` / `test_two_instances_share_one_row` already use to avoid this timing coupling.
- `test_tokens_refill_over_time` keeps a real accrual-over-a-sleep assertion (drain → sleep 50ms → acquire succeeds) but no longer depends on inter-round-trip wall-clock timing.
- Test-only change; `PgTokenBucket` production code is untouched.

## Test plan
- [x] `DATABASE_URL_TEST=... uv run pytest -v -m pg tests/integration/test_discogs_rate_bucket.py` — 10 passed
- [x] Ran the pg-marked pair 20x back-to-back with no flakes
- [x] Reproduced the original flake mechanism directly against `PgTokenBucket` (inserted a 15ms gap between two `try_acquire` calls on a `refill=100.0` bucket → second call returned `allowed=True`, confirming the diagnosis and that the new test structure no longer makes that assertion)
- [x] `uv run pytest -q -m pg` — full pg suite green (524 passed, 9 skipped)
- [x] `uv run pytest -q` — full default suite green (4499 passed, 1 skipped, 2 xfailed)
- [x] `ruff check` / `ruff format --check` — clean

Closes #934