### PR TITLE
refactor(auth): consolidate admin auth onto a shared, timing-safe bearer dependency

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -1,11 +1,16 @@
-"""Bearer-token auth for tubafrenzy / Backend-Service -> LML calls.
+"""Bearer-token auth for tubafrenzy / Backend-Service -> LML calls, plus /admin/*.
 
-This is a separate auth mechanism from ``routers/admin.py``'s ``ADMIN_TOKEN``
-(used for library.db uploads) and from the ``ETL_NOTIFY_KEY`` LML uses when
-*pushing* the streaming-status webhook to tubafrenzy. ``LML_API_KEY`` covers
-the *inbound* direction: callers like tubafrenzy (servlets) and Backend-Service
-include ``Authorization: Bearer <LML_API_KEY>`` on every request to a
-protected endpoint.
+``require_lml_key`` is a separate auth mechanism -- deliberately, a separate
+secret -- from ``require_admin_token``'s ``ADMIN_TOKEN`` (used for
+library.db / streaming_availability.db uploads and tombstone clearing) and
+from the ``ETL_NOTIFY_KEY`` LML uses when *pushing* the streaming-status
+webhook to tubafrenzy. ``LML_API_KEY`` covers the *inbound* direction:
+callers like tubafrenzy (servlets) and Backend-Service include
+``Authorization: Bearer <LML_API_KEY>`` on every request to a protected
+endpoint. The two deps share their bearer-parsing and constant-time-compare
+core (``_parse_bearer_token`` / ``_token_matches``) but keep independent
+policy -- most visibly, what happens when the expected secret itself isn't
+configured (see ``require_admin_token``'s docstring for the asymmetry).
 
 Enforcement is gated by ``LML_REQUIRE_AUTH`` so the dep can be deployed and
 attached to routes before consumers are updated. Roll out: deploy with the
@@ -104,6 +109,33 @@ def _log_legacy_key_used(request: Request) -> None:
     logger.warning("lml.auth.legacy_key_used %s", fields, extra=fields)
 
 
+def _parse_bearer_token(authorization: str) -> str | None:
+    """Extract the token from an ``Authorization: Bearer <token>`` header value.
+
+    Returns ``None`` when the header isn't in "<scheme> <token>" form, or the
+    scheme isn't ``bearer`` (case-insensitive per RFC 7235). Assumes the header
+    is present -- callers check that first, since ``require_lml_key`` and
+    ``require_admin_token`` both distinguish "missing" (401) from "malformed"
+    (403) and this helper only covers the latter.
+    """
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1]
+
+
+def _token_matches(token: str, expected: str) -> bool:
+    """Constant-time comparison of a bearer token against an expected secret.
+
+    Shared by ``require_lml_key`` (``LML_API_KEY``) and ``require_admin_token``
+    (``ADMIN_TOKEN``) -- two distinct secrets, same timing-safe comparison
+    core. Compares the bytes form (not the str form) deliberately:
+    ``secrets.compare_digest`` raises ``TypeError`` on a non-ASCII str, which
+    would turn a wrong-token 403 into a 500.
+    """
+    return secrets.compare_digest(token.encode(), expected.encode())
+
+
 def _tag_caller(caller_name: str) -> None:
     """Stamp the resolved caller name onto the request's Sentry span.
 
@@ -165,12 +197,10 @@ async def require_lml_key(
         _log_auth_rejection(request, reason="missing_authorization")
         raise HTTPException(status_code=401, detail="Missing authorization")
 
-    parts = authorization.split(" ", 1)
-    if len(parts) != 2 or parts[0].lower() != "bearer":
+    token = _parse_bearer_token(authorization)
+    if token is None:
         _log_auth_rejection(request, reason="invalid_token_scheme")
         raise HTTPException(status_code=403, detail="Invalid token")
-
-    token = parts[1]
 
     if cache is not None:
         # Hash once and reuse the digest for both the lookup and the touch.
@@ -181,14 +211,56 @@ async def require_lml_key(
             _tag_caller(caller_name)
             return
 
-    # Constant-time compare of the shared secret. The bytes form (not the str
-    # form) is deliberate: secrets.compare_digest raises TypeError on a
-    # non-ASCII str, which would turn a wrong-token 403 into a 500.
-    if settings.lml_api_key and secrets.compare_digest(
-        token.encode(), settings.lml_api_key.encode()
-    ):
+    # Constant-time compare of the shared secret (see _token_matches).
+    if settings.lml_api_key and _token_matches(token, settings.lml_api_key):
         _log_legacy_key_used(request)
         return
 
     _log_auth_rejection(request, reason="invalid_token_value")
     raise HTTPException(status_code=403, detail="Invalid token")
+
+
+async def require_admin_token(
+    settings: Settings = Depends(get_settings),
+    authorization: str | None = Header(None),
+) -> None:
+    """Validate ``Authorization: Bearer <token>`` against ``ADMIN_TOKEN``.
+
+    Guards ``routers/admin.py``'s incident-grade endpoints (library.db /
+    streaming_availability.db upload + download, tombstone clearing) -- a
+    deliberately separate secret from ``require_lml_key``'s ``LML_API_KEY``,
+    so routine tubafrenzy / Backend-Service callers never inherit admin write
+    access by sharing a token.
+
+    Extracted from ``routers/admin.py``'s formerly hand-rolled
+    ``_validate_auth`` (WXYC/library-metadata-lookup#1047), which compared the
+    token with a timing-unsafe ``!=``; this shares ``_parse_bearer_token`` /
+    ``_token_matches`` with ``require_lml_key``, so the comparison is now
+    constant-time. Every status code and message below is otherwise unchanged
+    from ``_validate_auth``'s wire behavior -- this is a consolidation, not a
+    policy change.
+
+    Behavior matrix:
+
+    - ``ADMIN_TOKEN`` unset -> 403 "Admin endpoint disabled (no ADMIN_TOKEN
+      set)", checked before the header is even inspected. This is a
+      deliberate asymmetry with ``require_lml_key``, which 500s on its
+      analogous misconfiguration (no legacy key + empty table-backed cache):
+      admin's unset-token case has returned 403 since the endpoints were
+      introduced, and this refactor preserves that rather than also
+      reconciling the inconsistency.
+    - Header missing -> 401 "Missing authorization".
+    - Header present but malformed (not "Bearer <token>", or a non-bearer
+      scheme) -> 403 "Invalid token".
+    - Token present but doesn't match ``ADMIN_TOKEN`` -> 403 "Invalid token".
+    - Token matches -> pass.
+    """
+    if not settings.admin_token:
+        raise HTTPException(status_code=403, detail="Admin endpoint disabled (no ADMIN_TOKEN set)")
+
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing authorization")
+
+    token = _parse_bearer_token(authorization)
+    if token is None or not _token_matches(token, settings.admin_token):
+        raise HTTPException(status_code=403, detail="Invalid token")

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -88,7 +88,7 @@ Three auth surfaces in this service, intentionally separate:
 | Surface | Direction | Env var | Implementation |
 |---|---|---|---|
 | Inbound from tubafrenzy / Backend-Service | tubafrenzy → LML | `LML_API_KEY` | `core/auth.py:require_lml_key` (router-level dep) |
-| `/admin/*` (library.db upload) | ETL → LML | `ADMIN_TOKEN` | `routers/admin.py:_validate_auth` (per-route call) |
+| `/admin/*` (library.db upload) | ETL → LML | `ADMIN_TOKEN` | `core/auth.py:require_admin_token` (per-route dep in `routers/admin.py`) |
 | Outbound streaming-status webhook | LML → tubafrenzy | `ETL_NOTIFY_KEY` | `routers/admin.py:_send_streaming_webhook` (sends `Authorization: Bearer ...`) |
 
 Untouched: `/health`, `/identity/resolve`, `/identity/bulk`. Identity routes are consumed by semantic-index too, so locking them down is a separate decision.

--- a/main.py
+++ b/main.py
@@ -559,7 +559,8 @@ async def _validation_exception_handler(
 
 # Health and admin keep their own auth posture:
 #   - /health is open for Railway healthchecks
-#   - /admin/* uses ADMIN_TOKEN (see routers/admin.py:_validate_auth)
+#   - /admin/* uses ADMIN_TOKEN, attached per-route via core.auth.require_admin_token
+#     (routers/admin.py) -- a separate secret from LML_API_KEY below
 # Identity is open for now (semantic-index consumes it; separate decision).
 app.include_router(health_router, prefix="", tags=["health"])
 app.include_router(admin_router, prefix="/admin", tags=["admin"])

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -10,11 +10,12 @@ from pathlib import Path
 from typing import Literal
 
 import httpx
-from fastapi import APIRouter, Depends, Header, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi import Path as PathParam
 from fastapi.responses import JSONResponse, Response
 
 from config.settings import Settings, get_settings
+from core.auth import require_admin_token
 from core.dependencies import (
     close_library_db,
     get_discogs_cache_service_from_pool,
@@ -238,22 +239,6 @@ async def _send_streaming_webhooks(
     return results
 
 
-def _validate_auth(
-    settings: Settings,
-    authorization: str | None,
-) -> None:
-    """Validate bearer token against ADMIN_TOKEN setting."""
-    if not settings.admin_token:
-        raise HTTPException(status_code=403, detail="Admin endpoint disabled (no ADMIN_TOKEN set)")
-
-    if not authorization:
-        raise HTTPException(status_code=401, detail="Missing authorization")
-
-    parts = authorization.split(" ", 1)
-    if len(parts) != 2 or parts[0].lower() != "bearer" or parts[1] != settings.admin_token:
-        raise HTTPException(status_code=403, detail="Invalid token")
-
-
 @router.post(
     "/upload-library-db",
     summary="Upload a new library.db file",
@@ -263,12 +248,12 @@ def _validate_auth(
         401: {"description": "Missing authorization"},
         403: {"description": "Invalid or missing token"},
     },
+    dependencies=[Depends(require_admin_token)],
 )
 async def upload_library_db(
     file: UploadFile,
     settings: Settings = Depends(get_settings),
     object_store: ObjectStore = Depends(get_object_store),
-    authorization: str | None = Header(None),
 ):
     """Replace the library.db file with an uploaded SQLite database.
 
@@ -288,8 +273,6 @@ async def upload_library_db(
     the replica that served the request; others refresh at next restart) is a
     runbook note, not code (epic #834, PR 4).
     """
-    _validate_auth(settings, authorization)
-
     db_path = settings.resolved_library_db_path
     # ``.upload.tmp`` (not ``.tmp``) so this scratch file never collides with
     # ``LocalDirStore.put``'s own internal ``<name>.tmp`` in local mode, where the
@@ -382,13 +365,13 @@ async def upload_library_db(
         },
         500: {"description": "Server-side fault writing or reading the file"},
     },
+    dependencies=[Depends(require_admin_token)],
 )
 async def upload_streaming_db(
     file: UploadFile,
     force: bool = False,
     settings: Settings = Depends(get_settings),
     object_store: ObjectStore = Depends(get_object_store),
-    authorization: str | None = Header(None),
 ):
     """Store a streaming_availability.db backup in the object store.
 
@@ -414,8 +397,6 @@ async def upload_streaming_db(
     object fails closed at 409. ``put`` is atomic per object (S3 PUT; the local
     store does tmp + ``os.replace``), so no replace dance is needed here.
     """
-    _validate_auth(settings, authorization)
-
     with tempfile.TemporaryDirectory(prefix="lml-streaming-upload-") as td:
         tdir = Path(td)
         # The upload scratch file MUST end in ``.tmp`` and the baseline temp below
@@ -545,11 +526,10 @@ async def upload_streaming_db(
         403: {"description": "Invalid or missing token"},
         404: {"description": "streaming_availability.db not present in the store"},
     },
+    dependencies=[Depends(require_admin_token)],
 )
 async def download_streaming_db(
-    settings: Settings = Depends(get_settings),
     object_store: ObjectStore = Depends(get_object_store),
-    authorization: str | None = Header(None),
 ):
     """Stream the current streaming_availability.db from the object store.
 
@@ -559,8 +539,6 @@ async def download_streaming_db(
     object (~53MB) is buffered and returned in one response; that egress is
     negligible at the daily sync cadence.
     """
-    _validate_auth(settings, authorization)
-
     try:
         data = await object_store.get(STREAMING_DB_FILENAME)
     except ObjectNotFoundError:
@@ -604,12 +582,11 @@ TombstoneEntityType = Literal["release", "artist"]
         404: {"description": "Row not found, or row exists but is not a tombstone"},
         503: {"description": "Discogs cache pool not configured"},
     },
+    dependencies=[Depends(require_admin_token)],
 )
 async def delete_tombstone(
     entity_type: TombstoneEntityType = PathParam(..., description="`release` or `artist`"),
     entity_id: int = PathParam(..., description="Discogs id"),
-    settings: Settings = Depends(get_settings),
-    authorization: str | None = Header(None),
     cache_service: DiscogsCacheService | None = Depends(get_discogs_cache_service_from_pool),
 ):
     """Delete a tombstoned row + evict the L1 entry.
@@ -628,8 +605,6 @@ async def delete_tombstone(
     only, and a tombstone lives in L2 (PG); we read it back and re-serve
     it. This endpoint is the L2 surface.
     """
-    _validate_auth(settings, authorization)
-
     if cache_service is None:
         raise HTTPException(
             status_code=503,

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -370,7 +370,6 @@ async def upload_library_db(
 async def upload_streaming_db(
     file: UploadFile,
     force: bool = False,
-    settings: Settings = Depends(get_settings),
     object_store: ObjectStore = Depends(get_object_store),
 ):
     """Store a streaming_availability.db backup in the object store.

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import secrets
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,19 @@ def _settings(*, require_auth: bool = False, key: str | None = None) -> Settings
     return Settings(
         lml_require_auth=require_auth,
         lml_api_key=key,
+        discogs_token=None,
+        database_url_discogs=None,
+        sentry_dsn=None,
+        posthog_api_key=None,
+        enable_telemetry=False,
+        library_db_path="test.db",
+    )
+
+
+def _admin_settings(*, admin_token: str | None = None) -> Settings:
+    """Settings with just ``admin_token`` set and unrelated config quieted."""
+    return Settings(
+        admin_token=admin_token,
         discogs_token=None,
         database_url_discogs=None,
         sentry_dsn=None,
@@ -205,6 +219,152 @@ class TestRequireLmlKey:
                 authorization="Bearer anything",
             )
         assert exc.value.status_code == 500
+
+
+class TestRequireAdminToken:
+    """Direct unit tests for the dep guarding ``/admin/*`` (routers/admin.py).
+
+    Pins the exact wire behavior of the ``_validate_auth`` this dep replaces --
+    same status codes and messages for every rejection branch, with the token
+    comparison now going through the shared, timing-safe ``_token_matches``
+    instead of a plain ``!=``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_admin_token_configured_returns_403(self):
+        from core.auth import require_admin_token
+
+        with pytest.raises(HTTPException) as exc:
+            await require_admin_token(
+                settings=_admin_settings(admin_token=None),
+                authorization="Bearer anything",
+            )
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Admin endpoint disabled (no ADMIN_TOKEN set)"
+
+    @pytest.mark.asyncio
+    async def test_no_admin_token_configured_returns_403_even_without_header(self):
+        # Matches _validate_auth's check order: the misconfiguration check runs
+        # before the header is even inspected.
+        from core.auth import require_admin_token
+
+        with pytest.raises(HTTPException) as exc:
+            await require_admin_token(
+                settings=_admin_settings(admin_token=None),
+                authorization=None,
+            )
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Admin endpoint disabled (no ADMIN_TOKEN set)"
+
+    @pytest.mark.asyncio
+    async def test_missing_header_returns_401(self):
+        from core.auth import require_admin_token
+
+        with pytest.raises(HTTPException) as exc:
+            await require_admin_token(
+                settings=_admin_settings(admin_token="secret"),
+                authorization=None,
+            )
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Missing authorization"
+
+    @pytest.mark.asyncio
+    async def test_malformed_header_returns_403(self):
+        # Header present but not in "<scheme> <token>" form.
+        from core.auth import require_admin_token
+
+        with pytest.raises(HTTPException) as exc:
+            await require_admin_token(
+                settings=_admin_settings(admin_token="secret"),
+                authorization="secret",
+            )
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Invalid token"
+
+    @pytest.mark.asyncio
+    async def test_wrong_scheme_returns_403(self):
+        from core.auth import require_admin_token
+
+        with pytest.raises(HTTPException) as exc:
+            await require_admin_token(
+                settings=_admin_settings(admin_token="secret"),
+                authorization="Basic c2VjcmV0",
+            )
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Invalid token"
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_returns_403(self):
+        from core.auth import require_admin_token
+
+        with pytest.raises(HTTPException) as exc:
+            await require_admin_token(
+                settings=_admin_settings(admin_token="secret"),
+                authorization="Bearer wrong",
+            )
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Invalid token"
+
+    @pytest.mark.asyncio
+    async def test_correct_bearer_passes(self):
+        from core.auth import require_admin_token
+
+        await require_admin_token(
+            settings=_admin_settings(admin_token="secret"),
+            authorization="Bearer secret",
+        )
+
+    @pytest.mark.asyncio
+    async def test_lowercase_scheme_passes(self):
+        # RFC 7235 says the scheme is case-insensitive.
+        from core.auth import require_admin_token
+
+        await require_admin_token(
+            settings=_admin_settings(admin_token="secret"),
+            authorization="bearer secret",
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_token_is_rejected_not_500(self):
+        # secrets.compare_digest on *str* raises TypeError for non-ASCII input,
+        # which would surface as a 500; the shared _token_matches helper
+        # compares the bytes form, so this is a clean 403 instead.
+        from core.auth import require_admin_token
+
+        with pytest.raises(HTTPException) as exc:
+            await require_admin_token(
+                settings=_admin_settings(admin_token="secret"),
+                authorization="Bearer nördic-tøken",
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_uses_constant_time_compare(self):
+        # The one behavior change from the `!=` this dep replaces: the token
+        # comparison must go through secrets.compare_digest.
+        from core.auth import require_admin_token
+
+        with patch("core.auth.secrets.compare_digest", wraps=secrets.compare_digest) as spy:
+            await require_admin_token(
+                settings=_admin_settings(admin_token="secret"),
+                authorization="Bearer secret",
+            )
+        spy.assert_called_once_with(b"secret", b"secret")
+
+    @pytest.mark.asyncio
+    async def test_shares_bearer_parse_helper_with_require_lml_key(self):
+        # Both deps must go through the same parsing core rather than each
+        # re-implementing the split/scheme-check logic.
+        from core.auth import _parse_bearer_token
+
+        with patch("core.auth._parse_bearer_token", wraps=_parse_bearer_token) as spy:
+            from core.auth import require_admin_token
+
+            await require_admin_token(
+                settings=_admin_settings(admin_token="secret"),
+                authorization="Bearer secret",
+            )
+        spy.assert_called_once_with("Bearer secret")
 
 
 class TestRequireLmlKeyTableBackedKeys:
@@ -592,6 +752,51 @@ class TestProtectedRouteRegistration:
 
     @pytest.mark.parametrize("method,path", EXPECTED_UNPROTECTED)
     def test_route_does_not_have_require_lml_key(self, method, path):
+        from core.auth import require_lml_key
+        from main import app
+
+        route = _find_route(app, method, path)
+        assert route is not None, f"Route {method} {path} not found in app.routes"
+        deps = _collect_dep_callables(route)
+        assert require_lml_key not in deps, (
+            f"Route {method} {path} should NOT have require_lml_key. "
+            f"Resolved deps: {sorted(d.__name__ for d in deps)}"
+        )
+
+
+class TestAdminRouteAuthRegistration:
+    """Guards that ``require_admin_token`` is attached to every ``/admin/*`` route.
+
+    Mirrors ``TestProtectedRouteRegistration``'s ``require_lml_key`` sweep so a
+    future admin endpoint that forgets the dep is caught the same way, rather
+    than silently shipping unauthenticated.
+    """
+
+    ADMIN_ROUTES = [
+        ("POST", "/admin/upload-library-db"),
+        ("POST", "/admin/upload-streaming-db"),
+        ("GET", "/admin/download-streaming-db"),
+        ("DELETE", "/admin/discogs/tombstone/{entity_type}/{entity_id}"),
+    ]
+
+    @pytest.mark.parametrize("method,path", ADMIN_ROUTES)
+    def test_route_has_require_admin_token(self, method, path):
+        from core.auth import require_admin_token
+        from main import app
+
+        route = _find_route(app, method, path)
+        assert route is not None, f"Route {method} {path} not found in app.routes"
+        deps = _collect_dep_callables(route)
+        assert require_admin_token in deps, (
+            f"Route {method} {path} is missing require_admin_token dep. "
+            f"Resolved deps: {sorted(d.__name__ for d in deps)}"
+        )
+
+    @pytest.mark.parametrize("method,path", ADMIN_ROUTES)
+    def test_route_does_not_have_require_lml_key(self, method, path):
+        # /admin/* uses ADMIN_TOKEN, a deliberately separate secret from the
+        # LML_API_KEY tubafrenzy/Backend-Service callers use -- confirms the
+        # consolidation didn't accidentally fold the two auth surfaces together.
         from core.auth import require_lml_key
         from main import app
 


### PR DESCRIPTION
## Summary
- Extract a shared bearer-parse (`_parse_bearer_token`) and constant-time-compare (`_token_matches`) core in `core/auth.py`, and add a new `require_admin_token` dependency built on it that authenticates `/admin/*` against `ADMIN_TOKEN`.
- `require_lml_key` (the existing `LML_API_KEY` dependency) refactors onto the same shared helpers instead of duplicating the bearer-parse logic and hand-rolling `secrets.compare_digest` inline.
- `routers/admin.py` drops `_validate_auth` and each handler's `authorization: str | None = Header(None)` param + imperative `_validate_auth(settings, authorization)` call; the four routes (`upload_library_db`, `upload_streaming_db`, `download_streaming_db`, `delete_tombstone`) attach auth via `Depends(require_admin_token)` on the route decorator instead.
- `ADMIN_TOKEN` stays a separate secret from `LML_API_KEY` -- unchanged, intentional privilege separation between admin's incident-grade write access and routine tubafrenzy/Backend-Service traffic.
- The only behavior change on the wire is the token comparison going from a timing-unsafe `!=` to `secrets.compare_digest`. Every status code and message is otherwise preserved, including the asymmetry where an unset `ADMIN_TOKEN` 403s (unlike `require_lml_key`'s analogous misconfiguration, which 500s) -- called out explicitly in `require_admin_token`'s docstring rather than silently reconciled.

## Test plan
- [x] New unit tests in `tests/unit/test_auth.py` (`TestRequireAdminToken`) cover: unset `ADMIN_TOKEN`, missing header, malformed header, wrong scheme, wrong token, correct token, non-ASCII token (403, not 500), and that the comparison goes through `secrets.compare_digest`.
- [x] New `TestAdminRouteAuthRegistration` sweep confirms `require_admin_token` is attached to all four admin routes (and that `require_lml_key` is not).
- [x] All pre-existing admin test files pass unmodified: `tests/unit/test_admin_router.py`, `tests/unit/test_admin_tombstone_router.py` (which mounts `routers.admin.router` into an isolated `FastAPI()` app, bypassing `main.py` -- confirms the dependency is attached per-route rather than only at `main.py`'s `include_router` call), `tests/unit/test_admin_streaming_guard.py`, `tests/unit/test_admin_library_store_bucket.py`, `tests/unit/test_admin_streaming_store_bucket.py`.
- [x] `uv run --no-sync ruff format --check .`
- [x] `uv run --no-sync ruff check .`
- [x] `uv run --no-sync mypy core/auth.py routers/admin.py --ignore-missing-imports`
- [x] `uv run --no-sync pytest tests/unit -q` (4611 passed)

Closes #1047
