### PR TITLE
fix(#771): normalize error-payload wire contract to ApiErrorResponse {message}

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,8 +11,12 @@ from typing import Any
 
 import sentry_sdk
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from wxyc_fastapi.observability import init_sentry, shutdown_posthog
 
 from artists.router import router as artists_router
@@ -30,6 +34,7 @@ from core.event_loop_lag import start_sampler, stop_sampler
 from core.logging import setup_logging
 from core.server_timing_middleware import LmlWallTimingMiddleware
 from discogs.router import router as discogs_router
+from generated.api_models import ApiErrorResponse
 from identity.dependencies import close_entity_store
 from identity.router import api_v1_router as identity_api_v1_router
 from identity.router import router as identity_router
@@ -505,6 +510,39 @@ app.add_middleware(
 # the window `lml_wall` is meant to measure — see
 # `core/server_timing_middleware.py` for what the leg measures and why.
 app.add_middleware(LmlWallTimingMiddleware)
+
+
+# LML#771: normalize every route's error body to wxyc-shared api.yaml's
+# ApiErrorResponse ({message, code?, details?}) instead of FastAPI's default
+# {detail}. DECISION LOCKED Option A (fix LML-side, no api.yaml change) — see
+# the issue for the rejected Option B. Registering a StarletteHTTPException
+# handler overrides FastAPI's default for every HTTPException app-wide, so
+# every route conforms without per-route edits. Wire status codes are
+# untouched; only the body shape changes.
+@app.exception_handler(StarletteHTTPException)
+async def _http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+    if isinstance(exc.detail, str):
+        payload = ApiErrorResponse(message=exc.detail)
+    else:
+        # Structured detail (e.g. core/bulk_body.py's parse_bulk_body raises
+        # detail=e.errors(), a list) stays machine-readable under `details`
+        # rather than being stringified — flattening it would regress #767's
+        # structured-errors win.
+        payload = ApiErrorResponse(
+            message="Request failed", details={"detail": jsonable_encoder(exc.detail)}
+        )
+    return JSONResponse(status_code=exc.status_code, content=payload.model_dump(exclude_none=True))
+
+
+@app.exception_handler(RequestValidationError)
+async def _validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    payload = ApiErrorResponse(
+        message="Request validation failed",
+        details={"errors": jsonable_encoder(exc.errors())},
+    )
+    return JSONResponse(status_code=422, content=payload.model_dump(exclude_none=True))
 
 
 # Health and admin keep their own auth posture:

--- a/tests/integration/test_artist_resolve_bulk.py
+++ b/tests/integration/test_artist_resolve_bulk.py
@@ -407,7 +407,7 @@ class TestArtistResolveQualifierSemantics:
             "/api/v1/artists/resolve/bulk", json={"names": ["Wishy", "   "]}
         )
         assert resp.status_code == 422
-        assert "names[1]" in resp.json()["detail"]
+        assert "names[1]" in resp.json()["message"]
 
         read = await app_client.get("/identity/resolve", params={"name": "Wishy"})
         assert read.status_code == 404

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -519,7 +519,7 @@ class TestIdentityRouterEntityStoreUnavailable:
             resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
 
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_bulk_returns_503_when_entity_schema_missing(self, app_with_pg_dsn):

--- a/tests/integration/test_error_resilience.py
+++ b/tests/integration/test_error_resilience.py
@@ -408,7 +408,7 @@ class TestEntityStoreGracefulDegradation:
             "/identity/resolve", params={"name": "Stereolab"}
         )
         assert resp.status_code == 503
-        assert "not available" in resp.json()["detail"].lower()
+        assert "not available" in resp.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_bulk_returns_503_when_entity_store_unavailable(self, app_client_no_entity_store):

--- a/tests/unit/test_admin_router.py
+++ b/tests/unit/test_admin_router.py
@@ -186,7 +186,7 @@ class TestUploadLibraryDB:
                     )
 
         assert resp.status_code == 400
