### PR TITLE
Totality meta-tests: guard-column classification + lifespan bootstrap registration

### DIFF
--- a/entity/streaming_catalog.py
+++ b/entity/streaming_catalog.py
@@ -654,6 +654,84 @@ _TABLES = (
     "streaming_coverage_baseline",
 )
 
+# Guard-column classification (LML#891). Every column across the four CREATE
+# TABLE statements above must appear in exactly one bucket here — that
+# totality is enforced by tests/unit/test_streaming_catalog_schema.py, which
+# parses the column names straight out of the DDL. Nothing else forces an
+# author adding or renaming a column to decide whether it needs a no-regress
+# clause, so without this net the guard functions above one-column-at-a-time
+# stop covering what the tables actually carry.
+#
+# The four GUARDED_* buckets are cross-checked against the guard-function
+# bodies (_DDL_GUARD_ALBUM_FN et al.): a column classified guarded must be
+# referenced by its table's guard function, so "classify it guarded" can't be
+# satisfied without also writing the clause that actually protects it.
+# UNGUARDED_DELIBERATE is for columns the guards intentionally leave freely
+# correctable — display copy, provenance arrays/flags, and bookkeeping
+# timestamps like ``checked_at``/``created_at``/``updated_at``.
+GUARDED_URL = frozenset(
+    {
+        "url",
+        "slug",
+        "spotify_url",
+        "deezer_url",
+    }
+)
+GUARDED_STATUS = frozenset(
+    {
+        "discogs_status",
+        "status",
+        "resolution_status",
+    }
+)
+GUARDED_IDENTITY = frozenset(
+    {
+        "id",
+        "normalized_artist",
+        "normalized_title",
+        "album_id",
+        "service",
+        "artist",
+        "title",
+        "metric",
+    }
+)
+GUARDED_METADATA = frozenset(
+    {
+        "discogs_release_id",
+        "discogs_artist",
+        "discogs_title",
+        "service_item_id",
+        "matched_artist",
+        "matched_title",
+        "confidence",
+        "resolved_via",
+        "resolved_album_id",
+        "resolved_release_id",
+        "spotify_confidence",
+        "deezer_confidence",
+        "value",
+    }
+)
+UNGUARDED_DELIBERATE = frozenset(
+    {
+        "display_artist",
+        "display_title",
+        "library_ids",
+        "formats",
+        "genre",
+        "label",
+        "is_compilation",
+        "is_single",
+        "created_at",
+        "checked_at",
+        "position",
+        "source",
+        "source_type",
+        "updated_at",
+    }
+)
+
 # Ordered: schema first, parents before children (FKs), tables before their
 # widen block/indexes/triggers. Kept as a module constant so the bootstrap
 # and the unit parity tests reference one list; the .sql reference mirrors

