### PR TITLE
fix: stop find_similar_artist from correcting an exact library artist

### DIFF
--- a/library/db.py
+++ b/library/db.py
@@ -563,10 +563,50 @@ class LibraryDB:
         artist_cache[cache_key] = result
         return result
 
+    async def _artist_exists_exactly(self, artist_lower: str, artist_compare: str) -> bool:
+        """Check whether the typed artist is already an exact library artist.
+
+        Run before any fuzzy candidate search so a name that's already in the
+        library (e.g. "John Lennon") is never "corrected" to a different,
+        merely-similar-scoring artist that happened to survive the candidate cap.
+        """
+        assert self._conn is not None  # Caller validates
+
+        exact_filter = "LOWER(artist) = ? OR LOWER(artist) = ?"
+        unions = [f"SELECT 1 FROM library WHERE {exact_filter}"]
+        params_list = [artist_lower, artist_compare]
+        if self._has_alternate_artist:
+            unions.append(
+                "SELECT 1 FROM library WHERE alternate_artist_name IS NOT NULL "
+                "AND (LOWER(alternate_artist_name) = ? OR LOWER(alternate_artist_name) = ?)"
+            )
+            params_list.extend([artist_lower, artist_compare])
+        if self._has_album_artist:
+            unions.append(
+                "SELECT 1 FROM library WHERE album_artist IS NOT NULL "
+                "AND (LOWER(album_artist) = ? OR LOWER(album_artist) = ?)"
+            )
+            params_list.extend([artist_lower, artist_compare])
+        if self._has_compilation_track_artist:
+            unions.append(
+                "SELECT 1 FROM compilation_track_artist "
+                "WHERE LOWER(artist_name) = ? OR LOWER(artist_name) = ?"
+            )
+            params_list.extend([artist_lower, artist_compare])
+
+        sql = f"SELECT 1 FROM ({' UNION ALL '.join(unions)}) LIMIT 1"
+        cursor = await self._conn.execute(sql, params_list)
+        row = await cursor.fetchone()
+        return row is not None
+
     async def _find_similar_artist_uncached(self, artist: str, threshold: int = 85) -> str | None:
         assert self._conn is not None  # Caller validates
         # Get candidate artists using prefix of first significant word
         artist_lower = artist.lower()
+        artist_compare = strip_leading_article(artist_lower) or artist_lower
+
+        if await self._artist_exists_exactly(artist_lower, artist_compare):
+            return None
 
         # For short names, a single-character difference is proportionally large,
         # so raise the threshold to prevent false corrections (e.g. "Plug" -> "Plugz")
@@ -593,7 +633,6 @@ class LibraryDB:
             for w in words
             if len(w) >= 3 and w != search_word and w not in LEADING_ARTICLES
         )
-        artist_compare = strip_leading_article(artist_lower) or artist_lower
 
         column_filter = " OR ".join("artist LIKE ?" for _ in candidate_patterns)
         unions = [f"SELECT artist AS name FROM library WHERE {column_filter}"]
@@ -619,7 +658,12 @@ class LibraryDB:
             )
             params_list.extend(candidate_patterns)
 
-        sql = f"SELECT DISTINCT name FROM ({' UNION '.join(unions)}) LIMIT 100"
+        sql = (
+            f"SELECT DISTINCT name FROM ({' UNION '.join(unions)}) "
+            "ORDER BY CASE WHEN LOWER(name) = ? OR LOWER(name) = ? THEN 0 ELSE 1 END "
+            "LIMIT 100"
+        )
+        params_list = [*params_list, artist_lower, artist_compare]
         cursor = await self._conn.execute(sql, params_list)
         rows = await cursor.fetchall()
 

--- a/tests/integration/test_library_db.py
+++ b/tests/integration/test_library_db.py
@@ -183,6 +183,12 @@ class TestFindSimilarArtist:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_genuine_misspelling_still_corrected(self, library_db):
+        """Regression guard: a real typo of a library artist still binds (LML#857)."""
+        result = await library_db.find_similar_artist("Stereolb")
+        assert result == "Stereolab"
+
+    @pytest.mark.asyncio
     async def test_short_word(self, library_db):
         result = await library_db.find_similar_artist("XY")
         assert result is None

--- a/tests/integration/test_lookup_pipeline.py
+++ b/tests/integration/test_lookup_pipeline.py
@@ -71,6 +71,24 @@ class TestLookupPipeline:
         )
 
     @pytest.mark.asyncio