-        assert "Invalid SQLite database" in resp.json()["detail"]
+        assert "Invalid SQLite database" in resp.json()["message"]
 
     @pytest.mark.asyncio
     async def test_sqlite_missing_library_table(self, tmp_path, admin_settings):
@@ -220,7 +220,7 @@ class TestUploadLibraryDB:
                     )
 
         assert resp.status_code == 400
-        assert "Invalid SQLite database" in resp.json()["detail"]
+        assert "Invalid SQLite database" in resp.json()["message"]
 
     @pytest.mark.asyncio
     async def test_missing_auth_header(self, admin_settings):
@@ -247,7 +247,7 @@ class TestUploadLibraryDB:
                 )
 
         assert resp.status_code == 401
-        assert resp.json()["detail"] == "Missing authorization"
+        assert resp.json()["message"] == "Missing authorization"
 
     @pytest.mark.asyncio
     async def test_wrong_bearer_token(self, admin_settings):
@@ -275,7 +275,7 @@ class TestUploadLibraryDB:
                 )
 
         assert resp.status_code == 403
-        assert resp.json()["detail"] == "Invalid token"
+        assert resp.json()["message"] == "Invalid token"
 
     @pytest.mark.asyncio
     async def test_no_admin_token_configured(self, no_token_settings):
@@ -764,7 +764,7 @@ class TestDownloadStreamingDB:
 
         resp = await self._get(app, admin_settings)
         assert resp.status_code == 401
-        assert resp.json()["detail"] == "Missing authorization"
+        assert resp.json()["message"] == "Missing authorization"
 
     @pytest.mark.asyncio
     async def test_malformed_auth_header(self, admin_settings):
@@ -773,7 +773,7 @@ class TestDownloadStreamingDB:
 
         resp = await self._get(app, admin_settings, headers={"Authorization": "test-secret-token"})
         assert resp.status_code == 403
-        assert resp.json()["detail"] == "Invalid token"
+        assert resp.json()["message"] == "Invalid token"
 
     @pytest.mark.asyncio
     async def test_wrong_bearer_token(self, admin_settings):
@@ -782,7 +782,7 @@ class TestDownloadStreamingDB:
 
         resp = await self._get(app, admin_settings, headers={"Authorization": "Bearer wrong-token"})
         assert resp.status_code == 403
-        assert resp.json()["detail"] == "Invalid token"
+        assert resp.json()["message"] == "Invalid token"
 
     @pytest.mark.asyncio
     async def test_no_admin_token_configured(self, no_token_settings):
@@ -807,7 +807,7 @@ class TestDownloadStreamingDB:
             app, admin_settings, headers={"Authorization": "Bearer test-secret-token"}
         )
         assert resp.status_code == 404
-        assert "streaming_availability.db" in resp.json()["detail"]
+        assert "streaming_availability.db" in resp.json()["message"]
 
     @pytest.mark.asyncio
     async def test_successful_download(self, admin_settings):

--- a/tests/unit/test_admin_streaming_guard.py
+++ b/tests/unit/test_admin_streaming_guard.py
@@ -348,7 +348,7 @@ class TestUploadStreamingGuard:
 
         resp = await self._upload(app, admin_settings, upload)
         assert resp.status_code == 409
-        regs = resp.json()["detail"]["regressions"]
+        regs = resp.json()["details"]["detail"]["regressions"]
         assert any(r["metric"] == "apple_url" for r in regs)
         # On-disk file is untouched.
         assert vol.read_bytes() == before
@@ -377,7 +377,7 @@ class TestUploadStreamingGuard:
 
         resp = await self._upload(app, admin_settings, upload)
         assert resp.status_code == 409
-        regs = resp.json()["detail"]["regressions"]
+        regs = resp.json()["details"]["detail"]["regressions"]
         assert any(r["metric"] == "track_results" for r in regs)
 
     @pytest.mark.asyncio
@@ -457,7 +457,7 @@ class TestUploadStreamingGuard:
 
         resp = await self._upload(app, admin_settings, upload)
         assert resp.status_code == 409
