### PR TITLE
fix(#971): bind library row by Discogs release credit in TRACK_ON_COMPILATION

### DIFF
--- a/discogs/matching.py
+++ b/discogs/matching.py
@@ -35,6 +35,11 @@ from wxyc_etl.text import to_match_form as normalize_for_comparison
 # Discogs disambiguation suffix: (2), (22), etc.
 _DISCOGS_SUFFIX_RE = re.compile(r"\s*\(\d+\)$")
 
+# Discogs Artist Name Variation (ANV) marker: a trailing '*' on a release
+# credit signals the name shown differs from that artist's canonical/primary
+# name (e.g. "C.S. Yeh*" credits "C. Spencer Yeh" via the alias "C.S. Yeh").
+_ANV_MARKER_RE = re.compile(r"\*+\s*$")
+
 
 def strip_discogs_suffix(name: str) -> str:
     """Remove Discogs numeric disambiguation suffixes like '(2)' or '(22)'.
@@ -45,6 +50,50 @@ def strip_discogs_suffix(name: str) -> str:
     if not name:
         return name
     return _DISCOGS_SUFFIX_RE.sub("", name)
+
+
+def strip_release_artist_suffix(name: str) -> str:
+    """Remove Discogs release-credit decorations from an artist string.
+
+    Strips the trailing Artist Name Variation marker ('*') and the numeric
+    disambiguation suffix ('(2)', '(22)', ...). No real artist name legitimately
+    ends in '*', so this is safe to apply unconditionally to a release-credit
+    string. Safe to apply to names with neither decoration (no-op).
+
+    Only the canonical Discogs ordering ``Name (N)*`` is handled -- the
+    reverse ``Name* (N)`` leaves a residual '*', since ``_ANV_MARKER_RE`` is
+    anchored to the end of the string. Not worth a more permissive regex:
+    ``credit_uses_anv`` (the caller's gate for whether to trust this string at
+    all) is anchored the same way, so a reverse-order credit simply never
+    reaches this function in practice.
+
+    Distinct from ``strip_discogs_suffix``: that function's callers span
+    several catalog-enrichment scripts operating on artist/label names sourced
+    from the Postgres discogs-cache (not split from a raw search-result
+    title), so widening its contract to also strip '*' there would be an
+    unreviewed blast-radius increase. This helper is scoped to the
+    ``ReleaseInfo.artist``-shaped strings produced by
+    ``DiscogsService._parse_title`` splitting a "Credit* - Album" search
+    result, where the ANV marker is a known, well-understood artifact.
+    """
+    if not name:
+        return name
+    return strip_discogs_suffix(_ANV_MARKER_RE.sub("", name)).strip()
+
+
+def credit_uses_anv(name: str | None) -> bool:
+    """True when ``name`` (a raw Discogs release-credit string) ends in the
+    Artist Name Variation marker ('*').
+
+    Deliberately narrower than "did stripping change anything": a numeric
+    disambiguator alone (``"Sun (2)"``) is NOT an alias signal -- it only says
+    "the Nth Discogs artist named Sun", carrying no information that the
+    credited name means a *different* canonical artist. Callers that want to
+    know "is this credit trustworthy as an alternate name for the searched
+    artist" must gate on this predicate specifically, not on whether
+    ``strip_release_artist_suffix`` altered the string.
+    """
+    return bool(_ANV_MARKER_RE.search(name or ""))
 
 
 def normalize_for_track_comparison(text: str | None) -> str:

--- a/lookup/strategies/track_on_compilation.py
+++ b/lookup/strategies/track_on_compilation.py
@@ -36,6 +36,7 @@ from core.search import (
     song_not_found_with_artist_and_song,
 )
 from discogs.lookup import lookup_releases_by_track
+from discogs.matching import credit_uses_anv, strip_release_artist_suffix
 from discogs.models import ReleaseInfo, TrackReleasesResponse
 from discogs.service import DiscogsService
 from entity.sources import PgSource
@@ -490,9 +491,40 @@ async def search_compilations_for_track(
                 filtered_matches = []
                 discogs_is_compilation = release_info.is_compilation
                 release_album_lower = release_album.lower()
+                # LML#971: also keep a title-matched row when it prefix-matches the
+                # release's OWN ANV-marked Discogs credit, not only the typed
+                # `lib_artist` -- rescues rows filed under a band name / abbreviated
+                # alias (e.g. library "Burning Star Core" / alternate_artist_name
+                # "C.S. Yeh" for Discogs release credit "C.S. Yeh*") that the typed
+                # artist alone can't prefix-match and that isn't a V/A compilation,
+                # so the carve-out below can't rescue it either.
+                #
+                # Gated on `credit_uses_anv` (the trailing `*` marker) SPECIFICALLY,
+                # not on "any decoration". A numeric disambiguator alone
+                # (``"Sun (2)"``) is NOT an alias signal -- it only says "the Nth
+                # Discogs artist named Sun" -- so treating it as trustworthy would
+                # reopen the exact false-positive prefix collisions `lib_artist` and
+                # the title-score gate below both exist to close (a plain "Sun (2)"
+                # credit prefix-matching library row "Sunburned Hand of the Man"; a
+                # plain "Various (2)" credit -- not compilation-artist-shaped, so
+                # `is_compilation_artist` is False too -- bypassing the title-score
+                # check below entirely). Still a STRICT prefix match;
+                # `validate_release_for_track` below (on the TYPED artist) validates
+                # the release, not the surfaced row, so it does NOT catch a
+                # wrong-row bind here -- the ANV gate is the only thing standing
+                # between this branch and that false-positive class.
+                raw_release_credit = (release_info.artist or "").strip()
+                credit_has_anv_marker = credit_uses_anv(raw_release_credit)
+                release_credit = strip_release_artist_suffix(raw_release_credit)
 
                 for match in matches:
                     if artist_matches_item(match, lib_artist):
+                        filtered_matches.append(match)
+                    elif (
+                        credit_has_anv_marker
+                        and release_credit
+                        and artist_matches_item(match, release_credit)
+                    ):
                         filtered_matches.append(match)
                     elif discogs_is_compilation and is_compilation_artist(match.artist or ""):
                         title_score = _fuzz.ratio(release_album_lower, (match.title or "").lower())

--- a/tests/unit/test_matching.py
+++ b/tests/unit/test_matching.py
@@ -6,9 +6,11 @@ from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from core.search import detect_ambiguous_format
 from discogs.matching import (
+    credit_uses_anv,
     normalize_artist_for_validation,
     normalize_for_track_comparison,
     strip_discogs_suffix,
+    strip_release_artist_suffix,
 )
 from discogs.service import calculate_confidence
 from lookup.matching import is_self_titled, map_library_format_to_discogs
@@ -38,6 +40,62 @@ class TestStripDiscogsSuffix:
     )
     def test_strip_discogs_suffix(self, input_text, expected):
         assert strip_discogs_suffix(input_text) == expected
+
+
+# ---------------------------------------------------------------------------
+# strip_release_artist_suffix
+# ---------------------------------------------------------------------------
+
+
+class TestStripReleaseArtistSuffix:
+    """Tests for the release-credit ANV-marker + numeric-suffix strip.
+
+    See WXYC/library-metadata-lookup#971 -- the "C.S. Yeh*" repro.
+    """
+
+    @pytest.mark.parametrize(
+        "input_text, expected",
+        [
+            pytest.param("C.S. Yeh*", "C.S. Yeh", id="anv-marker"),
+            pytest.param("DNA (22)", "DNA", id="numeric-suffix-22"),
+            pytest.param("Bjork", "Bjork", id="no-decoration-unchanged"),
+            pytest.param("", "", id="empty-string"),
+            pytest.param("John Smith (3)*", "John Smith", id="anv-marker-and-numeric-suffix"),
+            pytest.param(
+                "Moon Pix (Deluxe Edition)",
+                "Moon Pix (Deluxe Edition)",
+                id="non-numeric-parens-preserved",
+            ),
+        ],
+    )
+    def test_strip_release_artist_suffix(self, input_text, expected):
+        assert strip_release_artist_suffix(input_text) == expected
+
+
+# ---------------------------------------------------------------------------
+# credit_uses_anv
+# ---------------------------------------------------------------------------
+
+
+class TestCreditUsesAnv:
+    """The ANV-`*`-specific gate: a numeric disambiguator alone is NOT an
+    alias signal and must not be conflated with the ANV marker.
+    """
+
+    @pytest.mark.parametrize(
+        "input_text, expected",
+        [
+            pytest.param("C.S. Yeh*", True, id="anv-marker"),
+            pytest.param("John Smith (3)*", True, id="anv-marker-after-numeric-suffix"),
+            pytest.param("Sun (2)", False, id="numeric-suffix-only-not-anv"),
+            pytest.param("Various (2)", False, id="numeric-suffix-only-not-anv-various"),
+            pytest.param("Bjork", False, id="no-decoration"),
+            pytest.param("", False, id="empty-string"),
+            pytest.param(None, False, id="none"),
+        ],
+    )
+    def test_credit_uses_anv(self, input_text, expected):
+        assert credit_uses_anv(input_text) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_track_on_compilation_release_credit_bind.py
+++ b/tests/unit/test_track_on_compilation_release_credit_bind.py
@@ -1,0 +1,255 @@
+"""Unit tests for the TRACK_ON_COMPILATION release-credit artist bind (LML#971).
+
+Repro: artist="C. Spencer Yeh", song="In the Blink of an Eye" (no album)
+returned no library results even though WXYC owns the release (library id
+57833, artist "Burning Star Core" -- Yeh's band -- with alternate_artist_name
+"C.S. Yeh"). Discogs credits the release (2789357) to "C.S. Yeh*", an Artist
+Name Variation of the canonical "C. Spencer Yeh"; the trailing ``*`` is the
+Discogs ANV marker ``DiscogsService._parse_title`` leaves in place.
+
+``process_release`` found the row by title via ``search_album_fuzzy``, but
+its strict artist filter only checked the typed artist ("C. Spencer Yeh")
+against the row -- which prefix-matches neither the band name nor the alias
+-- and the row isn't a V/A compilation, so the compilation carve-out couldn't
+rescue it either. The row was silently dropped despite Discogs' own track
+search returning this exact release for this exact artist.
+
+Fix: the strict filter also accepts a title-matched row that prefix-matches
+the release's OWN (ANV-stripped) Discogs credit. ``validate_release_for_track``
+(run right after, keyed on the TYPED artist) remains the safety belt.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discogs.models import ReleaseInfo, TrackReleasesResponse
+from lookup.strategies.track_on_compilation import search_compilations_for_track
+from services.parser import ParsedRequest
+from tests.factories import make_library_item
+
+_LIBRARY_ID = 57833
+_RELEASE_ID = 2789357
+_SONG = "In the Blink of an Eye"
+_ARTIST = "C. Spencer Yeh"
+_RELEASE_CREDIT = "C.S. Yeh*"
+_RELEASE_ALBUM = "In The Blink Of An Eye"
+
+
+def _burning_star_core_row() -> object:
+    return make_library_item(
+        id=_LIBRARY_ID,
+        artist="Burning Star Core",
+        alternate_artist_name="C.S. Yeh",
+        title='"In The Blink of an Eye" 7-inch',
+        genre="Rock",
+    )
+
+
+def _yeh_release_response(artist_credit: str = _RELEASE_CREDIT) -> TrackReleasesResponse:
+    return TrackReleasesResponse(
+        track=_SONG,
+        artist=artist_credit,
+        releases=[
+            ReleaseInfo(
+                album=_RELEASE_ALBUM,
+                artist=artist_credit,
+                release_id=_RELEASE_ID,
+                release_url=f"https://www.discogs.com/release/{_RELEASE_ID}",
+                is_compilation=False,
+            )
+        ],
+        total=1,
+    )
+
+
+def _service(artist_credit: str = _RELEASE_CREDIT) -> AsyncMock:
+    """A DiscogsService double whose track search returns the C.S. Yeh* release
+    and whose per-track validator passes -- the "Discogs side works" half of
+    the bug (already confirmed live)."""
+    service = AsyncMock()
+    service.cache_service = None
+    service.search_releases_by_track = AsyncMock(return_value=_yeh_release_response(artist_credit))
+    service.validate_track_on_release = AsyncMock(return_value=True)
+    return service
+
+
+def _parsed() -> ParsedRequest:
+    return ParsedRequest(
+        artist=_ARTIST,
+        song=_SONG,
+        raw_message="In the Blink of an Eye by C. Spencer Yeh",
+    )
+
+
+@pytest.mark.asyncio
+class TestReleaseCreditArtistBind:
+    async def test_binds_library_row_via_release_credit_when_typed_artist_misses(self):
+        """The core repro: the typed artist doesn't prefix-match the library
+        row, but the release's own (ANV-marked) credit does -- the row must
+        surface, carrying the validated release on the discogs_titles seam."""
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[_burning_star_core_row()])
+        db.search = AsyncMock(return_value=[])
+
+        service = _service()
+
+        results, discogs_titles = await search_compilations_for_track(
+            db, _parsed(), discogs_service=service
+        )
+
+        assert [r.id for r in results] == [_LIBRARY_ID]
+        assert _LIBRARY_ID in discogs_titles
+        assert discogs_titles[_LIBRARY_ID].release_id == _RELEASE_ID
+
+        # The safety belt still runs, keyed on the TYPED artist -- not the
+        # release credit -- so binding on the credit can't skip validation.
+        service.validate_track_on_release.assert_awaited_once_with(_RELEASE_ID, _SONG, _ARTIST)
+
+    async def test_failed_validation_still_drops_the_row(self):
+        """The release-credit bind is not a bypass for validate_release_for_track:
+        a title+credit match that fails per-track validation is still dropped."""
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[_burning_star_core_row()])
+        db.search = AsyncMock(return_value=[])
+
+        service = _service()
+        service.validate_track_on_release = AsyncMock(return_value=False)
+
+        results, discogs_titles = await search_compilations_for_track(
+            db, _parsed(), discogs_service=service
+        )
+
+        assert results == []
+        assert discogs_titles == {}
+
+    async def test_row_matching_neither_typed_artist_nor_release_credit_stays_dropped(self):
+        """Guard against over-admission: a title-matched row whose artist matches
+        NEITHER the typed artist NOR the (stripped) release credit must still be
+        dropped by the strict filter -- and never reach validation."""
+        db = AsyncMock()
+        unrelated_row = make_library_item(
+            id=99999,
+            artist="Some Unrelated Artist",
+            title='"In The Blink of an Eye" 7-inch',
+            genre="Rock",
+        )
+        db.exact_title = AsyncMock(return_value=[unrelated_row])
+        db.search = AsyncMock(return_value=[])
+
+        service = _service()
+
+        results, discogs_titles = await search_compilations_for_track(
+            db, _parsed(), discogs_service=service
+        )
+
+        assert results == []
+        assert discogs_titles == {}
+        service.validate_track_on_release.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestNumericSuffixIsNotAnAliasSignal:
+    """A numeric-only Discogs disambiguator ('(N)', no ANV '*') must NOT open
+    the release-credit match-back path -- unlike the ANV marker, it carries no
+    "this credits a different canonical artist" signal, only "the Nth Discogs
+    artist with this name". Regression coverage for a bug caught in review of
+    the LML#971 fix itself: gating the new branch on "any decoration changed
+    the string" (rather than the ANV marker specifically) let a plain
+    numeric-suffixed credit prefix-match an unrelated library row.
+    """
+
+    async def test_numeric_suffix_credit_does_not_bind_unrelated_row(self):
+        """ "Sun (2)" strips to "Sun", which prefix-matches library row
+        "Sunburned Hand of the Man" -- an unrelated artist. The numeric suffix
+        alone must not make that prefix match trustworthy."""
+        db = AsyncMock()
+        sunburned_row = make_library_item(
+            id=42,
+            artist="Sunburned Hand of the Man",
+            title="Headdress",
+        )
+        db.exact_title = AsyncMock(return_value=[sunburned_row])
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = None
+        service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="Headdress",
+                artist="Sun (2)",
+                releases=[
+                    ReleaseInfo(
+                        album="Headdress",
+                        artist="Sun (2)",
+                        release_id=556,
+                        release_url="https://www.discogs.com/release/556",
+                        is_compilation=False,
+                    )
+                ],
+                total=1,
+            )
+        )
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="Sun Araw",
+            song="Headdress",
+            raw_message="Sun Araw - Headdress",
+        )
+
+        results, discogs_titles = await search_compilations_for_track(
+            db, parsed, discogs_service=service
+        )
+
+        assert results == []
+        assert discogs_titles == {}
+
+    async def test_numeric_suffix_credit_does_not_bypass_title_score_gate(self):
+        """ "Various (2)" strips to "Various", which prefix-matches a library
+        row filed under "Various Artists ..." -- but the release isn't flagged
+        as a compilation, so the title-score carve-out never gets a chance to
+        run. The numeric suffix must not open a side door around it."""
+        db = AsyncMock()
+        va_row = make_library_item(
+            id=7001,
+            artist="Various Artists - Rock - D",
+            title="Totally Different Comp Title",
+        )
+        db.exact_title = AsyncMock(return_value=[va_row])
+        db.search = AsyncMock(return_value=[])
+
+        service = AsyncMock()
+        service.cache_service = None
+        service.search_releases_by_track = AsyncMock(
+            return_value=TrackReleasesResponse(
+                track="No Way Back",
+                artist="Various (2)",
+                releases=[
+                    ReleaseInfo(
+                        album="Some Other Compilation",
+                        artist="Various (2)",
+                        release_id=8001,
+                        release_url="https://www.discogs.com/release/8001",
+                        is_compilation=False,
+                    )
+                ],
+                total=1,
+            )
+        )
+        service.validate_track_on_release = AsyncMock(return_value=True)
+
+        parsed = ParsedRequest(
+            artist="Adonis",
+            song="No Way Back",
+            raw_message="No Way Back by Adonis",
+        )
+
+        results, discogs_titles = await search_compilations_for_track(
+            db, parsed, discogs_service=service
+        )
+
+        assert results == []
+        assert discogs_titles == {}


