### PR TITLE
Rewrite lml_wall Server-Timing middleware as pure-ASGI

### DIFF
--- a/core/server_timing_middleware.py
+++ b/core/server_timing_middleware.py
@@ -1,4 +1,4 @@
-"""ASGI middleware surfacing the ``lml_wall`` Server-Timing leg (LML#907 follow-up).
+"""Pure-ASGI middleware surfacing the ``lml_wall`` Server-Timing leg (LML#946).
 
 ``RequestTelemetry`` (constructed inside the ``/lookup`` in-flight-cap permit —
 see ``lookup/router.py:handle_lookup``) only times the window between its own
@@ -11,17 +11,30 @@ its own wall-clock time for the whole HTTP round trip (request-o-matic's
 ``lookup_service`` metric) then sees a residual the LML-side header cannot
 explain.
 
-This middleware times request-received -> response-ready around ``call_next``
-and APPENDS an ``lml_wall;dur=<ms>`` entry to whatever ``Server-Timing`` header
-the handler already produced — never overwrites it. ``lml_wall - total -
-queue_wait`` is then the honest LML-side estimate of DI + deserialization +
-serialization overhead outside the tracked pipeline.
+This middleware times request-received -> response-ready around the wrapped
+ASGI app and APPENDS an ``lml_wall;dur=<ms>`` entry to whatever
+``Server-Timing`` header the handler already produced — never overwrites it.
+``lml_wall - total - queue_wait`` is then the honest LML-side estimate of DI +
+deserialization + serialization overhead outside the tracked pipeline.
+
+It is written as a plain ASGI callable — ``__init__(self, app)`` /
+``async def __call__(self, scope, receive, send)`` — rather than a
+``starlette.middleware.base.BaseHTTPMiddleware`` subclass. ``BaseHTTPMiddleware``
+wraps EVERY request in an anyio task group plus a streaming-response shim
+before any of its own dispatch code runs, and that machinery is not free; the
+original implementation paid it on every single request (including the hot
+``/health`` Railway poll) just to reach a path-string compare that immediately
+returned. The ASGI form lets the scope-type check, the ``/api/v1/lookup``
+path check, and the ``lml_emit_server_timing`` gate check all short-circuit
+straight to ``await self.app(scope, receive, send)`` — the bare wrapped call,
+no task group, no response interception — for every request this middleware
+doesn't care about. Only a request that is HTTP, on the timed path, with the
+gate on pays for a ``send`` wrapper.
 
 Scoped to the single-lookup path only (``/api/v1/lookup`` — see
 ``_TIMED_PATH``): the endpoint the residual was measured against. Every other
-route (``/health``, ``/api/v1/lookup/bulk``, admin, etc.) passes through
-untouched at the cost of one path-string compare. Gated on the same
-``LML_EMIT_SERVER_TIMING`` kill switch ``lookup/router.py``'s
+route (``/health``, ``/api/v1/lookup/bulk``, admin, etc.) is a pure passthrough.
+Gated on the same ``LML_EMIT_SERVER_TIMING`` kill switch ``lookup/router.py``'s
 ``_emit_server_timing_header`` reads, so the two either both fire or both stay
 silent. Wrapped so a failure here can never break the response: observability
 must not break the request path, matching the posture of every other
@@ -32,9 +45,8 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Awaitable, Callable
 
-from fastapi import Request, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from config.settings import get_settings
 
@@ -43,9 +55,11 @@ logger = logging.getLogger(__name__)
 # The one route this middleware instruments today. A prefix/set could widen
 # later (e.g. to also cover ``/api/v1/lookup/bulk``), but the residual this
 # leg exists to explain was measured specifically against single ``/lookup``;
-# scoping narrowly keeps the per-request cost (one string compare) off every
-# other route, including the hot ``/health`` check uvicorn/Railway poll.
+# scoping narrowly keeps every other route, including the hot ``/health``
+# check uvicorn/Railway poll, on the zero-wrapper passthrough path below.
 _TIMED_PATH = "/api/v1/lookup"
+
+_SERVER_TIMING_HEADER = b"server-timing"
 
 
 def _format_ms(value: float) -> str:
@@ -58,38 +72,81 @@ def _format_ms(value: float) -> str:
     return f"{value:.2f}".rstrip("0").rstrip(".")
 
 
-async def lml_wall_timing_middleware(
-    request: Request, call_next: Callable[[Request], Awaitable[Response]]
-) -> Response:
-    """Time request-received -> response-ready and append the ``lml_wall`` leg.
+def _with_appended_server_timing(
+    headers: list[tuple[bytes, bytes]], entry: bytes
+) -> list[tuple[bytes, bytes]]:
+    """Return a NEW headers list with ``entry`` appended to an existing
+    ``Server-Timing`` header, or added as a fresh one if absent.
 
-    Registered via ``app.middleware("http")`` in ``main.py``, positioned so it
-    wraps only the routing/handler/serialization layer (see the registration
-    site's comment for the ordering rationale — it deliberately excludes the
-    sibling ``posthog_flush_middleware``'s synchronous flush from the timed
-    window, so ``lml_wall`` isn't inflated by unrelated middleware cost).
-
-    ``call_next`` itself is never wrapped in try/except: a genuine failure
-    inside routing must still propagate to Starlette's ``ServerErrorMiddleware``
-    for normal 500 handling. Only the instrumentation AFTER ``call_next``
-    returns (the settings read, the header append) is guarded, so this
-    middleware can neither turn a good response into a bad one nor mask a real
-    error behind a swallowed one.
+    ASGI header names are ``bytes`` and (per spec, and per Starlette's own
+    ``MutableHeaders.__setitem__``) always lowercased by a compliant sender —
+    but the match here is still done case-insensitively to stay correct
+    against any upstream app that doesn't normalize casing. The original
+    name's casing is preserved in the merged tuple; only the comparison is
+    case-folded.
     """
-    if request.url.path != _TIMED_PATH:
-        return await call_next(request)
+    merged: list[tuple[bytes, bytes]] = []
+    found = False
+    for name, value in headers:
+        if name.lower() == _SERVER_TIMING_HEADER:
+            merged.append((name, value + b", " + entry))
+            found = True
+        else:
+            merged.append((name, value))
+    if not found:
+        merged.append((_SERVER_TIMING_HEADER, entry))
+    return merged
 
-    start = time.perf_counter()
-    response = await call_next(request)
 
-    try:
-        if not get_settings().lml_emit_server_timing:
-            return response
-        dur_ms = (time.perf_counter() - start) * 1000.0
-        entry = f"lml_wall;dur={_format_ms(dur_ms)}"
-        existing = response.headers.get("Server-Timing")
-        response.headers["Server-Timing"] = f"{existing}, {entry}" if existing else entry
-    except Exception as e:
-        logger.warning("Failed to append lml_wall Server-Timing leg: %s", e)
+class LmlWallTimingMiddleware:
+    """ASGI middleware appending the ``lml_wall`` Server-Timing leg.
 
-    return response
+    Registered via ``app.add_middleware(LmlWallTimingMiddleware)`` in
+    ``main.py``, positioned so it wraps only the routing/handler/serialization
+    layer (see the registration site's comment for the ordering rationale — it
+    deliberately excludes the sibling ``posthog_flush_middleware``'s
+    synchronous flush from the timed window, so ``lml_wall`` isn't inflated by
+    unrelated middleware cost).
+
+    The wrapped app (``self.app``) is never called inside a try/except: a
+    genuine failure inside routing must still propagate to Starlette's
+    ``ServerErrorMiddleware`` for normal 500 handling. Only this middleware's
+    OWN instrumentation — the settings read and the ``send`` message rewrite —
+    is guarded, so it can neither turn a good response into a bad one nor mask
+    a real error behind a swallowed one.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope.get("path") != _TIMED_PATH:
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            emit = get_settings().lml_emit_server_timing
+        except Exception as e:
+            logger.warning(
+                "Failed to read lml_emit_server_timing setting; skipping lml_wall leg: %s", e
+            )
+            emit = False
+
+        if not emit:
+            await self.app(scope, receive, send)
+            return
+
+        start = time.perf_counter()
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                try:
+                    dur_ms = (time.perf_counter() - start) * 1000.0
+                    entry = f"lml_wall;dur={_format_ms(dur_ms)}".encode("latin-1")
+                    headers = _with_appended_server_timing(list(message.get("headers", [])), entry)
+                    message = {**message, "headers": headers}
+                except Exception as e:
+                    logger.warning("Failed to append lml_wall Server-Timing leg: %s", e)
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)

--- a/core/server_timing_middleware.py
+++ b/core/server_timing_middleware.py
@@ -4,8 +4,8 @@
 see ``lookup/router.py:handle_lookup``) only times the window between its own
 construction and ``as_server_timing()``: the pipeline itself. FastAPI's
 dependency injection, the Pydantic request deserialization, and the
