### PR TITLE
Harden the streaming-catalog bootstrap: foreign-form widen handling + steady-state CREATE OR REPLACE churn

### DIFF
--- a/entity/streaming_catalog.py
+++ b/entity/streaming_catalog.py
@@ -30,7 +30,7 @@ Distinct from the runtime ``lml_cache.album_streaming_url_cache`` (lookup
 post-process cache keyed on normalized request strings): this is the offline
 catalog keyed on library-album identity. Do not conflate them.
 
-**No-regress guards.** ``BEFORE UPDATE OR DELETE`` row triggers plus ``BEFORE
+**No-regress guards.** ``BEFORE DELETE OR UPDATE`` row triggers plus ``BEFORE
 TRUNCATE`` statement triggers on all four tables structurally replace the
 #672 whole-file coverage guard: any DML transition that would discard
 collected streaming data is rejected at the database, not detected after the
@@ -202,23 +202,42 @@ CREATE TABLE IF NOT EXISTS lml_cache.streaming_album_service (
 # EXCLUSIVE lock plus a full re-validation scan on EVERY boot, and (b) narrow
 # the constraint under a rollback deploy, aborting the whole bootstrap
 # transaction against collected rows that use a service the older code
-# doesn't ship. This DO block instead deparses the deployed constraint,
-# extracts its quoted literals, and rewrites only when the shipped
-# ``_SERVICES`` adds something — merging, never narrowing, and leaving the
-# constraint (and its OID) untouched on a steady-state boot. The rewrite must
-# emit the ``service IN (...)`` form: PG deparses IN as ``= ANY (ARRAY[...])``
-# and the extraction reads the quoted literals out of that deparse, whereas an
+# doesn't ship. This DO block deparses the deployed constraint and
+# distinguishes three states (LML#890):
+#
+# * PARSEABLE — the deparse matches the exact ``service = ANY (ARRAY[...])``
+#   shape this bootstrap itself emits (PG's canonical deparse of ``service IN
+#   (...)``). Its quoted literals are extracted with a quote-aware pattern
+#   (handles an escaped quote inside a literal, e.g. ``'o''brien'``, without
+#   fragmenting it) and the extraction is round-tripped — rebuilt and diffed
+#   against the deparsed array — before being trusted. Merges only when the
+#   shipped ``_SERVICES`` adds something, leaving the constraint (and its
+#   OID) untouched on a steady-state boot.
+# * ABSENT — dropped out-of-band. The re-ADD folds in every service value
+#   already live in the table, so the recovery boot's re-validation can't
+#   fail against collected out-of-set rows — which would otherwise abort
+#   EVERY subsequent bootstrap until manual repair.
+# * FOREIGN-FORM — deployed but not in a shape this bootstrap can confidently
+#   parse: a hand-repaired regex CHECK, an ``= ANY`` array-literal constant
+#   instead of ``ARRAY[...]``, or anything the round-trip can't reproduce
+#   byte-for-byte. Policy (decided LML#890): WARN AND SKIP — ``RAISE
+#   WARNING`` naming the unparsed deparse and leave the constraint untouched.
+#   Never drop-and-rebuild or rebuild-from-live-rows here: a foreign form
+#   implies deliberate out-of-band operator action, and guessing at a
+#   replacement risks silently narrowing what the operator installed.
+#
+# The rewrite (PARSEABLE-widen and ABSENT-recovery) must emit the
+# ``service IN (...)`` form: PG deparses IN as ``= ANY (ARRAY[...])`` and the
+# extraction reads the quoted literals out of that deparse, whereas an
 # array-literal Const (``'{...}'::text[]``) deparses as ONE literal and would
-# corrupt the next boot's extraction. When the constraint is ABSENT (dropped
-# out-of-band), the re-ADD folds in every service value already live in the
-# table, so the recovery boot's re-validation can't fail against collected
-# out-of-set rows — which would otherwise abort EVERY subsequent bootstrap
-# until manual repair.
+# corrupt the next boot's extraction.
 _DDL_ALBUM_SERVICE_WIDEN_CHECK = f"""\
 DO $catalog_check$
 DECLARE
     existing_def text;
+    inner_array text;
     existing_services text[];
+    rebuilt_array text;
     code_services text[] := ARRAY[
         {_SERVICE_IN_LIST}];
     merged_list text;
@@ -228,8 +247,25 @@ BEGIN
         WHERE conrelid = 'lml_cache.streaming_album_service'::regclass
             AND conname = 'streaming_album_service_valid';
     IF existing_def IS NOT NULL THEN
-        SELECT array_agg(m[1]) INTO existing_services
-            FROM regexp_matches(existing_def, '''([^'']+)''', 'g') AS m;
+        inner_array := substring(
+            existing_def FROM '^CHECK \\(\\(service = ANY \\(ARRAY\\[(.*)\\]\\)\\)\\)$'
+        );
+        IF inner_array IS NULL THEN
+            RAISE WARNING 'streaming_album_service_valid: deployed CHECK (%) is not in the '
+                'expected service = ANY (ARRAY[...]) shape this bootstrap can parse; '
+                'leaving it untouched (foreign-form policy: warn-and-skip)', existing_def;
+            RETURN;
+        END IF;
+        SELECT array_agg(replace(m[1], '''''', '''')) INTO existing_services
+            FROM regexp_matches(inner_array, '''((?:[^'']|'''')*)''', 'g') AS m;
+        SELECT string_agg(quote_literal(s) || '::text', ', ') INTO rebuilt_array
+            FROM unnest(existing_services) AS s;
+        IF rebuilt_array IS DISTINCT FROM inner_array THEN
+            RAISE WARNING 'streaming_album_service_valid: deployed CHECK (%) has literals this '
+                'bootstrap could not confidently round-trip; leaving it untouched '
+                '(foreign-form policy: warn-and-skip)', existing_def;
+            RETURN;
+        END IF;
         IF existing_services @> code_services THEN
             RETURN;
         END IF;
@@ -338,7 +374,7 @@ _DDL_GUARD_ALBUM_FN = f"""\
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_album()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('{ALLOW_URL_REMOVAL_GUC}', true) = 'on' THEN
         IF TG_OP = 'DELETE' THEN
@@ -381,7 +417,7 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$\
+$function$\
 """
 
 # All four row triggers deliberately carry no ``UPDATE OF`` column list: an
@@ -391,7 +427,7 @@ $$\
 # bodies. Fire on every UPDATE; the function decides.
 _DDL_GUARD_ALBUM_TRIGGER = """\
 CREATE OR REPLACE TRIGGER streaming_album_no_regress
-BEFORE UPDATE OR DELETE ON lml_cache.streaming_album
+BEFORE DELETE OR UPDATE ON lml_cache.streaming_album
 FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_album()\
 """
 
@@ -411,7 +447,7 @@ _DDL_GUARD_ALBUM_SERVICE_FN = f"""\
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_album_service()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('{ALLOW_URL_REMOVAL_GUC}', true) = 'on' THEN
         IF TG_OP = 'DELETE' THEN
@@ -466,12 +502,12 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$\
+$function$\
 """
 
 _DDL_GUARD_ALBUM_SERVICE_TRIGGER = """\
 CREATE OR REPLACE TRIGGER streaming_album_service_no_regress
-BEFORE UPDATE OR DELETE ON lml_cache.streaming_album_service
+BEFORE DELETE OR UPDATE ON lml_cache.streaming_album_service
 FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_album_service()\
 """
 
@@ -486,7 +522,7 @@ _DDL_GUARD_TRACK_RESULT_FN = f"""\
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_track_result()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('{ALLOW_URL_REMOVAL_GUC}', true) = 'on' THEN
         IF TG_OP = 'DELETE' THEN
@@ -538,12 +574,12 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$\
+$function$\
 """
 
 _DDL_GUARD_TRACK_RESULT_TRIGGER = """\
 CREATE OR REPLACE TRIGGER streaming_track_result_no_regress
-BEFORE UPDATE OR DELETE ON lml_cache.streaming_track_result
+BEFORE DELETE OR UPDATE ON lml_cache.streaming_track_result
 FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_track_result()\
 """
 
@@ -560,7 +596,7 @@ _DDL_GUARD_BASELINE_FN = f"""\
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_coverage_baseline()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('{ALLOW_URL_REMOVAL_GUC}', true) = 'on' THEN
         IF TG_OP = 'DELETE' THEN
@@ -587,12 +623,12 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$\
+$function$\
 """
 
 _DDL_GUARD_BASELINE_TRIGGER = """\
 CREATE OR REPLACE TRIGGER streaming_coverage_baseline_no_regress
-BEFORE UPDATE OR DELETE ON lml_cache.streaming_coverage_baseline
+BEFORE DELETE OR UPDATE ON lml_cache.streaming_coverage_baseline
 FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_coverage_baseline()\
 """
 
@@ -606,7 +642,7 @@ _DDL_GUARD_TRUNCATE_FN = f"""\
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_truncate()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('{ALLOW_URL_REMOVAL_GUC}', true) = 'on' THEN
         RETURN NULL;
@@ -615,7 +651,7 @@ BEGIN
         '{_OPT_IN_HINT}',
         TG_TABLE_NAME;
 END;
-$$\
+$function$\
 """
 
 _DDL_GUARD_ALBUM_TRUNCATE_TRIGGER = """\
@@ -698,6 +734,73 @@ _BOOTSTRAP_LOCK_TIMEOUT = "SET LOCAL lock_timeout = '10s'"
 _BOOTSTRAP_ADVISORY_LOCK = f"SELECT pg_advisory_xact_lock({_BOOTSTRAP_ADVISORY_LOCK_KEY})"
 
 
+# Steady-state idempotency for the 5 functions + 8 triggers (LML#890): a
+# ``CREATE OR REPLACE`` always writes a fresh catalog row even when the
+# definition is byte-identical, and for a TRIGGER that write takes a SHARE ROW
+# EXCLUSIVE lock on the table — a real cost on a boot racing a long pipeline
+# transaction, paid on every single boot even in steady state. Before issuing
+# either form this module compares the shipped statement against the live
+# definition (``pg_get_functiondef`` / ``pg_get_triggerdef``) and skips the
+# replace when they match, so a boot over an already-current schema issues no
+# writes for these statements at all.
+#
+# The comparison is a checksum-by-round-trip, not OID/xmin: PG's own
+# re-rendering re-indents and re-tags dollar-quoting, so a byte comparison
+# against this module's hand-formatted source needs both sides normalized to
+# the same whitespace-collapsed form (``_normalize_definition``) — and the
+# function/trigger DDL below is deliberately authored to match PG's canonical
+# re-rendering choices (the ``$function$`` dollar-quote tag ``pg_get_
+# functiondef`` always uses, and ``DELETE OR UPDATE`` event order, which is
+# how ``pg_get_triggerdef`` canonicalizes ``UPDATE OR DELETE``) so a
+# genuinely unchanged definition round-trips byte-for-byte once normalized.
+def _normalize_definition(text: str) -> str:
+    return " ".join(text.split())
+
+
+_FUNCTION_NAME_RE = re.compile(r"^CREATE OR REPLACE FUNCTION (\S+\(\))")
+_TRIGGER_HEADER_RE = re.compile(r"^CREATE OR REPLACE TRIGGER (\S+)\nBEFORE .*? ON (\S+)\n")
+
+
+async def _function_definition_is_unchanged(conn, statement: str) -> bool:
+    """True when ``statement``'s function already matches the live definition.
+
+    ``to_regprocedure`` returns NULL (rather than raising) for a function
+    that doesn't exist yet, so a first boot always falls through to the
+    real ``CREATE OR REPLACE``.
+    """
+    match = _FUNCTION_NAME_RE.match(statement)
+    assert match is not None, f"not a CREATE OR REPLACE FUNCTION statement: {statement[:60]!r}"
+    live_def = await conn.fetchval(
+        "SELECT pg_get_functiondef(oid) FROM pg_proc WHERE oid = to_regprocedure($1)",
+        match.group(1),
+    )
+    return live_def is not None and _normalize_definition(live_def) == _normalize_definition(
+        statement
+    )
+
+
+async def _trigger_definition_is_unchanged(conn, statement: str) -> bool:
+    """True when ``statement``'s trigger already matches the live definition.
+
+    ``pg_get_triggerdef`` never emits ``OR REPLACE`` (it reconstructs from the
+    catalog, not from how the trigger was created), so the desired side of the
+    comparison substitutes ``CREATE TRIGGER`` before normalizing.
+    """
+    match = _TRIGGER_HEADER_RE.match(statement)
+    assert match is not None, f"not a CREATE OR REPLACE TRIGGER statement: {statement[:60]!r}"
+    trigger_name, table_name = match.group(1), match.group(2)
+    live_def = await conn.fetchval(
+        "SELECT pg_get_triggerdef(oid) FROM pg_trigger "
+        "WHERE tgname = $1 AND tgrelid = $2::regclass AND NOT tgisinternal",
+        trigger_name,
+        table_name,
+    )
+    if live_def is None:
+        return False
+    desired = statement.replace("CREATE OR REPLACE TRIGGER", "CREATE TRIGGER", 1)
+    return _normalize_definition(live_def) == _normalize_definition(desired)
+
+
 async def set_up_streaming_catalog_schema(pg: PgSource) -> None:
     """Apply the idempotent streaming-catalog DDL (tables, indexes, guards).
 
@@ -712,13 +815,22 @@ async def set_up_streaming_catalog_schema(pg: PgSource) -> None:
     preamble bounds lock waits and serializes concurrent bootstraps (see the
     constants above). The ``CREATE OR REPLACE`` function/trigger forms are the
     idempotent equivalents of ``IF NOT EXISTS`` (which triggers don't
-    support); replacing an identical definition is a no-op in effect. The
-    service-CHECK maintenance semantics (widen-only, steady-state no-op) are
-    documented on ``_DDL_ALBUM_SERVICE_WIDEN_CHECK`` above.
+    support); a function or trigger statement whose live definition already
+    matches is skipped entirely rather than replaced (see
+    ``_function_definition_is_unchanged`` / ``_trigger_definition_is_unchanged``
+    above) so a steady-state boot takes no lock for it. The service-CHECK
+    maintenance semantics (widen-only, steady-state no-op, foreign-form
+    warn-and-skip) are documented on ``_DDL_ALBUM_SERVICE_WIDEN_CHECK`` above.
     """
     async with pg.acquire() as conn:
         async with conn.transaction():
             await conn.execute(_BOOTSTRAP_LOCK_TIMEOUT)
             await conn.execute(_BOOTSTRAP_ADVISORY_LOCK)
             for statement in _DDL_STATEMENTS:
+                if statement.startswith("CREATE OR REPLACE FUNCTION"):
+                    if await _function_definition_is_unchanged(conn, statement):
+                        continue
+                elif statement.startswith("CREATE OR REPLACE TRIGGER"):
+                    if await _trigger_definition_is_unchanged(conn, statement):
+                        continue
                 await conn.execute(statement)

--- a/entity/streaming_catalog.sql
+++ b/entity/streaming_catalog.sql
@@ -137,23 +137,31 @@ CREATE TABLE IF NOT EXISTS lml_cache.streaming_album_service (
 
 -- Widen-only maintenance of the named service CHECK, so an already-created
 -- table (where CREATE TABLE IF NOT EXISTS is a no-op) picks up service values
--- added after its creation. Deparses the deployed constraint, extracts its
--- quoted literals, and rewrites only when the shipped set adds something —
--- merging, never narrowing (a rollback deploy must not abort the bootstrap
--- against rows using a newer service), and skipping the rewrite entirely on a
--- steady-state boot (stable constraint OID, no ACCESS EXCLUSIVE lock, no
--- re-validation scan). The rewrite emits the IN (...) form on purpose: PG
--- deparses IN as = ANY (ARRAY[...]) and the extraction reads quoted literals
--- from that deparse; an array-literal constant would deparse as ONE literal
--- and corrupt the next boot's extraction. When the constraint is ABSENT
--- (dropped out-of-band), the re-ADD folds in every service value already
--- live in the table, so a recovery boot can't brick on rows outside the
--- shipped set.
+-- added after its creation. Deparses the deployed constraint and
+-- distinguishes three states: PARSEABLE (matches the exact
+-- service = ANY (ARRAY[...]) shape this bootstrap emits; quoted literals are
+-- extracted with a quote-aware pattern -- handles an escaped quote inside a
+-- literal, e.g. 'o''brien' -- and round-tripped before being trusted, then
+-- merged only when the shipped set adds something, never narrowing, skipping
+-- the rewrite entirely on a steady-state boot); ABSENT (dropped out-of-band;
+-- the re-ADD folds in every service value already live in the table so a
+-- recovery boot can't brick on rows outside the shipped set); and
+-- FOREIGN-FORM (a hand-repaired regex CHECK, an array-literal constant, or
+-- anything the round-trip can't reproduce byte-for-byte -- policy is WARN
+-- AND SKIP: RAISE WARNING naming the unparsed deparse and leave the
+-- constraint untouched, never drop-and-rebuild or rebuild-from-live-rows,
+-- since a foreign form implies deliberate out-of-band operator action). The
+-- rewrite emits the IN (...) form on purpose: PG deparses IN as
+-- = ANY (ARRAY[...]) and the extraction reads quoted literals from that
+-- deparse; an array-literal constant would deparse as ONE literal and
+-- corrupt the next boot's extraction.
 
 DO $catalog_check$
 DECLARE
     existing_def text;
+    inner_array text;
     existing_services text[];
+    rebuilt_array text;
     code_services text[] := ARRAY[
         'spotify', 'deezer', 'apple_music', 'bandcamp', 'tidal', 'youtube_music', 'soundcloud'];
     merged_list text;
@@ -163,8 +171,25 @@ BEGIN
         WHERE conrelid = 'lml_cache.streaming_album_service'::regclass
             AND conname = 'streaming_album_service_valid';
     IF existing_def IS NOT NULL THEN
-        SELECT array_agg(m[1]) INTO existing_services
-            FROM regexp_matches(existing_def, '''([^'']+)''', 'g') AS m;
+        inner_array := substring(
+            existing_def FROM '^CHECK \(\(service = ANY \(ARRAY\[(.*)\]\)\)\)$'
+        );
+        IF inner_array IS NULL THEN
+            RAISE WARNING 'streaming_album_service_valid: deployed CHECK (%) is not in the '
+                'expected service = ANY (ARRAY[...]) shape this bootstrap can parse; '
+                'leaving it untouched (foreign-form policy: warn-and-skip)', existing_def;
+            RETURN;
+        END IF;
+        SELECT array_agg(replace(m[1], '''''', '''')) INTO existing_services
+            FROM regexp_matches(inner_array, '''((?:[^'']|'''')*)''', 'g') AS m;
+        SELECT string_agg(quote_literal(s) || '::text', ', ') INTO rebuilt_array
+            FROM unnest(existing_services) AS s;
+        IF rebuilt_array IS DISTINCT FROM inner_array THEN
+            RAISE WARNING 'streaming_album_service_valid: deployed CHECK (%) has literals this '
+                'bootstrap could not confidently round-trip; leaving it untouched '
+                '(foreign-form policy: warn-and-skip)', existing_def;
+            RETURN;
+        END IF;
         IF existing_services @> code_services THEN
             RETURN;
         END IF;
@@ -279,7 +304,7 @@ CREATE TABLE IF NOT EXISTS lml_cache.streaming_coverage_baseline (
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_album()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('lml_cache.allow_url_removal', true) = 'on' THEN
         IF TG_OP = 'DELETE' THEN
@@ -322,10 +347,10 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$;
+$function$;
 
 CREATE OR REPLACE TRIGGER streaming_album_no_regress
-BEFORE UPDATE OR DELETE ON lml_cache.streaming_album
+BEFORE DELETE OR UPDATE ON lml_cache.streaming_album
 FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_album();
 
 -- Total status gate (IS DISTINCT FROM 'found'), not a demotion blocklist:
@@ -339,7 +364,7 @@ FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_album();
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_album_service()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('lml_cache.allow_url_removal', true) = 'on' THEN
         IF TG_OP = 'DELETE' THEN
@@ -394,10 +419,10 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$;
+$function$;
 
 CREATE OR REPLACE TRIGGER streaming_album_service_no_regress
-BEFORE UPDATE OR DELETE ON lml_cache.streaming_album_service
+BEFORE DELETE OR UPDATE ON lml_cache.streaming_album_service
 FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_album_service();
 
 -- Same total gate on the resolved pair; the lateral local_match <-> api_match
@@ -410,7 +435,7 @@ FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_album_service();
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_track_result()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('lml_cache.allow_url_removal', true) = 'on' THEN
         IF TG_OP = 'DELETE' THEN
@@ -462,10 +487,10 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$;
+$function$;
 
 CREATE OR REPLACE TRIGGER streaming_track_result_no_regress
-BEFORE UPDATE OR DELETE ON lml_cache.streaming_track_result
+BEFORE DELETE OR UPDATE ON lml_cache.streaming_track_result
 FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_track_result();
 
 -- Outside an opted-in transaction the floor only ratchets upward (equal is
@@ -478,7 +503,7 @@ FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_track_result();
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_coverage_baseline()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('lml_cache.allow_url_removal', true) = 'on' THEN
         IF TG_OP = 'DELETE' THEN
@@ -505,10 +530,10 @@ BEGIN
     END IF;
     RETURN NEW;
 END;
-$$;
+$function$;
 
 CREATE OR REPLACE TRIGGER streaming_coverage_baseline_no_regress
-BEFORE UPDATE OR DELETE ON lml_cache.streaming_coverage_baseline
+BEFORE DELETE OR UPDATE ON lml_cache.streaming_coverage_baseline
 FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_coverage_baseline();
 
 -- TRUNCATE never fires row-level triggers, so without these the row guards
@@ -521,7 +546,7 @@ FOR EACH ROW EXECUTE FUNCTION lml_cache.guard_streaming_coverage_baseline();
 CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_truncate()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+AS $function$
 BEGIN
     IF current_setting('lml_cache.allow_url_removal', true) = 'on' THEN
         RETURN NULL;
@@ -530,7 +555,7 @@ BEGIN
         'opt in via set_config(''lml_cache.allow_url_removal'', ''on'', true) in this transaction',
         TG_TABLE_NAME;
 END;
-$$;
+$function$;
 
 CREATE OR REPLACE TRIGGER streaming_album_no_truncate
 BEFORE TRUNCATE ON lml_cache.streaming_album

--- a/scripts/regenerate_streaming_catalog_sql.py
+++ b/scripts/regenerate_streaming_catalog_sql.py
@@ -130,18 +130,24 @@ _COMMENTS: dict[str, str] = {
     "DO $catalog_check$": """\
 -- Widen-only maintenance of the named service CHECK, so an already-created
 -- table (where CREATE TABLE IF NOT EXISTS is a no-op) picks up service values
--- added after its creation. Deparses the deployed constraint, extracts its
--- quoted literals, and rewrites only when the shipped set adds something —
--- merging, never narrowing (a rollback deploy must not abort the bootstrap
--- against rows using a newer service), and skipping the rewrite entirely on a
--- steady-state boot (stable constraint OID, no ACCESS EXCLUSIVE lock, no
--- re-validation scan). The rewrite emits the IN (...) form on purpose: PG
--- deparses IN as = ANY (ARRAY[...]) and the extraction reads quoted literals
--- from that deparse; an array-literal constant would deparse as ONE literal
--- and corrupt the next boot's extraction. When the constraint is ABSENT
--- (dropped out-of-band), the re-ADD folds in every service value already
--- live in the table, so a recovery boot can't brick on rows outside the
--- shipped set.""",
+-- added after its creation. Deparses the deployed constraint and
+-- distinguishes three states: PARSEABLE (matches the exact
+-- service = ANY (ARRAY[...]) shape this bootstrap emits; quoted literals are
+-- extracted with a quote-aware pattern -- handles an escaped quote inside a
+-- literal, e.g. 'o''brien' -- and round-tripped before being trusted, then
+-- merged only when the shipped set adds something, never narrowing, skipping
+-- the rewrite entirely on a steady-state boot); ABSENT (dropped out-of-band;
+-- the re-ADD folds in every service value already live in the table so a
+-- recovery boot can't brick on rows outside the shipped set); and
+-- FOREIGN-FORM (a hand-repaired regex CHECK, an array-literal constant, or
+-- anything the round-trip can't reproduce byte-for-byte -- policy is WARN
+-- AND SKIP: RAISE WARNING naming the unparsed deparse and leave the
+-- constraint untouched, never drop-and-rebuild or rebuild-from-live-rows,
+-- since a foreign form implies deliberate out-of-band operator action). The
+-- rewrite emits the IN (...) form on purpose: PG deparses IN as
+-- = ANY (ARRAY[...]) and the extraction reads quoted literals from that
+-- deparse; an array-literal constant would deparse as ONE literal and
+-- corrupt the next boot's extraction.""",
     "CREATE INDEX IF NOT EXISTS idx_streaming_album_service_status": """\
 -- Pending-scan support for the pipelines ("next albums to probe on service
 -- X"), mirroring the legacy per-service status indexes. Shape is provisional

--- a/tests/integration/test_streaming_catalog.py
+++ b/tests/integration/test_streaming_catalog.py
@@ -620,6 +620,140 @@ class TestServiceCheckWiden:
         assert oid is not None
         assert preserved == 1
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "foreign_form_check",
+        [
+            "service ~ '^[a-z_]+$'",
+            "service = ANY ('{spotify,deezer}'::text[])",
+        ],
+        ids=["hand-repaired-regex", "array-literal-constant"],
+    )
+    async def test_boot_leaves_a_foreign_form_check_untouched(
+        self, pg_pool, pg_source, foreign_form_check
+    ):
+        """Neither a hand-repaired regex CHECK nor an ``= ANY`` array-literal
+        constant deparses into the ``service = ANY (ARRAY[...])`` shape this
+        bootstrap's extraction understands (an array-literal Const deparses
+        as ONE literal, corrupting any attempted split). Policy is
+        warn-and-skip: the boot must complete without raising and the
+        constraint must be left byte-for-byte untouched — never narrowed,
+        never silently replaced with a garbage merge, never aborted."""
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "ALTER TABLE lml_cache.streaming_album_service "
+                "DROP CONSTRAINT streaming_album_service_valid, "
+                f"ADD CONSTRAINT streaming_album_service_valid CHECK ({foreign_form_check})"
+            )
+            oid_before = await conn.fetchval(_SERVICE_CHECK_OID)
+            def_before = await conn.fetchval(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE oid = $1", oid_before
+            )
+
+        await set_up_streaming_catalog_schema(pg_source)
+
+        async with pg_pool.acquire() as conn:
+            oid_after = await conn.fetchval(_SERVICE_CHECK_OID)
+            def_after = await conn.fetchval(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE oid = $1", oid_after
+            )
+        assert oid_after == oid_before
+        assert def_after == def_before
+
+    @pytest.mark.asyncio
+    async def test_boot_widens_a_narrower_check_preserving_a_quote_bearing_literal(
+        self, pg_pool, pg_source
+    ):
+        """A deployed CHECK narrower than the shipped set (so a widen is
+        required) that also carries a quote-bearing literal -- e.g. an
+        apostrophe-bearing service value folded in by an earlier
+        ABSENT-recovery boot -- must not have that literal's escaped quote
+        fragment the extraction. Pre-hardening, ``'o''brien'`` extracts as two
+        bogus entries {'o', 'brien'}; the merged re-ADD then omits the real
+        ``o'brien`` value entirely, and the ALTER's re-validation scan aborts
+        against the live row still using it -- on every subsequent boot."""
+        album_id = await _make_album(pg_pool)
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "ALTER TABLE lml_cache.streaming_album_service "
+                "DROP CONSTRAINT streaming_album_service_valid, "
+                "ADD CONSTRAINT streaming_album_service_valid "
+                "CHECK (service IN ('spotify', 'deezer', 'o''brien'))"
+            )
+            await conn.execute(
+                _INSERT_SERVICE, album_id, "o'brien", "found", "https://example.test/obrien"
+            )
+
+        await set_up_streaming_catalog_schema(pg_source)
+
+        async with pg_pool.acquire() as conn:
+            preserved = await conn.fetchval(
+                "SELECT count(*) FROM lml_cache.streaming_album_service WHERE service = $1",
+                "o'brien",
+            )
+            # The widened constraint must still admit the full shipped set...
+            await conn.execute(_INSERT_SERVICE, album_id, "bandcamp", "pending", None)
+            # ...and still reject a value from neither set.
+            with pytest.raises(asyncpg.CheckViolationError):
+                await conn.execute(_INSERT_SERVICE, album_id, "myspace", "pending", None)
+        assert preserved == 1
+
+
+@pytest.mark.pg
+class TestSteadyStateNoChurn:
+    """Second boot over an up-to-date schema must not re-issue CREATE OR
+    REPLACE for any of the 5 guard functions or 8 triggers (LML#890): a
+    function replace writes a fresh catalog row and a trigger replace also
+    takes a SHARE ROW EXCLUSIVE lock on its table -- neither is warranted when
+    the live definition already matches. ``xmin`` is the tell: CREATE OR
+    REPLACE always bumps it, even when re-applying an identical definition,
+    while the object's OID stays stable either way (so OID alone can't
+    distinguish a skip from a no-op replace)."""
+
+    @pytest.mark.asyncio
+    async def test_second_boot_does_not_replace_unchanged_functions_or_triggers(
+        self, pg_pool, pg_source
+    ):
+        async with pg_pool.acquire() as conn:
+            procs_before = {
+                r["oid"]: r["xmin"]
+                for r in await conn.fetch(
+                    "SELECT oid, xmin FROM pg_proc WHERE pronamespace = 'lml_cache'::regnamespace"
+                )
+            }
+            triggers_before = {
+                r["oid"]: r["xmin"]
+                for r in await conn.fetch(
+                    "SELECT t.oid, t.xmin FROM pg_trigger t "
+                    "JOIN pg_class c ON c.oid = t.tgrelid "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE n.nspname = 'lml_cache' AND NOT t.tgisinternal"
+                )
+            }
+        assert len(procs_before) == 5
+        assert len(triggers_before) == 8
+
+        await set_up_streaming_catalog_schema(pg_source)
+
+        async with pg_pool.acquire() as conn:
+            procs_after = {
+                r["oid"]: r["xmin"]
+                for r in await conn.fetch(
+                    "SELECT oid, xmin FROM pg_proc WHERE pronamespace = 'lml_cache'::regnamespace"
+                )
+            }
+            triggers_after = {
+                r["oid"]: r["xmin"]
+                for r in await conn.fetch(
+                    "SELECT t.oid, t.xmin FROM pg_trigger t "
+                    "JOIN pg_class c ON c.oid = t.tgrelid "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE n.nspname = 'lml_cache' AND NOT t.tgisinternal"
+                )
+            }
+        assert procs_after == procs_before
+        assert triggers_after == triggers_before
+
 
 @pytest.mark.pg
 class TestAlbumRowGuard:

--- a/tests/unit/test_streaming_catalog_schema.py
+++ b/tests/unit/test_streaming_catalog_schema.py
@@ -78,6 +78,13 @@ class _FakeConnection:
             raise RuntimeError(f"injected failure on {fail_on!r}")
         return "CREATE"
 
+    async def fetchval(self, sql: str, *args: object) -> object:
+        # Backs the function/trigger steady-state drift check: keyed by the
+        # query's positional args (the qualified function name, or the
+        # (trigger, table) pair) so a test can simulate "already matches" per
+        # object without modeling the real pg_proc/pg_trigger catalogs.
+        return self._source.fetchval_responses.get(args)
+
 
 class _FakePgSource:
     """Records every statement the bootstrap issues and whether it ran inside
@@ -85,15 +92,23 @@ class _FakePgSource:
     other attribute access (pool-level ``execute``/``fetchone``) is an
     ``AttributeError``, which doubles as the only-one-connection assertion.
     ``fail_on`` injects a mid-boot failure on the first statement containing
-    that substring, for the error-propagation test."""
+    that substring, for the error-propagation test. ``fetchval_responses``
+    seeds the function/trigger drift-check's ``fetchval`` lookups; omitted
+    keys resolve to ``None`` (object doesn't exist live yet), matching a
+    from-scratch bootstrap where every CREATE OR REPLACE actually executes."""
 
-    def __init__(self, fail_on: str | None = None) -> None:
+    def __init__(
+        self,
+        fail_on: str | None = None,
+        fetchval_responses: dict[tuple[object, ...], object] | None = None,
+    ) -> None:
         self.executed: list[tuple[str, bool]] = []
         self.acquire_count = 0
         self.transaction_starts = 0
         self.transaction_ends = 0
         self.in_transaction = False
         self.fail_on = fail_on
+        self.fetchval_responses = fetchval_responses or {}
 
     @property
     def statements(self) -> list[str]:
@@ -326,7 +341,7 @@ class TestSetUpStreamingCatalogSchema:
     async def test_bootstrap_is_pure_ddl_after_the_preamble(self):
         # The bootstrap must never mutate rows. The sibling tests grep for
         # INSERT/UPDATE/DELETE substrings, but the guard-trigger DDL here
-        # legitimately contains "BEFORE UPDATE OR DELETE" — so assert on the
+        # legitimately contains "BEFORE DELETE OR UPDATE" — so assert on the
         # statement head instead: after the two-statement preamble (SET LOCAL
         # + advisory lock SELECT, both row-neutral), every statement is CREATE,
         # ALTER, the widen-only DO block (which only ever EXECUTEs an ALTER), or
@@ -344,3 +359,61 @@ class TestSetUpStreamingCatalogSchema:
             assert head in {"CREATE", "ALTER", "DO", "DROP"}, (
                 f"non-DDL statement in bootstrap: {sql[:80]!r}"
             )
+
+    async def test_first_boot_replaces_every_function_and_trigger(self):
+        # No live definitions yet (the default _FakePgSource fetchval_responses
+        # is empty, so every drift check resolves to "not unchanged") — a
+        # from-scratch bootstrap must still issue all 5 + 8 CREATE OR REPLACE
+        # statements, matching the pre-#890 behavior.
+        pg = _FakePgSource()
+
+        await set_up_streaming_catalog_schema(pg)
+
+        assert sum(s.startswith("CREATE OR REPLACE FUNCTION") for s in pg.statements) == 5
+        assert sum(s.startswith("CREATE OR REPLACE TRIGGER") for s in pg.statements) == 8
+
+    async def test_second_boot_skips_every_unchanged_function_and_trigger(self):
+        # Simulate a steady-state boot: fetchval echoes back exactly the
+        # definition each statement would create, so every drift check must
+        # find "unchanged" and the bootstrap must not re-issue any of the 5
+        # function or 8 trigger CREATE OR REPLACE statements (LML#890) — only
+        # the row-neutral CREATE/ALTER/DO/DROP statements still run every boot.
+        responses: dict[tuple[object, ...], object] = {}
+        for statement in _DDL_STATEMENTS:
+            fn_match = re.match(r"^CREATE OR REPLACE FUNCTION (\S+\(\))", statement)
+            if fn_match:
+                responses[(fn_match.group(1),)] = statement
+                continue
+            trg_match = re.match(
+                r"^CREATE OR REPLACE TRIGGER (\S+)\nBEFORE .*? ON (\S+)\n", statement
+            )
+            if trg_match:
+                trigger_name, table_name = trg_match.group(1), trg_match.group(2)
+                responses[(trigger_name, table_name)] = statement.replace(
+                    "CREATE OR REPLACE TRIGGER", "CREATE TRIGGER", 1
+                )
+        assert len(responses) == 13, "expected 5 functions + 8 triggers to be keyed"
+        pg = _FakePgSource(fetchval_responses=responses)
+
+        await set_up_streaming_catalog_schema(pg)
+
+        assert not any(s.startswith("CREATE OR REPLACE FUNCTION") for s in pg.statements)
+        assert not any(s.startswith("CREATE OR REPLACE TRIGGER") for s in pg.statements)
+        # Row-neutral DDL (tables, indexes, the widen block) still runs.
+        for table in _TABLES:
+            assert f"CREATE TABLE IF NOT EXISTS lml_cache.{table}" in "\n".join(pg.statements)
+
+    async def test_boot_still_replaces_a_function_whose_live_body_drifted(self):
+        # A drift check that finds a DIFFERENT live definition must not skip —
+        # only a byte-for-byte (normalized) match short-circuits the replace.
+        drifted = "CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_album() ... stale ..."
+        pg = _FakePgSource(fetchval_responses={("lml_cache.guard_streaming_album()",): drifted})
+
+        await set_up_streaming_catalog_schema(pg)
+
+        replaced = [
+            s
+            for s in pg.statements
+            if s.startswith("CREATE OR REPLACE FUNCTION lml_cache.guard_streaming_album()")
+        ]
+        assert len(replaced) == 1


### PR DESCRIPTION
## Summary

Two hardening gaps in the `lml_cache` streaming-catalog bootstrap (`entity/streaming_catalog.py`), both flagged in #883's review round and deferred as non-blockers since that PR shipped no runtime callers.

**1. Foreign-form widen handling.** The widen-only DO block for `streaming_album_service_valid` assumed the deployed constraint was always in the exact `service = ANY (ARRAY[...])` shape this bootstrap emits (PG's canonical deparse of `service IN (...)`), and extracted quoted literals out of it unconditionally. A hand-repaired regex CHECK, an `= ANY` array-literal constant, or any other foreign form got extracted anyway, producing a garbage merge that could re-validate against out-of-set rows and abort the bootstrap transaction — recurring on every boot until an operator intervened.

The DO block now distinguishes three deployed-constraint states:
- **Parseable** — merge, never narrow, skip when nothing to add (unchanged behavior).
- **Absent** — re-ADD folding in live out-of-set values (unchanged behavior).
- **Foreign-form** — a round-trip check (extract → rebuild → diff against the original deparse) catches anything that doesn't match byte-for-byte. Policy (decided on the issue): **warn-and-skip** — `RAISE WARNING` naming the unparsed deparse and leave the constraint untouched. Never drop-and-rebuild or rebuild-from-live-rows: a foreign form implies deliberate out-of-band operator action, and guessing at a replacement risks silently narrowing what the operator installed.

The same round-trip hardens the quoted-literal extraction itself against an escaped quote inside a legitimate literal (e.g. `'o''brien'`), which previously fragmented into bogus entries and could poison a subsequent widen.

**2. Steady-state `CREATE OR REPLACE` churn.** All 5 guard functions and 8 triggers re-executed their `CREATE OR REPLACE` on every boot, even when nothing changed. Each `CREATE OR REPLACE TRIGGER` takes a `SHARE ROW EXCLUSIVE` lock on its table, so a steady-state boot needlessly contends with any concurrent pipeline transaction on that table. The bootstrap now compares each function/trigger's live definition (`pg_get_functiondef` / `pg_get_triggerdef`, whitespace-normalized) against the shipped statement and skips the replace when they already match. Making that comparison reliable required authoring the function bodies with the `$function$` dollar-quote tag and the trigger event order (`DELETE OR UPDATE`) that PostgreSQL itself canonicalizes to, so a genuinely unchanged definition round-trips byte-for-byte after whitespace normalization.

Per the locked decision on the issue, the adversarial out-of-band precondition test (drop constraint + insert a naming-convention-violating row + widen) is split out to #1005; this PR covers the extraction hardening itself with a non-adversarial reproduction.

## Test plan

- [x] New integration tests: a hand-repaired regex CHECK and an `= ANY` array-literal-constant CHECK both survive a boot untouched (byte-identical `pg_get_constraintdef`, stable OID)
- [x] New integration test: a narrower deployed CHECK carrying a quote-bearing literal widens correctly without fragmenting/losing that literal
- [x] New integration test: a second boot over an up-to-date schema leaves every function/trigger's `xmin` unchanged (no `CREATE OR REPLACE` re-issued)
- [x] New unit tests: first boot replaces every function/trigger; second boot (simulated live-definition match) skips all of them; a genuinely drifted function is still replaced
- [x] Verified all four new integration tests fail against the pre-fix code (confirms they catch the described bugs, not vacuous)
- [x] `.sql` twin regenerated via `scripts/regenerate_streaming_catalog_sql.py`; unit parity tests (byte-equality + statement-equality) green
- [x] Full local suite green: `ruff check`, `ruff format --check`, `mypy`, unit tests (4476 passed), `-m pg` integration tests (533 passed, 9 skipped)

Closes #890