### PR TITLE
Expose discogs_live_requests_total on /health

### DIFF
--- a/discogs/live_request_counter.py
+++ b/discogs/live_request_counter.py
@@ -1,0 +1,94 @@
+"""Process-global live-Discogs-request-attempt counter (LML#940).
+
+Exposes a read-only "is LML actively attempting live Discogs lookups right
+now" signal on ``GET /health`` as the top-level ``discogs_live_requests_total``
+field -- see ``routers/health.py`` and the field's documented semantics in
+``docs/deployment.md``.
+
+## Why this exists
+
+The wxyc-canary probes ``/health`` and reads the sibling ``discogs_breaker_state``
+field (LML#757) to detect a sustained Discogs-saturation shed. That signal has
+a known "idle tail" false positive (``docs/deployment.md``'s "Idle post-cooldown
+``open``" bullet): the breaker's ``open -> half-open`` recovery transition only
+advances inside ``DiscogsCircuitBreaker.allow_request()`` (``discogs/breaker.py``),
+which only the live ``/lookup`` path calls. Reading ``.state`` via ``/health``
+never advances the state machine, so after a genuine trip, if no live Discogs
+lookups follow (an overnight quiet window -- cache-hit library searches never
+reach the live leg), ``.state`` stays latched ``open`` even though the next
+real lookup would almost certainly recover it. A black-box canary that can
+only read ``/health`` cannot tell that idle tail apart from an active,
+ongoing shed.
+
+This counter closes that gap: a monotonic total of every live-Discogs request
+*attempt*, incremented at the sole ``allow_request()`` call site
+(``DiscogsService._request_with_retry``, ``discogs/service.py``) -- BEFORE the
+breaker's admit/shed decision, so a shed attempt counts too. A future canary
+iteration can diff this total across polls: a flat total during a sustained
+``open``/``half-open`` reading is the idle tail (no traffic -- don't page); a
+climbing one is a real shed under load (page).
+
+## Counting unit
+
+Live-Discogs *attempts*, not ``/lookup`` calls. Cache hits short-circuit in
+``discogs/fallthrough.py`` before ever reaching ``allow_request()``, so they
+correctly never increment this counter -- counting ``/lookup`` requests
+instead would show "traffic flowing" during a busy-cache / idle-Discogs
+window, exactly the idle-latched-open scenario this must NOT alarm on. One
+uncached ``/lookup`` fans out roughly five live Discogs calls, so this total
+runs well ahead of ``/lookup`` request volume.
+
+## Shape
+
+A plain process-global monotonic total (mirrors the process-global-primitive
+pattern in ``core/event_loop_lag.py`` -- module global + getter + a
+``reset_*`` for test isolation -- rather than the per-event-loop dict in
+``discogs/ratelimit.py``: this counts a fact about the process, not about the
+currently running loop, so a single global is correct and simpler). Resets to
+0 only on process restart. No lock: the increment is a single ``+= 1`` on the
+event loop, mutated only between ``await`` points under asyncio's cooperative
+scheduling (same rationale as ``discogs/breaker.py``'s lock-free note).
+
+Single-worker scope today, same caveat as the breaker and the loop-lag gauge:
+if ``UVICORN_WORKERS > 1`` ever ships (LML#747), this becomes a per-worker
+total, not a service-wide one.
+"""
+
+from __future__ import annotations
+
+_discogs_live_requests_total: int = 0
+
+
+def increment_discogs_live_requests_total() -> None:
+    """Record one live-Discogs request attempt (admitted or breaker-shed).
+
+    Called once per pass through ``DiscogsService._request_with_retry``, at
+    the ``breaker.allow_request()`` call site -- before the admit/shed
+    decision, so a shed attempt still counts. This is the whole point: during
+    a real sustained shed the breaker sheds almost everything, so if sheds
+    didn't count, the total would flatline during exactly the incident this
+    field exists to distinguish from the wxyc-canary idle-tail false positive.
+    Cache hits never reach this call site, so they are correctly excluded.
+    """
+    global _discogs_live_requests_total
+    _discogs_live_requests_total += 1
+
+
+def get_discogs_live_requests_total() -> int:
+    """Return the process-global live-Discogs-attempt total.
+
+    Monotonic for the life of the process; resets to 0 only on restart (or via
+    :func:`reset_discogs_live_requests_total` in tests). A fresh process with
+    no live-Discogs traffic yet correctly reports 0.
+    """
+    return _discogs_live_requests_total
+
+
+def reset_discogs_live_requests_total() -> None:
+    """Reset the counter to zero.
+
+    Test isolation only -- mirrors the process-restart semantics the real
+    counter has in production.
+    """
+    global _discogs_live_requests_total
+    _discogs_live_requests_total = 0

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -24,6 +24,7 @@ from wxyc_fastapi.observability import (
 from config.settings import get_settings
 from discogs.breaker import DiscogsBreakerOpenError
 from discogs.fallthrough import apply_request_ctx_tags, fallthrough, request_context
+from discogs.live_request_counter import increment_discogs_live_requests_total
 from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
 from discogs.memory_cache import (
     ARTIST_CACHE,
@@ -472,6 +473,13 @@ class DiscogsService:
         # live-probe tail is shed. ``epoch`` guards the half-open trial: the
         # terminal ``record_*`` below only drives a half-open transition when its
         # epoch still matches (FIX 6).
+        #
+        # LML#940: count every live-Discogs request *attempt* right here,
+        # before the admit/shed decision -- a shed attempt is demand too, and
+        # this is the sole ``allow_request()`` call site. See
+        # ``discogs/live_request_counter.py`` for why counting here (not per
+        # ``/lookup``) is required for the wxyc-canary idle-tail fix.
+        increment_discogs_live_requests_total()
         epoch = breaker.allow_request()
         if epoch is None:
             self._record_breaker_shed(method, path)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -226,13 +226,31 @@ The probe also projects its result onto the active Sentry trace as the `discogs_
 The breaker's state is authoritative over `services.discogs_api`'s independent live probe: when the breaker is `open` or `half-open` (both are "shedding" — a half-open breaker still sheds every caller except its single in-flight trial), `services.discogs_api` short-circuits to `rate-limited` and the probe's own live call to Discogs is skipped entirely — it does not run and then get overridden. This closes the two-independent-detectors gap behind the 2026-07-13/14 incident: the breaker latched `half-open` and shed 100% of live Discogs calls for roughly 8 hours while the old `services.discogs_api` probe, dispatched independently of the breaker, kept landing in a momentary token-bucket refill and reporting `ok` the whole time — so the one signal an operator or the wxyc-canary would check said everything was fine while the lookup path was actually degraded to cache-only. Only when the breaker is `closed` does `services.discogs_api` defer to the live probe's own result (the vocabulary table above).
 
 ```json
-{ "status": "degraded", "version": "0.1.0", "commit_sha": "abc123...", "discogs_breaker_state": "open", "services": { "database": "ok", "discogs_api": "rate-limited", "discogs_cache": "ok" } }
+{ "status": "degraded", "version": "0.1.0", "commit_sha": "abc123...", "discogs_breaker_state": "open", "discogs_live_requests_total": 1842, "services": { "database": "ok", "discogs_api": "rate-limited", "discogs_cache": "ok" } }
 ```
 
 Two known limitations follow from `/health` reading the breaker's raw `.state` and treating any shedding state as authoritative:
 
-- **Idle post-cooldown `open` reads as `degraded` until traffic resumes.** The `open → half-open` recovery transition (and the LML#787 watchdog) fire only inside `allow_request()`, which only the live lookup path calls — reading `.state` never advances the state machine. So after an `open` episode's cool-down elapses, if no live Discogs lookups follow, `.state` stays `open` and `/health` keeps reporting `discogs_api: rate-limited` / `status: degraded` even though the next request would admit a recovery trial and likely close the breaker. This is honest (recovery is unproven until a request tries), but a canary that probes `/health` without generating live Discogs traffic (cache-hit library searches don't advance the breaker) can see a sustained `degraded` on an already-recovered-pending-traffic breaker — size any wxyc-canary#79 sustained-shed alarm window with this idle tail in mind.
+- **Idle post-cooldown `open` reads as `degraded` until traffic resumes.** The `open → half-open` recovery transition (and the LML#787 watchdog) fire only inside `allow_request()`, which only the live lookup path calls — reading `.state` never advances the state machine. So after an `open` episode's cool-down elapses, if no live Discogs lookups follow, `.state` stays `open` and `/health` keeps reporting `discogs_api: rate-limited` / `status: degraded` even though the next request would admit a recovery trial and likely close the breaker. This is honest (recovery is unproven until a request tries), but a canary that probes `/health` without generating live Discogs traffic (cache-hit library searches don't advance the breaker) can see a sustained `degraded` on an already-recovered-pending-traffic breaker — size any wxyc-canary#79 sustained-shed alarm window with this idle tail in mind. **`discogs_live_requests_total` (LML#940, below) is the eventual fix**: a caller diffs it across polls to tell a real sustained shed (climbing) apart from this idle tail (flat).
 - **A shed masks a concurrent auth/network fault on `discogs_api`.** When the breaker is `open`/`half-open` the live probe is skipped, so a coincident token/auth drift (401/403) or connection failure surfaces as `rate-limited` rather than `auth-error`/`network-error`. The `discogs_api.check` Sentry trace tag also goes quiet during a shed (the probe that sets it doesn't run). Drop to `discogs_breaker_state: closed` windows to read live Discogs auth/network health.
+
+### `discogs_live_requests_total` (LML#940 — the wxyc-canary idle-tail fix)
+
+`GET /health` also returns a top-level `discogs_live_requests_total`: a process-global, monotonic count of live-Discogs request *attempts*. It increments at the sole `breaker.allow_request()` call site inside `DiscogsService._request_with_retry` (`discogs/service.py`), **before** the breaker's admit/shed decision — so an attempt the breaker sheds (`allow_request()` returning `None`) still counts. Cache hits short-circuit in `discogs/fallthrough.py` before ever reaching that call site, so they are correctly excluded. Implementation lives in `discogs/live_request_counter.py`, modeled on the `core/event_loop_lag.py` process-global-primitive pattern.
+
+Unit and semantics:
+
+- **Counts live-Discogs-leg attempts, not `/lookup` calls.** One uncached `/lookup` fans out roughly five live Discogs calls (the primary search plus supplemental strategies), so this total runs well ahead of `/lookup` request volume — it is not a request-rate metric, and counting `/lookup` calls instead would defeat the point: a busy-cache / idle-Discogs window would show "traffic flowing" even though live Discogs demand is zero, which is exactly the idle-latched-open scenario this field must NOT mistake for real traffic.
+- **Monotonic total, resets to 0 on process restart.** There is no rolling window. A caller polling on a fixed cadence (e.g. the wxyc-canary's 5-minute tick) diffs `total_now - total_prev`; a negative diff means the process restarted mid-window and carries no signal for that tick (treat as an abstain, not a drop to zero).
+- **Present even when Discogs is unconfigured.** Unlike `discogs_breaker_state`, no breaker is read to answer this field — it's a plain global-int read, so a fresh process with no Discogs token reports `0` (correct: no live-Discogs traffic has happened, or ever will, for that process).
+- **Kept out of `services`**, same reasoning as `discogs_breaker_state`: `services` values feed the `("ok", "unavailable")` `all_configured_ok` check, and a number there would spuriously flip a healthy deploy to `degraded`.
+- **Single-worker scope today.** Per-worker (not service-wide) if `UVICORN_WORKERS > 1` ever ships (LML#747) — same caveat as the breaker and the event-loop-lag gauge.
+
+This is the read-only volume signal the idle-tail limitation above was missing: a caller can now distinguish "breaker `open`/`half-open` and this total is climbing across polls" (a real shed under load — page) from "breaker `open`/`half-open` and this total is flat" (the idle tail — no live-Discogs traffic has been attempted since the last poll, so recovery is simply unproven, not blocked — don't page). Consuming this signal in the wxyc-canary is tracked as a follow-up filed once this field ships; see WXYC/library-metadata-lookup#940.
+
+```json
+{ "status": "degraded", "version": "0.1.0", "commit_sha": "abc123...", "discogs_breaker_state": "open", "discogs_live_requests_total": 1842, "services": { "database": "ok", "discogs_api": "rate-limited", "discogs_cache": "ok" } }
+```
 
 ### `commit_sha` (deploy identity)
 
@@ -245,7 +263,7 @@ Two known limitations follow from `/health` reading the breaker's raw `.state` a
 Empty or whitespace-only values at any tier coerce to `null`, so the "null when unset" contract holds and downstream equality checks are never fooled by `""`.
 
 ```json
-{ "status": "healthy", "version": "0.1.0", "commit_sha": "abc123...", "discogs_breaker_state": "closed", "services": { ... } }
+{ "status": "healthy", "version": "0.1.0", "commit_sha": "abc123...", "discogs_breaker_state": "closed", "discogs_live_requests_total": 1842, "services": { ... } }
 ```
 
 #### Why a baked file rather than `RAILWAY_GIT_COMMIT_SHA` (LML#509)

--- a/routers/health.py
+++ b/routers/health.py
@@ -41,6 +41,7 @@ from wxyc_fastapi.healthcheck import DEFAULT_TIMEOUT_SECONDS, Check
 from config.settings import Settings, get_settings
 from core.dependencies import get_discogs_service, get_library_db
 from discogs.breaker import BreakerState
+from discogs.live_request_counter import get_discogs_live_requests_total
 from discogs.ratelimit import get_discogs_breaker
 from discogs.service import DiscogsApiCheckResult, DiscogsService
 from library.db import LibraryDB
@@ -218,6 +219,12 @@ async def health_check(
     # field reports ``null`` (same "null when N/A" convention as
     # ``commit_sha``) rather than a misleading ``"closed"`` for an inert breaker.
     breaker_state = get_discogs_breaker().state if discogs_service is not None else None
+    # LML#940: read the process-global live-Discogs-request-attempt counter
+    # once, up front -- same pattern as ``breaker_state`` above. Unlike the
+    # breaker, this is a plain global-int read with nothing to materialize, so
+    # it is read unconditionally: a fresh process with Discogs unconfigured
+    # correctly reports 0 rather than null/absent.
+    discogs_live_requests_total = get_discogs_live_requests_total()
     checks = _build_checks(db=db, discogs_service=discogs_service, breaker_state=breaker_state)
     results = await asyncio.gather(
         *(_run_check_preserving_value(c, DEFAULT_TIMEOUT_SECONDS) for c in checks)
@@ -246,6 +253,19 @@ async def health_check(
         # "closed" is neither, so folding it in there would spuriously flip a
         # fully healthy service to "degraded".
         "discogs_breaker_state": breaker_state.value if breaker_state is not None else None,
+        # LML#940: a read-only, additive volume signal alongside the breaker
+        # state above -- the count of live-Discogs request *attempts* this
+        # process has made (including breaker-shed ones), monotonic until
+        # restart. Lets a black-box caller (the wxyc-canary) tell a real
+        # sustained shed (this total climbing across polls while
+        # ``discogs_breaker_state`` is open/half-open) apart from the idle
+        # tail (this total flat -- no live-Discogs traffic attempted, so the
+        # breaker's recovery is merely unproven, not blocked). Kept OUT of
+        # ``services`` for the same reason as ``discogs_breaker_state``: that
+        # dict feeds ``all_configured_ok`` via an ``("ok", "unavailable")``
+        # membership check, and a number there is neither. See
+        # docs/deployment.md for the full unit + semantics writeup.
+        "discogs_live_requests_total": discogs_live_requests_total,
         "services": services,
     }
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from config.settings import Settings, get_settings
+from discogs.live_request_counter import reset_discogs_live_requests_total
 from discogs.memory_cache import clear_all_caches, set_skip_cache
 from discogs.ratelimit import reset_rate_limiting
 
@@ -287,6 +288,10 @@ def reset_caches():
     yield
     clear_all_caches()
     reset_rate_limiting()
+    # LML#940: the live-Discogs-attempt counter is a process global fed from
+    # the same ``_request_with_retry`` chokepoint the rate limiter guards, so
+    # it resets alongside it for the same reason -- test isolation.
+    reset_discogs_live_requests_total()
     # Clear library caches (separate from Discogs caches)
     from library.db import clear_library_caches
 

--- a/tests/unit/test_discogs_breaker_request.py
+++ b/tests/unit/test_discogs_breaker_request.py
@@ -29,6 +29,10 @@ import httpx
 import pytest
 
 from discogs.breaker import DiscogsBreakerOpenError, DiscogsCircuitBreaker
+from discogs.live_request_counter import (
+    get_discogs_live_requests_total,
+    reset_discogs_live_requests_total,
+)
 from discogs.service import BREAKER_OPEN_STAT_KEY, DiscogsService
 from tests.unit.conftest import MonotonicClock
 
@@ -109,6 +113,34 @@ async def test_open_breaker_emits_the_counter(fake_limiter):
 
 
 @pytest.mark.asyncio
+async def test_open_breaker_shed_increments_live_request_counter(fake_limiter):
+    """LML#940: a shed attempt still counts as live-Discogs *demand*.
+
+    During a real sustained shed the breaker sheds almost everything, so if
+    shed attempts didn't count, the counter would flatline during exactly the
+    incident it exists to distinguish from the wxyc-canary idle-tail false
+    positive (a quiet period with zero live-Discogs demand, where the breaker
+    is merely latched OPEN with nothing to shed)."""
+    reset_discogs_live_requests_total()
+    breaker = DiscogsCircuitBreaker(failure_threshold=1, remaining_floor=0, cooldown_seconds=60.0)
+    breaker.force_open()
+
+    client = MagicMock()
+    client.request = AsyncMock()
+    service = _make_service(client)
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=asyncio.Semaphore(5)),
+        patch("discogs.service.get_discogs_rate_gate", return_value=fake_limiter),
+        patch("discogs.service.get_discogs_breaker", return_value=breaker),
+    ):
+        with pytest.raises(DiscogsBreakerOpenError):
+            await service._request_with_retry("GET", "/database/search")
+
+    assert get_discogs_live_requests_total() == 1
+
+
+@pytest.mark.asyncio
 async def test_closed_breaker_healthy_request_passes_through(fake_limiter):
     """A CLOSED breaker with a healthy Discogs response is a pure pass-through:
     the client is called and the response is returned unchanged. Organic
@@ -133,6 +165,28 @@ async def test_closed_breaker_healthy_request_passes_through(fake_limiter):
     # assert the return, don't discard it).
     assert breaker.allow_request() is not None
     assert breaker.state.value == "closed"
+
+
+@pytest.mark.asyncio
+async def test_admitted_request_increments_live_request_counter(fake_limiter):
+    """LML#940: an admitted (non-shed) live-Discogs attempt also counts -- the
+    counter measures demand at the chokepoint regardless of outcome."""
+    reset_discogs_live_requests_total()
+    breaker = DiscogsCircuitBreaker(failure_threshold=3, remaining_floor=2, cooldown_seconds=60.0)
+
+    client = MagicMock()
+    ok = _response(200, {"X-Discogs-Ratelimit-Remaining": "48"})
+    client.request = AsyncMock(return_value=ok)
+    service = _make_service(client)
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=asyncio.Semaphore(5)),
+        patch("discogs.service.get_discogs_rate_gate", return_value=fake_limiter),
+        patch("discogs.service.get_discogs_breaker", return_value=breaker),
+    ):
+        await service._request_with_retry("GET", "/database/search")
+
+    assert get_discogs_live_requests_total() == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_discogs_live_request_counter.py
+++ b/tests/unit/test_discogs_live_request_counter.py
@@ -1,0 +1,63 @@
+"""LML#940: process-global live-Discogs-request-attempt counter.
+
+Mirrors ``tests/unit/test_event_loop_lag.py``'s coverage shape for the
+process-global-primitive pattern this counter clones: it starts at a known
+baseline, ``increment_discogs_live_requests_total()`` advances it, and
+``reset_discogs_live_requests_total()`` returns it to that baseline for test
+isolation.
+
+The behavioral wiring -- an admitted OR breaker-shed live-Discogs attempt
+increments it, a cache hit does not -- is covered where the counter is
+actually driven, not here:
+
+- ``tests/unit/test_discogs_breaker_request.py`` (the ``_request_with_retry``
+  chokepoint, both the admitted and shed paths)
+- ``tests/unit/test_discogs_service.py`` (a PG cache hit, which never reaches
+  that chokepoint)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    from discogs.live_request_counter import reset_discogs_live_requests_total
+
+    reset_discogs_live_requests_total()
+    yield
+    reset_discogs_live_requests_total()
+
+
+class TestLiveRequestCounter:
+    def test_starts_at_zero(self):
+        from discogs.live_request_counter import get_discogs_live_requests_total
+
+        assert get_discogs_live_requests_total() == 0
+
+    def test_increment_advances_the_total(self):
+        from discogs.live_request_counter import (
+            get_discogs_live_requests_total,
+            increment_discogs_live_requests_total,
+        )
+
+        increment_discogs_live_requests_total()
+        assert get_discogs_live_requests_total() == 1
+
+        increment_discogs_live_requests_total()
+        assert get_discogs_live_requests_total() == 2
+
+    def test_reset_returns_to_baseline(self):
+        from discogs.live_request_counter import (
+            get_discogs_live_requests_total,
+            increment_discogs_live_requests_total,
+            reset_discogs_live_requests_total,
+        )
+
+        increment_discogs_live_requests_total()
+        increment_discogs_live_requests_total()
+
+        reset_discogs_live_requests_total()
+
+        assert get_discogs_live_requests_total() == 0

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -675,6 +675,37 @@ class TestSearchReleasesByTrack:
         assert len(result.releases) == 1
 
     @pytest.mark.asyncio
+    async def test_cache_hit_does_not_increment_live_request_counter(self, service_with_cache):
+        """LML#940: a PG cache hit short-circuits before ``_request_with_retry``
+        -- and therefore before the live-Discogs-attempt chokepoint -- so it
+        must not advance the counter the wxyc-canary idle-tail fix reads.
+        Counting ``/lookup`` calls instead of live-Discogs attempts would show
+        "traffic flowing" during a busy-cache / idle-Discogs window, exactly
+        the false-positive scenario the counter exists to rule out."""
+        from discogs.live_request_counter import (
+            get_discogs_live_requests_total,
+            reset_discogs_live_requests_total,
+        )
+        from discogs.models import ReleaseInfo
+
+        reset_discogs_live_requests_total()
+        service_with_cache.cache_service.search_releases_by_track = AsyncMock(
+            return_value=[
+                ReleaseInfo(
+                    album="On Your Own Love Again",
+                    artist="Jessica Pratt",
+                    release_id=456,
+                    release_url="https://discogs.com/release/456",
+                )
+            ]
+        )
+
+        result = await service_with_cache.search_releases_by_track("Back, Baby", "Jessica Pratt")
+
+        assert result.cached is True
+        assert get_discogs_live_requests_total() == 0
+
+    @pytest.mark.asyncio
     async def test_cache_error_falls_back_to_api(self, service_with_cache):
         service_with_cache.cache_service.search_releases_by_track = AsyncMock(
             side_effect=Exception("cache down")

--- a/tests/unit/test_health_router.py
+++ b/tests/unit/test_health_router.py
@@ -729,6 +729,113 @@ class TestHealthEndpoint:
         assert body["services"]["discogs_api"] == "unavailable"
         breaker_probe.assert_not_called()
 
+    # -----------------------------------------------------------------
+    # LML#940: a read-only, additive top-level field carrying the
+    # process-global live-Discogs-request-attempt count -- the volume signal
+    # the wxyc-canary needs to tell a real sustained breaker shed (this total
+    # climbing across polls) apart from the idle-tail false positive (breaker
+    # latched open/half-open but this total is flat, i.e. no live-Discogs
+    # traffic has been attempted).
+    # -----------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_includes_discogs_live_requests_total(
+        self, mock_db, mock_discogs, mock_settings, monkeypatch
+    ):
+        """The field is read once up front (mirroring ``breaker_state`` at
+        :220) and reflects the counter verbatim."""
+        import routers.health as health_module
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from main import app
+
+        monkeypatch.setattr(health_module, "get_discogs_live_requests_total", lambda: 42)
+
+        with override_deps(
+            app,
+            {
+                get_library_db: mock_db,
+                get_discogs_service: mock_discogs,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+            },
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["discogs_live_requests_total"] == 42
+
+    @pytest.mark.asyncio
+    async def test_discogs_live_requests_total_kept_out_of_services(
+        self, mock_db, mock_discogs, mock_settings, monkeypatch
+    ):
+        """Kept out of ``services`` -- that dict feeds the ``("ok",
+        "unavailable")`` ``all_configured_ok`` check, and a number there would
+        spuriously flip a healthy deploy to degraded (same reasoning as
+        ``discogs_breaker_state``)."""
+        import routers.health as health_module
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from main import app
+
+        monkeypatch.setattr(health_module, "get_discogs_live_requests_total", lambda: 7)
+
+        with override_deps(
+            app,
+            {
+                get_library_db: mock_db,
+                get_discogs_service: mock_discogs,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+            },
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "healthy"
+        assert "discogs_live_requests_total" not in body["services"]
+
+    @pytest.mark.asyncio
+    async def test_discogs_live_requests_total_present_when_discogs_unconfigured(
+        self, mock_db, mock_settings
+    ):
+        """Unlike ``discogs_breaker_state``, no breaker needs to exist to
+        answer this field -- it's a plain global-int read, so a fresh process
+        with Discogs unconfigured still reports ``0`` (correct: no
+        live-Discogs traffic has happened), not ``null`` or an absent key."""
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from discogs.live_request_counter import reset_discogs_live_requests_total
+        from main import app
+
+        reset_discogs_live_requests_total()
+
+        with override_deps(
+            app,
+            {
+                get_library_db: mock_db,
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+            },
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["discogs_live_requests_total"] == 0
+
     @pytest.mark.asyncio
     async def test_unhealthy_returns_503(self, mock_settings):
         """Core service (database) down -> unhealthy + 503."""


### PR DESCRIPTION
## Summary

Adds a process-global monotonic counter of live-Discogs request attempts (`discogs/live_request_counter.py`, modeled on `core/event_loop_lag.py`), incremented at the sole `allow_request()` call site in `DiscogsService._request_with_retry` (`discogs/service.py:475`) **before** the breaker's admit/shed decision, so a shed attempt counts too. Cache hits short-circuit in `discogs/fallthrough.py` before ever reaching that call site, so they are correctly excluded.

`GET /health` surfaces the total as a new additive top-level `discogs_live_requests_total` field — read once up front alongside `discogs_breaker_state` (`routers/health.py`) and kept out of `services` so it can't perturb the `("ok", "unavailable")` `all_configured_ok` aggregation. The field is present even when Discogs is unconfigured (a fresh process reports `0`).

This is the volume signal the wxyc-canary's `lml-discogs-breaker-shed` check (WXYC/wxyc-canary#79) needs to tell a real sustained Discogs breaker shed (`discogs_live_requests_total` climbing across polls while `discogs_breaker_state` is `open`/`half-open`) apart from the documented idle-tail false positive (a latched-`open` breaker with zero live-Discogs traffic since the last poll). `docs/deployment.md` documents the field's unit (live-Discogs-leg attempts including sheds, not `/lookup` calls), the monotonic-resets-on-restart semantics, and the single-worker caveat, and cross-links the idle-tail bullet to it.

Consuming this signal from the canary side (gating the shed alarm on the counter advancing) is out of scope here and tracked as a wxyc-canary follow-up per the issue.

## Test plan

- [x] New unit test module `tests/unit/test_discogs_live_request_counter.py` (mirrors `tests/unit/test_event_loop_lag.py`): `increment_discogs_live_requests_total()` advances the total, the getter reads it, `reset_discogs_live_requests_total()` returns to baseline.
- [x] `tests/unit/test_discogs_breaker_request.py`: an admitted live-Discogs attempt increments the counter; a breaker-shed attempt also increments it.
- [x] `tests/unit/test_discogs_service.py`: a PG cache hit does not increment the counter.
- [x] `tests/unit/test_health_router.py`: `/health` includes `discogs_live_requests_total`, reflects the counter value, stays out of `services`, and is present (`0`) when Discogs is unconfigured.
- [x] `ruff check .` / `ruff format --check .` clean.
- [x] `mypy . --ignore-missing-imports` clean (matches CI invocation).
- [x] Full `pytest tests/unit/` (4216 tests) passes.

Closes #940