### PR TITLE
feat(#1014): point library_url at the dj.wxyc.org per-release permalink

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -105,6 +105,18 @@ class Settings(BaseSettings):
     port: int = Field(default=8000, description="Port to run the server on")
     log_level: str = Field(default="INFO", description="Logging level")
 
+    # dj-site integration
+    # Base URL for the per-release permalinks LibraryItem.library_url emits. Consumers
+    # (the `lookup` tool, Slack, Backend-Service, iOS) land on the dj-site legacy front
+    # door `{dj_site_base_url}/dashboard/album/legacy/{id}`, which 308-redirects the
+    # legacy library id (== tubafrenzy LIBRARY_RELEASE.ID, LML's own id) to the canonical
+    # Backend-Service serial route server-side (WXYC/dj-site#1050). Trailing slashes are
+    # trimmed at render time so an override with a stray "/" can't double the separator.
+    dj_site_base_url: str = Field(
+        default="https://dj.wxyc.org",
+        description="dj-site base URL for per-release library permalinks",
+    )
+
     # Feature Flags
     enable_artwork_lookup: bool = Field(
         default=True, description="Enable artwork lookup from external APIs"

--- a/library/models.py
+++ b/library/models.py
@@ -56,8 +56,20 @@ class LibraryItem(BaseModel):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def library_url(self) -> str:
-        """URL to view this release in the WXYC library."""
-        return f"http://www.wxyc.info/wxycdb/libraryRelease?id={self.id}"
+        """Per-release permalink for viewing this release in the WXYC library.
+
+        Points at the dj-site legacy front door
+        (``{dj_site_base_url}/dashboard/album/legacy/{id}``), which resolves this
+        legacy library id -- ``self.id`` is the tubafrenzy ``LIBRARY_RELEASE.ID``,
+        NOT the Backend-Service serial -- to the canonical serial route server-side
+        and 308-redirects (WXYC/dj-site#1050). The lazy ``get_settings()`` import
+        mirrors ``library/db.py`` and avoids an import cycle; it is ``lru_cache``d,
+        so calling it per render is cheap.
+        """
+        from config.settings import get_settings
+
+        base_url = get_settings().dj_site_base_url.rstrip("/")
+        return f"{base_url}/dashboard/album/legacy/{self.id}"
 
     def to_catalog_item(self) -> LibraryCatalogItem:
         """Convert to the API contract model (generated from wxyc-shared/api.yaml)."""

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -50,7 +50,7 @@ def make_catalog_item(id=1, artist="Stereolab", title="Aluminum Tunes", **kwargs
         "genre": "Rock",
         "format": "CD",
         "call_number": "Rock CD S 1/1",
-        "library_url": f"http://www.wxyc.info/wxycdb/libraryRelease?id={id}",
+        "library_url": f"https://dj.wxyc.org/dashboard/album/legacy/{id}",
     }
     defaults.update(kwargs)
     return LibraryCatalogItem(id=id, artist=artist, title=title, **defaults)

--- a/tests/unit/test_generated_models.py
+++ b/tests/unit/test_generated_models.py
@@ -48,11 +48,11 @@ class TestLibraryCatalogItem:
             artist="Stereolab",
             title="Aluminum Tunes",
             call_number="Rock CD S 1/1",
-            library_url="http://www.wxyc.info/wxycdb/libraryRelease?id=1",
+            library_url="https://dj.wxyc.org/dashboard/album/legacy/1",
         )
         data = item.model_dump()
         assert data["call_number"] == "Rock CD S 1/1"
-        assert data["library_url"] == "http://www.wxyc.info/wxycdb/libraryRelease?id=1"
+        assert data["library_url"] == "https://dj.wxyc.org/dashboard/album/legacy/1"
 
     def test_required_fields(self):
         with pytest.raises(ValueError):
@@ -82,7 +82,7 @@ class TestLookupResultItem:
         catalog = LibraryCatalogItem(
             id=1,
             call_number="Rock CD S 1/1",
-            library_url="http://www.wxyc.info/wxycdb/libraryRelease?id=1",
+            library_url="https://dj.wxyc.org/dashboard/album/legacy/1",
         )
         item = LookupResultItem(library_item=catalog)
         assert item.library_item.id == 1

--- a/tests/unit/test_library_models.py
+++ b/tests/unit/test_library_models.py
@@ -56,14 +56,14 @@ class TestLibraryItemCallNumber:
 
 class TestLibraryItemLibraryUrl:
     def test_url_format(self):
-        item = LibraryItem(id=42, artist="Queen", title="The Game")
-        assert item.library_url == "http://www.wxyc.info/wxycdb/libraryRelease?id=42"
+        item = LibraryItem(id=42, artist="Stereolab", title="Aluminum Tunes")
+        assert item.library_url == "https://dj.wxyc.org/dashboard/album/legacy/42"
 
     def test_url_included_in_serialization(self):
         item = LibraryItem(id=99)
         data = item.model_dump()
         assert "library_url" in data
-        assert data["library_url"] == "http://www.wxyc.info/wxycdb/libraryRelease?id=99"
+        assert data["library_url"] == "https://dj.wxyc.org/dashboard/album/legacy/99"
 
 
 class TestToCatalogItem:
@@ -104,14 +104,14 @@ class TestToCatalogItem:
     def test_includes_library_url(self):
         item = LibraryItem(id=42)
         catalog = item.to_catalog_item()
-        assert catalog.library_url == "http://www.wxyc.info/wxycdb/libraryRelease?id=42"
+        assert catalog.library_url == "https://dj.wxyc.org/dashboard/album/legacy/42"
 
     def test_minimal_item(self):
         item = LibraryItem(id=5)
         catalog = item.to_catalog_item()
         assert catalog.id == 5
         assert catalog.call_number == ""
-        assert catalog.library_url == "http://www.wxyc.info/wxycdb/libraryRelease?id=5"
+        assert catalog.library_url == "https://dj.wxyc.org/dashboard/album/legacy/5"
 
     def test_excludes_alternate_artist_name(self):
         item = LibraryItem(id=1, alternate_artist_name="Alt Name")

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -1055,7 +1055,7 @@ class TestHandleLookup:
         assert resp.status_code == 200
         library_item = resp.json()["results"][0]["library_item"]
         assert library_item["call_number"] == "Rock CD S 1/1"
-        assert library_item["library_url"] == "http://www.wxyc.info/wxycdb/libraryRelease?id=10"
+        assert library_item["library_url"] == "https://dj.wxyc.org/dashboard/album/legacy/10"
 
 
 class TestCallerClassLowPriorityLane:


### PR DESCRIPTION
Closes #1014.

## What

`LibraryItem.library_url` now emits the dj-site per-release permalink instead of the legacy tubafrenzy page:

```
- http://www.wxyc.info/wxycdb/libraryRelease?id={id}
+ https://dj.wxyc.org/dashboard/album/legacy/{id}
```

Every consumer of a library row (request-o-matic `lookup`, Slack, Backend-Service, iOS) picks this up through the single `library_url` property.

## How

- **`config/settings.py`** — new `dj_site_base_url` field (env `DJ_SITE_BASE_URL`, default `https://dj.wxyc.org`) so staging/dev can retarget the base without a code change.
- **`library/models.py`** — the `library_url` computed property reads `get_settings().dj_site_base_url` (lazy import mirroring `library/db.py`; `lru_cache`d, so per-render cost is negligible) and `.rstrip("/")`s it so an override with a stray trailing slash can't double the separator.

### The id-space detail (why `/legacy/{id}`)

`self.id` is the **legacy** library id — identical to tubafrenzy `LIBRARY_RELEASE.ID` — not the Backend-Service serial `library.id`. The `/dashboard/album/legacy/{id}` front door ([dj-site#1050](https://github.com/WXYC/dj-site/pull/1050)) resolves legacy → serial server-side (via [Backend-Service#1881](https://github.com/WXYC/Backend-Service/pull/1881)'s `GET /library/info?legacy_release_id=`) and 308-redirects to the canonical serial route. A naive `/dashboard/album/{id}` would link to the wrong release.

## Safety: the `id==0` sentinel is untouched

Row-less results build their `LibraryCatalogItem` directly via `lookup/external_search.py:build_external_catalog_item`, which hard-codes `library_url=""`. `to_catalog_item()` — the only caller of the swapped property — is reached only for real, non-zero ids (`lookup/orchestrator.py:942-946` routes `item.id == 0` to the sentinel builder). Verified the sentinel still serializes `library_url == ""`.

## Testing

- TDD: flipped the property-driven assertions in `tests/unit/test_library_models.py` red first, then made the swap. Kept the fixture defaults (`tests/factories.py`, `tests/unit/test_lookup_router.py`, `tests/unit/test_generated_models.py`) consistent with the new canonical URL.
- Local: `ruff check .`, `ruff format --check .`, `mypy . --ignore-missing-imports` all clean; full default unit suite green (4859 passed).
- Runtime: exercised `LibraryItem(id=N).library_url`, `model_dump()`, and `to_catalog_item()` (all emit the new shape) plus the `DJ_SITE_BASE_URL` override with trailing-slash trim.

## Deploy consequence

Merging to `main` deploys to **staging**. Production requires promoting `main` → `prod`. Safe to promote now that PR3 (dj-site#1050) is live in prod.

## Chain

PR4 of 5. PR2 (BS#1881) and PR3 (dj-site#1050) merged + deployed prod. PR5 (follow-up): update the two `library_url` field descriptions in `wxyc-shared/api.yaml` and regenerate.