-        detail = resp.json()["detail"]
+        detail = resp.json()["details"]["detail"]
         assert "error" in detail
         assert "regressions" not in detail
 

--- a/tests/unit/test_admin_streaming_store_bucket.py
+++ b/tests/unit/test_admin_streaming_store_bucket.py
@@ -150,7 +150,7 @@ class TestUploadBucketGuard:
 
         resp = await _upload(app, admin_settings, s3_store, upload)
         assert resp.status_code == 409
-        regs = resp.json()["detail"]["regressions"]
+        regs = resp.json()["details"]["detail"]["regressions"]
         assert any(r["metric"] == "apple_url" for r in regs)
         # The object in the bucket is left untouched.
         assert await _apple_count_in_store(s3_store, tmp_path) == 288
@@ -180,7 +180,7 @@ class TestUploadBucketGuard:
 
         resp = await _upload(app, admin_settings, s3_store, upload)
         assert resp.status_code == 409
-        detail = resp.json()["detail"]
+        detail = resp.json()["details"]["detail"]
         assert "error" in detail
         assert "regressions" not in detail
         # The corrupt object is left untouched.

--- a/tests/unit/test_admin_tombstone_router.py
+++ b/tests/unit/test_admin_tombstone_router.py
@@ -102,6 +102,11 @@ async def test_exists_not_tombstone_returns_404_with_distinct_detail(client):
         headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
     )
     assert resp.status_code == 404
+    # This test mounts an isolated FastAPI() with only admin_router (not
+    # main.app), so the LML#771 ApiErrorResponse handlers registered on
+    # main.app don't apply here — the router itself still raises the same
+    # structured HTTPException; FastAPI's default `{"detail": ...}` shape is
+    # what's on the wire for this isolated app.
     body = resp.json()["detail"]
     assert body["detail"] == "row exists but is not a tombstone"
     assert body["id"] == 42

--- a/tests/unit/test_artist_resolve_router.py
+++ b/tests/unit/test_artist_resolve_router.py
@@ -247,7 +247,7 @@ class TestBodyParse:
         with ctx:
             resp = await _post(app, {"names": ["Wishy"]})
         assert resp.status_code == 400
-        assert "disconnected" in resp.json()["detail"]
+        assert "disconnected" in resp.json()["message"]
 
 
 class TestServiceUnavailable:
@@ -262,7 +262,7 @@ class TestServiceUnavailable:
         with ctx:
             resp = await _post(app, {"names": ["Wishy"]})
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_503_when_discogs_cache_none(self, make_app):
@@ -272,7 +272,7 @@ class TestServiceUnavailable:
         with ctx:
             resp = await _post(app, {"names": ["Wishy"]})
         assert resp.status_code == 503
-        assert resp.json()["detail"] == _DISCOGS_CACHE_UNAVAILABLE_DETAIL
+        assert resp.json()["message"] == _DISCOGS_CACHE_UNAVAILABLE_DETAIL
 
 
 class TestErrorClassRouting:
@@ -292,7 +292,7 @@ class TestErrorClassRouting:
         assert resp.status_code == 503
         # The TRANSIENT-shaped detail, not the dependency-gate config hint —
         # the deps were wired; the query failed mid-flight.
-        assert resp.json()["detail"] == _DISCOGS_CACHE_QUERY_FAILED_DETAIL
+        assert resp.json()["message"] == _DISCOGS_CACHE_QUERY_FAILED_DETAIL
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -326,7 +326,7 @@ class TestErrorClassRouting:
             resp = await _post(app, {"names": ["Wishy"]})
 
         assert resp.status_code == 503
