### PR TITLE
fix(#972): escape FTS5 query terms so punctuated artist names don't degrade to LIKE-AND

### DIFF
--- a/library/db.py
+++ b/library/db.py
@@ -63,6 +63,30 @@ LIBRARY_FTS_CREATE_SQL = f"""
     )
 """
 
+
+def _to_fts_match_query(query: str) -> str:
+    """Quote each whitespace-separated term as an FTS5 string literal.
+
+    FTS5 metacharacters (``.`` ``"`` ``*`` ``:`` ``(`` ``)`` etc.) inside a
+    double-quoted term are treated as literal content, not query syntax, so
+    punctuated/initials artist names ("M.I.A.", "J. Mascis") tokenize
+    instead of raising ``fts5: syntax error``. Joining the quoted terms with
+    spaces preserves the implicit AND-across-terms semantics of an
+    unescaped multi-word MATCH query, so clean queries are unaffected.
+
+    This is a query-parse fix only -- it does not touch the on-disk
+    tokenizer (:data:`LIBRARY_FTS_TOKENIZER`), which must stay byte-identical
+    to discogs-etl's ``export_to_sqlite.py``.
+
+    Returns ``""`` when the query has no terms (empty or all-whitespace) --
+    the caller must treat that as "no FTS query" and route to the LIKE/fuzzy
+    fallback chain instead of executing ``MATCH ''``, which is itself an
+    ``fts5: syntax error``.
+    """
+    terms = query.split()
+    return " ".join('"' + t.replace('"', '""') + '"' for t in terms)
+
+
 # Module-level caches for library search results.
 # Lazy-initialized from settings. Cleared when the database is closed/replaced.
 _artist_cache: TTLCache | None = None
@@ -237,7 +261,12 @@ class LibraryDB:
     ) -> list[LibraryItem]:
         assert self._conn is not None  # Caller validates
         if query:
-            # Full-text search using FTS5
+            # Full-text search using FTS5. Query terms are quoted as FTS5
+            # string literals (see _to_fts_match_query) so metacharacters
+            # (. " * : ( ) etc.) in punctuated/initials artist names are
+            # treated as literal content instead of raising
+            # `fts5: syntax error`.
+            match_query = _to_fts_match_query(query)
             sql = f"""
                 SELECT {self._select_columns("l")}
                 FROM library l
@@ -246,8 +275,15 @@ class LibraryDB:
                 LIMIT ?
             """
             try:
-                cursor = await self._conn.execute(sql, (query, limit))
-                rows = await cursor.fetchall()
+                if match_query:
+                    cursor = await self._conn.execute(sql, (match_query, limit))
+                    rows = await cursor.fetchall()
+                else:
+                    # An empty/all-whitespace query quotes down to "", and
+                    # `MATCH ''` is itself an fts5 syntax error. Skip the FTS
+                    # execute entirely and treat it as "no FTS results" so we
+                    # fall straight through to the LIKE/fuzzy chain below.
+                    rows = []
 
                 # If no results and fallback enabled, try LIKE search
                 if not rows and fallback_to_like:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -375,6 +375,11 @@ SEED_ITEMS = [
     # re-search, so the found_on_compilation result must trust-bind the carried
     # (already-validated) release instead of dropping its artwork.
     (70001, "Orcutt-Shelley-Miller", "Bill Orcutt", "OR", 1, 1, "Jazz", "Vinyl"),
+    # Punctuated/initials artist name (LML#972). Unescaped, "M.I.A." raises
+    # `fts5: syntax error near "."` in MATCH and silently degrades to the
+    # LIKE-AND fallback, which then requires "kala" and "m" and "i" and "a"
+    # to all co-occur on one row -- a search for "M.I.A." never surfaces it.
+    (80001, "Kala", "M.I.A.", "M", 1, 1, "Electronic", "CD"),
 ]
 
 

--- a/tests/integration/test_library_db.py
+++ b/tests/integration/test_library_db.py
@@ -43,6 +43,79 @@ class TestFTS5Search:
         assert results == []
 
 
