### PR TITLE
Drop the label-image artwork fallback rung

### DIFF
--- a/lookup/artwork.py
+++ b/lookup/artwork.py
@@ -3,9 +3,9 @@
 Home of the Step-4 artwork fetch (``fetch_artwork_for_items`` — per-item
 Discogs search with the LML#478 80/80 fuzzy floor), the LML#604
 trust-and-bind of an already-validated ``ResolvedRelease``
-(``_bind_resolved_release``), and the release-cover → artist-image →
-label-image fallback cascade (``_resolve_fallback_artwork``). Extracted
-verbatim from ``lookup/orchestrator.py`` (LML#728).
+(``_bind_resolved_release``), and the release-cover → artist-image
+fallback cascade (``_resolve_fallback_artwork``). Extracted verbatim from
+``lookup/orchestrator.py`` (LML#728).
 """
 
 import asyncio
@@ -44,7 +44,13 @@ measurement's compilation handling provably-aligned with production."""
 
 
 async def _resolve_fallback_artwork(discogs_service: DiscogsService, release_id: int) -> str | None:
-    """Try the release's own cover (images[0]), then artist image, then label image.
+    """Try the release's own cover (images[0]), then artist image.
+
+    LML#687: the label-image rung was removed -- a label logo is essentially
+    never correct album art (the motivating case: Autechre's *Confield* had no
+    cover and returned the Warp Records logo as its artwork). A missing cover
+    now resolves to ``None`` after the artist-image rung rather than falling
+    all the way through to the release's label.
 
     Structurally invalid ids (``release_id <= 0``) short-circuit before the
     Discogs round-trip — the LML#401 synthesis pattern produces a
@@ -70,12 +76,6 @@ async def _resolve_fallback_artwork(discogs_service: DiscogsService, release_id:
         image = await discogs_service.get_artist_image(release.artist_id)
         if image:
             logger.info(f"Using artist image fallback for release {release_id}")
-            return image
-
-    if release.label_id:
-        image = await discogs_service.get_label_image(release.label_id)
-        if image:
-            logger.info(f"Using label image fallback for release {release_id}")
             return image
 
     return None

--- a/tests/unit/test_orchestrator_helpers.py
+++ b/tests/unit/test_orchestrator_helpers.py
@@ -2545,7 +2545,8 @@ class TestFetchArtworkFoundOnCompilation:
 
 
 class TestFetchArtworkFallback:
-    """Tests for artwork fallback to artist/label images."""
+    """Tests for artwork fallback to the artist image (LML#687: the label
+    image rung was removed -- a label logo is not album art)."""
 
     @pytest.mark.asyncio
     async def test_falls_back_to_artist_image(self, mock_discogs_service):
@@ -2578,8 +2579,10 @@ class TestFetchArtworkFallback:
         mock_discogs_service.get_artist_image.assert_called_once_with(77)
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_label_image(self, mock_discogs_service):
-        """When artist image also unavailable, fall back to label image."""
+    async def test_no_label_image_fallback(self, mock_discogs_service):
+        """When artist image is also unavailable, artwork_url resolves to None
+        rather than falling back to the label logo (LML#687) -- a label image
+        is essentially never correct album art."""
         items = [make_library_item(id=1, artist="Autechre", title="Confield")]
 
         mock_discogs_service.search.return_value = DiscogsSearchResponse(
@@ -2604,8 +2607,8 @@ class TestFetchArtworkFallback:
 
         assert len(results) == 1
         assert results[0][1] is not None
-        assert results[0][1].artwork_url == "https://i.discogs.com/label-logo.jpg"
-        mock_discogs_service.get_label_image.assert_called_once_with(233)
+        assert results[0][1].artwork_url is None
+        mock_discogs_service.get_label_image.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_fallback_when_artwork_exists(self, mock_discogs_service):


### PR DESCRIPTION
## Summary

`_resolve_fallback_artwork` resolved album artwork through release cover -> artist image -> label image. When a release had no cover (e.g. Autechre's *Confield*, Discogs release 28138), the chain fell all the way through to the label logo and returned that as the album's `artwork_url` -- misleading art masquerading as a cover (the motivating case surfaced client-side in WXYC/wxyc-dj-ios#42).

- Removes the label-image rung from `_resolve_fallback_artwork`; a missing cover now resolves to `artwork_url=None` after the artist-image rung.
- Inverts `test_falls_back_to_label_image` -> `test_no_label_image_fallback`, asserting no label-image fallback and `get_label_image.assert_not_called()`.
- Updates the module and function docstrings to drop the label-image mention.
- `get_label_image` is left in place -- it has its own direct test coverage in `test_discogs_service.py` and is documented as one of the API-only methods that bypass the Discogs fallthrough seam, so removing it is out of scope for this ticket.
- The artist-image rung is left as-is; the issue flags it as a separate open question (an artist photo isn't album art either, but it at least depicts the right artist) for a follow-up decision.

Closes #687

## Test plan

- [x] `uv run --no-sync pytest tests/unit/test_orchestrator_helpers.py` -- 147 passed
- [x] `uv run --no-sync pytest tests/unit` -- 4418 passed
- [x] `uv run --no-sync ruff check` / `ruff format --check`
- [x] `uv run --no-sync mypy lookup/artwork.py --ignore-missing-imports`