### PR TITLE
fix(#956): bind the track-validated release for compilation artwork

### DIFF
--- a/lookup/artwork.py
+++ b/lookup/artwork.py
@@ -156,16 +156,21 @@ async def fetch_artwork_for_items(
     soft-confidence on a row-less carried bind (LML#629): a no-album query's
     row-less release binds at ``ROWLESS_NO_ALBUM_CONFIDENCE`` rather than 1.0.
 
-    ``found_on_compilation`` (LML#684): when the result came from
-    ``search_compilations_for_track`` (TRACK_ON_COMPILATION), an in-library row
-    carries an already-validated ``ResolvedRelease`` on the seam. The artist-floor
-    re-search systematically rejects *non*-Various-Artists trio / collaboration
-    credits (the row is filed under one member, e.g. "Bill Orcutt", while Discogs
-    credits the full trio), leaving the result with no artwork. When the floor
-    rejects every candidate and a release is carried, that validated release is
-    trust-bound for artwork — independent of ``lml_resolve_compilation_release``,
-    since binding an already-carried release costs no extra Discogs fan-out
-    (unlike the flag-gated lazy ``resolve_release_for_track`` fallback below).
+    ``found_on_compilation`` (LML#684, widened by LML#956): when the result came
+    from ``search_compilations_for_track`` (TRACK_ON_COMPILATION), an in-library
+    row carries an already-validated ``ResolvedRelease`` on the seam. That
+    carried release is trust-bound for artwork *before* the artist-floor
+    re-search — whenever one is carried, not only when the floor rejects — so the
+    displayed release is always the one validation confirmed. This covers two
+    floor failure modes: the floor *rejects* every candidate (the systematic
+    *non*-Various-Artists trio / collaboration case, e.g. the row filed under
+    "Bill Orcutt" while Discogs credits the full trio, which would otherwise leave
+    the result with no artwork), and the floor *clears on the wrong release* (a
+    generic V/A comp title where the title+artist floor binds a *same-titled*
+    release that does not carry the track — LML#956). Independent of
+    ``lml_resolve_compilation_release``, since binding an already-carried release
+    costs no extra Discogs fan-out (unlike the flag-gated lazy
+    ``resolve_release_for_track`` fallback below).
 
     ``release_overrides`` (LML#850): a ``library_id -> discogs_release_id`` map of
     **hand-verified** pins the orchestrator prefetched for this request (empty /
@@ -331,8 +336,10 @@ async def fetch_artwork_for_items(
             if result is None:
                 # A found-on-compilation in-library row that carries a validated
                 # release is already trust-bound above (before this re-search), so
-                # only the resolved-is-None cases reach here. The lazy fallback
-                # below resolves a release when the seam carried none.
+                # no such row reaches here — the remaining found-on-compilation
+                # rows that reach this branch carried nothing (resolved is None).
+                # The lazy fallback below resolves a release for exactly that
+                # resolved-is-None case.
                 #
                 # Lazy release-resolution fallback (LML#604): the artist floor
                 # rejected every candidate — the systematic failure for a V/A

--- a/lookup/artwork.py
+++ b/lookup/artwork.py
@@ -246,6 +246,27 @@ async def fetch_artwork_for_items(
                     discogs_service, resolved, item, album=request_album
                 )
 
+            # Found-on-compilation trust-bind (LML#684, widened): an in-library
+            # compilation row carries a release the strategy already resolved AND
+            # track-validated this same request (via validate_release_for_track in
+            # search_compilations_for_track). The title+artist re-search below
+            # scores candidates against the row's OWN title (album_variants
+            # appends item.title), so for a generic V/A comp title it can bind a
+            # *same-titled* release that does NOT carry the track — the prod
+            # divergence (LML#956) where "Greatest hits of the 50s & 60s" bound
+            # Plaza House's 13332759 instead of the validated 605487. The carried release is
+            # already validated and binding it costs no extra Discogs fan-out (only
+            # a cached get_release), so prefer it over the unvalidated title pick —
+            # not only when the search returns None (#684's original gate) but
+            # whenever a validated release is carried. Independent of
+            # lml_resolve_compilation_release (that flag was off at prod runtime).
+            # The row-less (id==0) carry-through is bound by the flag-gated
+            # bind_carried branch above, so it is excluded here.
+            if found_on_compilation and resolved is not None and item.id != ROWLESS_LIBRARY_ID:
+                return await _bind_resolved_release(
+                    discogs_service, resolved, item, album=request_album
+                )
+
             album = resolved.album_title if resolved is not None else item.title
 
             # Self-titled albums stored as "S/t" should use the artist name
@@ -308,24 +329,11 @@ async def fetch_artwork_for_items(
                 title_fn=lambda r: r.album,
             )
             if result is None:
-                # LML#684: a found-on-compilation in-library row carries a
-                # release the search strategy already resolved AND validated this
-                # same request (via validate_release_for_track in
-                # search_compilations_for_track). The artist-floor re-search above
-                # just rejected every candidate — the systematic failure for a
-                # *non*-Various-Artists trio / collaboration credit (the row is
-                # filed under one member, e.g. "Bill Orcutt", but Discogs credits
-                # the full trio on "Orcutt Shelley Miller", release 34993109).
-                # Trust-bind the carried, validated release for artwork rather than
-                # dropping it. Independent of lml_resolve_compilation_release:
-                # binding an already-carried release costs no extra Discogs fan-out
-                # (only a cached get_release), unlike the lazy fallback below. The
-                # row-less (id==0) carry-through is handled by the flag-gated
-                # bind_carried branch at the top, so it is excluded here.
-                if found_on_compilation and resolved is not None and item.id != ROWLESS_LIBRARY_ID:
-                    return await _bind_resolved_release(
-                        discogs_service, resolved, item, album=request_album
-                    )
+                # A found-on-compilation in-library row that carries a validated
+                # release is already trust-bound above (before this re-search), so
+                # only the resolved-is-None cases reach here. The lazy fallback
+                # below resolves a release when the seam carried none.
+                #
                 # Lazy release-resolution fallback (LML#604): the artist floor
                 # rejected every candidate — the systematic failure for a V/A
                 # compilation row filed under the track artist. When the flag is

--- a/tests/unit/test_compilation_artwork_validated_bind.py
+++ b/tests/unit/test_compilation_artwork_validated_bind.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from discogs.models import DiscogsSearchResponse, ReleaseMetadataResponse
+from library.models import LibraryItem
 from lookup.artwork import fetch_artwork_for_items
 from lookup.release_resolution import ResolvedRelease
 from tests.factories import make_discogs_result, make_library_item
@@ -84,7 +85,7 @@ def _carried_validated_release() -> ResolvedRelease:
     )
 
 
-def _comp_row() -> object:
+def _comp_row() -> LibraryItem:
     return make_library_item(
         id=_LIBRARY_ID,
         artist="Various Artists - Rock - G",

--- a/tests/unit/test_compilation_artwork_validated_bind.py
+++ b/tests/unit/test_compilation_artwork_validated_bind.py
@@ -1,0 +1,174 @@
+"""A found-on-compilation row must display the *track-validated* release.
+
+Repro of the prod bug behind ``lookup "i only have eyes for you by the
+flamingos"``: the TRACK_ON_COMPILATION strategy found and track-validated a real
+release for the library row "Various - Greatest hits of the 50s & 60s" and
+carried it on the ``discogs_titles`` seam, but the artwork-binding step
+re-derived the Discogs release with a title+artist search whose ``album_variants``
+include the library row's own title. For a generic V/A comp title that search
+binds a *same-titled* release that does NOT carry the track (Plaza House's
+"Greatest Hits Of The 50s & 60s", release 13332759), at confidence 1.0 —
+diverging display from what validation actually confirmed.
+
+The carried release is already validated (``validate_release_for_track`` in
+``search_compilations_for_track``), so binding it costs no extra Discogs fan-out
+and must win over the unvalidated title-search pick. This holds *independent* of
+``lml_resolve_compilation_release`` — that flag was OFF at prod runtime, which is
+exactly when the divergence surfaced (with it on, the LML#604 trust-bind already
+binds the carried release for every row).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.models import DiscogsSearchResponse, ReleaseMetadataResponse
+from lookup.artwork import fetch_artwork_for_items
+from lookup.release_resolution import ResolvedRelease
+from tests.factories import make_discogs_result, make_library_item
+
+# The library row (a Various-Artists compilation whose title is generic enough
+# that Discogs holds a *different* same-titled comp).
+_LIBRARY_ID = 58775
+_LIBRARY_TITLE = "Greatest hits of the 50s & 60s"
+
+# The release TRACK_ON_COMPILATION validated the track on and carried on the seam.
+_VALIDATED_RELEASE_ID = 605487
+_VALIDATED_ALBUM_TITLE = "Greatest Hits Of The 50's"
+
+# The wrong, same-titled release the artwork title-search would bind: its album
+# is an exact match to the library row's own title, so it clears the 80/80 floor
+# via the ``item.title`` album-variant even though it lacks the track.
+_WRONG_SEARCH_RELEASE_ID = 13332759
+
+
+def _svc_binding_validated_release() -> AsyncMock:
+    """A Discogs service whose ``get_release`` resolves the *validated* release.
+
+    ``_bind_resolved_release`` fetches artwork for the bound release via
+    ``_resolve_fallback_artwork`` -> ``get_release``. ``search`` returns the
+    WRONG same-titled release so a test can prove the carried validated release
+    wins over the title-search pick.
+    """
+    svc = AsyncMock()
+    svc.cache_service = None
+    svc.get_release = AsyncMock(
+        return_value=ReleaseMetadataResponse(
+            release_id=_VALIDATED_RELEASE_ID,
+            title=_VALIDATED_ALBUM_TITLE,
+            artist="Various",
+            release_url=f"https://www.discogs.com/release/{_VALIDATED_RELEASE_ID}",
+            artwork_url="https://i.discogs.com/validated.jpg",
+        )
+    )
+    # The title search, if it ran, would bind this WRONG same-titled release —
+    # album matches the library row's own title exactly.
+    wrong = make_discogs_result(
+        release_id=_WRONG_SEARCH_RELEASE_ID,
+        album=_LIBRARY_TITLE,
+        artist="Various",
+        artwork_url="https://example.com/wrong.jpg",
+    )
+    svc.search = AsyncMock(return_value=DiscogsSearchResponse(results=[wrong]))
+    return svc
+
+
+def _carried_validated_release() -> ResolvedRelease:
+    return ResolvedRelease(
+        release_id=_VALIDATED_RELEASE_ID,
+        release_url=f"https://www.discogs.com/release/{_VALIDATED_RELEASE_ID}",
+        is_compilation=True,
+        album_title=_VALIDATED_ALBUM_TITLE,
+    )
+
+
+def _comp_row() -> object:
+    return make_library_item(
+        id=_LIBRARY_ID,
+        artist="Various Artists - Rock - G",
+        title=_LIBRARY_TITLE,
+        format="vinyl",
+    )
+
+
+@pytest.mark.asyncio
+class TestCarriedValidatedReleaseWins:
+    async def test_flag_off_binds_carried_release_not_same_title_search(self, monkeypatch):
+        # The prod-at-runtime condition: the compilation trust-bind flag is OFF.
+        monkeypatch.setenv("LML_RESOLVE_COMPILATION_RELEASE", "false")
+        from config.settings import get_settings
+
+        get_settings.cache_clear()
+        try:
+            svc = _svc_binding_validated_release()
+
+            results = await fetch_artwork_for_items(
+                [_comp_row()],
+                svc,
+                {_LIBRARY_ID: _carried_validated_release()},  # discogs_titles seam
+                song="I Only Have Eyes for You",
+                found_on_compilation=True,
+            )
+
+            bound = results[0][1]
+            assert bound is not None
+            # Displays the track-validated release, not the same-titled title-search pick.
+            assert bound.release_id == _VALIDATED_RELEASE_ID
+            # Binding an already-carried release skips the title re-search entirely.
+            svc.search.assert_not_awaited()
+        finally:
+            get_settings.cache_clear()
+
+    async def test_no_carried_release_still_falls_through_to_search(self, monkeypatch):
+        # Guard: the new bind is scoped to rows that actually carry a validated
+        # release. With nothing on the seam, a found-on-compilation row re-searches
+        # exactly as before (no regression, no crash).
+        monkeypatch.setenv("LML_RESOLVE_COMPILATION_RELEASE", "false")
+        from config.settings import get_settings
+
+        get_settings.cache_clear()
+        try:
+            svc = _svc_binding_validated_release()
+
+            results = await fetch_artwork_for_items(
+                [_comp_row()],
+                svc,
+                {},  # no carried release for this id
+                song="I Only Have Eyes for You",
+                found_on_compilation=True,
+            )
+
+            bound = results[0][1]
+            assert bound is not None
+            assert bound.release_id == _WRONG_SEARCH_RELEASE_ID
+            svc.search.assert_awaited()
+        finally:
+            get_settings.cache_clear()
+
+    async def test_non_compilation_row_unchanged_uses_search(self, monkeypatch):
+        # Guard: the new bind is scoped to the compilation path. A row NOT flagged
+        # ``found_on_compilation`` re-searches by title exactly as before, even
+        # with a release on the seam and the flag off.
+        monkeypatch.setenv("LML_RESOLVE_COMPILATION_RELEASE", "false")
+        from config.settings import get_settings
+
+        get_settings.cache_clear()
+        try:
+            svc = _svc_binding_validated_release()
+
+            results = await fetch_artwork_for_items(
+                [_comp_row()],
+                svc,
+                {_LIBRARY_ID: _carried_validated_release()},
+                song="I Only Have Eyes for You",
+                found_on_compilation=False,
+            )
+
+            bound = results[0][1]
+            assert bound is not None
+            assert bound.release_id == _WRONG_SEARCH_RELEASE_ID
+            svc.search.assert_awaited()
+        finally:
+            get_settings.cache_clear()

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -2404,8 +2404,11 @@ class TestFetchArtworkFoundOnCompilation:
         rejects. Binding the carried release also skips the re-search entirely.
         """
         item, discogs_titles, svc = self._trio_inputs()
-        # Even when the floor search returns a clean, matching candidate, the
-        # validated carried release (34993109) is preferred over it (111).
+        # Arm the floor with a clean, matching candidate (111) that WOULD win if
+        # the re-search ran. The early trust-bind returns before the search, so
+        # this candidate is deliberately never consumed — the ``assert_not_awaited``
+        # below proves the carried release (34993109) pre-empts even a
+        # would-succeed floor, not merely a rejecting one.
         svc.search = AsyncMock(
             return_value=DiscogsSearchResponse(
                 results=[

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -2296,18 +2296,28 @@ class TestFetchArtworkRowlessBindKillSwitch:
 
 
 class TestFetchArtworkFoundOnCompilation:
-    """LML#684: a ``found_on_compilation`` in-library result carries a validated
-    ``ResolvedRelease`` on the seam. When the artist-floor re-search rejects the
-    candidate — the systematic failure for a *non*-Various-Artists trio /
-    collaboration credit (e.g. library row filed under "Bill Orcutt" vs the
-    Discogs trio credit on "Orcutt Shelley Miller", release 34993109) — the
-    carried release must still surface its artwork.
+    """LML#684 (widened): a ``found_on_compilation`` in-library result carries a
+    validated ``ResolvedRelease`` on the seam, and that release is preferred over
+    the artist-floor re-search for artwork binding.
+
+    Two failure modes the carried bind covers:
+
+    - The floor re-search *rejects* every candidate — the systematic failure for
+      a *non*-Various-Artists trio / collaboration credit (library row filed
+      under "Bill Orcutt" vs the Discogs trio credit on "Orcutt Shelley Miller",
+      release 34993109). Without the bind the row surfaces with no artwork.
+    - The floor re-search *clears on the wrong release* — for a generic V/A comp
+      title the floor (title+artist similarity only, never track-validated) can
+      bind a *same-titled* release that does not carry the track. This is the
+      prod divergence (LML#956) where "Greatest hits of the 50s & 60s"
+      bound Plaza House's 13332759 instead of the validated 605487.
 
     The carried release was already validated by ``validate_release_for_track``
-    during ``search_compilations_for_track``, so trust-binding it costs no extra
-    Discogs fan-out (unlike the ``lml_resolve_compilation_release`` lazy
-    ``resolve_release_for_track`` fallback). The bind is therefore independent of
-    that flag — these tests run with it at its default (off).
+    during ``search_compilations_for_track``, so it is strictly more trustworthy
+    than the floor pick and binding it costs no extra Discogs fan-out (unlike the
+    ``lml_resolve_compilation_release`` lazy ``resolve_release_for_track``
+    fallback). The bind is therefore independent of that flag — these tests run
+    with it at its default (off).
     """
 
     def _trio_inputs(self):
@@ -2381,12 +2391,21 @@ class TestFetchArtworkFoundOnCompilation:
         svc.get_release.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_floor_match_preferred_over_carried_bind(self):
-        """When the floor re-search DOES clear (the Various-Artists case that
-        already works), the floor result is used as before — the #684 bind is a
-        fallback for the rejection case only, not a replacement for the floor."""
+    async def test_carried_validated_release_preferred_over_floor_match(self):
+        """The carried release wins even when the floor re-search clears.
+
+        The floor re-search is only a title+artist similarity match (never
+        track-validated), so for a generic V/A comp title it can clear the floor
+        on a *same-titled* release that does NOT carry the track — the prod
+        divergence where "Greatest hits of the 50s & 60s" bound Plaza House's
+        13332759 instead of the validated 605487. The carried release WAS
+        track-validated in search_compilations_for_track, so it must win over the
+        unvalidated floor pick, not merely serve as a fallback when the floor
+        rejects. Binding the carried release also skips the re-search entirely.
+        """
         item, discogs_titles, svc = self._trio_inputs()
-        # This time the floor search returns a clean, matching candidate.
+        # Even when the floor search returns a clean, matching candidate, the
+        # validated carried release (34993109) is preferred over it (111).
         svc.search = AsyncMock(
             return_value=DiscogsSearchResponse(
                 results=[
@@ -2411,10 +2430,11 @@ class TestFetchArtworkFoundOnCompilation:
 
         bound = results[0][1]
         assert bound is not None
-        assert bound.release_id == 111
-        assert bound.artwork_url == "https://i.discogs.com/floor.jpg"
-        # Floor cleared, so the carried-release trust-bind never fired.
-        svc.get_release.assert_not_awaited()
+        assert bound.release_id == 34993109
+        assert bound.artwork_url == "https://i.discogs.com/osm.jpg"
+        # The carried release binds before the re-search, so the floor never runs.
+        svc.search.assert_not_awaited()
+        svc.get_release.assert_awaited()
 
 
 class TestFetchArtworkFallback:


### PR DESCRIPTION
## What

A `TRACK_ON_COMPILATION` result could display a Discogs release that does **not** contain the matched track. `search_compilations_for_track` track-validates a release per library row and carries it on the `discogs_titles` seam, but the artwork step (`fetch_one` in `lookup/artwork.py`) re-derived the release with a title+artist floor search whose `album_variants` include the library row's own title. For a generic V/A comp title, a same-titled but track-absent release wins that floor at `confidence: 1.0`, diverging the displayed release from what validation confirmed.

Reproduced with `lookup "i only have eyes for you by the flamingos"`:

| Library row | Was displaying | Contains track? | Now binds (validated) |
|---|---|---|---|
| 58775 "Greatest hits of the 50s & 60s" | 13332759 (Plaza House) | no | 605487 |
| 58225 "American Graffiti" | 3338440 ("More American Graffiti") | no | 13625223 |

## Fix

Promote the LML#684 carried-release trust-bind ahead of the title re-search: a `found_on_compilation` row that carries a track-validated `ResolvedRelease` binds that release whenever one is carried, not only when the floor search returns `None`. Binding an already-carried release costs no extra Discogs fan-out (only a cached `get_release`) and is independent of `lml_resolve_compilation_release` (which was off at prod runtime — exactly when the bug surfaced).

`TestFetchArtworkFoundOnCompilation.test_floor_match_preferred_over_carried_bind` encoded the inverted contract (an unvalidated floor pick preferred over the validated release); it is updated to the corrected contract and renamed.

## Tests

- New: `tests/unit/test_compilation_artwork_validated_bind.py` — reproduces the prod bind (13332759 over 605487) and asserts the validated release wins with the flag off; guards that no-carried and non-compilation rows re-search unchanged.
- Full unit suite green (4295 passed); ruff + mypy clean.

## Not in scope (follow-up)

Row 58775 is also a false-positive row: even its validated release (605487, a Disky CD) differs from WXYC's vinyl copy (the Plaza House LP, which lacks the track). LML can't verify the specific pressing — `library.db` has no per-release tracklists. Filed separately.

Closes #956