### PR TITLE
Consolidate duplicated unit-test SQL helpers into tests/unit/conftest.py

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -71,6 +71,45 @@ def scrub_credential_env():
     get_settings.cache_clear()
 
 
+def strip_sql_comments(sql: str) -> str:
+    """Drop ``--`` line comments and collapse incidental whitespace.
+
+    Lets a parity check compare the *shape* of two DDL statements without
+    tripping on the explanatory comments a ``.sql`` reference carries inline.
+    Known limitation: splits on ``--`` anywhere in a line, including inside a
+    string literal. Callers that pin this against runtime DDL compensate by
+    asserting the runtime statements carry no ``--`` in the first place.
+    """
+    lines = []
+    for raw in sql.splitlines():
+        line = raw.split("--", 1)[0].rstrip()
+        if line.strip():
+            lines.append(line.strip())
+    return " ".join(lines)
+
+
+def extract_create_table(ddl: str) -> str:
+    """Pull the single ``CREATE TABLE ...);`` statement out of a ``.sql`` file."""
+    start = ddl.index("CREATE TABLE")
+    end = ddl.index(";", start)
+    return strip_sql_comments(ddl[start:end]).strip().rstrip(";")
+
+
+def normalize_sql(text: str) -> str:
+    """Strip ``--`` comments, drop semicolons, collapse whitespace.
+
+    A stricter superset of :func:`strip_sql_comments`: also removes every
+    ``;`` so PL/pgSQL bodies (which carry internal statement terminators the
+    runtime DDL list doesn't) compare equal. Keep this distinct from
+    ``strip_sql_comments`` rather than folding one into the other — the
+    exact-equality parity test in ``test_streaming_catalog_schema.py`` is
+    sensitive to this normalizer's exact semantics. Same ``--``-inside-a-line
+    limitation as ``strip_sql_comments``.
+    """
+    lines = [line.split("--", 1)[0] for line in text.splitlines()]
+    return " ".join(" ".join(lines).replace(";", " ").split())
+
+
 @contextmanager
 def override_deps(app, overrides):
     """Set FastAPI dependency overrides and clear them on exit.

--- a/tests/unit/test_conftest_sql_helpers.py
+++ b/tests/unit/test_conftest_sql_helpers.py
@@ -1,0 +1,55 @@
+"""Unit tests for the shared SQL test helpers in ``tests/unit/conftest.py`` (LML#887).
+
+Pins the behavior of ``strip_sql_comments``, ``extract_create_table``, and
+``normalize_sql`` now that the schema-parity test files import a single shared
+copy instead of each carrying its own. ``normalize_sql`` is a distinct,
+stricter helper (drops ``;`` and collapses whitespace) kept separate from
+``strip_sql_comments`` per the exact-equality parity test in
+``test_streaming_catalog_schema.py``.
+"""
+
+from __future__ import annotations
+
+from tests.unit.conftest import extract_create_table, normalize_sql, strip_sql_comments
+
+
+class TestStripSqlComments:
+    def test_drops_line_comments(self):
+        sql = "CREATE TABLE foo (\n    id INT -- primary key\n);"
+        assert "--" not in strip_sql_comments(sql)
+        assert "primary key" not in strip_sql_comments(sql)
+
+    def test_collapses_to_single_line(self):
+        sql = "CREATE TABLE foo (\n    id INT,\n    name TEXT\n);"
+        result = strip_sql_comments(sql)
+        assert "\n" not in result
+        assert result == "CREATE TABLE foo ( id INT, name TEXT );"
+
+    def test_drops_blank_lines(self):
+        sql = "CREATE TABLE foo (\n\n    id INT\n);"
+        assert strip_sql_comments(sql) == "CREATE TABLE foo ( id INT );"
+
+
+class TestExtractCreateTable:
+    def test_pulls_create_table_statement(self):
+        ddl = "-- header comment\nCREATE TABLE foo (id INT);\nCREATE TABLE bar (id INT);"
+        assert extract_create_table(ddl) == "CREATE TABLE foo (id INT)"
+
+    def test_strips_comments_within_extracted_statement(self):
+        ddl = "CREATE TABLE foo (\n    id INT -- comment\n);"
+        assert extract_create_table(ddl) == "CREATE TABLE foo ( id INT );".rstrip(";").strip()
+
+
+class TestNormalizeSql:
+    def test_drops_line_comments(self):
+        assert "--" not in normalize_sql("SELECT 1; -- a comment")
+
+    def test_drops_semicolons(self):
+        assert ";" not in normalize_sql("CREATE TABLE foo (id INT);")
+
+    def test_collapses_whitespace(self):
+        assert normalize_sql("CREATE  TABLE\nfoo (id INT)") == "CREATE TABLE foo (id INT)"
+
+    def test_distinct_from_strip_sql_comments(self):
+        sql = "CREATE TABLE foo (id INT);"
+        assert normalize_sql(sql) != strip_sql_comments(sql)

--- a/tests/unit/test_library_release_override_schema.py
+++ b/tests/unit/test_library_release_override_schema.py
@@ -27,32 +27,12 @@ from entity.library_release_override import (
     set_up_library_release_override_schema,
 )
 from entity.sources import PgSource
+from tests.unit.conftest import extract_create_table as _extract_create_table
+from tests.unit.conftest import strip_sql_comments as _strip_sql_comments
 
 _SQL_REFERENCE = (
     Path(__file__).resolve().parent.parent.parent / "entity" / "library_release_override.sql"
 )
-
-
-def _strip_sql_comments(sql: str) -> str:
-    """Drop ``--`` line comments and collapse incidental whitespace.
-
-    Lets the parity check compare the *shape* of the two DDL statements without
-    tripping on the explanatory comments the ``.sql`` reference carries inline.
-    Mirrors the helper in ``test_release_resolution_cache_schema.py``.
-    """
-    lines = []
-    for raw in sql.splitlines():
-        line = raw.split("--", 1)[0].rstrip()
-        if line.strip():
-            lines.append(line.strip())
-    return " ".join(lines)
-
-
-def _extract_create_table(ddl: str) -> str:
-    """Pull the single ``CREATE TABLE ...);`` statement out of the .sql file."""
-    start = ddl.index("CREATE TABLE")
-    end = ddl.index(";", start)
-    return _strip_sql_comments(ddl[start:end]).strip().rstrip(";")
 
 
 class TestCanonicalDDLReference:

--- a/tests/unit/test_release_resolution_cache_schema.py
+++ b/tests/unit/test_release_resolution_cache_schema.py
@@ -29,6 +29,8 @@ from entity.release_resolution_cache import (
     set_up_release_resolution_cache_schema,
 )
 from entity.sources import PgSource
+from tests.unit.conftest import extract_create_table as _extract_create_table
+from tests.unit.conftest import strip_sql_comments as _strip_sql_comments
 
 _SQL_REFERENCE = (
     Path(__file__).resolve().parent.parent.parent / "entity" / "release_resolution_cache.sql"
@@ -75,27 +77,6 @@ class TestCanonicalDDLReference:
             "entity/release_resolution_cache.sql CREATE TABLE drifted from the "
             "_DDL_TABLE in entity/release_resolution_cache.py — update both."
         )
-
-
-def _strip_sql_comments(sql: str) -> str:
-    """Drop ``--`` line comments and collapse incidental whitespace.
-
-    Lets the parity check compare the *shape* of the two DDL statements without
-    tripping on the explanatory comments the ``.sql`` reference carries inline.
-    """
-    lines = []
-    for raw in sql.splitlines():
-        line = raw.split("--", 1)[0].rstrip()
-        if line.strip():
-            lines.append(line.strip())
-    return " ".join(lines)
-
-
-def _extract_create_table(ddl: str) -> str:
-    """Pull the single ``CREATE TABLE ...);`` statement out of the .sql file."""
-    start = ddl.index("CREATE TABLE")
-    end = ddl.index(";", start)
-    return _strip_sql_comments(ddl[start:end]).strip().rstrip(";")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_streaming_catalog_schema.py
+++ b/tests/unit/test_streaming_catalog_schema.py
@@ -45,23 +45,9 @@ from entity.streaming_catalog import (
     ALLOW_URL_REMOVAL_GUC,
     set_up_streaming_catalog_schema,
 )
+from tests.unit.conftest import normalize_sql as _normalize_sql
 
 _SQL_REFERENCE = Path(__file__).resolve().parent.parent.parent / "entity" / "streaming_catalog.sql"
-
-
-def _normalize_sql(text: str) -> str:
-    """Strip ``--`` comments, drop semicolons, collapse whitespace.
-
-    Semicolons are replaced on BOTH sides of every comparison (the .sql
-    carries statement terminators, the runtime statements don't; the ones
-    inside the PL/pgSQL bodies are dropped symmetrically, so equality is
-    unaffected). A ``--`` inside a runtime statement would silently truncate
-    it — ``test_runtime_statements_carry_no_line_comments`` guards that side;
-    the .sql's ``--`` prose is the point of the reference file. The RAISE
-    messages use an em-dash, never ``--``.
-    """
-    lines = [line.split("--", 1)[0] for line in text.splitlines()]
-    return " ".join(" ".join(lines).replace(";", " ").split())
 
 
 class _FakeTransaction:


### PR DESCRIPTION
## Summary

The three schema-parity unit-test files (`test_library_release_override_schema.py`, `test_release_resolution_cache_schema.py`, `test_streaming_catalog_schema.py`) each carried their own private copy of the same SQL text-munging helpers. A bug fixed in one normalizer would silently stay broken in the others, and the next `.sql`-twin parity suite would have copied a fourth.

- Moves `strip_sql_comments`, `extract_create_table`, and `normalize_sql` into `tests/unit/conftest.py` as shared, docstringed helper functions.
- Updates the three test files to import from the shared location; deletes the duplicated module-level copies.
- Keeps `normalize_sql` distinct from `strip_sql_comments` (per the issue's guidance) since the exact-equality parity test in `test_streaming_catalog_schema.py` is sensitive to the stricter semantics (drops `;`, collapses whitespace).
- Adds `tests/unit/test_conftest_sql_helpers.py` pinning the shared helpers' behavior directly.
- Pure test-code move; no runtime (non-test) files touched.

Closes #887

## Test plan

- [x] `uv run --no-sync pytest tests/unit -q` — 4453 passed
- [x] `uv run --no-sync ruff check` / `ruff format --check` — clean
- [x] `uv run --no-sync mypy tests/unit/conftest.py tests/unit/test_conftest_sql_helpers.py --ignore-missing-imports` — clean