### PR TITLE
fix(discogs): defensive DiscogsBreakerOpenError->503 wrap in get_artist

### DIFF
--- a/discogs/router.py
+++ b/discogs/router.py
@@ -150,9 +150,16 @@ async def get_artist(
     try:
         result = await svc.get_artist_details(artist_id)
     except DiscogsBreakerOpenError as e:
-        # LML#755 R2-3: the Discogs saturation breaker shed this live probe. 503
-        # (transient / retryable), not a raw 500 — the caller should back off and
-        # retry rather than treat this as a hard failure.
+        # LML#1031: defensive wrap, mirroring resolve_entity's framing below —
+        # NOT closing an active 500. get_artist_details's own _api_fetch
+        # currently CATCHES DiscogsBreakerOpenError internally and returns
+        # None (LML#805, service.py ~1685-1695) rather than propagating it,
+        # unlike get_release's _api_fetch, which re-raises (service.py
+        # ~1520-1526, "FIX 1"). So today a real breaker shed here surfaces as
+        # the 404 branch below, not this one. This except exists so the 503
+        # contract holds the moment get_artist_details ever starts
+        # propagating a shed instead of swallowing it. LML#1049 tracks the
+        # decision on whether/how to close that gap (shed -> misleading 404).
         raise HTTPException(
             status_code=503,
             detail="Discogs temporarily shed (rate-saturated); retry shortly.",

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -147,7 +147,16 @@ async def get_artist(
     svc = _require_service(service)
     if refresh:
         _refresh_l1(DiscogsService.get_artist_details, artist_id)
-    result = await svc.get_artist_details(artist_id)
+    try:
+        result = await svc.get_artist_details(artist_id)
+    except DiscogsBreakerOpenError as e:
+        # LML#755 R2-3: the Discogs saturation breaker shed this live probe. 503
+        # (transient / retryable), not a raw 500 — the caller should back off and
+        # retry rather than treat this as a hard failure.
+        raise HTTPException(
+            status_code=503,
+            detail="Discogs temporarily shed (rate-saturated); retry shortly.",
+        ) from e
 
     if result is None:
         raise HTTPException(

--- a/tests/unit/test_discogs_router.py
+++ b/tests/unit/test_discogs_router.py
@@ -234,6 +234,21 @@ class TestGetArtist:
 
         assert resp.status_code == 503
 
+    @pytest.mark.asyncio
+    async def test_breaker_shed_returns_503(self, app_with_discogs, mock_discogs):
+        """R2-3: a saturation-breaker shed on this route returns 503 (transient /
+        retryable), NOT a raw 500. Mirrors ``TestGetRelease.test_breaker_shed_returns_503``."""
+        from discogs.breaker import DiscogsBreakerOpenError
+
+        mock_discogs.get_artist_details = AsyncMock(side_effect=DiscogsBreakerOpenError("shed"))
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_discogs), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/v1/discogs/artist/45")
+
+        assert resp.status_code == 503
+
 
 # ---------------------------------------------------------------------------
 # GET /discogs/entity/{entity_type}/{entity_id}

--- a/tests/unit/test_discogs_router.py
+++ b/tests/unit/test_discogs_router.py
@@ -235,9 +235,16 @@ class TestGetArtist:
         assert resp.status_code == 503
 
     @pytest.mark.asyncio
-    async def test_breaker_shed_returns_503(self, app_with_discogs, mock_discogs):
-        """R2-3: a saturation-breaker shed on this route returns 503 (transient /
-        retryable), NOT a raw 500. Mirrors ``TestGetRelease.test_breaker_shed_returns_503``."""
+    async def test_defensive_breaker_wrap_returns_503_if_propagated(
+        self, app_with_discogs, mock_discogs
+    ):
+        """LML#1031: pins the DEFENSIVE contract, not current production
+        behavior. IF ``get_artist_details`` ever raises ``DiscogsBreakerOpenError``
+        directly -- which it does not today, see
+        ``test_current_shed_behavior_swallows_to_404`` below -- the router must
+        translate that into a 503 (transient/retryable), not a raw 500. Mirrors
+        ``TestGetRelease.test_breaker_shed_returns_503`` and ``resolve_entity``'s
+        defensive wrap."""
         from discogs.breaker import DiscogsBreakerOpenError
 
         mock_discogs.get_artist_details = AsyncMock(side_effect=DiscogsBreakerOpenError("shed"))
@@ -248,6 +255,56 @@ class TestGetArtist:
             resp = await client.get("/api/v1/discogs/artist/45")
 
         assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_current_shed_behavior_swallows_to_404(self, mock_settings):
+        """LML#1049: pins the REAL current shed path (known-suboptimal).
+
+        Unlike ``get_release``'s ``_api_fetch`` (which re-raises
+        ``DiscogsBreakerOpenError``, ``discogs/service.py`` ~1520-1526, "FIX 1"),
+        ``get_artist_details``'s own ``_api_fetch`` catches
+        ``DiscogsBreakerOpenError`` internally and returns ``None`` (LML#805,
+        ``discogs/service.py`` ~1685-1695). So a real breaker shed during an
+        artist fetch never reaches the router's 503 branch above -- it degrades
+        to a plain ``None``, and ``get_artist`` raises the same 404 it would for
+        a genuine "no such artist." This violates the breaker's "never return a
+        definitive negative from a shed" contract (``discogs/breaker.py``
+        ~147-156); LML#1049 tracks the fix decision. This test uses a REAL
+        ``DiscogsService`` (not a full mock) with ``_request_with_retry`` stubbed
+        to shed, so it exercises the actual swallow path rather than a mocked
+        shortcut -- it must start failing (and be rewritten) the moment #1049
+        changes this behavior.
+        """
+        from config.settings import get_settings
+        from core.dependencies import get_discogs_service, get_library_db, get_posthog_client
+        from discogs.breaker import DiscogsBreakerOpenError
+        from main import app
+
+        real_service = DiscogsService(token="test-token")
+
+        with (
+            patch.object(
+                real_service,
+                "_request_with_retry",
+                new_callable=AsyncMock,
+                side_effect=DiscogsBreakerOpenError("shed"),
+            ),
+            override_deps(
+                app,
+                {
+                    get_library_db: AsyncMock(),
+                    get_discogs_service: real_service,
+                    get_posthog_client: None,
+                    get_settings: mock_settings,
+                },
+            ),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.get("/api/v1/discogs/artist/45")
+
+        assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`get_artist` was the one Discogs-entity-fetch handler in `discogs/router.py` that didn't have a `try/except DiscogsBreakerOpenError` wrap. This adds one, matching the `HTTPException(503, ...)` shape used by `get_release` and `resolve_entity`.

**Revised scope (post-review):** the original description claimed this closes an active 500. It doesn't. Unlike `get_release`'s `_api_fetch` (which re-raises `DiscogsBreakerOpenError`), `get_artist_details`'s own `_api_fetch` catches it internally and returns `None` (LML#805, `discogs/service.py` ~1685-1695), so a real breaker shed today surfaces as a 404 "not found," never as a 500 -- the new `except` branch cannot be reached through any current code path. This PR is therefore a **defensive parity wrap** (mirrors `resolve_entity`'s own honestly-defensive framing: it guards the day `get_artist_details` starts propagating a shed instead of swallowing it), not a fix for an existing crash. The real behavioral gap -- a breaker shed being indistinguishable from a genuine not-found on the artist path -- is tracked separately in #1049, since fixing it touches `get_artist_details`'s swallow behavior, which also backs the `/lookup` enrichment tail and needs its own decision.

Closes #1031

## Test plan
- [x] `TestGetArtist::test_defensive_breaker_wrap_returns_503_if_propagated` -- mocks `get_artist_details` to raise `DiscogsBreakerOpenError` directly, pinning the defensive contract (not current production behavior).
- [x] `TestGetArtist::test_current_shed_behavior_swallows_to_404` -- pins the REAL current behavior: a real `DiscogsService` with `_request_with_retry` stubbed to shed (so `get_artist_details` swallows internally, matching `_api_fetch`'s current catch-and-return-`None`) still returns 404 today. Documents the known-suboptimal status quo per #1049 so a future fix trips this test deliberately.
- [x] `uv run --no-sync ruff format --check .`
- [x] `uv run --no-sync ruff check .`
- [x] `uv run --no-sync mypy discogs/router.py --ignore-missing-imports`
- [x] `uv run --no-sync pytest tests/unit -q` (4594 passed)

## Follow-up
- #1049 tracks the real fix decision (propagate the shed out of `get_artist_details`, mirroring `get_release`'s FIX 1, vs. a narrower router-only breaker-state check) plus a related bare `except Exception` on the profile-markup path in the same handler that could independently swallow a shed.
