### PR TITLE
Cap Discogs retry backoff against the caller budget

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -849,7 +849,20 @@ async def _run_strategy_pipeline(
     # in the same task after the pipeline returns, mirroring
     # ``_cap_fire_count_var``'s set-at-entry/reset-in-finally propagation
     # across the same ``strategy.attempt`` / ``asyncio.wait_for`` boundary.
-    deadline_token = set_retry_budget_deadline(start + budget_ms / 1000.0)
+    #
+    # Only armed when the CALLER supplied a budget (``caller_budget_ms`` --
+    # the X-Caller-Budget-Ms header, LML#345), not from ``budget_ms`` alone.
+    # ``budget_ms`` is ``resolve_effective_search_budget_ms(caller_budget_ms)``,
+    # which falls back to the env soft default (~4s) when no header was
+    # sent. Arming the retry deadline from that default would cap 429 retry
+    # sleeps at ~4s for every no-header warm-cache/write-path caller,
+    # silently re-imposing the soft budget the loop above deliberately does
+    # NOT enforce for them (see the caller-budget-gate comment below) and
+    # eroding the pre-#758 "keep grinding to the hard cap on empty results"
+    # contract (LML#340/#347) a header-less caller is still entitled to.
+    deadline_token = set_retry_budget_deadline(
+        start + budget_ms / 1000.0 if caller_budget_ms is not None else None
+    )
     try:
         for idx, strategy in enumerate(strategies):
             elapsed_ms = (time.monotonic() - start) * 1000

--- a/core/search.py
+++ b/core/search.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, ClassVar, Protocol
 import sentry_sdk
 
 from discogs.breaker import DiscogsBreakerOpenError
+from discogs.service import reset_retry_budget_deadline, set_retry_budget_deadline
 from generated.api_models import TrackMatchHint
 from library.models import LibraryItem
 from services.parser import ParsedRequest
@@ -840,137 +841,149 @@ async def _run_strategy_pipeline(
     # default) reproduces the pre-#865 step-3-entry clock exactly.
     start = time.monotonic() - pipeline_start_offset_ms / 1000.0
 
-    for idx, strategy in enumerate(strategies):
-        elapsed_ms = (time.monotonic() - start) * 1000
+    # LML#758: publish an absolute deadline for this pipeline's effective
+    # search budget so ``discogs.service._request_with_retry``'s 429 backoff
+    # can cap its sleep against the caller's remaining time instead of riding
+    # the retry loop's up-to-60s ceiling blind to it. Reset in the
+    # ``finally`` below so the deadline doesn't leak into whatever runs next
+    # in the same task after the pipeline returns, mirroring
+    # ``_cap_fire_count_var``'s set-at-entry/reset-in-finally propagation
+    # across the same ``strategy.attempt`` / ``asyncio.wait_for`` boundary.
+    deadline_token = set_retry_budget_deadline(start + budget_ms / 1000.0)
+    try:
+        for idx, strategy in enumerate(strategies):
+            elapsed_ms = (time.monotonic() - start) * 1000
 
-        # Hard cap (LML#370). Fires regardless of state.results — the safety
-        # floor that bounds cascade-exhaustion tail latency. Layered ABOVE
-        # the soft-budget gate so that when both would fire, we record the
-        # cap (the more severe condition) and skip the budget telemetry.
-        if elapsed_ms > hard_cap_ms:
-            state.timed_out = True
-            _log_hard_cap_fired(
-                elapsed_ms=elapsed_ms,
-                skipped=[s.name for s in strategies[idx:]],
-                hard_cap_ms=hard_cap_ms,
-            )
-            break
+            # Hard cap (LML#370). Fires regardless of state.results — the safety
+            # floor that bounds cascade-exhaustion tail latency. Layered ABOVE
+            # the soft-budget gate so that when both would fire, we record the
+            # cap (the more severe condition) and skip the budget telemetry.
+            if elapsed_ms > hard_cap_ms:
+                state.timed_out = True
+                _log_hard_cap_fired(
+                    elapsed_ms=elapsed_ms,
+                    skipped=[s.name for s in strategies[idx:]],
+                    hard_cap_ms=hard_cap_ms,
+                )
+                break
 
-        # Soft-budget gate (LML#340). Two clauses, both load-bearing:
-        #   1. elapsed_ms > budget — we've spent more time than the caller is
-        #      willing to wait.
-        #   2. state.results is non-empty — we have *something* to return.
-        # When the second clause is false we keep grinding: the user gets
-        # "nothing" either way, and the next strategy might surface results.
-        # The hard cap above catches the keep-grinding case when it grinds
-        # too long.
-        if elapsed_ms > budget_ms and state.results:
-            _log_search_budget_exceeded(
-                elapsed_ms=elapsed_ms,
-                skipped=[s.name for s in strategies[idx:]],
-                budget_ms=budget_ms,
-            )
-            break
+            # Soft-budget gate (LML#340). Two clauses, both load-bearing:
+            #   1. elapsed_ms > budget — we've spent more time than the caller is
+            #      willing to wait.
+            #   2. state.results is non-empty — we have *something* to return.
+            # When the second clause is false we keep grinding: the user gets
+            # "nothing" either way, and the next strategy might surface results.
+            # The hard cap above catches the keep-grinding case when it grinds
+            # too long.
+            if elapsed_ms > budget_ms and state.results:
+                _log_search_budget_exceeded(
+                    elapsed_ms=elapsed_ms,
+                    skipped=[s.name for s in strategies[idx:]],
+                    budget_ms=budget_ms,
+                )
+                break
 
-        # Caller-budget gate (LML#347 — Epic A no-results tail follow-up).
-        # An explicit X-Caller-Budget-Ms header is the caller saying "I will
-        # discard whatever arrives after my deadline." LML continuing past
-        # that deadline is wasted Discogs quota for an answer the caller
-        # already abandoned — see WXYC/library-metadata-lookup#337's
-        # Rita Villa / Fly Girlz tail (20+ s with empty results).
-        # Distinct from the env safety branch above: this gate fires when
-        # `state.results` is empty AND the caller opted in. Without a
-        # header, the safety branch above keeps the keep-grinding contract
-        # intact for warm-cache / write-path callers.
-        if caller_budget_ms is not None and elapsed_ms > budget_ms and not state.results:
-            state.timed_out = True
-            _log_search_budget_exceeded(
-                elapsed_ms=elapsed_ms,
-                skipped=[s.name for s in strategies[idx:]],
-                budget_ms=budget_ms,
-            )
-            break
+            # Caller-budget gate (LML#347 — Epic A no-results tail follow-up).
+            # An explicit X-Caller-Budget-Ms header is the caller saying "I will
+            # discard whatever arrives after my deadline." LML continuing past
+            # that deadline is wasted Discogs quota for an answer the caller
+            # already abandoned — see WXYC/library-metadata-lookup#337's
+            # Rita Villa / Fly Girlz tail (20+ s with empty results).
+            # Distinct from the env safety branch above: this gate fires when
+            # `state.results` is empty AND the caller opted in. Without a
+            # header, the safety branch above keeps the keep-grinding contract
+            # intact for warm-cache / write-path callers.
+            if caller_budget_ms is not None and elapsed_ms > budget_ms and not state.results:
+                state.timed_out = True
+                _log_search_budget_exceeded(
+                    elapsed_ms=elapsed_ms,
+                    skipped=[s.name for s in strategies[idx:]],
+                    budget_ms=budget_ms,
+                )
+                break
 
-        # Check if strategy should run.
-        if not strategy.should_attempt(parsed, state, raw_message):
-            continue
+            # Check if strategy should run.
+            if not strategy.should_attempt(parsed, state, raw_message):
+                continue
 
-        state.strategies_tried.append(strategy.name)
+            state.strategies_tried.append(strategy.name)
 
-        # Per-strategy ceiling. Caps the *currently-running* strategy at the
-        # remaining hard-cap budget, so a single slow Discogs cascade can't
-        # blow the loop-level gate (which only fires between strategies).
-        # The 0.01s floor avoids a degenerate wait_for(timeout=0) when
-        # elapsed_ms has just crossed hard_cap_ms due to scheduling jitter —
-        # the wait_for will TimeoutError immediately and the outer except
-        # records the strategy as timed out, same end state as a real cap fire.
-        remaining_budget_seconds = max(0.01, (hard_cap_ms - elapsed_ms) / 1000)
+            # Per-strategy ceiling. Caps the *currently-running* strategy at the
+            # remaining hard-cap budget, so a single slow Discogs cascade can't
+            # blow the loop-level gate (which only fires between strategies).
+            # The 0.01s floor avoids a degenerate wait_for(timeout=0) when
+            # elapsed_ms has just crossed hard_cap_ms due to scheduling jitter —
+            # the wait_for will TimeoutError immediately and the outer except
+            # records the strategy as timed out, same end state as a real cap fire.
+            remaining_budget_seconds = max(0.01, (hard_cap_ms - elapsed_ms) / 1000)
 
-        # Single try/except around the strategy invocation so the per-strategy
-        # wait_for ceiling fires uniformly. CancelledError → TimeoutError raised
-        # by wait_for propagates into in-flight asyncio.gather() probes inside
-        # the strategy, freeing the Discogs semaphore on cap-fire. The
-        # Outcome-returning contract (attempt cannot mutate state) makes a
-        # cancelled attempt a structural no-op against SearchState — no need
-        # for an await-then-commit discipline inside the strategy body.
-        strategy_cap_fire_baseline = cap_fire_counter[0]
-        try:
-            outcome = await asyncio.wait_for(
-                strategy.attempt(parsed, state, raw_message),
-                timeout=remaining_budget_seconds,
-            )
-        except TimeoutError:
-            state.timed_out = True
-            _log_hard_cap_fired(
-                elapsed_ms=(time.monotonic() - start) * 1000,
-                skipped=[s.name for s in strategies[idx + 1 :]],
-                hard_cap_ms=hard_cap_ms,
-            )
-            break
-        except DiscogsBreakerOpenError:
-            # LML#755 R2-2: the Discogs saturation breaker shed a live probe
-            # inside this strategy. A shed means "couldn't ask" — degrade to the
-            # same empty (cache-only) outcome a strategy miss produces, so the
-            # lookup returns library + already-cached results instead of 500ing.
-            # This is the ONE catch boundary for the shed on the search path: all
-            # strategies that fan out to Discogs are covered here, so no strategy
-            # needs its own catch. We ``continue`` (not ``break``) so a later
-            # strategy — which may hit only the cache — still runs.
-            logger.info(
-                "Discogs saturation breaker shed strategy %s; degrading to cache-only",
-                strategy.name,
-            )
-            outcome = Outcome.empty()
+            # Single try/except around the strategy invocation so the per-strategy
+            # wait_for ceiling fires uniformly. CancelledError → TimeoutError raised
+            # by wait_for propagates into in-flight asyncio.gather() probes inside
+            # the strategy, freeing the Discogs semaphore on cap-fire. The
+            # Outcome-returning contract (attempt cannot mutate state) makes a
+            # cancelled attempt a structural no-op against SearchState — no need
+            # for an await-then-commit discipline inside the strategy body.
+            strategy_cap_fire_baseline = cap_fire_counter[0]
+            try:
+                outcome = await asyncio.wait_for(
+                    strategy.attempt(parsed, state, raw_message),
+                    timeout=remaining_budget_seconds,
+                )
+            except TimeoutError:
+                state.timed_out = True
+                _log_hard_cap_fired(
+                    elapsed_ms=(time.monotonic() - start) * 1000,
+                    skipped=[s.name for s in strategies[idx + 1 :]],
+                    hard_cap_ms=hard_cap_ms,
+                )
+                break
+            except DiscogsBreakerOpenError:
+                # LML#755 R2-2: the Discogs saturation breaker shed a live probe
+                # inside this strategy. A shed means "couldn't ask" — degrade to the
+                # same empty (cache-only) outcome a strategy miss produces, so the
+                # lookup returns library + already-cached results instead of 500ing.
+                # This is the ONE catch boundary for the shed on the search path: all
+                # strategies that fan out to Discogs are covered here, so no strategy
+                # needs its own catch. We ``continue`` (not ``break``) so a later
+                # strategy — which may hit only the cache — still runs.
+                logger.info(
+                    "Discogs saturation breaker shed strategy %s; degrading to cache-only",
+                    strategy.name,
+                )
+                outcome = Outcome.empty()
 
-        # The one write site: every per-strategy ``SearchState`` mutation
-        # happens here, driven by the outcome's flags. See :func:`_apply`.
-        _apply(state, outcome)
+            # The one write site: every per-strategy ``SearchState`` mutation
+            # happens here, driven by the outcome's flags. See :func:`_apply`.
+            _apply(state, outcome)
 
-        # LML#543 cap-fire propagation. ``_chunked_gather`` bumps the per-task
-        # ``cap_fire_counter`` when it bails between chunks. We short-circuit
-        # the cascade exactly when the strategy fired the cap AND the natural-
-        # completion gate below would NOT have stopped us — so the artist-
-        # fallback shape (results + song_not_found) propagates, but a confirmed
-        # song match doesn't. See ``LML_SEARCH_MAX_API_CALLS`` in
-        # ``docs/env-vars.md`` for the full rationale.
-        if cap_fire_counter[0] > strategy_cap_fire_baseline and not (
-            state.results and not state.song_not_found
-        ):
-            state.timed_out = True
-            break
+            # LML#543 cap-fire propagation. ``_chunked_gather`` bumps the per-task
+            # ``cap_fire_counter`` when it bails between chunks. We short-circuit
+            # the cascade exactly when the strategy fired the cap AND the natural-
+            # completion gate below would NOT have stopped us — so the artist-
+            # fallback shape (results + song_not_found) propagates, but a confirmed
+            # song match doesn't. See ``LML_SEARCH_MAX_API_CALLS`` in
+            # ``docs/env-vars.md`` for the full rationale.
+            if cap_fire_counter[0] > strategy_cap_fire_baseline and not (
+                state.results and not state.song_not_found
+            ):
+                state.timed_out = True
+                break
 
-        # Stop when results are populated AND we're not still in the
-        # song-not-found cascade. The pre-#391 ``strategy.name !=
-        # TRACK_ON_COMPILATION`` clause collapsed away in step 1: every
-        # downstream strategy already gates on ``not state.results`` in its
-        # condition, so the name-check never changed the outcome. With the
-        # Outcome seam in place, the check simplifies to a pure state read —
-        # ``outcome.items`` would imply ``state.results`` here, so dropping
-        # the ``produced`` boolean from step 1 doesn't change semantics.
-        if state.results and not state.song_not_found:
-            break
+            # Stop when results are populated AND we're not still in the
+            # song-not-found cascade. The pre-#391 ``strategy.name !=
+            # TRACK_ON_COMPILATION`` clause collapsed away in step 1: every
+            # downstream strategy already gates on ``not state.results`` in its
+            # condition, so the name-check never changed the outcome. With the
+            # Outcome seam in place, the check simplifies to a pure state read —
+            # ``outcome.items`` would imply ``state.results`` here, so dropping
+            # the ``produced`` boolean from step 1 doesn't change semantics.
+            if state.results and not state.song_not_found:
+                break
 
-    return state
+        return state
+    finally:
+        reset_retry_budget_deadline(deadline_token)
 
 
 def get_search_type_from_state(state: SearchState) -> str:

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -94,8 +94,12 @@ _MAX_RETRY_DELAY_SECONDS = 60.0
 # retry-backoff sleep against the caller's remaining time instead of riding
 # the retry loop's up-to-60s ceiling blind to it. ``None`` when no pipeline
 # deadline is active -- the four API-only Discogs seam methods that bypass
-# the search pipeline, and any direct-call unit test -- so the retry loop
-# falls back to the pre-#758 attempt-count-only bound.
+# the search pipeline, any direct-call unit test, AND a pipeline run whose
+# caller never supplied a budget (the deadline is only armed from an actual
+# caller-supplied budget, not the default env soft budget -- see the
+# gating comment at ``core.search._run_strategy_pipeline``'s
+# ``set_retry_budget_deadline`` call) -- so the retry loop falls back to the
+# pre-#758 attempt-count-only bound.
 _retry_budget_deadline_var: ContextVar[float | None] = ContextVar(
     "lml_discogs_retry_budget_deadline", default=None
 )

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -8,6 +8,7 @@ import random
 import time
 import weakref
 from collections.abc import Iterator
+from contextvars import ContextVar, Token
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
@@ -84,6 +85,37 @@ DISCOGS_API_BASE = "https://api.discogs.com"
 # seconds; once we cross that, the bucket has reset and there's no benefit to
 # waiting longer for the same 429.
 _MAX_RETRY_DELAY_SECONDS = 60.0
+
+# LML#758: absolute ``time.monotonic()`` deadline for the caller budget
+# (X-Caller-Budget-Ms / LML#345) governing the search pipeline currently
+# running in this task. Set at ``core.search._run_strategy_pipeline`` entry
+# (mirroring ``core.search._cap_fire_count_var``'s set-at-entry/reset-in-
+# finally propagation) and read by ``_request_with_retry`` to cap the 429
+# retry-backoff sleep against the caller's remaining time instead of riding
+# the retry loop's up-to-60s ceiling blind to it. ``None`` when no pipeline
+# deadline is active -- the four API-only Discogs seam methods that bypass
+# the search pipeline, and any direct-call unit test -- so the retry loop
+# falls back to the pre-#758 attempt-count-only bound.
+_retry_budget_deadline_var: ContextVar[float | None] = ContextVar(
+    "lml_discogs_retry_budget_deadline", default=None
+)
+
+
+def set_retry_budget_deadline(deadline: float | None) -> Token:
+    """Set the active caller-budget deadline for the 429 retry loop; returns a reset token.
+
+    ``deadline`` is an absolute ``time.monotonic()`` value, not a duration.
+    Callers must ``reset_retry_budget_deadline(token)`` in a ``finally`` so
+    the deadline doesn't leak into whatever runs next in the same task after
+    the pipeline returns (LML#758, mirroring ``core.search._cap_fire_count_var``).
+    """
+    return _retry_budget_deadline_var.set(deadline)
+
+
+def reset_retry_budget_deadline(token: Token) -> None:
+    """Undo :func:`set_retry_budget_deadline`; see its docstring."""
+    _retry_budget_deadline_var.reset(token)
+
 
 # LML#755 saturation-breaker counter. Emitted on the #683 ``cache.*`` counter
 # surface (``get_cache_stats_recorder().record(...)``) every time a live Discogs
@@ -739,6 +771,34 @@ class DiscogsService:
                 if attempt < max_retries:
                     retry_after = response.headers.get("Retry-After")
                     delay = _compute_retry_delay(attempt, retry_after)
+
+                    # LML#758: don't sleep past the caller's remaining budget.
+                    # A deadline is only active when this call is running
+                    # inside a search pipeline (``core.search._run_strategy_
+                    # pipeline`` sets it); direct/API-only callers see ``None``
+                    # and keep the pre-#758 attempt-count-only bound.
+                    deadline = _retry_budget_deadline_var.get()
+                    if deadline is not None:
+                        remaining_budget = deadline - time.monotonic()
+                        if delay > remaining_budget:
+                            logger.warning(
+                                "Discogs rate limit hit, remaining caller budget "
+                                "(%.2fs) can't absorb the next retry delay "
+                                "(%.2fs); giving up early instead of sleeping "
+                                "past the deadline",
+                                remaining_budget,
+                                delay,
+                            )
+                            # Same terminal accounting as retries-exhausted
+                            # below: this attempt's response is a genuine 429,
+                            # so the breaker still learns from it. The `None`
+                            # return is the existing "unknown, not confirmed-
+                            # empty" degrade contract every caller of
+                            # `_request_with_retry` already honors (LML#755).
+                            recorded = True
+                            breaker.record_failure(remaining=remaining_value, epoch=epoch)
+                            return None
+
                     logger.warning(
                         f"Discogs rate limit hit, retrying in {delay:.2f}s "
                         f"(attempt {attempt + 1}/{max_retries + 1}, "

--- a/tests/unit/test_discogs_retry_budget_deadline.py
+++ b/tests/unit/test_discogs_retry_budget_deadline.py
@@ -90,6 +90,44 @@ async def test_retry_gives_up_when_next_delay_would_exceed_the_deadline(fake_lim
 
 
 @pytest.mark.asyncio
+async def test_retry_gives_up_when_the_deadline_has_already_passed(fake_limiter):
+    """A deadline that is already behind ``time.monotonic()`` (negative
+    remaining budget) still gives up on the first retry decision -- the
+    comparison ``delay > remaining_budget`` doesn't require a positive
+    ``remaining_budget`` to fire, but this pins it explicitly so a future
+    refactor (e.g. clamping ``remaining_budget`` to zero, or an ``if
+    remaining_budget <= 0`` short-circuit that skips the ``delay``
+    comparison) can't silently change the outcome."""
+    breaker = DiscogsCircuitBreaker(failure_threshold=99, remaining_floor=0, cooldown_seconds=60.0)
+
+    client = MagicMock()
+    # Retry-After=1s -- the smallest realistic delay -- against a deadline
+    # that already elapsed 10s ago.
+    client.request = AsyncMock(return_value=_response(429, {"Retry-After": "1"}))
+    service = _make_service(client)
+
+    sleep_spy = AsyncMock()
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=asyncio.Semaphore(5)),
+        patch("discogs.service.get_discogs_rate_gate", return_value=fake_limiter),
+        patch("discogs.service.get_discogs_breaker", return_value=breaker),
+        patch("discogs.service.asyncio.sleep", new=sleep_spy),
+        patch("discogs.service.time.monotonic", return_value=1000.0),
+    ):
+        token = set_retry_budget_deadline(990.0)  # deadline was 10s ago
+        try:
+            result = await service._request_with_retry("GET", "/database/search", max_retries=3)
+        finally:
+            reset_retry_budget_deadline(token)
+
+    assert result is None
+    sleep_spy.assert_not_awaited()
+    assert client.request.await_count == 1
+    assert breaker.state.value == "closed"
+
+
+@pytest.mark.asyncio
 async def test_retry_proceeds_when_the_deadline_can_absorb_the_delay(fake_limiter):
     """Plenty of remaining budget: the retry loop behaves exactly as it did
     pre-#758 -- it sleeps and retries, eventually succeeding."""

--- a/tests/unit/test_discogs_retry_budget_deadline.py
+++ b/tests/unit/test_discogs_retry_budget_deadline.py
@@ -1,0 +1,147 @@
+"""Unit tests for LML#758: the 429 retry loop honors the caller budget.
+
+``_request_with_retry`` retries a 429 with jittered exponential backoff up to
+``discogs_max_retries`` attempts, each sleep capped at
+``_MAX_RETRY_DELAY_SECONDS`` (60s) -- with no knowledge of the caller's
+remaining budget (``caller_budget_ms`` / X-Caller-Budget-Ms, LML#345). A
+request with, say, a 4s budget could still sleep through a 30s
+``Retry-After`` and return long after the caller gave up.
+
+``core.search._run_strategy_pipeline`` now publishes an absolute
+``time.monotonic()`` deadline (derived from the pipeline's effective search
+budget) on a ContextVar at pipeline entry; ``_request_with_retry`` reads it
+before each inter-attempt sleep and gives up early -- returning ``None``,
+the same "unknown, not confirmed-empty" degrade every caller of
+``_request_with_retry`` already honors (LML#755) -- instead of sleeping past
+it. Pure unit: a pre-injected mock client, patched rate limiter/semaphore,
+and a patched ``time.monotonic``/``asyncio.sleep`` -- nothing leaves the
+process. Default (no-marker) suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from discogs.breaker import DiscogsCircuitBreaker
+from discogs.service import (
+    DiscogsService,
+    reset_retry_budget_deadline,
+    set_retry_budget_deadline,
+)
+
+
+def _make_service(client: MagicMock) -> DiscogsService:
+    service = DiscogsService(token="test-token")
+    service._client = client
+    return service
+
+
+def _response(status_code: int, headers: dict[str, str] | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    return resp
+
+
+@pytest.fixture
+def fake_limiter() -> MagicMock:
+    limiter = MagicMock()
+    limiter.acquire = AsyncMock()
+    return limiter
+
+
+@pytest.mark.asyncio
+async def test_retry_gives_up_when_next_delay_would_exceed_the_deadline(fake_limiter):
+    """A ``Retry-After`` that would push the request past the active deadline
+    stops the retry loop and returns ``None`` instead of sleeping past it
+    (the core acceptance criterion of LML#758)."""
+    breaker = DiscogsCircuitBreaker(failure_threshold=99, remaining_floor=0, cooldown_seconds=60.0)
+
+    client = MagicMock()
+    # Retry-After=30s; the active budget below only has 2s left.
+    client.request = AsyncMock(return_value=_response(429, {"Retry-After": "30"}))
+    service = _make_service(client)
+
+    sleep_spy = AsyncMock()
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=asyncio.Semaphore(5)),
+        patch("discogs.service.get_discogs_rate_gate", return_value=fake_limiter),
+        patch("discogs.service.get_discogs_breaker", return_value=breaker),
+        patch("discogs.service.asyncio.sleep", new=sleep_spy),
+        patch("discogs.service.time.monotonic", return_value=1000.0),
+    ):
+        token = set_retry_budget_deadline(1002.0)  # 2s of budget remaining
+        try:
+            result = await service._request_with_retry("GET", "/database/search", max_retries=3)
+        finally:
+            reset_retry_budget_deadline(token)
+
+    assert result is None
+    # Gave up on the FIRST attempt's retry decision -- never slept.
+    sleep_spy.assert_not_awaited()
+    assert client.request.await_count == 1
+    # The 429 is still a genuine rate-limit signal; the breaker learns from it
+    # exactly like the retries-exhausted path (LML#755 FIX 2).
+    assert breaker.state.value == "closed"
+
+
+@pytest.mark.asyncio
+async def test_retry_proceeds_when_the_deadline_can_absorb_the_delay(fake_limiter):
+    """Plenty of remaining budget: the retry loop behaves exactly as it did
+    pre-#758 -- it sleeps and retries, eventually succeeding."""
+    breaker = DiscogsCircuitBreaker(failure_threshold=99, remaining_floor=0, cooldown_seconds=60.0)
+
+    client = MagicMock()
+    ok = _response(200, {"X-Discogs-Ratelimit-Remaining": "40"})
+    client.request = AsyncMock(side_effect=[_response(429, {"Retry-After": "1"}), ok])
+    service = _make_service(client)
+
+    sleep_spy = AsyncMock()
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=asyncio.Semaphore(5)),
+        patch("discogs.service.get_discogs_rate_gate", return_value=fake_limiter),
+        patch("discogs.service.get_discogs_breaker", return_value=breaker),
+        patch("discogs.service.asyncio.sleep", new=sleep_spy),
+        patch("discogs.service.time.monotonic", return_value=1000.0),
+    ):
+        token = set_retry_budget_deadline(1060.0)  # 60s of budget remaining
+        try:
+            result = await service._request_with_retry("GET", "/database/search", max_retries=3)
+        finally:
+            reset_retry_budget_deadline(token)
+
+    assert result is ok
+    sleep_spy.assert_awaited_once()
+    assert client.request.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_ignores_the_budget_when_no_deadline_is_active(fake_limiter):
+    """Direct/API-only callers that never entered a search pipeline see no
+    deadline (``None``) -- the retry loop keeps the pre-#758
+    attempt-count-only bound."""
+    breaker = DiscogsCircuitBreaker(failure_threshold=99, remaining_floor=0, cooldown_seconds=60.0)
+
+    client = MagicMock()
+    ok = _response(200, {"X-Discogs-Ratelimit-Remaining": "40"})
+    client.request = AsyncMock(side_effect=[_response(429, {"Retry-After": "30"}), ok])
+    service = _make_service(client)
+
+    sleep_spy = AsyncMock()
+
+    with (
+        patch("discogs.service.get_semaphore", return_value=asyncio.Semaphore(5)),
+        patch("discogs.service.get_discogs_rate_gate", return_value=fake_limiter),
+        patch("discogs.service.get_discogs_breaker", return_value=breaker),
+        patch("discogs.service.asyncio.sleep", new=sleep_spy),
+    ):
+        result = await service._request_with_retry("GET", "/database/search", max_retries=3)
+
+    assert result is ok
+    sleep_spy.assert_awaited_once()
+    assert client.request.await_count == 2

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -38,6 +38,7 @@ from core.search import (
     resolve_search_hard_timeout_ms,
     song_not_found_with_artist_and_song,
 )
