### PR TITLE
Null artwork.spotify_url/apple_music_url on artifact host mismatch

### DIFF
--- a/lookup/enrichment/item.py
+++ b/lookup/enrichment/item.py
@@ -51,7 +51,9 @@ from lookup.rowless import (
 )
 from lookup.streaming_url_postprocess import apply_streaming_url_postprocess
 from lookup.timeouts import apple_music_lookup_timeout_s
+from release.apple_music_url_parser import url_has_apple_music_host
 from release.musicbrainz_resolver import resolve_tracklist_via_musicbrainz
+from release.spotify_url_parser import url_has_spotify_host
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +205,18 @@ async def enrich_one(
             youtube_music_url = links.get("youtube_music_url")
             bandcamp_url = links.get("bandcamp_url")
             soundcloud_url = links.get("soundcloud_url")
+
+            # LML#873: the streaming-links reconciliation pipeline sometimes
+            # stores a non-Spotify (Deezer/Apple/Bandcamp) URL under the
+            # spotify_url column, and likewise a non-Apple URL under
+            # apple_music_url. Enforce the field-name/host invariant here,
+            # before either value can propagate to a response — a mismatched
+            # host is treated the same as "no override", not surfaced under
+            # the wrong field.
+            if spotify_url and not url_has_spotify_host(spotify_url):
+                spotify_url = None
+            if apple_music_override and not url_has_apple_music_host(apple_music_override):
+                apple_music_override = None
 
     # Apple Music probe. ``library_row_acceptable`` picks ``find_track_url``
     # (URL only — preserves LML#401 baseline); the synthesis path

--- a/release/apple_music_url_parser.py
+++ b/release/apple_music_url_parser.py
@@ -11,6 +11,7 @@ later removed entirely (WXYC/wiki#87); this parser is unaffected since
 from __future__ import annotations
 
 import re
+from urllib.parse import urlparse
 
 # Locale segment accepts:
 #   - 2-letter ISO codes ("us", "gb", "jp") — the canonical Apple shape.
@@ -36,3 +37,22 @@ def apple_album_id_from_url(url: str) -> str | None:
     """
     match = APPLE_ALBUM_ID_RE.search(url)
     return match.group(1) if match else None
+
+
+def url_has_apple_music_host(url: str) -> bool:
+    """True if ``url``'s host is ``apple.com`` or a subdomain of it.
+
+    Deliberately looser than :func:`apple_album_id_from_url` — a
+    field-name/host invariant check (LML#873) rather than an album-ID
+    extraction, so it accepts any Apple path, not just the canonical album
+    shape. Used to null out a mislabeled ``apple_music_url`` artifact (a
+    Deezer/Spotify/Bandcamp URL stored under that field name) before it
+    reaches a caller.
+    """
+    if not url:
+        return False
+    try:
+        host = urlparse(url).netloc.lower()
+    except ValueError:
+        return False
+    return host == "apple.com" or host.endswith(".apple.com")

--- a/release/spotify_url_parser.py
+++ b/release/spotify_url_parser.py
@@ -20,6 +20,7 @@ posture the Apple parser's ``\\d{6,}`` floor provides against
 from __future__ import annotations
 
 import re
+from urllib.parse import urlparse
 
 # Anchored on the Spotify host so a ``/album/<id>`` path on another domain
 # can't be mistaken for a Spotify album. ``//`` before the host and the
@@ -43,3 +44,22 @@ def spotify_album_id_from_url(url: str) -> str | None:
     """
     match = SPOTIFY_ALBUM_ID_RE.search(url)
     return match.group(1) if match else None
+
+
+def url_has_spotify_host(url: str) -> bool:
+    """True if ``url``'s host is ``spotify.com`` or a subdomain of it.
+
+    Deliberately looser than :func:`spotify_album_id_from_url` — a
+    field-name/host invariant check (LML#873) rather than an album-ID
+    extraction, so it accepts any Spotify path (track, artist, playlist),
+    not just the canonical album shape. Used to null out a mislabeled
+    ``spotify_url`` artifact (a Deezer/Apple/Bandcamp URL stored under that
+    field name) before it reaches a caller.
+    """
+    if not url:
+        return False
+    try:
+        host = urlparse(url).netloc.lower()
+    except ValueError:
+        return False
+    return host == "spotify.com" or host.endswith(".spotify.com")

--- a/tests/unit/test_apple_music_url_parser.py
+++ b/tests/unit/test_apple_music_url_parser.py
@@ -1,0 +1,53 @@
+"""Unit tests for ``release.apple_music_url_parser``.
+
+Mirrors ``tests/unit/test_spotify_url_parser.py``: covers both the strict
+album-ID extractor and the looser host-only invariant check (LML#873).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from release.apple_music_url_parser import apple_album_id_from_url, url_has_apple_music_host
+
+
+class TestAppleAlbumIdFromUrl:
+    def test_extracts_id_from_album_url(self):
+        url = "https://music.apple.com/us/album/some-album/1440857781"
+        assert apple_album_id_from_url(url) == "1440857781"
+
+    def test_extracts_id_with_id_prefix(self):
+        url = "https://music.apple.com/us/album/some-album/id1440857781"
+        assert apple_album_id_from_url(url) == "1440857781"
+
+    def test_returns_none_for_wrong_host(self):
+        assert apple_album_id_from_url("https://example.com/us/album/some-album/1440857781") is None
+
+    def test_returns_none_for_short_id(self):
+        assert apple_album_id_from_url("https://music.apple.com/us/album/some-album/222") is None
+
+
+class TestUrlHasAppleMusicHost:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://music.apple.com/us/album/oyola/222",
+            "http://apple.com/album/abc",
+        ],
+    )
+    def test_true_for_apple_hosts(self, url):
+        assert url_has_apple_music_host(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.deezer.com/album/254381182",
+            "https://open.spotify.com/album/oyola-id",
+            "https://autechre.bandcamp.com/album/confield",
+            "https://music.apple.com.evil.test/album/abc",
+            "",
+            "not a url",
+        ],
+    )
+    def test_false_for_non_apple_hosts(self, url):
+        assert url_has_apple_music_host(url) is False

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -2098,6 +2098,143 @@ class TestStreamingLinksTitleGate:
         assert enriched.spotify_url == verified_spotify
 
 
+class TestStreamingLinksHostInvariant:
+    """LML#873: ``streaming_links.spotify_url`` / ``.apple_music_url`` are
+    artifact columns populated by the streaming-links reconciliation
+    pipeline (#218/#207) and can hold a non-Spotify (Deezer/Apple/Bandcamp)
+    or non-Apple URL despite the field name. Enrichment must never surface
+    such a mislabeled value under the wrong field — null it out instead,
+    mirroring the Backend-Service ingestion-boundary guard (BS#1712) at the
+    source so every LML consumer is protected, not just BS.
+    """
+
+    @pytest.mark.asyncio
+    async def test_nulls_spotify_url_when_host_is_not_spotify(self):
+        # Pinned reproduction: library release id=1580 stores a Deezer URL
+        # in the spotify_url column.
+        item = make_library_item(id=1580, artist="Stereolab", title="Aluminum Tunes")
+        artwork = make_discogs_result(release_id=1, artist="Stereolab", album="Aluminum Tunes")
+
+        deezer_url_in_spotify_column = "https://www.deezer.com/album/254381182"
+
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": deezer_url_in_spotify_column,
+                "apple_music_url": None,
+                "youtube_music_url": None,
+                "bandcamp_url": None,
+                "soundcloud_url": None,
+            }
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=1,
+            title="Aluminum Tunes",
+            artist="Stereolab",
+            year=1998,
+            artist_id=None,
+            release_url="https://discogs.com/release/1",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            album="Aluminum Tunes",
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched.spotify_url != deezer_url_in_spotify_column
+        assert enriched.spotify_url is None
+
+    @pytest.mark.asyncio
+    async def test_nulls_apple_music_url_when_host_is_not_apple(self):
+        item = make_library_item(id=1581, artist="Cat Power", title="Moon Pix")
+        artwork = make_discogs_result(release_id=2, artist="Cat Power", album="Moon Pix")
+
+        deezer_url_in_apple_column = "https://www.deezer.com/album/1111111"
+
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": None,
+                "apple_music_url": deezer_url_in_apple_column,
+                "youtube_music_url": None,
+                "bandcamp_url": None,
+                "soundcloud_url": None,
+            }
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=2,
+            title="Moon Pix",
+            artist="Cat Power",
+            year=1998,
+            artist_id=None,
+            release_url="https://discogs.com/release/2",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            album="Moon Pix",
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched.apple_music_url != deezer_url_in_apple_column
+
+    @pytest.mark.asyncio
+    async def test_keeps_genuine_spotify_and_apple_urls(self):
+        # Non-regression: a correctly-hosted URL in each column still
+        # propagates.
+        item = make_library_item(id=1582, artist="Sessa", title="Pequena Vertigem de Amor")
+        artwork = make_discogs_result(
+            release_id=3, artist="Sessa", album="Pequena Vertigem de Amor"
+        )
+
+        verified_spotify = "https://open.spotify.com/album/pequena-id"
+        verified_apple = "https://music.apple.com/us/album/pequena/333333"
+
+        library_db = AsyncMock()
+        library_db._has_streaming_links = True
+        library_db.get_streaming_links = AsyncMock(
+            return_value={
+                "spotify_url": verified_spotify,
+                "apple_music_url": verified_apple,
+                "youtube_music_url": None,
+                "bandcamp_url": None,
+                "soundcloud_url": None,
+            }
+        )
+
+        discogs_service = AsyncMock()
+        discogs_service.get_release.return_value = ReleaseMetadataResponse(
+            release_id=3,
+            title="Pequena Vertigem de Amor",
+            artist="Sessa",
+            year=2019,
+            artist_id=None,
+            release_url="https://discogs.com/release/3",
+        )
+
+        results = await enrich_artwork_results(
+            [(item, artwork)],
+            discogs_service,
+            album="Pequena Vertigem de Amor",
+            library_db=library_db,
+        )
+
+        _, enriched = results[0]
+        assert enriched.spotify_url == verified_spotify
+        assert enriched.apple_music_url == verified_apple
+
+
 class TestExternalArtworkProbe:
     """LML#487 / BS#1184: when the WXYC library catalog has no row whose title
     clears the LML#477 (PR #481) gate against the requested album, probe Apple

--- a/tests/unit/test_spotify_url_parser.py
+++ b/tests/unit/test_spotify_url_parser.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from release.spotify_url_parser import spotify_album_id_from_url
+from release.spotify_url_parser import spotify_album_id_from_url, url_has_spotify_host
 
 # A canonical 22-char base62 Spotify album ID.
 _VALID_ID = "1A2GTWGt0LBTGQAyA3OKAf"
@@ -75,3 +75,30 @@ class TestSpotifyAlbumIdFromUrl:
         # surfaces as ``None`` so the post-process skips the mint rather
         # than minting a malformed external_id.
         assert spotify_album_id_from_url(f"https://open.spotify.com/album/{bad_id}") is None
+
+
+class TestUrlHasSpotifyHost:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://open.spotify.com/album/oyola-id",
+            "https://open.spotify.com/track/abc",
+            "http://spotify.com/album/abc",
+        ],
+    )
+    def test_true_for_spotify_hosts(self, url):
+        assert url_has_spotify_host(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.deezer.com/album/254381182",
+            "https://music.apple.com/us/album/oyola/222",
+            "https://autechre.bandcamp.com/album/confield",
+            "https://open.spotify.com.evil.test/album/abc",
+            "",
+            "not a url",
+        ],
+    )
+    def test_false_for_non_spotify_hosts(self, url):
+        assert url_has_spotify_host(url) is False


### PR DESCRIPTION
## Problem

`streaming_links.spotify_url` (and `.apple_music_url`) is an artifact column populated by the streaming-links reconciliation pipeline; for a subset of releases it stores a non-Spotify URL (Deezer/Apple/Bandcamp) despite the field name, so every LML consumer that trusts the field name gets a mislabeled link. Pinned repro: library release id=1580 returns a Deezer URL in `artwork.spotify_url`.

Backend-Service already added a defense-in-depth ingestion-boundary guard (BS#1712), but that only protects BS — every other LML consumer is still exposed.

## Fix

Serve-time guard only (artifact repair is a separate, out-of-scope track): enforce the field-name/host invariant right where `lookup/enrichment/item.py` reads the `streaming_links` row — a `spotify_url` whose host isn't under `spotify.com`, or an `apple_music_url` whose host isn't under `apple.com`, is nulled before it can propagate anywhere downstream (postprocess fallback, response composition).

Adds `url_has_spotify_host` / `url_has_apple_music_host` next to the existing (stricter, album-ID-extracting) parsers in `release/spotify_url_parser.py` / `release/apple_music_url_parser.py` — these are host-only checks, looser than the ID extractors, since the invariant is about the field name lying about the host, not about the exact album-URL shape.

## Testing

- New `TestUrlHasSpotifyHost` / `TestUrlHasAppleMusicHost` unit tests for the two host-check helpers.
- New `TestStreamingLinksHostInvariant` in `tests/unit/test_enrichment.py`, including the pinned release-1580-shaped Deezer-in-spotify_url repro, an Apple-column equivalent, and a non-regression case for genuinely-hosted URLs.
- Full local suite green: `ruff check` / `ruff format --check` / `mypy` / `pytest` (4809 passed).

Closes #873