### PR TITLE
refactor(core): introduce observability_guard/project_transaction/project_capped, collapse the worst clones

### DIFF
--- a/core/bulk_concurrency.py
+++ b/core/bulk_concurrency.py
@@ -76,6 +76,8 @@ from typing import Any
 import sentry_sdk
 from fastapi import Request
 
+from core.observability import observability_guard, project_capped
+
 logger = logging.getLogger(__name__)
 
 _BULK_MAX_CONCURRENT_ENV = "LML_BULK_MAX_CONCURRENT"
@@ -178,19 +180,27 @@ def _project_global_capped(wait_ms: float) -> None:
       tuning ``LML_BULK_GLOBAL_MAX_CONCURRENT``; running max across the
       transaction's items.
 
+    The running-max de-dup is this function's own bookkeeping (a bulk
+    request's items each acquire the permit independently, and only the
+    WORST wait should land as the measurement), so it stays local rather
+    than folding into :func:`core.observability.project_capped` — that
+    helper only knows how to set a tag + measurement for one call, not
+    de-dup across a transaction's many calls. The tag is idempotent
+    ("true" never changes), so gating the ``project_capped`` call on the
+    running-max check (rather than calling it unconditionally, as the
+    original unconditional ``set_tag`` did) has no observable difference:
+    the first capped call for a transaction always clears the check (a
+    genuine wait is never exactly 0.0), so the tag lands on that call same
+    as before.
+
     Observability must not break the request path; failures log and continue.
     """
-    try:
-        sentry_sdk.set_tag("lml.bulk.global_capped", "true")
+    with observability_guard("project global_capped onto Sentry transaction", logger):
         transaction = sentry_sdk.get_current_scope().transaction
-        if transaction is not None and wait_ms > _global_wait_max_by_transaction.get(
-            transaction, 0.0
-        ):
-            _global_wait_max_by_transaction[transaction] = wait_ms
-            transaction.set_measurement("lml.bulk.global_wait_ms", wait_ms)
-            transaction.set_data("lml.bulk.global_wait_ms", wait_ms)
-    except Exception as e:
-        logger.warning("Failed to project global_capped onto Sentry transaction: %s", e)
+        if transaction is None or wait_ms > _global_wait_max_by_transaction.get(transaction, 0.0):
+            if transaction is not None:
+                _global_wait_max_by_transaction[transaction] = wait_ms
+            project_capped("lml.bulk.global_capped", "lml.bulk.global_wait_ms", wait_ms)
 
 
 @contextlib.asynccontextmanager

--- a/core/observability.py
+++ b/core/observability.py
@@ -1,0 +1,139 @@
+"""Shared helpers for the "observability must not break the request path" idiom.
+
+Roughly 30 sites across this repo follow the same shape: attempt a bit of
+Sentry/telemetry work, and if the SDK (or an unexpected input shape) raises,
+log a WARNING and let the request continue rather than propagate the
+exception. This module gives that idiom composable primitives instead of a
+hand-rolled ``try/except`` at each site:
+
+- :func:`observability_guard` -- the ``try/except`` itself, as a context
+  manager (also usable as a decorator -- ``contextlib.contextmanager``
+  results implement ``ContextDecorator``). Swallows any ``Exception`` and
+  logs ``logger.warning("Failed to %s: %s", label, e)``. That exact message
+  shape is asserted by several existing tests across the call sites this
+  replaces, so it is preserved verbatim rather than reworded.
+- :func:`project_transaction` -- attach a dict of already-computed fields
+  onto the active Sentry transaction via ``set_data`` (and, opt-in, matching
+  ``set_measurement`` calls for numeric values). No-ops when there is no
+  active transaction. Mirrors the bodies of ``core.search._log_hard_cap_fired``
+  / ``_log_search_budget_exceeded``.
+- :func:`project_capped` -- the "in-flight cap engaged" tag+measurement pair
+  duplicated (with small per-site variations) across ``lookup/router.py``,
+  ``streaming/router.py``, and ``core/bulk_concurrency.py``.
+
+Neither ``project_transaction`` nor ``project_capped`` swallows exceptions on
+its own -- compose them with :func:`observability_guard` at the call site.
+Keeping the try/except separate from the Sentry calls means a call site with
+extra bookkeeping around the projection (e.g. ``core.bulk_concurrency``'s
+per-transaction running-max de-dup) can still share the primitive without the
+guard hiding exceptions raised by that bookkeeping itself.
+
+Layering: this module sits below ``lookup/`` (see the layering comment atop
+``core/search.py``) -- it must not import from ``lookup/`` or anything that
+does.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import Any
+
+import sentry_sdk
+
+
+@contextlib.contextmanager
+def observability_guard(label: str, logger: logging.Logger):
+    """Swallow any exception raised inside the block, logging a WARNING.
+
+    ``label`` describes the attempted action in a form that reads naturally
+    after "Failed to" -- e.g. ``observability_guard("record LML flag tags
+    into cache_stats", logger)`` logs ``"Failed to record LML flag tags into
+    cache_stats: <exception>"`` on failure. The message is built from two
+    separate ``%s`` args (``logger.warning("Failed to %s: %s", label, e)``),
+    not an f-string -- several existing tests assert on that exact shape.
+
+    Usable both as a context manager (``with observability_guard(...):``)
+    and, since ``contextlib.contextmanager`` results are ``ContextDecorator``s,
+    as a decorator on a synchronous function.
+
+    Only ``Exception`` is caught -- a ``KeyboardInterrupt``/``SystemExit``
+    still propagates, matching every site this replaces (a bare
+    ``except Exception`` never catches those).
+    """
+    try:
+        yield
+    except Exception as e:
+        logger.warning("Failed to %s: %s", label, e)
+
+
+def project_transaction(
+    data: dict[str, Any],
+    *,
+    measurements: bool = False,
+    prefix: str = "",
+) -> None:
+    """Attach ``data`` onto the active Sentry transaction via ``set_data``.
+
+    No-op when there is no active transaction (Sentry not initialized, or
+    called outside a request span) -- mirrors every site this replaces.
+
+    Each key is prefixed with ``prefix`` before being set, e.g.
+    ``prefix="lml.cache."`` turns ``"api_calls"`` into ``"lml.cache.api_calls"``.
+
+    When ``measurements`` is True, numeric entries (``int``/``float``,
+    excluding ``bool`` -- a ``bool`` is an ``int`` subclass in Python) are
+    ALSO recorded via ``set_measurement``, so they aggregate in Sentry's
+    metrics/alerting surface (``set_data`` alone reads back as "Unknown
+    attribute" there -- the LML#683 lesson). Every entry still gets
+    ``set_data`` regardless of type; ``measurements`` only controls whether
+    numeric entries additionally get ``set_measurement``.
+
+    Does not swallow exceptions -- wrap the call site in
+    :func:`observability_guard` for that.
+    """
+    transaction = sentry_sdk.get_current_scope().transaction
+    if transaction is None:
+        return
+    for key, value in data.items():
+        full_key = f"{prefix}{key}"
+        transaction.set_data(full_key, value)
+        if measurements and isinstance(value, (int, float)) and not isinstance(value, bool):
+            transaction.set_measurement(full_key, value)
+
+
+def project_capped(
+    tag_key: str,
+    measurement_key: str,
+    wait_ms: float,
+    *,
+    also_set_data: bool = True,
+) -> None:
+    """Project "this request queued on a capacity gate" onto Sentry.
+
+    Two channels, per the LML#683 lesson (``set_data`` alone is unqueryable
+    in the spans/metrics dataset):
+
+    * ``sentry_sdk.set_tag(tag_key, "true")`` -- the filterable engagement
+      flag. Call sites only invoke this when the gate was found saturated on
+      arrival, so uncontended requests stay untagged. Set unconditionally
+      (not gated on an active transaction existing).
+    * ``transaction.set_measurement(measurement_key, wait_ms)`` -- the
+      quantitative queue-wait series used to tune the gate's cap. Only set
+      when there is an active transaction. When ``also_set_data`` is True
+      (the default), a matching ``transaction.set_data(measurement_key,
+      wait_ms)`` is also recorded, mirroring the two call sites
+      (``lookup.router``, ``core.bulk_concurrency``) that duplicate the value
+      onto both channels; ``streaming.router``'s call site passes
+      ``also_set_data=False`` since its original body never called
+      ``set_data``.
+
+    Does not swallow exceptions -- wrap the call site in
+    :func:`observability_guard`.
+    """
+    sentry_sdk.set_tag(tag_key, "true")
+    transaction = sentry_sdk.get_current_scope().transaction
+    if transaction is not None:
+        transaction.set_measurement(measurement_key, wait_ms)
+        if also_set_data:
+            transaction.set_data(measurement_key, wait_ms)