+class TestFTS5PunctuationEscaping:
+    """LML#972: FTS5 metacharacters in a query (``.``, ``"``, ``*``, ``:``, ``(``, ``)``)
+
+    must not raise ``fts5: syntax error`` and silently degrade to the LIKE-AND
+    fallback -- that fallback requires every significant token to co-occur on
+    one row, which drops real matches like "M.I.A." (whose album is "Kala",
+    sharing no token with the artist query).
+    """
+
+    @pytest.mark.asyncio
+    async def test_punctuated_artist_name_matches_via_fts(self, library_db):
+        """A query for 'M.I.A.' finds the seeded row via a real FTS match.
+
+        Before the fix: MATCH 'M.I.A.' raises `fts5: syntax error near "."`,
+        caught by the broad except and degraded to LIKE-AND, which requires
+        "kala" AND "m" AND "i" AND "a" to all appear on one row -- so it
+        returns []. After the fix, the escaped MATCH tokenizes "M.I.A." into
+        `m i a`, which the FTS index actually contains for this row.
+
+        ``fallback_to_fuzzy=False`` isolates the FTS/LIKE path being fixed
+        here: with the default ``fallback_to_fuzzy=True``, this tiny seed
+        corpus lets the *fuzzy* fallback's permissive single-character-prefix
+        LIKE scan (``LIKE '%m%'``, then rapidfuzz-scored) coincidentally
+        catch "M.I.A." too, which would mask the FTS regression this test
+        exists to catch.
+        """
+        results = await library_db.search(query="M.I.A.", fallback_to_fuzzy=False)
+        assert any(r.artist == "M.I.A." for r in results), results
+
+    @pytest.mark.asyncio
+    async def test_punctuated_artist_name_matches_with_default_fallback_chain(self, library_db):
+        """Same query through the full default fallback chain (fuzzy included)."""
+        results = await library_db.search(query="M.I.A.")
+        assert any(r.artist == "M.I.A." for r in results), results
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "M.I.A.",
+            'a "quoted" thing',
+            "wild*card",
+            "colon:test",
+            "(paren)",
+            "St. Vincent",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_metacharacter_queries_do_not_raise(self, library_db, query):
+        """None of the FTS5 metacharacter class should raise; all return a list."""
+        results = await library_db.search(query=query)
+        assert isinstance(results, list)
+
+    @pytest.mark.parametrize("query", ["", "   ", "\t\n"])
+    @pytest.mark.asyncio
+    async def test_empty_or_whitespace_query_guarded(self, library_db, query):
+        """An empty/all-whitespace query must never reach `MATCH ''` (also a syntax error).
+
+        It should be guarded and routed straight to the LIKE/fuzzy fallback
+        chain instead, returning a (possibly empty) list without raising.
+        """
+        results = await library_db.search(query=query)
+        assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_clean_multiword_query_unaffected(self, library_db):
+        """Escaping is equivalence-preserving: a clean multi-word query still
+        returns the same rows as before the fix (same rows as
+        ``test_combined_artist_album``)."""
+        results = await library_db.search(query="Stereolab Dots Loops")
+        assert len(results) >= 1
+        assert any(r.title == "Dots and Loops" for r in results)
+
+
 class TestFilteredSearch:
     @pytest.mark.asyncio
     async def test_artist_filter(self, library_db):

