### PR TITLE
Add lml_cache.compilation_track_location V/A recall index

### DIFF
--- a/entity/compilation_track_location.py
+++ b/entity/compilation_track_location.py
@@ -1,0 +1,74 @@
+"""V/A recall index: ``lml_cache.compilation_track_location`` (LML#1019).
+
+Sub-issue of LML#271. Answers "which library shelf locations contain track
+*T* credited to artist *A*?" -- a deterministic reverse index for the
+interactive ``/lookup`` union (LML#1022), replacing a live Discogs keyword
+search that is title-distinctiveness-dependent and silently partial.
+
+Under the #271 grill-through's Option B (decouple), this is the cheap
+*recall/location* index only -- it carries no external-ID resolution and no
+Discogs-API matcher at read time. The expensive per-track *identity* matcher
+is a separate, deferred table (LML#1020/#1021).
+
+Same ``lml_cache.*`` ownership as ``entity/library_release_override.py``
+(LML-owned, no discogs-cache/alembic coordination) -- but with one added
+wrinkle: ``scripts/build_compilation_track_location.py`` populates this table
+from a **standalone process** running outside the FastAPI service (a
+discogs-etl-cloned checkout), so the bootstrap here must be self-sufficient
+(callable with nothing but a ``PgSource``) rather than assume the lifespan
+already ran. ``set_up_compilation_track_location_schema`` is exactly that:
+both the lifespan (``main.py``) and the build script call it directly.
+
+Population (matching comps to Discogs releases, fetching track credits,
+precomputing artwork) is the build script's job, not this module's -- this
+module owns only the idempotent DDL, matching the read-side/write-side split
+``entity/library_release_override.py`` established.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from entity.sources import PgSource
+
+logger = logging.getLogger(__name__)
+
+_DDL_SCHEMA = "CREATE SCHEMA IF NOT EXISTS lml_cache"
+
+# Column shapes and the credit_role tier set are documented in
+# entity/compilation_track_location.sql -- keep both in lockstep (the parity
+# assertions in tests/unit/test_compilation_track_location_schema.py pin it).
+_DDL_TABLE = """\
+CREATE TABLE IF NOT EXISTS lml_cache.compilation_track_location (
+    library_id          INTEGER NOT NULL,
+    track_position      TEXT NOT NULL,
+    track_artist        TEXT NOT NULL,
+    track_title         TEXT NOT NULL,
+    credit_role         TEXT NOT NULL CHECK (credit_role IN ('primary', 'featured', 'extra')),
+    discogs_release_id  INTEGER NOT NULL CHECK (discogs_release_id > 0),
+    artwork_url         TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (library_id, track_position, track_artist)
+)\
+"""
+
+_DDL_INDEX = """\
+CREATE INDEX IF NOT EXISTS idx_compilation_track_location_reverse
+    ON lml_cache.compilation_track_location (track_artist, track_title)\
+"""
+
+
+async def set_up_compilation_track_location_schema(pg: PgSource) -> None:
+    """Apply the idempotent recall-index schema DDL.
+
+    Called from both ``main.py`` lifespan (so the running service has the
+    table, even though it has no runtime reader yet -- LML#1022 adds one) and
+    ``scripts/build_compilation_track_location.py`` (so the standalone build
+    process works against a bare discogs-cache PG with no LML deploy behind
+    it). Schema, table, and index creation are all ``IF NOT EXISTS`` /
+    idempotent, so re-running on every boot -- or every build-script
+    invocation -- is safe and never mutates a populated row.
+    """
+    await pg.execute(_DDL_SCHEMA)
+    await pg.execute(_DDL_TABLE)
+    await pg.execute(_DDL_INDEX)

--- a/entity/compilation_track_location.sql
+++ b/entity/compilation_track_location.sql
@@ -1,0 +1,63 @@
+-- V/A recall index schema for LML#1019.
+--
+-- This file is the canonical DDL reference for the
+-- `lml_cache.compilation_track_location` table -- a reverse recall index
+-- answering "which library shelf locations contain track T credited to
+-- artist A?" for the interactive `/lookup` union (LML#1022). It lives in the
+-- LML-owned `lml_cache.*` schema (per WXYC/discogs-etl#288, Option 3), not
+-- the discogs-cache-owned `entity.*` contract, and is bootstrapped BOTH from
+-- LML's own FastAPI lifespan (`main.py`) AND standalone by
+-- `scripts/build_compilation_track_location.py`, which runs outside the
+-- service from a discogs-etl-cloned checkout.
+--
+-- This file exists so:
+--
+--   1. The LML PR's reviewer has the DDL inline for comparison.
+--   2. An operator can apply the schema directly to a non-discogs-cache PG
+--      (e.g. local dev) without booting the full LML app.
+--
+-- The runtime source of truth is `entity/compilation_track_location.py`
+-- (`set_up_compilation_track_location_schema`), which issues these
+-- statements via the `IF NOT EXISTS` forms on every boot. If the canonical
+-- shape changes, update both places (and the parity assertions in
+-- tests/unit/test_compilation_track_location_schema.py).
+
+CREATE SCHEMA IF NOT EXISTS lml_cache;
+
+CREATE TABLE IF NOT EXISTS lml_cache.compilation_track_location (
+    -- The WXYC library.id shelf location -- the compilation's physical
+    -- card-catalog slot (e.g. a "Various Artists - X" or "Soundtracks - L"
+    -- shelf row), not a per-track identity.
+    library_id          INTEGER NOT NULL,
+    -- Discogs track position (e.g. "A1", "2"). Falls back to the track
+    -- sequence number when Discogs carries no position string, so the
+    -- primary key component is never empty.
+    track_position      TEXT NOT NULL,
+    -- Credited track artist, normalized via wxyc_etl.text.to_match_form --
+    -- this IS the reverse-lookup key, not a display string. A runtime probe
+    -- (LML#1022) normalizes its typed artist the same way before an exact
+    -- match against this column.
+    track_artist        TEXT NOT NULL,
+    -- Credited track title, normalized the same way as track_artist.
+    track_title         TEXT NOT NULL,
+    -- Coarse credit tier from release_track_artist.extra/role. Precision is
+    -- carried by ranking in LML#1022 (credit-tier -> title-ratio -> id), not
+    -- by filtering here -- every credit is admitted.
+    credit_role         TEXT NOT NULL CHECK (credit_role IN ('primary', 'featured', 'extra')),
+    -- The comp's matched Discogs release (art re-resolution key). `> 0`
+    -- mirrors the LML#401/#518 sentinel guard (release ids start at 1).
+    discogs_release_id  INTEGER NOT NULL CHECK (discogs_release_id > 0),
+    -- Precomputed cover URL (lookup/artwork.py:_resolve_fallback_artwork),
+    -- so a hit never needs a live Discogs call to render art. NULL when the
+    -- release has no cover and no artist-image fallback.
+    artwork_url         TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (library_id, track_position, track_artist)
+);
+
+-- Reverse index (LML#1019 acceptance criterion): a runtime probe filters by
+-- the normalized (track_artist, track_title) pair. Both columns already
+-- store normalized values, so a plain btree suffices -- no expression index
+-- needed.
+CREATE INDEX IF NOT EXISTS idx_compilation_track_location_reverse
+    ON lml_cache.compilation_track_location (track_artist, track_title);

--- a/main.py
+++ b/main.py
@@ -346,6 +346,9 @@ async def lifespan(app: FastAPI):
     if settings.database_url_discogs:
         from core.dependencies import get_discogs_pool
         from entity.api_keys import set_up_api_keys_schema
+        from entity.compilation_track_location import (
+            set_up_compilation_track_location_schema,
+        )
         from entity.discogs_rate_bucket import set_up_discogs_rate_bucket_schema
         from entity.library_release_override import (
             set_up_library_release_override_schema,
@@ -434,6 +437,15 @@ async def lifespan(app: FastAPI):
                 (
                     "API keys",
                     set_up_api_keys_schema,
+                ),
+                # V/A recall index (LML#1019), another LML-owned lml_cache.*
+                # table. Same pool, same best-effort posture. No runtime
+                # reader yet -- scripts/build_compilation_track_location.py
+                # populates it out-of-band; LML#1022 adds the /lookup
+                # consumer.
+                (
+                    "Compilation track location",
+                    set_up_compilation_track_location_schema,
                 ),
             )
             await _run_lml_cache_bootstraps(source, bootstraps)

--- a/scripts/build_compilation_track_location.py
+++ b/scripts/build_compilation_track_location.py
@@ -1,0 +1,372 @@
+"""Build ``lml_cache.compilation_track_location``, the V/A recall index (LML#1019).
+
+Answers "which library shelf locations contain track *T* credited to artist
+*A*?" by walking every compilation-shelf row in ``library.db`` (any artist
+``wxyc_etl.text.is_compilation_artist`` recognizes -- "Various Artists - *"
+and "Soundtracks - *" shelf buckets alike), matching it to a Discogs release
+via the same normalized-title cascade ``scripts/match_compilations.py`` uses
+against ``va_release``, and persisting every ``release_track_artist`` credit
+for that release -- not just the primary artist -- tiered into a coarse
+``credit_role``. Precision ranking is LML#1022's job; this only guarantees
+every candidate row exists for it to rank.
+
+Runs standalone, outside the FastAPI service (a discogs-etl-cloned checkout
+per the ship-dag triage resolution on LML#1019), so schema bootstrap is
+self-sufficient: ``set_up_compilation_track_location_schema`` issues its own
+``CREATE SCHEMA/TABLE IF NOT EXISTS`` rather than assuming the LML lifespan
+already ran.
+
+Data-safe: every insert is ``ON CONFLICT (library_id, track_position,
+track_artist) DO NOTHING`` -- a successfully-populated row is never
+overwritten. A comp that fails to match (or matches a release with no cached
+tracklist) produces zero rows, so it stays absent and is retried on the next
+run for free, with no separate failure-tracking table needed.
+
+Modes:
+
+* ``--incremental`` -- only comps with **no existing row at all** (the cheap
+  "what's new since last run" diff, bounded per-run cost -- the daily
+  library.db-sync cadence per the issue's Freshness section).
+  * ``--full`` -- every compilation-shelf row in ``library.db``, including ones
+  already populated. Existing successful triples are untouched (``DO
+  NOTHING``); this mode's value is picking up NEW track/artist credits or a
+  now-resolvable match for a previously-failed comp after a discogs-cache
+  rebuild shifted the underlying data (the monthly cadence).
+
+Usage:
+    uv run python -m scripts.build_compilation_track_location --incremental
+    uv run python -m scripts.build_compilation_track_location --full --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from dataclasses import dataclass
+
+import aiosqlite
+import asyncpg
+from wxyc_etl.text import is_compilation_artist, to_match_form
+
+from entity.compilation_track_location import set_up_compilation_track_location_schema
+from entity.sources import PgSource
+from lookup.artwork import _resolve_fallback_artwork
+from scripts.match_compilations import (
+    CompAlbum,
+    exact_match,
+    normalize_comp_title,
+    prefix_strip_match,
+    trigram_match,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("build_compilation_track_location")
+
+DEFAULT_LIBRARY_DB_PATH = "library.db"
+
+# release_track_artist.extra=1 covers every non-primary credit (featured
+# artists, remixers, producers, writers, ...) undifferentiated at the source;
+# `role` is the only signal that separates a featured performer from the
+# rest. Coarse on purpose -- LML#1022 owns precision ranking, not this build.
+_FEATURED_ROLE_MARKERS = ("featur", "vocal", "voice")
+
+
+def tier_credit_role(extra: int, role: str | None) -> str:
+    """Coarse ``credit_role`` tier from ``release_track_artist.extra``/``role``.
+
+    ``extra == 0`` is always the track's primary credit. A non-primary credit
+    is tiered ``featured`` when its role text names a performer credit
+    (Featuring/Vocals/Voice), else ``extra`` (Producer, Remix, Written-By,
+    etc. -- non-performer contributions still worth carrying as a candidate,
+    just ranked lower downstream).
+    """
+    if not extra:
+        return "primary"
+    role_lower = (role or "").lower()
+    if any(marker in role_lower for marker in _FEATURED_ROLE_MARKERS):
+        return "featured"
+    return "extra"
+
+
+@dataclass(frozen=True)
+class CompCandidate:
+    """One compilation-shelf row from ``library.db`` awaiting a Discogs match."""
+
+    library_id: int
+    title: str
+    artist: str
+
+
+async def load_library_compilations(db_path: str) -> list[CompCandidate]:
+    """Every compilation-shelf ``library.db`` row, filtered via ``is_compilation_artist``.
+
+    Covers both the "Various Artists - *" and "Soundtracks - *" shelf
+    buckets (and any other form the shared classifier recognizes) -- the
+    issue's explicit requirement not to limit this to Various Artists alone.
+    """
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        rows = await db.execute_fetchall("SELECT id, title, artist FROM library")
+    return [
+        CompCandidate(library_id=row["id"], title=row["title"], artist=row["artist"])
+        for row in rows
+        if is_compilation_artist(row["artist"])
+    ]
+
+
+async def get_processed_library_ids(conn: asyncpg.Connection) -> set[int]:
+    """``library_id``s that already carry at least one recall-index row.
+
+    Used by ``--incremental`` to find "new since last run" comps. A comp
+    with zero rows is either never-attempted or previously match-failed --
+    both are retryable, and this diff doesn't need to tell them apart.
+    """
+    rows = await conn.fetch("SELECT DISTINCT library_id FROM lml_cache.compilation_track_location")
+    return {row["library_id"] for row in rows}
+
+
+async def match_comp_release(
+    conn: asyncpg.Connection, comps: list[CompCandidate]
+) -> dict[int, int]:
+    """Match each comp to a Discogs release id, reusing ``match_compilations.py``.
+
+    Runs the same exact -> prefix-strip -> trigram cascade the standalone VA
+    matcher uses against ``va_release``, so this build doesn't reinvent
+    comp-title matching. Returns ``library_id -> discogs_release_id`` for
+    every comp that matched; an unmatched comp is simply absent from the
+    result (retried on the next run).
+    """
+    if not comps:
+        return {}
+    albums = [
+        CompAlbum(
+            id=comp.library_id,
+            title=comp.title,
+            display_artist=comp.artist,
+            normalized_title=normalize_comp_title(comp.title),
+        )
+        for comp in comps
+    ]
+    await conn.execute("SET pg_trgm.similarity_threshold = 0.3")
+    exact_matches, remaining, title_map = await exact_match(conn, albums)
+    prefix_matches, remaining = await prefix_strip_match(title_map, remaining)
+    fuzzy_matches, _unmatched = await trigram_match(conn, remaining)
+    return {
+        match.comp_id: match.discogs_release_id
+        for match in (*exact_matches, *prefix_matches, *fuzzy_matches)
+    }
+
+
+_CREDITS_SQL = """\
+SELECT rta.release_id, rta.artist_name, rta.extra, rta.role,
+       rt.position, rt.title AS track_title, rt.sequence
+FROM release_track_artist rta
+JOIN release_track rt
+    ON rt.release_id = rta.release_id AND rt.sequence = rta.track_sequence
+WHERE rta.release_id = ANY($1)
+ORDER BY rta.release_id, rt.sequence\
+"""
+
+
+async def fetch_track_credits(
+    conn: asyncpg.Connection, release_ids: list[int]
+) -> dict[int, list[dict]]:
+    """All ``release_track_artist`` credits for ``release_ids`` (every tier, not just primary).
+
+    Joined to ``release_track`` for the track's position/title. Grouped by
+    ``release_id`` so the caller can build rows per matched comp without a
+    second round-trip per release.
+    """
+    if not release_ids:
+        return {}
+    rows = await conn.fetch(_CREDITS_SQL, release_ids)
+    by_release: dict[int, list[dict]] = {}
+    for row in rows:
+        by_release.setdefault(row["release_id"], []).append(dict(row))
+    return by_release
+
+
+_INSERT_SQL = """\
+INSERT INTO lml_cache.compilation_track_location
+    (library_id, track_position, track_artist, track_title, credit_role,
+     discogs_release_id, artwork_url)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (library_id, track_position, track_artist) DO NOTHING\
+"""
+
+
+def build_rows(
+    *,
+    library_id: int,
+    discogs_release_id: int,
+    credits: list[dict],
+    artwork_url: str | None,
+) -> list[tuple]:
+    """One row per credit, keyed to the recall index's normalized reverse-lookup columns.
+
+    ``track_artist``/``track_title`` are normalized with the same
+    ``wxyc_etl.text.to_match_form`` a runtime probe (LML#1022) applies to its
+    own input, so an exact-match probe hits these rows directly. Falls back
+    to the track sequence number when Discogs carries no ``position`` string
+    (e.g. some digital releases), so the primary-key component is never
+    empty.
+    """
+    rows = []
+    for credit in credits:
+        position = credit["position"] or str(credit["sequence"])
+        rows.append(
+            (
+                library_id,
+                position,
+                to_match_form(credit["artist_name"]),
+                to_match_form(credit["track_title"]),
+                tier_credit_role(credit["extra"], credit["role"]),
+                discogs_release_id,
+                artwork_url,
+            )
+        )
+    return rows
+
+
+async def build_compilation_track_location(
+    *,
+    library_db_path: str,
+    discogs_conn: asyncpg.Connection,
+    discogs_service,
+    full: bool,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Core build routine: discover comps, match, fetch credits, precompute art, write.
+
+    ``discogs_service`` is a live ``DiscogsService`` wired to the shared
+    Discogs rate bucket (LML#879) for the artwork precompute
+    (``lookup/artwork.py:_resolve_fallback_artwork``); pass ``None`` to skip
+    artwork resolution entirely (rows still insert with ``artwork_url =
+    NULL``), which is how the test suite exercises the match+insert path
+    without a live Discogs dependency.
+    """
+    comps = await load_library_compilations(library_db_path)
+    if not full:
+        processed = await get_processed_library_ids(discogs_conn)
+        comps = [comp for comp in comps if comp.library_id not in processed]
+    if limit is not None:
+        comps = comps[:limit]
+    if not comps:
+        log.info("no compilation candidates to process")
+        return {"candidates": 0, "matched": 0, "rows_inserted": 0}
+
+    matches = await match_comp_release(discogs_conn, comps)
+    log.info("matched %d/%d comps to a Discogs release", len(matches), len(comps))
+
+    release_ids = sorted(set(matches.values()))
+    credits_by_release = await fetch_track_credits(discogs_conn, release_ids)
+
+    rows_inserted = 0
+    for comp in comps:
+        release_id = matches.get(comp.library_id)
+        if release_id is None:
+            continue
+        credits = credits_by_release.get(release_id, [])
+        if not credits:
+            log.warning(
+                "library_id=%d matched release %d but it has no cached tracklist -- skipping",
+                comp.library_id,
+                release_id,
+            )
+            continue
+        artwork_url = None
+        if discogs_service is not None:
+            artwork_url = await _resolve_fallback_artwork(discogs_service, release_id)
+        rows = build_rows(
+            library_id=comp.library_id,
+            discogs_release_id=release_id,
+            credits=credits,
+            artwork_url=artwork_url,
+        )
+        if not dry_run:
+            await discogs_conn.executemany(_INSERT_SQL, rows)
+        rows_inserted += len(rows)
+
+    return {
+        "candidates": len(comps),
+        "matched": len(matches),
+        "rows_inserted": rows_inserted,
+    }
+
+
+async def main(args: argparse.Namespace) -> None:
+    from config.settings import get_settings
+    from discogs.cache_service import DiscogsCacheService
+    from discogs.service import DiscogsService
+
+    settings = get_settings()
+    db_url = settings.database_url_discogs
+    if not db_url:
+        raise SystemExit("DATABASE_URL_DISCOGS is not configured -- cannot build the recall index")
+
+    pool = await asyncpg.create_pool(db_url, min_size=1, max_size=4)
+    try:
+        pg = PgSource(pool=pool)
+        await set_up_compilation_track_location_schema(pg)
+
+        discogs_service = None
+        if not args.dry_run and settings.discogs_token:
+            discogs_service = DiscogsService(
+                token=settings.discogs_token, cache_service=DiscogsCacheService(pool)
+            )
+
+        async with pool.acquire() as conn:
+            stats = await build_compilation_track_location(
+                library_db_path=args.library_db,
+                discogs_conn=conn,
+                discogs_service=discogs_service,
+                full=args.full,
+                limit=args.limit,
+                dry_run=args.dry_run,
+            )
+        log.info(
+            "build complete: %d candidates, %d matched, %d rows inserted%s",
+            stats["candidates"],
+            stats["matched"],
+            stats["rows_inserted"],
+            " [dry-run]" if args.dry_run else "",
+        )
+    finally:
+        await pool.close()
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Only process comps with no existing recall-index row (daily cadence)",
+    )
+    mode.add_argument(
+        "--full",
+        action="store_true",
+        help="Reprocess every compilation-shelf row (monthly cadence)",
+    )
+    parser.add_argument(
+        "--library-db",
+        default=DEFAULT_LIBRARY_DB_PATH,
+        help=f"Path to library.db (default: {DEFAULT_LIBRARY_DB_PATH})",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Cap the number of comps processed")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Match + report only; no artwork resolution, no writes",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    asyncio.run(main(_build_arg_parser().parse_args()))

--- a/scripts/match_compilations.py
+++ b/scripts/match_compilations.py
@@ -85,7 +85,7 @@ async def load_compilations(db_path: str) -> list[CompAlbum]:
 
 async def exact_match(
     conn: asyncpg.Connection, comps: list[CompAlbum]
-) -> tuple[list[DiscogsMatch], list[CompAlbum]]:
+) -> tuple[list[DiscogsMatch], list[CompAlbum], dict[str, list[tuple[int, str]]]]:
     """Try exact case-insensitive title match against VA Discogs releases."""
     matched: list[DiscogsMatch] = []
     unmatched: list[CompAlbum] = []

--- a/tests/integration/test_build_compilation_track_location_pg.py
+++ b/tests/integration/test_build_compilation_track_location_pg.py
@@ -1,0 +1,278 @@
+"""Integration (``@pytest.mark.pg``) tests for the recall-index build (LML#1019).
+
+Drives ``build_compilation_track_location`` against real PostgreSQL tables
+shaped like discogs-cache's ``va_release`` / ``release`` / ``release_track`` /
+``release_track_artist``, plus a real (tmp-file) SQLite ``library.db``. Unit
+coverage (``tests/unit/test_build_compilation_track_location.py``) mocks
+every collaborator; this file is the round-trip proof that the real
+``match_compilations`` cascade, the real credit-fetch join, and the real
+``ON CONFLICT DO NOTHING`` insert compose correctly -- including the
+data-safety invariant that a successfully-populated row is never overwritten.
+
+``discogs_service=None`` throughout -- artwork resolution is exercised at the
+unit level (``build_rows`` accepts a pre-resolved ``artwork_url``) and is not
+worth a live/mocked Discogs API dependency here.
+
+Run with: pytest -m pg -v tests/integration/test_build_compilation_track_location_pg.py
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from scripts.build_compilation_track_location import build_compilation_track_location
+from tests.integration.conftest import skip_if_named_tables_populated
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def fresh_schema(pg_pool):
+    """Bring up the discogs-cache tables the matcher + credit-fetch join touch.
+
+    Mirrors ``test_cache_lean_json_agg_parity.py``'s ``fresh_schema`` fixture
+    for the shared (non-LML-owned) ``release*`` tables. The LML-owned
+    ``lml_cache.compilation_track_location`` gets the stricter populated-table
+    veto (as in ``test_library_release_override.py``) since a mispointed
+    ``DATABASE_URL_TEST`` there would risk real collected recall-index rows.
+    """
+    async with pg_pool.acquire() as conn:
+        await skip_if_named_tables_populated(conn, (("lml_cache", "compilation_track_location"),))
+        await conn.execute("DROP TABLE IF EXISTS lml_cache.compilation_track_location")
+        for table in ("release_track_artist", "release_track", "va_release", "release"):
+            await conn.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+        await conn.execute("""
+            CREATE TABLE release (
+                id    integer PRIMARY KEY,
+                title text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE va_release (
+                id         integer PRIMARY KEY,
+                title      text NOT NULL,
+                norm_title text NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_track (
+                release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                sequence   integer NOT NULL,
+                position   text,
+                title      text NOT NULL,
+                duration   text
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE release_track_artist (
+                release_id     integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                track_sequence integer NOT NULL,
+                artist_name    text NOT NULL,
+                extra          integer DEFAULT 0,
+                role           text
+            )
+        """)
+    from entity.compilation_track_location import set_up_compilation_track_location_schema
+    from entity.sources import PgSource
+
+    await set_up_compilation_track_location_schema(PgSource(pool=pg_pool))
+    yield
+    async with pg_pool.acquire() as conn:
+        for table in (
+            "lml_cache.compilation_track_location",
+            "release_track_artist",
+            "release_track",
+            "va_release",
+            "release",
+        ):
+            await conn.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+
+
+async def _seed_the_sound_of_dub(conn):
+    """The Sound of Dub (library_id 28 in the LML seed fixture) -> Discogs release 555."""
+    await conn.execute("INSERT INTO release (id, title) VALUES (555, 'The Sound of Dub')")
+    await conn.execute(
+        "INSERT INTO va_release (id, title, norm_title) VALUES "
+        "(555, 'The Sound of Dub', 'the sound of dub')"
+    )
+    await conn.executemany(
+        "INSERT INTO release_track (release_id, sequence, position, title) VALUES ($1, $2, $3, $4)",
+        [(555, 1, "A1", "Overboard"), (555, 2, "A2", "Warrior")],
+    )
+    await conn.executemany(
+        "INSERT INTO release_track_artist "
+        "(release_id, track_sequence, artist_name, extra, role) VALUES ($1, $2, $3, $4, $5)",
+        [
+            (555, 1, "Mad Professor", 0, None),
+            (555, 2, "Scientist", 0, None),
+            (555, 2, "Kiki Hitomi", 1, "Featuring"),
+        ],
+    )
+
+
+async def _write_library_db(tmp_path, rows):
+    db_path = tmp_path / "library.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute("CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT)")
+        await db.executemany("INSERT INTO library (id, title, artist) VALUES (?, ?, ?)", rows)
+        await db.commit()
+    return str(db_path)
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+class TestBuildAgainstRealPostgres:
+    async def test_matches_credits_and_inserts_every_tier(self, pg_pool, tmp_path):
+        async with pg_pool.acquire() as conn:
+            await _seed_the_sound_of_dub(conn)
+
+        library_db = await _write_library_db(
+            tmp_path,
+            [
+                (1, "Aluminum Tunes", "Stereolab"),  # not a comp -- must be filtered out
+                (28, "The Sound of Dub", "Various Artists - Reggae"),
+            ],
+        )
+
+        async with pg_pool.acquire() as conn:
+            stats = await build_compilation_track_location(
+                library_db_path=library_db,
+                discogs_conn=conn,
+                discogs_service=None,
+                full=True,
+            )
+
+        assert stats == {"candidates": 1, "matched": 1, "rows_inserted": 3}
+
+        async with pg_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT track_position, track_artist, track_title, credit_role, "
+                "discogs_release_id, artwork_url "
+                "FROM lml_cache.compilation_track_location WHERE library_id = 28 "
+                "ORDER BY track_position, track_artist"
+            )
+
+        assert [dict(r) for r in rows] == [
+            {
+                "track_position": "A1",
+                "track_artist": "mad professor",
+                "track_title": "overboard",
+                "credit_role": "primary",
+                "discogs_release_id": 555,
+                "artwork_url": None,
+            },
+            {
+                "track_position": "A2",
+                "track_artist": "kiki hitomi",
+                "track_title": "warrior",
+                "credit_role": "featured",
+                "discogs_release_id": 555,
+                "artwork_url": None,
+            },
+            {
+                "track_position": "A2",
+                "track_artist": "scientist",
+                "track_title": "warrior",
+                "credit_role": "primary",
+                "discogs_release_id": 555,
+                "artwork_url": None,
+            },
+        ]
+
+    async def test_successful_rows_are_never_overwritten(self, pg_pool, tmp_path):
+        """Data-safety invariant: a re-run (even --full) must not clobber a populated row."""
+        async with pg_pool.acquire() as conn:
+            await _seed_the_sound_of_dub(conn)
+            # Pre-seed a row at the exact PK a real build would also produce,
+            # but with a distinguishable artwork_url -- standing in for a
+            # human/earlier-run-verified value the build must not stomp.
+            await conn.execute(
+                "INSERT INTO lml_cache.compilation_track_location "
+                "(library_id, track_position, track_artist, track_title, credit_role, "
+                " discogs_release_id, artwork_url) VALUES "
+                "(28, 'A1', 'mad professor', 'overboard', 'primary', 555, 'https://pre-existing.example/cover.jpg')"
+            )
+
+        library_db = await _write_library_db(
+            tmp_path, [(28, "The Sound of Dub", "Various Artists - Reggae")]
+        )
+
+        async with pg_pool.acquire() as conn:
+            stats = await build_compilation_track_location(
+                library_db_path=library_db,
+                discogs_conn=conn,
+                discogs_service=None,
+                full=True,
+            )
+
+        # The pre-existing row is untouched (ON CONFLICT DO NOTHING); the
+        # sibling A2 credits are new and DO get inserted.
+        assert stats["rows_inserted"] == 3
+        async with pg_pool.acquire() as conn:
+            preserved = await conn.fetchval(
+                "SELECT artwork_url FROM lml_cache.compilation_track_location "
+                "WHERE library_id = 28 AND track_position = 'A1' AND track_artist = 'mad professor'"
+            )
+        assert preserved == "https://pre-existing.example/cover.jpg"
+
+    async def test_incremental_mode_skips_already_processed_comps(self, pg_pool, tmp_path):
+        async with pg_pool.acquire() as conn:
+            await _seed_the_sound_of_dub(conn)
+            await conn.execute(
+                "INSERT INTO lml_cache.compilation_track_location "
+                "(library_id, track_position, track_artist, track_title, credit_role, "
+                " discogs_release_id) VALUES "
+                "(28, 'A1', 'mad professor', 'overboard', 'primary', 555)"
+            )
+
+        library_db = await _write_library_db(
+            tmp_path, [(28, "The Sound of Dub", "Various Artists - Reggae")]
+        )
+
+        async with pg_pool.acquire() as conn:
+            stats = await build_compilation_track_location(
+                library_db_path=library_db,
+                discogs_conn=conn,
+                discogs_service=None,
+                full=False,
+            )
+
+        assert stats == {"candidates": 0, "matched": 0, "rows_inserted": 0}
+
+    async def test_dry_run_reports_without_writing(self, pg_pool, tmp_path):
+        async with pg_pool.acquire() as conn:
+            await _seed_the_sound_of_dub(conn)
+
+        library_db = await _write_library_db(
+            tmp_path, [(28, "The Sound of Dub", "Various Artists - Reggae")]
+        )
+
+        async with pg_pool.acquire() as conn:
+            stats = await build_compilation_track_location(
+                library_db_path=library_db,
+                discogs_conn=conn,
+                discogs_service=None,
+                full=True,
+                dry_run=True,
+            )
+
+        assert stats["rows_inserted"] == 3
+        async with pg_pool.acquire() as conn:
+            count = await conn.fetchval("SELECT count(*) FROM lml_cache.compilation_track_location")
+        assert count == 0
+
+    async def test_unmatched_comp_leaves_no_row_and_stays_retryable(self, pg_pool, tmp_path):
+        # No va_release/release seeded at all -- the comp cannot match.
+        library_db = await _write_library_db(
+            tmp_path, [(29, "Some Obscure Comp Nobody Cached", "Various Artists")]
+        )
+
+        async with pg_pool.acquire() as conn:
+            stats = await build_compilation_track_location(
+                library_db_path=library_db,
+                discogs_conn=conn,
+                discogs_service=None,
+                full=True,
+            )
+
+        assert stats == {"candidates": 1, "matched": 0, "rows_inserted": 0}

--- a/tests/integration/test_compilation_track_location_schema.py
+++ b/tests/integration/test_compilation_track_location_schema.py
@@ -1,0 +1,144 @@
+"""Integration (``@pytest.mark.pg``) tests for the V/A recall index schema (LML#1019).
+
+All unit coverage mocks ``PgSource``; this file drives the real DDL -- the
+real composite primary key, the real ``credit_role`` / ``discogs_release_id``
+CHECKs, and the real reverse index -- against an actual PostgreSQL
+connection. Rows are inserted with raw SQL here (the build script -- and its
+own round-trip integration coverage -- lives in a separate test module).
+
+The EXPLAIN assertion is this ticket's headline acceptance criterion: the
+reverse ``(track_artist, track_title)`` btree must actually be usable by the
+planner, not just present in ``pg_indexes``.
+
+Run with: pytest -m pg -v tests/integration/test_compilation_track_location_schema.py
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from entity.compilation_track_location import set_up_compilation_track_location_schema
+from tests.integration.conftest import skip_if_named_tables_populated
+
+_INSERT_SQL = """\
+INSERT INTO lml_cache.compilation_track_location
+    (library_id, track_position, track_artist, track_title, credit_role, discogs_release_id)
+VALUES ($1, $2, $3, $4, $5, $6)\
+"""
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def set_up_recall_index_schema(pg_pool, pg_source):
+    """Reset just this table (not the whole ``lml_cache`` schema), then apply its DDL.
+
+    Mirrors ``test_library_release_override.py``'s fixture: the populated-table
+    veto runs FIRST so a mispointed ``DATABASE_URL_TEST`` at a real
+    discogs-cache can't drop collected data.
+    """
+    async with pg_pool.acquire() as conn:
+        await skip_if_named_tables_populated(conn, (("lml_cache", "compilation_track_location"),))
+        await conn.execute("DROP TABLE IF EXISTS lml_cache.compilation_track_location")
+    await set_up_compilation_track_location_schema(pg_source)
+    yield
+    async with pg_pool.acquire() as conn:
+        await conn.execute("DROP TABLE IF EXISTS lml_cache.compilation_track_location")
+
+
+@pytest.mark.pg
+class TestSchemaBootstrap:
+    @pytest.mark.asyncio
+    async def test_second_boot_is_a_no_op(self, pg_source, pg_pool):
+        await set_up_compilation_track_location_schema(pg_source)
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT count(*)::int AS n FROM information_schema.tables "
+                "WHERE table_schema = 'lml_cache' "
+                "AND table_name = 'compilation_track_location'"
+            )
+        assert row["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_reverse_index_exists(self, pg_pool):
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT indexdef FROM pg_indexes "
+                "WHERE schemaname = 'lml_cache' "
+                "AND indexname = 'idx_compilation_track_location_reverse'"
+            )
+        assert row is not None
+        assert "track_artist" in row["indexdef"]
+        assert "track_title" in row["indexdef"]
+
+    @pytest.mark.asyncio
+    async def test_credit_role_check_rejects_unknown_tier(self, pg_pool):
+        with pytest.raises(asyncpg.PostgresError):
+            async with pg_pool.acquire() as conn:
+                await conn.execute(_INSERT_SQL, 1, "A1", "the bug", "pressure", "remix", 12345)
+
+    @pytest.mark.asyncio
+    async def test_release_id_check_rejects_non_positive(self, pg_pool):
+        with pytest.raises(asyncpg.PostgresError):
+            async with pg_pool.acquire() as conn:
+                await conn.execute(_INSERT_SQL, 1, "A1", "the bug", "pressure", "primary", 0)
+
+    @pytest.mark.asyncio
+    async def test_primary_key_rejects_duplicate(self, pg_pool):
+        async with pg_pool.acquire() as conn:
+            await conn.execute(_INSERT_SQL, 1, "A1", "the bug", "pressure", "primary", 12345)
+            with pytest.raises(asyncpg.PostgresError):
+                await conn.execute(_INSERT_SQL, 1, "A1", "the bug", "pressure", "featured", 99999)
+
+    @pytest.mark.asyncio
+    async def test_distinct_track_artist_on_same_position_is_allowed(self, pg_pool):
+        # The composite PK is (library_id, track_position, track_artist) --
+        # two credited artists on the same track_position (e.g. a primary
+        # plus a featured artist) are two distinct rows, not a conflict.
+        async with pg_pool.acquire() as conn:
+            await conn.execute(_INSERT_SQL, 1, "A1", "the bug", "pressure", "primary", 12345)
+            await conn.execute(_INSERT_SQL, 1, "A1", "flowdan", "pressure", "featured", 12345)
+            rows = await conn.fetch(
+                "SELECT track_artist FROM lml_cache.compilation_track_location "
+                "WHERE library_id = 1 AND track_position = 'A1' ORDER BY track_artist"
+            )
+        assert [r["track_artist"] for r in rows] == ["flowdan", "the bug"]
+
+
+@pytest.mark.pg
+class TestReverseIndexUse:
+    @pytest.mark.asyncio
+    async def test_explain_uses_reverse_index(self, pg_pool):
+        """The planner must be ABLE to use the reverse index for an exact-match probe.
+
+        ``enable_seqscan = off`` (scoped to this connection's session) removes
+        the small-table cost-estimate noise that would otherwise make Postgres
+        prefer a sequential scan over a handful of rows regardless of index
+        presence -- the deterministic way to prove the index is usable, which
+        is the acceptance criterion (LML#1022 is the runtime consumer of this
+        query shape; this ticket only guarantees the index supports it).
+        """
+        async with pg_pool.acquire() as conn:
+            for i in range(20):
+                await conn.execute(
+                    _INSERT_SQL,
+                    i,
+                    "A1",
+                    f"artist {i}",
+                    f"title {i}",
+                    "primary",
+                    10000 + i,
+                )
+            await conn.execute("SET enable_seqscan = off")
+            try:
+                plan_rows = await conn.fetch(
+                    "EXPLAIN SELECT * FROM lml_cache.compilation_track_location "
+                    "WHERE track_artist = $1 AND track_title = $2",
+                    "artist 5",
+                    "title 5",
+                )
+            finally:
+                await conn.execute("RESET enable_seqscan")
+        plan = "\n".join(row["QUERY PLAN"] for row in plan_rows)
+        assert "idx_compilation_track_location_reverse" in plan
+        assert "Seq Scan" not in plan

--- a/tests/integration/test_pg_fixture_guard_adoption.py
+++ b/tests/integration/test_pg_fixture_guard_adoption.py
@@ -63,6 +63,8 @@ _LML_CACHE_FIXTURE_FILES = (
     "test_library_release_override.py",
     "test_seed_library_release_overrides.py",
     "test_api_keys_pg.py",
+    "test_compilation_track_location_schema.py",
+    "test_build_compilation_track_location_pg.py",
 )
 
 # Any DROP SCHEMA aimed at lml_cache, however spelled (with/without IF

--- a/tests/unit/test_build_compilation_track_location.py
+++ b/tests/unit/test_build_compilation_track_location.py
@@ -1,0 +1,313 @@
+"""Unit tests for ``scripts/build_compilation_track_location.py`` (LML#1019).
+
+Pure-logic + mocked-DB coverage. The real matching/credit-fetch/insert path
+against a live discogs-cache is exercised separately in
+``tests/integration/test_build_compilation_track_location_pg.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from scripts.build_compilation_track_location import (
+    CompCandidate,
+    build_compilation_track_location,
+    build_rows,
+    get_processed_library_ids,
+    load_library_compilations,
+    tier_credit_role,
+)
+
+
+class TestTierCreditRole:
+    def test_extra_zero_is_primary(self):
+        assert tier_credit_role(0, None) == "primary"
+        assert tier_credit_role(0, "Vocals") == "primary"
+
+    @pytest.mark.parametrize(
+        "role",
+        ["Featuring", "featuring", "Vocals", "Voice", "Lead Vocals", "Featuring [uncredited]"],
+    )
+    def test_extra_one_with_featured_marker_is_featured(self, role):
+        assert tier_credit_role(1, role) == "featured"
+
+    @pytest.mark.parametrize("role", ["Producer", "Written-By", "Remix", "Mixed By", None, ""])
+    def test_extra_one_without_featured_marker_is_extra(self, role):
+        assert tier_credit_role(1, role) == "extra"
+
+
+class TestBuildRows:
+    def test_normalizes_artist_and_title_and_tiers_role(self):
+        credits = [
+            {
+                "position": "A1",
+                "sequence": 1,
+                "artist_name": "The Bug",
+                "track_title": "Pressure",
+                "extra": 0,
+                "role": None,
+            },
+            {
+                "position": "A1",
+                "sequence": 1,
+                "artist_name": "Flowdan",
+                "track_title": "Pressure",
+                "extra": 1,
+                "role": "Featuring",
+            },
+        ]
+        rows = build_rows(
+            library_id=42,
+            discogs_release_id=12345,
+            credits=credits,
+            artwork_url="https://example.com/cover.jpg",
+        )
+        assert rows == [
+            (42, "A1", "the bug", "pressure", "primary", 12345, "https://example.com/cover.jpg"),
+            (42, "A1", "flowdan", "pressure", "featured", 12345, "https://example.com/cover.jpg"),
+        ]
+
+    def test_falls_back_to_sequence_when_position_is_blank(self):
+        credits = [
+            {
+                "position": None,
+                "sequence": 7,
+                "artist_name": "Some Artist",
+                "track_title": "Some Title",
+                "extra": 0,
+                "role": None,
+            }
+        ]
+        rows = build_rows(library_id=1, discogs_release_id=99, credits=credits, artwork_url=None)
+        assert rows == [(1, "7", "some artist", "some title", "primary", 99, None)]
+
+
+@pytest.mark.asyncio
+class TestLoadLibraryCompilations:
+    async def test_filters_to_compilation_shelf_rows_only(self, tmp_path):
+        db_path = tmp_path / "library.db"
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                "CREATE TABLE library (id INTEGER PRIMARY KEY, title TEXT, artist TEXT)"
+            )
+            await db.executemany(
+                "INSERT INTO library (id, title, artist) VALUES (?, ?, ?)",
+                [
+                    (1, "Aluminum Tunes", "Stereolab"),
+                    (2, "The Sound of Dub", "Various Artists - Reggae"),
+                    (3, "Local Hero", "Soundtracks - L"),
+                ],
+            )
+            await db.commit()
+
+        comps = await load_library_compilations(str(db_path))
+
+        assert comps == [
+            CompCandidate(
+                library_id=2, title="The Sound of Dub", artist="Various Artists - Reggae"
+            ),
+            CompCandidate(library_id=3, title="Local Hero", artist="Soundtracks - L"),
+        ]
+
+
+@pytest.mark.asyncio
+class TestGetProcessedLibraryIds:
+    async def test_returns_distinct_library_ids(self):
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(
+            return_value=[{"library_id": 2}, {"library_id": 3}, {"library_id": 2}]
+        )
+        result = await get_processed_library_ids(conn)
+        assert result == {2, 3}
+
+
+@pytest.mark.asyncio
+class TestBuildCompilationTrackLocationOrchestration:
+    """Mocked-collaborator coverage of the incremental/full/dry-run branching."""
+
+    @pytest.fixture
+    def comps(self):
+        return [
+            CompCandidate(
+                library_id=2, title="The Sound of Dub", artist="Various Artists - Reggae"
+            ),
+            CompCandidate(library_id=3, title="Local Hero", artist="Soundtracks - L"),
+        ]
+
+    async def _run(
+        self,
+        monkeypatch,
+        comps,
+        *,
+        full,
+        processed_ids,
+        matches,
+        credits_by_release,
+        dry_run=False,
+        limit=None,
+    ):
+        conn = AsyncMock()
+        conn.executemany = AsyncMock()
+
+        async def fake_load(db_path):
+            return comps
+
+        async def fake_processed(conn_arg):
+            assert conn_arg is conn
+            return processed_ids
+
+        async def fake_match(conn_arg, candidates):
+            assert conn_arg is conn
+            return {
+                c.library_id: matches[c.library_id] for c in candidates if c.library_id in matches
+            }
+
+        async def fake_credits(conn_arg, release_ids):
+            assert conn_arg is conn
+            return {rid: credits_by_release.get(rid, []) for rid in release_ids}
+
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.load_library_compilations", fake_load
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.get_processed_library_ids", fake_processed
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.match_comp_release", fake_match
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.fetch_track_credits", fake_credits
+        )
+
+        stats = await build_compilation_track_location(
+            library_db_path="unused.db",
+            discogs_conn=conn,
+            discogs_service=None,
+            full=full,
+            limit=limit,
+            dry_run=dry_run,
+        )
+        return conn, stats
+
+    async def test_incremental_skips_already_processed_library_ids(self, monkeypatch, comps):
+        conn, stats = await self._run(
+            monkeypatch,
+            comps,
+            full=False,
+            processed_ids={2},
+            matches={3: 555},
+            credits_by_release={
+                555: [
+                    {
+                        "position": "A1",
+                        "sequence": 1,
+                        "artist_name": "Some Artist",
+                        "track_title": "Some Title",
+                        "extra": 0,
+                        "role": None,
+                    }
+                ]
+            },
+        )
+        assert stats["candidates"] == 1
+        assert stats["matched"] == 1
+        assert stats["rows_inserted"] == 1
+        conn.executemany.assert_awaited_once()
+        rows = conn.executemany.await_args.args[1]
+        assert rows == [(3, "A1", "some artist", "some title", "primary", 555, None)]
+
+    async def test_full_mode_includes_already_processed_library_ids(self, monkeypatch, comps):
+        conn, stats = await self._run(
+            monkeypatch,
+            comps,
+            full=True,
+            processed_ids={2},
+            matches={2: 111, 3: 222},
+            credits_by_release={},
+        )
+        assert stats["candidates"] == 2
+        # Both matched, but neither has cached tracklist data -> zero rows.
+        assert stats["matched"] == 2
+        assert stats["rows_inserted"] == 0
+
+    async def test_unmatched_comp_is_skipped_and_retryable(self, monkeypatch, comps):
+        conn, stats = await self._run(
+            monkeypatch,
+            comps,
+            full=False,
+            processed_ids=set(),
+            matches={2: 111},  # library_id 3 never matches
+            credits_by_release={111: []},
+        )
+        assert stats["candidates"] == 2
+        assert stats["matched"] == 1
+        assert stats["rows_inserted"] == 0
+        conn.executemany.assert_not_awaited()
+
+    async def test_dry_run_never_writes(self, monkeypatch, comps):
+        conn, stats = await self._run(
+            monkeypatch,
+            comps,
+            full=False,
+            processed_ids=set(),
+            matches={2: 111},
+            credits_by_release={
+                111: [
+                    {
+                        "position": "A1",
+                        "sequence": 1,
+                        "artist_name": "Some Artist",
+                        "track_title": "Some Title",
+                        "extra": 0,
+                        "role": None,
+                    }
+                ]
+            },
+            dry_run=True,
+        )
+        assert stats["rows_inserted"] == 1
+        conn.executemany.assert_not_awaited()
+
+    async def test_limit_caps_candidate_count(self, monkeypatch, comps):
+        conn, stats = await self._run(
+            monkeypatch,
+            comps,
+            full=True,
+            processed_ids=set(),
+            matches={},
+            credits_by_release={},
+            limit=1,
+        )
+        assert stats["candidates"] == 1
+
+    async def test_no_candidates_short_circuits_without_matching(self, monkeypatch):
+        conn = AsyncMock()
+
+        async def fake_load(db_path):
+            return []
+
+        match_called = False
+
+        async def fake_match(conn_arg, candidates):
+            nonlocal match_called
+            match_called = True
+            return {}
+
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.load_library_compilations", fake_load
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.match_comp_release", fake_match
+        )
+
+        stats = await build_compilation_track_location(
+            library_db_path="unused.db",
+            discogs_conn=conn,
+            discogs_service=None,
+            full=True,
+        )
+        assert stats == {"candidates": 0, "matched": 0, "rows_inserted": 0}
+        assert match_called is False

--- a/tests/unit/test_compilation_track_location_schema.py
+++ b/tests/unit/test_compilation_track_location_schema.py
@@ -1,0 +1,124 @@
+"""Unit tests for the V/A recall-index schema bootstrap (LML#1019).
+
+Two surfaces, mirroring ``test_library_release_override_schema.py``:
+
+* ``entity/compilation_track_location.sql`` -- the canonical-DDL reference
+  file. It must describe the ``lml_cache.compilation_track_location`` table
+  with its composite primary key, the ``credit_role`` / ``discogs_release_id``
+  CHECKs, and the reverse ``(track_artist, track_title)`` index.
+* ``set_up_compilation_track_location_schema`` -- the bootstrap helper called
+  from both the FastAPI lifespan and the standalone build script. It must
+  issue ``CREATE SCHEMA`` then ``CREATE TABLE`` then ``CREATE INDEX`` (and
+  nothing that mutates existing rows), idempotently.
+
+PG is mocked; the integration layer
+(``tests/integration/test_compilation_track_location_schema.py``) drives the
+real DDL -- including the EXPLAIN index-use assertion -- against PostgreSQL.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from entity.compilation_track_location import (
+    _DDL_TABLE,
+    set_up_compilation_track_location_schema,
+)
+from entity.sources import PgSource
+from tests.unit.conftest import extract_create_table as _extract_create_table
+from tests.unit.conftest import strip_sql_comments as _strip_sql_comments
+
+_SQL_REFERENCE = (
+    Path(__file__).resolve().parent.parent.parent / "entity" / "compilation_track_location.sql"
+)
+
+
+class TestCanonicalDDLReference:
+    """``entity/compilation_track_location.sql`` is the inline DDL reference."""
+
+    def test_reference_file_exists(self):
+        assert _SQL_REFERENCE.is_file()
+
+    def test_targets_lml_cache_schema_and_table(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in ddl
+        assert "lml_cache.compilation_track_location" in ddl
+
+    def test_has_composite_primary_key(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "PRIMARY KEY (library_id, track_position, track_artist)" in ddl
+
+    def test_has_credit_role_check(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "CHECK (credit_role IN ('primary', 'featured', 'extra'))" in ddl
+
+    def test_has_positive_release_id_check(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "discogs_release_id" in ddl
+        assert "CHECK (discogs_release_id > 0)" in ddl
+
+    def test_has_reverse_index_on_artist_and_title(self):
+        ddl = _SQL_REFERENCE.read_text()
+        assert "CREATE INDEX IF NOT EXISTS idx_compilation_track_location_reverse" in ddl
+        assert "(track_artist, track_title)" in ddl
+
+    def test_module_create_table_matches_sql_reference(self):
+        # The .sql file is the hand-maintained mirror of the runtime DDL, and
+        # its header promises "update both places". Pin the module's CREATE
+        # TABLE (modulo comments + trailing semicolon) to the reference so the
+        # two can't silently drift.
+        ddl = _SQL_REFERENCE.read_text()
+        sql_create = _extract_create_table(ddl)
+        module_create = _strip_sql_comments(_DDL_TABLE).strip().rstrip(";")
+        assert sql_create == module_create, (
+            "entity/compilation_track_location.sql CREATE TABLE drifted from "
+            "the _DDL_TABLE in entity/compilation_track_location.py -- update both."
+        )
+
+
+@pytest.mark.asyncio
+class TestSetUpCompilationTrackLocationSchema:
+    """``set_up_compilation_track_location_schema`` runs exactly the idempotent DDL."""
+
+    async def test_creates_schema_table_then_index(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="CREATE")
+
+        await set_up_compilation_track_location_schema(pg)
+
+        assert pg.execute.await_count == 3
+        schema_sql = pg.execute.await_args_list[0].args[0]
+        table_sql = pg.execute.await_args_list[1].args[0]
+        index_sql = pg.execute.await_args_list[2].args[0]
+        assert "CREATE SCHEMA IF NOT EXISTS lml_cache" in schema_sql
+        assert "CREATE TABLE IF NOT EXISTS lml_cache.compilation_track_location" in table_sql
+        assert "PRIMARY KEY (library_id, track_position, track_artist)" in table_sql
+        assert "CHECK (credit_role IN ('primary', 'featured', 'extra'))" in table_sql
+        assert "CHECK (discogs_release_id > 0)" in table_sql
+        assert "CREATE INDEX IF NOT EXISTS idx_compilation_track_location_reverse" in index_sql
+
+    async def test_bootstrap_is_idempotent(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="CREATE")
+
+        await set_up_compilation_track_location_schema(pg)
+        first = [call.args[0] for call in pg.execute.await_args_list]
+        pg.execute.reset_mock()
+        await set_up_compilation_track_location_schema(pg)
+        second = [call.args[0] for call in pg.execute.await_args_list]
+
+        assert first == second
+
+    async def test_bootstrap_does_not_mutate_rows(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="CREATE")
+
+        await set_up_compilation_track_location_schema(pg)
+
+        executed = [call.args[0] for call in pg.execute.await_args_list]
+        assert not any("INSERT" in sql for sql in executed)
+        assert not any("UPDATE" in sql for sql in executed)
+        assert not any("DELETE" in sql for sql in executed)


### PR DESCRIPTION
## Summary

Foundation for the comprehensive multi-location union (#1022). Adds `lml_cache.compilation_track_location`, a reverse recall index answering "which library shelf locations contain track *T* credited to artist *A*?" deterministically, closing the gap where that question could only be answered by a live Discogs keyword search that is title-distinctiveness-dependent and silently partial (the #271 live-repro).

- `entity/compilation_track_location.py` / `.sql` — idempotent `CREATE SCHEMA/TABLE/INDEX IF NOT EXISTS` bootstrap, callable both from the FastAPI lifespan (`main.py`) and standalone, plus a btree reverse index on the normalized `(track_artist, track_title)` key.
- `scripts/build_compilation_track_location.py` — standalone `--incremental`/`--full` build script. Sources every credited track artist from discogs-cache `release_track_artist` (all credit tiers, tiered into a coarse `credit_role`; precision ranking is #1022's job), matches each library compilation-shelf row (Various Artists *and* Soundtracks buckets) to its Discogs release by reusing `scripts/match_compilations.py`'s normalized-title cascade, and persists the match instead of throwing it away as JSON.
- Data-safe: every insert is `ON CONFLICT (library_id, track_position, track_artist) DO NOTHING` — a successfully-populated row is never overwritten, and an unmatched comp simply stays absent and retryable on the next run.

## Scope

Per the pinned ship-dag triage resolution on #1019:
- **No `lookup/` changes** — freeze-safe under the post-launch service hardening initiative.
- **No ETL cron wiring** — ships as the companion discogs-etl#339 PR.
- **No prod population run** — the actual offline, rate-limited Discogs build against prod is a manual, human-authorized step (per the #858 seeding precedent), not part of this PR.

## Test plan

- [x] `pytest -m "not pg"` — 4897 passed
- [x] `pytest -m pg` (local postgres@16:5433) — 546 passed, including the EXPLAIN assertion that the reverse index is actually used (not just present in `pg_indexes`)
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy . --ignore-missing-imports` clean
- [x] Integration coverage proves the data-safety invariant: a re-run (even `--full`) never overwrites a previously-populated row

Closes #1019