### PR TITLE
feat(#944): traffic-class observability lead set: endpoint-family + caller-budget

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -824,6 +824,13 @@ async def _run_strategy_pipeline(
             transaction = sentry_sdk.get_current_scope().transaction
             if transaction is not None:
                 transaction.set_data("lml.caller_budget_ms", caller_budget_ms)
+                # LML#944: promoted alongside the existing set_data. set_data alone
+                # is per-trace only (opaque to the spans/metrics datasets — reads
+                # back as "Unknown attribute"); set_measurement makes the series
+                # aggregatable (avg/percentile), mirroring the set_data +
+                # set_measurement pairing in `_project_cache_stats_to_transaction`
+                # (lookup/router.py).
+                transaction.set_measurement("lml.caller_budget_ms", caller_budget_ms)
         except Exception as e:
             logger.warning("Failed to project lml.caller_budget_ms onto Sentry transaction: %s", e)
     # Re-base the clock to the lookup-spine start when a prior-work offset is

--- a/lookup/endpoint_family.py
+++ b/lookup/endpoint_family.py
@@ -1,0 +1,49 @@
+"""``lml.endpoint_family`` Sentry tag for ``/lookup`` and ``/lookup/bulk``
+(LML#944 traffic-class observability lead set).
+
+Split out of ``lookup/router.py`` to stay under its module-budget ceiling
+(LML#731 — see ``tests/unit/test_module_budgets.py``) rather than growing an
+already-at-ceiling file — the same rationale as ``lookup/server_timing_legs.py``.
+
+Carved out of the #931 traffic-class-observability umbrella as the
+**drain-independent** lead set: this dimension needs no new lanes, so it lands
+before the controlled prod bulk drain (LML#929) instead of waiting on it. It
+is a plain Sentry tag, not a ``cache_stats`` key — string-valued, and the #907
+``cache_stats`` seam (``_LML_CACHE_STATS_EXTRA_KEYS`` in ``lookup/router.py``)
+is numeric-only (``dict[str, float]`` via ``CacheStatsRecorder.record()``), so
+it rides the sibling per-request Sentry-tag / PostHog-freeform-dict channel
+instead. Forward-compatible: LML#929 is expected to add ``"library_search"``
+as a third value; no rework needed here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import sentry_sdk
+
+logger = logging.getLogger(__name__)
+
+ENDPOINT_FAMILY_LOOKUP = "lookup"
+ENDPOINT_FAMILY_LOOKUP_BULK = "lookup_bulk"
+
+
+def record_endpoint_family_tag(endpoint_family: str) -> None:
+    """Tag the current Sentry transaction with the traffic-class endpoint family.
+
+    Called once per ``cache_stats`` context, right after
+    ``lookup.router._record_event_loop_lag``, at BOTH ``handle_lookup``
+    (``ENDPOINT_FAMILY_LOOKUP``) and ``handle_bulk_lookup``
+    (``ENDPOINT_FAMILY_LOOKUP_BULK``) — the same call-site pattern as
+    ``lookup.router._record_lml_flag_tags``. The matching PostHog
+    ``endpoint_family`` property is set independently at each handler's
+    ``send_to_posthog`` call, using the same literal value, so the Sentry and
+    PostHog surfaces agree without sharing a projection path.
+
+    Observability must not break the request path, so any exception is
+    swallowed at WARNING (matches ``_record_lml_flag_tags``).
+    """
+    try:
+        sentry_sdk.set_tag("lml.endpoint_family", endpoint_family)
+    except Exception as e:
+        logger.warning("Failed to record lml.endpoint_family tag: %s", e)

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -52,6 +52,11 @@ from entity.store import EntityStore
 from generated.api_models import CacheStats
 from identity.dependencies import get_entity_store
 from library.db import LibraryDB
+from lookup.endpoint_family import (
+    ENDPOINT_FAMILY_LOOKUP,
+    ENDPOINT_FAMILY_LOOKUP_BULK,
+    record_endpoint_family_tag,
+)
 from lookup.enrichment import SKIPPED_PREFETCH_STAT_KEY
 from lookup.models import (
     BulkLookupRequest,
@@ -444,6 +449,7 @@ async def handle_lookup(
     # (0/1) once per context so the flip is sliceable in PostHog/Sentry.
     _record_lml_flag_tags()
     _record_event_loop_lag()
+    record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP)
     if skip_cache:
         set_skip_cache(True)
 
@@ -610,6 +616,7 @@ async def handle_lookup(
                     "reconciled_identity_count": sum(
                         1 for r in results if r.reconciled_identity is not None
                     ),
+                    "endpoint_family": ENDPOINT_FAMILY_LOOKUP,
                 },
             )
 
@@ -745,6 +752,7 @@ async def handle_bulk_lookup(
     # so the bulk value stays 0/1 instead of summing across items.
     _record_lml_flag_tags()
     _record_event_loop_lag()
+    record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP_BULK)
 
     max_concurrent = max_concurrency_from_env(_BULK_LOOKUP_DEFAULT_CONCURRENCY)
     semaphore = asyncio.Semaphore(max_concurrent)
@@ -926,6 +934,7 @@ async def handle_bulk_lookup(
                     "no_match_count": counts["no_match"],
                     "error_count": counts["error"],
                     "max_concurrent": max_concurrent,
+                    "endpoint_family": ENDPOINT_FAMILY_LOOKUP_BULK,
                 },
             )
 

--- a/tests/unit/test_module_budgets.py
+++ b/tests/unit/test_module_budgets.py
@@ -27,6 +27,7 @@ MODULE_BUDGETS: dict[str, int] = {
     "lookup/artwork.py": 500,
     "lookup/candidate_memo.py": 150,
     "lookup/concurrency.py": 200,
+    "lookup/endpoint_family.py": 100,
     "lookup/enrichment/__init__.py": 350,
     "lookup/enrichment/background.py": 100,
     "lookup/enrichment/context.py": 150,
@@ -37,7 +38,15 @@ MODULE_BUDGETS: dict[str, int] = {
     "lookup/models.py": 150,
     "lookup/orchestrator.py": 1300,
     "lookup/release_resolution.py": 550,
-    "lookup/router.py": 950,
+    # Recalibrated 2026-07-27 (LML#944): unrelated changes since the 2026-07-06
+    # calibration had already carried this file to exactly its old 950-line
+    # ceiling (zero headroom) before this ticket's two mandated Sentry-tag call
+    # sites landed. The new endpoint-family concern itself was extracted to
+    # `lookup/endpoint_family.py` per this module's own policy; the residual
+    # growth here (an import plus the two irreducible call sites) is
+    # recalibrated with the same formula as every other entry: smallest
+    # multiple of 50 at or above 1.3x the post-change 959-line size.
+    "lookup/router.py": 1250,
     "lookup/rowless.py": 450,
     "lookup/server_timing_legs.py": 100,
     "lookup/spine_deadline.py": 250,

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1527,6 +1527,13 @@ class TestCallerBudget:
         calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
         assert calls.get("search_budget_exceeded") is True
         assert calls.get("lml.caller_budget_ms") == TRANSPORT_OVERHEAD_MS + 1
+        # LML#944: the same value is ALSO promoted to a measurement (aggregatable
+        # across traces via avg/percentile), alongside the set_data above — set_data
+        # alone is opaque to the spans/metrics datasets ("Unknown attribute").
+        measurement_calls = {
+            c.args[0]: c.args[1] for c in mock_transaction.set_measurement.call_args_list
+        }
+        assert measurement_calls.get("lml.caller_budget_ms") == TRANSPORT_OVERHEAD_MS + 1
 
     @pytest.mark.asyncio
     async def test_pipeline_no_caller_budget_does_not_set_caller_attr(self, monkeypatch):
@@ -1568,6 +1575,10 @@ class TestCallerBudget:
 
         keys = {c.args[0] for c in mock_transaction.set_data.call_args_list}
         assert "lml.caller_budget_ms" not in keys
+        # LML#944: the set_measurement promotion sits behind the same
+        # `if caller_budget_ms is not None` guard, so it must be equally absent.
+        measurement_keys = {c.args[0] for c in mock_transaction.set_measurement.call_args_list}
+        assert "lml.caller_budget_ms" not in measurement_keys
 
     @pytest.mark.asyncio
     async def test_pipeline_caller_budget_cuts_off_empty_results(self, monkeypatch):

--- a/tests/unit/test_traffic_class_observability.py
+++ b/tests/unit/test_traffic_class_observability.py
@@ -1,0 +1,165 @@
+"""LML#944: traffic-class observability lead set — endpoint-family.
+
+Carved out of the #931 umbrella (traffic-class-aware observability) as the
+**drain-independent** lead set: this dimension needs no new lanes, so it lands
+before the controlled prod bulk drain ([#929](https://github.com/WXYC/library-metadata-lookup/issues/929))
+instead of waiting on it.
+
+``lml.endpoint_family`` distinguishes ``/lookup`` from ``/lookup/bulk`` traffic
+via a Sentry tag (``"lookup"`` | ``"lookup_bulk"``) plus a matching PostHog
+``endpoint_family`` property, recorded once per request/batch context right
+after ``_record_event_loop_lag`` — the same call-site pattern as the #681
+``_record_lml_flag_tags``. Unlike those, this dimension is string-valued, so it
+cannot ride the numeric-only ``cache_stats`` seam (``_LML_CACHE_STATS_EXTRA_KEYS``,
+``dict[str, float]`` via ``CacheStatsRecorder.record()``); it uses the sibling
+per-request Sentry-tag / PostHog-freeform-dict channel instead.
+
+The companion ``lml.caller_budget_ms`` -> ``set_measurement`` promotion lives in
+``tests/unit/test_search.py::TestCallerBudget`` alongside the existing
+``set_data`` coverage it extends.
+
+Forward-compatible: LML#929 is expected to add ``"library_search"`` as a third
+``endpoint_family`` value; no rework needed here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import get_settings
+from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+from lookup.endpoint_family import (
+    ENDPOINT_FAMILY_LOOKUP,
+    ENDPOINT_FAMILY_LOOKUP_BULK,
+    record_endpoint_family_tag,
+)
+from lookup.models import LookupResponse
+from main import app
+from tests.factories import LOOKUP_BODY
+from tests.unit.conftest import override_deps
+
+
+class TestRecordEndpointFamilyTag:
+    """Direct unit coverage for the LML#944 Sentry-tag helper.
+
+    Mirrors ``_record_lml_flag_tags``'s shape: a plain ``sentry_sdk.set_tag``
+    call whose failure must never break the request path.
+    """
+
+    def test_records_tag_for_lookup(self):
+        set_tag = Mock()
+        with patch("lookup.endpoint_family.sentry_sdk.set_tag", set_tag):
+            record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP)
+
+        set_tag.assert_called_once_with("lml.endpoint_family", "lookup")
+
+    def test_records_tag_for_lookup_bulk(self):
+        set_tag = Mock()
+        with patch("lookup.endpoint_family.sentry_sdk.set_tag", set_tag):
+            record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP_BULK)
+
+        set_tag.assert_called_once_with("lml.endpoint_family", "lookup_bulk")
+
+    def test_swallows_sdk_errors(self):
+        """Any SDK-side exception is swallowed so observability cannot break /lookup."""
+        with patch(
+            "lookup.endpoint_family.sentry_sdk.set_tag",
+            side_effect=RuntimeError("sentry exploded"),
+        ):
+            record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP)  # must not raise
+
+
+def _completed_properties(mock_posthog: Mock) -> dict:
+    """Pull the full properties dict off the PostHog ``*_completed`` event.
+
+    ``endpoint_family`` (LML#944) is a top-level property, a sibling of
+    ``cache``, not nested inside it — unlike the #681 flag tags, which ride
+    the ``cache`` sub-dict via ``cache_stats``.
+    """
+    for call in mock_posthog.capture.call_args_list:
+        event = call.kwargs.get("event", "")
+        if event.endswith("_completed"):
+            return call.kwargs["properties"]
+    raise AssertionError("no *_completed PostHog event captured")
+
+
+async def _post(
+    endpoint: str,
+    json_body: dict,
+    *,
+    mock_posthog: Mock,
+    set_tag: Mock,
+    mock_settings,
+) -> None:
+    """POST to a lookup endpoint with ``perform_lookup``, PostHog, and
+    ``sentry_sdk.set_tag`` all mocked. Shared scaffolding for both endpoints,
+    mirroring ``_post_for_cache_props`` in ``test_rowless_flag_observability.py``.
+    """
+    with (
+        override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: AsyncMock(),
+                get_posthog_client: mock_posthog,
+                get_settings: mock_settings,
+            },
+        ),
+        patch("lookup.endpoint_family.sentry_sdk.set_tag", set_tag),
+        patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=LookupResponse(results=[], search_type="none"),
+        ),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.post(endpoint, json=json_body)
+
+    assert resp.status_code == 200
+
+
+class TestEndpointFamilyWiredIntoHandlers:
+    """End-to-end (via ASGI client): both handlers call the helper with the
+    right family value, and PostHog's ``*_completed`` event carries the
+    sibling ``endpoint_family`` property (LML#944)."""
+
+    @pytest.mark.asyncio
+    async def test_lookup_tags_and_posthog_property(self, mock_settings):
+        mock_posthog = Mock()
+        mock_posthog.capture = Mock()
+        set_tag = Mock()
+
+        await _post(
+            "/api/v1/lookup",
+            LOOKUP_BODY,
+            mock_posthog=mock_posthog,
+            set_tag=set_tag,
+            mock_settings=mock_settings,
+        )
+
+        assert ("lml.endpoint_family", ENDPOINT_FAMILY_LOOKUP) in [
+            c.args for c in set_tag.call_args_list
+        ]
+        assert _completed_properties(mock_posthog)["endpoint_family"] == ENDPOINT_FAMILY_LOOKUP
+
+    @pytest.mark.asyncio
+    async def test_bulk_lookup_tags_and_posthog_property(self, mock_settings):
+        mock_posthog = Mock()
+        mock_posthog.capture = Mock()
+        set_tag = Mock()
+
+        await _post(
+            "/api/v1/lookup/bulk",
+            {"items": [{"artist": "Stereolab", "album": "Aluminum Tunes"}]},
+            mock_posthog=mock_posthog,
+            set_tag=set_tag,
+            mock_settings=mock_settings,
+        )
+
+        assert ("lml.endpoint_family", ENDPOINT_FAMILY_LOOKUP_BULK) in [
+            c.args for c in set_tag.call_args_list
+        ]
+        assert _completed_properties(mock_posthog)["endpoint_family"] == ENDPOINT_FAMILY_LOOKUP_BULK


