### PR TITLE
feat(#931): emit lml.caller_reason tag + PostHog property

### DIFF
--- a/lookup/caller_reason.py
+++ b/lookup/caller_reason.py
@@ -1,0 +1,60 @@
+"""``lml.caller_reason`` Sentry tag for ``/lookup`` and ``/lookup/bulk``
+(LML#931 traffic-class observability, caller-reason slice).
+
+Split out of ``lookup/router.py`` to stay under its module-budget ceiling
+(LML#731 -- see ``tests/unit/test_module_budgets.py``) rather than growing an
+already-at-ceiling file -- the same rationale as ``lookup/endpoint_family.py``
+(LML#944) and ``lookup/server_timing_legs.py``.
+
+Reads the caller-supplied ``X-Caller-Reason`` header (e.g.
+``proxy-library-search``, ``catalog-popularity-freetext-resolve``), forwarded
+by Backend-Service since BS#1843. Like ``endpoint_family``, this dimension is
+string-valued, so it cannot ride the numeric-only #907 ``cache_stats`` seam
+(``_LML_CACHE_STATS_EXTRA_KEYS`` in ``lookup/router.py``, ``dict[str, float]``
+via ``CacheStatsRecorder.record()``); it rides the sibling per-request
+Sentry-tag / PostHog-freeform-dict channel #944 already shipped for
+``endpoint_family`` instead.
+
+Unlike ``endpoint_family`` (always one of two fixed literals), this header is
+genuinely optional -- callers that predate BS#1843 send nothing. Absence must
+be a safe no-op: no tag, no PostHog property, never a crash, never a
+fabricated value. ``record_caller_reason_tag`` guards on ``None`` itself
+rather than pushing that check onto every call site.
+
+The other #931 lag dimensions (``admission-result``, ``degraded-mode-result``,
+``timeout-phase``) stay out of scope here, gated on #930/#943.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import sentry_sdk
+
+logger = logging.getLogger(__name__)
+
+
+def record_caller_reason_tag(caller_reason: str | None) -> None:
+    """Tag the current Sentry transaction with the caller-supplied reason label.
+
+    Called once per ``cache_stats`` context, right after
+    ``record_endpoint_family_tag``, at BOTH ``handle_lookup`` (with the
+    ``X-Caller-Reason`` header value) and ``handle_bulk_lookup`` -- the same
+    call-site pattern as ``lookup.router._record_lml_flag_tags``. The matching
+    PostHog ``caller_reason`` property is set independently at each handler's
+    ``send_to_posthog`` call, using the same value, so the Sentry and PostHog
+    surfaces agree without sharing a projection path.
+
+    ``caller_reason=None`` (the ``X-Caller-Reason`` header was absent) is a
+    no-op: no tag is set. This is the header-optionality contract, not an
+    error path.
+
+    Observability must not break the request path, so any exception is
+    swallowed at WARNING (matches ``record_endpoint_family_tag``).
+    """
+    if caller_reason is None:
+        return
+    try:
+        sentry_sdk.set_tag("lml.caller_reason", caller_reason)
+    except Exception as e:
+        logger.warning("Failed to record lml.caller_reason tag: %s", e)

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -52,6 +52,7 @@ from entity.store import EntityStore
 from generated.api_models import CacheStats
 from identity.dependencies import get_entity_store
 from library.db import LibraryDB
+from lookup.caller_reason import record_caller_reason_tag
 from lookup.endpoint_family import (
     ENDPOINT_FAMILY_LOOKUP,
     ENDPOINT_FAMILY_LOOKUP_BULK,
@@ -438,6 +439,18 @@ async def handle_lookup(
             "times out. Non-positive values fall back to the env default."
         ),
     ),
+    x_caller_reason: str | None = Header(
+        default=None,
+        alias="X-Caller-Reason",
+        description=(
+            "Optional caller-supplied traffic-class label forwarded by "
+            "Backend-Service (BS#1843), e.g. proxy-library-search or "
+            "catalog-popularity-freetext-resolve (LML#931). Purely "
+            "observational: tagged onto the Sentry transaction and the "
+            "PostHog completion event. Absent on callers that predate "
+            "BS#1843 -- treated as a safe no-op, never fabricated."
+        ),
+    ),
 ):
     """Process a lookup request."""
     # Pre-declare LML-specific cache-stats keys so PostHog/Sentry payload shapes
@@ -450,6 +463,7 @@ async def handle_lookup(
     _record_lml_flag_tags()
     _record_event_loop_lag()
     record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP)
+    record_caller_reason_tag(x_caller_reason)
     if skip_cache:
         set_skip_cache(True)
 
@@ -617,6 +631,7 @@ async def handle_lookup(
                         1 for r in results if r.reconciled_identity is not None
                     ),
                     "endpoint_family": ENDPOINT_FAMILY_LOOKUP,
+                    **({"caller_reason": x_caller_reason} if x_caller_reason is not None else {}),
                 },
             )
 
@@ -709,6 +724,18 @@ async def handle_bulk_lookup(
             "`LML#345 follow-up will redefine this as a batch-level budget."
         ),
     ),
+    x_caller_reason: str | None = Header(
+        default=None,
+        alias="X-Caller-Reason",
+        description=(
+            "Optional caller-supplied traffic-class label forwarded by "
+            "Backend-Service (BS#1843), e.g. proxy-library-search or "
+            "catalog-popularity-freetext-resolve (LML#931). Purely "
+            "observational: tagged onto the Sentry transaction and the "
+            "PostHog completion event. Absent on callers that predate "
+            "BS#1843 -- treated as a safe no-op, never fabricated."
+        ),
+    ),
 ) -> BulkLookupResponse:
     """Bulk lookup. See route docstring for protocol."""
     # Shared bulk envelope (LML#767): raw-JSON parse, ClientDisconnect -> 400,
@@ -753,6 +780,7 @@ async def handle_bulk_lookup(
     _record_lml_flag_tags()
     _record_event_loop_lag()
     record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP_BULK)
+    record_caller_reason_tag(x_caller_reason)
 
     max_concurrent = max_concurrency_from_env(_BULK_LOOKUP_DEFAULT_CONCURRENCY)
     semaphore = asyncio.Semaphore(max_concurrent)
@@ -935,6 +963,7 @@ async def handle_bulk_lookup(
                     "error_count": counts["error"],
                     "max_concurrent": max_concurrent,
                     "endpoint_family": ENDPOINT_FAMILY_LOOKUP_BULK,
+                    **({"caller_reason": x_caller_reason} if x_caller_reason is not None else {}),
                 },
             )
 

--- a/tests/unit/test_caller_reason_observability.py
+++ b/tests/unit/test_caller_reason_observability.py
@@ -1,0 +1,203 @@
+"""LML#931: traffic-class observability — caller-reason slice.
+
+Reads the caller-supplied ``X-Caller-Reason`` header (forwarded by
+Backend-Service since BS#1843, e.g. ``proxy-library-search`` or
+``catalog-popularity-freetext-resolve``) and emits it as a
+``lml.caller_reason`` Sentry tag plus a matching PostHog ``caller_reason``
+property, recorded once per request/batch context right after
+``record_endpoint_family_tag`` — the same call-site pattern as the #944
+``endpoint_family`` dimension this mirrors (see
+``tests/unit/test_traffic_class_observability.py``).
+
+Unlike ``endpoint_family`` (always one of two fixed literals), the header is
+genuinely optional: older callers and any hop that predates BS#1843 send
+nothing. Absence must be a safe no-op — no tag, no PostHog property, never a
+crash, never a fabricated value — so every "header present" test here has a
+paired "header absent" test.
+
+The other #931 lag dimensions (``admission-result``, ``degraded-mode-result``,
+``timeout-phase``) stay out of scope, gated on #930/#943.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import get_settings
+from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+from lookup.caller_reason import record_caller_reason_tag
+from lookup.models import LookupResponse
+from main import app
+from tests.factories import LOOKUP_BODY
+from tests.unit.conftest import override_deps
+
+
+class TestRecordCallerReasonTag:
+    """Direct unit coverage for the LML#931 Sentry-tag helper.
+
+    Mirrors ``TestRecordEndpointFamilyTag``'s shape, plus the ``None``-guard
+    that ``endpoint_family`` doesn't need (its two values are always
+    fixed literals, never absent).
+    """
+
+    def test_records_tag_when_reason_present(self):
+        set_tag = Mock()
+        with patch("lookup.caller_reason.sentry_sdk.set_tag", set_tag):
+            record_caller_reason_tag("proxy-library-search")
+
+        set_tag.assert_called_once_with("lml.caller_reason", "proxy-library-search")
+
+    def test_no_op_when_reason_absent(self):
+        """``None`` (header missing) must not touch the Sentry SDK at all."""
+        set_tag = Mock()
+        with patch("lookup.caller_reason.sentry_sdk.set_tag", set_tag):
+            record_caller_reason_tag(None)
+
+        set_tag.assert_not_called()
+
+    def test_swallows_sdk_errors(self):
+        """Any SDK-side exception is swallowed so observability cannot break /lookup."""
+        with patch(
+            "lookup.caller_reason.sentry_sdk.set_tag",
+            side_effect=RuntimeError("sentry exploded"),
+        ):
+            record_caller_reason_tag("proxy-library-search")  # must not raise
+
+
+def _completed_properties(mock_posthog: Mock) -> dict:
+    """Pull the full properties dict off the PostHog ``*_completed`` event."""
+    for call in mock_posthog.capture.call_args_list:
+        event = call.kwargs.get("event", "")
+        if event.endswith("_completed"):
+            return call.kwargs["properties"]
+    raise AssertionError("no *_completed PostHog event captured")
+
+
+async def _post(
+    endpoint: str,
+    json_body: dict,
+    *,
+    mock_posthog: Mock,
+    set_tag: Mock,
+    mock_settings,
+    headers: dict[str, str] | None = None,
+) -> None:
+    """POST to a lookup endpoint with ``perform_lookup``, PostHog, and
+    ``sentry_sdk.set_tag`` all mocked. Mirrors ``_post`` in
+    ``test_traffic_class_observability.py``, scoped to the
+    ``lookup.caller_reason`` tag instead of ``lookup.endpoint_family``.
+    """
+    with (
+        override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: AsyncMock(),
+                get_posthog_client: mock_posthog,
+                get_settings: mock_settings,
+            },
+        ),
+        patch("lookup.caller_reason.sentry_sdk.set_tag", set_tag),
+        patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=LookupResponse(results=[], search_type="none"),
+        ),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.post(endpoint, json=json_body, headers=headers or {})
+
+    assert resp.status_code == 200
+
+
+class TestCallerReasonWiredIntoHandlers:
+    """End-to-end (via ASGI client): both handlers thread ``X-Caller-Reason``
+    into the ``lml.caller_reason`` Sentry tag and the PostHog
+    ``*_completed`` event's ``caller_reason`` property when present, and
+    emit neither when the header is absent (LML#931)."""
+
+    @pytest.mark.asyncio
+    async def test_lookup_tags_and_posthog_property_when_header_present(self, mock_settings):
+        mock_posthog = Mock()
+        mock_posthog.capture = Mock()
+        set_tag = Mock()
+
+        await _post(
+            "/api/v1/lookup",
+            LOOKUP_BODY,
+            mock_posthog=mock_posthog,
+            set_tag=set_tag,
+            mock_settings=mock_settings,
+            headers={"X-Caller-Reason": "proxy-library-search"},
+        )
+
+        # `set_tag` is shared with `record_endpoint_family_tag` (both patch the
+        # same underlying `sentry_sdk` module), so both handlers' calls land on
+        # this one mock -- assert membership, mirroring
+        # `TestEndpointFamilyWiredIntoHandlers` in test_traffic_class_observability.py.
+        assert ("lml.caller_reason", "proxy-library-search") in [
+            c.args for c in set_tag.call_args_list
+        ]
+        assert _completed_properties(mock_posthog)["caller_reason"] == "proxy-library-search"
+
+    @pytest.mark.asyncio
+    async def test_lookup_omits_tag_and_property_when_header_absent(self, mock_settings):
+        mock_posthog = Mock()
+        mock_posthog.capture = Mock()
+        set_tag = Mock()
+
+        await _post(
+            "/api/v1/lookup",
+            LOOKUP_BODY,
+            mock_posthog=mock_posthog,
+            set_tag=set_tag,
+            mock_settings=mock_settings,
+        )
+
+        # `record_endpoint_family_tag` still fires unconditionally (out of
+        # scope here), so assert absence of the *caller_reason* key specifically.
+        assert "lml.caller_reason" not in {c.args[0] for c in set_tag.call_args_list}
+        assert "caller_reason" not in _completed_properties(mock_posthog)
+
+    @pytest.mark.asyncio
+    async def test_bulk_lookup_tags_and_posthog_property_when_header_present(self, mock_settings):
+        mock_posthog = Mock()
+        mock_posthog.capture = Mock()
+        set_tag = Mock()
+
+        await _post(
+            "/api/v1/lookup/bulk",
+            {"items": [{"artist": "Stereolab", "album": "Aluminum Tunes"}]},
+            mock_posthog=mock_posthog,
+            set_tag=set_tag,
+            mock_settings=mock_settings,
+            headers={"X-Caller-Reason": "catalog-popularity-freetext-resolve"},
+        )
+
+        assert ("lml.caller_reason", "catalog-popularity-freetext-resolve") in [
+            c.args for c in set_tag.call_args_list
+        ]
+        assert (
+            _completed_properties(mock_posthog)["caller_reason"]
+            == "catalog-popularity-freetext-resolve"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bulk_lookup_omits_tag_and_property_when_header_absent(self, mock_settings):
+        mock_posthog = Mock()
+        mock_posthog.capture = Mock()
+        set_tag = Mock()
+
+        await _post(
+            "/api/v1/lookup/bulk",
+            {"items": [{"artist": "Stereolab", "album": "Aluminum Tunes"}]},
+            mock_posthog=mock_posthog,
+            set_tag=set_tag,
+            mock_settings=mock_settings,
+        )
+
+        assert "lml.caller_reason" not in {c.args[0] for c in set_tag.call_args_list}
+        assert "caller_reason" not in _completed_properties(mock_posthog)

--- a/tests/unit/test_module_budgets.py
+++ b/tests/unit/test_module_budgets.py
@@ -25,6 +25,7 @@ MODULE_BUDGETS: dict[str, int] = {
     "lookup/__init__.py": 50,
     "lookup/artist_resolution.py": 550,
     "lookup/artwork.py": 500,
+    "lookup/caller_reason.py": 100,
     "lookup/candidate_memo.py": 150,
     "lookup/concurrency.py": 200,
     "lookup/endpoint_family.py": 100,


### PR DESCRIPTION
## Summary

- Reads the caller-supplied `X-Caller-Reason` header (forwarded by Backend-Service since BS#1843, e.g. `proxy-library-search` or `catalog-popularity-freetext-resolve`) at both `/lookup` and `/lookup/bulk`, mirroring the existing `X-Caller-Budget-Ms` `Header(alias=...)` seam.
- Emits it as an `lml.caller_reason` Sentry tag plus a matching PostHog `caller_reason` property, via the same per-request Sentry-tag / PostHog-freeform-dict channel #944 already shipped for `endpoint_family` -- **not** the numeric-only `_LML_CACHE_STATS_EXTRA_KEYS` seam, which cannot carry a string value.
- Absent header is a safe no-op: `record_caller_reason_tag` no-ops on `None` (no Sentry tag), and the PostHog properties dict omits the `caller_reason` key entirely rather than fabricating a null value.
- New `lookup/caller_reason.py` module (100-line budget) mirrors `lookup/endpoint_family.py`'s shape and call-site pattern, keeping `lookup/router.py` under its LML#731 module-budget ceiling.

Out of scope, per the issue: `admission-result`, `degraded-mode-result`, and `timeout-phase` stay deferred to #930/#943; `endpoint-family`, `caller-budget`, and `queue-wait` are untouched beyond placing `caller_reason` beside them in the router.

Adjacent-addition diff by design: sibling PR #928 is adding a different header (`X-Caller-Class`) at the same `Header(...)` seams concurrently, so this PR's new param is placed immediately after `x_caller_budget_ms` in both handlers with no reordering/reformatting of surrounding lines, to keep the eventual rebase trivial.

Closes #931

## Test plan

- [x] New `tests/unit/test_caller_reason_observability.py`: direct unit coverage for `record_caller_reason_tag` (present/absent/SDK-error-swallowed), plus ASGI end-to-end coverage for both `/lookup` and `/lookup/bulk` confirming the Sentry tag and PostHog property are set when the header is present and omitted when absent.
- [x] `tests/unit/test_module_budgets.py` updated with the new module's ceiling.
- [x] `ruff check .` and `ruff format --check .` pass.
- [x] `mypy . --ignore-missing-imports` passes.
- [x] Full default `pytest` suite (unit + integration + e2e, minus `pg`/`external_api`) passes: 4559 passed, 1 skipped, 551 deselected, 2 xfailed.