+from discogs.service import _retry_budget_deadline_var
 from generated.api_models import TrackMatchHint, TrackMatchSource
 from lookup.strategies import build_strategies
 from services.parser import ParsedRequest
@@ -1681,3 +1682,181 @@ class TestCallerBudget:
         # stayed empty, and the second strategy surfaced the late hit.
         assert state.results == [late_hit]
         assert state.timed_out is False
+
+
+class TestRetryBudgetDeadlineWiring:
+    """LML#758 follow-up: the retry-deadline ContextVar wiring itself.
+
+    ``tests/unit/test_discogs_retry_budget_deadline.py`` exercises
+    ``_request_with_retry`` against a manually-set ContextVar -- it never
+    calls ``execute_search_pipeline``, so it can't catch a regression where
+    the pipeline stops setting (or stops resetting) the deadline. These
+    tests drive the wiring at the seam: an attempt captures
+    ``discogs.service._retry_budget_deadline_var.get()`` from *inside* the
+    strategy call, which is the only vantage point that observes the value
+    the retry loop would actually see.
+
+    Also pins the fix for the #758 review finding that arming the deadline
+    from the *default* env budget (rather than only an explicit caller
+    budget/deadline) silently re-imposes the ~4s soft budget on the 429
+    retry sleep for no-header callers, eroding the pre-#758 "keep grinding
+    to the hard cap on empty results" contract (LML#340/#347).
+    """
+
+    @pytest.mark.asyncio
+    async def test_deadline_armed_when_caller_budget_present(self, monkeypatch):
+        """A caller-supplied budget arms the retry deadline for the duration
+        of the pipeline call, and the ContextVar is back to ``None`` once
+        the pipeline returns (leak guard)."""
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+
+        captured: list[float | None] = []
+
+        async def capture_and_return(*args, **kwargs):
+            captured.append(_retry_budget_deadline_var.get())
+            return ([], False)
+
+        search_lib = AsyncMock(side_effect=capture_and_return)
+        search_alt = AsyncMock(return_value=([], None, {}))
+        search_comp = AsyncMock(return_value=([], {}))
+
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+
+        assert _retry_budget_deadline_var.get() is None
+
+        await execute_search_pipeline(
+            parsed,
+            "Stereolab - Miss Modular",
+            strategies,
+            song_not_found=True,
+            caller_budget_ms=3000,
+        )
+
+        assert captured, "search_lib strategy never ran"
+        assert captured[0] is not None
+        # Reset in the pipeline's finally -- no leak into whatever runs next
+        # in the same task.
+        assert _retry_budget_deadline_var.get() is None
+
+    @pytest.mark.asyncio
+    async def test_deadline_not_armed_without_caller_budget(self, monkeypatch):
+        """Without a caller-supplied budget, the retry deadline stays
+        ``None`` -- the default ~4s soft budget must NOT cap the 429 retry
+        sleep, or a no-header warm-cache/write-path caller degrades to
+        cache-only early instead of grinding to the hard cap (the pre-#758
+        contract)."""
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+
+        captured: list[float | None] = []
+
+        async def capture_and_return(*args, **kwargs):
+            captured.append(_retry_budget_deadline_var.get())
+            return ([], False)
+
+        search_lib = AsyncMock(side_effect=capture_and_return)
+        search_alt = AsyncMock(return_value=([], None, {}))
+        search_comp = AsyncMock(return_value=([], {}))
+
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+
+        await execute_search_pipeline(
+            parsed,
+            "Stereolab - Miss Modular",
+            strategies,
+            song_not_found=True,
+            # caller_budget_ms not passed.
+        )
+
+        assert captured, "search_lib strategy never ran"
+        assert captured[0] is None
+        assert _retry_budget_deadline_var.get() is None
+
+    @pytest.mark.asyncio
+    async def test_deadline_reset_even_when_a_strategy_raises(self, monkeypatch):
+        """The reset-in-``finally`` must fire even when a strategy raises an
+        exception the pipeline doesn't catch (anything other than
+        ``TimeoutError``/``DiscogsBreakerOpenError``) -- otherwise a crashed
+        request would leak a stale deadline into whatever runs next on the
+        same task (LML#758 leak-guard, mirroring ``_cap_fire_count_var``)."""
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+
+        search_lib = AsyncMock(side_effect=RuntimeError("boom"))
+        search_alt = AsyncMock(return_value=([], None, {}))
+        search_comp = AsyncMock(return_value=([], {}))
+
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await execute_search_pipeline(
+                parsed,
+                "Stereolab - Miss Modular",
+                strategies,
+                song_not_found=True,
+                caller_budget_ms=3000,
+            )
+
+        assert _retry_budget_deadline_var.get() is None
+
+    @pytest.mark.asyncio
+    async def test_removing_the_deadline_wiring_would_fail_this_test(self, monkeypatch):
+        """Direct pin on the exact deadline value the pipeline arms, so
+        deleting the ``set_retry_budget_deadline(...)`` call (or wiring it
+        to the wrong budget) fails this test instead of passing silently.
+        """
+        monkeypatch.delenv("LML_SEARCH_BUDGET_MS", raising=False)
+
+        captured: list[float | None] = []
+        observed_monotonic: list[float] = []
+
+        async def capture_and_return(*args, **kwargs):
+            observed_monotonic.append(time.monotonic())
+            captured.append(_retry_budget_deadline_var.get())
+            return ([], False)
+
+        search_lib = AsyncMock(side_effect=capture_and_return)
+        search_alt = AsyncMock(return_value=([], None, {}))
+        search_comp = AsyncMock(return_value=([], {}))
+
+        strategies = _build_test_strategies(search_lib, search_alt, search_comp)
+
+        parsed = ParsedRequest(
+            artist="Stereolab",
+            song="Miss Modular",
+            raw_message="Stereolab - Miss Modular",
+        )
+
+        # caller_budget_ms = 3000 -> effective budget = 3000 - TRANSPORT_OVERHEAD_MS.
+        await execute_search_pipeline(
+            parsed,
+            "Stereolab - Miss Modular",
+            strategies,
+            song_not_found=True,
+            caller_budget_ms=3000,
+        )
+
+        assert captured[0] is not None
+        expected_budget_seconds = (3000 - TRANSPORT_OVERHEAD_MS) / 1000.0
+        # The deadline is an absolute monotonic instant ~budget-seconds ahead
+        # of when the strategy ran; allow generous slack for test overhead
+        # without weakening the assertion into a tautology.
+        assert captured[0] == pytest.approx(
+            observed_monotonic[0] + expected_budget_seconds, abs=0.5
+        )


