### PR TITLE
test: close three pre-existing test gaps surfaced by the #746 review

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,6 +207,25 @@ def _reset_discogs_pool_singleton():
     _reset()
 
 
+@pytest.fixture(autouse=True)
+def _reset_bio_warm_semaphore():
+    """Suite-wide reset of the bio-warm ``_warm_cache_semaphore`` (LML#748).
+
+    Sibling of ``reset_streaming_warm_state`` for the same failure mode:
+    ``lookup.enrichment.background._warm_cache_semaphore`` is lazily bound to
+    whichever event loop runs the first warm. Under pytest-asyncio's
+    fresh-loop-per-test model, a later test's warm raises ``RuntimeError(...
+    bound to a different event loop)``, which the warmer's blanket except
+    swallows — warms silently no-op for the rest of the session and
+    warm-side-effect assertions flake by test order.
+    """
+    from lookup.enrichment import background as _background_mod
+
+    _background_mod._warm_cache_semaphore = None
+    yield
+    _background_mod._warm_cache_semaphore = None
+
+
 def make_lml_telemetry() -> RequestTelemetry:
     """Build a `RequestTelemetry` with LML's production parameters.
 

--- a/tests/integration/test_error_resilience.py
+++ b/tests/integration/test_error_resilience.py
@@ -315,7 +315,11 @@ class TestSourceTransportFailures:
         pg = PgSource("postgresql://bogus_user:bad_pass@localhost:5433/postgres")
         try:
             await pg.fetchall("SELECT 1")
-        except asyncpg.InvalidPasswordError:
+        except (asyncpg.InvalidPasswordError, asyncpg.InvalidAuthorizationSpecificationError):
+            # Both are genuine auth rejections: a live server on 5433 with
+            # password auth enabled raises the former; a live server without
+            # the bogus role at all (the common local Discogs-dump Postgres
+            # setup) raises "role does not exist" as the latter.
             pass  # expected
         except OSError:
             pytest.skip("PostgreSQL not running on port 5433")

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1843,6 +1843,10 @@ class TestEnrichArtworkResultsWithAppleMusicClient:
         # explorer can filter for it.
         transaction.set_data.assert_any_call("apple_music.find_track_url.timeout", True)
 
+        # AND the disambiguating `.method` key is projected too, so a refactor
+        # that drops it (leaving only the legacy key) fails this test.
+        transaction.set_data.assert_any_call("apple_music.timeout.method", "find_track_metadata")
+
     @pytest.mark.asyncio
     async def test_apple_music_find_track_url_timeout_survives_no_active_transaction(
         self,


### PR DESCRIPTION
## Summary

Three pre-existing test gaps surfaced by the PR #746 (orchestrator decomposition 6b) review loop. None are regressions from the decomposition — each reproduces on the pre-decomposition tree — but the un-nesting made them visible.

- Pin the `apple_music.timeout.method` Sentry projection key: `test_apple_music_find_track_url_timeout_projects_sentry_marker` now also asserts `transaction.set_data.assert_any_call("apple_music.timeout.method", "find_track_metadata")`, so deleting that `set_data` call from `lookup/enrichment/item.py` fails a test instead of leaving the suite green.
- Add an autouse `_reset_bio_warm_semaphore` fixture in `tests/conftest.py` that resets `lookup.enrichment.background._warm_cache_semaphore` to `None` per test, mirroring the existing `reset_streaming_warm_state` pattern — the semaphore is lazily bound to whichever event loop runs the first warm, and under pytest-asyncio's fresh-loop-per-test model a later test's warm would otherwise raise a swallowed `RuntimeError` and silently no-op for the rest of the session.
- Widen `test_pg_source_bad_credentials` in `tests/integration/test_error_resilience.py` to accept `asyncpg.InvalidAuthorizationSpecificationError` alongside `asyncpg.InvalidPasswordError` — a live local Postgres on 5433 without the bogus role raises the former ("role does not exist"), which is a genuine auth rejection but wasn't previously accepted.

Closes #748

## Test plan

- [x] `uv run --no-sync pytest tests/unit -q` — 4418 passed
- [x] `uv run --no-sync pytest tests/integration -q` — 321 passed, 554 deselected, 2 xfailed
- [x] `uv run --no-sync ruff check` / `ruff format --check` clean
- [x] `uv run --no-sync mypy` clean on touched files