### PR TITLE
Fine-grained /lookup Server-Timing: queue_wait, event_loop_lag, lml_wall

### DIFF
--- a/core/server_timing_middleware.py
+++ b/core/server_timing_middleware.py
@@ -1,0 +1,95 @@
+"""ASGI middleware surfacing the ``lml_wall`` Server-Timing leg (LML#907 follow-up).
+
+``RequestTelemetry`` (constructed inside the ``/lookup`` in-flight-cap permit —
+see ``lookup/router.py:handle_lookup``) only times the window between its own
+construction and ``as_server_timing()``: the pipeline itself. FastAPI's
+dependency injection, the Pydantic request deserialization, and the
+``LookupResponse`` JSON serialization all happen OUTSIDE that window, inside
+the ASGI ``call_next`` a middleware wraps — no ``track_step`` span nor the
+``queue_wait``/``discogs`` ``extra`` legs can see that time. A caller measuring
+its own wall-clock time for the whole HTTP round trip (request-o-matic's
+``lookup_service`` metric) then sees a residual the LML-side header cannot
+explain.
+
+This middleware times request-received -> response-ready around ``call_next``
+and APPENDS an ``lml_wall;dur=<ms>`` entry to whatever ``Server-Timing`` header
+the handler already produced — never overwrites it. ``lml_wall - total -
+queue_wait`` is then the honest LML-side estimate of DI + deserialization +
+serialization overhead outside the tracked pipeline.
+
+Scoped to the single-lookup path only (``/api/v1/lookup`` — see
+``_TIMED_PATH``): the endpoint the residual was measured against. Every other
+route (``/health``, ``/api/v1/lookup/bulk``, admin, etc.) passes through
+untouched at the cost of one path-string compare. Gated on the same
+``LML_EMIT_SERVER_TIMING`` kill switch ``lookup/router.py``'s
+``_emit_server_timing_header`` reads, so the two either both fire or both stay
+silent. Wrapped so a failure here can never break the response: observability
+must not break the request path, matching the posture of every other
+Server-Timing helper in this repo.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
+from fastapi import Request, Response
+
+from config.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+# The one route this middleware instruments today. A prefix/set could widen
+# later (e.g. to also cover ``/api/v1/lookup/bulk``), but the residual this
+# leg exists to explain was measured specifically against single ``/lookup``;
+# scoping narrowly keeps the per-request cost (one string compare) off every
+# other route, including the hot ``/health`` check uvicorn/Railway poll.
+_TIMED_PATH = "/api/v1/lookup"
+
+
+def _format_ms(value: float) -> str:
+    """Format a millisecond duration matching ``RequestTelemetry``'s own wire
+    format (two decimals, trailing zeros stripped, always fixed-point —
+    ``wxyc_fastapi.observability.telemetry._fmt_dur``). Duplicated rather than
+    imported: that helper is a private module function, and what matters here
+    is an identical *format*, not sharing the implementation.
+    """
+    return f"{value:.2f}".rstrip("0").rstrip(".")
+
+
+async def lml_wall_timing_middleware(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """Time request-received -> response-ready and append the ``lml_wall`` leg.
+
+    Registered via ``app.middleware("http")`` in ``main.py``, positioned so it
+    wraps only the routing/handler/serialization layer (see the registration
+    site's comment for the ordering rationale — it deliberately excludes the
+    sibling ``posthog_flush_middleware``'s synchronous flush from the timed
+    window, so ``lml_wall`` isn't inflated by unrelated middleware cost).
+
+    ``call_next`` itself is never wrapped in try/except: a genuine failure
+    inside routing must still propagate to Starlette's ``ServerErrorMiddleware``
+    for normal 500 handling. Only the instrumentation AFTER ``call_next``
+    returns (the settings read, the header append) is guarded, so this
+    middleware can neither turn a good response into a bad one nor mask a real
+    error behind a swallowed one.
+    """
+    if request.url.path != _TIMED_PATH:
+        return await call_next(request)
+
+    start = time.perf_counter()
+    response = await call_next(request)
+
+    try:
+        if not get_settings().lml_emit_server_timing:
+            return response
+        dur_ms = (time.perf_counter() - start) * 1000.0
+        entry = f"lml_wall;dur={_format_ms(dur_ms)}"
+        existing = response.headers.get("Server-Timing")
+        response.headers["Server-Timing"] = f"{existing}, {entry}" if existing else entry
+    except Exception as e:
+        logger.warning("Failed to append lml_wall Server-Timing leg: %s", e)
+
+    return response

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -62,6 +62,7 @@ from lookup.models import (
 )
 from lookup.orchestrator import perform_lookup
 from lookup.rowless import NONLIBRARY_RELEASE_SURFACED_STAT_KEY
+from lookup.server_timing_legs import EVENT_LOOP_LAG_STAT_KEY, event_loop_lag_extra_leg
 from lookup.streaming_url_postprocess import set_suppress_streaming_warm
 from streaming.dependencies import (
     get_apple_music_client,
@@ -220,15 +221,6 @@ def _project_inflight_capped(wait_ms: float) -> None:
 # Settings field names so the dimension is self-describing.
 LML_RESOLVE_NONLIBRARY_RELEASE_STAT_KEY = "lml_resolve_nonlibrary_release"
 LML_RESOLVE_COMPILATION_RELEASE_STAT_KEY = "lml_resolve_compilation_release"
-
-# LML#907 event-loop-lag gauge. The process-global sampler (core.event_loop_lag,
-# started in main.py lifespan) measures how long the single uvicorn worker's loop
-# takes to resume past a fixed sleep — the /lookup starvation tax
-# (plans/lookup-latency-event-loop-starvation.md §3) that no track_step or
-# Server-Timing leg can see. Stamped once per cache_stats context so it rides the
-# cache.* / lml.cache.* projection to PostHog + Sentry as a per-request sample of
-# the process-global gauge.
-EVENT_LOOP_LAG_STAT_KEY = "event_loop_lag_ms"
 
 _LML_CACHE_STATS_EXTRA_KEYS: tuple[str, ...] = (
     "memory_cache_inflight_join",
@@ -534,9 +526,13 @@ async def handle_lookup(
             permit_held = True
             # Stop watching for disconnect; the permit-held phase is not reaped.
             await cancel_and_drain(sentinel_task)
+            # `queue_wait` Server-Timing leg (LML#907 follow-up): always
+            # computed (0.0 when uncontended) so it always renders via `extra`
+            # below; `total` (built after this point) never includes it.
+            queue_wait_ms = 0.0
             if capped_on_arrival:
-                wait_ms = (time.perf_counter() - wait_start) * 1000.0
-                _project_inflight_capped(wait_ms)
+                queue_wait_ms = (time.perf_counter() - wait_start) * 1000.0
+                _project_inflight_capped(queue_wait_ms)
                 # Debit the queue wait from the caller's budget so the A8 /
                 # LML#345 contract ("LML returns slightly before the caller
                 # times out") holds under saturation — the pipeline's budget
@@ -547,7 +543,7 @@ async def handle_lookup(
                 # almost immediately — the cheap outcome the (likely already
                 # timed-out) caller would want.
                 if x_caller_budget_ms is not None and x_caller_budget_ms > 0:
-                    x_caller_budget_ms = max(1, x_caller_budget_ms - int(wait_ms))
+                    x_caller_budget_ms = max(1, x_caller_budget_ms - int(queue_wait_ms))
             # Constructed inside the permit so telemetry's total-duration
             # series keeps meaning "lookup work", not "queue wait + work" —
             # the wait is reported separately via the Sentry measurement.
@@ -593,7 +589,12 @@ async def handle_lookup(
         # to 0 rather than TypeError, mirroring the CacheStats guard above.
         pg_ms = stats.get("pg_time_ms", 0) if stats else 0
         api_ms = stats.get("api_time_ms", 0) if stats else 0
-        _emit_server_timing_header(http_response, telemetry, extra={"discogs": pg_ms + api_ms})
+        # `queue_wait` nets out of the middleware-timed `lml_wall` leg to
+        # isolate DI/(de)serialization overhead; `event_loop_lag` is omitted
+        # (not zeroed) when unsampled — see `lookup.server_timing_legs`.
+        extra: dict[str, float] = {"discogs": pg_ms + api_ms, "queue_wait": queue_wait_ms}
+        extra.update(event_loop_lag_extra_leg(stats))
+        _emit_server_timing_header(http_response, telemetry, extra=extra)
 
         # Send telemetry
         if posthog_client:

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -593,7 +593,7 @@ async def handle_lookup(
         # isolate DI/(de)serialization overhead; `event_loop_lag` is omitted
         # (not zeroed) when unsampled — see `lookup.server_timing_legs`.
         extra: dict[str, float] = {"discogs": pg_ms + api_ms, "queue_wait": queue_wait_ms}
-        extra.update(event_loop_lag_extra_leg(stats))
+        extra.update(event_loop_lag_extra_leg())
         _emit_server_timing_header(http_response, telemetry, extra=extra)
 
         # Send telemetry

--- a/lookup/server_timing_legs.py
+++ b/lookup/server_timing_legs.py
@@ -1,0 +1,64 @@
+"""Server-Timing ``extra`` leg builders for ``/lookup`` (LML#907 fine-grained-
+timing follow-up).
+
+Split out of ``lookup/router.py`` to stay under its module-budget ceiling
+(LML#731 — see ``tests/unit/test_module_budgets.py``) rather than growing an
+already-at-ceiling file. Home for derived-leg builders that don't belong on
+``RequestTelemetry`` itself (that stays in ``wxyc_fastapi``, shared with
+request-o-matic) but are too fiddly to inline at the router's single call site
+— today just the event-loop-lag leg; the router's own ``discogs`` and
+``queue_wait`` legs stay inline since they're one-liners.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from config.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+# LML#907 event-loop-lag gauge. The process-global sampler (core.event_loop_lag,
+# started in main.py lifespan) measures how long the single uvicorn worker's loop
+# takes to resume past a fixed sleep — the /lookup starvation tax
+# (plans/lookup-latency-event-loop-starvation.md §3) that no track_step or
+# Server-Timing leg can see. Stamped once per cache_stats context so it rides the
+# cache.* / lml.cache.* projection to PostHog + Sentry as a per-request sample of
+# the process-global gauge.
+EVENT_LOOP_LAG_STAT_KEY = "event_loop_lag_ms"
+
+
+def event_loop_lag_extra_leg(stats: dict | None) -> dict[str, float]:
+    """Build the ``event_loop_lag`` Server-Timing ``extra`` leg, if any.
+
+    Surfaces the LML#907 gauge sample that ``lookup.router._record_event_loop_lag``
+    already stamped onto ``cache_stats`` (``EVENT_LOOP_LAG_STAT_KEY``) as a
+    per-request Server-Timing entry, so a reader can see loop starvation on the
+    SAME request whose wall time it inflated, not only in the aggregated
+    PostHog/Sentry series.
+
+    Mirrors ``_record_event_loop_lag``'s own gate rather than trusting the
+    ``cache_stats`` value alone: ``init_cache_stats`` seeds the key to ``0`` for
+    every request (a shape guarantee), so "the gauge is off" and "the gauge
+    measured ~0 lag" are indistinguishable from the stats value by itself.
+    Reading the same ``lml_event_loop_lag_gauge`` setting the recorder reads
+    keeps the two in lockstep: disabled or unsampled (first ~interval of
+    process life, or the kill switch off) degrades to an OMITTED leg, never a
+    misleading zero.
+
+    Observability must not break the request path: any exception (a settings
+    read, a malformed stats value) degrades to "leg omitted", matching
+    ``lookup.router._emit_server_timing_header``'s own failure posture.
+    """
+    try:
+        if not get_settings().lml_event_loop_lag_gauge:
+            return {}
+        if not stats or EVENT_LOOP_LAG_STAT_KEY not in stats:
+            return {}
+        value = stats[EVENT_LOOP_LAG_STAT_KEY]
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            return {}
+        return {"event_loop_lag": float(value)}
+    except Exception as e:
+        logger.warning("Failed to build event_loop_lag Server-Timing leg: %s", e)
+        return {}

--- a/lookup/server_timing_legs.py
+++ b/lookup/server_timing_legs.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 
 from config.settings import get_settings
+from core.event_loop_lag import get_event_loop_lag_ms
 
 logger = logging.getLogger(__name__)
 
@@ -28,37 +29,35 @@ logger = logging.getLogger(__name__)
 EVENT_LOOP_LAG_STAT_KEY = "event_loop_lag_ms"
 
 
-def event_loop_lag_extra_leg(stats: dict | None) -> dict[str, float]:
+def event_loop_lag_extra_leg() -> dict[str, float]:
     """Build the ``event_loop_lag`` Server-Timing ``extra`` leg, if any.
 
-    Surfaces the LML#907 gauge sample that ``lookup.router._record_event_loop_lag``
-    already stamped onto ``cache_stats`` (``EVENT_LOOP_LAG_STAT_KEY``) as a
-    per-request Server-Timing entry, so a reader can see loop starvation on the
-    SAME request whose wall time it inflated, not only in the aggregated
-    PostHog/Sentry series.
+    Surfaces the LML#907 gauge as a per-request Server-Timing entry, so a reader
+    can see loop starvation on the SAME request whose wall time it inflated, not
+    only in the aggregated PostHog/Sentry series.
 
-    Mirrors ``_record_event_loop_lag``'s own gate rather than trusting the
-    ``cache_stats`` value alone: ``init_cache_stats`` seeds the key to ``0`` for
-    every request (a shape guarantee), so "the gauge is off" and "the gauge
-    measured ~0 lag" are indistinguishable from the stats value by itself.
-    Reading the same ``lml_event_loop_lag_gauge`` setting the recorder reads
-    keeps the two in lockstep: disabled or unsampled (first ~interval of
-    process life, or the kill switch off) degrades to an OMITTED leg, never a
-    misleading zero.
+    Reads the process-global gauge directly (``get_event_loop_lag_ms``) — the
+    SAME source ``lookup.router._record_event_loop_lag`` samples — rather than
+    the ``cache_stats`` value. ``init_cache_stats`` seeds ``event_loop_lag_ms``
+    to ``0`` for every request (a shape guarantee), so an enabled-but-unsampled
+    gauge (the first ~interval of process life, right after a redeploy) would
+    leave that seeded ``0`` and leak a misleading ``event_loop_lag;dur=0``
+    exactly when starvation matters most. Gating on the gauge's own ``None``
+    return — the same signal the recorder gates on — keeps the two in lockstep:
+    the kill switch off, or an unsampled gauge, degrades to an OMITTED leg,
+    never a zero.
 
     Observability must not break the request path: any exception (a settings
-    read, a malformed stats value) degrades to "leg omitted", matching
+    read, a gauge read) degrades to "leg omitted", matching
     ``lookup.router._emit_server_timing_header``'s own failure posture.
     """
     try:
         if not get_settings().lml_event_loop_lag_gauge:
             return {}
-        if not stats or EVENT_LOOP_LAG_STAT_KEY not in stats:
+        lag_ms = get_event_loop_lag_ms()
+        if lag_ms is None:
             return {}
-        value = stats[EVENT_LOOP_LAG_STAT_KEY]
-        if not isinstance(value, (int, float)) or isinstance(value, bool):
-            return {}
-        return {"event_loop_lag": float(value)}
+        return {"event_loop_lag": float(lag_ms)}
     except Exception as e:
         logger.warning("Failed to build event_loop_lag Server-Timing leg: %s", e)
         return {}

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from core.dependencies import (
 )
 from core.event_loop_lag import start_sampler, stop_sampler
 from core.logging import setup_logging
+from core.server_timing_middleware import lml_wall_timing_middleware
 from discogs.router import router as discogs_router
 from identity.dependencies import close_entity_store
 from identity.router import api_v1_router as identity_api_v1_router
@@ -492,6 +493,16 @@ app.add_middleware(
     allow_methods=["GET", "POST"],
     allow_headers=["Content-Type"],
 )
+
+# Registered BEFORE `posthog_flush_middleware` below deliberately — Starlette's
+# `add_middleware`/`@app.middleware("http")` prepend to the user-middleware
+# list, so the LAST one registered ends up OUTERMOST (it sees the request
+# first and the response last). Registering the wall-clock timer first makes
+# it the INNER of the two: `posthog_flush_middleware`'s synchronous
+# `flush_posthog()` call then runs OUTSIDE the timed window, so it can't
+# inflate the `lml_wall` Server-Timing leg with unrelated middleware cost. See
+# `core/server_timing_middleware.py` for what the leg measures and why.
+app.middleware("http")(lml_wall_timing_middleware)
 
 
 @app.middleware("http")

--- a/tests/unit/test_lookup_inflight_cap.py
+++ b/tests/unit/test_lookup_inflight_cap.py
@@ -53,6 +53,28 @@ LOOKUP_BODY = {
 }
 
 
+def _parse_server_timing(value: str) -> dict[str, float | None]:
+    """Parse a ``Server-Timing`` header value into ``{name: dur_ms}``.
+
+    Local copy of the helper in ``tests/unit/test_lookup_router.py`` — small
+    enough (and this repo's tests don't import fixtures across test modules)
+    that duplicating it here is simpler than adding cross-file coupling.
+    """
+    parsed: dict[str, float | None] = {}
+    for entry in value.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        name, _, params = entry.partition(";")
+        dur: float | None = None
+        for param in params.split(";"):
+            param = param.strip()
+            if param.startswith("dur="):
+                dur = float(param[len("dur=") :])
+        parsed[name.strip()] = dur
+    return parsed
+
+
 async def _wait_until(predicate, *, timeout_s: float = 5.0, message: str = "condition"):
     """Poll ``predicate`` on the loop until true, failing loudly at the deadline.
 
@@ -522,6 +544,82 @@ class TestInFlightCapObservability:
             c.args[0] == "lml.lookup.inflight_wait_ms"
             for c in transaction.set_measurement.call_args_list
         )
+
+
+class TestQueueWaitServerTimingLeg:
+    """The ``queue_wait`` Server-Timing leg (LML#907 fine-grained-timing
+    follow-up) must render on EVERY response — 0 on the uncontended path, the
+    actual measured wait on a capped one — mirroring the Sentry
+    ``lml.lookup.inflight_wait_ms`` measurement above but surfaced in-band on
+    the response itself. Reuses the cap=1 gating pattern from
+    ``TestCallerBudgetDeduction``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_capped_request_queue_wait_leg_reflects_measured_wait(
+        self, app_client, monkeypatch
+    ):
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "1")
+
+        gate = asyncio.Event()
+        started = 0
+
+        async def gated_lookup(request, **kwargs):
+            nonlocal started
+            started += 1
+            if started == 1:
+                await gate.wait()
+            return _empty_response()
+
+        with patch(
+            "lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=gated_lookup
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                first = asyncio.create_task(ac.post("/api/v1/lookup", json=LOOKUP_BODY))
+                await _wait_until(lambda: started >= 1, message="first lookup to start")
+                second = asyncio.create_task(ac.post("/api/v1/lookup", json=LOOKUP_BODY))
+                # Deterministic parking, then accrue >=50ms of measured queue
+                # wait before releasing (same pattern as
+                # TestCallerBudgetDeduction's capped-deduction test).
+                await _wait_until(
+                    _lookup_semaphore_has_waiters, message="second request to park on the cap"
+                )
+                await asyncio.sleep(0.05)
+                gate.set()
+                first_resp, second_resp = await asyncio.gather(first, second)
+
+        assert first_resp.status_code == 200
+        assert second_resp.status_code == 200
+
+        first_parsed = _parse_server_timing(first_resp.headers["Server-Timing"])
+        second_parsed = _parse_server_timing(second_resp.headers["Server-Timing"])
+
+        # The permit-holder never queued: its leg is exactly 0, not absent.
+        assert first_parsed.get("queue_wait") == 0
+        # The parked request accrued >=50ms of real wait; allow a little
+        # scheduling slack (>=40ms) the way the budget-deduction test does.
+        assert second_parsed.get("queue_wait") is not None
+        assert second_parsed["queue_wait"] >= 40
+
+    @pytest.mark.asyncio
+    async def test_uncontended_request_queue_wait_leg_is_zero(self, app_client, monkeypatch):
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "8")
+
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_empty_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        parsed = _parse_server_timing(resp.headers["Server-Timing"])
+        assert parsed.get("queue_wait") == 0
 
 
 class TestInFlightCapClientAbort:

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -658,7 +658,10 @@ class TestHandleLookup:
     @pytest.mark.asyncio
     async def test_server_timing_header_absent_when_flag_off(self, app_client, mock_settings):
         """With LML_EMIT_SERVER_TIMING off, no header is emitted — the kill
-        switch is honored and the response is otherwise unchanged.
+        switch is honored and the response is otherwise unchanged. Both
+        Server-Timing writers read the flag independently (the router's own
+        legs AND the ``lml_wall`` middleware leg — see
+        ``core/server_timing_middleware.py``), so both must be pinned off here.
         """
         response = LookupResponse(results=[], search_type="direct")
         flag_off = mock_settings.model_copy(update={"lml_emit_server_timing": False})
@@ -666,6 +669,7 @@ class TestHandleLookup:
         with (
             patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
             patch("lookup.router.get_settings", return_value=flag_off),
+            patch("core.server_timing_middleware.get_settings", return_value=flag_off),
         ):
             mock_lookup.return_value = response
             async with AsyncClient(
@@ -735,6 +739,10 @@ class TestHandleLookup:
                 patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
                 patch("lookup.router.get_cache_stats", return_value=stats),
                 patch("lookup.router.get_settings", return_value=get_settings_return),
+                patch(
+                    "core.server_timing_middleware.get_settings",
+                    return_value=get_settings_return,
+                ),
             ):
                 mock_lookup.return_value = response
                 async with AsyncClient(
@@ -798,8 +806,12 @@ class TestHandleLookup:
 
     @pytest.mark.asyncio
     async def test_server_timing_failure_does_not_break_request(self, app_client):
-        """Observability must not break the request path: if the header build
-        raises, the request still returns 200 with no header.
+        """Observability must not break the request path: if the router's own
+        header build raises, the request still returns 200 and the router
+        contributes no legs. The ``lml_wall`` middleware leg is a SEPARATE,
+        independent measurement (it never touches ``RequestTelemetry``), so it
+        still renders — proving the router-side failure was swallowed rather
+        than corrupting the header outright.
         """
         response = LookupResponse(results=[], search_type="direct")
 
@@ -817,7 +829,8 @@ class TestHandleLookup:
                 resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
 
         assert resp.status_code == 200
-        assert "Server-Timing" not in resp.headers
+        parsed = _parse_server_timing(resp.headers["Server-Timing"])
+        assert set(parsed) == {"lml_wall"}
 
     @pytest.mark.asyncio
     async def test_server_timing_wire_format_is_strict_parser_safe(
@@ -827,12 +840,19 @@ class TestHandleLookup:
         (request-o-matic's ``lookup`` CLI, the next PR in the trace). Drives the REAL
         orchestrator and asserts LML's own wiring end-to-end: every entry is
         ``name;dur=<plain-decimal>`` joined by ``", "`` (never scientific notation),
-        ``total`` appears exactly once and last, and the derived ``discogs`` leg sits
-        among the entries. Parsing into an ordered LIST (not a dict/set) is deliberate
-        so a double-``total`` regression — e.g. an accidental ``extra={"total": …}`` —
+        ``total`` appears exactly once, and the derived ``discogs`` leg sits among
+        the entries. Parsing into an ordered LIST (not a dict/set) is deliberate so
+        a double-``total`` regression — e.g. an accidental ``extra={"total": …}`` —
         is visible; that LML-side wiring the upstream ``as_server_timing`` unit tests
-        can't see. The flag is pinned on explicitly (``lookup.router.get_settings``, the
-        module global the helper reads) so the assertion never rides the ambient default.
+        can't see. The flag is pinned on explicitly for both Server-Timing writers
+        (``lookup.router.get_settings`` for the router's own legs,
+        ``core.server_timing_middleware.get_settings`` for the appended ``lml_wall``
+        leg) so the assertion never rides the ambient default.
+
+        ``lml_wall`` (the middleware-appended leg, see
+        ``core/server_timing_middleware.py``) is necessarily the LAST entry — it is
+        appended after the router has already finished building its own header — so
+        the router's own canonical ``total`` is second-to-last, not last.
         """
         import re
 
@@ -853,6 +873,7 @@ class TestHandleLookup:
                 },
             ),
             patch("lookup.router.get_settings", return_value=mock_settings),
