### PR TITLE
Consolidate the 10 copy-pasted pg_source fixtures into tests/integration/conftest.py

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,7 @@ import pytest_asyncio
 
 from config.settings import Settings
 from discogs.models import DiscogsSearchResponse
+from entity.sources import PgSource
 from entity.streaming_catalog import ALLOW_URL_REMOVAL_GUC
 from library.db import LibraryDB
 from tests.factories import make_discogs_result
@@ -258,6 +259,23 @@ async def pg_pool_large():
     """
     async for pool in _make_pg_pool(max_size=4):
         yield pool
+
+
+@pytest_asyncio.fixture
+async def pg_source(pg_pool) -> PgSource:
+    """A ``PgSource`` borrowing the test pool (no-op close).
+
+    Shared by every DAO/bootstrap-level integration test in this directory
+    that needs a real ``PgSource`` -- see WXYC/library-metadata-lookup#892
+    (10 near-identical per-file copies consolidated here).
+    """
+    return PgSource(pool=pg_pool)
+
+
+@pytest_asyncio.fixture
+async def pg_source_large(pg_pool_large) -> PgSource:
+    """A ``PgSource`` borrowing the large test pool (headroom for the gather)."""
+    return PgSource(pool=pg_pool_large)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_api_keys_pg.py
+++ b/tests/integration/test_api_keys_pg.py
@@ -24,17 +24,10 @@ from entity.api_keys import (
     revoke_api_key,
     set_up_api_keys_schema,
 )
-from entity.sources import PgSource
 from tests.integration.conftest import skip_if_named_tables_populated
 
 _CALLER = "wxyc-canary"
 _TOKEN = "lml_test-token-do-not-use"
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """A ``PgSource`` borrowing the test pool (no-op close)."""
-    return PgSource(pool=pg_pool)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_cache_refresh_for_identities.py
+++ b/tests/integration/test_cache_refresh_for_identities.py
@@ -25,14 +25,7 @@ import pytest_asyncio
 from discogs.models import ArtistCredit, ArtistDetails, ReleaseMetadataResponse
 from entity.sources import PgSource
 from entity.store import EntityStore
-
-# ``DATABASE_URL`` (and the conftest ``pg_pool_large``) come from conftest;
-# imported here for the ``source._dsn`` wiring and ``monkeypatch.setenv`` below.
-from tests.integration.conftest import (
-    DATABASE_URL,
-    ENTITY_IDENTITY_DDL,
-    skip_if_drop_targets_populated,
-)
+from tests.integration.conftest import ENTITY_IDENTITY_DDL, skip_if_drop_targets_populated
 
 
 @pytest_asyncio.fixture
@@ -44,14 +37,6 @@ async def pg_pool(pg_pool_large):
     re-typing every request.
     """
     yield pg_pool_large
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    source = PgSource.__new__(PgSource)
-    source._dsn = DATABASE_URL
-    source._pool = pg_pool
-    return source
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_discogs_rate_bucket.py
+++ b/tests/integration/test_discogs_rate_bucket.py
@@ -40,13 +40,7 @@ _TINY_REFILL = 0.001
 
 
 @pytest_asyncio.fixture
-async def pg_source(pg_pool_large) -> PgSource:
-    """A ``PgSource`` borrowing the large test pool (headroom for the gather)."""
-    return PgSource(pool=pg_pool_large)
-
-
-@pytest_asyncio.fixture
-async def bucket_key(pg_source) -> AsyncIterator[str]:
+async def bucket_key(pg_source_large) -> AsyncIterator[str]:
     """A unique bucket key per test, torn down afterwards.
 
     Isolates each test from every other and from any real seeded ``'discogs'``
@@ -54,18 +48,22 @@ async def bucket_key(pg_source) -> AsyncIterator[str]:
     """
     key = f"test_{uuid.uuid4().hex[:12]}"
     yield key
