### PR TITLE
refactor(artists-router): consolidate entity_store 503 guard onto require_entity_store

### DIFF
--- a/artists/router.py
+++ b/artists/router.py
@@ -50,7 +50,7 @@ from generated.api_models import (
     ArtistSearchAliasesBulkRequest,
     ArtistSearchAliasesBulkResponse,
 )
-from identity.dependencies import get_entity_store
+from identity.dependencies import get_entity_store, require_entity_store
 
 if TYPE_CHECKING:
     from posthog import Posthog
@@ -101,10 +101,6 @@ _GENRES_ROUTE_PATH = "/api/v1/artists/genres/bulk"
 # inside Railway's ~5-minute request-timeout ceiling. Callers page.
 _GENRES_INPUT_CAP = 25
 
-_ENTITY_STORE_UNAVAILABLE_DETAIL = (
-    "Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
-    "and the entity schema has been applied."
-)
 _DISCOGS_CACHE_UNAVAILABLE_DETAIL = (
     "Discogs cache is not available. Ensure DATABASE_URL_DISCOGS is configured."
 )
@@ -156,8 +152,7 @@ async def search_aliases_bulk(
         http_request, ArtistSearchAliasesBulkRequest, _BULK_INPUT_CAP, field="names"
     )
 
-    if entity_store is None:
-        raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL)
+    entity_store = require_entity_store(entity_store)
     if discogs_cache is None:
         raise HTTPException(status_code=503, detail=_DISCOGS_CACHE_UNAVAILABLE_DETAIL)
 
@@ -311,8 +306,7 @@ async def resolve_bulk(
         http_request, ArtistResolveBulkRequest, _RESOLVE_INPUT_CAP, field="names"
     )
 
-    if entity_store is None:
-        raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL)
+    entity_store = require_entity_store(entity_store)
     if discogs_cache is None:
         raise HTTPException(status_code=503, detail=_DISCOGS_CACHE_UNAVAILABLE_DETAIL)
 

--- a/tests/unit/test_artist_resolve_router.py
+++ b/tests/unit/test_artist_resolve_router.py
@@ -258,13 +258,11 @@ class TestServiceUnavailable:
 
     @pytest.mark.asyncio
     async def test_503_when_entity_store_none(self, make_app):
-        from artists.router import _ENTITY_STORE_UNAVAILABLE_DETAIL
-
         ctx, app = make_app(entity_store=None)
         with ctx:
             resp = await _post(app, {"names": ["Wishy"]})
         assert resp.status_code == 503
-        assert resp.json()["detail"] == _ENTITY_STORE_UNAVAILABLE_DETAIL
+        assert "entity store" in resp.json()["detail"].lower()
 
     @pytest.mark.asyncio
     async def test_503_when_discogs_cache_none(self, make_app):

--- a/tests/unit/test_artist_search_aliases_router.py
+++ b/tests/unit/test_artist_search_aliases_router.py
@@ -299,9 +299,7 @@ class TestServiceUnavailable:
                 )
 
         assert resp.status_code == 503
-        from artists.router import _ENTITY_STORE_UNAVAILABLE_DETAIL
-
-        assert resp.json()["detail"] == _ENTITY_STORE_UNAVAILABLE_DETAIL
+        assert "entity store" in resp.json()["detail"].lower()
 
     @pytest.mark.asyncio
     async def test_503_when_discogs_cache_none(self, mock_settings, mock_entity_store):
@@ -335,6 +333,17 @@ class TestServiceUnavailable:
         from artists.router import _DISCOGS_CACHE_UNAVAILABLE_DETAIL
 
         assert resp.json()["detail"] == _DISCOGS_CACHE_UNAVAILABLE_DETAIL
+
+
+class TestEntityStoreDetailConsolidation:
+    """The entity-store-unavailable 503 detail lives only in
+    `identity.dependencies` (WXYC/library-metadata-lookup#960/#961); this
+    router must not carry its own copy that could silently drift from it."""
+
+    def test_no_local_detail_redefinition(self):
+        import artists.router as artists_router
+
+        assert not hasattr(artists_router, "_ENTITY_STORE_UNAVAILABLE_DETAIL")
 
 
 class TestDuplicateInputDedup:


### PR DESCRIPTION
Closes #968

`artists/router.py` inlined the "entity store unavailable -> HTTP 503" guard in both bulk endpoints and locally redefined the detail constant, duplicating the shared `require_entity_store` helper that #960/#961 already introduced and applied to `cache/router.py` and `identity/router.py`.

## Change

- Import `require_entity_store` from `identity.dependencies` in `artists/router.py`.
- Replace each `if entity_store is None: raise HTTPException(...)` block with `entity_store = require_entity_store(entity_store)`, which raises the 503 and narrows `EntityStore | None` to `EntityStore` for the downstream non-optional uses.
- Delete the local `_ENTITY_STORE_UNAVAILABLE_DETAIL` redefinition. Its string value was byte-identical to the canonical constant in `identity/dependencies.py`, so the response body is unchanged; the canonical constant is now the single source of truth.
- Add a drift guard (`TestEntityStoreDetailConsolidation`) asserting `artists.router` no longer defines `_ENTITY_STORE_UNAVAILABLE_DETAIL`, so a future PR can't silently reintroduce the duplicate.
- Repoint the two `test_503_when_entity_store_none` tests at a detail-substring check, matching the pattern already used by the `identity/router.py` and `cache/router.py` equivalents, since the private constant they previously imported from `artists.router` no longer exists.

Out of scope: the separate `_DISCOGS_CACHE_UNAVAILABLE_DETAIL` guards (three call sites). There is no shared helper for those; this PR does not touch them.

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `mypy . --ignore-missing-imports`
- [x] `pytest` (4631 passed, 1 skipped, 551 deselected, 2 xfailed -- pre-existing/unrelated)