### PR DESCRIPTION
## Problem

`DiscogsService._request_with_retry` retries a 429 with jittered exponential backoff up to `discogs_max_retries` (default 5) attempts, each sleep capped at 60s -- so a single request can spend ~47-62s in backoff. That loop does not consult the caller's deadline. LML already threads a per-request budget (`caller_budget_ms` / `X-Caller-Budget-Ms`, the LML#345 "return before the caller times out" contract), but it was only honored by the search-strategy cascade short-circuit -- never by the Discogs retry/backoff loop. A request with, say, a 4s budget could still enter `_request_with_retry` and sleep through a 30s `Retry-After`, returning long after the caller already gave up.

This was surfaced during the LML#755 review and consciously deferred at merge.

## Fix

`core.search._run_strategy_pipeline` now publishes an absolute monotonic deadline (derived from the pipeline's effective search budget) on a ContextVar at pipeline entry, mirroring `_cap_fire_count_var`'s set-at-entry / reset-in-finally propagation across the same `strategy.attempt` / `asyncio.wait_for` boundary -- no signature changes needed at any intermediate call site. `_request_with_retry` reads the deadline before each inter-attempt sleep; if the next backoff delay would exceed the remaining budget, it gives up early and returns `None` instead of sleeping past the deadline.

A budget-exceeded exit reuses the exact same terminal accounting as the existing retries-exhausted path: the breaker still learns from the genuine 429 signal, and the `None` return is the same "unknown, not confirmed-empty" degrade contract every caller of `_request_with_retry` already honors (LML#755) -- so it composes cleanly with the negative-cache / release-identity handling already in place. Direct/API-only callers that never enter a search pipeline see no deadline (`None`) and keep the pre-existing attempt-count-only bound.

The semaphore permit is still released before the retry sleep in every branch, so LML#569's behavior (no permit parked across the inter-attempt sleep) is unchanged.

## Testing

- New unit tests in `tests/unit/test_discogs_retry_budget_deadline.py`: a `Retry-After` that would exceed the remaining budget stops the loop and returns `None` without sleeping; ample remaining budget behaves exactly as before; no active deadline (direct callers) falls back to the pre-existing behavior.
- Full local suite (ruff check, ruff format --check, mypy, `pytest`) green.

Closes #758