--- a/tests/unit/test_lifespan_bootstrap_totality.py
+++ b/tests/unit/test_lifespan_bootstrap_totality.py
@@ -1,0 +1,87 @@
+"""Discovery net for LML#891 — every ``entity/*.py`` schema bootstrap must be
+wired into ``main.py``'s lifespan.
+
+``main.py``'s lifespan runs the ``lml_cache.*`` bootstraps from an inline
+``bootstraps`` tuple (LML#883's review explicitly rejected a registry
+indirection for this — settings coupling isn't worth it for six call sites).
+That leaves nothing to stop a new ``entity/*.py`` cache module from shipping
+with its ``set_up_*_schema`` never called: the deployed app would simply lack
+the table until someone notices downstream. This is a static, PG-free source
+check, mirroring the fixture-file discovery net in
+``tests/integration/test_pg_fixture_guard_adoption.py``
+(``test_every_lml_cache_dropping_suite_is_registered``): glob every
+``entity/*.py`` module for a module-level ``set_up_*_schema`` coroutine, and
+require ``main.py`` to both import it and reference its name — the same style
+of "a hit sits outside the roster and must be registered" check the fixture
+net runs for lml_cache-dropping test files.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ENTITY_DIR = Path(__file__).resolve().parent.parent.parent / "entity"
+_MAIN_PY = Path(__file__).resolve().parent.parent.parent / "main.py"
+
+# Module-level bootstrap coroutine: no leading indent, ``async def
+# set_up_..._schema(``. Excludes nested/test-local helpers of the same shape
+# (e.g. fixture-local ``set_up_entity_schema`` in tests/integration/*) because
+# this only globs ``entity/*.py``.
+_BOOTSTRAP_DEF = re.compile(r"^async def (set_up_\w+_schema)\(", re.MULTILINE)
+
+# Deliberate exceptions: entity/*.py modules that define a `set_up_*_schema`
+# coroutine but are NOT called from main.py's lifespan (e.g. a schema bootstrap
+# only ever invoked from a script or a per-test fixture). Empty today — every
+# entity/*.py bootstrap is a real lifespan-registered lml_cache.* table.
+_LIFESPAN_EXEMPT: frozenset[str] = frozenset()
+
+
+def _discover_bootstraps() -> dict[str, str]:
+    """Map bootstrap function name -> owning module name for every
+    ``entity/*.py`` file that defines one."""
+    found: dict[str, str] = {}
+    for path in sorted(_ENTITY_DIR.glob("*.py")):
+        src = path.read_text(encoding="utf-8")
+        for match in _BOOTSTRAP_DEF.finditer(src):
+            found[match.group(1)] = path.stem
+    return found
+
+
+def test_discovery_finds_the_known_bootstraps():
+    # Guards the discovery regex itself: if this drifts to zero (or an
+    # unexpected count), the totality check below would vacuously pass.
+    found = _discover_bootstraps()
+    assert found, "no entity/*.py set_up_*_schema coroutines discovered — regex drifted?"
+    assert "set_up_streaming_catalog_schema" in found
+    assert "set_up_api_keys_schema" in found
+
+
+def test_every_entity_schema_bootstrap_is_registered_in_main_lifespan():
+    """Every non-exempt ``set_up_*_schema`` coroutine in ``entity/*.py`` must
+    be both imported and referenced by name in ``main.py`` — the two
+    ingredients the lifespan's inline ``bootstraps`` tuple needs to actually
+    call it. A module whose author forgets the tuple entry (or the import)
+    fails here instead of shipping a silently-missing table."""
+    main_src = _MAIN_PY.read_text(encoding="utf-8")
+    found = _discover_bootstraps()
+
+    missing = []
+    for name, module in sorted(found.items()):
+        if name in _LIFESPAN_EXEMPT:
+            continue
+        # Registered means: main.py imports FROM the owning module (guards
+        # against a same-named coincidental import from elsewhere), and the
+        # bootstrap name itself appears a second time beyond that import line
+        # (the bootstraps-tuple call site) — imports may be single-line or
+        # parenthesized multi-line, so this checks co-occurrence rather than
+        # anchoring a single regex across the import's exact shape.
+        imports_from_module = f"from entity.{module} import" in main_src
+        if not imports_from_module or main_src.count(name) < 2:
+            missing.append(f"{name} (entity/{module}.py)")
+
+    assert not missing, (
+        f"{missing} define a set_up_*_schema coroutine that main.py does not both import "
+        "and invoke from the lifespan's inline bootstraps tuple — register it (or add it "
+        "to _LIFESPAN_EXEMPT with a comment explaining why it's intentionally uncalled)"
+    )

--- a/tests/unit/test_streaming_catalog_schema.py
+++ b/tests/unit/test_streaming_catalog_schema.py
@@ -38,13 +38,105 @@ import pytest
 
 from entity.streaming_catalog import (
     _BOOTSTRAP_ADVISORY_LOCK_KEY,
+    _DDL_ALBUM,
+    _DDL_ALBUM_SERVICE,
+    _DDL_COVERAGE_BASELINE,
+    _DDL_GUARD_ALBUM_FN,
+    _DDL_GUARD_ALBUM_SERVICE_FN,
+    _DDL_GUARD_BASELINE_FN,
+    _DDL_GUARD_TRACK_RESULT_FN,
     _DDL_STATEMENTS,
+    _DDL_TRACK_RESULT,
     _SERVICES,
     _TABLES,
     ALLOW_URL_REMOVAL_GUC,
+    GUARDED_IDENTITY,
+    GUARDED_METADATA,
+    GUARDED_STATUS,
+    GUARDED_URL,
+    UNGUARDED_DELIBERATE,
     set_up_streaming_catalog_schema,
 )
 from tests.unit.conftest import normalize_sql as _normalize_sql
+
+# (create-table DDL, its table's no-regress guard-function body) pairs — the
+# guarded buckets below are asserted against the guard body, not just
+# hand-copied, so a column that gets classified guarded without a matching
+# guard-function clause fails loudly instead of silently trusting the author.
+_TABLE_DDL_AND_GUARD_FN = (
+    (_DDL_ALBUM, _DDL_GUARD_ALBUM_FN),
+    (_DDL_ALBUM_SERVICE, _DDL_GUARD_ALBUM_SERVICE_FN),
+    (_DDL_TRACK_RESULT, _DDL_GUARD_TRACK_RESULT_FN),
+    (_DDL_COVERAGE_BASELINE, _DDL_GUARD_BASELINE_FN),
+)
+
+# The column-name line shape inside a CREATE TABLE statement: leading
+# four-space indent, then a lowercase-leading identifier. Constraint/key
+# clauses (``CONSTRAINT``, ``UNIQUE``, ``PRIMARY KEY``) start uppercase, so
+# this shape naturally excludes them without a keyword blocklist.
+_COLUMN_LINE = re.compile(r"^    ([a-z][a-z0-9_]*) ", re.MULTILINE)
+
+
+def _columns(ddl: str) -> list[str]:
+    return _COLUMN_LINE.findall(ddl)
+
+
+class TestGuardColumnClassification:
+    """Totality net for LML#891: every column across the four catalog tables
+    must be classified exactly once, and every guarded classification must be
+    backed by an actual guard-function clause — closing the gap where PR D/E
+    (or any later change) adds a column that nothing forces an author to
+    triage into a guard bucket."""
+
+    def test_every_column_is_classified_exactly_once(self):
+        buckets = (
+            GUARDED_URL,
+            GUARDED_STATUS,
+            GUARDED_IDENTITY,
+            GUARDED_METADATA,
+            UNGUARDED_DELIBERATE,
+        )
+        for ddl, _guard_fn in _TABLE_DDL_AND_GUARD_FN:
+            for column in _columns(ddl):
+                hits = [bucket for bucket in buckets if column in bucket]
+                assert hits, (
+                    f"column {column!r} in {ddl.splitlines()[0]!r} is not classified in any "
+                    "guard bucket — add it to GUARDED_URL/GUARDED_STATUS/GUARDED_IDENTITY/"
+                    "GUARDED_METADATA (if a guard function polices it) or "
+                    "UNGUARDED_DELIBERATE (if the guards deliberately leave it correctable)"
+                )
+                assert len(hits) == 1, (
+                    f"column {column!r} is classified in more than one bucket: {hits}"
+                )
+
+    def test_guarded_columns_are_backed_by_the_guard_function_body(self):
+        guarded = GUARDED_URL | GUARDED_STATUS | GUARDED_IDENTITY | GUARDED_METADATA
+        for ddl, guard_fn in _TABLE_DDL_AND_GUARD_FN:
+            for column in _columns(ddl):
+                if column not in guarded:
+                    continue
+                assert re.search(rf"\b{re.escape(column)}\b", guard_fn), (
+                    f"{column!r} is classified as guarded but "
+                    f"{guard_fn.splitlines()[1]!r} never references it — either the "
+                    "classification is wrong or the guard function is missing a clause"
+                )
+
+    def test_no_classified_column_is_absent_from_every_table(self):
+        # The reverse-direction net: a bucket entry that doesn't correspond to
+        # any real column is dead weight that would mask a rename silently
+        # slipping the totality check (the renamed column would need a NEW
+        # entry, and the stale one would go unnoticed forever).
+        all_columns = {column for ddl, _ in _TABLE_DDL_AND_GUARD_FN for column in _columns(ddl)}
+        for bucket in (
+            GUARDED_URL,
+            GUARDED_STATUS,
+            GUARDED_IDENTITY,
+            GUARDED_METADATA,
+            UNGUARDED_DELIBERATE,
+        ):
+            stale = bucket - all_columns
+            assert not stale, f"classified but no longer a real column: {stale}"
+
 
 _SQL_REFERENCE = Path(__file__).resolve().parent.parent.parent / "entity" / "streaming_catalog.sql"
 


### PR DESCRIPTION
## Summary

- Exports an explicit `GUARDED_URL` / `GUARDED_STATUS` / `GUARDED_IDENTITY` / `GUARDED_METADATA` / `UNGUARDED_DELIBERATE` classification constant from `entity/streaming_catalog.py`, next to `_SERVICES`/`_TABLES`.
- Adds `TestGuardColumnClassification` to `tests/unit/test_streaming_catalog_schema.py`: parses column names out of the four `CREATE TABLE` statements in `_DDL_STATEMENTS` and asserts every column is classified exactly once, with guarded buckets cross-checked against the corresponding guard-function body — a column classified guarded without a matching guard-function clause fails.
- Adds `tests/unit/test_lifespan_bootstrap_totality.py`: globs `entity/*.py` for module-level `set_up_*_schema` coroutines and asserts each one is both imported and invoked in `main.py`'s inline lifespan `bootstraps` tuple, mirroring the static discovery-net pattern in `tests/integration/test_pg_fixture_guard_adoption.py`.

Both tests are pure-unit (no `pg` marker) and were manually verified to fail against an unclassified column, a guarded-without-body classification, and a missing lifespan registration before being confirmed green against the current source.

Closes #891

## Test plan

- [x] `uv run --no-sync pytest tests/unit/ -q` — 4478 passed
- [x] `uv run --no-sync ruff check .` / `ruff format --check .`
- [x] `uv run --no-sync mypy` on the touched files
- [x] Manually broke each of the three failure modes the issue's acceptance criteria calls out (unclassified column, guarded-without-body, missing lifespan registration) and confirmed each fails the suite, then reverted