-        assert resp.json()["detail"] == _ENTITY_STORE_QUERY_FAILED_DETAIL
+        assert resp.json()["message"] == _ENTITY_STORE_QUERY_FAILED_DETAIL
 
     @pytest.mark.asyncio
     async def test_cancelled_error_logs_abort_and_propagates(
@@ -450,7 +450,7 @@ class TestInvalidNameErrorMapping:
             resp = await _post(app, {"names": ["Wishy", bad_name]})
 
         assert resp.status_code == 422
-        assert "names[1]" in resp.json()["detail"]
+        assert "names[1]" in resp.json()["message"]
         # Validation precedes every tier.
         mock_entity_store.bulk_resolve_library_names.assert_not_awaited()
 
@@ -465,7 +465,7 @@ class TestRouteEnvelopeGaps:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 resp = await ac.post(_ROUTE, json=["Wishy"])
         assert resp.status_code == 400
-        assert "JSON object" in resp.json()["detail"]
+        assert "JSON object" in resp.json()["message"]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/unit/test_artist_search_aliases_router.py
+++ b/tests/unit/test_artist_search_aliases_router.py
@@ -108,7 +108,7 @@ class TestErrorClassRouting:
         # config hint (deps were wired; the query failed).
         from artists.router import _DISCOGS_CACHE_QUERY_FAILED_DETAIL
 
-        assert resp.json()["detail"] == _DISCOGS_CACHE_QUERY_FAILED_DETAIL
+        assert resp.json()["message"] == _DISCOGS_CACHE_QUERY_FAILED_DETAIL
 
     @pytest.mark.asyncio
     async def test_entity_store_pg_failure_returns_503_with_entity_detail(
@@ -131,7 +131,7 @@ class TestErrorClassRouting:
         assert resp.status_code == 503
         from artists.router import _ENTITY_STORE_QUERY_FAILED_DETAIL
 
-        assert resp.json()["detail"] == _ENTITY_STORE_QUERY_FAILED_DETAIL
+        assert resp.json()["message"] == _ENTITY_STORE_QUERY_FAILED_DETAIL
 
     @pytest.mark.asyncio
     async def test_asyncpg_interface_error_returns_503_not_500(self, app_client, mock_entity_store):
@@ -155,7 +155,7 @@ class TestErrorClassRouting:
         assert resp.status_code == 503
         from artists.router import _ENTITY_STORE_QUERY_FAILED_DETAIL
 
-        assert resp.json()["detail"] == _ENTITY_STORE_QUERY_FAILED_DETAIL
+        assert resp.json()["message"] == _ENTITY_STORE_QUERY_FAILED_DETAIL
 
     @pytest.mark.asyncio
     async def test_cancelled_error_logs_abort_and_propagates(
@@ -299,7 +299,7 @@ class TestServiceUnavailable:
                 )
 
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_503_when_discogs_cache_none(self, mock_settings, mock_entity_store):
@@ -332,7 +332,7 @@ class TestServiceUnavailable:
         assert resp.status_code == 503
         from artists.router import _DISCOGS_CACHE_UNAVAILABLE_DETAIL
 
-        assert resp.json()["detail"] == _DISCOGS_CACHE_UNAVAILABLE_DETAIL
+        assert resp.json()["message"] == _DISCOGS_CACHE_UNAVAILABLE_DETAIL
 
 
 class TestEntityStoreDetailConsolidation:

--- a/tests/unit/test_bulk_lookup_endpoint.py
+++ b/tests/unit/test_bulk_lookup_endpoint.py
@@ -591,7 +591,7 @@ class TestBulkLookupEndpoint:
                 )
 
         assert resp.status_code == 400
-        assert "malformed json" in resp.json()["detail"].lower()
+        assert "malformed json" in resp.json()["message"].lower()
         mock_lookup.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1317,7 +1317,7 @@ class TestBulkLookupFamilyAlignment:
                 )
 
         assert resp.status_code == 400
-        assert "disconnected" in resp.json()["detail"].lower()
+        assert "disconnected" in resp.json()["message"].lower()
         mock_lookup.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1332,7 +1332,7 @@ class TestBulkLookupFamilyAlignment:
                 resp = await ac.post("/api/v1/lookup/bulk", json={})
 
         assert resp.status_code == 422
-        detail = resp.json()["detail"]
+        detail = resp.json()["details"]["detail"]
         assert isinstance(detail, list)
         assert detail[0]["loc"] == ["items"]
         assert detail[0]["type"] == "missing"