+            patch("core.server_timing_middleware.get_settings", return_value=mock_settings),
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
@@ -872,9 +893,126 @@ class TestHandleLookup:
 
         names = [entry.split(";")[0] for entry in entries]
         assert names.count("total") == 1  # exactly one canonical total
-        assert names[-1] == "total"  # ...and it is last
+        assert names.count("lml_wall") == 1  # exactly one middleware-appended leg
+        assert names[-1] == "lml_wall"  # the middleware leg is appended last
+        assert names[-2] == "total"  # ...right after the router's own canonical total
         assert "discogs" in names  # the derived pg+api leg
+        assert "queue_wait" in names  # always-present LML#907 follow-up leg
         assert "library_search" in names  # a real track_step stage
+
+    @pytest.mark.asyncio
+    async def test_server_timing_queue_wait_present_and_zero_when_uncontended(self, app_client):
+        """``queue_wait`` (LML#907 fine-grained-timing follow-up) is always
+        present, not only when the in-flight cap was engaged. An uncontended
+        request (the default single-request `app_client` case) never queued,
+        so the leg must read exactly 0 — never absent.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup:
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        parsed = _parse_server_timing(resp.headers["Server-Timing"])
+        assert "queue_wait" in parsed
+        assert parsed["queue_wait"] == 0
+
+    @pytest.mark.asyncio
+    async def test_server_timing_event_loop_lag_present_when_gauge_yields_a_value(
+        self, app_client, mock_settings
+    ):
+        """When the LML#907 gauge has sampled a value, it rides the header as
+        ``event_loop_lag`` alongside the existing cache_stats projection. The
+        leg builder lives in ``lookup.server_timing_legs`` (split out to stay
+        under the router's module-budget ceiling), which imports its own
+        ``get_settings`` — pinned here alongside the router's, mirroring the
+        ``core.server_timing_middleware`` pattern above.
+        """
+        from lookup.router import EVENT_LOOP_LAG_STAT_KEY
+
+        response = LookupResponse(results=[], search_type="direct")
+        stats = {**_full_cache_stats(), EVENT_LOOP_LAG_STAT_KEY: 42.5}
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value=stats),
+            patch("lookup.router.get_settings", return_value=mock_settings),
+            patch("lookup.server_timing_legs.get_settings", return_value=mock_settings),
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        parsed = _parse_server_timing(resp.headers["Server-Timing"])
+        assert parsed.get("event_loop_lag") == pytest.approx(42.5)
+
+    @pytest.mark.asyncio
+    async def test_server_timing_event_loop_lag_omitted_when_gauge_disabled(
+        self, app_client, mock_settings
+    ):
+        """With ``lml_event_loop_lag_gauge`` off, the leg is OMITTED, never a
+        misleading zero — the sampled ``cache_stats`` value (present here to
+        prove the omission isn't just "value absent") must not leak through.
+        Both Server-Timing writers that read settings independently
+        (``lookup.router`` and ``lookup.server_timing_legs``) are pinned off.
+        """
+        from lookup.router import EVENT_LOOP_LAG_STAT_KEY
+
+        response = LookupResponse(results=[], search_type="direct")
+        stats = {**_full_cache_stats(), EVENT_LOOP_LAG_STAT_KEY: 42.5}
+        gauge_off = mock_settings.model_copy(update={"lml_event_loop_lag_gauge": False})
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value=stats),
+            patch("lookup.router.get_settings", return_value=gauge_off),
+            patch("lookup.server_timing_legs.get_settings", return_value=gauge_off),
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        parsed = _parse_server_timing(resp.headers["Server-Timing"])
+        assert "event_loop_lag" not in parsed
+        # The rest of the header is unaffected by the gate.
+        assert "discogs" in parsed
+        assert "total" in parsed
+
+    @pytest.mark.asyncio
+    async def test_server_timing_event_loop_lag_omitted_when_key_absent(
+        self, app_client, mock_settings
+    ):
+        """Defensive: an uninitialized/older cache_stats dict missing the LML#907
+        key degrades to omission rather than a KeyError -> 500.
+        """
+        response = LookupResponse(results=[], search_type="direct")
+        stats = _full_cache_stats()  # no EVENT_LOOP_LAG_STAT_KEY entry
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
+            patch("lookup.router.get_cache_stats", return_value=stats),
+            patch("lookup.router.get_settings", return_value=mock_settings),
+            patch("lookup.server_timing_legs.get_settings", return_value=mock_settings),
+        ):
+            mock_lookup.return_value = response
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.post("/api/v1/lookup", json=LOOKUP_BODY)
+
+        assert resp.status_code == 200
+        parsed = _parse_server_timing(resp.headers["Server-Timing"])
+        assert "event_loop_lag" not in parsed
 
     @pytest.mark.asyncio
     async def test_response_includes_call_number(self, app_client):

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -932,16 +932,20 @@ class TestHandleLookup:
         ``get_settings`` — pinned here alongside the router's, mirroring the
         ``core.server_timing_middleware`` pattern above.
         """
+        # Value comes from the process-global gauge (the same source the
+        # recorder reads), NOT the cache_stats dict — seed the stats key with a
+        # decoy 0.0 to prove the leg reflects the gauge, not the seeded value.
         from lookup.router import EVENT_LOOP_LAG_STAT_KEY
 
         response = LookupResponse(results=[], search_type="direct")
-        stats = {**_full_cache_stats(), EVENT_LOOP_LAG_STAT_KEY: 42.5}
+        stats = {**_full_cache_stats(), EVENT_LOOP_LAG_STAT_KEY: 0.0}
 
         with (
             patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
             patch("lookup.router.get_cache_stats", return_value=stats),
             patch("lookup.router.get_settings", return_value=mock_settings),
             patch("lookup.server_timing_legs.get_settings", return_value=mock_settings),
+            patch("lookup.server_timing_legs.get_event_loop_lag_ms", return_value=42.5),
         ):
             mock_lookup.return_value = response
             async with AsyncClient(
@@ -974,6 +978,7 @@ class TestHandleLookup:
             patch("lookup.router.get_cache_stats", return_value=stats),
             patch("lookup.router.get_settings", return_value=gauge_off),
             patch("lookup.server_timing_legs.get_settings", return_value=gauge_off),
+            patch("lookup.server_timing_legs.get_event_loop_lag_ms", return_value=42.5),
         ):
             mock_lookup.return_value = response
             async with AsyncClient(
@@ -989,20 +994,28 @@ class TestHandleLookup:
         assert "total" in parsed
 
     @pytest.mark.asyncio
-    async def test_server_timing_event_loop_lag_omitted_when_key_absent(
+    async def test_server_timing_event_loop_lag_omitted_when_gauge_unsampled(
         self, app_client, mock_settings
     ):
-        """Defensive: an uninitialized/older cache_stats dict missing the LML#907
-        key degrades to omission rather than a KeyError -> 500.
+        """Regression (review B#1): with the gauge ENABLED but unsampled (the
+        first ~interval of process life, right after a redeploy),
+        ``get_event_loop_lag_ms()`` returns ``None`` while ``init_cache_stats``
+        has already seeded ``event_loop_lag_ms`` to 0. The leg must be OMITTED,
+        not emitted as a misleading ``event_loop_lag;dur=0`` — the builder reads
+        the gauge, not the seeded stats value.
         """
+        from lookup.router import EVENT_LOOP_LAG_STAT_KEY
+
         response = LookupResponse(results=[], search_type="direct")
-        stats = _full_cache_stats()  # no EVENT_LOOP_LAG_STAT_KEY entry
+        # Production shape: init_cache_stats seeds the key to 0 on every request.
+        stats = {**_full_cache_stats(), EVENT_LOOP_LAG_STAT_KEY: 0.0}
 
         with (
             patch("lookup.router.perform_lookup", new_callable=AsyncMock) as mock_lookup,
             patch("lookup.router.get_cache_stats", return_value=stats),
             patch("lookup.router.get_settings", return_value=mock_settings),
             patch("lookup.server_timing_legs.get_settings", return_value=mock_settings),
+            patch("lookup.server_timing_legs.get_event_loop_lag_ms", return_value=None),
         ):
             mock_lookup.return_value = response
             async with AsyncClient(

--- a/tests/unit/test_module_budgets.py
+++ b/tests/unit/test_module_budgets.py
@@ -39,6 +39,7 @@ MODULE_BUDGETS: dict[str, int] = {
     "lookup/release_resolution.py": 550,
     "lookup/router.py": 950,
     "lookup/rowless.py": 450,
+    "lookup/server_timing_legs.py": 100,
     "lookup/spine_deadline.py": 250,
     "lookup/strategies/__init__.py": 150,
     "lookup/strategies/artist_plus_album.py": 300,

--- a/tests/unit/test_server_timing_middleware.py
+++ b/tests/unit/test_server_timing_middleware.py
@@ -1,0 +1,231 @@
+"""Unit tests for core/server_timing_middleware.py (LML#907 fine-grained-timing
+follow-up: the `lml_wall` Server-Timing leg).
+
+Exercises the middleware in isolation against a minimal FastAPI app rather than
+the full `main.app` — the router-level integration is covered by
+`test_lookup_router.py`'s `TestHandleLookup.test_server_timing_wire_format_is_
+strict_parser_safe` and `test_server_timing_failure_does_not_break_request`,
+which drive the real app end-to-end and assert `lml_wall` shows up alongside
+the router's own legs.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, Response
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import Settings
+from core.server_timing_middleware import lml_wall_timing_middleware
+
+_DUR_GRAMMAR = re.compile(r"^lml_wall;dur=\d+(?:\.\d+)?$")
+
+
+def _build_app(*, existing_header: str | None) -> FastAPI:
+    """A minimal app with the middleware installed and two routes:
+    ``/api/v1/lookup`` (the scoped path) and ``/health`` (an out-of-scope
+    control). Each route optionally pre-sets ``Server-Timing`` on the
+    ``Response`` it's handed, mimicking a handler that already emitted its own
+    header (or one that didn't, e.g. because ``LML_EMIT_SERVER_TIMING`` was off
+    or the build failed).
+    """
+    app = FastAPI()
+    app.middleware("http")(lml_wall_timing_middleware)
+
+    @app.get("/api/v1/lookup")
+    async def timed_route(response: Response):
+        if existing_header is not None:
+            response.headers["Server-Timing"] = existing_header
+        return {"ok": True}
+
+    @app.get("/health")
+    async def health_route(response: Response):
+        if existing_header is not None:
+            response.headers["Server-Timing"] = existing_header
+        return {"ok": True}
+
+    return app
+
+
+@pytest.fixture
+def settings_on() -> Settings:
+    return Settings(
+        discogs_token=None,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+        library_db_path="test_library.db",
+        lml_emit_server_timing=True,
+    )
+
+
+@pytest.fixture
+def settings_off(settings_on: Settings) -> Settings:
+    return settings_on.model_copy(update={"lml_emit_server_timing": False})
+
+
+class TestLmlWallTimingMiddleware:
+    @pytest.mark.asyncio
+    async def test_appends_lml_wall_without_clobbering_existing_legs(self, settings_on):
+        """The core contract (item 3): APPEND, never overwrite. The handler's
+        three legs must survive byte-for-byte, with ``lml_wall`` added after.
+        """
+        app = _build_app(existing_header="library_search;dur=12.34, discogs;dur=5, total;dur=20")
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/lookup")
+
+        assert resp.status_code == 200
+        entries = resp.headers["Server-Timing"].split(", ")
+        names = [e.split(";")[0] for e in entries]
+        assert names == ["library_search", "discogs", "total", "lml_wall"]
+        # The pre-existing legs are untouched, not just present-by-name.
+        assert entries[:3] == ["library_search;dur=12.34", "discogs;dur=5", "total;dur=20"]
+        assert _DUR_GRAMMAR.match(entries[3])
+
+    @pytest.mark.asyncio
+    async def test_creates_header_when_handler_emitted_none(self, settings_on):
+        """No existing header (flag was off for the handler, or its build
+        failed) still gets an ``lml_wall``-only header when the middleware's
+        own gate is on — the two writers are independently gated by design.
+        """
+        app = _build_app(existing_header=None)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/lookup")
+
+        assert resp.status_code == 200
+        assert resp.headers["Server-Timing"].split(";")[0] == "lml_wall"
+        assert _DUR_GRAMMAR.match(resp.headers["Server-Timing"])
+
+    @pytest.mark.asyncio
+    async def test_gated_off_leaves_existing_header_untouched(self, settings_off):
+        app = _build_app(existing_header="total;dur=20")
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_off):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/lookup")
+
+        assert resp.status_code == 200
+        assert resp.headers["Server-Timing"] == "total;dur=20"
+
+    @pytest.mark.asyncio
+    async def test_gated_off_with_no_existing_header_stays_absent(self, settings_off):
+        app = _build_app(existing_header=None)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_off):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/lookup")
+
+        assert resp.status_code == 200
+        assert "Server-Timing" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_non_lookup_path_is_untouched(self, settings_on):
+        """Scoped to `/api/v1/lookup` only — `/health` and everything else
+        passes through with zero interference, even with the flag on.
+        """
+        app = _build_app(existing_header="total;dur=1")
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/health")
+
+        assert resp.status_code == 200
+        assert resp.headers["Server-Timing"] == "total;dur=1"
+
+    @pytest.mark.asyncio
+    async def test_path_not_instrumented_when_handler_emits_nothing(self, settings_on):
+        """An out-of-scope path that never sets Server-Timing stays headerless
+        — the middleware must not manufacture a header outside its scope.
+        """
+        app = _build_app(existing_header=None)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/health")
+
+        assert resp.status_code == 200
+        assert "Server-Timing" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_settings_read_failure_does_not_break_response(self, settings_on):
+        """Observability must not break the request path: a raising
+        ``get_settings()`` degrades to 'no leg appended', not a 500, and the
+        handler's own header (out of this middleware's control) survives.
+        """
+        app = _build_app(existing_header="total;dur=1")
+
+        with patch("core.server_timing_middleware.get_settings", side_effect=RuntimeError("boom")):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/lookup")
+
+        assert resp.status_code == 200
+        assert resp.headers["Server-Timing"] == "total;dur=1"
+
+    @pytest.mark.asyncio
+    async def test_dur_formatting_matches_request_telemetry_grammar(self, settings_on):
+        """Two-decimal precision with trailing zeros stripped, always
+        fixed-point — the same wire format ``RequestTelemetry.as_server_timing``
+        uses (`wxyc_fastapi.observability.telemetry._fmt_dur`), so a strict
+        downstream parser sees one consistent grammar across every leg.
+        """
+        app = _build_app(existing_header=None)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/lookup")
+
+        entry = resp.headers["Server-Timing"]
+        assert _DUR_GRAMMAR.match(entry)
+        dur_str = entry.split("dur=")[1]
+        assert "e" not in dur_str.lower()  # never scientific notation
+        if "." in dur_str:
+            assert len(dur_str.split(".")[1]) <= 2
+
+    @pytest.mark.asyncio
+    async def test_call_next_exception_still_propagates(self, settings_on):
+        """A genuine failure inside routing must still surface — the
+        middleware only guards its OWN instrumentation (the settings read +
+        header append AFTER ``call_next`` returns), never the routing call
+        itself, so it must never swallow a real handler error into a silent
+        success. An unhandled (non-``HTTPException``) exception is Starlette's
+        own contract to re-raise past ``ServerErrorMiddleware`` after sending a
+        500 — asserting the raise (rather than inspecting a response object)
+        proves this middleware doesn't intercept and suppress it.
+        """
+        app = FastAPI()
+        app.middleware("http")(lml_wall_timing_middleware)
+
+        @app.get("/api/v1/lookup")
+        async def boom():
+            raise RuntimeError("handler exploded")
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                with pytest.raises(RuntimeError, match="handler exploded"):
+                    await client.get("/api/v1/lookup")


### PR DESCRIPTION
## What

Adds three finer-grained `Server-Timing` legs to `/lookup` to close the large untimed gap that sits OUTSIDE the pipeline spine (network / DI / request deserialization / response serialization / queue wait):

- `queue_wait` — in-flight-semaphore wait, always emitted (0.0 when uncontended).
- `event_loop_lag` — surfaces the LML#907 gauge as a per-request leg (reads the process-global gauge directly; omitted when unsampled).
- `lml_wall` — a middleware-timed request-received→response-ready leg (captures DI + deserialization + Pydantic response serialization), scoped to `/api/v1/lookup`.

Part of the enrichment-pipeline observability work (Epic G, WXYC/Backend-Service#881). Pairs with request-o-matic's `lml_total` forwarding.

## Notes

- Every new path is flag-gated (`lml_emit_server_timing` / `lml_event_loop_lag_gauge`) and try/except-wrapped; the middleware never wraps `call_next`, so a genuine handler/routing exception still propagates. No response body or status change.
- Post-review fix: `event_loop_lag` reads the gauge directly and omits on `None`, so it cannot leak the `init_cache_stats`-seeded `0` during the post-deploy unsampled window (it previously would have).
- Deferred to a follow-up: annotating the overlapping (cross-cutting) `discogs` leg with a `;desc` param — that needs a change to the shared `wxyc-fastapi` Server-Timing primitive, which request-o-matic also depends on.

## Test

4205 unit tests pass; `ruff` + `mypy` clean.