### PR DESCRIPTION
## Summary

An artist+song lookup for artist="C. Spencer Yeh", song="In the Blink of an Eye" returned no library results even though WXYC owns the release. The library row is filed under the band name "Burning Star Core" with `alternate_artist_name` "C.S. Yeh", while Discogs credits release 2789357 to the Artist Name Variation "C.S. Yeh*". In `search_compilations_for_track` → `process_release`, the album-title search finds the row, but the strict artist filter only compared it against the typed artist ("C. Spencer Yeh") — which prefix-matches neither the band name nor the alias — and the row isn't a V/A compilation, so the compilation carve-out couldn't rescue it either. The correctly-located row was discarded before `validate_release_for_track` ever ran.

## Change

The strict artist filter now also keeps a title-matched row when it prefix-matches the release's own Discogs credit (`release_info.artist`), gated specifically on the ANV `*` marker via the new `credit_uses_anv` predicate. `validate_release_for_track` (on the typed artist) runs immediately after and remains the safety belt against a bad bind.

The gate is deliberately ANV-`*`-specific rather than "any Discogs decoration": a bare numeric disambiguator (`"Sun (2)"`) is not an alias signal, and because `validate_release_for_track` only validates the release against the typed artist — never the surfaced library row — treating a stripped generic base name as an independent match-back path would reopen prefix-collision false positives (a "Sun (2)" credit binding "Sunburned Hand of the Man"; a "Various (2)" credit binding a "Various Artists" row while bypassing the title-score gate).

