### PR TITLE
refactor(library): hoist duplicated FTS query-normalization line

### DIFF
--- a/library/db.py
+++ b/library/db.py
@@ -87,6 +87,23 @@ def _to_fts_match_query(query: str) -> str:
     return " ".join('"' + t.replace('"', '""') + '"' for t in terms)
 
 
+def _fts_normalize(query: str) -> str:
+    """Normalize a query for the LIKE/fuzzy fallback tokenizers.
+
+    First strips diacritics and lowercases via the shared ``wxyc_etl``
+    ``to_match_form`` (so e.g. "Nilüfer Yanya" matches "nilufer yanya"),
+    then collapses every remaining non-ASCII-alphanumeric, non-whitespace
+    character to a space. The collapse-to-space (rather than delete) keeps
+    punctuation from fusing adjacent words together -- "Chuquimamani-Condori"
+    becomes "chuquimamani condori", two tokens, not "chuquimamanicondori".
+
+    Used by :meth:`LibraryDB._fallback_like_search` and
+    :meth:`LibraryDB._fuzzy_search`, which both split the result on
+    whitespace to build their word lists.
+    """
+    return re.sub(r"[^a-z0-9\s]", " ", normalize_for_comparison(query))
+
+
 # Module-level caches for library search results.
 # Lazy-initialized from settings. Cleared when the database is closed/replaced.
 _artist_cache: TTLCache | None = None
@@ -389,7 +406,7 @@ class LibraryDB:
         Splits query into words and searches for titles/artists containing all words.
         """
         # Strip diacritics first, then remove remaining special chars
-        normalized = re.sub(r"[^a-z0-9\s]", " ", normalize_for_comparison(query))
+        normalized = _fts_normalize(query)
         words = normalized.split()
 
         # Remove stopwords that might cause mismatches
@@ -487,7 +504,7 @@ class LibraryDB:
             threshold: Minimum fuzzy match score (0-100) to include results
         """
         # Strip diacritics first, then remove remaining special chars
-        normalized = re.sub(r"[^a-z0-9\s]", " ", normalize_for_comparison(query))
+        normalized = _fts_normalize(query)
         words = normalized.split()
 
         if not words:

--- a/tests/unit/test_library_db.py
+++ b/tests/unit/test_library_db.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from library.db import LibraryDB, _to_fts_match_query
+from library.db import LibraryDB, _fts_normalize, _to_fts_match_query
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -399,6 +399,36 @@ class TestToFtsMatchQuery:
     def test_whitespace_only_query_yields_empty_string(self):
         assert _to_fts_match_query("   ") == ""
         assert _to_fts_match_query("\t\n") == ""
+
+
+# ---------------------------------------------------------------------------
+# _fts_normalize
+# ---------------------------------------------------------------------------
+
+
+class TestFtsNormalize:
+    """Pure helper shared by ``_fallback_like_search`` and ``_fuzzy_search``:
+    strips diacritics via wxyc_etl's ``to_match_form`` and then collapses any
+    remaining non-alphanumeric character to a space, so the LIKE/fuzzy
+    fallback chain tokenizes on plain ASCII words."""
+
+    @pytest.mark.parametrize(
+        "query, expected",
+        [
+            # Diacritics are stripped to their ASCII base letters.
+            ("Nilüfer Yanya", "nilufer yanya"),
+            ("Hermanos Gutiérrez", "hermanos gutierrez"),
+            # Punctuation collapses to whitespace rather than disappearing,
+            # so words on either side don't fuse together.
+            ("Chuquimamani-Condori", "chuquimamani condori"),
+            ("Duke Ellington & John Coltrane", "duke ellington   john coltrane"),
+            # Empty and whitespace-only input yields empty output.
+            ("", ""),
+            ("   ", ""),
+        ],
+    )
+    def test_normalizes_query(self, query, expected):
+        assert _fts_normalize(query) == expected
 
 
 class TestSearchEmptyMatchQueryGuard:


### PR DESCRIPTION
## Summary

- `_fallback_like_search` and `_fuzzy_search` in `library/db.py` each inlined the exact same query-normalization regex (`re.sub(r"[^a-z0-9\s]", " ", normalize_for_comparison(query))`). Hoisted it into a single module-private `_fts_normalize(query: str) -> str` helper, defined alongside the existing `_to_fts_match_query` helper it sits next to, with a docstring describing what it does (diacritic-strip + lowercase via `to_match_form`, then collapse remaining punctuation to spaces so words don't fuse together) and why.
- Both call sites now call the helper instead of inlining the regex. Behavior-preserving -- output is byte-identical for every input.
- Added a parameterized unit test (`TestFtsNormalize`) covering the helper directly: diacritics (Nilüfer Yanya, Hermanos Gutiérrez), punctuation collapse (Chuquimamani-Condori, Duke Ellington & John Coltrane), and empty/whitespace-only input.

Closes #1039

## Test plan

- [x] New test confirmed failing before the helper existed (`ImportError: cannot import name '_fts_normalize'`)
- [x] `uv run --no-sync pytest tests/unit/test_library_db.py -q` -- 102 passed, including the new `TestFtsNormalize` class and the pre-existing `TestFallbackLikeNormalization` / `TestFuzzySearchNormalization` classes that exercise this normalization indirectly
- [x] `uv run --no-sync pytest tests/unit -q` -- 4598 passed
- [x] `uv run --no-sync ruff format --check .`
- [x] `uv run --no-sync ruff check .`
- [x] `uv run --no-sync mypy library/db.py --ignore-missing-imports`
