### PR TITLE
Switch the streaming-URL cache service CHECK to widen-only maintenance

### DIFF
--- a/entity/streaming_url_cache.py
+++ b/entity/streaming_url_cache.py
@@ -36,7 +36,8 @@ PG failures degrade to a no-op: ``get`` returns ``None``, ``set`` swallows
 the exception. The caller (``lookup/streaming_url_postprocess.py``) then falls
 through to the live probe as if no cache were configured. Schema bootstrap
 (``set_up_streaming_url_cache_schema``) is called from ``main.py`` lifespan;
-the DDL is ``IF NOT EXISTS`` so re-running on every boot is safe.
+the schema/table DDL is ``IF NOT EXISTS`` and the service CHECK is maintained
+by a widen-only DO block (LML#886), so re-running on every boot is safe.
 
 **Timeout relocation (LML#573, preempts #594).** Unlike LML#571's resolver,
 ``resolve_streaming_url_with_cache`` does NOT wrap the live probe in
@@ -74,21 +75,21 @@ DEFAULT_MISS_TTL = timedelta(days=7)
 
 # The services the cache ships. The named CHECK constraint pins this set at
 # the DB level; a future PR adding a service (Deezer's 'deezer_album') extends
-# this tuple and the ALTER below picks it up. Kept as a module constant so the
-# bootstrap DDL and a parity test can both reference it without re-typing the
-# literal. PR-3 added 'bandcamp'.
+# this tuple and the widen DO block below picks it up. Kept as a module
+# constant so the bootstrap DDL and a parity test can both reference it
+# without re-typing the literal. PR-3 added 'bandcamp'.
 _SERVICES = ("apple_music_album", "spotify_album", "bandcamp")
 
-# Shared IN-list literal so the CREATE-time CHECK and the idempotent ALTER are
-# generated from the same source — they can never drift.
+# Shared IN-list literal so the CREATE-time CHECK and the widen DO block's
+# code-side array are generated from the same source — they can never drift.
 _SERVICE_IN_LIST = ", ".join(f"'{s}'" for s in _SERVICES)
 
 _DDL_SCHEMA = "CREATE SCHEMA IF NOT EXISTS lml_cache"
 
 # Named CHECK constraint (``album_streaming_url_cache_service_valid``) avoids
-# reliance on PG auto-naming so the ALTER below can DROP/ADD it by name. The
-# service-value list is generated from ``_SERVICES`` so the two stay in
-# lockstep.
+# reliance on PG auto-naming so the widen DO block below can manage it by
+# name. The service-value list is generated from ``_SERVICES`` so the two
+# stay in lockstep.
 _DDL_TABLE = f"""\
 CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
     service TEXT NOT NULL,
@@ -103,24 +104,73 @@ CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
 )\
 """
 
-# Idempotent widen of the named CHECK. ``CREATE TABLE IF NOT EXISTS`` is a
-# no-op on an already-created prod table, so a new service value added to
-# ``_SERVICES`` would never reach an existing table without this ALTER. The
-# DROP-IF-EXISTS + ADD pair is byte-stable across boots and runs atomically
-# within the single statement. Note ``ADD CONSTRAINT … CHECK`` is NOT a metadata
-# no-op even when the constraint text is unchanged: PostgreSQL re-validates every
-# existing row (a brief seq scan under an ACCESS EXCLUSIVE lock) on each boot.
-# That cost is acceptable here — this cache table is modest and the bootstrap
-# runs once per process start, not per request — and the set only ever grows, so
-# existing apple/spotify/bandcamp rows always pass. Driven from the same
-# ``_SERVICE_IN_LIST`` as the CREATE so the two can't drift.
-_DDL_ALTER_CHECK = f"""\
-ALTER TABLE lml_cache.album_streaming_url_cache
-    DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid,
-    ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK (
-        service IN ({_SERVICE_IN_LIST})
-    )\
+# Widen-only maintenance of the named service CHECK (ported from
+# ``entity/streaming_catalog.py``'s ``_DDL_ALBUM_SERVICE_WIDEN_CHECK``,
+# LML#886). A static DROP+ADD (this module's prior pattern) would (a) take an
+# ACCESS EXCLUSIVE lock plus a full re-validation scan on EVERY boot even
+# though the steady-state constraint is already correct, and (b) narrow the
+# constraint under a rollback deploy — the ALTER is generated from the
+# shipped ``_SERVICES`` tuple, so deploying an older build against a table
+# whose rows already use a newer service value fails validation and aborts
+# the whole bootstrap transaction. This DO block instead deparses the
+# deployed constraint, extracts its quoted literals, and rewrites only when
+# the shipped ``_SERVICES`` adds something — merging, never narrowing, and
+# leaving the constraint (and its OID) untouched on a steady-state boot. The
+# rewrite must emit the ``service IN (...)`` form: PG deparses IN as ``= ANY
+# (ARRAY[...])`` and the extraction reads the quoted literals out of that
+# deparse, whereas an array-literal Const (``'{...}'::text[]``) deparses as
+# ONE literal and would corrupt the next boot's extraction. When the
+# constraint is ABSENT (dropped out-of-band), the re-ADD folds in every
+# service value already live in the table, so the recovery boot's
+# re-validation can't fail against collected out-of-set rows — which would
+# otherwise abort EVERY subsequent bootstrap until manual repair.
+_DDL_SERVICE_WIDEN_CHECK = f"""\
+DO $cache_check$
+DECLARE
+    existing_def text;
+    existing_services text[];
+    code_services text[] := ARRAY[
+        {_SERVICE_IN_LIST}];
+    merged_list text;
+BEGIN
+    SELECT pg_get_constraintdef(oid) INTO existing_def
+        FROM pg_constraint
+        WHERE conrelid = 'lml_cache.album_streaming_url_cache'::regclass
+            AND conname = 'album_streaming_url_cache_service_valid';
+    IF existing_def IS NOT NULL THEN
+        SELECT array_agg(m[1]) INTO existing_services
+            FROM regexp_matches(existing_def, '''([^'']+)''', 'g') AS m;
+        IF existing_services @> code_services THEN
+            RETURN;
+        END IF;
+    ELSE
+        SELECT array_agg(DISTINCT service) INTO existing_services
+            FROM lml_cache.album_streaming_url_cache;
+    END IF;
+    SELECT string_agg(DISTINCT quote_literal(s), ', ' ORDER BY quote_literal(s))
+        INTO merged_list
+        FROM unnest(coalesce(existing_services, ARRAY[]::text[]) || code_services) AS s;
+    EXECUTE 'ALTER TABLE lml_cache.album_streaming_url_cache '
+        'DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid, '
+        'ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK (service IN ('
+        || merged_list || '))';
+END;
+$cache_check$\
 """
+
+# Bootstrap preamble, run inside the single wrapping transaction:
+#
+# - ``lock_timeout`` bounds how long boot DDL waits behind a conflicting lock
+#   instead of queueing indefinitely and stalling the lifespan.
+# - ``pg_advisory_xact_lock`` serializes concurrent bootstraps so two
+#   simultaneous boots can't interleave the widen block's deparse/rewrite
+#   steps. Key 886001 = LML#886; arbitrary but stable, auto-released at
+#   COMMIT/ROLLBACK. Advisory keys share one keyspace per database — record
+#   new discogs-cache advisory keys in discogs-etl's CLAUDE.md before
+#   allocating another (842001 is ``entity/streaming_catalog.py``'s).
+_BOOTSTRAP_ADVISORY_LOCK_KEY = 886001
+_BOOTSTRAP_LOCK_TIMEOUT = "SET LOCAL lock_timeout = '10s'"
+_BOOTSTRAP_ADVISORY_LOCK = f"SELECT pg_advisory_xact_lock({_BOOTSTRAP_ADVISORY_LOCK_KEY})"
 
 # Staleness lives in the WHERE clause (LML#576). ``$1`` is the service key,
 # ``$4`` the lower bound on ``last_checked_at`` for a "fresh" known miss
@@ -158,14 +208,26 @@ async def set_up_streaming_url_cache_schema(pg: PgSource) -> None:
     caller logs and continues; the cache layer degrades to a no-op until the
     next deploy.
 
-    The final ALTER widens the named CHECK constraint to the current
-    ``_SERVICES`` set. ``CREATE TABLE IF NOT EXISTS`` cannot add a value to an
-    already-created table's constraint, so without the ALTER a prod table frozen
-    at an older service set would reject UPSERTs for a newly-added service.
+    Runs as a single transaction on one pooled connection, behind the
+    ``lock_timeout`` + advisory-lock preamble (ported from
+    ``entity/streaming_catalog.py``'s bootstrap convention, LML#886): the rare
+    widen-block rewrite (DROP + ADD) is otherwise non-atomic, and two
+    concurrent boots could interleave its deparse/rewrite steps.
+
+    The final DO block widens the named CHECK constraint to the current
+    ``_SERVICES`` set, merging rather than narrowing (see
+    ``_DDL_SERVICE_WIDEN_CHECK``). ``CREATE TABLE IF NOT EXISTS`` cannot add a
+    value to an already-created table's constraint, so without it a prod
+    table frozen at an older service set would reject UPSERTs for a
+    newly-added service.
     """
-    await pg.execute(_DDL_SCHEMA)
-    await pg.execute(_DDL_TABLE)
-    await pg.execute(_DDL_ALTER_CHECK)
+    async with pg.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(_BOOTSTRAP_LOCK_TIMEOUT)
+            await conn.execute(_BOOTSTRAP_ADVISORY_LOCK)
+            await conn.execute(_DDL_SCHEMA)
+            await conn.execute(_DDL_TABLE)
+            await conn.execute(_DDL_SERVICE_WIDEN_CHECK)
 
 
 @dataclass(frozen=True)

--- a/entity/streaming_url_cache.sql
+++ b/entity/streaming_url_cache.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
     -- Service discriminator. The named CHECK constraint pins the allowed set
     -- so a typo'd service key fails loudly at write time rather than minting a
     -- silently-unreadable row. PR-3 added 'bandcamp'; a new service is added by
-    -- extending this list AND the idempotent ALTER below (the runtime drives
+    -- extending this list AND the widen DO block below (the runtime drives
     -- both from `_SERVICES`).
     service TEXT NOT NULL,
     artist_normalized TEXT NOT NULL,
@@ -41,13 +41,50 @@ CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache (
     )
 );
 
--- Idempotent widen of the named CHECK so an already-created table (where
--- `CREATE TABLE IF NOT EXISTS` is a no-op) picks up service values added after
--- its creation. Byte-stable across boots; runs atomically within the one
--- statement. The runtime (`set_up_streaming_url_cache_schema`) issues this on
--- every boot, generated from `_SERVICES`.
-ALTER TABLE lml_cache.album_streaming_url_cache
-    DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid,
-    ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK (
-        service IN ('apple_music_album', 'spotify_album', 'bandcamp')
-    );
+-- Widen-only maintenance of the named service CHECK (LML#886, ported from
+-- `entity/streaming_catalog.py`'s `_DDL_ALBUM_SERVICE_WIDEN_CHECK`), so an
+-- already-created table (where `CREATE TABLE IF NOT EXISTS` is a no-op)
+-- picks up service values added after its creation. Deparses the deployed
+-- constraint, extracts its quoted literals, and rewrites only when the
+-- shipped set adds something — merging, never narrowing (a rollback deploy
+-- must not abort the bootstrap against rows using a newer service), and
+-- skipping the rewrite entirely on a steady-state boot (stable constraint
+-- OID, no ACCESS EXCLUSIVE lock, no re-validation scan). The rewrite emits
+-- the IN (...) form on purpose: PG deparses IN as = ANY (ARRAY[...]) and the
+-- extraction reads quoted literals from that deparse; an array-literal
+-- constant would deparse as ONE literal and corrupt the next boot's
+-- extraction. When the constraint is ABSENT (dropped out-of-band), the
+-- re-ADD folds in every service value already live in the table, so a
+-- recovery boot can't brick on rows outside the shipped set.
+
+DO $cache_check$
+DECLARE
+    existing_def text;
+    existing_services text[];
+    code_services text[] := ARRAY[
+        'apple_music_album', 'spotify_album', 'bandcamp'];
+    merged_list text;
+BEGIN
+    SELECT pg_get_constraintdef(oid) INTO existing_def
+        FROM pg_constraint
+        WHERE conrelid = 'lml_cache.album_streaming_url_cache'::regclass
+            AND conname = 'album_streaming_url_cache_service_valid';
+    IF existing_def IS NOT NULL THEN
+        SELECT array_agg(m[1]) INTO existing_services
+            FROM regexp_matches(existing_def, '''([^'']+)''', 'g') AS m;
+        IF existing_services @> code_services THEN
+            RETURN;
+        END IF;
+    ELSE
+        SELECT array_agg(DISTINCT service) INTO existing_services
+            FROM lml_cache.album_streaming_url_cache;
+    END IF;
+    SELECT string_agg(DISTINCT quote_literal(s), ', ' ORDER BY quote_literal(s))
+        INTO merged_list
+        FROM unnest(coalesce(existing_services, ARRAY[]::text[]) || code_services) AS s;
+    EXECUTE 'ALTER TABLE lml_cache.album_streaming_url_cache '
+        'DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid, '
+        'ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK (service IN ('
+        || merged_list || '))';
+END;
+$cache_check$;

--- a/tests/integration/test_streaming_url_persistent_lookup.py
+++ b/tests/integration/test_streaming_url_persistent_lookup.py
@@ -45,6 +45,12 @@ _SERVICE_CASES = [
     ("bandcamp", "https://juanamolina.bandcamp.com/album/doga"),
 ]
 
+_SERVICE_CHECK_OID = (
+    "SELECT oid FROM pg_constraint "
+    "WHERE conname = 'album_streaming_url_cache_service_valid' "
+    "AND conrelid = 'lml_cache.album_streaming_url_cache'::regclass"
+)
+
 
 @pytest_asyncio.fixture
 async def pg_pool(pg_pool_large):
@@ -153,6 +159,58 @@ class TestSchemaBootstrap:
                 "SELECT url FROM lml_cache.album_streaming_url_cache WHERE service = 'bandcamp'"
             )
         assert row["url"] == "https://x.bandcamp.com/album/y"
+
+    @pytest.mark.asyncio
+    async def test_second_boot_leaves_the_check_constraint_untouched(self, pg_pool, pg_source):
+        # Re-booting over an up-to-date table must not DROP+ADD the CHECK:
+        # the constraint OID is the tell (a rewrite allocates a new one), and
+        # a rewrite costs an ACCESS EXCLUSIVE lock plus a full-table
+        # re-validation scan on every production boot.
+        async with pg_pool.acquire() as conn:
+            oid_before = await conn.fetchval(_SERVICE_CHECK_OID)
+
+        await set_up_streaming_url_cache_schema(pg_source)
+
+        async with pg_pool.acquire() as conn:
+            oid_after = await conn.fetchval(_SERVICE_CHECK_OID)
+        assert oid_before is not None
+        assert oid_after == oid_before
+
+    @pytest.mark.asyncio
+    async def test_boot_preserves_a_preexisting_superset_constraint(self, pg_pool, pg_source):
+        # A deployed table may admit services this code version doesn't ship
+        # (a newer deploy widened it, then this build rolled back). Boot must
+        # merge, never narrow: narrowing re-validates and would abort on any
+        # row using the extra service, taking the whole bootstrap transaction
+        # down with it. Simulate by hand-widening the constraint to a strict
+        # superset and seeding a row using the extra service.
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "ALTER TABLE lml_cache.album_streaming_url_cache "
+                "DROP CONSTRAINT album_streaming_url_cache_service_valid, "
+                "ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK ("
+                "  service IN ('apple_music_album', 'spotify_album', 'bandcamp', 'deezer_album')"
+                ")"
+            )
+            await conn.execute(
+                "INSERT INTO lml_cache.album_streaming_url_cache "
+                "(service, artist_normalized, album_normalized, url) "
+                "VALUES ('deezer_album', 'x', 'y', 'https://example.test/deezer')"
+            )
+            oid_before = await conn.fetchval(_SERVICE_CHECK_OID)
+
+        await set_up_streaming_url_cache_schema(pg_source)
+
+        async with pg_pool.acquire() as conn:
+            # Nothing to add (existing set is a superset), so the constraint
+            # must be untouched — and the collected deezer row intact.
+            oid_after = await conn.fetchval(_SERVICE_CHECK_OID)
+            preserved = await conn.fetchval(
+                "SELECT count(*) FROM lml_cache.album_streaming_url_cache "
+                "WHERE service = 'deezer_album'"
+            )
+        assert oid_after == oid_before
+        assert preserved == 1
 
 
 @pytest.mark.pg

--- a/tests/unit/test_streaming_url_cache_schema.py
+++ b/tests/unit/test_streaming_url_cache_schema.py
@@ -1,4 +1,4 @@
-"""Unit tests for the streaming-URL cache schema bootstrap (LML#573).
+"""Unit tests for the streaming-URL cache schema bootstrap (LML#573, LML#886).
 
 Two surfaces:
 
@@ -7,23 +7,84 @@ Two surfaces:
   ``lml_cache.album_streaming_url_cache`` table with the named CHECK
   constraint and composite PK, so a reviewer / operator has the DDL inline.
 * ``set_up_streaming_url_cache_schema`` — the lifespan bootstrap helper. It
-  must issue ``CREATE SCHEMA`` then ``CREATE TABLE`` (named CHECK) and nothing
-  else (the LML#571→#573 apple-table backfill was removed in #573's PR-2).
+  must issue ``CREATE SCHEMA`` then ``CREATE TABLE`` (named CHECK), then the
+  widen-only DO block (LML#886 — ported from ``entity/streaming_catalog.py``'s
+  ``_DDL_ALBUM_SERVICE_WIDEN_CHECK``), all inside one transaction on one
+  connection behind a ``lock_timeout`` + advisory-lock preamble. No row
+  mutation (the LML#571→#573 apple-table backfill was removed in #573's
+  PR-2).
 
-PG is mocked; the integration layer
+PG is faked with a recording double (mirrors
+``test_streaming_catalog_schema.py``'s ``_FakePgSource``): ``AsyncMock`` can
+model ``async with pg.acquire()``, but the nested ``conn.transaction()``
+bookkeeping needed to assert the wrapping-transaction shape isn't expressible
+with the conftest AsyncMock helpers. The integration layer
 (``tests/integration/test_streaming_url_persistent_lookup.py``) drives the
-real DDL against PostgreSQL.
+real DDL — including the widen-only rewrite semantics — against PostgreSQL.
 """
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 
-from entity.sources import PgSource
-from entity.streaming_url_cache import set_up_streaming_url_cache_schema
+from entity.streaming_url_cache import (
+    _BOOTSTRAP_ADVISORY_LOCK,
+    _BOOTSTRAP_LOCK_TIMEOUT,
+    set_up_streaming_url_cache_schema,
+)
+
+
+class _FakeTransaction:
+    def __init__(self, source: _FakePgSource) -> None:
+        self._source = source
+
+    async def __aenter__(self) -> _FakeTransaction:
+        self._source.transaction_starts += 1
+        self._source.in_transaction = True
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        self._source.transaction_ends += 1
+        self._source.in_transaction = False
+
+
+class _FakeConnection:
+    def __init__(self, source: _FakePgSource) -> None:
+        self._source = source
+
+    def transaction(self) -> _FakeTransaction:
+        return _FakeTransaction(self._source)
+
+    async def execute(self, sql: str, *args: object) -> str:
+        self._source.executed.append((sql, self._source.in_transaction))
+        return "CREATE"
+
+
+class _FakePgSource:
+    """Records every statement the bootstrap issues and whether it ran inside
+    the wrapping transaction. Deliberately defines only ``acquire`` — any
+    other attribute access (pool-level ``execute``/``fetchone``) is an
+    ``AttributeError``, which doubles as the only-one-connection assertion."""
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, bool]] = []
+        self.acquire_count = 0
+        self.transaction_starts = 0
+        self.transaction_ends = 0
+        self.in_transaction = False
+
+    @property
+    def statements(self) -> list[str]:
+        return [sql for sql, _ in self.executed]
+
+    @asynccontextmanager
+    async def acquire(self):
+        self.acquire_count += 1
+        yield _FakeConnection(self)
+
 
 _SQL_REFERENCE = (
     Path(__file__).resolve().parent.parent.parent / "entity" / "streaming_url_cache.sql"
@@ -77,71 +138,86 @@ class TestCanonicalDDLReference:
 class TestSetUpStreamingUrlCacheSchema:
     """``set_up_streaming_url_cache_schema`` runs exactly the idempotent DDL."""
 
-    async def test_creates_schema_table_then_alters_check(self):
-        pg = AsyncMock(spec=PgSource)
-        pg.execute = AsyncMock(return_value="CREATE")
+    async def test_creates_schema_table_then_widens_check(self):
+        pg = _FakePgSource()
 
         await set_up_streaming_url_cache_schema(pg)
 
-        # Exactly three executes — schema, table, then the idempotent CHECK
-        # ALTER (so a pre-existing prod table picks up new service values that
-        # CREATE TABLE IF NOT EXISTS cannot add). No backfill.
-        assert pg.execute.await_count == 3
-        schema_sql = pg.execute.await_args_list[0].args[0]
-        table_sql = pg.execute.await_args_list[1].args[0]
-        alter_sql = pg.execute.await_args_list[2].args[0]
+        # Two-statement preamble, then schema, table, then the widen-only DO
+        # block (so a pre-existing prod table picks up new service values
+        # that CREATE TABLE IF NOT EXISTS cannot add). No backfill.
+        ddl = pg.statements[2:]
+        assert len(ddl) == 3
+        schema_sql, table_sql, widen_sql = ddl
         assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in schema_sql
         assert "CREATE TABLE IF NOT EXISTS lml_cache.album_streaming_url_cache" in table_sql
         assert "CONSTRAINT album_streaming_url_cache_service_valid CHECK" in table_sql
         assert "PRIMARY KEY (service, artist_normalized, album_normalized)" in table_sql
-        assert "ALTER TABLE lml_cache.album_streaming_url_cache" in alter_sql
-        assert "DROP CONSTRAINT IF EXISTS album_streaming_url_cache_service_valid" in alter_sql
-        assert "ADD CONSTRAINT album_streaming_url_cache_service_valid CHECK" in alter_sql
+        assert "DO $cache_check$" in widen_sql
+        assert "album_streaming_url_cache_service_valid" in widen_sql
 
-    async def test_alter_check_admits_the_full_service_set(self):
-        # The ALTER's IN-list must carry every ``_SERVICES`` value (including
-        # bandcamp) so an existing prod table gets the widened allowlist.
+    async def test_widen_block_admits_the_full_service_set(self):
+        # The widen-only DO block carries the shipped set as a PL/pgSQL array
+        # (``code_services``); the merged IN-list is computed at runtime, so
+        # this is the one place the code-side set is statically visible.
         import re
 
         from entity.streaming_url_cache import _SERVICES
 
-        pg = AsyncMock(spec=PgSource)
-        pg.execute = AsyncMock(return_value="ALTER")
+        pg = _FakePgSource()
 
         await set_up_streaming_url_cache_schema(pg)
 
-        alter_sql = pg.execute.await_args_list[2].args[0]
-        in_list = re.search(r"ADD CONSTRAINT.*?service\s+IN\s*\(([^)]*)\)", alter_sql, re.DOTALL)
-        assert in_list is not None, "ADD CONSTRAINT IN-list not found in the ALTER"
-        alter_services = set(re.findall(r"'([^']+)'", in_list.group(1)))
-        assert alter_services == set(_SERVICES)
-        assert "bandcamp" in alter_services
+        widen_sql = pg.statements[-1]
+        in_list = re.search(r"code_services\s+text\[\]\s*:=\s*ARRAY\[([^\]]*)\]", widen_sql)
+        assert in_list is not None, "code_services array not found in the widen DO block"
+        widen_services = set(re.findall(r"'([^']+)'", in_list.group(1)))
+        assert widen_services == set(_SERVICES)
+        assert "bandcamp" in widen_services
 
     async def test_bootstrap_is_idempotent(self):
-        # Re-running the bootstrap issues the byte-identical DDL each time: the
-        # DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT pair is a safe no-op on a
-        # table whose constraint already matches.
-        pg = AsyncMock(spec=PgSource)
-        pg.execute = AsyncMock(return_value="ALTER")
+        # Re-running the bootstrap issues the byte-identical DDL each time —
+        # whether the widen block actually rewrites the constraint at runtime
+        # is a PG-side decision the mock can't model (see the integration
+        # layer), but the statements the bootstrap *issues* never change.
+        pg = _FakePgSource()
 
         await set_up_streaming_url_cache_schema(pg)
-        first = [call.args[0] for call in pg.execute.await_args_list]
-        pg.execute.reset_mock()
-        await set_up_streaming_url_cache_schema(pg)
-        second = [call.args[0] for call in pg.execute.await_args_list]
+        first = list(pg.statements)
+        pg2 = _FakePgSource()
+        await set_up_streaming_url_cache_schema(pg2)
+        second = list(pg2.statements)
 
         assert first == second
 
     async def test_does_not_probe_or_backfill_the_old_apple_table(self):
         # Regression guard for #573 PR-2: the grandfathered
         # ``entity.album_apple_music_lookup_cache`` backfill is gone — the
-        # bootstrap must not probe ``to_regclass`` or run any INSERT.
-        pg = AsyncMock(spec=PgSource)
-        pg.execute = AsyncMock(return_value="CREATE")
+        # bootstrap must not run any INSERT.
+        pg = _FakePgSource()
 
         await set_up_streaming_url_cache_schema(pg)
 
-        pg.fetchone.assert_not_awaited()
-        executed = [call.args[0] for call in pg.execute.await_args_list]
-        assert not any("INSERT" in sql for sql in executed)
-        assert not any("album_apple_music_lookup_cache" in sql for sql in executed)
+        assert not any("INSERT" in sql for sql in pg.statements)
+        assert not any("album_apple_music_lookup_cache" in sql for sql in pg.statements)
+
+    async def test_runs_as_one_transaction_on_one_connection(self):
+        # All-or-nothing: a mid-boot failure must never leave the table
+        # standing without its service CHECK.
+        pg = _FakePgSource()
+
+        await set_up_streaming_url_cache_schema(pg)
+
+        assert pg.acquire_count == 1
+        assert pg.transaction_starts == 1
+        assert pg.transaction_ends == 1
+        assert pg.in_transaction is False
+        assert all(in_txn for _, in_txn in pg.executed)
+
+    async def test_preamble_bounds_lock_waits_and_serializes_boots(self):
+        pg = _FakePgSource()
+
+        await set_up_streaming_url_cache_schema(pg)
+
+        assert pg.statements[0] == _BOOTSTRAP_LOCK_TIMEOUT
+        assert pg.statements[1] == _BOOTSTRAP_ADVISORY_LOCK


### PR DESCRIPTION
## Summary
- Replaces the static `DROP CONSTRAINT` + `ADD CONSTRAINT` in `entity/streaming_url_cache.py`'s bootstrap with a widen-only DO block, ported from PR#883's `entity/streaming_catalog.py` (`_DDL_ALBUM_SERVICE_WIDEN_CHECK`): it deparses the deployed constraint, extracts its quoted literals by regexp, and rewrites only when the shipped `_SERVICES` set adds something — leaving the constraint (and its OID) untouched on a steady-state boot instead of paying an ACCESS EXCLUSIVE lock and a full re-validation scan every time.
- Wraps the whole bootstrap in one transaction on one pooled connection behind a `SET LOCAL lock_timeout` + `pg_advisory_xact_lock` preamble (key `886001`), so the rare widen rewrite can't half-apply on failure or interleave across concurrent boots. The key is registered in discogs-etl's shared-PG advisory-lock registry: WXYC/discogs-etl#337.
- Mirrors `entity/streaming_url_cache.sql`'s hand-maintained DDL reference with the same DO block.
- Unit test pins the DO block's code-side `_SERVICES` array (`test_widen_block_admits_the_full_service_set`), plus coverage for the transaction/preamble shape.
- Integration tests add the two cases a static ALTER can't exercise: a second boot leaves the constraint OID unchanged, and a deployed constraint that's a strict superset of the shipped set is left untouched with its rows intact (rollback-deploy simulation).

No behavior change for the cache's readers/writers — `get_cached_streaming_url`/`set_cached_streaming_url` and their callers are untouched.

Closes #886

## Test plan
- [x] `uv run --no-sync pytest tests/unit/test_streaming_url_cache_schema.py -m "not pg"` — 11 passed
- [x] `uv run --no-sync pytest -m pg tests/integration/test_streaming_url_persistent_lookup.py` — 23 passed
- [x] `uv run --no-sync pytest` (full suite) — 4753 passed, 1 skipped, 2 xfailed (pre-existing)
- [x] `uv run --no-sync ruff check .` / `ruff format --check .`
- [x] `uv run --no-sync mypy entity/streaming_url_cache.py --ignore-missing-imports`