### PR TITLE
Guard the album axis in find_track_metadata against token_set subset-inflation

### DIFF
--- a/clients/streaming/apple_music.py
+++ b/clients/streaming/apple_music.py
@@ -50,6 +50,7 @@ from wxyc_etl.text import to_match_form as normalize_for_comparison
 from clients.streaming.base import BaseStreamingClient
 from clients.streaming.matching import (
     SCORE_MATCH_ACCEPTANCE_FLOOR,
+    album_subset_is_degenerate,
     find_best_source_match,
     record_match_telemetry,
     title_subset_is_degenerate,
@@ -473,6 +474,7 @@ class AppleMusicClient(BaseStreamingClient):
             norm_song=norm_song,
             norm_album=norm_album,
             raw_song=song,
+            raw_album=album,
         )
 
         # LML#782: album-title divergence. The WXYC catalog album and
@@ -505,6 +507,7 @@ class AppleMusicClient(BaseStreamingClient):
                 norm_song=norm_song,
                 norm_album=None,
                 raw_song=song,
+                raw_album=None,
             )
             album_fallback = True
 
@@ -564,20 +567,23 @@ def _select_best_track_candidate(
     norm_song: str,
     norm_album: str | None,
     raw_song: str,
+    raw_album: str | None,
 ) -> tuple[dict | None, tuple[float, float]]:
     """One scoring pass over a ``search_song`` response.
 
     Applies the 80/80(/80) ``token_set_ratio`` floor per axis plus the
-    LML#719 degenerate-subset guard on the title axis, and picks the
-    highest-combined-score candidate — PREFERRING floor-clearers that
-    carry ``attributes.artwork`` over higher-scoring ones that lack it
-    (see ``find_track_metadata``'s docstring for why).
+    LML#719 degenerate-subset guard on the title axis and its LML#721
+    sibling on the album axis, and picks the highest-combined-score
+    candidate — PREFERRING floor-clearers that carry ``attributes.artwork``
+    over higher-scoring ones that lack it (see ``find_track_metadata``'s
+    docstring for why).
 
     Extracted from ``find_track_metadata`` so the LML#782 album-less
     fallback can re-score the same in-memory response with
     ``norm_album=None`` instead of paying a second Apple Music call.
-    ``raw_song`` is the un-normalized request title — the LML#719 guard
-    does its own normalization internally.
+    ``raw_song`` is the un-normalized request title and ``raw_album`` the
+    un-normalized request album (``None`` when the album axis is dropped) —
+    the LML#719/#721 guards do their own normalization internally.
 
     Returns ``(best, (artist_score, track_score))`` — the chosen record
     (or ``None`` when nothing clears) plus its per-axis scores, stashed
@@ -633,6 +639,16 @@ def _select_best_track_candidate(
                 norm_album, normalize_for_comparison(attrs.get("albumName") or "")
             )
             if album_score < _APPLE_MUSIC_MATCH_FLOOR:
+                continue
+            # LML#721: sibling of the LML#719 title guard above. The album
+            # axis is a third AND-gate on top of artist+title, so this
+            # can't by itself cause a false ACCEPT — but an unguarded
+            # token_set_ratio clear here would falsely mark a wrong-album
+            # candidate as album_verified=True (carrying that album's
+            # artwork/year) instead of letting it fall through to the
+            # LML#782 album-less fallback, which is the correct outcome
+            # for a candidate whose album doesn't really agree.
+            if album_subset_is_degenerate(raw_album or "", attrs.get("albumName") or ""):
                 continue
             combined = (artist_score + track_score + album_score) / 3
         else:

--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -343,6 +343,38 @@ def title_subset_is_degenerate(query_title: str, candidate_title: str) -> bool:
     return score_match_track(query_title, candidate_title) < SCORE_MATCH_ACCEPTANCE_FLOOR
 
 
+def album_subset_is_degenerate(query_album: str, candidate_album: str) -> bool:
+    """True when an album's ``token_set_ratio`` clear is pure subset-inflation (LML#721).
+
+    Sibling of ``title_subset_is_degenerate`` for the album axis. The album
+    axis in ``find_track_metadata`` is a third AND-gate on top of artist +
+    title, so its subset-inflation can't by itself cause a false ACCEPT —
+    what it weakens is the album axis's ability to *reject* a wrong-album
+    candidate (LML#487 Tzenni-vs-Yenbett shape): a short generic query album
+    (``Live``) is a token-subset of a long unrelated candidate album (``Live
+    at the Apollo, Vol. 2``), scoring a perfect 100 with no real agreement.
+
+    Unlike the title axis, the album axis has no per-track variant markers to
+    strip (``score_match_track``'s ``strip_track_suffix`` targets shapes like
+    "(Live)"/"(Remix)" that would wrongly gut a legitimate album title
+    containing those same words). ``score_match`` alone is the right
+    comparator here: its ``strip_format_suffix`` already strips album-level
+    reissue/remaster parentheticals, so a legitimate reissue subset (``Tzenni``
+    vs ``Tzenni (Deluxe Edition)``) still scores 100 and is retained.
+
+    * degenerate:  ``Live`` vs ``Live at the Apollo, Vol. 2``   -> 26.7
+    * degenerate:  ``Demos`` vs ``Demos and Rarities 1998-2004`` -> 30.3
+    * degenerate:  ``Singles`` vs ``Singles Going Steady``       -> 51.9
+    * legitimate:  ``Tzenni`` vs ``Tzenni (Deluxe Edition)``     -> 100
+
+    Returns True (degenerate — reject) when the pair falls below the
+    acceptance floor under ``score_match``. A caller scoring the album axis
+    with ``token_set_ratio`` should reject any candidate for which this
+    returns True *after* it has cleared the ``token_set_ratio`` floor.
+    """
+    return score_match(query_album, candidate_album) < SCORE_MATCH_ACCEPTANCE_FLOOR
+
+
 # LML#592 telemetry bands. The 80/80 floor admits organic short-name artist
 # collisions on a shared album title ("Wand" vs "Wanda" scores 88.89 against
 # an identical title at 100). These bands classify the *signature* of such a

--- a/tests/unit/test_apple_music_client.py
+++ b/tests/unit/test_apple_music_client.py
@@ -1156,6 +1156,101 @@ class TestFindTrackMetadataTitleSubsetInflation:
         assert match.url == "https://music.apple.com/us/song/little-fury-things/321"
 
 
+class TestFindTrackMetadataAlbumSubsetInflation:
+    """LML#721: the album axis inside ``find_track_metadata`` shares the same
+    ``token_set_ratio`` subset-inflation weakness #719 fixed on the title axis.
+
+    A short generic query album (``Live``) is a token-subset of a long
+    unrelated candidate album (``Live at the Apollo, Vol. 2``), so
+    ``token_set_ratio`` scores it 100 with no real album agreement. Because
+    the album axis is a third AND-gate on top of artist+title, this can't by
+    itself cause a false ACCEPT — but it does let a wrong-album candidate be
+    treated as ``album_verified=True`` (carrying that album's artwork/year)
+    instead of falling through to the LML#782 album-less fallback, which is
+    exactly the wrong-album leak LML#487 exists to prevent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_subset_inflated_album_does_not_verify_wrong_album(self, es256_keypair):
+        """Production-shape repro (LML#721 table): querying ``album='Live'``
+        against a candidate whose real album is ``'Live at the Apollo, Vol.
+        2'`` clears the 80 floor via pure subset-inflation
+        (``token_set_ratio('live', 'live at the apollo, vol. 2') == 100``)
+        even though the two albums share no real signal
+        (``token_sort_ratio`` == 26.7). The guard must reject the album axis
+        here, sending the candidate through the album-less fallback instead
+        of surfacing it as album-verified with that album's artwork/year."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response(
+                [_make_song_data_full(album_name="Live at the Apollo, Vol. 2")]
+            )
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Live"
+        )
+        assert match is not None
+        assert match.url == "https://music.apple.com/us/song/hebebeb-zrag/9"
+        assert match.album_verified is False
+        assert match.artwork_url is None
+        assert match.release_year is None
+
+    @pytest.mark.asyncio
+    async def test_retains_legitimate_album_reissue_suffix_subset(self, es256_keypair):
+        """No-regression: a candidate album that differs only by a
+        recognized reissue suffix (``Tzenni`` vs ``Tzenni (Deluxe Edition)``)
+        is a legitimate subset — the suffix is stripped before scoring, so
+        ``token_sort_ratio`` still agrees at 100. The guard must not reject
+        it (mirrors ``test_accepts_album_reissue_variant``)."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response(
+                [_make_song_data_full(album_name="Tzenni (Deluxe Edition)")]
+            )
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata(
+            "Noura Mint Seymali", "Hebebeb (Zrag)", album="Tzenni"
+        )
+        assert match is not None
+        assert match.album_verified is True
+
+    @pytest.mark.asyncio
+    async def test_retains_legitimate_canonical_title_extension_subset(self, es256_keypair):
+        """No-regression: the reordered-shortform shape
+        (``test_accepts_album_with_extra_tokens_in_canonical_title``) still
+        resolves a URL — even though its ``token_sort_ratio`` (61.5) also
+        falls under 80, so the guard rejects the constrained pass, the
+        LML#782 album-less fallback re-scores the same response and
+        surfaces the same URL. Pins the guard's actual effect on this shape:
+        the URL still resolves, just no longer ``album_verified``."""
+        client = _client(es256_keypair)
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.get = AsyncMock(
+            return_value=_songs_response(
+                [
+                    _make_song_data_full(
+                        name="Glósóli",
+                        artist_name="Sigur Rós",
+                        album_name="Með suð í eyrum við spilum endalaust",
+                        url="https://music.apple.com/us/song/glosoli/902",
+                    )
+                ]
+            )
+        )
+        client._http = mock_http
+
+        match = await client.find_track_metadata("Sigur Rós", "Glósóli", album="Eyrum Spilum Suð")
+        assert match is not None
+        assert match.url == "https://music.apple.com/us/song/glosoli/902"
+        assert match.album_verified is False
+
+
 class TestFindTrackMetadataEmits:
     """LML#592: the Apple track probe (``token_set_ratio``) emits match
     telemetry for the winner under ``surface="track"``.

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from clients.streaming.matching import (
+    album_subset_is_degenerate,
     is_acceptable_match,
     normalize_album_title,
     normalize_artist_name,
@@ -400,6 +401,37 @@ class TestTitleSubsetIsDegenerate:
 
     def test_identical_titles_not_degenerate(self):
         assert title_subset_is_degenerate("Back, Baby", "Back, Baby") is False
+
+
+class TestAlbumSubsetIsDegenerate:
+    """LML#721: the album-axis sibling of ``title_subset_is_degenerate``.
+    Separates a *degenerate* subset (short generic query album buried in a
+    long unrelated candidate album, ``token_set_ratio`` == 100 with no real
+    signal) from a *legitimate* one (differs only by a recognized
+    reissue/remaster suffix). The boundary is ``score_match`` (``token_sort_ratio``,
+    with ``strip_format_suffix`` already applied) below the floor.
+    """
+
+    def test_rejects_generic_album_buried_in_unrelated_candidate(self):
+        # The production shape: `live` ⊂ `live at the apollo, vol. 2` scores
+        # token_set 100 but score_match (token_sort) 26.7.
+        assert album_subset_is_degenerate("Live", "Live at the Apollo, Vol. 2") is True
+
+    def test_rejects_generic_album_demos(self):
+        assert album_subset_is_degenerate("Demos", "Demos and Rarities 1998-2004") is True
+
+    def test_rejects_generic_album_singles(self):
+        assert album_subset_is_degenerate("Singles", "Singles Going Steady") is True
+
+    def test_retains_reissue_suffix_subset(self):
+        # `(Deluxe Edition)` is stripped by strip_format_suffix → the sides match.
+        assert album_subset_is_degenerate("Tzenni", "Tzenni (Deluxe Edition)") is False
+
+    def test_retains_remaster_suffix_subset(self):
+        assert album_subset_is_degenerate("Moon Pix", "Moon Pix (Remastered)") is False
+
+    def test_identical_albums_not_degenerate(self):
+        assert album_subset_is_degenerate("Aluminum Tunes", "Aluminum Tunes") is False
 
 
 class TestStripDiscogsSuffix:


### PR DESCRIPTION
## Summary

The album score block inside `find_track_metadata` (Apple Music client) scored the album axis with unguarded `fuzz.token_set_ratio`, sharing the same subset-inflation weakness #719 fixed on the title axis: a short generic query album (`Live`) that is a token-subset of a long unrelated candidate album (`Live at the Apollo, Vol. 2`) clears the shared 80 floor with `token_set_ratio` == 100, despite `token_sort_ratio` scoring only 26.7.

## Exploitability characterization

The album axis is a third AND-gate on top of artist+title, so this cannot by itself cause a false ACCEPT the way the title axis did. What it weakens is the axis's ability to reject a wrong-album candidate (the LML#487 Tzenni-vs-Yenbett failure mode): a subset-inflated album score lets a candidate whose album doesn't really agree with the request be treated as `album_verified=True`, carrying that album's `artwork_url`/`release_year` — instead of correctly falling through to the LML#782 album-less fallback (`album_verified=False`, no album-derived fields). Repro added in `TestFindTrackMetadataAlbumSubsetInflation::test_subset_inflated_album_does_not_verify_wrong_album`. Disposition: fix, not won't-fix — the wrong-album-artwork leak this weakens the guard against is exactly the failure mode LML#487 exists to prevent.

## Fix

Adds `album_subset_is_degenerate` (`clients/streaming/matching.py`), a sibling of the #720 title-axis guard `title_subset_is_degenerate`. It gates on `score_match` (`token_sort_ratio`, which already strips album-level reissue/remaster parentheticals via `strip_format_suffix`) rather than `score_match_track` — whose track-suffix stripping targets markers like "Live"/"Remix" that would wrongly gut a legitimate album title containing those same words. `SCORE_MATCH_ACCEPTANCE_FLOOR` itself is untouched, per the LML#638 decision.

This retains legitimate reissue-suffix subsets (`Tzenni` vs `Tzenni (Deluxe Edition)` → 100 after suffix strip) while rejecting the degenerate short-generic-album shapes (`Live`, `Demos`, `Singles` examples, all < 30-52 under `token_sort_ratio`). The canonical-title-extension shape (`test_accepts_album_with_extra_tokens_in_canonical_title`, Sigur Rós "Glósóli") also falls below the guard's floor on the constrained pass, but its URL still resolves via the LML#782 album-less fallback — no regression to the existing `find_track_url`/`find_track_metadata` URL contract, just no longer `album_verified` for that shape (not previously pinned by any test).

## Test plan

- [x] TDD repro (`test_subset_inflated_album_does_not_verify_wrong_album`) fails before the fix, passes after
- [x] New unit tests for `album_subset_is_degenerate` covering degenerate and legitimate shapes
- [x] Retained-legitimate-album-subset tests for both the reissue-suffix and canonical-title-extension shapes
- [x] Full existing `apple_music`/`matching` test suites pass unmodified
- [x] `ruff check` / `ruff format --check` / `mypy` / full non-pg, non-external-api test suite all green

Closes #721