-``LookupResponse`` JSON serialization all happen OUTSIDE that window, inside
-the ASGI ``call_next`` a middleware wraps — no ``track_step`` span nor the
+``LookupResponse`` JSON serialization all happen OUTSIDE that window, in the
+routing and serialization layer this middleware wraps — no ``track_step`` span nor the
 ``queue_wait``/``discogs`` ``extra`` legs can see that time. A caller measuring
 its own wall-clock time for the whole HTTP round trip (request-o-matic's
 ``lookup_service`` metric) then sees a residual the LML-side header cannot
@@ -84,16 +84,21 @@ def _with_appended_server_timing(
     against any upstream app that doesn't normalize casing. The original
     name's casing is preserved in the merged tuple; only the comparison is
     case-folded.
+
+    If the app emitted more than one ``Server-Timing`` line (legal but rare),
+    ``entry`` is appended to the FIRST match only -- appending to every line
+    would emit ``lml_wall`` more than once and a reader would double-count it.
+    The ``/lookup`` handler emits exactly one, so this guard is defensive.
     """
     merged: list[tuple[bytes, bytes]] = []
-    found = False
+    appended = False
     for name, value in headers:
-        if name.lower() == _SERVER_TIMING_HEADER:
+        if not appended and name.lower() == _SERVER_TIMING_HEADER:
             merged.append((name, value + b", " + entry))
-            found = True
+            appended = True
         else:
             merged.append((name, value))
-    if not found:
+    if not appended:
         merged.append((_SERVER_TIMING_HEADER, entry))
     return merged
 

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from core.dependencies import (
 )
 from core.event_loop_lag import start_sampler, stop_sampler
 from core.logging import setup_logging
-from core.server_timing_middleware import lml_wall_timing_middleware
+from core.server_timing_middleware import LmlWallTimingMiddleware
 from discogs.router import router as discogs_router
 from identity.dependencies import close_entity_store
 from identity.router import api_v1_router as identity_api_v1_router
@@ -501,8 +501,11 @@ app.add_middleware(
 # it the INNER of the two: `posthog_flush_middleware`'s synchronous
 # `flush_posthog()` call then runs OUTSIDE the timed window, so it can't
 # inflate the `lml_wall` Server-Timing leg with unrelated middleware cost. See
-# `core/server_timing_middleware.py` for what the leg measures and why.
-app.middleware("http")(lml_wall_timing_middleware)
+# `core/server_timing_middleware.py` for what the leg measures and why. Pure
+# ASGI middleware (LmlWallTimingMiddleware) still goes through `add_middleware`
+# like any other Starlette middleware, so this ordering rule applies exactly
+# the same as it did for the old `@app.middleware("http")` registration.
+app.add_middleware(LmlWallTimingMiddleware)
 
 
 @app.middleware("http")

--- a/tests/unit/test_server_timing_middleware.py
+++ b/tests/unit/test_server_timing_middleware.py
@@ -1,5 +1,5 @@
 """Unit tests for core/server_timing_middleware.py (LML#907 fine-grained-timing
-follow-up: the `lml_wall` Server-Timing leg).
+leg; LML#946 rewrote the middleware itself as pure ASGI).
 
 Exercises the middleware in isolation against a minimal FastAPI app rather than
 the full `main.app` — the router-level integration is covered by
@@ -7,6 +7,13 @@ the full `main.app` — the router-level integration is covered by
 strict_parser_safe` and `test_server_timing_failure_does_not_break_request`,
 which drive the real app end-to-end and assert `lml_wall` shows up alongside
 the router's own legs.
+
+`TestLmlWallTimingMiddleware` drives the middleware through a real FastAPI/
+httpx round trip (installed via `app.add_middleware`, same as `main.py`).
+`TestLmlWallTimingMiddlewareRawASGI` drives `LmlWallTimingMiddleware.__call__`
+directly against bare `(scope, receive, send)` — the only way to prove the
+passthrough paths build zero `send` wrapper, which is the entire point of the
+pure-ASGI rewrite (see the module docstring on `core/server_timing_middleware.py`).
 """
 
 from __future__ import annotations
@@ -17,9 +24,10 @@ from unittest.mock import patch
 import pytest
 from fastapi import FastAPI, Response
 from httpx import ASGITransport, AsyncClient
+from starlette.types import Message, Receive, Scope, Send
 
 from config.settings import Settings
-from core.server_timing_middleware import lml_wall_timing_middleware
+from core.server_timing_middleware import LmlWallTimingMiddleware, _with_appended_server_timing
 
 _DUR_GRAMMAR = re.compile(r"^lml_wall;dur=\d+(?:\.\d+)?$")
 
@@ -33,7 +41,7 @@ def _build_app(*, existing_header: str | None) -> FastAPI:
     or the build failed).
     """
     app = FastAPI()
-    app.middleware("http")(lml_wall_timing_middleware)
+    app.add_middleware(LmlWallTimingMiddleware)
 
     @app.get("/api/v1/lookup")
     async def timed_route(response: Response):
@@ -217,7 +225,7 @@ class TestLmlWallTimingMiddleware:
         proves this middleware doesn't intercept and suppress it.
         """
         app = FastAPI()
-        app.middleware("http")(lml_wall_timing_middleware)
+        app.add_middleware(LmlWallTimingMiddleware)
 
         @app.get("/api/v1/lookup")
         async def boom():
@@ -229,3 +237,207 @@ class TestLmlWallTimingMiddleware:
             ) as client:
                 with pytest.raises(RuntimeError, match="handler exploded"):
                     await client.get("/api/v1/lookup")
+
+
+class _RecordingApp:
+    """A bare ASGI app standing in for ``self.app`` inside the middleware.
+
+    Records the exact ``send`` callable it was handed (so tests can assert
+    object identity — proof the middleware did NOT build a wrapper) and, for
+    HTTP scopes, replays a canned ``http.response.start``/``http.response.body``
+    pair through whatever ``send`` it was given.
+    """
+
+    def __init__(self, *, response_headers: list[tuple[bytes, bytes]] | None = None) -> None:
+        self.received_scope: Scope | None = None
+        self.received_send: Send | None = None
+        self._response_headers = response_headers or []
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        self.received_scope = scope
+        self.received_send = send
+        if scope["type"] != "http":
+            return
+        await send(
+            {"type": "http.response.start", "status": 200, "headers": self._response_headers}
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+
+
+def _noop_receive() -> Receive:
+    async def receive() -> Message:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return receive
+
+
+class TestLmlWallTimingMiddlewareRawASGI:
+    """Exercises ``LmlWallTimingMiddleware.__call__`` directly against the raw
+    ASGI protocol (bypassing FastAPI/httpx) to prove the passthrough paths do
+    NOT build a ``send`` wrapper at all, and to pin the byte-level header
+    format the ``send`` wrapper produces when it does engage.
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_http_scope_is_passthrough_and_never_reads_settings(self):
+        """A non-``http`` scope (e.g. ``lifespan``, ``websocket``) must
+        short-circuit before the settings gate is even consulted — proven by
+        making ``get_settings`` raise if it's called at all — and the inner
+        app must receive the ORIGINAL ``send`` (identity, not a wrapper).
+        """
+        inner = _RecordingApp()
+        middleware = LmlWallTimingMiddleware(inner)
+        scope: Scope = {"type": "lifespan"}
+        sent: list[Message] = []
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        with patch(
+            "core.server_timing_middleware.get_settings",
+            side_effect=AssertionError("get_settings must not be called for a non-http scope"),
+        ) as mock_settings:
+            await middleware(scope, _noop_receive(), send)
+
+        mock_settings.assert_not_called()
+        assert inner.received_send is send
+
+    @pytest.mark.asyncio
+    async def test_non_lookup_path_is_passthrough_with_no_send_wrapping(self, settings_on):
+        """An HTTP request outside ``/api/v1/lookup`` never gets a ``send``
+        wrapper — the inner app's ``send`` is the exact object passed in.
+        """
+        inner = _RecordingApp(response_headers=[(b"server-timing", b"total;dur=1")])
+        middleware = LmlWallTimingMiddleware(inner)
+        scope: Scope = {"type": "http", "path": "/health"}
+        sent: list[Message] = []
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            await middleware(scope, _noop_receive(), send)
+
+        assert inner.received_send is send
+        start = sent[0]
+        assert start["headers"] == [(b"server-timing", b"total;dur=1")]
+
+    @pytest.mark.asyncio
+    async def test_gate_off_is_passthrough_with_no_send_wrapping(self, settings_off):
+        """Scoped path + gate off must also be a bare passthrough: no wrapper
+        object is created merely because the path matched.
+        """
+        inner = _RecordingApp()
+        middleware = LmlWallTimingMiddleware(inner)
+        scope: Scope = {"type": "http", "path": "/api/v1/lookup"}
+        sent: list[Message] = []
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_off):
+            await middleware(scope, _noop_receive(), send)
+
+        assert inner.received_send is send
+
+    @pytest.mark.asyncio
+    async def test_send_wrapper_appends_when_server_timing_present(self, settings_on):
+        inner = _RecordingApp(response_headers=[(b"server-timing", b"total;dur=5")])
+        middleware = LmlWallTimingMiddleware(inner)
+        scope: Scope = {"type": "http", "path": "/api/v1/lookup"}
+        sent: list[Message] = []
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            await middleware(scope, _noop_receive(), send)
+
+        # A wrapper WAS built for the matching, gated-on path.
+        assert inner.received_send is not send
+        start = sent[0]
+        assert start["type"] == "http.response.start"
+        headers = dict(start["headers"])
+        assert headers[b"server-timing"].startswith(b"total;dur=5, lml_wall;dur=")
+        # Everything else on the message (status, other keys) is untouched.
+        assert start["status"] == 200
+        # The body message passes straight through, unmodified.
+        assert sent[1] == {"type": "http.response.body", "body": b"{}"}
+
+    @pytest.mark.asyncio
+    async def test_send_wrapper_sets_header_when_absent(self, settings_on):
+        inner = _RecordingApp(response_headers=[])
+        middleware = LmlWallTimingMiddleware(inner)
+        scope: Scope = {"type": "http", "path": "/api/v1/lookup"}
+        sent: list[Message] = []
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            await middleware(scope, _noop_receive(), send)
+
+        headers = dict(sent[0]["headers"])
+        assert _DUR_GRAMMAR.match(headers[b"server-timing"].decode("latin-1"))
+
+    @pytest.mark.asyncio
+    async def test_send_wrapper_matches_server_timing_case_insensitively(self, settings_on):
+        """Defensive against an upstream app that didn't lowercase the header
+        name (ASGI/Starlette always do, but the merge must not assume it).
+        Original name casing is preserved; only the match is case-folded.
+        """
+        inner = _RecordingApp(response_headers=[(b"Server-Timing", b"total;dur=5")])
+        middleware = LmlWallTimingMiddleware(inner)
+        scope: Scope = {"type": "http", "path": "/api/v1/lookup"}
+        sent: list[Message] = []
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        with patch("core.server_timing_middleware.get_settings", return_value=settings_on):
+            await middleware(scope, _noop_receive(), send)
+
+        headers = sent[0]["headers"]
+        assert len(headers) == 1
+        name, value = headers[0]
+        assert name == b"Server-Timing"  # casing preserved, not forced to lowercase
+        assert value.startswith(b"total;dur=5, lml_wall;dur=")
+
+    @pytest.mark.asyncio
+    async def test_send_wrapper_injection_failure_forwards_original_message(self, settings_on):
+        """If the header-merge step itself raises, the ORIGINAL message must
+        still reach ``send`` unmodified — never a broken/partial response.
+        """
+        inner = _RecordingApp(response_headers=[(b"server-timing", b"total;dur=5")])
+        middleware = LmlWallTimingMiddleware(inner)
+        scope: Scope = {"type": "http", "path": "/api/v1/lookup"}
+        sent: list[Message] = []
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        with (
+            patch("core.server_timing_middleware.get_settings", return_value=settings_on),
+            patch(
+                "core.server_timing_middleware._with_appended_server_timing",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            await middleware(scope, _noop_receive(), send)
+
+        assert sent[0] == {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"server-timing", b"total;dur=5")],
+        }
+
+    def test_with_appended_server_timing_helper_appends_and_sets(self):
+        """Unit-level pin on the pure header-merge helper, independent of the
+        ASGI plumbing around it.
+        """
+        assert _with_appended_server_timing([], b"lml_wall;dur=1") == [
+            (b"server-timing", b"lml_wall;dur=1")
+        ]
+        assert _with_appended_server_timing(
+            [(b"server-timing", b"total;dur=5")], b"lml_wall;dur=1"
+        ) == [(b"server-timing", b"total;dur=5, lml_wall;dur=1")]

--- a/tests/unit/test_server_timing_middleware.py
+++ b/tests/unit/test_server_timing_middleware.py
@@ -441,3 +441,18 @@ class TestLmlWallTimingMiddlewareRawASGI:
         assert _with_appended_server_timing(
             [(b"server-timing", b"total;dur=5")], b"lml_wall;dur=1"
         ) == [(b"server-timing", b"total;dur=5, lml_wall;dur=1")]
+
+    def test_with_appended_server_timing_appends_to_first_of_multiple(self):
+        """If the app emitted more than one ``Server-Timing`` header line,
+        ``lml_wall`` is appended to the FIRST match only -- never duplicated
+        onto every line. A naive append-to-each would emit ``lml_wall`` twice,
+        so a reader would double-count the wall-clock leg.
+        """
+        result = _with_appended_server_timing(
+            [(b"server-timing", b"a;dur=1"), (b"server-timing", b"b;dur=2")],
+            b"lml_wall;dur=3",
+        )
+        assert result == [
+            (b"server-timing", b"a;dur=1, lml_wall;dur=3"),
+            (b"server-timing", b"b;dur=2"),
+        ]


### PR DESCRIPTION
Closes #946.

Rewrites the `lml_wall` Server-Timing middleware from a `BaseHTTPMiddleware` dispatch function to a pure-ASGI class (`LmlWallTimingMiddleware`, `__init__(app)` / `async __call__(scope, receive, send)`). `BaseHTTPMiddleware` wraps *every* request in an anyio task group + streaming-response shim before its own path check runs, so the hot `/health` Railway poll (and every other non-lookup route) paid that overhead just to early-return. The ASGI form short-circuits to a bare `await self.app(scope, receive, send)` — no wrapper object — for any request that isn't HTTP, isn't `/api/v1/lookup`, or has the `lml_emit_server_timing` gate off. Only a matching, gated-on request builds a `send` wrapper that appends `lml_wall;dur=<ms>` to the response's `Server-Timing` header on `http.response.start`.

## Correctness

- **Ordering preserved**: registration switched from `app.middleware("http")(...)` to `app.add_middleware(LmlWallTimingMiddleware)` at the same call site; `posthog_flush_middleware` stays strictly outside the timed window (outer→inner: `ServerError → posthog_flush → LmlWall → CORS → router`).
- **No timing regression**: the old `BaseHTTPMiddleware` measured until `call_next` returned, which (per Starlette 0.52.1) is right after `http.response.start` — the same point the new `send` wrapper stops at. For `/lookup`'s fully-rendered `JSONResponse`, serialization completes before `http.response.start`, so it's still captured and `lml_wall >= total` holds.
- **Exception-safe**: the wrapped app call is outside any try/except (handler errors still reach `ServerErrorMiddleware`); only the header-merge is guarded, and on failure it forwards the original message untouched.

## From code review

`_with_appended_server_timing` now appends `lml_wall` to the **first** `Server-Timing` line only (a multi-line response — legal but not emitted by `/lookup` — would otherwise carry `lml_wall` twice), and a stale module-docstring reference to the ASGI `call_next` (a `BaseHTTPMiddleware` term) was corrected.

## Tests

`test_server_timing_middleware.py` — the FastAPI/httpx round-trip suite (append-not-clobber, gate off, path scoping, exception propagation) plus raw-ASGI tests proving the passthrough paths build zero `send` wrapper (object identity) and pinning the byte-level header merge, including the append-to-first-of-multiple guard. `18` middleware + `12` router-integration + full unit tier `4225 passed`; ruff / format / mypy clean.
