### PR TITLE
Track streaming_status: the one untimed await in the lookup spine

### DIFF
--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -723,12 +723,14 @@ async def _step_populate_streaming_status(
     WRITES: no ``LookupState`` field is rebound.
     """
     if state.library_results and getattr(services.db, "_has_streaming_links", None) is True:
+        # Time only the awaited DB call; the sync fan-out below is not I/O and
+        # would otherwise inflate the streaming_status leg on large result sets.
         with services.telemetry.track_step("streaming_status"):
             streaming_status = await services.db.get_streaming_status(
                 [r.id for r in state.library_results]
             )
-            for result in state.library_results:
-                result.on_streaming = streaming_status.get(result.id, False)
+        for result in state.library_results:
+            result.on_streaming = streaming_status.get(result.id, False)
 
 
 async def _prefetch_release_overrides(

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -723,11 +723,12 @@ async def _step_populate_streaming_status(
     WRITES: no ``LookupState`` field is rebound.
     """
     if state.library_results and getattr(services.db, "_has_streaming_links", None) is True:
-        streaming_status = await services.db.get_streaming_status(
-            [r.id for r in state.library_results]
-        )
-        for result in state.library_results:
-            result.on_streaming = streaming_status.get(result.id, False)
+        with services.telemetry.track_step("streaming_status"):
+            streaming_status = await services.db.get_streaming_status(
+                [r.id for r in state.library_results]
+            )
+            for result in state.library_results:
+                result.on_streaming = streaming_status.get(result.id, False)
 
 
 async def _prefetch_release_overrides(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -374,6 +374,9 @@ class TestPerformLookupTelemetrySpans:
         assert response.results[0].library_item.id == stereolab_item.id
         assert telemetry.steps.get("streaming_status") is not None
         assert telemetry.steps["streaming_status"].success is True
+        # Narrowing the span to just the await must not drop the sync fan-out
+        # that sets on_streaming — lock the observable effect.
+        assert response.results[0].library_item.on_streaming is True
 
     @pytest.mark.asyncio
     async def test_streaming_status_step_not_tracked_when_no_streaming_links(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -338,6 +338,67 @@ class TestPerformLookupBasic:
 
 
 # ---------------------------------------------------------------------------
+# Tests: perform_lookup - intra-spine telemetry spans
+# ---------------------------------------------------------------------------
+
+
+class TestPerformLookupTelemetrySpans:
+    """Cover pipeline regions that run awaited work outside every existing
+    ``track_step`` span (the "intra-spine" gap between spans)."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_status_step_is_tracked(
+        self, mock_library_db, mock_discogs_service, telemetry, stereolab_item
+    ):
+        """Step 3c's ``get_streaming_status`` DB call is awaited work with no
+        span of its own — it must be tracked so the Server-Timing sum stops
+        losing that duration."""
+        mock_library_db.search.return_value = [stereolab_item]
+        mock_library_db._has_streaming_links = True
+        mock_library_db.get_streaming_status = AsyncMock(return_value={stereolab_item.id: True})
+        # Also exercised by enrichment's librarian-override lookup (item.py) once
+        # ``_has_streaming_links`` is True; None keeps it a no-op so this test
+        # stays focused on step 3c's own span.
+        mock_library_db.get_streaming_links = AsyncMock(return_value=None)
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Emperor Tomato Ketchup",
+            raw_message="Emperor Tomato Ketchup by Stereolab",
+        )
+
+        response = await perform_lookup(request, mock_library_db, mock_discogs_service, telemetry)
+
+        mock_library_db.get_streaming_status.assert_awaited_once_with([stereolab_item.id])
+        assert response.results[0].library_item.id == stereolab_item.id
+        assert telemetry.steps.get("streaming_status") is not None
+        assert telemetry.steps["streaming_status"].success is True
+
+    @pytest.mark.asyncio
+    async def test_streaming_status_step_not_tracked_when_no_streaming_links(
+        self, mock_library_db, mock_discogs_service, telemetry, stereolab_item
+    ):
+        """Sanity check on the negative: when the library has no streaming_links
+        table, step 3c does no awaited work, so no span should be recorded
+        (mirrors the existing gate at ``_step_populate_streaming_status``)."""
+        mock_library_db.search.return_value = [stereolab_item]
+        mock_library_db._has_streaming_links = False
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(results=[])
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Emperor Tomato Ketchup",
+            raw_message="Emperor Tomato Ketchup by Stereolab",
+        )
+
+        await perform_lookup(request, mock_library_db, mock_discogs_service, telemetry)
+
+        mock_library_db.get_streaming_status.assert_not_awaited()
+        assert "streaming_status" not in telemetry.steps
+
+
+# ---------------------------------------------------------------------------
 # Tests: perform_lookup - artist correction
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

An audit of `perform_lookup` found the pipeline spine is already almost fully instrumented — every `track_step` span wraps its awaited body — except Step 3c's `get_streaming_status` DB call, which ran with no span. This wraps that awaited call as a `streaming_status` span so the Server-Timing sub-span sum stops losing that duration.

Part of the enrichment-pipeline observability work (Epic G, WXYC/Backend-Service#881).

## Notes

- The span is strictly sequential with the existing spans — no nesting — which matters because the shared `RequestTelemetry` primitive uses a single flat `_step_start`.
- Post-review: the span wraps only the awaited call, not the synchronous `on_streaming` fan-out loop (which would inflate the leg on large result sets); the test now also asserts the `on_streaming` effect still lands.

## Test

4191 unit tests pass; `ruff` + `mypy` clean.
