### PR TITLE
refactor: reuse the canonical SpotifyClient in scripts

### DIFF
--- a/scripts/revalidate_spotify.py
+++ b/scripts/revalidate_spotify.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import base64
 import json
 import logging
 import os
@@ -22,6 +21,8 @@ import aiosqlite
 import httpx
 from dotenv import load_dotenv
 from rapidfuzz import fuzz
+
+from clients.streaming.spotify import SpotifyClient
 
 load_dotenv()
 
@@ -33,33 +34,18 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 SQLITE_PATH = "streaming_availability.db"
-SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
-SPOTIFY_API_BASE = "https://api.spotify.com/v1"
 
 
-class SpotifyValidator:
-    def __init__(self) -> None:
-        self._client_id = os.environ["SPOTIFY_CLIENT_ID"]
-        self._client_secret = os.environ["SPOTIFY_CLIENT_SECRET"]
-        self._token: str | None = None
-        self._semaphore = asyncio.Semaphore(3)
+class SpotifyValidator(SpotifyClient):
+    """Adds single-resource validation lookups on top of the canonical client's token/init.
 
-    async def _get_token(self, client: httpx.AsyncClient) -> str:
-        if self._token:
-            return self._token
-        creds = base64.b64encode(f"{self._client_id}:{self._client_secret}".encode()).decode()
-        resp = await client.post(
-            SPOTIFY_TOKEN_URL,
-            headers={"Authorization": f"Basic {creds}"},
-            data={"grant_type": "client_credentials"},
-        )
-        resp.raise_for_status()
-        self._token = resp.json()["access_token"]
-        return self._token
+    Token acquisition and client-credentials init are inherited from
+    ``clients.streaming.spotify.SpotifyClient`` (LML dedup) — only
+    ``validate_url``, which the canonical client doesn't expose, is
+    script-specific.
+    """
 
-    async def validate_url(
-        self, client: httpx.AsyncClient, url: str, expected_artist: str, expected_title: str
-    ) -> tuple:
+    async def validate_url(self, url: str, expected_artist: str, expected_title: str) -> tuple:
         """Returns (is_valid, actual_title) or (None, reason) for errors."""
         match = re.search(r"/(album|track|artist)/([A-Za-z0-9]+)", url)
         if not match:
@@ -71,17 +57,18 @@ class SpotifyValidator:
 
         async with self._semaphore:
             try:
-                token = await self._get_token(client)
-                resp = await client.get(
-                    f"{SPOTIFY_API_BASE}/{resource_type}s/{resource_id}",
+                http = await self._get_client()
+                token = await self._ensure_token()
+                resp = await http.get(
+                    f"{self.API_BASE}/{resource_type}s/{resource_id}",
                     headers={"Authorization": f"Bearer {token}"},
                     timeout=10.0,
                 )
                 if resp.status_code == 401:
-                    self._token = None
-                    token = await self._get_token(client)
-                    resp = await client.get(
-                        f"{SPOTIFY_API_BASE}/{resource_type}s/{resource_id}",
+                    self._access_token = None
+                    token = await self._ensure_token()
+                    resp = await http.get(
+                        f"{self.API_BASE}/{resource_type}s/{resource_id}",
                         headers={"Authorization": f"Bearer {token}"},
                         timeout=10.0,
                     )
@@ -142,13 +129,15 @@ async def main(args: argparse.Namespace) -> None:
 
     log.info(f"Spotify URLs to validate: {len(albums):,}")
 
-    validator = SpotifyValidator()
+    client_id = os.environ["SPOTIFY_CLIENT_ID"]
+    client_secret = os.environ["SPOTIFY_CLIENT_SECRET"]
+    validator = SpotifyValidator(client_id, client_secret)
     valid = 0
     invalid = 0
     skipped = 0
     false_positives = []
 
-    async with httpx.AsyncClient() as client:
+    try:
         batch_size = 3  # match semaphore to avoid bursts
         for batch_start in range(0, len(albums), batch_size):
             batch = albums[batch_start : batch_start + batch_size]
@@ -160,7 +149,7 @@ async def main(args: argparse.Namespace) -> None:
                     artist,
                     title,
                     url,
-                    await validator.validate_url(client, url, artist, title),
+                    await validator.validate_url(url, artist, title),
                 )
 
             results = await asyncio.gather(
@@ -205,6 +194,8 @@ async def main(args: argparse.Namespace) -> None:
                 log.info(
                     f"  {done:,}/{len(albums):,}: {valid} valid, {invalid} invalid, {skipped} skipped"
                 )
+    finally:
+        await validator.close()
 
     checked = valid + invalid
     rate = invalid / checked * 100 if checked else 0

--- a/scripts/spotify_artist_catalog.py
+++ b/scripts/spotify_artist_catalog.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import base64
 import json
 import logging
 import os
@@ -20,9 +19,10 @@ import re
 
 import aiosqlite
 import asyncpg
-import httpx
 from dotenv import load_dotenv
 from rapidfuzz import fuzz
+
+from clients.streaming.spotify import SpotifyClient as CanonicalSpotifyClient
 
 load_dotenv()
 
@@ -36,48 +36,36 @@ log = logging.getLogger(__name__)
 SQLITE_PATH = "streaming_availability.db"
 WIKIDATA_URL = "postgresql://jake@localhost/wikidata"
 DISCOGS_URL = "postgresql://jake@localhost/discogs"
-SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
-SPOTIFY_API_BASE = "https://api.spotify.com/v1"
 
 
-class SpotifyClient:
-    def __init__(self) -> None:
-        self._client_id = os.environ["SPOTIFY_CLIENT_ID"]
-        self._client_secret = os.environ["SPOTIFY_CLIENT_SECRET"]
-        self._token: str | None = None
-        self._semaphore = asyncio.Semaphore(3)
+class ArtistCatalogClient(CanonicalSpotifyClient):
+    """Adds full-catalog pagination on top of the canonical client's token/init.
 
-    async def _get_token(self, client: httpx.AsyncClient) -> str:
-        if self._token:
-            return self._token
-        creds = base64.b64encode(f"{self._client_id}:{self._client_secret}".encode()).decode()
-        resp = await client.post(
-            SPOTIFY_TOKEN_URL,
-            headers={"Authorization": f"Basic {creds}"},
-            data={"grant_type": "client_credentials"},
-        )
-        resp.raise_for_status()
-        self._token = resp.json()["access_token"]
-        return self._token
+    Token acquisition and client-credentials init are inherited from
+    ``clients.streaming.spotify.SpotifyClient`` (LML dedup) — only the
+    artist-albums pagination, which the canonical client doesn't expose, is
+    script-specific.
+    """
 
-    async def get_artist_albums(self, client: httpx.AsyncClient, artist_id: str) -> list[dict]:
+    async def get_artist_albums(self, artist_id: str) -> list[dict]:
         """Get all albums for a Spotify artist."""
         async with self._semaphore:
-            token = await self._get_token(client)
+            http = await self._get_client()
+            token = await self._ensure_token()
             albums = []
-            url = f"{SPOTIFY_API_BASE}/artists/{artist_id}/albums"
+            url = f"{self.API_BASE}/artists/{artist_id}/albums"
             params = {"limit": 50, "include_groups": "album,single,compilation"}
 
             while url:
-                resp = await client.get(
+                resp = await http.get(
                     url,
                     headers={"Authorization": f"Bearer {token}"},
                     params=params,
                     timeout=10.0,
                 )
                 if resp.status_code == 401:
-                    self._token = None
-                    token = await self._get_token(client)
+                    self._access_token = None
+                    token = await self._ensure_token()
                     continue
                 if resp.status_code == 429:
                     retry = int(resp.headers.get("Retry-After", "5"))
@@ -164,14 +152,16 @@ async def main(args: argparse.Namespace) -> None:
         return
 
     # Pull catalogs and match
-    spotify = SpotifyClient()
+    client_id = os.environ["SPOTIFY_CLIENT_ID"]
+    client_secret = os.environ["SPOTIFY_CLIENT_SECRET"]
+    spotify = ArtistCatalogClient(client_id, client_secret)
     found = 0
     results = []
 
-    async with httpx.AsyncClient() as client:
+    try:
         for i, (spotify_id, albs) in enumerate(artist_albums.items()):
             try:
-                catalog = await spotify.get_artist_albums(client, spotify_id)
+                catalog = await spotify.get_artist_albums(spotify_id)
             except Exception as e:
                 log.warning(f"Failed to fetch {spotify_id}: {e}")
                 continue
@@ -202,6 +192,8 @@ async def main(args: argparse.Namespace) -> None:
 
             if (i + 1) % 100 == 0 or i + 1 == len(artist_albums):
                 log.info(f"  {i + 1}/{len(artist_albums)} artists, {found} albums matched")
+    finally:
+        await spotify.close()
 
     log.info(f"Total matched: {found}")
 

--- a/tests/unit/test_revalidate_spotify.py
+++ b/tests/unit/test_revalidate_spotify.py
@@ -1,0 +1,137 @@
+"""Characterization tests for scripts/revalidate_spotify.py's Spotify client.
+
+Pins the token-acquisition and single-resource validation request shapes so
+the refactor that consolidates this script onto the canonical
+``clients.streaming.spotify.SpotifyClient`` (LML dedup) can't silently
+change what gets sent to Spotify. ``SpotifyValidator`` subclasses the
+canonical client for token/init and only adds ``validate_url``, which the
+canonical client doesn't expose, so the token-request assertions here
+mirror ``tests/unit/test_spotify_client.py`` almost exactly.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from clients.streaming.spotify import SpotifyClient as CanonicalSpotifyClient
+from scripts.revalidate_spotify import SpotifyValidator
+
+
+def _token_response(access_token: str = "revalidate-token") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"access_token": access_token, "token_type": "Bearer", "expires_in": 3600},
+        request=httpx.Request("POST", "https://accounts.spotify.com/api/token"),
+    )
+
+
+def _album_response(name: str = "Aluminum Tunes", artist: str = "Stereolab") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"name": name, "artists": [{"name": artist}]},
+        request=httpx.Request("GET", "https://api.spotify.com/v1/albums/alb1"),
+    )
+
+
+class TestNoDuplicatedTokenLogic:
+    """Regression guard: the dedup must not creep back."""
+
+    def test_subclasses_canonical_client(self):
+        assert issubclass(SpotifyValidator, CanonicalSpotifyClient)
+
+    def test_does_not_redefine_token_or_init(self):
+        assert "__init__" not in SpotifyValidator.__dict__
+        assert "_get_token" not in SpotifyValidator.__dict__
+        assert "_ensure_token" not in SpotifyValidator.__dict__
+
+
+class TestTokenAcquisition:
+    """Pins the client-credentials token request shape."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_token_with_client_credentials(self):
+        validator = SpotifyValidator("wxyc-id", "wxyc-secret")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(return_value=_token_response())
+        mock_http.get = AsyncMock(return_value=_album_response())
+        validator._http = mock_http
+
+        await validator.validate_url(
+            "https://open.spotify.com/album/alb1", "Stereolab", "Aluminum Tunes"
+        )
+
+        mock_http.post.assert_awaited_once()
+        args, kwargs = mock_http.post.call_args
+        assert args[0] == "https://accounts.spotify.com/api/token"
+        expected_creds = base64.b64encode(b"wxyc-id:wxyc-secret").decode()
+        assert kwargs["headers"]["Authorization"] == f"Basic {expected_creds}"
+        assert kwargs["data"] == {"grant_type": "client_credentials"}
+
+    def test_configured_attributes_from_constructor(self):
+        validator = SpotifyValidator("wxyc-id", "wxyc-secret")
+        assert validator._client_id == "wxyc-id"
+        assert validator._client_secret == "wxyc-secret"
+
+
+class TestValidateUrl:
+    """Pins bearer-token behavior of the extra, script-specific method."""
+
+    @pytest.mark.asyncio
+    async def test_uses_bearer_token_for_album_lookup(self):
+        validator = SpotifyValidator("wxyc-id", "wxyc-secret")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(return_value=_token_response())
+        mock_http.get = AsyncMock(return_value=_album_response("Aluminum Tunes", "Stereolab"))
+        validator._http = mock_http
+
+        is_valid, actual = await validator.validate_url(
+            "https://open.spotify.com/album/alb1", "Stereolab", "Aluminum Tunes"
+        )
+
+        assert is_valid is True
+        assert actual == "Stereolab - Aluminum Tunes"
+        call = mock_http.get.call_args
+        assert call.args[0] == "https://api.spotify.com/v1/albums/alb1"
+        assert call.kwargs["headers"]["Authorization"] == "Bearer revalidate-token"
+
+    @pytest.mark.asyncio
+    async def test_refreshes_token_on_401(self):
+        validator = SpotifyValidator("wxyc-id", "wxyc-secret")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(
+            side_effect=[_token_response("stale-token"), _token_response("fresh-token")]
+        )
+        unauthorized = httpx.Response(
+            401, request=httpx.Request("GET", "https://api.spotify.com/v1/albums/alb1")
+        )
+        success = _album_response("Aluminum Tunes", "Stereolab")
+        mock_http.get = AsyncMock(side_effect=[unauthorized, success])
+        validator._http = mock_http
+
+        is_valid, actual = await validator.validate_url(
+            "https://open.spotify.com/album/alb1", "Stereolab", "Aluminum Tunes"
+        )
+
+        assert is_valid is True
+        assert mock_http.post.call_count == 2
+        last_call = mock_http.get.call_args_list[-1]
+        assert last_call.kwargs["headers"]["Authorization"] == "Bearer fresh-token"
+
+    @pytest.mark.asyncio
+    async def test_skips_artist_urls(self):
+        validator = SpotifyValidator("wxyc-id", "wxyc-secret")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        validator._http = mock_http
+
+        is_valid, reason = await validator.validate_url(
+            "https://open.spotify.com/artist/art1", "Stereolab", "Aluminum Tunes"
+        )
+
+        assert is_valid is True
+        assert reason == "artist URL (skip)"
+        mock_http.get.assert_not_called()
+        mock_http.post.assert_not_called()

--- a/tests/unit/test_spotify_artist_catalog.py
+++ b/tests/unit/test_spotify_artist_catalog.py
@@ -1,0 +1,129 @@
+"""Characterization tests for scripts/spotify_artist_catalog.py's Spotify client.
+
+Pins the token-acquisition and artist-catalog request shapes so the
+refactor that consolidates this script onto the canonical
+``clients.streaming.spotify.SpotifyClient`` (LML dedup) can't silently
+change what gets sent to Spotify. ``ArtistCatalogClient`` subclasses the
+canonical client for token/init and only adds the artist-albums pagination
+the canonical client doesn't expose, so the token-request assertions here
+mirror ``tests/unit/test_spotify_client.py`` almost exactly.
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from clients.streaming.spotify import SpotifyClient as CanonicalSpotifyClient
+from scripts.spotify_artist_catalog import ArtistCatalogClient
+
+
+def _token_response(access_token: str = "artist-catalog-token") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"access_token": access_token, "token_type": "Bearer", "expires_in": 3600},
+        request=httpx.Request("POST", "https://accounts.spotify.com/api/token"),
+    )
+
+
+def _albums_page(items: list[dict], next_url: str | None = None) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"items": items, "next": next_url},
+        request=httpx.Request("GET", "https://api.spotify.com/v1/artists/xyz/albums"),
+    )
+
+
+def _make_album(name: str = "Edits", album_id: str = "alb1") -> dict:
+    return {
+        "name": name,
+        "id": album_id,
+        "external_urls": {"spotify": f"https://open.spotify.com/album/{album_id}"},
+    }
+
+
+class TestNoDuplicatedTokenLogic:
+    """Regression guard: the dedup must not creep back."""
+
+    def test_subclasses_canonical_client(self):
+        assert issubclass(ArtistCatalogClient, CanonicalSpotifyClient)
+
+    def test_does_not_redefine_token_or_init(self):
+        assert "__init__" not in ArtistCatalogClient.__dict__
+        assert "_get_token" not in ArtistCatalogClient.__dict__
+        assert "_ensure_token" not in ArtistCatalogClient.__dict__
+
+
+class TestTokenAcquisition:
+    """Pins the client-credentials token request shape."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_token_with_client_credentials(self):
+        spotify = ArtistCatalogClient("wxyc-id", "wxyc-secret")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(return_value=_token_response())
+        mock_http.get = AsyncMock(return_value=_albums_page([]))
+        spotify._http = mock_http
+
+        await spotify.get_artist_albums("artist123")
+
+        mock_http.post.assert_awaited_once()
+        args, kwargs = mock_http.post.call_args
+        assert args[0] == "https://accounts.spotify.com/api/token"
+        expected_creds = base64.b64encode(b"wxyc-id:wxyc-secret").decode()
+        assert kwargs["headers"]["Authorization"] == f"Basic {expected_creds}"
+        assert kwargs["data"] == {"grant_type": "client_credentials"}
+
+    def test_configured_attributes_from_constructor(self):
+        spotify = ArtistCatalogClient("wxyc-id", "wxyc-secret")
+        assert spotify._client_id == "wxyc-id"
+        assert spotify._client_secret == "wxyc-secret"
+
+
+class TestGetArtistAlbums:
+    """Pins pagination + bearer-token behavior of the extra, script-specific method."""
+
+    @pytest.mark.asyncio
+    async def test_paginates_and_uses_bearer_token(self):
+        spotify = ArtistCatalogClient("wxyc-id", "wxyc-secret")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(return_value=_token_response())
+        page1 = _albums_page(
+            [_make_album("Edits", "alb1")], next_url="https://api.spotify.com/v1/next"
+        )
+        page2 = _albums_page([_make_album("DOGA", "alb2")])
+        mock_http.get = AsyncMock(side_effect=[page1, page2])
+        spotify._http = mock_http
+
+        albums = await spotify.get_artist_albums("artist123")
+
+        assert [a["id"] for a in albums] == ["alb1", "alb2"]
+        assert mock_http.get.call_count == 2
+        for call in mock_http.get.call_args_list:
+            assert call.kwargs["headers"]["Authorization"] == "Bearer artist-catalog-token"
+        # Token fetched once and reused across both pages.
+        assert mock_http.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_refreshes_token_on_401(self):
+        spotify = ArtistCatalogClient("wxyc-id", "wxyc-secret")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(
+            side_effect=[_token_response("stale-token"), _token_response("fresh-token")]
+        )
+        unauthorized = httpx.Response(
+            401, request=httpx.Request("GET", "https://api.spotify.com/v1/artists/xyz/albums")
+        )
+        success = _albums_page([_make_album()])
+        mock_http.get = AsyncMock(side_effect=[unauthorized, success])
+        spotify._http = mock_http
+
+        albums = await spotify.get_artist_albums("artist123")
+
+        assert len(albums) == 1
+        assert mock_http.post.call_count == 2
+        last_call = mock_http.get.call_args_list[-1]
+        assert last_call.kwargs["headers"]["Authorization"] == "Bearer fresh-token"


### PR DESCRIPTION
Closes #963

## What

Removes two byte-identical re-implementations of Spotify client-credentials token acquisition + init, leaving the canonical `clients/streaming/spotify.py:SpotifyClient` as the single source of truth:

- `scripts/spotify_artist_catalog.py`: local `SpotifyClient` (`__init__` + `_get_token`) → `ArtistCatalogClient(CanonicalSpotifyClient)`, keeping only the script-specific `get_artist_albums` pagination.
- `scripts/revalidate_spotify.py`: `SpotifyValidator` (`__init__` + `_get_token`) → `SpotifyValidator(SpotifyClient)`, keeping only the script-specific `validate_url` single-resource lookup.

Both now import `SpotifyClient` from `clients.streaming.spotify` and construct it with `(client_id, client_secret)`, matching the pattern already used by `scripts/revalidate_misses.py`, `scripts/search_unmatched_compilations.py`, `scripts/recheck_streaming_after_mojibake.py`, `scripts/track_streaming/__main__.py`, and `scripts/streaming_availability/__main__.py`.

## Why

A June structural audit flagged the canonical `SpotifyClient` and one duplicate; a follow-up pass found a third copy (`SpotifyValidator`) that had independently drifted into existence with the identical token/init logic. Three copies of the same Basic-auth client-credentials flow is exactly the kind of drift risk (env var rename, base URL change, auth flow change) this consolidation removes.

## Behavior preserved

Verified before refactoring that the canonical client and both scripts agreed on every observable detail:
- Same token endpoint (`https://accounts.spotify.com/api/token`), same Basic-auth header shape (`base64(client_id:client_secret)`), same `grant_type=client_credentials` form body.
- Same env vars (`SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET`).
- Same API base (`https://api.spotify.com/v1`) and same `Bearer <token>` header shape for authenticated requests.

One intentional, safe difference: the canonical client proactively refreshes the token based on the response's `expires_in` (with a 60s buffer), where the old script copies cached the token forever and only refreshed reactively on a 401. The 401-triggered refresh path is preserved in both scripts (now resetting the canonical client's `_access_token`) as a defensive fallback, so behavior on an actual 401 is unchanged; the proactive-refresh path only reduces the odds of ever hitting one.

Both scripts also drop their own `httpx.AsyncClient` management in favor of the canonical client's internal singleton-managed client (`_get_client()` / `close()`), matching how the app and other scripts already use it.

## Testing

Added focused characterization tests (`tests/unit/test_spotify_artist_catalog.py`, `tests/unit/test_revalidate_spotify.py`) that pin the token-fetch request shape (URL, Basic-auth header, form body), configured attributes, and the extra script-specific behavior (pagination + bearer header; single-resource lookup + bearer header + 401 refresh). Confirmed these passed against the pre-refactor duplicated implementations first, then adjusted the call shape to match the new subclassing (fewer args, since the HTTP client is now managed internally) and confirmed still green post-refactor. Also added a regression guard asserting the script classes don't redefine `__init__`/`_get_token`/`_ensure_token`, so the duplication can't silently creep back.

Local checks, all green:
- `ruff check .`
- `ruff format --check .`
- `mypy . --ignore-missing-imports`
- `pytest` (4624 passed, 1 skipped, 551 deselected, 2 xfailed)

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `mypy . --ignore-missing-imports`
- [x] `pytest`
- [ ] Manual smoke of `scripts/spotify_artist_catalog.py --dry-run` and `scripts/revalidate_spotify.py --dry-run` against real Spotify credentials (no CI coverage for these scripts' `main()`; recommend before running against prod data)