### PR TITLE
refactor(release): drop misleading underscore on ResolverDependencies

### DIFF
--- a/release/dependencies.py
+++ b/release/dependencies.py
@@ -12,7 +12,7 @@ from core.dependencies import get_discogs_service
 from discogs.service import DiscogsService
 from entity.store import EntityStore
 from identity.dependencies import get_entity_store
-from release.orchestrator import _ResolverDependencies
+from release.orchestrator import ResolverDependencies
 from streaming.dependencies import (
     get_apple_music_client,
     get_bandcamp_client,
@@ -28,14 +28,14 @@ def get_resolver_dependencies(
     deezer: DeezerClient = Depends(get_deezer_client),
     apple_music: AppleMusicClient | None = Depends(get_apple_music_client),
     entity_store: EntityStore | None = Depends(get_entity_store),
-) -> _ResolverDependencies:
+) -> ResolverDependencies:
     """Bundle the I/O clients the resolver orchestrator needs.
 
     Reuses existing DI providers so the lifecycle (close on shutdown) is
     already wired in main.py. Spotify and the entity store are optional and
     may be None; the orchestrator handles that correctly.
     """
-    return _ResolverDependencies(
+    return ResolverDependencies(
         discogs=discogs,
         bandcamp=bandcamp,
         spotify=spotify,

--- a/release/orchestrator.py
+++ b/release/orchestrator.py
@@ -56,7 +56,7 @@ from streaming.orchestrator import check_streaming_availability
 logger = logging.getLogger(__name__)
 
 
-class _ResolverDependencies:
+class ResolverDependencies:
     """Bundle the I/O dependencies the orchestrator needs.
 
     Kept as a private class so the FastAPI router (and the tests) can build
@@ -84,7 +84,7 @@ class _ResolverDependencies:
 
 async def resolve_release(
     request: ReleaseResolveRequest,
-    deps: _ResolverDependencies,
+    deps: ResolverDependencies,
 ) -> ReleaseResolveResponse:
     """Resolve a paste-URL or (source, id) into the prefill payload."""
     parsed = _resolve_to_parsed_url(request)
@@ -165,7 +165,7 @@ def _resolve_to_parsed_url(request: ReleaseResolveRequest) -> ParsedUrl | None:
 async def _check_streaming(
     canonical: CanonicalRelease | None,
     parsed: ParsedUrl,
-    deps: _ResolverDependencies,
+    deps: ResolverDependencies,
     warnings: list[str],
 ) -> StreamingCheckResponse | None:
     """Run the streaming-availability fan-out.

--- a/release/router.py
+++ b/release/router.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends
 
 from release.dependencies import get_resolver_dependencies
 from release.models import ReleaseResolveRequest, ReleaseResolveResponse
-from release.orchestrator import _ResolverDependencies, resolve_release
+from release.orchestrator import ResolverDependencies, resolve_release
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ router = APIRouter(tags=["release"])
 )
 async def handle_resolve(
     request: ReleaseResolveRequest,
-    deps: _ResolverDependencies = Depends(get_resolver_dependencies),
+    deps: ResolverDependencies = Depends(get_resolver_dependencies),
 ) -> ReleaseResolveResponse:
     """Resolve and return. Errors are converted to warnings inside the orchestrator."""
     return await resolve_release(request, deps)

--- a/tests/unit/release/test_orchestrator.py
+++ b/tests/unit/release/test_orchestrator.py
@@ -13,7 +13,7 @@ from generated.api_models import (
 from release.apple_music_url_parser import apple_album_id_from_url
 from release.models import ReleaseResolveRequest
 from release.orchestrator import (
-    _ResolverDependencies,
+    ResolverDependencies,
     _spotify_album_id_from_url,
     resolve_release,
 )
@@ -29,8 +29,8 @@ def _deps(
     apple_music=None,
     entity_store=None,
 ):
-    """Build a _ResolverDependencies with sensible defaults for tests."""
-    return _ResolverDependencies(
+    """Build a ResolverDependencies with sensible defaults for tests."""
+    return ResolverDependencies(
         discogs=discogs or AsyncMock(),
         bandcamp=bandcamp or MagicMock(),
         spotify=spotify,

--- a/tests/unit/release/test_router.py
+++ b/tests/unit/release/test_router.py
@@ -12,7 +12,7 @@ from generated.api_models import (
     DiscogsReleaseMetadata,
 )
 from release.dependencies import get_resolver_dependencies
-from release.orchestrator import _ResolverDependencies
+from release.orchestrator import ResolverDependencies
 from streaming.models import SourceMatch, StreamingCheckResponse, StreamingCheckSources
 from tests.unit.conftest import override_deps
 
@@ -33,10 +33,10 @@ def _release(**overrides) -> DiscogsReleaseMetadata:
 
 
 def _deps_with_discogs(release):
-    """Build a _ResolverDependencies whose Discogs service returns the given release."""
+    """Build a ResolverDependencies whose Discogs service returns the given release."""
     discogs = AsyncMock()
     discogs.get_release.return_value = release
-    return _ResolverDependencies(
+    return ResolverDependencies(
         discogs=discogs,
         bandcamp=MagicMock(),
         spotify=None,


### PR DESCRIPTION
## Summary

`release/orchestrator.py` defines `@dataclass class _ResolverDependencies`, but the class is imported and used across module boundaries: `release/dependencies.py` (import, return type, construction), `release/router.py` (import, `Depends(...)` param type), and both `tests/unit/release/test_orchestrator.py` and `tests/unit/release/test_router.py` (import, construction). The leading underscore signals private-to-this-module, which is no longer true.

This renames `_ResolverDependencies` to `ResolverDependencies` everywhere it appears -- class definition, imports, type annotations, constructor calls, and docstrings. Pure rename, no behavior change. `release/__init__.py` is empty and there is no `__all__` to update.

## Test plan

- [x] `ruff check .` -- clean
- [x] `ruff format --check .` -- clean
- [x] `mypy . --ignore-missing-imports` -- clean (would have flagged any missed reference)
- [x] `pytest` -- 4630 passed, 1 skipped, 2 xfailed (pre-existing, unrelated)
- [x] `pytest tests/unit/release/` -- 115 passed

Closes #966