### PR TITLE
feat(#334): consult cross_reference_names in artist_matches_item

### DIFF
--- a/library/db.py
+++ b/library/db.py
@@ -127,6 +127,7 @@ class LibraryDB:
         self._has_alternate_artist: bool = False
         self._has_album_artist: bool = False
         self._has_label: bool = False
+        self._has_cross_reference_names: bool = False
         self._has_compilation_track_artist: bool = False
         self._has_streaming_links: bool = False
 
@@ -158,6 +159,7 @@ class LibraryDB:
         self._has_alternate_artist = "alternate_artist_name" in column_names
         self._has_album_artist = "album_artist" in column_names
         self._has_label = "label" in column_names
+        self._has_cross_reference_names = "cross_reference_names" in column_names
 
         # Detect optional tables
         tables_cursor = await self._conn.execute(
@@ -175,6 +177,7 @@ class LibraryDB:
             f"(alternate_artist_name: {'yes' if self._has_alternate_artist else 'no'}, "
             f"album_artist: {'yes' if self._has_album_artist else 'no'}, "
             f"label: {'yes' if self._has_label else 'no'}, "
+            f"cross_reference_names: {'yes' if self._has_cross_reference_names else 'no'}, "
             f"compilation_track_artist: {'yes' if self._has_compilation_track_artist else 'no'}, "
             f"streaming_links: {'yes' if self._has_streaming_links else 'no'})"
         )
@@ -211,6 +214,8 @@ class LibraryDB:
             cols += f", {p}album_artist"
         if self._has_label:
             cols += f", {p}label"
+        if self._has_cross_reference_names:
+            cols += f", {p}cross_reference_names"
         return cols
 
     async def search(

--- a/library/models.py
+++ b/library/models.py
@@ -30,6 +30,11 @@ class LibraryItem(BaseModel):
     format: str | None = None
     alternate_artist_name: str | None = None
     label: str | None = None
+    # Pipe-joined (" | ") PRESENTATION_NAMEs of any WXYC catalog LIBRARY_CODEs
+    # cataloger-cross-referenced to this row's own code (e.g. a release filed
+    # under a band name carries a member's personal name). Optional column;
+    # absent from library.db files predating WXYC/discogs-etl#334.
+    cross_reference_names: str | None = None
     on_streaming: bool | None = None
 
     @property

--- a/lookup/matching.py
+++ b/lookup/matching.py
@@ -93,6 +93,13 @@ def limit_results(results: list) -> list:
     return results[:MAX_SEARCH_RESULTS]
 
 
+# The delimiter the discogs-etl / wxyc-catalog library.db build uses to join
+# multiple cross-reference aliases into the single ``cross_reference_names``
+# column (WXYC/discogs-etl#334). Producer/consumer contract: if the ETL ever
+# changes this separator, this constant must change in lockstep.
+CROSS_REFERENCE_NAMES_SEPARATOR = " | "
+
+
 def artist_matches_item(item: LibraryItem, artist: str) -> bool:
     """Check if a library item matches the given artist name.
 
@@ -117,7 +124,7 @@ def artist_matches_item(item: LibraryItem, artist: str) -> bool:
 
     candidates = [item.artist, item.alternate_artist_name]
     if item.cross_reference_names:
-        candidates.extend(item.cross_reference_names.split(" | "))
+        candidates.extend(item.cross_reference_names.split(CROSS_REFERENCE_NAMES_SEPARATOR))
 
     for candidate in candidates:
         if not candidate:

--- a/lookup/matching.py
+++ b/lookup/matching.py
@@ -96,7 +96,14 @@ def limit_results(results: list) -> list:
 def artist_matches_item(item: LibraryItem, artist: str) -> bool:
     """Check if a library item matches the given artist name.
 
-    Compares against both ``item.artist`` and ``item.alternate_artist_name``.
+    Compares against ``item.artist``, ``item.alternate_artist_name``, and
+    each ``" | "``-split value of ``item.cross_reference_names`` — the
+    cataloger-recorded WXYC LIBRARY_CODE_CROSS_REFERENCE aliases (e.g. a
+    release filed under a band name, like "Burning Star Core", carries a
+    link to a member's personal name, "C. Spencer Yeh"; see
+    WXYC/discogs-etl#334). ``cross_reference_names`` is optional and absent
+    on library.db files predating that column.
+
     Tolerates a leading-article asymmetry between query and catalog —
     library catalogers commonly file "The Black Dog" as "Black Dog
     Productions" while user input and Discogs credits keep the article,
@@ -108,7 +115,11 @@ def artist_matches_item(item: LibraryItem, artist: str) -> bool:
     artist_normalized = normalize_for_comparison(artist)
     artist_no_article = strip_leading_article(artist_normalized)
 
-    for candidate in (item.artist, item.alternate_artist_name):
+    candidates = [item.artist, item.alternate_artist_name]
+    if item.cross_reference_names:
+        candidates.extend(item.cross_reference_names.split(" | "))
+
+    for candidate in candidates:
         if not candidate:
             continue
         cand_normalized = normalize_for_comparison(candidate)

--- a/tests/integration/test_cross_reference_names.py
+++ b/tests/integration/test_cross_reference_names.py
@@ -1,0 +1,126 @@
+"""Integration test for cross_reference_names artist alias search (WXYC/discogs-etl#334).
+
+Mirrors ``tests/integration/test_alternate_artist.py``'s real-SQLite pattern
+but for the WXYC catalog's cataloger-recorded LIBRARY_CODE_CROSS_REFERENCE
+aliases rather than the hand-typed ALTERNATE_ARTIST_NAME field. Worked
+example: library.db row 57833 is filed under the band name "Burning Star
+Core" -- neither ``artist`` nor ``alternate_artist_name`` ("C.S. Yeh")
+prefix-matches a DJ typing the member's full personal name "C. Spencer Yeh",
+but the catalog's cross-reference table links the two codes, and library.db
+now carries that link as ``cross_reference_names``.
+
+Note on scope: ``cross_reference_names`` is consulted by
+``artist_matches_item`` (the post-retrieval artist *filter*), not indexed in
+``library_fts`` (the retrieval layer) -- that's the Phase 3 scope this ticket
+draws (``lookup/matching.py`` + ``library/db.py`` + ``library/models.py``
+only). So a real-SQLite FTS/LIKE/fuzzy search using ONLY the typed artist
+name as the query text ("C. Spencer Yeh") cannot retrieve row 57833 by
+itself here -- none of its indexed columns (title, artist,
+alternate_artist_name) contain those tokens. The fix surfaces the row on
+paths where retrieval happens via a different axis (an album/track *title*
+match, e.g. ``search_compilations_for_track``'s ``search_album_fuzzy`` +
+``artist_matches_item`` split -- see ``tests/unit/test_orchestrator_gaps.py``
+and ``tests/unit/test_orchestrator_helpers.py`` for the mocked-db end-to-end
+coverage of that split) and the artist-filter step is what needs to accept
+the cross-referenced name.
+"""
+
+import sqlite3
+
+import pytest
+import pytest_asyncio
+
+from library.db import LibraryDB
+from lookup.matching import filter_results_by_artist
+from lookup.strategies.artist_plus_album import search_library_with_fallback
+from services.parser import ParsedRequest
+
+
+class TestCrossReferenceNamesIntegration:
+    """End-to-end test with a real SQLite database carrying cross_reference_names."""
+
+    @pytest_asyncio.fixture
+    async def db_with_cross_reference(self, tmp_path):
+        """Create a test SQLite database shaped like library.db row 57833."""
+        db_file = tmp_path / "test_library.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("""
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                artist TEXT,
+                call_letters TEXT,
+                artist_call_number INTEGER,
+                release_call_number INTEGER,
+                genre TEXT,
+                format TEXT,
+                alternate_artist_name TEXT,
+                cross_reference_names TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE VIRTUAL TABLE library_fts USING fts5(
+                title, artist, alternate_artist_name,
+                content='library', content_rowid='id'
+            )
+        """)
+        # Real WXYC library.db row: C. Spencer Yeh's 7-inch, filed under his
+        # band name "Burning Star Core", with the hand-typed alternate name
+        # "C.S. Yeh" AND the catalog's cross-referenced personal name.
+        conn.execute(
+            "INSERT INTO library VALUES "
+            "(57833, '\"In The Blink of an Eye\" 7-inch', 'Burning Star Core', 'BU', "
+            "110, 6, 'Rock', 'vinyl - 7\"', 'C.S. Yeh', 'C. Spencer Yeh')"
+        )
+        conn.execute(
+            "INSERT INTO library_fts(rowid, title, artist, alternate_artist_name) "
+            "VALUES (57833, 'In The Blink of an Eye', 'Burning Star Core', 'C.S. Yeh')"
+        )
+        # A second Burning Star Core release with no cross-reference recorded,
+        # to prove the match isn't accidentally artist-wide.
+        conn.execute(
+            "INSERT INTO library VALUES "
+            "(57834, 'Challenger', 'Burning Star Core', 'BU', 110, 7, 'Rock', 'CD', NULL, NULL)"
+        )
+        conn.execute(
+            "INSERT INTO library_fts(rowid, title, artist, alternate_artist_name) "
+            "VALUES (57834, 'Challenger', 'Burning Star Core', NULL)"
+        )
+        conn.commit()
+        conn.close()
+
+        db = LibraryDB(db_path=db_file)
+        await db.connect()
+        yield db
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_filter_results_by_artist_matches_cross_reference_name(
+        self, db_with_cross_reference
+    ):
+        """A title-retrieved candidate set, filtered by the typed personal name
+        'C. Spencer Yeh', keeps only the cross-referenced row (57833) -- not its
+        cross-reference-less sibling (57834)."""
+        db = db_with_cross_reference
+
+        results = await db.search(query="Blink of an Eye")
+        filtered = filter_results_by_artist(results, "C. Spencer Yeh")
+
+        assert len(filtered) == 1
+        assert filtered[0].id == 57833
+
+    @pytest.mark.asyncio
+    async def test_search_by_primary_artist_still_finds_both_releases(
+        self, db_with_cross_reference
+    ):
+        """Searching by the primary catalog name still finds both releases
+        (the cross-reference extension doesn't narrow the existing primary-name path)."""
+        db = db_with_cross_reference
+        parsed = ParsedRequest(
+            artist="Burning Star Core",
+            raw_message="Burning Star Core",
+        )
+
+        results, _fallback_used = await search_library_with_fallback(db, parsed, albums=[])
+
+        assert {r.id for r in results} == {57833, 57834}

--- a/tests/integration/test_cross_reference_names.py
+++ b/tests/integration/test_cross_reference_names.py
@@ -98,9 +98,12 @@ class TestCrossReferenceNamesIntegration:
     async def test_filter_results_by_artist_matches_cross_reference_name(
         self, db_with_cross_reference
     ):
-        """A title-retrieved candidate set, filtered by the typed personal name
-        'C. Spencer Yeh', keeps only the cross-referenced row (57833) -- not its
-        cross-reference-less sibling (57834)."""
+        """A title-retrieved candidate (row 57833) passes filter_results_by_artist
+        for the typed personal name 'C. Spencer Yeh' via its cross_reference_names,
+        even though neither its primary artist ('Burning Star Core') nor its
+        alternate_artist_name matches that name. (Sibling 57834 is excluded upstream
+        by the title query, so it is not the negative control here; the primary-name
+        path is covered by test_search_by_primary_artist_still_finds_both_releases.)"""
         db = db_with_cross_reference
 
         results = await db.search(query="Blink of an Eye")

--- a/tests/unit/test_library_db.py
+++ b/tests/unit/test_library_db.py
@@ -1128,6 +1128,147 @@ class TestLabelColumn:
 
 
 # ---------------------------------------------------------------------------
+# cross_reference_names column (WXYC/discogs-etl#334)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossReferenceNamesColumn:
+    """Tests for cross_reference_names column detection and queries."""
+
+    @pytest.mark.asyncio
+    async def test_connect_detects_cross_reference_names_column(self, tmp_path):
+        """connect() should detect the cross_reference_names column and set flag."""
+        import sqlite3
+
+        db_file = tmp_path / "test.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("""
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                artist TEXT,
+                call_letters TEXT,
+                artist_call_number INTEGER,
+                release_call_number INTEGER,
+                genre TEXT,
+                format TEXT,
+                alternate_artist_name TEXT,
+                label TEXT,
+                cross_reference_names TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE VIRTUAL TABLE library_fts USING fts5(
+                title, artist, alternate_artist_name,
+                content='library', content_rowid='id'
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        db = LibraryDB(db_path=db_file)
+        await db.connect()
+        assert db._has_cross_reference_names is True
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_connect_without_cross_reference_names_column(self, tmp_path):
+        """connect() should set flag to False when cross_reference_names is absent.
+
+        Back-compat: a library.db predating WXYC/discogs-etl#334 must still load.
+        """
+        import sqlite3
+
+        db_file = tmp_path / "test.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("""
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                artist TEXT,
+                call_letters TEXT,
+                artist_call_number INTEGER,
+                release_call_number INTEGER,
+                genre TEXT,
+                format TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE VIRTUAL TABLE library_fts USING fts5(
+                title, artist,
+                content='library', content_rowid='id'
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        db = LibraryDB(db_path=db_file)
+        await db.connect()
+        assert db._has_cross_reference_names is False
+        await db.close()
+
+    @pytest.mark.asyncio
+    async def test_search_returns_cross_reference_names_when_present(self, tmp_path):
+        """Search results should include cross_reference_names data when the column exists."""
+        import sqlite3
+
+        db_file = tmp_path / "test.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("""
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                artist TEXT,
+                call_letters TEXT,
+                artist_call_number INTEGER,
+                release_call_number INTEGER,
+                genre TEXT,
+                format TEXT,
+                alternate_artist_name TEXT,
+                cross_reference_names TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE VIRTUAL TABLE library_fts USING fts5(
+                title, artist, alternate_artist_name,
+                content='library', content_rowid='id'
+            )
+        """)
+        conn.execute(
+            "INSERT INTO library VALUES "
+            "(57833, '\"In The Blink of an Eye\" 7-inch', 'Burning Star Core', 'BU', "
+            "110, 6, 'Rock', 'vinyl - 7\"', 'C.S. Yeh', 'C. Spencer Yeh')"
+        )
+        conn.execute(
+            "INSERT INTO library_fts(rowid, title, artist, alternate_artist_name) "
+            "VALUES (57833, 'In The Blink of an Eye', 'Burning Star Core', 'C.S. Yeh')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = LibraryDB(db_path=db_file)
+        await db.connect()
+        results = await db.search(artist="Burning Star Core")
+        assert len(results) == 1
+        assert results[0].cross_reference_names == "C. Spencer Yeh"
+        await db.close()
+
+    def test_select_columns_includes_cross_reference_names(self):
+        db = LibraryDB()
+        db._has_alternate_artist = True
+        db._has_cross_reference_names = True
+        cols = db._select_columns()
+        assert "cross_reference_names" in cols
+
+    def test_select_columns_excludes_cross_reference_names(self):
+        db = LibraryDB()
+        db._has_alternate_artist = True
+        db._has_cross_reference_names = False
+        cols = db._select_columns()
+        assert "cross_reference_names" not in cols
+
+
+# ---------------------------------------------------------------------------
 # compilation_track_artist table
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_orchestrator_gaps.py
+++ b/tests/unit/test_orchestrator_gaps.py
@@ -586,6 +586,47 @@ class TestSearchCompilationsForTrack:
         assert len(results) >= 1
 
     @pytest.mark.asyncio
+    async def test_keyword_search_surfaces_row_via_cross_reference_name(self):
+        """WXYC/discogs-etl#334 end-to-end: the keyword-search branch's artist
+        filter (``artist_matches_item(item, lib_artist)``) now accepts a
+        library.db row 57833-shaped candidate -- filed under the band name
+        "Burning Star Core" -- for a typed personal name "C. Spencer Yeh",
+        via the row's cross_reference_names.
+
+        db.search is mocked (retrieval is not under test here); what changed
+        is that the keyword-search branch's artist filter, at
+        lookup/strategies/track_on_compilation.py, now keeps this candidate
+        instead of dropping it as neither-artist-nor-alternate-matches.
+        """
+        db = AsyncMock()
+        db.exact_title = AsyncMock(return_value=[])
+        item = _item(
+            id=57833,
+            artist="Burning Star Core",
+            title='"In The Blink of an Eye" 7-inch',
+            alternate_artist_name="C.S. Yeh",
+            cross_reference_names="C. Spencer Yeh",
+        )
+        db.search = AsyncMock(return_value=[item])
+
+        parsed = ParsedRequest(
+            artist="C. Spencer Yeh",
+            song="In the Blink of an Eye",
+            raw_message="C. Spencer Yeh - In the Blink of an Eye",
+        )
+
+        with patch(
+            "lookup.strategies.track_on_compilation.lookup_releases_by_track",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            results, _ = await search_compilations_for_track(db, parsed)
+
+        assert any(r.id == 57833 for r in results), (
+            f"Expected row 57833 (via cross_reference_names) in {[r.id for r in results]}"
+        )
+
+    @pytest.mark.asyncio
     async def test_discogs_cross_reference(self):
         """Finds track on a compilation via Discogs cross-reference."""
         db = AsyncMock()

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -264,6 +264,74 @@ class TestArtistMatchesItem:
         item = make_library_item(id=1, artist="The Microphones", title="The Glow Pt. 2")
         assert artist_matches_item(item, "The Black Dog") is False
 
+    # ------------------------------------------------------------------
+    # cross_reference_names (WXYC/discogs-etl#334) -- catalog-recorded
+    # LIBRARY_CODE_CROSS_REFERENCE aliases, pipe-joined (" | ").
+    #
+    # Worked example: library.db row 57833 is filed under the band name
+    # "Burning Star Core" with alternate_artist_name "C.S. Yeh" -- neither
+    # prefix-matches a DJ typing the member's full personal name "C. Spencer
+    # Yeh". The catalog's cross-reference table links the two codes, so
+    # library.db now carries that link as cross_reference_names, and
+    # artist_matches_item must consult it with the same strict,
+    # leading-article-tolerant prefix rule as artist/alternate_artist_name.
+    # ------------------------------------------------------------------
+
+    def test_cross_reference_name_matches(self):
+        item = make_library_item(
+            id=57833,
+            artist="Burning Star Core",
+            title='"In The Blink of an Eye" 7-inch',
+            alternate_artist_name="C.S. Yeh",
+            cross_reference_names="C. Spencer Yeh",
+        )
+        assert artist_matches_item(item, "C. Spencer Yeh") is True
+
+    def test_cross_reference_name_prefix_matches(self):
+        item = make_library_item(
+            id=57833,
+            artist="Burning Star Core",
+            title='"In The Blink of an Eye" 7-inch',
+            cross_reference_names="C. Spencer Yeh",
+        )
+        assert artist_matches_item(item, "C. Spencer") is True
+
+    def test_cross_reference_names_multiple_pipe_joined(self):
+        """Multiple cross-referenced codes are pipe-joined; any one must match."""
+        item = make_library_item(
+            id=1,
+            artist="Return to Forever",
+            title="Live",
+            cross_reference_names="Chick Corea (Return to Forever) | Elf Power",
+        )
+        assert artist_matches_item(item, "Elf Power") is True
+        assert artist_matches_item(item, "Chick Corea (Return to Forever)") is True
+
+    def test_cross_reference_names_absent_falls_back_to_no_match(self):
+        """No cross_reference_names means only artist/alternate_artist_name are checked."""
+        item = make_library_item(id=1, artist="Burning Star Core", title="Album")
+        assert artist_matches_item(item, "C. Spencer Yeh") is False
+
+    def test_cross_reference_names_leading_article_tolerance(self):
+        """The leading-article tolerance rule also applies to cross_reference_names."""
+        item = make_library_item(
+            id=1,
+            artist="Black Dog Productions",
+            title="Spanners",
+            cross_reference_names="Black Dog",
+        )
+        assert artist_matches_item(item, "The Black Dog") is True
+
+    def test_cross_reference_names_does_not_create_false_positive(self):
+        """An unrelated typed artist must not match via cross_reference_names."""
+        item = make_library_item(
+            id=57833,
+            artist="Burning Star Core",
+            title='"In The Blink of an Eye" 7-inch',
+            cross_reference_names="C. Spencer Yeh",
+        )
+        assert artist_matches_item(item, "Stereolab") is False
+
 
 # ---------------------------------------------------------------------------
 # Tests: build_context_message
@@ -829,6 +897,42 @@ class TestSearchLibraryWithFallback:
         )
         assert len(results) == 1
         assert results[0].title == "DJ Kicks: Honey Dijon"
+
+    @pytest.mark.asyncio
+    async def test_artist_only_surfaces_row_via_cross_reference_name(self, mock_library_db):
+        """WXYC/discogs-etl#334 end-to-end: an artist-only lookup for the
+        cataloger-cross-referenced personal name "C. Spencer Yeh" keeps the
+        library.db row 57833-shaped candidate (filed under the band name
+        "Burning Star Core") that the artist-only fallback search surfaces.
+
+        db.search is mocked (retrieval is not under test here -- library_fts
+        does not index cross_reference_names, see
+        tests/integration/test_cross_reference_names.py); what changed is
+        that the subsequent artist_matches_item filter, applied by
+        search_library_with_fallback's artist-only branch, now accepts this
+        candidate via its cross_reference_names instead of dropping it.
+        """
+        item = make_library_item(
+            id=57833,
+            artist="Burning Star Core",
+            title='"In The Blink of an Eye" 7-inch',
+            alternate_artist_name="C.S. Yeh",
+            cross_reference_names="C. Spencer Yeh",
+        )
+        mock_library_db.search.return_value = [item]
+
+        parsed = ParsedRequest(
+            artist="C. Spencer Yeh",
+            raw_message="C. Spencer Yeh - In the Blink of an Eye",
+            is_request=True,
+            message_type=MessageType.REQUEST,
+        )
+
+        results, fallback = await search_library_with_fallback(mock_library_db, parsed, [])
+
+        assert fallback is True
+        assert len(results) == 1
+        assert results[0].id == 57833
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Consumer PR for WXYC/discogs-etl#335 + WXYC/wxyc-catalog#34, which add an optional `cross_reference_names` column to library.db (pipe-joined WXYC catalog cross-referenced aliases). See #335 for the full design and Phase 0 coverage numbers.

- `lookup/matching.py`: `artist_matches_item` now also prefix-matches each `" | "`-split value of `item.cross_reference_names`, with the same strict, leading-article-tolerant rule already applied to `item.artist` / `item.alternate_artist_name`.
- `library/db.py`: detects the column via `PRAGMA table_info` (`self._has_cross_reference_names`, mirroring the existing `_has_label` pattern) and includes it in `_select_columns()` when present.
- `library/models.py`: adds the optional `cross_reference_names` field to `LibraryItem`.

Worked example: library.db row 57833 (`artist="Burning Star Core"`, `alternate_artist_name="C.S. Yeh"`, `cross_reference_names="C. Spencer Yeh"`) now satisfies `artist_matches_item(row, "C. Spencer Yeh")`.

**Scope note** (see the docstring in `tests/integration/test_cross_reference_names.py`): `cross_reference_names` is consulted only as a post-retrieval artist-match *filter* -- it is not indexed in `library_fts`. So a bare artist-only query still depends on some other search axis (an album/track title match, the primary artist name, etc.) retrieving the candidate row first; the fix surfaces the row on paths where retrieval happens independently of the typed artist name (e.g. `search_compilations_for_track`'s title-driven `search_album_fuzzy` + a separate `artist_matches_item` filter). This matches the ticket's Phase 3 checklist, which scopes the change to `library/db.py` + `library/models.py` + `lookup/matching.py` only, not the FTS schema.

## Test plan

- [x] TDD: failing tests first, confirmed red, then implemented
- [x] `tests/unit/test_orchestrator_helpers.py::TestArtistMatchesItem`: 6 new tests (direct match, prefix match, multiple pipe-joined names, absent-column fallback, leading-article tolerance, no-false-positive)
- [x] `tests/unit/test_library_db.py::TestCrossReferenceNamesColumn`: 5 new tests mirroring `TestLabelColumn` -- column detection, **back-compat test for a library.db without the column**, search round-trip, `_select_columns()` include/exclude
- [x] `tests/integration/test_cross_reference_names.py` (new): real-SQLite test for the `filter_results_by_artist` composition (row-57833 shaped fixture)
- [x] Mocked-db end-to-end tests proving both named functions surface a cross-referenced row that an unextended matcher would drop: `TestSearchLibraryWithFallback::test_artist_only_surfaces_row_via_cross_reference_name`, `TestSearchCompilationsForTrack::test_keyword_search_surfaces_row_via_cross_reference_name` -- both verified to fail without the `lookup/matching.py` / `library/models.py` changes (stashed them and reran)
- [x] Full suite: `4625 passed, 1 skipped, 551 deselected, 2 xfailed`
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy . --ignore-missing-imports`: `Success: no issues found in 471 source files`

## Related

Refs WXYC/discogs-etl#334. Sibling PRs: WXYC/discogs-etl#335, WXYC/wxyc-catalog#34 (both must land first -- this PR is the consumer of their schema change). Complementary to #971 (Discogs-ANV subset of the same class of bug).
