### PR TITLE
Acquire the bulk-global permit before the interactive lookup semaphore

### DIFF
--- a/core/bulk_concurrency.py
+++ b/core/bulk_concurrency.py
@@ -27,18 +27,27 @@ The pieces:
   calling ``.cancel()`` doesn't free the permits until the task observes the
   cancel and unwinds.
 - ``resolve_caller_class(raw)`` / ``is_low_priority_caller_class(caller_class)``
-  / ``maybe_acquire_bulk_global_permit(condition)`` (LML#928) — generalizes
-  the ``/lookup/bulk`` drain's implicit low-priority placement into an
-  explicit, caller-declared policy. ``resolve_caller_class`` parses the
-  ``X-Caller-Class`` header (1-5, forwarded by Backend-Service per BS#1843),
-  tolerating garbage as ``None``; ``is_low_priority_caller_class`` is the
-  down-rank-only predicate (True only for class 5); and
-  ``maybe_acquire_bulk_global_permit`` lets a single ``/lookup`` request
-  conditionally join the SAME ``acquire_bulk_global_permit`` budget bulk
-  items use, so a class-5 caller shares the low-priority lane's budget
-  rather than a lookalike. The Discogs-semaphore-level priority reservation
-  (reserving headroom at the 5-permit gate itself, superseding the #924
-  interim) is a separate, still-open slice — LML#927.
+  (LML#928) — generalizes the ``/lookup/bulk`` drain's implicit low-priority
+  placement into an explicit, caller-declared policy. ``resolve_caller_class``
+  parses the ``X-Caller-Class`` header (1-5, forwarded by Backend-Service per
+  BS#1843), tolerating garbage as ``None``; ``is_low_priority_caller_class``
+  is the down-rank-only predicate (True only for class 5).
+- ``acquire_bulk_global_permit_or_reap(request)`` /
+  ``maybe_acquire_bulk_global_permit_or_reap(condition, request)`` (LML#953,
+  replacing LML#928's ``maybe_acquire_bulk_global_permit``) — lets a single
+  ``/lookup`` request conditionally join the SAME ``acquire_bulk_global_permit``
+  budget bulk items use, so a class-5 caller shares the low-priority lane's
+  budget rather than a lookalike. Unlike the plain ``acquire_bulk_global_permit``
+  bulk items use (which rely on their batch's own outer disconnect sentinel),
+  a single ``/lookup`` request has no such outer race, so this variant races
+  the wait itself against ``watch_disconnect`` and yields the measured queue
+  wait in ms (0.0 if uncontended) so the caller can debit it from
+  ``X-Caller-Budget-Ms`` the same way the interactive in-flight cap already
+  does. Raises ``ClientDisconnectedWhileQueuedError`` if the client departs before
+  the permit is granted; the permit is never held in that case. The
+  Discogs-semaphore-level priority reservation (reserving headroom at the
+  5-permit gate itself, superseding the #924 interim) is a separate,
+  still-open slice — LML#927.
 
 The per-request env knob (default 10) is shared between the endpoints
 intentionally — they have the same outer/inner gate shape and similar
@@ -256,25 +265,105 @@ def is_low_priority_caller_class(caller_class: int | None) -> bool:
     return caller_class == LOW_PRIORITY_CALLER_CLASS
 
 
-@contextlib.asynccontextmanager
-async def maybe_acquire_bulk_global_permit(condition: bool):
-    """Conditionally hold the LML#716/#924 low-priority global permit (LML#928).
+class ClientDisconnectedWhileQueuedError(Exception):
+    """Raised by :func:`acquire_bulk_global_permit_or_reap` (and its
+    conditional wrapper) when the client disconnects before the global
+    permit is granted.
 
-    ``async with maybe_acquire_bulk_global_permit(is_low_priority_caller_class(caller_class)):``
-    is a no-op context when ``condition`` is False, so a call site can route
-    onto the low-priority lane for exactly one branch (a class-5 caller)
-    without duplicating its body for the common (unaffected) case. When
-    ``condition`` is True it delegates to :func:`acquire_bulk_global_permit`
-    -- the identical process-global semaphore ``/lookup/bulk`` items already
-    share -- so a class-5 single ``/lookup`` request draws from the SAME
+    The permit was never taken -- the caller should treat this as a reap
+    signal (the LML#715 in-flight-cap pattern) and short-circuit, e.g. with a
+    499, without running any further work for the departed caller.
+    """
+
+
+@contextlib.asynccontextmanager
+async def acquire_bulk_global_permit_or_reap(request: Request):
+    """Acquire the LML#716/#924 global bulk-item permit, racing a saturated
+    wait against client disconnect (LML#953).
+
+    Mirrors the #706/#715 in-flight-cap pattern ``lookup.router.handle_lookup``
+    uses for the interactive semaphore: a caller that departs while parked on
+    a saturated budget must not later run a lookup nobody reads. Unlike
+    :func:`acquire_bulk_global_permit` (used by every batched bulk-family
+    dispatcher, which already race a DIFFERENT outer-scope disconnect
+    sentinel around the whole batch), a single class-5 ``/lookup`` request
+    has no such outer race, so it needs its own.
+
+    Yields the measured queue wait in milliseconds (``0.0`` when the permit
+    was free on arrival, mirroring :func:`acquire_bulk_global_permit`'s own
+    ``capped_on_arrival`` convention). Raises
+    :class:`ClientDisconnectedWhileQueuedError` when the client disconnects before
+    the permit is granted -- the permit is never held in that case.
+
+    Only one ``watch_disconnect(request)`` reader may be active on a given
+    request at a time (the ASGI receive channel has no fan-out), so callers
+    must not hold this open concurrently with another disconnect sentinel on
+    the same request -- sequence them instead, same as the interactive cap
+    does when it starts its own sentinel only after this one is drained.
+    """
+    semaphore = _get_bulk_global_semaphore()
+    capped_on_arrival = semaphore.locked()
+    wait_start = time.perf_counter()
+    acquire_future = asyncio.ensure_future(semaphore.acquire())
+    sentinel_task = asyncio.create_task(
+        watch_disconnect(request), name="lml.lookup.bulk_global_disconnect_sentinel"
+    )
+    # Same guaranteed-release shape as the interactive cap below: track
+    # "did we end up holding a permit" explicitly and release exactly once,
+    # in the `finally`, whatever path leaves this context.
+    permit_held = False
+    try:
+        try:
+            done, _pending = await asyncio.wait(
+                {acquire_future, sentinel_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+        except BaseException:
+            await cancel_and_drain(acquire_future)
+            permit_held = acquire_future.done() and not acquire_future.cancelled()
+            await cancel_and_drain(sentinel_task)
+            raise
+
+        if sentinel_task in done and not acquire_future.done():
+            # Client departed while queued. Free the never-taken slot and
+            # signal the caller to reap -- nobody reads the eventual result.
+            await cancel_and_drain(acquire_future)
+            raise ClientDisconnectedWhileQueuedError()
+
+        permit_held = True
+        await cancel_and_drain(sentinel_task)
+        wait_ms = 0.0
+        if capped_on_arrival:
+            wait_ms = (time.perf_counter() - wait_start) * 1000.0
+            _project_global_capped(wait_ms)
+        yield wait_ms
+    finally:
+        if permit_held:
+            semaphore.release()
+
+
+@contextlib.asynccontextmanager
+async def maybe_acquire_bulk_global_permit_or_reap(condition: bool, request: Request):
+    """Conditionally hold the low-priority global permit, disconnect-aware (LML#953).
+
+    ``async with maybe_acquire_bulk_global_permit_or_reap(condition, http_request):`` is a
+    no-op context when ``condition`` is False (yields ``0.0`` and never
+    touches the semaphore or spawns a disconnect sentinel), so a call site
+    can route onto the low-priority lane for exactly one branch (a class-5
+    caller) without duplicating its body for the common (unaffected) case.
+    When ``condition`` is True it delegates to
+    :func:`acquire_bulk_global_permit_or_reap` -- the identical
+    process-global semaphore ``/lookup/bulk`` items already share -- so a
+    class-5 single ``/lookup`` request draws from the SAME
     ``LML_BULK_GLOBAL_MAX_CONCURRENT`` budget as a bulk drain, rather than a
-    lookalike budget that would let batch traffic double its effective quota.
+    lookalike budget that would let batch traffic double its effective
+    quota. Replaces LML#928's ``maybe_acquire_bulk_global_permit``, which had
+    no disconnect awareness and no wait measurement.
     """
     if condition:
-        async with acquire_bulk_global_permit():
-            yield
+        async with acquire_bulk_global_permit_or_reap(request) as wait_ms:
+            yield wait_ms
     else:
-        yield
+        yield 0.0
 
 
 async def cancel_and_drain(future: asyncio.Future[Any]) -> None:
@@ -293,10 +382,12 @@ async def cancel_and_drain(future: asyncio.Future[Any]) -> None:
 
 __all__ = [
     "LOW_PRIORITY_CALLER_CLASS",
+    "ClientDisconnectedWhileQueuedError",
     "acquire_bulk_global_permit",
+    "acquire_bulk_global_permit_or_reap",
     "cancel_and_drain",
     "is_low_priority_caller_class",
-    "maybe_acquire_bulk_global_permit",
+    "maybe_acquire_bulk_global_permit_or_reap",
     "max_concurrency_from_env",
     "resolve_caller_class",
     "watch_disconnect",

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -23,11 +23,12 @@ from clients.streaming.spotify import SpotifyClient
 from config.settings import get_settings
 from core.bulk_body import parse_bulk_body
 from core.bulk_concurrency import (
+    ClientDisconnectedWhileQueuedError,
     acquire_bulk_global_permit,
     cancel_and_drain,
     is_low_priority_caller_class,
     max_concurrency_from_env,
-    maybe_acquire_bulk_global_permit,
+    maybe_acquire_bulk_global_permit_or_reap,
     resolve_caller_class,
     watch_disconnect,
 )
@@ -486,117 +487,134 @@ async def handle_lookup(
         set_skip_cache(True)
 
     try:
-        # LML#706 PR3: bound in-flight lookups process-wide. On this repo's
-        # Python (>=3.12) the `locked()` pre-check is EXACT, not racy: there is
-        # no await between the check and the acquire (one event-loop slice),
-        # and 3.12's `locked()` returns True when the value is exhausted OR
-        # waiters exist — the same predicate `acquire()` uses to decide whether
-        # to park. So `capped_on_arrival` ⇔ this request actually queued.
-        semaphore = _get_lookup_semaphore()
-        capped_on_arrival = semaphore.locked()
-        wait_start = time.perf_counter()
+        # LML#928/#953: class 5 (batch/cron/backfill) additionally routes this
+        # request onto the low-priority lane -- the same LML#716/#924
+        # process-global bulk permit `/lookup/bulk` items already share.
+        # Down-rank only: classes 1-4, absent, and invalid values resolve to a
+        # no-op (today's interactive-only behavior, unchanged). Resolved here,
+        # before ANY permit is touched -- LML#953 requires the bulk-global
+        # wait to happen BEFORE (outside) the interactive
+        # `LML_LOOKUP_MAX_CONCURRENT` semaphore below, so a class-5 request
+        # parked on a saturated bulk budget never pins an interactive slot
+        # while it waits (the #951 review's priority-inversion finding).
+        # Deadlock-free: nothing holding the bulk-global permit ever waits on
+        # the lookup semaphore, so acquiring strictly in this order can never
+        # form a cycle with the reverse order.
+        caller_class = resolve_caller_class(x_caller_class)
+        low_priority = is_low_priority_caller_class(caller_class)
 
-        # LML#715: reap callers that disconnect WHILE QUEUED. Starlette runs a
-        # non-streaming handler to completion after the client's socket closes,
-        # so a request whose caller already timed out and retried (the #706
-        # cold-storm shape) would otherwise keep its FIFO slot, later acquire a
-        # permit, and run a full cold lookup nobody receives — retry-amplified
-        # zombie work that spends the scarce cap. Race the permit acquire
-        # against the same `watch_disconnect` sentinel the /lookup/bulk and
-        # identity bulk-resolve paths use; on disconnect, cancel the acquire so
-        # the queue slot frees and no lookup runs. This guards the QUEUED phase
-        # ONLY — once the permit is held the sentinel is cancelled and
-        # perform_lookup runs to completion (a disconnect mid-lookup is not
-        # reaped; that phase already holds its resources).
-        #
-        # Cancelling `semaphore.acquire()` is permit-safe on this repo's Python
-        # (>=3.12): if the acquire is cancelled AFTER the permit was granted
-        # (the acquire/sentinel tie), Semaphore.acquire returns the permit and
-        # re-raises, so `cancel_and_drain` cannot strand a slot.
-        acquire_future = asyncio.ensure_future(semaphore.acquire())
-        sentinel_task = asyncio.create_task(
-            watch_disconnect(http_request), name="lml.lookup.disconnect_sentinel"
-        )
-        # A single guaranteed-release scope guards the permit from the moment it
-        # could be held. `cancel_and_drain` is a no-op on an already-done future,
-        # so it does NOT return a granted permit; and the sentinel cleanup on
-        # the success path can re-raise (a `receive()` error) before the lookup.
-        # Both are permit leaks on the process-global cap if release is tied to
-        # a narrower `try`. Track "did we end up holding a permit" explicitly and
-        # release it once in the outer `finally`, whatever path we leave by.
-        permit_held = False
-        try:
-            try:
-                done, _pending = await asyncio.wait(
-                    {acquire_future, sentinel_task}, return_when=asyncio.FIRST_COMPLETED
-                )
-            except BaseException:
-                # Handler cancellation can arrive with the acquire already
-                # granted (grant + cancel in the same loop cycle). Drain the
-                # acquire, then flag the granted permit so the outer `finally`
-                # releases it — a still-pending acquire drains as CANCELLED and
-                # never took a permit, so it stays False.
-                await cancel_and_drain(acquire_future)
-                permit_held = acquire_future.done() and not acquire_future.cancelled()
-                await cancel_and_drain(sentinel_task)
-                raise
+        async with maybe_acquire_bulk_global_permit_or_reap(
+            low_priority, http_request
+        ) as bulk_wait_ms:
+            # LML#706 PR3: bound in-flight lookups process-wide. On this repo's
+            # Python (>=3.12) the `locked()` pre-check is EXACT, not racy: there is
+            # no await between the check and the acquire (one event-loop slice),
+            # and 3.12's `locked()` returns True when the value is exhausted OR
+            # waiters exist — the same predicate `acquire()` uses to decide whether
+            # to park. So `capped_on_arrival` ⇔ this request actually queued.
+            semaphore = _get_lookup_semaphore()
+            capped_on_arrival = semaphore.locked()
+            wait_start = time.perf_counter()
 
-            # Tie broken toward "acquired": if both completed, the acquire holds
-            # a permit, so proceed rather than reap. `acquire_future.done()` is
-            # exact here — no await separates the wait() return from this check,
-            # so the single event loop cannot flip the state underneath us.
-            if sentinel_task in done and not acquire_future.done():
-                # Client departed while queued. Free the never-taken slot and
-                # short-circuit; nobody reads the body. The tag mirrors the bulk
-                # path so `lml.client_aborted:true` surfaces reaped requests in
-                # the Sentry trace explorer.
-                await cancel_and_drain(acquire_future)
-                sentry_sdk.set_tag("lml.client_aborted", "true")
-                logger.warning(
-                    "lookup reaped: client disconnected while queued on the in-flight cap"
-                )
-                http_response.status_code = 499
-                return LookupResponse(results=[], search_type="none")
-
-            # Permit held from here — the outer `finally` owns its release, so a
-            # raising sentinel drain (below) or perform_lookup error can't strand
-            # it.
-            permit_held = True
-            # Stop watching for disconnect; the permit-held phase is not reaped.
-            await cancel_and_drain(sentinel_task)
-            # `queue_wait` Server-Timing leg (LML#907 follow-up): always
-            # computed (0.0 when uncontended) so it always renders via `extra`
-            # below; `total` (built after this point) never includes it.
-            queue_wait_ms = 0.0
-            if capped_on_arrival:
-                queue_wait_ms = (time.perf_counter() - wait_start) * 1000.0
-                _project_inflight_capped(queue_wait_ms)
-                # Debit the queue wait from the caller's budget so the A8 /
-                # LML#345 contract ("LML returns slightly before the caller
-                # times out") holds under saturation — the pipeline's budget
-                # clock only starts inside perform_lookup. Floor at 1: the
-                # budget resolver treats non-positive as "unset → env
-                # default", which would hand the MOST delayed caller the
-                # LARGEST budget. A 1ms budget short-circuits the pipeline
-                # almost immediately — the cheap outcome the (likely already
-                # timed-out) caller would want.
-                if x_caller_budget_ms is not None and x_caller_budget_ms > 0:
-                    x_caller_budget_ms = max(1, x_caller_budget_ms - int(queue_wait_ms))
-            # Constructed inside the permit so telemetry's total-duration
-            # series keeps meaning "lookup work", not "queue wait + work" —
-            # the wait is reported separately via the Sentry measurement.
-            telemetry = RequestTelemetry(
-                api_call_keys=["discogs"],
-                distinct_id="library-metadata-lookup-service",
-                event_prefix="lookup",
+            # LML#715: reap callers that disconnect WHILE QUEUED. Starlette runs a
+            # non-streaming handler to completion after the client's socket closes,
+            # so a request whose caller already timed out and retried (the #706
+            # cold-storm shape) would otherwise keep its FIFO slot, later acquire a
+            # permit, and run a full cold lookup nobody receives — retry-amplified
+            # zombie work that spends the scarce cap. Race the permit acquire
+            # against the same `watch_disconnect` sentinel the /lookup/bulk and
+            # identity bulk-resolve paths use; on disconnect, cancel the acquire so
+            # the queue slot frees and no lookup runs. This guards the QUEUED phase
+            # ONLY — once the permit is held the sentinel is cancelled and
+            # perform_lookup runs to completion (a disconnect mid-lookup is not
+            # reaped; that phase already holds its resources).
+            #
+            # Cancelling `semaphore.acquire()` is permit-safe on this repo's Python
+            # (>=3.12): if the acquire is cancelled AFTER the permit was granted
+            # (the acquire/sentinel tie), Semaphore.acquire returns the permit and
+            # re-raises, so `cancel_and_drain` cannot strand a slot.
+            acquire_future = asyncio.ensure_future(semaphore.acquire())
+            sentinel_task = asyncio.create_task(
+                watch_disconnect(http_request), name="lml.lookup.disconnect_sentinel"
             )
-            # LML#928: class 5 (batch/cron/backfill) additionally routes this
-            # request onto the low-priority lane -- the same LML#716/#924
-            # process-global bulk permit `/lookup/bulk` items already share.
-            # Down-rank only: classes 1-4, absent, and invalid values resolve
-            # to a no-op here (today's interactive-only behavior, unchanged).
-            caller_class = resolve_caller_class(x_caller_class)
-            async with maybe_acquire_bulk_global_permit(is_low_priority_caller_class(caller_class)):
+            # A single guaranteed-release scope guards the permit from the moment it
+            # could be held. `cancel_and_drain` is a no-op on an already-done future,
+            # so it does NOT return a granted permit; and the sentinel cleanup on
+            # the success path can re-raise (a `receive()` error) before the lookup.
+            # Both are permit leaks on the process-global cap if release is tied to
+            # a narrower `try`. Track "did we end up holding a permit" explicitly and
+            # release it once in the outer `finally`, whatever path we leave by.
+            permit_held = False
+            try:
+                try:
+                    done, _pending = await asyncio.wait(
+                        {acquire_future, sentinel_task}, return_when=asyncio.FIRST_COMPLETED
+                    )
+                except BaseException:
+                    # Handler cancellation can arrive with the acquire already
+                    # granted (grant + cancel in the same loop cycle). Drain the
+                    # acquire, then flag the granted permit so the outer `finally`
+                    # releases it — a still-pending acquire drains as CANCELLED and
+                    # never took a permit, so it stays False.
+                    await cancel_and_drain(acquire_future)
+                    permit_held = acquire_future.done() and not acquire_future.cancelled()
+                    await cancel_and_drain(sentinel_task)
+                    raise
+
+                # Tie broken toward "acquired": if both completed, the acquire holds
+                # a permit, so proceed rather than reap. `acquire_future.done()` is
+                # exact here — no await separates the wait() return from this check,
+                # so the single event loop cannot flip the state underneath us.
+                if sentinel_task in done and not acquire_future.done():
+                    # Client departed while queued. Free the never-taken slot and
+                    # short-circuit; nobody reads the body. The tag mirrors the bulk
+                    # path so `lml.client_aborted:true` surfaces reaped requests in
+                    # the Sentry trace explorer.
+                    await cancel_and_drain(acquire_future)
+                    sentry_sdk.set_tag("lml.client_aborted", "true")
+                    logger.warning(
+                        "lookup reaped: client disconnected while queued on the in-flight cap"
+                    )
+                    http_response.status_code = 499
+                    return LookupResponse(results=[], search_type="none")
+
+                # Permit held from here — the outer `finally` owns its release, so a
+                # raising sentinel drain (below) or perform_lookup error can't strand
+                # it.
+                permit_held = True
+                # Stop watching for disconnect; the permit-held phase is not reaped.
+                await cancel_and_drain(sentinel_task)
+                # `queue_wait` Server-Timing leg (LML#907 follow-up, extended by
+                # LML#953): the sum of BOTH gates' measured wait -- the
+                # bulk-global wait (`bulk_wait_ms`, 0.0 unless this is a capped
+                # class-5 request) plus this semaphore's own wait -- always
+                # computed (0.0 when uncontended on both) so it always renders
+                # via `extra` below; `total` (built after this point) never
+                # includes it.
+                queue_wait_ms = bulk_wait_ms
+                if capped_on_arrival:
+                    interactive_wait_ms = (time.perf_counter() - wait_start) * 1000.0
+                    _project_inflight_capped(interactive_wait_ms)
+                    queue_wait_ms += interactive_wait_ms
+                # Debit the TOTAL queue wait (bulk-global + interactive) from the
+                # caller's budget so the A8 / LML#345 contract ("LML returns
+                # slightly before the caller times out") holds under saturation
+                # on EITHER gate — the pipeline's budget clock only starts
+                # inside perform_lookup. Floor at 1: the budget resolver treats
+                # non-positive as "unset → env default", which would hand the
+                # MOST delayed caller the LARGEST budget. A 1ms budget
+                # short-circuits the pipeline almost immediately — the cheap
+                # outcome the (likely already timed-out) caller would want.
+                if queue_wait_ms > 0 and x_caller_budget_ms is not None and x_caller_budget_ms > 0:
+                    x_caller_budget_ms = max(1, x_caller_budget_ms - int(queue_wait_ms))
+                # Constructed inside the permit so telemetry's total-duration
+                # series keeps meaning "lookup work", not "queue wait + work" —
+                # the wait is reported separately via the Sentry measurement.
+                telemetry = RequestTelemetry(
+                    api_call_keys=["discogs"],
+                    distinct_id="library-metadata-lookup-service",
+                    event_prefix="lookup",
+                )
                 response = await perform_lookup(
                     request=request,
                     db=db,
@@ -611,9 +629,9 @@ async def handle_lookup(
                     discogs_cache_pg=discogs_cache_pg,
                     caller_budget_ms=x_caller_budget_ms,
                 )
-        finally:
-            if permit_held:
-                semaphore.release()
+            finally:
+                if permit_held:
+                    semaphore.release()
 
         # Attach cache stats. wxyc-shared#86 has shipped the typed CacheStats
         # Pydantic model, so the response field is no longer dict-shaped —
@@ -664,6 +682,15 @@ async def handle_lookup(
 
     except HTTPException:
         raise
+    except ClientDisconnectedWhileQueuedError:
+        # LML#953: client departed while parked on a saturated bulk-global
+        # budget -- mirrors the in-flight cap's own reap branch above (the
+        # tag/log/499 shape), just for the OUTER gate instead of the inner
+        # one. The permit was never taken; nobody reads the body.
+        sentry_sdk.set_tag("lml.client_aborted", "true")
+        logger.warning("lookup reaped: client disconnected while queued on the bulk-global permit")
+        http_response.status_code = 499
+        return LookupResponse(results=[], search_type="none")
     except Exception as e:
         logger.error(f"Lookup failed: {e}")
         raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -497,9 +497,13 @@ async def handle_lookup(
         # `LML_LOOKUP_MAX_CONCURRENT` semaphore below, so a class-5 request
         # parked on a saturated bulk budget never pins an interactive slot
         # while it waits (the #951 review's priority-inversion finding).
-        # Deadlock-free: nothing holding the bulk-global permit ever waits on
-        # the lookup semaphore, so acquiring strictly in this order can never
-        # form a cycle with the reverse order.
+        # Deadlock-free: acquisition is strictly ordered bulk-global permit ->
+        # interactive lookup semaphore and never the reverse. The class-5 path
+        # deliberately holds the bulk permit while parked on the lookup
+        # semaphore -- that is the intended forward edge, not a cycle. Safety
+        # comes from the reverse never happening: nothing that already holds the
+        # lookup semaphore ever waits on the bulk-global permit, so no acquire
+        # cycle can form.
         caller_class = resolve_caller_class(x_caller_class)
         low_priority = is_low_priority_caller_class(caller_class)
 

--- a/tests/unit/test_caller_class.py
+++ b/tests/unit/test_caller_class.py
@@ -19,15 +19,27 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from unittest.mock import patch
 
 import pytest
 
 from core.bulk_concurrency import (
     LOW_PRIORITY_CALLER_CLASS,
+    ClientDisconnectedWhileQueuedError,
     is_low_priority_caller_class,
-    maybe_acquire_bulk_global_permit,
+    maybe_acquire_bulk_global_permit_or_reap,
     resolve_caller_class,
 )
+
+
+async def _never_disconnects(_request) -> None:
+    """A ``watch_disconnect`` replacement that never observes a disconnect.
+
+    Every test below that doesn't specifically exercise the disconnect race
+    patches this in, so the fake ``request`` object it's paired with (never a
+    real ASGI ``Request``) is never actually touched.
+    """
+    await asyncio.Event().wait()
 
 
 class TestResolveCallerClass:
@@ -82,11 +94,16 @@ class TestIsLowPriorityCallerClass:
         assert LOW_PRIORITY_CALLER_CLASS == 5
 
 
-class TestMaybeAcquireBulkGlobalPermit:
-    """``maybe_acquire_bulk_global_permit`` must gate the REAL LML#716/#924
-    global bulk semaphore -- the identical one ``/lookup/bulk`` items use --
-    not a lookalike, so the class-5 low-priority lane genuinely shares the
-    same budget as bulk drains."""
+class TestMaybeAcquireBulkGlobalPermitOrReap:
+    """``maybe_acquire_bulk_global_permit_or_reap`` (LML#953) must gate the
+    REAL LML#716/#924 global bulk semaphore -- the identical one
+    ``/lookup/bulk`` items use -- not a lookalike, so the class-5
+    low-priority lane genuinely shares the same budget as bulk drains. Unlike
+    its LML#928 predecessor (``maybe_acquire_bulk_global_permit``, removed),
+    it also races a saturated wait against client disconnect and reports the
+    measured wait, so a single ``/lookup`` request can debit it from the
+    caller budget the same way the interactive in-flight cap already does.
+    """
 
     @pytest.mark.asyncio
     async def test_false_condition_does_not_touch_the_semaphore(self, monkeypatch):
@@ -100,18 +117,38 @@ class TestMaybeAcquireBulkGlobalPermit:
         async with acquire_bulk_global_permit():
             # The single permit is held here; a real acquire would hang.
             async with asyncio.timeout(0.2):
-                async with maybe_acquire_bulk_global_permit(False):
-                    pass
+                async with maybe_acquire_bulk_global_permit_or_reap(False, object()) as wait_ms:
+                    assert wait_ms == 0.0
+
+    @pytest.mark.asyncio
+    async def test_false_condition_never_watches_for_disconnect(self, monkeypatch):
+        """A False condition must not spawn a disconnect sentinel at all --
+        the common (non-class-5) path stays exactly as cheap as before."""
+        from core import bulk_concurrency as bc
+
+        watched: list[object] = []
+
+        async def _tracking_watch(request):
+            watched.append(request)
+            await asyncio.sleep(10)
+
+        with patch.object(bc, "watch_disconnect", _tracking_watch):
+            async with maybe_acquire_bulk_global_permit_or_reap(False, object()):
+                pass
+
+        assert watched == []
 
     @pytest.mark.asyncio
     async def test_true_condition_holds_the_real_global_permit(self, monkeypatch):
         """Condition True must route through the SAME semaphore bulk items use.
 
         Budget of 1: a concurrent direct `acquire_bulk_global_permit()` call
-        must queue behind the `maybe_acquire_bulk_global_permit(True)` holder,
-        proving it's the identical process-global semaphore, not a lookalike.
+        must queue behind the `maybe_acquire_bulk_global_permit_or_reap(True, ...)`
+        holder, proving it's the identical process-global semaphore, not a
+        lookalike.
         """
         monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        from core import bulk_concurrency as bc
         from core.bulk_concurrency import acquire_bulk_global_permit
 
         entered_second = asyncio.Event()
@@ -120,11 +157,114 @@ class TestMaybeAcquireBulkGlobalPermit:
             async with acquire_bulk_global_permit():
                 entered_second.set()
 
-        async with maybe_acquire_bulk_global_permit(True):
-            second = asyncio.create_task(_second_holder())
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            assert not entered_second.is_set(), "second holder should queue behind the first"
+        with patch.object(bc, "watch_disconnect", _never_disconnects):
+            async with maybe_acquire_bulk_global_permit_or_reap(True, object()) as wait_ms:
+                assert wait_ms == 0.0, "uncontended acquire must report zero wait"
+                second = asyncio.create_task(_second_holder())
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                assert not entered_second.is_set(), "second holder should queue behind the first"
 
-        await asyncio.wait_for(second, timeout=1.0)
+            await asyncio.wait_for(second, timeout=1.0)
         assert entered_second.is_set()
+
+    @pytest.mark.asyncio
+    async def test_true_condition_reports_measured_wait_when_capped(self, monkeypatch):
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        from core import bulk_concurrency as bc
+        from core.bulk_concurrency import _get_bulk_global_semaphore, acquire_bulk_global_permit
+
+        release = asyncio.Event()
+
+        async def _holder():
+            async with acquire_bulk_global_permit():
+                await release.wait()
+
+        holder = asyncio.create_task(_holder())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        wait_ms_holder: list[float] = []
+
+        async def _second():
+            async with maybe_acquire_bulk_global_permit_or_reap(True, object()) as wait_ms:
+                wait_ms_holder.append(wait_ms)
+
+        with patch.object(bc, "watch_disconnect", _never_disconnects):
+            second = asyncio.create_task(_second())
+            for _ in range(100):
+                if getattr(_get_bulk_global_semaphore(), "_waiters", None):
+                    break
+                await asyncio.sleep(0.001)
+            else:
+                pytest.fail("second holder never parked on the global permit")
+
+            await asyncio.sleep(0.05)
+            release.set()
+            await asyncio.gather(holder, second)
+
+        assert wait_ms_holder[0] >= 40
+
+    @pytest.mark.asyncio
+    async def test_disconnect_while_parked_raises_and_frees_the_permit(self, monkeypatch):
+        """A client that disconnects while parked on a saturated budget must
+        never take the permit -- the exception signals the caller to reap
+        the request (LML#953), mirroring the #706/#715 in-flight-cap pattern.
+        """
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        from core import bulk_concurrency as bc
+        from core.bulk_concurrency import _get_bulk_global_semaphore, acquire_bulk_global_permit
+
+        release = asyncio.Event()
+
+        async def _holder():
+            async with acquire_bulk_global_permit():
+                await release.wait()
+
+        holder = asyncio.create_task(_holder())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        async def _disconnect_after_parked(_request):
+            for _ in range(100):
+                if getattr(_get_bulk_global_semaphore(), "_waiters", None):
+                    return
+                await asyncio.sleep(0.001)
+            pytest.fail("second holder never parked on the global permit")
+
+        entered = False
+        with patch.object(bc, "watch_disconnect", _disconnect_after_parked):
+            with pytest.raises(ClientDisconnectedWhileQueuedError):
+                async with maybe_acquire_bulk_global_permit_or_reap(True, object()):
+                    entered = True
+
+        assert not entered, "the guarded block must never run for a reaped request"
+
+        release.set()
+        await asyncio.wait_for(holder, timeout=1.0)
+
+        # The permit was never taken by the reaped waiter: the semaphore
+        # accepts a fresh acquire immediately once the original holder frees
+        # it, with no stranded slot.
+        async with asyncio.timeout(0.2):
+            async with acquire_bulk_global_permit():
+                pass
+
+    @pytest.mark.asyncio
+    async def test_uncontended_disconnect_after_grant_does_not_reap(self, monkeypatch):
+        """A disconnect signalled AFTER an uncontended acquire must not reap --
+        mirrors the interactive cap's "permit holder unaffected" contract.
+        """
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "4")
+        from core import bulk_concurrency as bc
+
+        async def _disconnect_soon(_request):
+            await asyncio.sleep(0.05)
+
+        entered = False
+        with patch.object(bc, "watch_disconnect", _disconnect_soon):
+            async with maybe_acquire_bulk_global_permit_or_reap(True, object()):
+                entered = True
+                await asyncio.sleep(0.1)
+
+        assert entered

--- a/tests/unit/test_lookup_class5_bulk_permit_ordering.py
+++ b/tests/unit/test_lookup_class5_bulk_permit_ordering.py
@@ -1,0 +1,557 @@
+"""Unit tests for LML#953: class-5 `/lookup` must not pin an interactive slot
+while parked on the bulk-global lane.
+
+LML#928 routed a class-5 `/lookup` request onto the low-priority lane by
+acquiring the LML#716/#924 process-global bulk permit AROUND `perform_lookup`
+-- but that acquisition happened while the request still held the interactive
+`LML_LOOKUP_MAX_CONCURRENT` permit (acquired near the top of `handle_lookup`).
+Under compound saturation this is a priority inversion: a batch/cron job
+firing >= LML_LOOKUP_MAX_CONCURRENT concurrent class-5 requests takes every
+interactive slot, then only LML_BULK_GLOBAL_MAX_CONCURRENT of them progress at
+a time -- the rest sit parked holding an interactive slot doing no work, so a
+concurrent class-1 request finds zero free slots.
+
+The fix (this file) moves the bulk-global-permit acquisition BEFORE (outside)
+the interactive semaphore, races that wait against client disconnect (mirrors
+the #706/#715 in-flight-cap pattern), and debits the bulk-global wait from the
+caller budget / `queue_wait` Server-Timing leg the same way the interactive
+wait already was.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from config.settings import get_settings
+from core import bulk_concurrency as bc
+from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+from discogs.service import DiscogsService
+from library.db import LibraryDB
+from lookup import router as router_mod
+from lookup.models import LookupResponse
+from main import app
+from tests.unit.conftest import override_deps
+
+LOOKUP_BODY = {
+    "artist": "Chuquimamani-Condori",
+    "album": "Edits",
+    "raw_message": "Chuquimamani-Condori - Edits",
+}
+
+
+async def _wait_until(predicate, *, timeout_s: float = 5.0, message: str = "condition"):
+    """Poll ``predicate`` on the loop until true, failing loudly at the deadline.
+
+    Mirrors the identical helper in ``test_lookup_inflight_cap.py`` -- this
+    repo's tests deliberately don't import fixtures across test modules, so
+    small helpers like this are duplicated per file rather than shared.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while not predicate():
+        if loop.time() > deadline:
+            pytest.fail(f"timed out after {timeout_s}s waiting for: {message}")
+        await asyncio.sleep(0.005)
+
+
+def _bulk_global_has_waiters() -> bool:
+    sem = bc._get_bulk_global_semaphore()
+    return bool(getattr(sem, "_waiters", None))
+
+
+def _lookup_semaphore_has_waiters() -> bool:
+    sem = router_mod._lookup_semaphore
+    return bool(sem is not None and getattr(sem, "_waiters", None))
+
+
+def _empty_response() -> LookupResponse:
+    return LookupResponse(results=[], search_type="none")
+
+
+def _parse_server_timing(value: str) -> dict[str, float | None]:
+    """Local copy of the helper duplicated across this suite's router tests."""
+    parsed: dict[str, float | None] = {}
+    for entry in value.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        name, _, params = entry.partition(";")
+        dur: float | None = None
+        for param in params.split(";"):
+            param = param.strip()
+            if param.startswith("dur="):
+                dur = float(param[len("dur=") :])
+        parsed[name.strip()] = dur
+    return parsed
+
+
+@pytest.fixture
+def app_client(mock_settings):
+    with override_deps(
+        app,
+        {
+            get_library_db: AsyncMock(spec=LibraryDB),
+            get_discogs_service: AsyncMock(spec=DiscogsService),
+            get_posthog_client: None,
+            get_settings: mock_settings,
+        },
+    ):
+        yield app
+
+
+class TestClassFiveDoesNotPinInteractiveSlot:
+    """The core LML#953 regression: a class-5 request parked on a saturated
+    bulk-global budget must not hold an interactive `LML_LOOKUP_MAX_CONCURRENT`
+    permit while it waits."""
+
+    @pytest.mark.asyncio
+    async def test_parked_class_five_does_not_hold_interactive_permit(
+        self, app_client, monkeypatch
+    ):
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "8")
+
+        release_bulk = asyncio.Event()
+
+        async def _occupy_bulk_permit():
+            async with bc.acquire_bulk_global_permit():
+                await release_bulk.wait()
+
+        occupier = asyncio.create_task(_occupy_bulk_permit())
+        await _wait_until(lambda: bc._get_bulk_global_semaphore().locked())
+
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_empty_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                class_five = asyncio.create_task(
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "5"},
+                    )
+                )
+                await _wait_until(
+                    _bulk_global_has_waiters,
+                    message="class-5 request to park on the bulk-global permit",
+                )
+
+                # The interactive semaphore must be untouched: the class-5
+                # request hasn't reached that stage yet, so the process-wide
+                # cap still shows its full unclaimed value.
+                assert router_mod._get_lookup_semaphore()._value == 8
+                assert not _lookup_semaphore_has_waiters()
+
+                release_bulk.set()
+                resp = await asyncio.wait_for(class_five, timeout=3.0)
+                await asyncio.wait_for(occupier, timeout=3.0)
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_class_one_not_starved_by_parked_class_five(self, app_client, monkeypatch):
+        """The acceptance-criteria regression test (LML#953): N > cap
+        concurrent class-5 single lookups parked on a saturated bulk budget
+        must not block a concurrent class-1 `/lookup` from acquiring an
+        interactive slot.
+
+        Cap the interactive semaphore at 2 and park 3 class-5 requests on a
+        bulk-global budget of 1 (occupied by a fourth holder). Under the OLD
+        ordering, the 3 parked class-5 requests would have claimed both
+        interactive slots and left none for a concurrent class-1 request,
+        which would then time out below. Under the fix, the class-5 requests
+        never reach the interactive semaphore while parked, so the class-1
+        request completes promptly.
+        """
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "2")
+
+        release_bulk = asyncio.Event()
+
+        async def _occupy_bulk_permit():
+            async with bc.acquire_bulk_global_permit():
+                await release_bulk.wait()
+
+        occupier = asyncio.create_task(_occupy_bulk_permit())
+        await _wait_until(lambda: bc._get_bulk_global_semaphore().locked())
+
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_empty_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                five_tasks = [
+                    asyncio.create_task(
+                        ac.post(
+                            "/api/v1/lookup",
+                            json=LOOKUP_BODY,
+                            headers={"X-Caller-Class": "5"},
+                        )
+                    )
+                    for _ in range(3)
+                ]
+                await _wait_until(
+                    lambda: (
+                        len(getattr(bc._get_bulk_global_semaphore(), "_waiters", []) or []) >= 3
+                    ),
+                    message="3 class-5 requests to park on the bulk-global permit",
+                )
+
+                one_resp = await asyncio.wait_for(
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "1"},
+                    ),
+                    timeout=1.0,
+                )
+
+                release_bulk.set()
+                five_resps = await asyncio.gather(*five_tasks)
+                await asyncio.wait_for(occupier, timeout=3.0)
+
+        assert one_resp.status_code == 200
+        assert all(r.status_code == 200 for r in five_resps)
+
+
+class TestClassFiveBulkStageDisconnect:
+    """LML#953 sub-effect 2: the disconnect sentinel must cover the
+    bulk-global wait, not just the interactive-semaphore wait."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_while_parked_on_bulk_stage_returns_499_and_runs_no_lookup(
+        self, app_client, monkeypatch
+    ):
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "8")
+
+        release_bulk = asyncio.Event()
+
+        async def _occupy_bulk_permit():
+            async with bc.acquire_bulk_global_permit():
+                await release_bulk.wait()
+
+        occupier = asyncio.create_task(_occupy_bulk_permit())
+        await _wait_until(lambda: bc._get_bulk_global_semaphore().locked())
+
+        started = 0
+
+        async def fake_lookup(request, **kwargs):
+            nonlocal started
+            started += 1
+            return _empty_response()
+
+        async def _disconnect_after_parked(_request):
+            await _wait_until(
+                _bulk_global_has_waiters, message="request to park on the bulk-global permit"
+            )
+
+        with (
+            patch("lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=fake_lookup),
+            patch.object(bc, "watch_disconnect", _disconnect_after_parked),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await asyncio.wait_for(
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "5"},
+                    ),
+                    timeout=3.0,
+                )
+
+        assert resp.status_code == 499
+        assert started == 0, "a reaped class-5 request must never run perform_lookup"
+
+        release_bulk.set()
+        await asyncio.wait_for(occupier, timeout=3.0)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_while_parked_on_bulk_stage_sets_sentry_tag(
+        self, app_client, monkeypatch
+    ):
+        import sentry_sdk
+
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "8")
+
+        release_bulk = asyncio.Event()
+
+        async def _occupy_bulk_permit():
+            async with bc.acquire_bulk_global_permit():
+                await release_bulk.wait()
+
+        occupier = asyncio.create_task(_occupy_bulk_permit())
+        await _wait_until(lambda: bc._get_bulk_global_semaphore().locked())
+
+        captured_tags: dict[str, str] = {}
+        original_set_tag = sentry_sdk.set_tag
+
+        def capture_tag(key, value):
+            captured_tags[key] = value
+            return original_set_tag(key, value)
+
+        async def _disconnect_after_parked(_request):
+            await _wait_until(_bulk_global_has_waiters, message="request to park on bulk permit")
+
+        with (
+            patch(
+                "lookup.router.perform_lookup",
+                new_callable=AsyncMock,
+                return_value=_empty_response(),
+            ),
+            patch.object(bc, "watch_disconnect", _disconnect_after_parked),
+            patch("lookup.router.sentry_sdk.set_tag", side_effect=capture_tag),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await asyncio.wait_for(
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "5"},
+                    ),
+                    timeout=3.0,
+                )
+
+        assert resp.status_code == 499
+        assert captured_tags.get("lml.client_aborted") == "true"
+
+        release_bulk.set()
+        await asyncio.wait_for(occupier, timeout=3.0)
+
+    @pytest.mark.asyncio
+    async def test_reaped_bulk_stage_disconnect_does_not_leak_a_permit(
+        self, app_client, monkeypatch
+    ):
+        """A reaped class-5 request must return its never-taken bulk permit."""
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "8")
+
+        release_bulk = asyncio.Event()
+
+        async def _occupy_bulk_permit():
+            async with bc.acquire_bulk_global_permit():
+                await release_bulk.wait()
+
+        occupier = asyncio.create_task(_occupy_bulk_permit())
+        await _wait_until(lambda: bc._get_bulk_global_semaphore().locked())
+
+        async def _disconnect_after_parked(_request):
+            await _wait_until(_bulk_global_has_waiters, message="request to park on bulk permit")
+
+        with (
+            patch(
+                "lookup.router.perform_lookup",
+                new_callable=AsyncMock,
+                return_value=_empty_response(),
+            ),
+            patch.object(bc, "watch_disconnect", _disconnect_after_parked),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                reaped = await asyncio.wait_for(
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "5"},
+                    ),
+                    timeout=3.0,
+                )
+
+        assert reaped.status_code == 499
+
+        release_bulk.set()
+        await asyncio.wait_for(occupier, timeout=3.0)
+
+        # The permit is back in the pool: a fresh class-5 request acquires it
+        # uncontended, proving the reap never stranded a slot.
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_empty_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                third = await asyncio.wait_for(
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "5"},
+                    ),
+                    timeout=3.0,
+                )
+
+        assert third.status_code == 200
+
+
+class TestClassFiveBudgetAndServerTiming:
+    """LML#953 sub-effect 3: the bulk-global queue wait must be debited from
+    ``X-Caller-Budget-Ms`` and reflected in the ``queue_wait`` Server-Timing
+    leg, the same way the interactive-semaphore wait already is."""
+
+    @pytest.mark.asyncio
+    async def test_bulk_stage_wait_is_debited_from_caller_budget(self, app_client, monkeypatch):
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "8")
+
+        release_bulk = asyncio.Event()
+
+        async def _occupy_bulk_permit():
+            async with bc.acquire_bulk_global_permit():
+                await release_bulk.wait()
+
+        occupier = asyncio.create_task(_occupy_bulk_permit())
+        await _wait_until(lambda: bc._get_bulk_global_semaphore().locked())
+
+        received_budgets: list[int | None] = []
+
+        async def recording_lookup(request, **kwargs):
+            received_budgets.append(kwargs.get("caller_budget_ms"))
+            return _empty_response()
+
+        with patch(
+            "lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=recording_lookup
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                five = asyncio.create_task(
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "5", "X-Caller-Budget-Ms": "10000"},
+                    )
+                )
+                await _wait_until(
+                    _bulk_global_has_waiters, message="class-5 request to park on bulk permit"
+                )
+                await asyncio.sleep(0.05)
+                release_bulk.set()
+                resp = await asyncio.wait_for(five, timeout=3.0)
+                await asyncio.wait_for(occupier, timeout=3.0)
+
+        assert resp.status_code == 200
+        assert len(received_budgets) == 1
+        deducted = received_budgets[0]
+        assert deducted is not None
+        assert 1 <= deducted < 10000
+        assert deducted <= 10000 - 40
+
+    @pytest.mark.asyncio
+    async def test_bulk_stage_wait_reflected_in_queue_wait_server_timing_leg(
+        self, app_client, monkeypatch
+    ):
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "1")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "8")
+
+        release_bulk = asyncio.Event()
+
+        async def _occupy_bulk_permit():
+            async with bc.acquire_bulk_global_permit():
+                await release_bulk.wait()
+
+        occupier = asyncio.create_task(_occupy_bulk_permit())
+        await _wait_until(lambda: bc._get_bulk_global_semaphore().locked())
+
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_empty_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                five = asyncio.create_task(
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "5"},
+                    )
+                )
+                await _wait_until(
+                    _bulk_global_has_waiters, message="class-5 request to park on bulk permit"
+                )
+                await asyncio.sleep(0.05)
+                release_bulk.set()
+                resp = await asyncio.wait_for(five, timeout=3.0)
+                await asyncio.wait_for(occupier, timeout=3.0)
+
+        assert resp.status_code == 200
+        parsed = _parse_server_timing(resp.headers["Server-Timing"])
+        assert parsed.get("queue_wait") is not None
+        assert parsed["queue_wait"] >= 40
+
+    @pytest.mark.asyncio
+    async def test_uncontended_class_five_has_zero_queue_wait(self, app_client, monkeypatch):
+        """A class-5 request that finds the bulk-global budget free must
+        report a zero queue wait, exactly like an uncontended interactive
+        request today."""
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "4")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "8")
+
+        with patch(
+            "lookup.router.perform_lookup",
+            new_callable=AsyncMock,
+            return_value=_empty_response(),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                resp = await ac.post(
+                    "/api/v1/lookup",
+                    json=LOOKUP_BODY,
+                    headers={"X-Caller-Class": "5"},
+                )
+
+        assert resp.status_code == 200
+        parsed = _parse_server_timing(resp.headers["Server-Timing"])
+        assert parsed.get("queue_wait") == 0
+
+
+class TestNoDeadlock:
+    """LML#953's ordering must not deadlock: many concurrent class-5 AND
+    class-1 requests, both gates saturated, must all eventually complete."""
+
+    @pytest.mark.asyncio
+    async def test_mixed_class_traffic_under_double_saturation_completes(
+        self, app_client, monkeypatch
+    ):
+        monkeypatch.setenv("LML_BULK_GLOBAL_MAX_CONCURRENT", "2")
+        monkeypatch.setenv("LML_LOOKUP_MAX_CONCURRENT", "2")
+
+        async def fake_lookup(request, **kwargs):
+            await asyncio.sleep(0.01)
+            return _empty_response()
+
+        with patch("lookup.router.perform_lookup", new_callable=AsyncMock, side_effect=fake_lookup):
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as ac:
+                requests = [
+                    ac.post(
+                        "/api/v1/lookup",
+                        json=LOOKUP_BODY,
+                        headers={"X-Caller-Class": "5"} if i % 2 == 0 else {},
+                    )
+                    for i in range(12)
+                ]
+                responses = await asyncio.wait_for(asyncio.gather(*requests), timeout=5.0)
+
+        assert [r.status_code for r in responses] == [200] * 12

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -1059,25 +1059,29 @@ class TestHandleLookup:
 
 
 class TestCallerClassLowPriorityLane:
-    """LML#928: ``X-Caller-Class`` routes a single ``/lookup`` request onto
-    the low-priority lane (the LML#716/#924 process-global bulk permit) when
-    -- and only when -- the caller declares class 5 (batch/cron/backfill).
+    """LML#928/#953: ``X-Caller-Class`` routes a single ``/lookup`` request
+    onto the low-priority lane (the LML#716/#924 process-global bulk permit)
+    when -- and only when -- the caller declares class 5 (batch/cron/backfill).
 
-    Patches ``lookup.router.maybe_acquire_bulk_global_permit`` (the exact
-    name ``handle_lookup`` calls) with a spy that records the boolean
+    Patches ``lookup.router.maybe_acquire_bulk_global_permit_or_reap`` (the
+    exact name ``handle_lookup`` calls) with a spy that records the boolean
     condition it was entered with, so this test pins the router's
     class→condition wiring in isolation from the semaphore itself -- which
     ``test_caller_class.py`` pins directly. Together the two prove the full
     invariant: class 5 -> low-priority lane; classes 1-4, absent, and invalid
-    values -> today's interactive-only behavior, unchanged.
+    values -> today's interactive-only behavior, unchanged. LML#953 replaced
+    the underlying primitive (now disconnect-aware and acquired BEFORE the
+    interactive semaphore, not just around ``perform_lookup``) but this
+    class→condition invariant is unchanged, so the fake still just records
+    the condition and yields immediately.
     """
 
     @staticmethod
     def _fake_maybe_acquire(calls: list[bool]):
         @contextlib.asynccontextmanager
-        async def _fake(condition: bool):
+        async def _fake(condition: bool, request):
             calls.append(condition)
-            yield
+            yield 0.0
 
         return _fake
 
@@ -1089,7 +1093,7 @@ class TestCallerClassLowPriorityLane:
         with (
             patch("lookup.router.perform_lookup", new_callable=AsyncMock, return_value=response),
             patch(
-                "lookup.router.maybe_acquire_bulk_global_permit",
+                "lookup.router.maybe_acquire_bulk_global_permit_or_reap",
                 self._fake_maybe_acquire(calls),
             ),
         ):
@@ -1142,7 +1146,7 @@ class TestCallerClassLowPriorityLane:
         with (
             patch("lookup.router.perform_lookup", new_callable=AsyncMock, return_value=response),
             patch(
-                "lookup.router.maybe_acquire_bulk_global_permit",
+                "lookup.router.maybe_acquire_bulk_global_permit_or_reap",
                 self._fake_maybe_acquire(calls),
             ),
         ):


### PR DESCRIPTION
## Summary

Closes #953

LML#928 routed a class-5 (`X-Caller-Class: 5`) single `/lookup` request onto the low-priority bulk lane by acquiring the LML#716/#924 process-global bulk permit (`maybe_acquire_bulk_global_permit`) around the `perform_lookup` call -- but that acquisition happened while the request still held the interactive `LML_LOOKUP_MAX_CONCURRENT` permit. Under compound saturation this was a priority inversion (surfaced in the #951 review, findings 1-4): a batch/cron job firing >= `LML_LOOKUP_MAX_CONCURRENT` concurrent class-5 requests would take every interactive slot, then only `LML_BULK_GLOBAL_MAX_CONCURRENT` of them progress at a time, leaving the rest parked holding an interactive slot doing no work -- so a concurrent class-1 `/lookup` could find zero free slots.

This PR moves the bulk-global-permit acquisition to happen BEFORE (outside) the interactive semaphore, and closes the two coupled gaps that came with it:

- The LML#715 disconnect sentinel now covers the bulk-global wait too, so a client that disconnects while parked on a saturated bulk budget is reaped (499, no `perform_lookup`) instead of running a full cold lookup nobody reads.
- The bulk-global queue wait is now debited from `X-Caller-Budget-Ms` and reflected in the `queue_wait` `Server-Timing` leg, the same way the interactive-semaphore wait already was.

Deadlock-free by construction: nothing holding the bulk-global permit ever waits on the lookup semaphore, so acquiring strictly in this order can't form a cycle with the reverse order.

`handle_bulk_lookup` and the other bulk-family dispatchers (`cache/router.py`, `identity/router.py`) are unaffected -- they already run every item under the low-priority lane unconditionally via the untouched `acquire_bulk_global_permit()`.

## Implementation

- `core/bulk_concurrency.py`: replaces the LML#928 `maybe_acquire_bulk_global_permit` primitive (which had no disconnect awareness and no wait measurement) with `acquire_bulk_global_permit_or_reap` / `maybe_acquire_bulk_global_permit_or_reap`, mirroring the existing `acquire_bulk_global_permit` but racing the wait against `watch_disconnect` and yielding the measured wait. Raises `ClientDisconnectedWhileQueuedError` on a queued disconnect.
- `lookup/router.py`: `handle_lookup` now resolves `caller_class` before touching any permit, wraps the interactive-semaphore-acquire + `perform_lookup` block in `maybe_acquire_bulk_global_permit_or_reap(low_priority, http_request)`, and sums both gates' measured wait for the budget debit and `queue_wait` leg.

## Test plan

- [x] `tests/unit/test_caller_class.py` -- direct unit tests for `acquire_bulk_global_permit_or_reap` / `maybe_acquire_bulk_global_permit_or_reap` (sizing, disconnect race, permit-leak safety)
- [x] `tests/unit/test_lookup_class5_bulk_permit_ordering.py` (new) -- the LML#953 acceptance criteria: a parked class-5 request does not hold the interactive semaphore; a concurrent class-1 request is not starved; disconnect while parked on the bulk stage reaps with 499 and runs no lookup with no permit leak; budget debit + `queue_wait` leg include the bulk-global wait; mixed class-5/class-1 traffic under double saturation completes with no deadlock
- [x] `tests/unit/test_lookup_router.py` -- updated `TestCallerClassLowPriorityLane` to the new seam, preserving the down-rank-only / anti-up-rank invariant
- [x] Full existing suite (`tests/unit/`, `tests/integration/`, unmarked) green: `uv run --no-sync pytest -m "not pg and not external_api"` -- 4611 passed
- [x] `ruff check` / `ruff format --check` / `mypy . --ignore-missing-imports` all clean