--- a/core/search.py
+++ b/core/search.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, ClassVar, Protocol
 
 import sentry_sdk
 
+from core.observability import observability_guard, project_transaction
 from discogs.breaker import DiscogsBreakerOpenError
 from discogs.service import reset_retry_budget_deadline, set_retry_budget_deadline
 from generated.api_models import TrackMatchHint
@@ -216,14 +217,13 @@ def _log_search_budget_exceeded(
         "skipped": [s.value for s in skipped],
     }
     logger.info("search_budget_exceeded %s", payload)
-    try:
-        transaction = sentry_sdk.get_current_scope().transaction
-        if transaction is None:
-            return
-        transaction.set_data("search_budget_exceeded", True)
-        transaction.set_data("search_strategies_skipped", payload["skipped"])
-    except Exception as e:
-        logger.warning("Failed to project search_budget_exceeded onto Sentry transaction: %s", e)
+    with observability_guard("project search_budget_exceeded onto Sentry transaction", logger):
+        project_transaction(
+            {
+                "search_budget_exceeded": True,
+                "search_strategies_skipped": payload["skipped"],
+            }
+        )
 
 
 def _log_hard_cap_fired(
@@ -246,15 +246,14 @@ def _log_hard_cap_fired(
         "skipped": [s.value for s in skipped],
     }
     logger.info("hard_cap_fired %s", payload)
-    try:
-        transaction = sentry_sdk.get_current_scope().transaction
-        if transaction is None:
-            return
-        transaction.set_data("hard_cap_fired", True)
-        transaction.set_data("hard_cap_skipped_strategies", payload["skipped"])
-        transaction.set_data("hard_cap_elapsed_ms", payload["elapsed_ms"])
-    except Exception as e:
-        logger.warning("Failed to project hard_cap_fired onto Sentry transaction: %s", e)
+    with observability_guard("project hard_cap_fired onto Sentry transaction", logger):
+        project_transaction(
+            {
+                "hard_cap_fired": True,
+                "hard_cap_skipped_strategies": payload["skipped"],
+                "hard_cap_elapsed_ms": payload["elapsed_ms"],
+            }
+        )
 
 
 def detect_ambiguous_format(raw_message: str) -> tuple[str, str] | None:

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -42,6 +42,7 @@ from core.dependencies import (
     get_posthog_client,
 )
 from core.event_loop_lag import get_event_loop_lag_ms
+from core.observability import observability_guard, project_capped
 from core.search import SEARCH_API_CALL_CAP_FIRED_STAT_KEY, resolve_positive_int_env
 from discogs.cache_service import DiscogsCacheService
 from discogs.memory_cache import set_skip_cache
@@ -222,14 +223,8 @@ def _project_inflight_capped(wait_ms: float) -> None:
 
     Observability must not break the request path; failures log and continue.
     """
-    try:
-        sentry_sdk.set_tag("lml.lookup.inflight_capped", "true")
-        scope = sentry_sdk.get_current_scope()
-        if scope.transaction is not None:
-            scope.transaction.set_measurement("lml.lookup.inflight_wait_ms", wait_ms)
-            scope.transaction.set_data("lml.lookup.inflight_wait_ms", wait_ms)
-    except Exception as e:
-        logger.warning("Failed to project inflight_capped onto Sentry transaction: %s", e)
+    with observability_guard("project inflight_capped onto Sentry transaction", logger):
+        project_capped("lml.lookup.inflight_capped", "lml.lookup.inflight_wait_ms", wait_ms)
 
 
 # LML#681 flag-tag keys. Recorded once per cache_stats context at the router
@@ -290,7 +285,7 @@ def _record_lml_flag_tags() -> None:
     is swallowed (matches ``_project_cache_stats_to_transaction``). ``record`` is
     a no-op when ``init_cache_stats`` wasn't called for the context.
     """
-    try:
+    with observability_guard("record LML flag tags into cache_stats", logger):
         settings = get_settings()
         recorder = get_cache_stats_recorder()
         recorder.record(
@@ -301,8 +296,6 @@ def _record_lml_flag_tags() -> None:
             LML_RESOLVE_COMPILATION_RELEASE_STAT_KEY,
             1 if settings.lml_resolve_compilation_release else 0,
         )
-    except Exception as e:
-        logger.warning("Failed to record LML flag tags into cache_stats: %s", e)
 
 
 def _record_event_loop_lag() -> None:
@@ -320,15 +313,13 @@ def _record_event_loop_lag() -> None:
     life), leaving the seeded ``0``. Observability must not break the request
     path: any exception is swallowed at WARNING (matches ``_record_lml_flag_tags``).
     """
-    try:
+    with observability_guard("record event-loop lag into cache_stats", logger):
         if not get_settings().lml_event_loop_lag_gauge:
             return
         lag_ms = get_event_loop_lag_ms()
         if lag_ms is None:
             return
         get_cache_stats_recorder().record(EVENT_LOOP_LAG_STAT_KEY, lag_ms)
-    except Exception as e:
-        logger.warning("Failed to record event-loop lag into cache_stats: %s", e)
 
 
 # Canonical full path for the bulk endpoint. Referenced by the explicit
@@ -368,7 +359,7 @@ def _project_cache_stats_to_transaction(stats: dict | None) -> None:
     """
     if not stats:
         return