### PR DESCRIPTION
Closes #944

## Summary

Two drain-independent traffic-class observability dimensions, carved out of the #931 umbrella so the #929 controlled prod bulk drain is legible instead of half-blind:

- **endpoint-family** — `sentry_sdk.set_tag("lml.endpoint_family", "lookup" | "lookup_bulk")` recorded once per request/batch context, right after `_record_event_loop_lag`, at both `handle_lookup` and `handle_bulk_lookup` — the same call-site pattern as `_record_lml_flag_tags`. A matching `endpoint_family` key is added to each handler's `send_to_posthog(...)` properties dict. Forward-compatible: #929 can add `"library_search"` as a third value with no rework.
- **caller-budget** — `core/search.py::_run_strategy_pipeline` now calls `transaction.set_measurement("lml.caller_budget_ms", ...)` alongside the existing `transaction.set_data(...)`, so the caller-supplied budget becomes aggregatable (avg/percentile across traces) instead of per-trace only. `set_data` is kept, not replaced.

`endpoint_family` is string-valued, so it cannot ride the numeric-only #907 `cache_stats` seam (`_LML_CACHE_STATS_EXTRA_KEYS`, `dict[str, float]` via `CacheStatsRecorder.record()`); it uses the sibling per-request Sentry-tag / PostHog-freeform-dict channel instead, per the issue's load-bearing seam nuance.

