### PR TITLE
refactor: consolidate _require_entity_store into a shared dependency

### DIFF
--- a/cache/router.py
+++ b/cache/router.py
@@ -54,7 +54,7 @@ from core.bulk_concurrency import (
 from core.dependencies import get_discogs_service, get_musicbrainz_pg
 from discogs.service import DiscogsService
 from entity.store import EntityStore
-from identity.dependencies import get_entity_store
+from identity.dependencies import get_entity_store, require_entity_store
 from streaming.dependencies import (
     get_apple_music_client,
     get_bandcamp_client,
@@ -93,21 +93,10 @@ _REFRESH_DEFAULT_CONCURRENCY = 10
 
 _REFRESH_ROUTE = "/api/v1/cache/refresh-for-identities"
 
-_ENTITY_STORE_UNAVAILABLE_DETAIL = (
-    "Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
-    "and the entity schema has been applied."
-)
-
 _DISCOGS_SERVICE_UNAVAILABLE_DETAIL = (
     "Discogs service is not available. Ensure DISCOGS_TOKEN (or "
     "DISCOGS_API_KEY / DISCOGS_API_SECRET) is configured."
 )
-
-
-def _require_entity_store(store: EntityStore | None) -> EntityStore:
-    if store is None:
-        raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
-    return store
 
 
 def _require_discogs_service(service: DiscogsService | None) -> DiscogsService:
@@ -163,7 +152,7 @@ async def handle_refresh_for_identities(
         cap_status=400,
     )
 
-    store = _require_entity_store(entity_store)
+    store = require_entity_store(entity_store)
     discogs = _require_discogs_service(discogs_service)
 
     identity_ids = request.identity_ids

--- a/identity/dependencies.py
+++ b/identity/dependencies.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 
 from config.settings import Settings, get_settings
 from core.bulk_body import TRANSIENT_PG_ERRORS
@@ -12,6 +12,13 @@ from entity.sources import PgSource
 from entity.store import EntityStore
 
 logger = logging.getLogger(__name__)
+
+# Shared across every router that depends on `get_entity_store` (cache/router.py,
+# identity/router.py, ...) — previously duplicated verbatim in each router module.
+_ENTITY_STORE_UNAVAILABLE_DETAIL = (
+    "Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
+    "and the entity schema has been applied."
+)
 
 _entity_store: EntityStore | None = None
 _entity_probe_failed: bool = False
@@ -96,6 +103,19 @@ async def get_entity_store(
         _entity_store = EntityStore(pg)
         logger.info("Entity store initialized")
         return _entity_store
+
+
+def require_entity_store(store: EntityStore | None) -> EntityStore:
+    """Raise 503 if the entity store is not available.
+
+    Shared guard for router handlers that take ``get_entity_store``'s
+    ``EntityStore | None`` result and need the non-optional store or a 503.
+    Previously duplicated verbatim as a private ``_require_entity_store``
+    helper in both ``cache/router.py`` and ``identity/router.py``.
+    """
+    if store is None:
+        raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
+    return store
 
 
 async def close_entity_store() -> None:

--- a/identity/router.py
+++ b/identity/router.py
@@ -43,7 +43,7 @@ from generated.api_models import (
     ReleaseIdentityResolveResponse,
 )
 from identity.bulk_resolve import compilation_result, compose_for_identity
-from identity.dependencies import get_entity_store
+from identity.dependencies import get_entity_store, require_entity_store
 from identity.models import (
     BulkIdentityRequest,
     BulkIdentityResponse,
@@ -109,13 +109,6 @@ _ENTITY_STORE_UNAVAILABLE_DETAIL = (
 )
 
 
-def _require_entity_store(store: EntityStore | None) -> EntityStore:
-    """Raise 503 if the entity store is not available."""
-    if store is None:
-        raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
-    return store
-
-
 @router.get(
     "/resolve",
     response_model=IdentityResponse,
@@ -131,7 +124,7 @@ async def resolve_identity(
     entity_store: EntityStore | None = Depends(get_entity_store),
 ) -> IdentityResponse:
     """Look up a single artist name in the entity identity store."""
-    store = _require_entity_store(entity_store)
+    store = require_entity_store(entity_store)
     try:
         identity = await store.get_identity(name)
     except TRANSIENT_PG_ERRORS:
@@ -160,7 +153,7 @@ async def bulk_resolve_identities(
     Returns resolved identities and a list of names that could not be found.
     Designed for batch consumers like semantic-index (20-30K artists).
     """
-    store = _require_entity_store(entity_store)
+    store = require_entity_store(entity_store)
 
     identities: list[IdentityResponse] = []
     unresolved: list[str] = []
@@ -232,7 +225,7 @@ async def bulk_resolve_libraries(
         http_request, BulkResolveLibrariesRequest, _BULK_RESOLVE_INPUT_CAP, field="inputs"
     )
 
-    store = _require_entity_store(entity_store)
+    store = require_entity_store(entity_store)
 
     # Entry signal (LML#430, sibling-of-#371). Fires before the per-input PG
     # loop, so a handler that hangs inside the loop still leaves a trace —
@@ -454,7 +447,7 @@ async def resolve_release_identity(
     trace; the exit log fires after the span closes so its timestamp reflects
     span completion.
     """
-    store = _require_entity_store(entity_store)
+    store = require_entity_store(entity_store)
 
     try:
         canonical_external_id = validate_and_canonicalize_external_id(

--- a/tests/unit/test_cache_refresh_endpoint.py
+++ b/tests/unit/test_cache_refresh_endpoint.py
@@ -93,6 +93,33 @@ class TestCacheRefreshGlobalBound:
         )
 
 
+class TestCacheRefreshEntityStoreUnavailable:
+    @pytest.mark.asyncio
+    async def test_returns_503_when_entity_store_unavailable(self, mock_settings):
+        """POST /api/v1/cache/refresh-for-identities returns 503 when the
+        entity store is not configured (mirrors the `/identity/*` posture)."""
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service
+        from identity.dependencies import get_entity_store
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_settings: mock_settings,
+                get_entity_store: None,
+                get_discogs_service: AsyncMock(),
+            },
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                resp = await ac.post(
+                    "/api/v1/cache/refresh-for-identities", json={"identity_ids": [42]}
+                )
+
+        assert resp.status_code == 503
+        assert "entity store" in resp.json()["detail"].lower()
+
+
 class TestCacheRefreshFamilyAlignment:
     """LML#767: the cache-refresh route joins the shared envelope + transient
     tuple. InterfaceError -> 503, ClientDisconnect -> 400, absent batch field

--- a/tests/unit/test_identity_router.py
+++ b/tests/unit/test_identity_router.py
@@ -212,6 +212,57 @@ class TestEntityStoreUnavailable:
         assert "entity store" in resp.json()["detail"].lower()
 
     @pytest.mark.asyncio
+    async def test_bulk_returns_503_when_store_unavailable(self, mock_settings):
+        """POST /identity/bulk returns 503 when entity store is not configured."""
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from identity.dependencies import get_entity_store
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+                get_entity_store: None,
+            },
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                resp = await ac.post("/identity/bulk", json={"names": ["Stereolab"]})
+
+        assert resp.status_code == 503
+        assert "entity store" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_release_identity_resolve_returns_503_when_store_unavailable(self, mock_settings):
+        """POST /api/v1/identity/resolve returns 503 when entity store is not configured."""
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from identity.dependencies import get_entity_store
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+                get_entity_store: None,
+            },
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                resp = await ac.post(
+                    "/api/v1/identity/resolve",
+                    json={"kind": "release", "source": "discogs_release", "external_id": "12345"},
+                )
+
+        assert resp.status_code == 503
+        assert "entity store" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
     async def test_resolve_returns_503_when_pg_raises_undefined_table(
         self, app_client, mock_entity_store
     ):


### PR DESCRIPTION
## What

\`_require_entity_store\` — the "raise 503 if the entity store is unavailable" guard — was defined twice, byte-identical, in \`cache/router.py\` and \`identity/router.py\`. This moves it into \`identity/dependencies.py\` (where \`get_entity_store\`, the provider it guards, already lives — both routers already import from there, so no new module and no import-cycle risk) as a public \`require_entity_store\`, and routes every call site through it.

## Call sites consolidated

- \`cache/router.py\`: \`handle_refresh_for_identities\` (\`POST /api/v1/cache/refresh-for-identities\`)
- \`identity/router.py\`: \`resolve_identity\` (\`GET /identity/resolve\`), \`bulk_resolve_identities\` (\`POST /identity/bulk\`), \`bulk_resolve_libraries\` (\`POST /api/v1/identity/bulk-resolve-libraries\`), \`resolve_release_identity\` (\`POST /api/v1/identity/resolve\`)

Both previous local function definitions (and \`cache/router.py\`'s now-unused local \`_ENTITY_STORE_UNAVAILABLE_DETAIL\` constant) are removed.

**Left untouched, on purpose:** \`identity/router.py\` also has several \`except TRANSIENT_PG_ERRORS: raise HTTPException(503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL)\` blocks. Those fire when a query against an already-non-None store fails at runtime — a different guard than "the DI provider returned None" — so folding them into \`require_entity_store\` (which takes an \`EntityStore | None\` and only checks for \`None\`) would either be a no-op or require restructuring control flow. Out of scope for this pure consolidation.

## How behavior is preserved

Same status code (503), same detail string, same synchronous \`(EntityStore | None) -> EntityStore\` signature — only the import path changed at each call site.

## Testing

Per repo TDD policy, added characterization tests *before* refactoring for the three call sites that had no existing unit coverage of the store-unavailable 503 (confirmed passing against pre-refactor code first):

- \`POST /identity/bulk\` — \`tests/unit/test_identity_router.py::TestEntityStoreUnavailable::test_bulk_returns_503_when_store_unavailable\`
- \`POST /api/v1/identity/resolve\` — \`tests/unit/test_identity_router.py::TestEntityStoreUnavailable::test_release_identity_resolve_returns_503_when_store_unavailable\`
- \`POST /api/v1/cache/refresh-for-identities\` — \`tests/unit/test_cache_refresh_endpoint.py::TestCacheRefreshEntityStoreUnavailable::test_returns_503_when_entity_store_unavailable\`

The other two call sites (\`GET /identity/resolve\`, \`POST /api/v1/identity/bulk-resolve-libraries\`) already had unit coverage; no assertions changed anywhere.

Local checks, all green:
- \`ruff check .\`
- \`ruff format --check .\`
- \`mypy . --ignore-missing-imports\`
- \`pytest\` (4614 passed, 1 skipped, 551 deselected, 2 xfailed — same counts before and after the refactor)

Closes #960