-    await pg_source.execute("DELETE FROM lml_cache.discogs_rate_bucket WHERE bucket_key = $1", key)
-
-
-async def _seed(pg_source: PgSource, key: str, *, capacity: float, refill: float) -> PgTokenBucket:
-    await set_up_discogs_rate_bucket_schema(
-        pg_source, bucket_key=key, capacity=capacity, refill_per_sec=refill
+    await pg_source_large.execute(
+        "DELETE FROM lml_cache.discogs_rate_bucket WHERE bucket_key = $1", key
     )
-    return PgTokenBucket(pg_source, bucket_key=key)
 
 
-async def _row(pg_source: PgSource, key: str) -> dict[str, Any]:
-    row = await pg_source.fetchone(
+async def _seed(
+    pg_source_large: PgSource, key: str, *, capacity: float, refill: float
+) -> PgTokenBucket:
+    await set_up_discogs_rate_bucket_schema(
+        pg_source_large, bucket_key=key, capacity=capacity, refill_per_sec=refill
+    )
+    return PgTokenBucket(pg_source_large, bucket_key=key)
+
+
+async def _row(pg_source_large: PgSource, key: str) -> dict[str, Any]:
+    row = await pg_source_large.fetchone(
         "SELECT tokens, capacity, refill_per_sec "
         "FROM lml_cache.discogs_rate_bucket WHERE bucket_key = $1",
         key,
@@ -74,55 +72,55 @@ async def _row(pg_source: PgSource, key: str) -> dict[str, Any]:
     return row
 
 
-async def test_schema_bootstrap_is_idempotent(pg_source, bucket_key):
+async def test_schema_bootstrap_is_idempotent(pg_source_large, bucket_key):
     """Running the bootstrap twice leaves exactly one row seeded from settings."""
     await set_up_discogs_rate_bucket_schema(
-        pg_source, bucket_key=bucket_key, capacity=5, refill_per_sec=_TINY_REFILL
+        pg_source_large, bucket_key=bucket_key, capacity=5, refill_per_sec=_TINY_REFILL
     )
     await set_up_discogs_rate_bucket_schema(
-        pg_source, bucket_key=bucket_key, capacity=5, refill_per_sec=_TINY_REFILL
+        pg_source_large, bucket_key=bucket_key, capacity=5, refill_per_sec=_TINY_REFILL
     )
-    count = await pg_source.fetchone(
+    count = await pg_source_large.fetchone(
         "SELECT count(*) AS n FROM lml_cache.discogs_rate_bucket WHERE bucket_key = $1",
         bucket_key,
     )
     assert count["n"] == 1
-    row = await _row(pg_source, bucket_key)
+    row = await _row(pg_source_large, bucket_key)
     assert row["capacity"] == 5
     assert row["refill_per_sec"] == pytest.approx(_TINY_REFILL)
     # Seeded full.
     assert row["tokens"] == pytest.approx(5, abs=0.01)
 
 
-async def test_reseed_does_not_clobber_existing_capacity(pg_source, bucket_key):
+async def test_reseed_does_not_clobber_existing_capacity(pg_source_large, bucket_key):
     """ON CONFLICT DO NOTHING: a second bootstrap with a different budget is a no-op.
 
     Prod owns the budget value; a staging boot with a different ``discogs_rate_limit``
     must not oscillate the shared row (plan §Risks).
     """
     await set_up_discogs_rate_bucket_schema(
-        pg_source, bucket_key=bucket_key, capacity=5, refill_per_sec=_TINY_REFILL
+        pg_source_large, bucket_key=bucket_key, capacity=5, refill_per_sec=_TINY_REFILL
     )
     await set_up_discogs_rate_bucket_schema(
-        pg_source, bucket_key=bucket_key, capacity=99, refill_per_sec=1.0
+        pg_source_large, bucket_key=bucket_key, capacity=99, refill_per_sec=1.0
     )
-    row = await _row(pg_source, bucket_key)
+    row = await _row(pg_source_large, bucket_key)
     assert row["capacity"] == 5
 
 
-async def test_try_acquire_spends_one_token(pg_source, bucket_key):
-    bucket = await _seed(pg_source, bucket_key, capacity=5, refill=_TINY_REFILL)
+async def test_try_acquire_spends_one_token(pg_source_large, bucket_key):
+    bucket = await _seed(pg_source_large, bucket_key, capacity=5, refill=_TINY_REFILL)
     res = await bucket.try_acquire()
     assert isinstance(res, TokenAcquisition)
     assert res.allowed is True
     assert res.retry_after_s == pytest.approx(0.0)
-    row = await _row(pg_source, bucket_key)
+    row = await _row(pg_source_large, bucket_key)
     # One token spent (minus negligible refill).
     assert 3.9 < row["tokens"] < 5.0
 
 
-async def test_burst_exhausts_then_denies_with_retry_after(pg_source, bucket_key):
-    bucket = await _seed(pg_source, bucket_key, capacity=3, refill=_TINY_REFILL)
+async def test_burst_exhausts_then_denies_with_retry_after(pg_source_large, bucket_key):
+    bucket = await _seed(pg_source_large, bucket_key, capacity=3, refill=_TINY_REFILL)
     for _ in range(3):
         assert (await bucket.try_acquire()).allowed is True
     denied = await bucket.try_acquire()
@@ -130,7 +128,7 @@ async def test_burst_exhausts_then_denies_with_retry_after(pg_source, bucket_key
     assert denied.retry_after_s > 0.0
 
 
-async def test_stays_drained_immediately_after_burst(pg_source, bucket_key):
+async def test_stays_drained_immediately_after_burst(pg_source_large, bucket_key):
     """No meaningful refill happens between two back-to-back acquires.
 
     Uses ``_TINY_REFILL`` (like the concurrency tests below) so the "still
@@ -138,12 +136,12 @@ async def test_stays_drained_immediately_after_burst(pg_source, bucket_key):
     latency -- see ``test_tokens_refill_over_time`` for the fast-refill,
     accrual-over-a-real-sleep counterpart.
     """
-    bucket = await _seed(pg_source, bucket_key, capacity=1, refill=_TINY_REFILL)
+    bucket = await _seed(pg_source_large, bucket_key, capacity=1, refill=_TINY_REFILL)
     assert (await bucket.try_acquire()).allowed is True
     assert (await bucket.try_acquire()).allowed is False  # drained
 
 
-async def test_tokens_refill_over_time(pg_source, bucket_key):
+async def test_tokens_refill_over_time(pg_source_large, bucket_key):
     """A token becomes available again once enough wall-clock time has passed.
 
     Fast refill (100/s => a token every 10ms), capacity 1. Deliberately does
@@ -153,46 +151,46 @@ async def test_tokens_refill_over_time(pg_source, bucket_key):
     is racy against the fast refill rate (LML#934). The 50ms sleep here is
     far larger than any round-trip jitter, so it stays deterministic.
     """
-    bucket = await _seed(pg_source, bucket_key, capacity=1, refill=100.0)
+    bucket = await _seed(pg_source_large, bucket_key, capacity=1, refill=100.0)
     assert (await bucket.try_acquire()).allowed is True  # drains the seeded token
     await asyncio.sleep(0.05)  # 0.05 * 100 = 5 tokens accrue, capped at capacity 1
     assert (await bucket.try_acquire()).allowed is True
 
 
-async def test_concurrent_acquires_never_over_issue(pg_source, bucket_key):
+async def test_concurrent_acquires_never_over_issue(pg_source_large, bucket_key):
     """The core invariant: N concurrent try_acquire against one row yield exactly
     ``capacity`` allows — the FOR UPDATE serialization makes refill/spend atomic."""
     capacity = 5
-    bucket = await _seed(pg_source, bucket_key, capacity=capacity, refill=_TINY_REFILL)
+    bucket = await _seed(pg_source_large, bucket_key, capacity=capacity, refill=_TINY_REFILL)
     results = await asyncio.gather(*(bucket.try_acquire() for _ in range(capacity + 10)))
     allowed = [r for r in results if r.allowed]
     assert len(allowed) == capacity
 
 
-async def test_two_instances_share_one_row(pg_source, bucket_key):
+async def test_two_instances_share_one_row(pg_source_large, bucket_key):
     """Two independent PgTokenBucket instances (staging + prod) are collectively
     bounded by ``capacity`` — enforcement is on the row, not the instance."""
     capacity = 4
     await set_up_discogs_rate_bucket_schema(
-        pg_source, bucket_key=bucket_key, capacity=capacity, refill_per_sec=_TINY_REFILL
+        pg_source_large, bucket_key=bucket_key, capacity=capacity, refill_per_sec=_TINY_REFILL
     )
-    prod = PgTokenBucket(pg_source, bucket_key=bucket_key)
-    staging = PgTokenBucket(pg_source, bucket_key=bucket_key)
+    prod = PgTokenBucket(pg_source_large, bucket_key=bucket_key)
+    staging = PgTokenBucket(pg_source_large, bucket_key=bucket_key)
     both = [prod, staging] * (capacity + 3)  # > capacity acquires split across instances
     results = await asyncio.gather(*(b.try_acquire() for b in both))
     allowed = [r for r in results if r.allowed]
     assert len(allowed) == capacity
 
 
-async def test_negative_balance_is_floored_to_zero(pg_source, bucket_key):
+async def test_negative_balance_is_floored_to_zero(pg_source_large, bucket_key):
     """LML#841 review (Finding 3): a pathological negative balance — e.g. a
     backward wall-clock jump making the refill term deeply negative — must not
     yield an unbounded ``retry_after_s`` nor persist a deeper-negative balance.
     The ``GREATEST(0.0, …)`` floor clamps ``avail`` to ``[0, capacity]``."""
-    bucket = await _seed(pg_source, bucket_key, capacity=1, refill=100.0)
+    bucket = await _seed(pg_source_large, bucket_key, capacity=1, refill=100.0)
     # No public API mints a negative balance; corrupt the row directly to model
     # the clock-skew / underflow case. last_refill=now() minimizes accrual.
-    await pg_source.execute(
+    await pg_source_large.execute(
         "UPDATE lml_cache.discogs_rate_bucket SET tokens = -100, last_refill = now() "
         "WHERE bucket_key = $1",
         bucket_key,
@@ -202,15 +200,15 @@ async def test_negative_balance_is_floored_to_zero(pg_source, bucket_key):
     # Floored: retry_after ≈ (1 - 0) / 100 = 0.01s, NOT the un-floored
     # (1 - (-100)) / 100 = 1.01s.
     assert res.retry_after_s < 0.5
-    row = await _row(pg_source, bucket_key)
+    row = await _row(pg_source_large, bucket_key)
     assert row["tokens"] >= 0.0  # never persists a deeper-negative balance
 
 
-async def test_try_acquire_missing_row_raises(pg_source):
+async def test_try_acquire_missing_row_raises(pg_source_large):
     """An unseeded key has no row; try_acquire raises so the gate can fail open."""
     await set_up_discogs_rate_bucket_schema(
-        pg_source, bucket_key="test_seeded_other", capacity=1, refill_per_sec=_TINY_REFILL
+        pg_source_large, bucket_key="test_seeded_other", capacity=1, refill_per_sec=_TINY_REFILL
     )
-    orphan = PgTokenBucket(pg_source, bucket_key=f"test_absent_{uuid.uuid4().hex[:8]}")
+    orphan = PgTokenBucket(pg_source_large, bucket_key=f"test_absent_{uuid.uuid4().hex[:8]}")
     with pytest.raises(RateBucketMissingRowError):
         await orphan.try_acquire()

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -14,7 +14,6 @@ from unittest.mock import AsyncMock
 import pytest
 import pytest_asyncio
 
-from entity.sources import PgSource
 from entity.store import EntityStore
 from scripts.entity_resolution.__main__ import (
     OrphanDrainAbortError,
@@ -37,15 +36,6 @@ from tests.integration.conftest import (
     skip_if_drop_targets_populated,
     skip_unless_wxyc_identity_match_artist,
 )
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """PgSource wrapping the test pool."""
-    source = PgSource.__new__(PgSource)
-    source._dsn = DATABASE_URL
-    source._pool = pg_pool
-    return source
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_fill_identity_discogs_id.py
+++ b/tests/integration/test_fill_identity_discogs_id.py
@@ -29,12 +29,6 @@ def _source(pg_pool) -> PgSource:
     return source
 
 
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """PgSource wrapping the test pool."""
-    return _source(pg_pool)
-
-
 @pytest_asyncio.fixture(autouse=True)
 async def set_up_entity_schema(pg_pool):
     """Create (or re-create) the entity schema for each test.

--- a/tests/integration/test_library_release_override.py
+++ b/tests/integration/test_library_release_override.py
@@ -26,19 +26,12 @@ from entity.library_release_override import (
     get_library_release_overrides,
     set_up_library_release_override_schema,
 )
-from entity.sources import PgSource
 from tests.integration.conftest import skip_if_named_tables_populated
 
 _INSERT_SQL = (
     "INSERT INTO lml_cache.library_release_override "
     "(library_id, discogs_release_id) VALUES ($1, $2)"
 )
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """A ``PgSource`` borrowing the test pool (no-op close)."""
-    return PgSource(pool=pg_pool)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_release_identity.py
+++ b/tests/integration/test_release_identity.py
@@ -26,16 +26,8 @@ import asyncio
 import pytest
 import pytest_asyncio
 
-from entity.sources import PgSource
 from entity.store import EntityStore
-
-# ``DATABASE_URL`` (and the conftest ``pg_pool_large``) come from conftest;
-# imported here for the ``source._dsn`` wiring and ``monkeypatch.setenv`` below.
-from tests.integration.conftest import (
-    DATABASE_URL,
-    ENTITY_IDENTITY_DDL,
-    skip_if_drop_targets_populated,
-)
+from tests.integration.conftest import ENTITY_IDENTITY_DDL, skip_if_drop_targets_populated
 
 
 @pytest_asyncio.fixture
@@ -47,14 +39,6 @@ async def pg_pool(pg_pool_large):
     re-typing every request.
     """
     yield pg_pool_large
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    source = PgSource.__new__(PgSource)
-    source._dsn = DATABASE_URL
-    source._pool = pg_pool
-    return source
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_release_resolution_cache.py
+++ b/tests/integration/test_release_resolution_cache.py
@@ -35,14 +35,7 @@ from entity.release_resolution_cache import (
     set_cached_release_id,
     set_up_release_resolution_cache_schema,
 )
-from entity.sources import PgSource
 from tests.integration.conftest import skip_if_named_tables_populated
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """A ``PgSource`` borrowing the test pool (no-op close)."""
-    return PgSource(pool=pg_pool)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_seed_library_release_overrides.py
+++ b/tests/integration/test_seed_library_release_overrides.py
@@ -25,17 +25,10 @@ from entity.library_release_override import (
     get_library_release_overrides,
     set_up_library_release_override_schema,
 )
-from entity.sources import PgSource
 from scripts.seed_library_release_overrides import OverrideRow, seed_overrides
 from tests.integration.conftest import skip_if_named_tables_populated
 
 _SOURCE = "alex-l-2026"
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """A ``PgSource`` borrowing the test pool (no-op close)."""
-    return PgSource(pool=pg_pool)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_streaming_catalog.py
+++ b/tests/integration/test_streaming_catalog.py
@@ -26,7 +26,6 @@ import asyncpg
 import pytest
 import pytest_asyncio
 
-from entity.sources import PgSource
 from entity.streaming_catalog import (
     _SERVICE_IN_LIST,
     _TABLES,
@@ -83,12 +82,6 @@ _SERVICE_CHECK_OID = (
     "SELECT oid FROM pg_constraint WHERE conname = 'streaming_album_service_valid' "
     "AND conrelid = 'lml_cache.streaming_album_service'::regclass"
 )
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """A ``PgSource`` borrowing the test pool (no-op close)."""
-    return PgSource(pool=pg_pool)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_streaming_url_persistent_lookup.py
+++ b/tests/integration/test_streaming_url_persistent_lookup.py
@@ -29,7 +29,6 @@ import pytest
 import pytest_asyncio
 
 from clients.streaming.base import BaseStreamingClient
-from entity.sources import PgSource
 from entity.streaming_url_cache import (
     get_cached_streaming_url,
     resolve_streaming_url_with_cache,
@@ -61,12 +60,6 @@ async def pg_pool(pg_pool_large):
     re-typing every request.
     """
     yield pg_pool_large
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """A ``PgSource`` borrowing the test pool (no-op close)."""
-    return PgSource(pool=pg_pool)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/integration/test_track_streaming_url_cache_pg.py
+++ b/tests/integration/test_track_streaming_url_cache_pg.py
@@ -21,7 +21,6 @@ import asyncpg
 import pytest
 import pytest_asyncio
 
-from entity.sources import PgSource
 from entity.track_streaming_url_cache import (
     APPLE_MUSIC_TRACK_SERVICE,
     get_cached_track_streaming_url,
@@ -35,12 +34,6 @@ _ALBUM = "DOGA"
 _SONG = "la paradoja"
 _OTHER_SONG = "eras"
 _TRACK_URL = "https://music.apple.com/us/song/la-paradoja/1234567890"
-
-
-@pytest_asyncio.fixture
-async def pg_source(pg_pool):
-    """A ``PgSource`` borrowing the test pool (no-op close)."""
-    return PgSource(pool=pg_pool)
 
 
 @pytest_asyncio.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Ten DAO/bootstrap-level integration suites in `tests/integration/` each defined their own function-scoped `pg_source` fixture wrapping the session `pg_pool` in a `PgSource`, in four slight variants (plain wrap, wrap of `pg_pool_large`, wrap via `PgSource.__new__` plus manual `_dsn`/`_pool` assignment, wrap plus local imports). Two more undocumented copies (`test_api_keys_pg.py`, `test_track_streaming_url_cache_pg.py`) turned up during the sweep. A change to `PgSource` construction meant touching all of these, and every new `lml_cache` suite copied the fixture again.

Two shared fixtures now live in `tests/integration/conftest.py`, next to `pg_pool` and `pg_pool_large`:

- `pg_source` — wraps `pg_pool` (the common case)
- `pg_source_large` — wraps `pg_pool_large`, used only by `test_discogs_rate_bucket.py`, which renames its own `pg_source` parameter to `pg_source_large` throughout to keep the large-pool variant explicit

The two files with a local `pg_pool` alias to `pg_pool_large` (`test_release_identity.py`, `test_cache_refresh_for_identities.py`, `test_streaming_url_persistent_lookup.py`) keep that alias — the shared `pg_source` fixture picks it up transparently through normal pytest fixture shadowing.

All twelve local `pg_source` definitions are deleted; each file now just takes `pg_source` (or `pg_source_large`) as a parameter, with the `entity.sources.PgSource` import removed except where it's still needed as a type hint. Pure test refactor — no production code touched, no behavior changes.

## Test plan

- [x] `grep -rn "def pg_source" tests/` returns only the two conftest definitions
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `mypy tests/integration/ --ignore-missing-imports` clean
- [x] `pytest -m pg -q` — 527 passed, 9 skipped
- [x] Full `pytest -q` — 4751 passed, 1 skipped, 2 xfailed (unrelated pre-existing warnings only)

Closes #892