+    async def test_exact_library_artist_resolves_to_library_row(self, app_client):
+        """LML#857: an artist already in the library must resolve to its
+        library row (non-zero library_item.id), not a rowless Discogs-only
+        fallback caused by a false artist "correction"."""
+        resp = await app_client.post(
+            "/api/v1/lookup",
+            json={
+                "artist": "Stereolab",
+                "album": "Dots and Loops",
+                "raw_message": "Stereolab - Dots and Loops",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["results"]) >= 1
+        assert all(r["library_item"]["id"] != 0 for r in body["results"])
+
+    @pytest.mark.asyncio
     async def test_no_results(self, app_client):
         """Nonexistent artist returns empty results."""
         resp = await app_client.post(

--- a/tests/unit/test_library_db.py
+++ b/tests/unit/test_library_db.py
@@ -667,6 +667,7 @@ class TestFindSimilarArtist:
         mock_cursor.fetchall = AsyncMock(return_value=[])
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_cursor.fetchone = AsyncMock(return_value=None)
 
         result = await db.find_similar_artist("Nonexistent")
         assert result is None
@@ -688,6 +689,7 @@ class TestFindSimilarArtist:
         mock_cursor.fetchall = AsyncMock(return_value=[FakeRow("Living Colour")])
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_cursor.fetchone = AsyncMock(return_value=None)
 
         result = await db.find_similar_artist("Living Color")
         assert result == "Living Colour"
@@ -708,6 +710,7 @@ class TestFindSimilarArtist:
         mock_cursor.fetchall = AsyncMock(return_value=[FakeRow("Queen")])
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_cursor.fetchone = AsyncMock(return_value=None)
 
         result = await db.find_similar_artist("Queen")
         assert result is None
@@ -727,6 +730,7 @@ class TestFindSimilarArtist:
         mock_cursor.fetchall = AsyncMock(return_value=[FakeRow(None), FakeRow("Radiohead")])
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_cursor.fetchone = AsyncMock(return_value=None)
 
         result = await db.find_similar_artist("Radiohed")
         assert result == "Radiohead"
@@ -751,6 +755,7 @@ class TestFindSimilarArtist:
         mock_cursor.fetchall = AsyncMock(return_value=[FakeRow("Plugz")])
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_cursor.fetchone = AsyncMock(return_value=None)
 
         result = await db.find_similar_artist("Plug")
         assert result is None, (
@@ -781,6 +786,7 @@ class TestFindSimilarArtist:
         mock_cursor.fetchall = AsyncMock(return_value=[FakeRow(candidate)])
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_cursor.fetchone = AsyncMock(return_value=None)
 
         result = await db.find_similar_artist(misspelled)
         assert result == expected
@@ -801,12 +807,13 @@ class TestFindSimilarArtist:
         mock_cursor.fetchall = AsyncMock(return_value=[FakeRow("Black Dog")])
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_cursor.fetchone = AsyncMock(return_value=None)
 
         result = await db.find_similar_artist("The Bleack Dog")
 
         assert result == "Black Dog"
         _, params = db._conn.execute.await_args.args
-        assert params == ["ble%", "%dog%"]
+        assert params == ["ble%", "%dog%", "the bleack dog", "bleack dog"]
         assert "the%" not in params
 
     @pytest.mark.asyncio
@@ -825,10 +832,91 @@ class TestFindSimilarArtist:
         mock_cursor.fetchall = AsyncMock(return_value=[FakeRow("Black Dog")])
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
+        mock_cursor.fetchone = AsyncMock(return_value=None)
 
         result = await db.find_similar_artist("The Black Dog")
 
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_exact_library_artist_short_circuits_before_candidate_search(self):
+        """An artist that's an exact library match is never 'corrected' to a
+        different, merely-similar-scoring distractor.
+
+        Regression for LML#857: the "John Lennon" -> "Don Lennon" false
+        correction. Even if the candidate query would (nondeterministically)
+        surface a distractor as the only row, the exact-match short-circuit
+        must fire first and the candidate query must never run.
+        """
+        db = LibraryDB()
+
+        class FakeRow:
+            def __init__(self, val):
+                self.val = val
+
+            def __getitem__(self, idx):
+                return self.val
+
+        exact_cursor = AsyncMock()
+        exact_cursor.fetchone = AsyncMock(return_value=(1,))
+
+        candidate_cursor = AsyncMock()
+        candidate_cursor.fetchall = AsyncMock(return_value=[FakeRow("Don Lennon")])
+
+        db._conn = AsyncMock()
+        db._conn.execute = AsyncMock(side_effect=[exact_cursor, candidate_cursor])
+
+        result = await db.find_similar_artist("John Lennon")
+
+        assert result is None
+        db._conn.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_exact_library_artist_resolves_via_real_db(self, tmp_path):
+        """John Lennon / Don Lennon reproduces the exact bug scenario end to end.
+
+        A distractor artist ("Don Lennon") that would otherwise win the
+        candidate-cap race must not cause "John Lennon" -- already an exact
+        library artist -- to be corrected away.
+        """
+        import sqlite3
+
+        db_file = tmp_path / "test.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("""
+            CREATE TABLE library (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                artist TEXT,
+                call_letters TEXT,
+                artist_call_number INTEGER,
+                release_call_number INTEGER,
+                genre TEXT,
+                format TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE VIRTUAL TABLE library_fts USING fts5(
+                title, artist,
+                content='library', content_rowid='id'
+            )
+        """)
+        conn.execute(
+            "INSERT INTO library VALUES "
+            "(1, 'Double Fantasy', 'John Lennon', 'L', 1, 1, 'Rock', 'LP')"
+        )
+        conn.execute(
+            "INSERT INTO library VALUES (2, 'Some Album', 'Don Lennon', 'L', 2, 2, 'Rock', 'LP')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = LibraryDB(db_path=db_file)
+        await db.connect()
+
+        result = await db.find_similar_artist("John Lennon")
+        assert result is None
+        await db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -1477,6 +1565,7 @@ class TestLibraryDBFindSimilarArtistCache:
 
         mock_cursor = AsyncMock()
         mock_cursor.fetchall = AsyncMock(return_value=[FakeRow("Living Colour")])
+        mock_cursor.fetchone = AsyncMock(return_value=None)
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
 
@@ -1485,7 +1574,7 @@ class TestLibraryDBFindSimilarArtistCache:
 
         assert result1 == "Living Colour"
         assert result1 == result2
-        assert db._conn.execute.call_count == 1
+        assert db._conn.execute.call_count == 2
 
     @pytest.mark.asyncio
     async def test_find_similar_artist_caches_none(self):
@@ -1493,6 +1582,7 @@ class TestLibraryDBFindSimilarArtistCache:
         db = LibraryDB()
         mock_cursor = AsyncMock()
         mock_cursor.fetchall = AsyncMock(return_value=[])
+        mock_cursor.fetchone = AsyncMock(return_value=None)
         db._conn = AsyncMock()
         db._conn.execute = AsyncMock(return_value=mock_cursor)
 
@@ -1501,7 +1591,7 @@ class TestLibraryDBFindSimilarArtistCache:
 
         assert result1 is None
         assert result2 is None
-        assert db._conn.execute.call_count == 1
+        assert db._conn.execute.call_count == 2
 
 
 class TestLibraryDBCacheInvalidation:


### PR DESCRIPTION
## Summary

`find_similar_artist` could falsely "correct" a typed artist that already exists exactly in the library to a different, merely-similar-scoring distractor artist (`John Lennon` -> `Don Lennon`), because the candidate query was capped at `LIMIT 100` with no `ORDER BY`, letting it silently drop the exact self-match from the candidate set while a distractor survived. Once corrected, the two-channel library-search seam routes the wrong name, so the lookup collapses to a rowless Discogs-only fallback and never binds the WXYC library row.

Fix:
- Add an exact-match short-circuit (`_artist_exists_exactly`) that checks `artist`, `alternate_artist_name`, `album_artist`, and `compilation_track_artist` before any fuzzy candidate search runs. If the typed artist already exists exactly, return `None` immediately -- no correction.
- Order the fuzzy candidate query so an exact self-match always sorts first (`ORDER BY ... THEN 0 ELSE 1`), so it can no longer be dropped by the `LIMIT 100` cap even in the general (non-short-circuited) path.

## Test plan

- [x] Unit test reproducing the John Lennon / Don Lennon scenario against a real sqlite fixture, asserting no correction
- [x] Unit test asserting the exact-match short-circuit fires before the candidate query ever runs
- [x] Integration test asserting `POST /api/v1/lookup` for an exact library artist resolves to a non-zero `library_item.id`
- [x] Regression test confirming a genuine misspelling (`Stereolb` -> `Stereolab`) still corrects and binds its library row
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] Full non-pg/non-external-api test suite green (4755 passed)

Closes #857