-    try:
+    with observability_guard("project cache_stats onto Sentry transaction", logger):
         transaction = sentry_sdk.get_current_scope().transaction
         if transaction is None:
             return
@@ -376,8 +367,6 @@ def _project_cache_stats_to_transaction(stats: dict | None) -> None:
             if isinstance(value, (int, float)) and not isinstance(value, bool):
                 transaction.set_data(f"lml.cache.{key}", value)
                 transaction.set_measurement(f"lml.cache.{key}", value)
-    except Exception as e:
-        logger.warning("Failed to project cache_stats onto Sentry transaction: %s", e)
 
 
 def _emit_server_timing_header(
@@ -400,12 +389,10 @@ def _emit_server_timing_header(
     Observability must not break the request path — any failure (a settings read
     or the serialize) logs at WARNING and the response ships without the header.
     """
-    try:
+    with observability_guard("emit Server-Timing header", logger):
         if not get_settings().lml_emit_server_timing:
             return
         http_response.headers["Server-Timing"] = telemetry.as_server_timing(extra=extra)
-    except Exception as e:
-        logger.warning("Failed to emit Server-Timing header: %s", e)
 
 
 @router.post(

--- a/streaming/router.py
+++ b/streaming/router.py
@@ -7,7 +7,6 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException
 from wxyc_fastapi.observability import RequestTelemetry, init_cache_stats
 
@@ -16,6 +15,7 @@ from clients.streaming.apple_music import AppleMusicClient
 from clients.streaming.deezer import DeezerClient
 from clients.streaming.spotify import SpotifyClient
 from core.dependencies import get_streaming_posthog_client
+from core.observability import observability_guard, project_capped
 from core.search import resolve_positive_int_env
 from streaming.dependencies import (
     get_apple_music_client,
@@ -110,13 +110,13 @@ def _project_inflight_capped(wait_ms: float) -> None:
 
     Observability must not break the request path; failures log and continue.
     """
-    try:
-        sentry_sdk.set_tag("lml.streaming_check.inflight_capped", "true")
-        scope = sentry_sdk.get_current_scope()
-        if scope.transaction is not None:
-            scope.transaction.set_measurement("lml.streaming_check.inflight_wait_ms", wait_ms)
-    except Exception as e:
-        logger.warning("Failed to project inflight_capped onto Sentry transaction: %s", e)
+    with observability_guard("project inflight_capped onto Sentry transaction", logger):
+        project_capped(
+            "lml.streaming_check.inflight_capped",
+            "lml.streaming_check.inflight_wait_ms",
+            wait_ms,
+            also_set_data=False,
+        )
 
 
 def _summary_properties(

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,252 @@
+"""Tests for ``core/observability.py`` -- the shared "observability must not
+break the request path" helpers.
+
+Pins the three primitives this module introduces:
+
+- ``observability_guard`` -- swallow-and-warn context manager (the try/except
+  boilerplate duplicated at ~30 sites).
+- ``project_transaction`` -- attach a dict of fields onto the active Sentry
+  transaction, mirroring ``core.search._log_hard_cap_fired`` /
+  ``_log_search_budget_exceeded``'s bodies.
+- ``project_capped`` -- the "in-flight cap engaged" tag+measurement pair
+  duplicated across ``lookup/router.py``, ``streaming/router.py``, and
+  ``core/bulk_concurrency.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+class TestObservabilityGuard:
+    """The shared try/except-and-warn context manager."""
+
+    def test_reraises_nothing_on_success(self):
+        from core.observability import observability_guard
+
+        logger = Mock(spec=logging.Logger)
+        ran = False
+        with observability_guard("do the thing", logger):
+            ran = True
+        assert ran is True
+        logger.warning.assert_not_called()
+
+    def test_swallows_exception_and_warns_with_exact_message_shape(self):
+        """Pins the message shape several call sites' tests assert on:
+        ``logger.warning("Failed to %s: %s", label, e)`` -- NOT an f-string,
+        so the label and the exception are separate ``%s`` args.
+        """
+        from core.observability import observability_guard
+
+        logger = Mock(spec=logging.Logger)
+        boom = RuntimeError("boom")
+        with observability_guard("project widgets onto Sentry", logger):
+            raise boom
+
+        logger.warning.assert_called_once_with(
+            "Failed to %s: %s", "project widgets onto Sentry", boom
+        )
+
+    def test_only_swallows_exception_not_other_baseexceptions(self):
+        """``except Exception`` -- a KeyboardInterrupt/SystemExit must still propagate.
+
+        Observability guards protect the request path from SDK/telemetry bugs,
+        not from process-level control flow.
+        """
+        from core.observability import observability_guard
+
+        logger = Mock(spec=logging.Logger)
+        with pytest.raises(SystemExit):
+            with observability_guard("do the thing", logger):
+                raise SystemExit(1)
+        logger.warning.assert_not_called()
+
+    def test_usable_as_a_decorator(self):
+        """``contextlib.contextmanager`` results are also ``ContextDecorator``s."""
+        from core.observability import observability_guard
+
+        logger = Mock(spec=logging.Logger)
+
+        @observability_guard("decorate the thing", logger)
+        def raises():
+            raise RuntimeError("boom")
+
+        raises()  # must not raise
+        logger.warning.assert_called_once()
+
+
+class TestProjectTransaction:
+    """``set_data`` (+ optional ``set_measurement``) fan-out onto the active transaction."""
+
+    def test_noop_when_no_active_transaction(self):
+        from core.observability import project_transaction
+
+        mock_scope = Mock()
+        mock_scope.transaction = None
+        with patch("core.observability.sentry_sdk.get_current_scope", return_value=mock_scope):
+            # Must not raise.
+            project_transaction({"hard_cap_fired": True})
+
+    def test_sets_data_for_every_entry_by_default(self):
+        """Mirrors ``_log_hard_cap_fired`` / ``_log_search_budget_exceeded``'s
+        bodies: every entry gets ``set_data``, including non-numeric values
+        (bools, lists) -- there is no numeric filter unless ``measurements=True``.
+        """
+        from core.observability import project_transaction
+
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+        data = {"hard_cap_fired": True, "hard_cap_skipped_strategies": ["a", "b"]}
+
+        with patch("core.observability.sentry_sdk.get_current_scope", return_value=mock_scope):
+            project_transaction(data)
+
+        calls = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert calls == data
+        mock_transaction.set_measurement.assert_not_called()
+
+    def test_prefix_is_prepended_to_every_key(self):
+        from core.observability import project_transaction
+
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with patch("core.observability.sentry_sdk.get_current_scope", return_value=mock_scope):
+            project_transaction({"api_calls": 2}, prefix="lml.cache.")
+
+        mock_transaction.set_data.assert_called_once_with("lml.cache.api_calls", 2)
+
+    def test_measurements_true_also_sets_measurement_for_numeric_entries(self):
+        from core.observability import project_transaction
+
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+        data = {"api_calls": 2, "pg_time_ms": 12.5, "weird_string": "nope"}
+
+        with patch("core.observability.sentry_sdk.get_current_scope", return_value=mock_scope):
+            project_transaction(data, measurements=True)
+
+        measured = {c.args[0]: c.args[1] for c in mock_transaction.set_measurement.call_args_list}
+        assert measured == {"api_calls": 2, "pg_time_ms": 12.5}
+        # Non-numeric entries still get set_data even though they're not measured.
+        projected = {c.args[0]: c.args[1] for c in mock_transaction.set_data.call_args_list}
+        assert projected == data
+
+    def test_measurements_true_excludes_bool_despite_being_an_int_subclass(self):
+        from core.observability import project_transaction
+
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+
+        with patch("core.observability.sentry_sdk.get_current_scope", return_value=mock_scope):
+            project_transaction({"flag": True}, measurements=True)
+
+        mock_transaction.set_measurement.assert_not_called()
+        mock_transaction.set_data.assert_called_once_with("flag", True)
+
+
+class TestProjectCapped:
+    """The in-flight-cap tag+measurement pair, parameterized by key."""
+
+    def test_noop_measurement_when_no_active_transaction(self):
+        from core.observability import project_capped
+
+        mock_scope = Mock()
+        mock_scope.transaction = None
+        set_tag = Mock()
+        with (
+            patch("core.observability.sentry_sdk.get_current_scope", return_value=mock_scope),
+            patch("core.observability.sentry_sdk.set_tag", set_tag),
+        ):
+            # Must not raise even with no active transaction.
+            project_capped("lml.lookup.inflight_capped", "lml.lookup.inflight_wait_ms", 42.0)
+
+        set_tag.assert_called_once_with("lml.lookup.inflight_capped", "true")
+
+    def test_sets_tag_and_measurement_and_data_by_default(self):
+        """Default shape matches ``lookup.router``'s original
+        ``_project_inflight_capped`` -- tag + measurement + set_data.
+        """
+        from core.observability import project_capped
+
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+        set_tag = Mock()
+
+        with (
+            patch("core.observability.sentry_sdk.get_current_scope", return_value=mock_scope),
+            patch("core.observability.sentry_sdk.set_tag", set_tag),
+        ):
+            project_capped("lml.lookup.inflight_capped", "lml.lookup.inflight_wait_ms", 123.5)
+
+        set_tag.assert_called_once_with("lml.lookup.inflight_capped", "true")
+        mock_transaction.set_measurement.assert_called_once_with(
+            "lml.lookup.inflight_wait_ms", 123.5
+        )
+        mock_transaction.set_data.assert_called_once_with("lml.lookup.inflight_wait_ms", 123.5)
+
+    def test_also_set_data_false_skips_set_data(self):
+        """Matches ``streaming.router``'s original ``_project_inflight_capped``,
+        which only sets the measurement, not ``set_data``.
+        """
+        from core.observability import project_capped
+
+        mock_transaction = Mock()
+        mock_scope = Mock()
+        mock_scope.transaction = mock_transaction
+        set_tag = Mock()
+
+        with (
+            patch("core.observability.sentry_sdk.get_current_scope", return_value=mock_scope),
+            patch("core.observability.sentry_sdk.set_tag", set_tag),
+        ):
+            project_capped(
+                "lml.streaming_check.inflight_capped",
+                "lml.streaming_check.inflight_wait_ms",
+                77.0,
+                also_set_data=False,
+            )
+
+        mock_transaction.set_measurement.assert_called_once_with(
+            "lml.streaming_check.inflight_wait_ms", 77.0
+        )
+        mock_transaction.set_data.assert_not_called()
+
+    def test_does_not_swallow_exceptions(self):
+        """``project_capped`` has no internal try/except -- callers compose it
+        with ``observability_guard`` for that. Pins the composition contract.
+        """
+        from core.observability import project_capped
+
+        with patch(
+            "core.observability.sentry_sdk.set_tag", side_effect=RuntimeError("sdk exploded")
+        ):
+            with pytest.raises(RuntimeError):
+                project_capped("some.tag", "some.measurement", 1.0)
+
+
+class TestObservabilityGuardComposesWithProjectCapped:
+    """Integration: the documented composition pattern call sites use."""
+
+    def test_sdk_failure_inside_guarded_project_capped_is_swallowed(self):
+        from core.observability import observability_guard, project_capped
+
+        logger = Mock(spec=logging.Logger)
+        with patch(
+            "core.observability.sentry_sdk.set_tag", side_effect=RuntimeError("sdk exploded")
+        ):
+            with observability_guard("project inflight_capped onto Sentry transaction", logger):
+                project_capped("some.tag", "some.measurement", 1.0)
+
+        logger.warning.assert_called_once()
+        args = logger.warning.call_args.args
+        assert args[0] == "Failed to %s: %s"
+        assert args[1] == "project inflight_capped onto Sentry transaction"

--- a/tests/unit/test_streaming_check_inflight_cap.py
+++ b/tests/unit/test_streaming_check_inflight_cap.py
@@ -21,6 +21,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from config.settings import get_settings
+from core import observability
 from core.dependencies import get_streaming_posthog_client
 from streaming import router as router_mod
 from streaming.dependencies import (
@@ -220,8 +221,8 @@ class TestInFlightCapObservability:
                 new_callable=AsyncMock,
                 side_effect=gated_check,
             ),
-            patch.object(router_mod.sentry_sdk, "get_current_scope", return_value=scope),
-            patch.object(router_mod.sentry_sdk, "set_tag", set_tag),
+            patch.object(observability.sentry_sdk, "get_current_scope", return_value=scope),
+            patch.object(observability.sentry_sdk, "set_tag", set_tag),
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app_client), base_url="http://test"
@@ -275,8 +276,8 @@ class TestInFlightCapObservability:
                 new_callable=AsyncMock,
                 return_value=_empty_response(),
             ),
-            patch.object(router_mod.sentry_sdk, "get_current_scope", return_value=scope),
-            patch.object(router_mod.sentry_sdk, "set_tag", set_tag),
+            patch.object(observability.sentry_sdk, "get_current_scope", return_value=scope),
+            patch.object(observability.sentry_sdk, "set_tag", set_tag),
         ):
             async with AsyncClient(
                 transport=ASGITransport(app=app_client), base_url="http://test"


### PR DESCRIPTION
## Summary

- Adds `core/observability.py` with three composable primitives for the "observability must not break the request path" idiom: `observability_guard(label, logger)` (the try/except-and-warn context manager, also usable as a decorator), `project_transaction(data, *, measurements=False, prefix="")` (set_data/set_measurement fan-out onto the active Sentry transaction), and `project_capped(tag_key, measurement_key, wait_ms, *, also_set_data=True)` (the tag+measurement pair the in-flight-cap projections share).
- Converts the three near-verbatim capped-projection helpers (`lookup/router.py::_project_inflight_capped`, `streaming/router.py::_project_inflight_capped`, `core/bulk_concurrency.py::_project_global_capped`) to delegate to `project_capped`, keeping each site's own tag/measurement keys, `set_data` behavior, and (for bulk_concurrency) its per-transaction running-max de-dup as local bookkeeping around the shared call.
- Converts the `core/search.py` sibling pair (`_log_search_budget_exceeded`, `_log_hard_cap_fired`) to keep their structured `logger.info` lines and delegate the Sentry-projection half to `project_transaction` under `observability_guard`.
- Converts four more `lookup/router.py` sites (`_record_lml_flag_tags`, `_record_event_loop_lag`, `_project_cache_stats_to_transaction`, `_emit_server_timing_header`) to wrap their existing bodies in `observability_guard` instead of a hand-rolled try/except.
- Does **not** sweep the remaining ~35-40 sites using the same bare-try/except idiom elsewhere in the repo — those adopt the helper opportunistically, tracked in the issue this closes.

Strictly behavior-preserving: same log messages at the same levels, same Sentry tag/measurement/data keys, same no-op conditions. Two pre-existing tests (`tests/unit/test_streaming_check_inflight_cap.py`) had their `sentry_sdk` patch target updated from `streaming.router.sentry_sdk` to `core.observability.sentry_sdk`, since that's where the SDK call now actually executes (patching the module attribute still hits the same underlying `sentry_sdk` singleton either way, but the old target module no longer imports `sentry_sdk` at all).

## Test plan

- [x] New `tests/unit/test_observability.py` (TDD: written first, confirmed failing before `core/observability.py` existed) covers `observability_guard` (swallow + exact `"Failed to %s: %s"` message shape, non-`Exception` propagation, decorator usage), `project_transaction` (no-op without a transaction, per-entry `set_data`, `measurements=True` numeric filter excluding `bool`, `prefix`), and `project_capped` (tag always set, measurement/data gated on an active transaction, `also_set_data=False`, no internal exception-swallowing).
- [x] `uv run --no-sync ruff format --check .`
- [x] `uv run --no-sync ruff check .`
- [x] `uv run --no-sync mypy core/observability.py core/search.py core/bulk_concurrency.py lookup/router.py streaming/router.py --ignore-missing-imports`
- [x] `uv run --no-sync pytest tests/unit -q` — 4606 passed

Closes #1050