--- a/tests/unit/test_bulk_resolve_libraries_endpoint.py
+++ b/tests/unit/test_bulk_resolve_libraries_endpoint.py
@@ -1137,7 +1137,7 @@ class TestBulkResolveFamilyAlignment:
             )
 
         assert resp.status_code == 400
-        assert "disconnected" in resp.json()["detail"].lower()
+        assert "disconnected" in resp.json()["message"].lower()
         mock_entity_store.resolve_library_name.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1151,7 +1151,7 @@ class TestBulkResolveFamilyAlignment:
             resp = await ac.post("/api/v1/identity/bulk-resolve-libraries", json={})
 
         assert resp.status_code == 422
-        detail = resp.json()["detail"]
+        detail = resp.json()["details"]["detail"]
         assert isinstance(detail, list)
         assert detail[0]["loc"] == ["inputs"]
         assert detail[0]["type"] == "missing"

--- a/tests/unit/test_cache_refresh_endpoint.py
+++ b/tests/unit/test_cache_refresh_endpoint.py
@@ -117,7 +117,7 @@ class TestCacheRefreshEntityStoreUnavailable:
                 )
 
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
 
 class TestCacheRefreshFamilyAlignment:
@@ -166,7 +166,7 @@ class TestCacheRefreshFamilyAlignment:
             )
 
         assert resp.status_code == 400
-        assert "disconnected" in resp.json()["detail"].lower()
+        assert "disconnected" in resp.json()["message"].lower()
         mock_entity_store.get_release_identity_provenance_bulk.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -182,7 +182,7 @@ class TestCacheRefreshFamilyAlignment:
             resp = await ac.post("/api/v1/cache/refresh-for-identities", json={})
 
         assert resp.status_code == 422
-        detail = resp.json()["detail"]
+        detail = resp.json()["details"]["detail"]
         assert isinstance(detail, list)
         assert detail[0]["loc"] == ["identity_ids"]
         assert detail[0]["type"] == "missing"