--- a/tests/unit/test_library_db.py
+++ b/tests/unit/test_library_db.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from library.db import LibraryDB
+from library.db import LibraryDB, _to_fts_match_query
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -364,6 +364,74 @@ class TestLibraryDBSearch:
 
         results = await db.search(query="nothing", fallback_to_like=False, fallback_to_fuzzy=False)
         assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _to_fts_match_query (LML#972)
+# ---------------------------------------------------------------------------
+
+
+class TestToFtsMatchQuery:
+    """Pure helper: quotes each whitespace-separated term as an FTS5 string
+    literal so metacharacters (. " * : ( ) etc.) are treated as literal
+    content rather than query syntax."""
+
+    def test_single_term_gets_quoted(self):
+        assert _to_fts_match_query("M.I.A.") == '"M.I.A."'
+
+    def test_multiple_terms_each_quoted(self):
+        assert _to_fts_match_query("J. Mascis") == '"J." "Mascis"'
+
+    def test_embedded_quote_is_doubled(self):
+        assert _to_fts_match_query('a "quoted" thing') == '"a" """quoted""" "thing"'
+
+    def test_other_metacharacters_pass_through_inside_quotes(self):
+        assert _to_fts_match_query("wild*card") == '"wild*card"'
+        assert _to_fts_match_query("colon:test") == '"colon:test"'
+        assert _to_fts_match_query("(paren)") == '"(paren)"'
+
+    def test_clean_multiword_query_quoted_per_term(self):
+        assert _to_fts_match_query("Stereolab Dots Loops") == '"Stereolab" "Dots" "Loops"'
+
+    def test_empty_query_yields_empty_string(self):
+        assert _to_fts_match_query("") == ""
+
+    def test_whitespace_only_query_yields_empty_string(self):
+        assert _to_fts_match_query("   ") == ""
+        assert _to_fts_match_query("\t\n") == ""
+
+
+class TestSearchEmptyMatchQueryGuard:
+    """LML#972: an empty/all-whitespace query must never reach `MATCH ''`
+
+    (also a syntax error: `fts5: syntax error near ""`). It must be guarded
+    so the FTS branch never executes `MATCH ''` at all. For a whitespace-only
+    query, ``_fallback_like_search``/``_fuzzy_search`` also find no
+    significant words and short-circuit to ``[]`` before touching the
+    database (see their own ``if not significant_words / words: return []``
+    guards) -- so the whole call must be a no-op that returns a list without
+    ever calling ``_conn.execute``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_whitespace_query_never_calls_execute(self):
+        db = LibraryDB()
+        db._conn = AsyncMock()
+
+        results = await db.search(query="   ")
+
+        assert results == []
+        db._conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tabs_and_newlines_only_query_never_calls_execute(self):
+        db = LibraryDB()
+        db._conn = AsyncMock()
+
+        results = await db.search(query="\t\n")
+
+        assert results == []
+        db._conn.execute.assert_not_called()
 
 
 class TestSearchFallbackLogLevels:


### PR DESCRIPTION
## Summary

Library FTS5 search silently degraded to a LIKE-AND fallback for any query containing an FTS5 metacharacter — most commonly `.` in initials/punctuated artist names (`M.I.A.`, `J. Mascis`, `St. Vincent`, `C. Spencer Yeh`). `LibraryDB._search_uncached` passed the raw query straight into `library_fts MATCH ?`, so `.` raised `fts5: syntax error near "."`; that error was swallowed by the branch's broad `except Exception` and degraded to `_fallback_like_search`, which requires every significant token to co-occur on one row (an AND across `title`/`artist`/`alternate_artist_name`). The degrade was silent, so it quietly narrowed recall across a whole class of artist names — not just the one lookup that surfaced it.

## Fix

Query-side only: a new pure helper `_to_fts_match_query` quotes each whitespace-separated term as an FTS5 string literal (doubling any embedded `"`), joined with spaces. FTS5 treats a double-quoted run as literal content, so metacharacters no longer parse as syntax — `"M.I.A."` tokenizes to `m i a` and matches. Joining quoted terms with spaces preserves the existing implicit-AND-across-terms semantics, so clean multi-word queries return identical results. The on-disk tokenizer (`LIBRARY_FTS_TOKENIZER` / `LIBRARY_FTS_CREATE_SQL`) is deliberately untouched — it must stay byte-identical to discogs-etl's `export_to_sqlite.py`, and this bug is a MATCH-parse issue, not a tokenizer one, so no cross-repo coordination is needed.

Edge case handled: an empty or all-whitespace query quotes down to `""`, and `MATCH ''` is itself an `fts5: syntax error`. The FTS branch guards this and routes straight to the LIKE/fuzzy fallback chain instead of executing an empty MATCH. The existing `except Exception → _fallback_like_search` net is kept as a defensive backstop.

## Tests (TDD)

Red-first, then green. Integration (`TestFTS5PunctuationEscaping`, in-memory SQLite+FTS5 via the existing `library_db` fixture): a punctuated query now matches via a real FTS match (isolated with `fallback_to_fuzzy=False`, because the tiny seed corpus's fuzzy fallback would otherwise mask the FTS regression), the full metacharacter class (`.` `"` `*` `:` `(` `)`) does not raise, the empty/whitespace query is guarded, and a clean multi-word query is unchanged. Unit (`TestToFtsMatchQuery`, `TestSearchEmptyMatchQueryGuard`): white-box coverage of the helper plus assertions that `_conn.execute` is never called for a whitespace-only query.

Full suite green locally (4609 passed); `ruff check`, `ruff format --check`, and `mypy library/db.py` clean.

Closes #972
