### PR TITLE
refactor: collapse duplicated host-matcher and positive-int validator

### DIFF
--- a/identity/release_validation.py
+++ b/identity/release_validation.py
@@ -79,8 +79,45 @@ class InvalidReleaseExternalIdError(ValueError):
     """
 
 
-def _validate_discogs_positive_int(source: str, external_id: str) -> str:
-    """Discogs release/master IDs: positive decimal integer, rejecting ``0``.
+def _make_positive_int_validator(
+    *, zero_sentinel_reason: str, doc: str | None = None
+) -> Callable[[str, str], str]:
+    """Build a positive-decimal-integer validator with a source-specific zero explanation.
+
+    Shared by the Discogs (release/master) and Apple Music album ID rules —
+    both matched ``_DISCOGS_POSITIVE_INT_RE.fullmatch`` and reported the same
+    malformed-shape error text; the only thing that varied between the two
+    hand-written functions was *why* ``0`` is rejected. ``zero_sentinel_reason``
+    fills that clause verbatim (it follows ``"{source} external_id must be > 0; "``
+    in the raised message), so each call site keeps its own wording.
+
+    ``doc``, if given, becomes the returned validator's ``__doc__`` so a
+    module-level assignment like
+    ``_validate_discogs_positive_int = _make_positive_int_validator(...)``
+    keeps a docstring for ``help()`` / IDE tooltips at the call site.
+    """
+
+    def validator(source: str, external_id: str) -> str:
+        if external_id == "0":
+            raise InvalidReleaseExternalIdError(
+                f"{source} external_id must be > 0; {zero_sentinel_reason}"
+            )
+        if not _DISCOGS_POSITIVE_INT_RE.fullmatch(external_id):
+            raise InvalidReleaseExternalIdError(
+                f"{source} external_id must be a positive decimal integer "
+                f"(digits only, no leading sign / whitespace / underscores / "
+                f"leading zeros), got {external_id!r}"
+            )
+        return external_id
+
+    if doc is not None:
+        validator.__doc__ = doc
+    return validator
+
+
+_validate_discogs_positive_int = _make_positive_int_validator(
+    zero_sentinel_reason="0 is the Discogs unknown-release sentinel.",
+    doc="""Discogs release/master IDs: positive decimal integer, rejecting ``0``.
 
     Discogs uses ``0`` to mark the unknown-release / unknown-master placeholder.
     Negative IDs are never valid. The match against ``[1-9][0-9]*`` is strict —
@@ -88,22 +125,12 @@ def _validate_discogs_positive_int(source: str, external_id: str) -> str:
     separators (``"12_000"``) are all rejected, because bare ``int()`` would
     silently accept them and coerce to a *different* Discogs release than the
     caller meant. Returns the input verbatim on success.
-    """
-    if external_id == "0":
-        raise InvalidReleaseExternalIdError(
-            f"{source} external_id must be > 0; 0 is the Discogs unknown-release sentinel."
-        )
-    if not _DISCOGS_POSITIVE_INT_RE.fullmatch(external_id):
-        raise InvalidReleaseExternalIdError(
-            f"{source} external_id must be a positive decimal integer "
-            f"(digits only, no leading sign / whitespace / underscores / "
-            f"leading zeros), got {external_id!r}"
-        )
-    return external_id
+    """,
+)
 
-
-def _validate_apple_music_album_id(source: str, external_id: str) -> str:
-    """Apple Music album IDs: positive decimal integer.
+_validate_apple_music_album_id = _make_positive_int_validator(
+    zero_sentinel_reason="0 is not a valid Apple Music album ID.",
+    doc="""Apple Music album IDs: positive decimal integer.
 
     Apple's URLs of the form
     ``music.apple.com/<locale>/album/<slug>/<id>`` use a numeric album ID
@@ -115,18 +142,8 @@ def _validate_apple_music_album_id(source: str, external_id: str) -> str:
     validator accepts any positive integer-shaped string so an upstream
     that hands a shorter ID is rejected on its own merits, not on a
     digit-count mismatch with the parser.
-    """
-    if external_id == "0":
-        raise InvalidReleaseExternalIdError(
-            "apple_music_album external_id must be > 0; 0 is not a valid Apple Music album ID."
-        )
-    if not _DISCOGS_POSITIVE_INT_RE.fullmatch(external_id):
-        raise InvalidReleaseExternalIdError(
-            f"apple_music_album external_id must be a positive decimal integer "
-            f"(digits only, no leading sign / whitespace / underscores / "
-            f"leading zeros), got {external_id!r}"
-        )
-    return external_id
+    """,
+)
 
 
 def _validate_bandcamp_album_url(source: str, external_id: str) -> str:

--- a/release/apple_music_url_parser.py
+++ b/release/apple_music_url_parser.py
@@ -11,7 +11,8 @@ later removed entirely (WXYC/wiki#87); this parser is unaffected since
 from __future__ import annotations
 
 import re
-from urllib.parse import urlparse
+
+from release.host_matching import host_matcher
 
 # Locale segment accepts:
 #   - 2-letter ISO codes ("us", "gb", "jp") — the canonical Apple shape.
@@ -39,8 +40,9 @@ def apple_album_id_from_url(url: str) -> str | None:
     return match.group(1) if match else None
 
 
-def url_has_apple_music_host(url: str) -> bool:
-    """True if ``url``'s host is ``apple.com`` or a subdomain of it.
+url_has_apple_music_host = host_matcher(
+    "apple.com",
+    doc="""True if ``url``'s host is ``apple.com`` or a subdomain of it.
 
     Deliberately looser than :func:`apple_album_id_from_url` — a
     field-name/host invariant check (LML#873) rather than an album-ID
@@ -48,11 +50,5 @@ def url_has_apple_music_host(url: str) -> bool:
     shape. Used to null out a mislabeled ``apple_music_url`` artifact (a
     Deezer/Spotify/Bandcamp URL stored under that field name) before it
     reaches a caller.
-    """
-    if not url:
-        return False
-    try:
-        host = urlparse(url).netloc.lower()
-    except ValueError:
-        return False
-    return host == "apple.com" or host.endswith(".apple.com")
+    """,
+)

--- a/release/host_matching.py
+++ b/release/host_matching.py
@@ -1,0 +1,49 @@
+"""Shared host-matching factory for streaming-URL field-name/host invariant checks.
+
+``release/apple_music_url_parser.py`` and ``release/spotify_url_parser.py``
+each need "does this URL's host belong to domain X" — exact match or a
+``.``-suffixed subdomain — as a looser check than their strict album-ID
+extractors (LML#873): both are used to null out a mislabeled
+``apple_music_url`` / ``spotify_url`` artifact (a URL from a *different*
+streaming service stored under the wrong field name) before it reaches a
+caller. The two implementations were line-for-line identical modulo the host
+literal; ``host_matcher`` factors the shared guard-empty /
+urlparse-with-ValueError-guard / exact-or-suffix logic into one place so the
+two call sites can't drift from each other.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+
+def host_matcher(domain: str, *, doc: str | None = None) -> Callable[[str | None], bool]:
+    """Build a predicate: True if a URL's host is ``domain`` or a subdomain of it.
+
+    ``domain`` is the bare registrable domain (e.g. ``"apple.com"``); the
+    returned predicate matches it exactly or as a ``.``-suffix (e.g.
+    ``music.apple.com``), which also rejects lookalike hosts that merely
+    contain ``domain`` as a substring (e.g. ``apple.com.evil.test``).
+
+    The predicate guards empty/``None`` input and a ``urlparse`` ``ValueError``
+    (malformed URL) by returning ``False`` rather than raising — callers treat
+    "not this host" and "unparseable" the same way.
+
+    ``doc``, if given, becomes the returned callable's ``__doc__`` so a
+    module-level assignment like ``url_has_apple_music_host = host_matcher(...)``
+    keeps a docstring for ``help()`` / IDE tooltips at the call site.
+    """
+
+    def matcher(url: str | None) -> bool:
+        if not url:
+            return False
+        try:
+            host = urlparse(url).netloc.lower()
+        except ValueError:
+            return False
+        return host == domain or host.endswith(f".{domain}")
+
+    if doc is not None:
+        matcher.__doc__ = doc
+    return matcher

--- a/release/spotify_url_parser.py
+++ b/release/spotify_url_parser.py
@@ -20,7 +20,8 @@ posture the Apple parser's ``\\d{6,}`` floor provides against
 from __future__ import annotations
 
 import re
-from urllib.parse import urlparse
+
+from release.host_matching import host_matcher
 
 # Anchored on the Spotify host so a ``/album/<id>`` path on another domain
 # can't be mistaken for a Spotify album. ``//`` before the host and the
@@ -46,8 +47,9 @@ def spotify_album_id_from_url(url: str) -> str | None:
     return match.group(1) if match else None
 
 
-def url_has_spotify_host(url: str) -> bool:
-    """True if ``url``'s host is ``spotify.com`` or a subdomain of it.
+url_has_spotify_host = host_matcher(
+    "spotify.com",
+    doc="""True if ``url``'s host is ``spotify.com`` or a subdomain of it.
 
     Deliberately looser than :func:`spotify_album_id_from_url` — a
     field-name/host invariant check (LML#873) rather than an album-ID
@@ -55,11 +57,5 @@ def url_has_spotify_host(url: str) -> bool:
     not just the canonical album shape. Used to null out a mislabeled
     ``spotify_url`` artifact (a Deezer/Apple/Bandcamp URL stored under that
     field name) before it reaches a caller.
-    """
-    if not url:
-        return False
-    try:
-        host = urlparse(url).netloc.lower()
-    except ValueError:
-        return False
-    return host == "spotify.com" or host.endswith(".spotify.com")
+    """,
+)

--- a/tests/unit/test_host_matching.py
+++ b/tests/unit/test_host_matching.py
@@ -1,0 +1,65 @@
+"""Unit tests for ``release.host_matching.host_matcher``.
+
+This factory backs ``url_has_apple_music_host`` (``release/apple_music_url_parser.py``)
+and ``url_has_spotify_host`` (``release/spotify_url_parser.py``) — both were
+line-for-line identical modulo the host literal before this dedup. Those two
+call sites keep their own behavioral test coverage in
+``tests/unit/test_apple_music_url_parser.py`` and
+``tests/unit/test_spotify_url_parser.py`` (unaffected by this refactor, since
+the module-level names stay importable from the same places); this file
+exercises the shared factory directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from release.host_matching import host_matcher
+
+
+class TestHostMatcher:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/album/abc",
+            "http://sub.example.com/x",
+            "https://a.b.example.com/x",
+        ],
+    )
+    def test_true_for_exact_or_subdomain_host(self, url):
+        matcher = host_matcher("example.com")
+        assert matcher(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://notexample.com/x",
+            "https://example.com.evil.test/x",
+            "https://example.org/x",
+            "",
+            None,
+            "not a url",
+        ],
+    )
+    def test_false_for_non_matching_or_empty_or_malformed(self, url):
+        matcher = host_matcher("example.com")
+        assert matcher(url) is False
+
+    def test_returns_independent_callable_per_domain(self):
+        # Each host_matcher() call must close over its own domain — a shared
+        # mutable default would let two matchers built back-to-back bleed
+        # into each other.
+        apple = host_matcher("apple.com")
+        spotify = host_matcher("spotify.com")
+        assert apple("https://apple.com/x") is True
+        assert apple("https://spotify.com/x") is False
+        assert spotify("https://spotify.com/x") is True
+        assert spotify("https://apple.com/x") is False
+
+    def test_doc_kwarg_sets_returned_callable_docstring(self):
+        matcher = host_matcher("example.com", doc="custom docstring")
+        assert matcher.__doc__ == "custom docstring"
+
+    def test_doc_defaults_to_none_when_omitted(self):
+        matcher = host_matcher("example.com")
+        assert matcher.__doc__ is None

--- a/tests/unit/test_release_validation.py
+++ b/tests/unit/test_release_validation.py
@@ -129,6 +129,26 @@ class TestValidateDiscogsRelease:
         with pytest.raises(InvalidReleaseExternalIdError):
             validate_and_canonicalize_external_id("discogs_release", external_id)
 
+    def test_zero_sentinel_error_message_is_exact(self):
+        # The Discogs and Apple Music validators share one factory
+        # (identity/release_validation.py) — pin the exact wording so a
+        # collapse of the two near-identical functions can't drift it. These
+        # strings surface verbatim in the 422 response detail.
+        with pytest.raises(InvalidReleaseExternalIdError) as exc_info:
+            validate_and_canonicalize_external_id("discogs_release", "0")
+        assert str(exc_info.value) == (
+            "discogs_release external_id must be > 0; 0 is the Discogs unknown-release sentinel."
+        )
+
+    def test_malformed_shape_error_message_is_exact(self):
+        with pytest.raises(InvalidReleaseExternalIdError) as exc_info:
+            validate_and_canonicalize_external_id("discogs_release", "12_000")
+        assert str(exc_info.value) == (
+            "discogs_release external_id must be a positive decimal integer "
+            "(digits only, no leading sign / whitespace / underscores / "
+            "leading zeros), got '12_000'"
+        )
+
 
 class TestValidateDiscogsMaster:
     """Discogs master IDs follow the same rule as releases."""
@@ -143,6 +163,15 @@ class TestValidateDiscogsMaster:
     def test_rejects_negative(self):
         with pytest.raises(InvalidReleaseExternalIdError):
             validate_and_canonicalize_external_id("discogs_master", "-5")
+
+    def test_zero_sentinel_error_message_is_exact(self):
+        # Same shared factory as discogs_release, but the {source} token must
+        # still resolve per-call — "master", not "release".
+        with pytest.raises(InvalidReleaseExternalIdError) as exc_info:
+            validate_and_canonicalize_external_id("discogs_master", "0")
+        assert str(exc_info.value) == (
+            "discogs_master external_id must be > 0; 0 is the Discogs unknown-release sentinel."
+        )
 
 
 class TestValidateBandcamp:
@@ -228,6 +257,27 @@ class TestValidateAppleMusicAlbum:
     def test_rejects_non_integer(self, external_id):
         with pytest.raises(InvalidReleaseExternalIdError):
             validate_and_canonicalize_external_id("apple_music_album", external_id)
+
+    def test_zero_error_message_is_exact(self):
+        # Apple's "0 is not a valid..." explanation differs from Discogs's
+        # "0 is the Discogs unknown-release sentinel." wording even though
+        # both validators now share one factory — pin the exact string so a
+        # collapse can't quietly blend the two source-specific explanations.
+        # These strings surface verbatim in the 422 response detail.
+        with pytest.raises(InvalidReleaseExternalIdError) as exc_info:
+            validate_and_canonicalize_external_id("apple_music_album", "0")
+        assert str(exc_info.value) == (
+            "apple_music_album external_id must be > 0; 0 is not a valid Apple Music album ID."
+        )
+
+    def test_malformed_shape_error_message_is_exact(self):
+        with pytest.raises(InvalidReleaseExternalIdError) as exc_info:
+            validate_and_canonicalize_external_id("apple_music_album", "12_000")
+        assert str(exc_info.value) == (
+            "apple_music_album external_id must be a positive decimal integer "
+            "(digits only, no leading sign / whitespace / underscores / "
+            "leading zeros), got '12_000'"
+        )
 
 
 class TestValidateSpotifyAlbum:


### PR DESCRIPTION
## Summary

- Collapse `url_has_apple_music_host` / `url_has_spotify_host` (identical modulo the host literal) into one `host_matcher(domain) -> Callable[[str | None], bool]` factory in a new `release/host_matching.py`; both names stay importable from their existing modules for every current import site.
- Collapse `_validate_discogs_positive_int` / `_validate_apple_music_album_id` (identical regex + reject-`0` + error shape, differing only in the zero-sentinel explanation) into one `_make_positive_int_validator` factory in `identity/release_validation.py`, parameterized by that explanation string.
- No behavior change: every `InvalidReleaseExternalIdError` message string is preserved byte-for-byte (these surface verbatim in `POST /api/v1/identity/resolve`'s 422 `detail`), locked in by new exact-string assertions in `tests/unit/test_release_validation.py`.

Closes #1045

## Test plan

- [x] New `tests/unit/test_host_matching.py` exercises the factory directly: exact host, subdomain, lookalike/spoofed host, empty/`None`/malformed URL, independent-callable-per-domain, `doc` kwarg wiring.
- [x] New tests in `tests/unit/test_release_validation.py` assert the exact zero-sentinel and malformed-shape error strings for `discogs_release`, `discogs_master`, and `apple_music_album` — verified green against the pre-refactor code first, then verified still green after the collapse.
- [x] `uv run --no-sync ruff format --check .`
- [x] `uv run --no-sync ruff check .`
- [x] `uv run --no-sync mypy release/ identity/release_validation.py --ignore-missing-imports`
- [x] `uv run --no-sync pytest tests/unit -q` (4609 passed)
