### PR TITLE
feat(#929): guard local-catalog search against enrichment + emit library_search traffic-class label

### DIFF
--- a/library/router.py
+++ b/library/router.py
@@ -7,6 +7,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from core.dependencies import get_library_db
 from library.db import LibraryDB
 from library.models import LibrarySearchResponse
+from lookup.endpoint_family import (
+    ENDPOINT_FAMILY_LIBRARY_SEARCH,
+    record_endpoint_family_tag,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +49,15 @@ async def search_library(
     db: LibraryDB = Depends(get_library_db),
 ):
     """Search the library catalog."""
+    # LML#929: label this request's Sentry transaction with the local-catalog
+    # traffic class so the #931 observability residual can slice protected-search
+    # latency during a /lookup/bulk flood. Emitted at handler entry so every
+    # search request (including the 400 below) carries the label. This path
+    # invokes zero Discogs/Apple/streaming/enrichment code (guarded by
+    # tests/unit/test_library_router.py) — the label is the only cross-module
+    # touch, and record_endpoint_family_tag swallows its own errors.
+    record_endpoint_family_tag(ENDPOINT_FAMILY_LIBRARY_SEARCH)
+
     if not q and not artist and not title:
         raise HTTPException(
             status_code=400,

--- a/lookup/endpoint_family.py
+++ b/lookup/endpoint_family.py
@@ -12,8 +12,10 @@ is a plain Sentry tag, not a ``cache_stats`` key — string-valued, and the #907
 ``cache_stats`` seam (``_LML_CACHE_STATS_EXTRA_KEYS`` in ``lookup/router.py``)
 is numeric-only (``dict[str, float]`` via ``CacheStatsRecorder.record()``), so
 it rides the sibling per-request Sentry-tag / PostHog-freeform-dict channel
-instead. Forward-compatible: LML#929 is expected to add ``"library_search"``
-as a third value; no rework needed here.
+instead. LML#929 added the third value ``"library_search"`` — emitted from
+``library/router.py``'s ``search_library`` handler (the local-catalog search
+path, which invokes zero Discogs/Apple/streaming/enrichment code) so the #931
+observability residual can slice the protected-search traffic class.
 """
 
 from __future__ import annotations
@@ -26,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 ENDPOINT_FAMILY_LOOKUP = "lookup"
 ENDPOINT_FAMILY_LOOKUP_BULK = "lookup_bulk"
+ENDPOINT_FAMILY_LIBRARY_SEARCH = "library_search"
 
 
 def record_endpoint_family_tag(endpoint_family: str) -> None:

--- a/tests/unit/test_library_router.py
+++ b/tests/unit/test_library_router.py
@@ -1,11 +1,16 @@
 """Unit tests for library/router.py."""
 
-from unittest.mock import AsyncMock
+import ast
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+import library.router
+import lookup.endpoint_family
 from library.db import LibraryDB
+from lookup.endpoint_family import ENDPOINT_FAMILY_LIBRARY_SEARCH
 from tests.factories import make_library_item
 from tests.unit.conftest import override_deps
 
@@ -95,3 +100,135 @@ class TestSearchLibrary:
             resp = await client.get("/api/v1/library/search", params={"q": "test"})
 
         assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# LML#929 — protect the local-catalog search path (rung-a, #926 ADR)
+# ---------------------------------------------------------------------------
+
+#: The only modules `library/router.py` is permitted to import. The
+#: `/library/search` path must stay a pure LibraryDB (aiosqlite) path with NO
+#: Discogs / Apple / streaming / enrichment dependency, so its degradation is
+#: only shared event-loop starvation — never upstream-fan-out latency. The
+#: allowlist is deliberately tight so that ANY new import trips the guard and
+#: forces a review of whether it belongs on the protected hot path.
+_ALLOWED_ROUTER_IMPORT_ROOTS = {
+    "logging",
+    "fastapi",
+    "core.dependencies",
+    "library.db",
+    "library.models",
+    # Telemetry label only (LML#929/#931). `lookup/__init__.py` is empty and
+    # `lookup/endpoint_family.py` imports only `logging` + `sentry_sdk`, so this
+    # pulls in zero enrichment code — verified by test_endpoint_family_import_is_enrichment_free.
+    "lookup.endpoint_family",
+}
+
+
+def _imported_modules(path: Path) -> set[str]:
+    """Every module `path` imports, as dotted names.
+
+    Relative imports (``level > 0``) are surfaced in dotted form (``.enrichment``,
+    ``..foo``) rather than skipped, so a *package-relative* enrichment import can
+    never silently match an absolute-name allowlist entry — it trips the guard
+    like an absolute one would. ``__future__`` (a compiler directive, not a real
+    dependency) is excluded.
+    """
+    tree = ast.parse(path.read_text())
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add("." * node.level + (node.module or ""))
+    imported.discard("__future__")
+    return imported
+
+
+class TestSearchPathStaysEnrichmentFree:
+    """Characterization guards that fail if enrichment is ever wired into the
+    `/library/search` handler (LML#929 unconditional deliverable)."""
+
+    def test_router_imports_stay_within_allowlist(self):
+        """Structural guard: `library/router.py`'s imports must be a subset of
+        the enrichment-free allowlist. A new Discogs/Apple/streaming/enrichment
+        import — absolute (`from discogs.service import …`) or package-relative
+        (`from .enrichment import …`) — is the realistic "wired enrichment into
+        search" change, and both forms trip this guard."""
+        imported = _imported_modules(Path(library.router.__file__))
+        unexpected = imported - _ALLOWED_ROUTER_IMPORT_ROOTS
+        assert not unexpected, (
+            f"library/router.py imports outside the LML#929 allowlist: {sorted(unexpected)}. "
+            "The /library/search path must stay a pure LibraryDB (aiosqlite) path with no "
+            "Discogs/Apple/streaming/enrichment dependency (rung-a of the #926 ADR). If this "
+            "is a legitimate non-enrichment dependency, add it to _ALLOWED_ROUTER_IMPORT_ROOTS; "
+            "if it is enrichment/upstream, do NOT wire it into the search handler — route it off "
+            "the protected hot path."
+        )
+
+    def test_endpoint_family_import_is_enrichment_free(self):
+        """The one cross-module import the allowlist permits (`lookup.endpoint_family`,
+        the traffic-class label) must itself stay enrichment-free, or it would be a
+        back-door onto the search path's import surface."""
+        imported = _imported_modules(Path(lookup.endpoint_family.__file__))
+        assert imported == {"logging", "sentry_sdk"}, (
+            f"lookup/endpoint_family.py grew imports beyond {{logging, sentry_sdk}}: "
+            f"{sorted(imported)}. It is on the /library/search import allowlist (LML#929); "
+            "keep it a pure Sentry-tag helper so it cannot pull enrichment onto the search path."
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_invokes_no_enrichment_function(self, app_client, mock_db):
+        """Runtime complement to the structural allowlist: a search request never
+        calls enrichment via a call-time-qualified
+        ``lookup.enrichment.enrich_artwork_results(...)``. Deliberately narrower
+        than the allowlist guard above — a top-level ``from lookup.enrichment
+        import enrich_artwork_results`` binding resolves before this ``patch``
+        and would slip past it — so ``test_router_imports_stay_within_allowlist``
+        is the authoritative "enrichment wired into search" detector; this arm is
+        just a runtime tripwire for the qualified-call pattern."""
+        item = make_library_item(id=1, artist="Juana Molina", title="Halo", call_letters="J")
+        mock_db.search = AsyncMock(return_value=[item])
+
+        with patch("lookup.enrichment.enrich_artwork_results") as enrich:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/library/search", params={"q": "Juana Molina"})
+
+        assert resp.status_code == 200
+        enrich.assert_not_called()
+
+
+class TestSearchTrafficClassLabel:
+    """The `library_search` endpoint-family label (LML#929 unconditional deliverable)."""
+
+    @pytest.mark.asyncio
+    async def test_search_emits_library_search_label(self, app_client, mock_db):
+        item = make_library_item(
+            id=2, artist="Jessica Pratt", title="Quiet Signs", call_letters="P"
+        )
+        mock_db.search = AsyncMock(return_value=[item])
+
+        with patch("library.router.record_endpoint_family_tag") as tag:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/library/search", params={"q": "Jessica Pratt"})
+
+        assert resp.status_code == 200
+        tag.assert_called_once_with(ENDPOINT_FAMILY_LIBRARY_SEARCH)
+        assert ENDPOINT_FAMILY_LIBRARY_SEARCH == "library_search"
+
+    @pytest.mark.asyncio
+    async def test_label_emitted_before_validation_on_400(self, app_client):
+        """The label rides at handler entry, so even a no-params 400 carries the
+        traffic class — the flood measurement counts rejected search hits too."""
+        with patch("library.router.record_endpoint_family_tag") as tag:
+            async with AsyncClient(
+                transport=ASGITransport(app=app_client), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/library/search")
+
+        assert resp.status_code == 400
+        tag.assert_called_once_with(ENDPOINT_FAMILY_LIBRARY_SEARCH)


### PR DESCRIPTION
## Summary

The **unconditional deliverables** of #929 (the #926 ADR's rung-a): a characterization guard that keeps `/api/v1/library/search` a pure local path, and the `library_search` traffic-class label. The **rung-a staging measurement + decision-record stay open** on the issue — they need a real multi-worker `/lookup/bulk` flood on staging (not CI), so this PR does **not** close #929.

### Why
`/api/v1/library/search` degrades under load only from **shared event-loop starvation**, not upstream fan-out — because its handler depends solely on `LibraryDB` (aiosqlite, off-loop, GIL-releasing) and invokes zero Discogs/Apple/streaming/enrichment code. Keeping it that way is the whole premise of rung-a. This PR locks that invariant in place and makes the search traffic class sliceable for the #931 observability work.

### What changed
- **Guard tests** (`tests/unit/test_library_router.py`), characterization — fail if enrichment is ever wired into `search_library`:
  - `test_router_imports_stay_within_allowlist` — AST-parses `library/router.py` and asserts its imports are a subset of a tight enrichment-free allowlist. A `discogs` / `clients.streaming` / `lookup.enrichment` / … import (the realistic "wired enrichment in" change) trips it, with a failure message that routes the reviewer to keep it off the hot path.
  - `test_endpoint_family_import_is_enrichment_free` — the one permitted cross-module import (`lookup.endpoint_family`, the label helper) must itself stay `{logging, sentry_sdk}` only, so it can't back-door enrichment onto the search surface.
  - `test_search_invokes_no_enrichment_function` — runtime complement: a real search request never calls `enrich_artwork_results`.
- **Traffic-class label**: `search_library` emits the `library_search` endpoint-family Sentry tag at handler entry (before validation, so even a 400 carries it) via the existing `record_endpoint_family_tag` helper — the third value `lookup/endpoint_family.py` always anticipated. Two tests pin emission on the 200 and 400 paths.

### Scope boundaries (per the issue)
- **Not** built here: rung-(b) search-only replica, an asyncio-priority scheduler, or a separate read connection — all rejected by the ADR. Orthogonal to #927 (search makes zero Discogs calls).
- The durable *production* multi-worker answer additionally needs #936 (runtime `library.db` freshness); the rung-a *staging* measurement does not and can proceed.

Local: full CI marker subset **4638 passed**, ruff check + format clean.

Part of #929. Does **not** close it — the rung-a staging measurement + decision-record remain.