## Module budget note

`lookup/router.py` had already reached its LML#731 950-line module-budget ceiling via unrelated changes since the 2026-07-06 calibration (confirmed via `git show origin/main:lookup/router.py | wc -l` = 950, i.e. zero headroom, before this PR touched it). Per that budget test's own stated policy ("extract a module, not... append"), the new endpoint-family constants and helper live in a new `lookup/endpoint_family.py` (mirroring the existing `lookup/server_timing_legs.py` precedent, which was split out of `router.py` for the identical reason). The residual, irreducible growth in `router.py` itself — one import plus the two mandated call sites and two PostHog dict keys — still pushed it 9 lines past 950, so `tests/unit/test_module_budgets.py` recalibrates the ceiling to 1250 (smallest multiple of 50 at or above 1.3x the post-change 959-line size, the same formula every other entry in that table follows) and adds a 100-line entry for the new file.

## Out of scope (per the issue)

- `upstream-provider` and the four lag dimensions (`admission-result`, `timeout-phase`, `degraded-mode-result`, `caller-reason`) stay deferred to #931.
- `queue-wait` (#923) is untouched.

## Test plan

- [x] New `tests/unit/test_traffic_class_observability.py`: direct unit coverage for the `record_endpoint_family_tag` helper (both family values + swallows-SDK-errors), plus ASGI-client round-trip tests proving both `handle_lookup` and `handle_bulk_lookup` set the Sentry tag and the PostHog `endpoint_family` property.
- [x] Extended `tests/unit/test_search.py::TestCallerBudget` — the existing "honors caller budget" test now also asserts `set_measurement` fires with the same value, and the existing "no caller budget" test now also asserts `set_measurement` stays silent.
- [x] `ruff check .` and `ruff format --check .` clean.
- [x] `mypy . --ignore-missing-imports` clean.
- [x] Full unit suite (4222 tests) and full default suite (`pytest -q`, unit+integration+e2e minus `pg`/`external_api`: 4541 passed, 1 pre-existing skip, 2 pre-existing xfails) green.