### PR TITLE
test(infra): reconcile the three app_client fixture families (audit #9)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -261,6 +261,101 @@ async def pg_pool_large():
 
 
 # ---------------------------------------------------------------------------
+# PG-backed ASGI test client (Family C -- reconciled from 4 near-duplicate
+# per-file ``app_client`` fixtures, LML#613)
+# ---------------------------------------------------------------------------
+
+
+async def _pg_app_client(
+    monkeypatch,
+    *,
+    discogs_mock=None,
+    require_auth: bool = True,
+    close_service: bool = False,
+):
+    """Shared setup/teardown core for the PG-backed ``pg_app_client*`` fixtures below.
+
+    Mirrors what were four near-identical, all literally-named ``app_client``
+    fixtures local to ``test_bulk_resolve_libraries.py``, ``test_release_identity.py``,
+    ``test_cache_refresh_for_identities.py``, and ``test_search_aliases_bulk.py`` --
+    each shadowing the library_db-backed :func:`app_client` above within its
+    own module. ``discogs_mock`` overrides ``get_discogs_service`` (the
+    ``test_cache_refresh_for_identities`` variant); ``require_auth=False`` +
+    ``close_service=True`` reproduce the ``test_search_aliases_bulk`` variant's
+    extra ``LML_REQUIRE_AUTH=false`` env var and ``close_discogs_service()``
+    teardown (that one also tears down the service, not just the pool).
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    import core.dependencies as core_deps
+    import identity.dependencies as deps
+    from config.settings import get_settings
+
+    monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
+    if not require_auth:
+        monkeypatch.setenv("LML_REQUIRE_AUTH", "false")
+    get_settings.cache_clear()
+    deps._entity_store = None
+    deps._entity_probe_failed = False
+    await core_deps.close_discogs_pool()
+    if close_service:
+        await core_deps.close_discogs_service()
+
+    from main import app
+
+    if discogs_mock is not None:
+        from core.dependencies import get_discogs_service
+
+        app.dependency_overrides[get_discogs_service] = lambda: discogs_mock
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+    if discogs_mock is not None:
+        app.dependency_overrides.clear()
+    deps._entity_store = None
+    deps._entity_probe_failed = False
+    await core_deps.close_discogs_pool()
+    if close_service:
+        await core_deps.close_discogs_service()
+    get_settings.cache_clear()
+
+
+@pytest_asyncio.fixture
+async def pg_app_client(monkeypatch):
+    """PG-backed ASGI client: DSN env + entity-store singleton clear, no discogs override.
+
+    Backs ``test_bulk_resolve_libraries.py`` and ``test_release_identity.py`` --
+    the two Family-C fixtures whose bodies were byte-identical (LML#613).
+    """
+    async for client in _pg_app_client(monkeypatch):
+        yield client
+
+
+@pytest_asyncio.fixture
+async def pg_app_client_with_discogs(monkeypatch, discogs_mock):
+    """PG-backed ASGI client with ``get_discogs_service`` overridden to ``discogs_mock``.
+
+    Backs ``test_cache_refresh_for_identities.py`` (LML#613); ``discogs_mock``
+    stays the caller's own fixture so each module keeps its own mock defaults.
+    """
+    async for client in _pg_app_client(monkeypatch, discogs_mock=discogs_mock):
+        yield client
+
+
+@pytest_asyncio.fixture
+async def pg_app_client_no_auth(monkeypatch):
+    """PG-backed ASGI client with auth off and the discogs *service* singleton closed too.
+
+    Backs ``test_search_aliases_bulk.py`` (LML#613) -- the one Family-C
+    fixture that also flips ``LML_REQUIRE_AUTH`` off and tears down
+    ``close_discogs_service()`` (not just the pool) on both sides.
+    """
+    async for client in _pg_app_client(monkeypatch, require_auth=False, close_service=True):
+        yield client
+
+
+# ---------------------------------------------------------------------------
 # Seed data -- representative catalog items
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_bulk_resolve_libraries.py
+++ b/tests/integration/test_bulk_resolve_libraries.py
@@ -13,13 +13,9 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 
-# ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
-# there for the ``monkeypatch.setenv("DATABASE_URL_DISCOGS", ...)`` wiring below.
-from tests.integration.conftest import (
-    DATABASE_URL,
-    ENTITY_IDENTITY_DDL,
-    skip_if_drop_targets_populated,
-)
+# ``pg_pool`` (max_size=3) and ``pg_app_client`` (the reconciled Family-C PG
+# client, LML#613) both live in conftest.
+from tests.integration.conftest import ENTITY_IDENTITY_DDL, skip_if_drop_targets_populated
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -74,42 +70,12 @@ async def set_up_entity_schema(pg_pool):
             await conn.execute("DROP SCHEMA IF EXISTS entity CASCADE")
 
 
-@pytest_asyncio.fixture
-async def app_client(monkeypatch):
-    """ASGI client with the LML app pointed at the test PG."""
-    from httpx import ASGITransport, AsyncClient
-
-    import core.dependencies as core_deps
-    import identity.dependencies as deps
-    from config.settings import get_settings
-
-    monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
-    get_settings.cache_clear()
-    deps._entity_store = None
-    deps._entity_probe_failed = False
-    # Post-WXYC#395 the entity store reuses ``core.dependencies.get_discogs_pool``.
-    # Clearing the entity-store singleton alone leaves the shared pool cached;
-    # the next ``get_entity_store`` would reuse it (which is fine within one
-    # test) but a parallel suite that toggles the DSN env var would race.
-    await core_deps.close_discogs_pool()
-
-    from main import app
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        yield ac
-
-    deps._entity_store = None
-    deps._entity_probe_failed = False
-    await core_deps.close_discogs_pool()
-    get_settings.cache_clear()
-
-
 @pytest.mark.pg
 class TestBulkResolveLibrariesEndpoint:
     @pytest.mark.asyncio
-    async def test_round_trip_single_artist_against_real_pg(self, app_client):
+    async def test_round_trip_single_artist_against_real_pg(self, pg_app_client):
         """End-to-end: seeded identity → composed single_artist verdict."""
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/bulk-resolve-libraries",
             json={
                 "inputs": [
@@ -135,9 +101,9 @@ class TestBulkResolveLibrariesEndpoint:
         assert len(result["provenance"]) == 2
 
     @pytest.mark.asyncio
-    async def test_input_order_preserved_across_mixed_kinds(self, app_client):
+    async def test_input_order_preserved_across_mixed_kinds(self, pg_app_client):
         """Response[i] corresponds to inputs[i] for compilation / hit / miss."""
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/bulk-resolve-libraries",
             json={
                 "inputs": [
@@ -160,7 +126,7 @@ class TestBulkResolveLibrariesEndpoint:
         ]
 
     @pytest.mark.asyncio
-    async def test_case_drift_resolves_via_lower_fall_through(self, app_client, pg_pool):
+    async def test_case_drift_resolves_via_lower_fall_through(self, pg_app_client, pg_pool):
         """Per #276: case drift between Backend input and verbatim-cased storage hits.
 
         Seeds verbatim mixed-case rows (the production shape per the #276
@@ -170,7 +136,7 @@ class TestBulkResolveLibrariesEndpoint:
         #275 ship: that PR canonicalized the input to lowercase and would
         have missed the verbatim-stored row entirely.
         """
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/bulk-resolve-libraries",
             json={
                 "inputs": [
@@ -186,7 +152,7 @@ class TestBulkResolveLibrariesEndpoint:
         assert results[1]["main"]["discogs_artist_id"] == 305253
 
     @pytest.mark.asyncio
-    async def test_canonical_lookup_collapses_divergence_vectors(self, app_client, pg_pool):
+    async def test_canonical_lookup_collapses_divergence_vectors(self, pg_app_client, pg_pool):
         """Per #274: diverged inputs resolve to the same canonical-form row.
 
         Seeds three identities in canonical form (lowercase, no diacritics,
@@ -205,7 +171,7 @@ class TestBulkResolveLibrariesEndpoint:
                 """
             )
 
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/bulk-resolve-libraries",
             json={
                 "inputs": [
@@ -226,7 +192,7 @@ class TestBulkResolveLibrariesEndpoint:
         assert results[2]["main"]["discogs_artist_id"] == 88888
 
     @pytest.mark.asyncio
-    async def test_all_three_legs_resolve_in_one_batch(self, app_client, pg_pool):
+    async def test_all_three_legs_resolve_in_one_batch(self, pg_app_client, pg_pool):
         """Mixed-shape stored rows + mixed-shape inputs all resolve in one call.
 
         Locks the full chain end-to-end. Seeds three rows in three different
@@ -255,7 +221,7 @@ class TestBulkResolveLibrariesEndpoint:
             # Note: 'Stereolab' is already seeded with discogs_artist_id=2154
             # by the schema fixture.
 
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/bulk-resolve-libraries",
             json={
                 "inputs": [
@@ -285,7 +251,7 @@ class TestBulkResolveLibrariesEndpoint:
         assert results[4]["main"] is None
 
     @pytest.mark.asyncio
-    async def test_leg_2_picks_lowest_id_when_two_rows_lower_match(self, app_client, pg_pool):
+    async def test_leg_2_picks_lowest_id_when_two_rows_lower_match(self, pg_app_client, pg_pool):
         """`library_name` is case-sensitive-UNIQUE; two case-variants can co-exist.
 
         Seed two rows whose lower-form is identical (``'Stereolab'`` already
@@ -302,7 +268,7 @@ class TestBulkResolveLibrariesEndpoint:
                 "VALUES ('stereolab', 99999)"
             )
 
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/bulk-resolve-libraries",
             json={
                 "inputs": [
@@ -319,12 +285,12 @@ class TestBulkResolveLibrariesEndpoint:
         assert result["main"]["discogs_artist_id"] == 2154
 
     @pytest.mark.asyncio
-    async def test_413_for_oversized_request(self, app_client):
+    async def test_413_for_oversized_request(self, pg_app_client):
         """1001 inputs → 413."""
         oversized = [
             {"library_id": i, "artist_name": f"Artist_{i}", "album_title": "x"} for i in range(1001)
         ]
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/bulk-resolve-libraries",
             json={"inputs": oversized},
         )

--- a/tests/integration/test_cache_refresh_for_identities.py
+++ b/tests/integration/test_cache_refresh_for_identities.py
@@ -21,7 +21,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
 
 from discogs.models import ArtistCredit, ArtistDetails, ReleaseMetadataResponse
 from entity.sources import PgSource
@@ -133,39 +132,6 @@ async def discogs_mock():
     return mock
 
 
-@pytest_asyncio.fixture
-async def app_client(monkeypatch, discogs_mock):
-    """ASGI client pointed at the test PG; Discogs service overridden to the mock.
-
-    Mirrors the ``test_release_identity.py`` fixture — DSN env, singleton
-    clear, fresh ``main.app`` import. ``LML_REQUIRE_AUTH`` stays off; auth is
-    covered by the dedicated test below.
-    """
-    import core.dependencies as core_deps
-    import identity.dependencies as deps
-    from config.settings import get_settings
-
-    monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
-    get_settings.cache_clear()
-    deps._entity_store = None
-    deps._entity_probe_failed = False
-    await core_deps.close_discogs_pool()
-
-    from core.dependencies import get_discogs_service
-    from main import app
-
-    app.dependency_overrides[get_discogs_service] = lambda: discogs_mock
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        yield ac
-
-    app.dependency_overrides.clear()
-    deps._entity_store = None
-    deps._entity_probe_failed = False
-    await core_deps.close_discogs_pool()
-    get_settings.cache_clear()
-
-
 async def _mint_release(pg_source: PgSource, source: str, external_id: str) -> int:
     """Mint a release_identity row via the real EntityStore and return id."""
     store = EntityStore(pg_source)
@@ -199,7 +165,7 @@ _ROUTE = "/api/v1/cache/refresh-for-identities"
 class TestCacheRefreshHappyPath:
     @pytest.mark.asyncio
     async def test_single_discogs_release_with_two_artists_warms_and_walks(
-        self, app_client, pg_source, discogs_mock
+        self, pg_app_client_with_discogs, pg_source, discogs_mock
     ):
         identity_id = await _mint_release(pg_source, "discogs_release", "12345")
         rel = _release(
@@ -212,7 +178,7 @@ class TestCacheRefreshHappyPath:
         discogs_mock.get_release = AsyncMock(return_value=rel)
         discogs_mock.get_artist_details = AsyncMock(side_effect=[_artist(42), _artist(99)])
 
-        resp = await app_client.post(_ROUTE, json={"identity_ids": [identity_id]})
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": [identity_id]})
 
         assert resp.status_code == 200, resp.text
         body = resp.json()
@@ -227,8 +193,10 @@ class TestCacheRefreshHappyPath:
         assert all(a["outcome"] == "success" for a in artists)
 
     @pytest.mark.asyncio
-    async def test_unknown_identity_id_returns_not_found_no_500(self, app_client, discogs_mock):
-        resp = await app_client.post(_ROUTE, json={"identity_ids": [999_999]})
+    async def test_unknown_identity_id_returns_not_found_no_500(
+        self, pg_app_client_with_discogs, discogs_mock
+    ):
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": [999_999]})
 
         assert resp.status_code == 200, resp.text
         item = resp.json()["results"][0]
@@ -239,7 +207,7 @@ class TestCacheRefreshHappyPath:
 
     @pytest.mark.asyncio
     async def test_tombstone_counts_as_success_with_no_artists(
-        self, app_client, pg_source, discogs_mock
+        self, pg_app_client_with_discogs, pg_source, discogs_mock
     ):
         """Tombstone-as-success: get_release returns None (LML#510 boundary)
         — release-leg ran and the cache state is current. No artists to walk.
@@ -247,7 +215,7 @@ class TestCacheRefreshHappyPath:
         identity_id = await _mint_release(pg_source, "discogs_release", "12345")
         discogs_mock.get_release = AsyncMock(return_value=None)
 
-        resp = await app_client.post(_ROUTE, json={"identity_ids": [identity_id]})
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": [identity_id]})
 
         item = resp.json()["results"][0]
         assert item["status"] == "warmed"
@@ -260,11 +228,11 @@ class TestCacheRefreshHappyPath:
 class TestCacheRefreshMultiSource:
     @pytest.mark.asyncio
     async def test_discogs_master_only_row_returns_not_implemented(
-        self, app_client, pg_source, discogs_mock
+        self, pg_app_client_with_discogs, pg_source, discogs_mock
     ):
         identity_id = await _mint_release(pg_source, "discogs_master", "789")
 
-        resp = await app_client.post(_ROUTE, json={"identity_ids": [identity_id]})
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": [identity_id]})
 
         item = resp.json()["results"][0]
         assert item["status"] == "not_implemented"
@@ -273,7 +241,7 @@ class TestCacheRefreshMultiSource:
 
     @pytest.mark.asyncio
     async def test_dual_populated_release_and_master_warms_via_release_leg(
-        self, app_client, pg_source, discogs_mock
+        self, pg_app_client_with_discogs, pg_source, discogs_mock
     ):
         identity_id = await _mint_release(pg_source, "discogs_release", "12345")
         # Co-populate the master column on the same row.
@@ -286,7 +254,7 @@ class TestCacheRefreshMultiSource:
         discogs_mock.get_release = AsyncMock(return_value=rel)
         discogs_mock.get_artist_details = AsyncMock(return_value=_artist(42))
 
-        resp = await app_client.post(_ROUTE, json={"identity_ids": [identity_id]})
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": [identity_id]})
 
         item = resp.json()["results"][0]
         assert item["status"] == "warmed"
@@ -300,7 +268,7 @@ class TestCacheRefreshSentinelGuard:
 
     @pytest.mark.asyncio
     async def test_walk_to_artist_skips_artist_id_zero_va_compilation(
-        self, app_client, pg_source, discogs_mock
+        self, pg_app_client_with_discogs, pg_source, discogs_mock
     ):
         """A VA compilation with `artist_id=0` must NOT call get_artist_details(0)."""
         identity_id = await _mint_release(pg_source, "discogs_release", "12345")
@@ -314,7 +282,7 @@ class TestCacheRefreshSentinelGuard:
         discogs_mock.get_release = AsyncMock(return_value=rel)
         discogs_mock.get_artist_details = AsyncMock(return_value=_artist(42))
 
-        resp = await app_client.post(_ROUTE, json={"identity_ids": [identity_id]})
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": [identity_id]})
 
         item = resp.json()["results"][0]
         assert item["status"] == "warmed"
@@ -329,7 +297,7 @@ class TestCacheRefreshSentinelGuard:
 class TestCacheRefreshIsolation:
     @pytest.mark.asyncio
     async def test_per_item_failure_does_not_poison_siblings(
-        self, app_client, pg_source, discogs_mock
+        self, pg_app_client_with_discogs, pg_source, discogs_mock
     ):
         ok_id = await _mint_release(pg_source, "discogs_release", "100")
         bad_id = await _mint_release(pg_source, "discogs_release", "200")
@@ -343,7 +311,7 @@ class TestCacheRefreshIsolation:
         discogs_mock.get_release = AsyncMock(side_effect=get_release_side_effect)
         discogs_mock.get_artist_details = AsyncMock(return_value=_artist(42))
 
-        resp = await app_client.post(_ROUTE, json={"identity_ids": [ok_id, bad_id]})
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": [ok_id, bad_id]})
 
         results = {r["identity_id"]: r for r in resp.json()["results"]}
         assert results[ok_id]["status"] == "warmed"
@@ -353,13 +321,15 @@ class TestCacheRefreshIsolation:
 
     @pytest.mark.asyncio
     async def test_duplicate_identity_ids_each_run_independently(
-        self, app_client, pg_source, discogs_mock
+        self, pg_app_client_with_discogs, pg_source, discogs_mock
     ):
         identity_id = await _mint_release(pg_source, "discogs_release", "12345")
         rel = _release(12345, artists=[])
         discogs_mock.get_release = AsyncMock(return_value=rel)
 
-        resp = await app_client.post(_ROUTE, json={"identity_ids": [identity_id, identity_id]})
+        resp = await pg_app_client_with_discogs.post(
+            _ROUTE, json={"identity_ids": [identity_id, identity_id]}
+        )
 
         body = resp.json()
         assert len(body["results"]) == 2
@@ -370,22 +340,22 @@ class TestCacheRefreshIsolation:
 @pytest.mark.pg
 class TestCacheRefreshInputValidation:
     @pytest.mark.asyncio
-    async def test_oversize_batch_returns_400(self, app_client):
+    async def test_oversize_batch_returns_400(self, pg_app_client_with_discogs):
         ids = list(range(1, 52))  # 51 ids > 50 cap
-        resp = await app_client.post(_ROUTE, json={"identity_ids": ids})
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": ids})
         assert resp.status_code == 400
         # Shared bulk envelope (LML#767) emits a generic "{cap}-item cap"
         # message; the 400 status is the load-bearing contract, not the noun.
         assert "50-item cap" in resp.text
 
     @pytest.mark.asyncio
-    async def test_empty_identity_ids_returns_422(self, app_client):
-        resp = await app_client.post(_ROUTE, json={"identity_ids": []})
+    async def test_empty_identity_ids_returns_422(self, pg_app_client_with_discogs):
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": []})
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_malformed_body_returns_400(self, app_client):
-        resp = await app_client.post(
+    async def test_malformed_body_returns_400(self, pg_app_client_with_discogs):
+        resp = await pg_app_client_with_discogs.post(
             _ROUTE,
             content=b"{not json}",
             headers={"Content-Type": "application/json"},
@@ -393,8 +363,8 @@ class TestCacheRefreshInputValidation:
         assert resp.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_non_array_identity_ids_returns_422(self, app_client):
-        resp = await app_client.post(_ROUTE, json={"identity_ids": "1,2,3"})
+    async def test_non_array_identity_ids_returns_422(self, pg_app_client_with_discogs):
+        resp = await pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": "1,2,3"})
         assert resp.status_code == 422
 
 
@@ -412,7 +382,7 @@ class TestCacheRefreshClientDisconnect:
 
     @pytest.mark.asyncio
     async def test_client_disconnect_returns_499_and_cancels_in_flight(
-        self, app_client, pg_source, discogs_mock
+        self, pg_app_client_with_discogs, pg_source, discogs_mock
     ):
         identity_id = await _mint_release(pg_source, "discogs_release", "12345")
 
@@ -424,7 +394,7 @@ class TestCacheRefreshClientDisconnect:
 
         with patch("cache.router.watch_disconnect", self._disconnect_after()):
             resp = await asyncio.wait_for(
-                app_client.post(_ROUTE, json={"identity_ids": [identity_id]}),
+                pg_app_client_with_discogs.post(_ROUTE, json={"identity_ids": [identity_id]}),
                 timeout=3.0,
             )
 

--- a/tests/integration/test_release_identity.py
+++ b/tests/integration/test_release_identity.py
@@ -439,45 +439,13 @@ class TestGetReleaseIdentityProvenanceBulk:
         assert result[id_c] == [("bandcamp", "https://x.bandcamp.com/album/y")]
 
 
-@pytest_asyncio.fixture
-async def app_client(monkeypatch):
-    """ASGI client with the LML app pointed at the test PG.
-
-    Mirrors the fixture in ``tests/integration/test_bulk_resolve_libraries.py`` —
-    monkeypatch the DSN, clear the entity-store singleton, then build a fresh
-    app. ``LML_REQUIRE_AUTH`` stays off by default (matching the prod rollout
-    posture); the auth-required case is covered by its own test below.
-    """
-    from httpx import ASGITransport, AsyncClient
-
-    import core.dependencies as core_deps
-    import identity.dependencies as deps
-    from config.settings import get_settings
-
-    monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
-    get_settings.cache_clear()
-    deps._entity_store = None
-    deps._entity_probe_failed = False
-    await core_deps.close_discogs_pool()
-
-    from main import app
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        yield ac
-
-    deps._entity_store = None
-    deps._entity_probe_failed = False
-    await core_deps.close_discogs_pool()
-    get_settings.cache_clear()
-
-
 @pytest.mark.pg
 class TestReleaseIdentityResolveEndpoint:
     """End-to-end POST /api/v1/identity/resolve."""
 
     @pytest.mark.asyncio
-    async def test_first_call_mints(self, app_client):
-        resp = await app_client.post(
+    async def test_first_call_mints(self, pg_app_client):
+        resp = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={
                 "kind": "release",
@@ -493,8 +461,8 @@ class TestReleaseIdentityResolveEndpoint:
         assert body["identity_id"] > 0
 
     @pytest.mark.asyncio
-    async def test_second_call_is_idempotent(self, app_client):
-        first = await app_client.post(
+    async def test_second_call_is_idempotent(self, pg_app_client):
+        first = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={
                 "kind": "release",
@@ -502,7 +470,7 @@ class TestReleaseIdentityResolveEndpoint:
                 "external_id": "12345",
             },
         )
-        second = await app_client.post(
+        second = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={
                 "kind": "release",
@@ -516,9 +484,9 @@ class TestReleaseIdentityResolveEndpoint:
         assert second.json()["identity_id"] == first.json()["identity_id"]
 
     @pytest.mark.asyncio
-    async def test_bandcamp_round_trip(self, app_client):
+    async def test_bandcamp_round_trip(self, pg_app_client):
         url = "https://autechre.bandcamp.com/album/confield"
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={"kind": "release", "source": "bandcamp", "external_id": url},
         )
@@ -528,10 +496,10 @@ class TestReleaseIdentityResolveEndpoint:
         assert body["kind"] == "release"
 
     @pytest.mark.asyncio
-    async def test_bandcamp_url_canonicalisation_collapses_trailing_slash(self, app_client):
+    async def test_bandcamp_url_canonicalisation_collapses_trailing_slash(self, pg_app_client):
         # Trailing-slash variant must hit the same identity row as the
         # bare form — the validator canonicalises before mint.
-        bare = await app_client.post(
+        bare = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={
                 "kind": "release",
@@ -539,7 +507,7 @@ class TestReleaseIdentityResolveEndpoint:
                 "external_id": "https://autechre.bandcamp.com/album/confield",
             },
         )
-        trailing = await app_client.post(
+        trailing = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={
                 "kind": "release",
@@ -552,9 +520,9 @@ class TestReleaseIdentityResolveEndpoint:
         assert trailing.json()["identity_id"] == bare.json()["identity_id"]
 
     @pytest.mark.asyncio
-    async def test_apple_music_album_round_trip(self, app_client):
+    async def test_apple_music_album_round_trip(self, pg_app_client):
         album_id = "1234567890"
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={"kind": "release", "source": "apple_music_album", "external_id": album_id},
         )
@@ -564,15 +532,15 @@ class TestReleaseIdentityResolveEndpoint:
         assert body["kind"] == "release"
 
     @pytest.mark.asyncio
-    async def test_apple_music_album_round_trip_idempotent(self, app_client):
+    async def test_apple_music_album_round_trip_idempotent(self, pg_app_client):
         # Second resolve of the same album_id returns the same identity_id
         # with minted=False — same posture as the Bandcamp idempotency test.
         album_id = "9876543210"
-        first = await app_client.post(
+        first = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={"kind": "release", "source": "apple_music_album", "external_id": album_id},
         )
-        second = await app_client.post(
+        second = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={"kind": "release", "source": "apple_music_album", "external_id": album_id},
         )
@@ -596,9 +564,9 @@ class TestReleaseIdentityResolveEndpoint:
         ],
     )
     async def test_invalid_external_id_is_rejected_before_mint(
-        self, app_client, source, external_id, pg_source
+        self, pg_app_client, source, external_id, pg_source
     ):
-        resp = await app_client.post(
+        resp = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={"kind": "release", "source": source, "external_id": external_id},
         )
@@ -608,8 +576,8 @@ class TestReleaseIdentityResolveEndpoint:
         assert row["n"] == 0
 
     @pytest.mark.asyncio
-    async def test_unknown_source_rejected_by_pydantic(self, app_client):
-        resp = await app_client.post(
+    async def test_unknown_source_rejected_by_pydantic(self, pg_app_client):
+        resp = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={
                 "kind": "release",
@@ -620,8 +588,8 @@ class TestReleaseIdentityResolveEndpoint:
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_unknown_kind_rejected_by_pydantic(self, app_client):
-        resp = await app_client.post(
+    async def test_unknown_kind_rejected_by_pydantic(self, pg_app_client):
+        resp = await pg_app_client.post(
             "/api/v1/identity/resolve",
             json={
                 "kind": "artist",
@@ -632,7 +600,7 @@ class TestReleaseIdentityResolveEndpoint:
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_requires_auth_when_enabled(self, monkeypatch, app_client):
+    async def test_requires_auth_when_enabled(self, monkeypatch, pg_app_client):
         """With LML_REQUIRE_AUTH=true and no header, the endpoint returns 401."""
         from config.settings import get_settings
 
@@ -645,7 +613,7 @@ class TestReleaseIdentityResolveEndpoint:
         # cache entry it primed survives unless we clear it here.
         get_settings.cache_clear()
         try:
-            resp = await app_client.post(
+            resp = await pg_app_client.post(
                 "/api/v1/identity/resolve",
                 json={
                     "kind": "release",

--- a/tests/integration/test_search_aliases_bulk.py
+++ b/tests/integration/test_search_aliases_bulk.py
@@ -17,13 +17,9 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 
-# ``pg_pool`` (max_size=3) lives in conftest; ``DATABASE_URL`` is imported from
-# there for the ``monkeypatch.setenv("DATABASE_URL_DISCOGS", ...)`` wiring below.
-from tests.integration.conftest import (
-    DATABASE_URL,
-    ENTITY_IDENTITY_DDL,
-    skip_if_drop_targets_populated,
-)
+# ``pg_pool`` (max_size=3) and ``pg_app_client_no_auth`` (the reconciled
+# Family-C PG client, LML#613) both live in conftest.
+from tests.integration.conftest import ENTITY_IDENTITY_DDL, skip_if_drop_targets_populated
 
 # The five public-schema discogs-cache tables this fixture drops and
 # recreates (the composer's read surface).
@@ -170,45 +166,12 @@ async def set_up_schemas(pg_pool):
             await conn.execute("DROP TABLE IF EXISTS artist CASCADE")
 
 
-@pytest_asyncio.fixture
-async def app_client(monkeypatch):
-    """ASGI client with the LML app pointed at the test PG, auth off."""
-    from httpx import ASGITransport, AsyncClient
-
-    import core.dependencies as core_deps
-    import identity.dependencies as deps
-    from config.settings import get_settings
-
-    monkeypatch.setenv("DATABASE_URL_DISCOGS", DATABASE_URL)
-    # Test posture mirrors `test_bulk_resolve_libraries.py`: leave
-    # `LML_REQUIRE_AUTH` off so we can assert the happy-path responses
-    # without provisioning a bearer. Auth enforcement is covered in
-    # `tests/unit/test_auth.py`.
-    monkeypatch.setenv("LML_REQUIRE_AUTH", "false")
-    get_settings.cache_clear()
-    deps._entity_store = None
-    deps._entity_probe_failed = False
-    await core_deps.close_discogs_pool()
-    await core_deps.close_discogs_service()
-
-    from main import app
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        yield ac
-
-    deps._entity_store = None
-    deps._entity_probe_failed = False
-    await core_deps.close_discogs_pool()
-    await core_deps.close_discogs_service()
-    get_settings.cache_clear()
-
-
 @pytest.mark.pg
 class TestSearchAliasesBulkEndpoint:
     @pytest.mark.asyncio
-    async def test_round_trip_emits_all_three_discogs_source_variants(self, app_client):
+    async def test_round_trip_emits_all_three_discogs_source_variants(self, pg_app_client_no_auth):
         """Stereolab returns one variant per source type and all three tags."""
-        resp = await app_client.post(
+        resp = await pg_app_client_no_auth.post(
             "/api/v1/artists/search-aliases/bulk",
             json={"names": ["Stereolab"]},
         )
@@ -235,9 +198,9 @@ class TestSearchAliasesBulkEndpoint:
         }
 
     @pytest.mark.asyncio
-    async def test_missing_identity_routed_to_missing_array(self, app_client):
+    async def test_missing_identity_routed_to_missing_array(self, pg_app_client_no_auth):
         """Names without an ``entity.identity`` row → in ``missing[]``, not ``artists[]``."""
-        resp = await app_client.post(
+        resp = await pg_app_client_no_auth.post(
             "/api/v1/artists/search-aliases/bulk",
             json={"names": ["Stereolab", "Nobody Knows"]},
         )
@@ -249,13 +212,15 @@ class TestSearchAliasesBulkEndpoint:
         assert data["missing"] == ["Nobody Knows"]
 
     @pytest.mark.asyncio
-    async def test_identity_without_discogs_id_yields_empty_sources_present(self, app_client):
+    async def test_identity_without_discogs_id_yields_empty_sources_present(
+        self, pg_app_client_no_auth
+    ):
         """Cat Power has NULL ``discogs_artist_id`` → empty variants AND empty sources_present.
 
         Reconcile contract: consumer must NOT delete cached rows for this
         artist because the composer never ran any source leg.
         """
-        resp = await app_client.post(
+        resp = await pg_app_client_no_auth.post(
             "/api/v1/artists/search-aliases/bulk",
             json={"names": ["Cat Power"]},
         )
@@ -265,14 +230,14 @@ class TestSearchAliasesBulkEndpoint:
         assert result["sources_present"] == []
 
     @pytest.mark.asyncio
-    async def test_discogs_cache_miss_keeps_sources_present_populated(self, app_client):
+    async def test_discogs_cache_miss_keeps_sources_present_populated(self, pg_app_client_no_auth):
         """Juana Molina has a Discogs id but no children in the cache.
 
         Composer ran the leg but found nothing — variants empty, but
         sources_present must list all three discogs_* tags. Consumer needs
         this to scope DELETE during reconcile.
         """
-        resp = await app_client.post(
+        resp = await pg_app_client_no_auth.post(
             "/api/v1/artists/search-aliases/bulk",
             json={"names": ["Juana Molina"]},
         )
@@ -286,24 +251,24 @@ class TestSearchAliasesBulkEndpoint:
         }
 
     @pytest.mark.asyncio
-    async def test_413_for_oversized_request(self, app_client):
+    async def test_413_for_oversized_request(self, pg_app_client_no_auth):
         """1001 names → 413 before any DB work."""
         oversized = [f"Artist_{i}" for i in range(1001)]
-        resp = await app_client.post(
+        resp = await pg_app_client_no_auth.post(
             "/api/v1/artists/search-aliases/bulk",
             json={"names": oversized},
         )
         assert resp.status_code == 413
 
     @pytest.mark.asyncio
-    async def test_case_drift_resolves_via_lower_fall_through(self, app_client):
+    async def test_case_drift_resolves_via_lower_fall_through(self, pg_app_client_no_auth):
         """Backend posts lowercase, storage is mixed-case → leg 2 resolves it.
 
         Mirrors the #276 fall-through contract: stored row ``'Stereolab'``,
         posted name ``'stereolab'`` — the composer's bulk variant of
         ``resolve_library_name`` finds the row via LOWER fall-through.
         """
-        resp = await app_client.post(
+        resp = await pg_app_client_no_auth.post(
             "/api/v1/artists/search-aliases/bulk",
             json={"names": ["stereolab"]},
         )
@@ -322,7 +287,7 @@ class TestSearchAliasesBulkEndpoint:
         }
 
     @pytest.mark.asyncio
-    async def test_case_variant_pair_both_resolve_against_real_pg(self, app_client):
+    async def test_case_variant_pair_both_resolve_against_real_pg(self, pg_app_client_no_auth):
         """Two case-variant inputs of the same stored row both resolve through real PG.
 
         End-to-end coverage for the leg-2 `DISTINCT ON (bind.name)` SQL.
@@ -333,7 +298,7 @@ class TestSearchAliasesBulkEndpoint:
         mapping via mocks; this test exercises the actual PG behavior so
         a future regression of the SQL is caught here.
         """
-        resp = await app_client.post(
+        resp = await pg_app_client_no_auth.post(
             "/api/v1/artists/search-aliases/bulk",
             json={"names": ["STEREOLAB", "stereolab"]},
         )


### PR DESCRIPTION
## Summary

Closes #613

Four integration-test modules (`test_bulk_resolve_libraries.py`, `test_release_identity.py`, `test_cache_refresh_for_identities.py`, `test_search_aliases_bulk.py`) each defined their own `app_client` fixture -- the "Family C" cluster from the LML structural audit (#608) -- all shadowing the library_db-backed `app_client` already defined in `tests/integration/conftest.py` (Family B) within their own module scope. Two of the four bodies were byte-identical (DSN env + entity-store singleton clear); the other two added one knob each: a `discogs_mock` override, and an `LML_REQUIRE_AUTH=false` + `close_discogs_service()` teardown pair.

This hoists the shared setup/teardown into a single `_pg_app_client` async-generator core in `conftest.py`, parameterized by the `discogs_mock` and `require_auth`/`close_service` axes (per the triage plan), and exposes it as three named fixtures the four modules now request instead of defining locally:

- `pg_app_client` -- the byte-identical baseline (`test_bulk_resolve_libraries.py`, `test_release_identity.py`)
- `pg_app_client_with_discogs(discogs_mock)` -- adds the `get_discogs_service` override (`test_cache_refresh_for_identities.py`; the module keeps its own `discogs_mock` fixture)
- `pg_app_client_no_auth` -- adds `LML_REQUIRE_AUTH=false` and closes the discogs *service* singleton, not just the pool (`test_search_aliases_bulk.py`)

Family A (per-router unit fixtures) and Family B (the library_db-backed `app_client`/`app_client_with_discogs` in conftest, plus the local variants in `test_error_resilience.py` and `test_external_cache_fallback.py`) are untouched -- out of scope per the issue.

## Test plan

- [x] `ruff check` / `ruff format --check` clean on all touched files
- [x] `mypy` clean on all touched files
- [x] `pytest -m pg tests/integration/` against real PostgreSQL: **527 passed, 8 skipped** -- run four times (original order, reversed order, and interleaved with sibling PG suites that touch the same singletons) with identical counts every time, matching the pre-change baseline exactly
- [x] Full non-pg suite (`pytest -m "not external_api"`): same 4 pre-existing failures in `tests/unit/test_discogs_404_tombstone.py` before and after this change (confirmed order-dependent on `main` too, unrelated to this PR)
- [x] No `app_client` fixture remains shadowed across scopes in the four target modules