The new `strip_release_artist_suffix` helper strips the trailing ANV `*` and the `(N)` disambiguator for building the comparison string; it is kept separate from `strip_discogs_suffix` so its `*`-stripping doesn't widen that function's contract across its catalog-enrichment callers.

## Testing

- New strategy-level tests through `search_compilations_for_track`: the repro (library row surfaces; validation is called with the typed artist), a validation-failure guard (a credit match is not a validation bypass), an over-admission guard (a row matching neither signal stays dropped), and two numeric-disambiguator regression tests (`"Sun (2)"` and `"Various (2)"` must not bind unrelated rows). The numeric-case tests were confirmed load-bearing by monkeypatching the gate to the pre-fix behavior and observing the wrong row surface.
- Unit tests for `credit_uses_anv` and `strip_release_artist_suffix`.
- Full `tests/unit` + `tests/integration` (excluding `pg` / `external_api`): 4595 passed, 2 pre-existing xfails, no regressions. `ruff check` / `ruff format --check` / `mypy` clean.

## Scope / follow-ups

- Only rescues the case where Discogs itself flags the alias with the ANV `*`. A release credited plainly to a band name with no Discogs decoration is a materially broader problem, addressed on the data side by enriching `library.db` from the WXYC catalog's own cross-reference table (separate discogs-etl ticket).
- The FTS-metacharacter recall degrade surfaced in the same investigation is tracked separately in #972.
- `ARTIST_PLUS_ALBUM` has the same shape of gap in principle but is library-only (no release credit to bind against) and is intentionally out of scope here.

Closes #971