--- a/tests/unit/test_error_payload_shape.py
+++ b/tests/unit/test_error_payload_shape.py
@@ -1,0 +1,186 @@
+"""Unit tests for the app-level error-payload normalization (LML#771).
+
+Every LML route used to emit FastAPI's default `{"detail": ...}` error body,
+while wxyc-shared's `api.yaml` `ApiErrorResponse` schema promises
+`{"message": ..., "code": ..., "details": ...}`. `main.py` registers a
+`StarletteHTTPException` handler and a `RequestValidationError` handler that
+reshape every route's error body to the `ApiErrorResponse` contract without
+per-route edits (DECISION LOCKED on #771: Option A, no api.yaml change).
+
+This file pins the shape for one representative route per status class
+(400 / 413 / 422 / 503) plus the 499 client-disconnect non-regression guard.
+Route-specific status/detail-string assertions stay in each route's own test
+file; this file only asserts the *envelope* the handlers produce.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from artists.router import _GENRES_INPUT_CAP
+from config.settings import get_settings
+from core.dependencies import get_discogs_cache_service_from_pool, get_discogs_service
+from discogs.cache_service import DiscogsCacheService
+from tests.unit.conftest import override_deps
+
+_GENRES_ROUTE = "/api/v1/artists/genres/bulk"
+
+
+@pytest.fixture
+def mock_cache():
+    cache = AsyncMock(spec=DiscogsCacheService)
+    cache.aggregate_artist_genre_style = AsyncMock(return_value=({}, {}))
+    cache.get_artist_details_bulk = AsyncMock(return_value={})
+    return cache
+
+
+@pytest.fixture
+def app_client(mock_settings, mock_cache):
+    from main import app
+
+    with override_deps(
+        app,
+        {
+            get_settings: mock_settings,
+            get_discogs_cache_service_from_pool: mock_cache,
+            get_discogs_service: None,
+        },
+    ):
+        yield app
+
+
+async def _post(app, path, *, json_body=None, content=None):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        if content is not None:
+            return await ac.post(
+                path, content=content, headers={"Content-Type": "application/json"}
+            )
+        return await ac.post(path, json=json_body)
+
+
+def _assert_envelope(body: dict) -> None:
+    """Every normalized error body carries `message` and never a top-level `detail`."""
+    assert "detail" not in body
+    assert isinstance(body["message"], str) and body["message"]
+
+
+class TestHttpExceptionEnvelope:
+    """Plain-string `HTTPException(detail=...)` -> `{"message": <that string>}`."""
+
+    @pytest.mark.asyncio
+    async def test_400_malformed_json_body(self, app_client):
+        resp = await _post(app_client, _GENRES_ROUTE, content=b"not json {")
+
+        assert resp.status_code == 400
+        body = resp.json()
+        _assert_envelope(body)
+        assert "Malformed JSON body" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_413_batch_over_cap(self, app_client):
+        artists = [{"artist_name": f"Artist {i}"} for i in range(_GENRES_INPUT_CAP + 1)]
+        resp = await _post(app_client, _GENRES_ROUTE, json_body={"artists": artists})
+
+        assert resp.status_code == 413
+        body = resp.json()
+        _assert_envelope(body)
+        assert "cap" in body["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_503_cache_unavailable(self, mock_settings):
+        # Force the dependency-gate 503: discogs_cache is None.
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_settings: mock_settings,
+                get_discogs_cache_service_from_pool: None,
+                get_discogs_service: None,
+            },
+        ):
+            resp = await _post(
+                app, _GENRES_ROUTE, json_body={"artists": [{"artist_name": "Stereolab"}]}
+            )
+
+        assert resp.status_code == 503
+        body = resp.json()
+        _assert_envelope(body)
+
+    @pytest.mark.asyncio
+    async def test_422_structured_bulk_validation_error_preserved_under_details(self, app_client):
+        """A bulk route's hand-raised `HTTPException(detail=e.errors())` (a
+        Pydantic `errors()` list, from `core/bulk_body.py::parse_bulk_body`)
+        must not be flattened to an opaque string (#767 regression guard) —
+        it stays a machine-readable list under `details.detail`.
+        """
+        resp = await _post(app_client, _GENRES_ROUTE, json_body={"artists": []})
+
+        assert resp.status_code == 422
+        body = resp.json()
+        _assert_envelope(body)
+        assert body["message"] == "Request failed"
+        errors = body["details"]["detail"]
+        assert isinstance(errors, list) and errors
+        assert all("type" in e and "loc" in e for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_499_client_disconnect_status_unchanged(self, app_client):
+        """A client-disconnect 499 (raised as a plain `HTTPException`) keeps
+        its status code — only the body shape changes, matching every other
+        route. Genuine mid-flight cancellation (`asyncio.CancelledError`) is a
+        `BaseException`, so it is never caught by either handler and still
+        propagates unconverted.
+        """
+
+        async def _always_disconnected(self):
+            return True
+
+        # is_disconnected is read off the raw Starlette Request, not a DI seam,
+        # so patch it directly rather than through dependency_overrides.
+        from starlette.requests import Request as StarletteRequest
+
+        original = StarletteRequest.is_disconnected
+        StarletteRequest.is_disconnected = _always_disconnected
+        try:
+            resp = await _post(
+                app_client, _GENRES_ROUTE, json_body={"artists": [{"artist_name": "Stereolab"}]}
+            )
+        finally:
+            StarletteRequest.is_disconnected = original
+
+        assert resp.status_code == 499
+
+
+class TestRequestValidationErrorEnvelope:
+    """Framework-level (`Query`/typed-`Body`) validation -> the 422 handler."""
+
+    @pytest.mark.asyncio
+    async def test_422_framework_validation_error(self, mock_settings):
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from identity.dependencies import get_entity_store
+        from main import app
+
+        with override_deps(
+            app,
+            {
+                get_library_db: AsyncMock(),
+                get_discogs_service: None,
+                get_posthog_client: None,
+                get_settings: mock_settings,
+                get_entity_store: AsyncMock(),
+            },
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                resp = await ac.get("/identity/resolve")  # missing required `name` query param
+
+        assert resp.status_code == 422
+        body = resp.json()
+        _assert_envelope(body)
+        assert body["message"] == "Request validation failed"
+        errors = body["details"]["errors"]
+        assert isinstance(errors, list) and errors
+        assert errors[0]["loc"] == ["query", "name"]

--- a/tests/unit/test_identity_router.py
+++ b/tests/unit/test_identity_router.py
@@ -98,7 +98,7 @@ class TestResolveEndpoint:
             resp = await ac.get("/identity/resolve", params={"name": "Nonexistent"})
 
         assert resp.status_code == 404
-        assert "Nonexistent" in resp.json()["detail"]
+        assert "Nonexistent" in resp.json()["message"]
 
     @pytest.mark.asyncio
     async def test_resolve_missing_param(self, app_client):
@@ -209,7 +209,7 @@ class TestEntityStoreUnavailable:
                 resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
 
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_bulk_returns_503_when_store_unavailable(self, mock_settings):
@@ -233,7 +233,7 @@ class TestEntityStoreUnavailable:
                 resp = await ac.post("/identity/bulk", json={"names": ["Stereolab"]})
 
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_release_identity_resolve_returns_503_when_store_unavailable(self, mock_settings):
@@ -260,7 +260,7 @@ class TestEntityStoreUnavailable:
                 )
 
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_resolve_returns_503_when_pg_raises_undefined_table(
@@ -277,7 +277,7 @@ class TestEntityStoreUnavailable:
             resp = await ac.get("/identity/resolve", params={"name": "Stereolab"})
 
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_resolve_returns_503_when_pg_unreachable(self, app_client, mock_entity_store):
@@ -317,7 +317,7 @@ class TestEntityStoreUnavailable:
             )
 
         assert resp.status_code == 503
-        assert "entity store" in resp.json()["detail"].lower()
+        assert "entity store" in resp.json()["message"].lower()
 
 
 class TestInterfaceErrorMapping:

--- a/tests/unit/test_streaming_check_router.py
+++ b/tests/unit/test_streaming_check_router.py
@@ -348,7 +348,7 @@ async def test_telemetry_failure_on_error_path_preserves_500(telemetry_app_clien
             )
 
     assert resp.status_code == 500
-    assert resp.json()["detail"] == "Streaming check failed"
+    assert resp.json()["message"] == "Streaming check failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Every LML route emitted FastAPI's default `{detail}` error body while wxyc-shared's `api.yaml` `ApiErrorResponse` schema promises `{message, code?, details?}`, so a client generating types from `api.yaml` never saw the field the service actually sent.

Per the DECISION LOCKED comment on the issue (Option A), `main.py` now registers app-level `StarletteHTTPException` and `RequestValidationError` handlers that reshape every route's error body to the `ApiErrorResponse` contract without touching individual routes or `api.yaml`. A string `HTTPException.detail` becomes `message` verbatim; a structured `detail` (e.g. `core/bulk_body.py`'s `parse_bulk_body` raising `detail=e.errors()`) is kept machine-readable under `details` rather than stringified, preserving #767's structured-errors win. Framework-level `RequestValidationError` gets its own handler so FastAPI's built-in validation 422s conform too. Wire status codes are untouched, and 499/client-disconnect (`CancelledError`, a `BaseException`) is unaffected since these are `Exception` handlers.

## Test plan

- [x] `tests/unit/test_error_payload_shape.py` (new) pins the `ApiErrorResponse` shape for one representative route per status class: 400, 413, 422 (both a bulk `HTTPException(detail=e.errors())` path and a framework `RequestValidationError` path), 503, plus a 499 client-disconnect regression guard
- [x] Existing test suite's error-shape assertions updated (`detail` -> `message`/`details`) across affected unit/integration tests
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy main.py --ignore-missing-imports` clean
- [x] Full unit + integration suite green (`pytest -m "not pg and not external_api and not stack"`)

Closes #771