### PR TITLE
refactor(#1035): extract shared tracklist-scan kernel into discogs/matching.py

### DIFF
--- a/discogs/cache_service.py
+++ b/discogs/cache_service.py
@@ -17,11 +17,10 @@ from dataclasses import dataclass, field, fields
 from typing import NoReturn
 
 import asyncpg
-from rapidfuzz import fuzz
 from wxyc_etl.text import to_match_form as normalize_for_comparison
 
 from config.settings import _WORK_MEM_RE, get_settings
-from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
+from discogs.matching import TracklistEntry, scan_tracklist_for_match
 from discogs.memory_cache import async_cached, create_ttl_cache
 from discogs.models import (
     ArtistCredit,
@@ -129,18 +128,6 @@ class ArtistEqualityCandidates:
             ids |= getattr(self, f.name)
         return ids
 
-
-# Mirrors ``_ARTIST_FUZZY_MATCH_THRESHOLD`` in ``discogs/service.py`` — the
-# release-level fuzzy fallback used here must score the same way the API path
-# does so cache hits and cache misses can't disagree about whether a track is
-# on a release. Tied to that constant by intent, not duplicated by accident.
-_ARTIST_FUZZY_MATCH_THRESHOLD = 70
-
-# Mirrors ``_TRACK_TITLE_FUZZY_MATCH_THRESHOLD`` in ``discogs/service.py`` (LML#334)
-# — the track-title fuzzy fallback applied here after the bidirectional substring
-# gate misses. Must score the same as the API path so cache hits and misses agree
-# on whether a (possibly misspelled) track title is on a release.
-_TRACK_TITLE_FUZZY_MATCH_THRESHOLD = 85
 
 # Default TTL for a negative-cache entry (7 days, matching the
 # migration's column default). 7 days is conservative: tracks that
@@ -2569,65 +2556,16 @@ class DiscogsCacheService:
 
             primary_artist = release_artist_row["artist_name"] if release_artist_row else ""
 
-            track_lower = normalize_for_track_comparison(track)
-            artist_lower = normalize_artist_for_validation(artist)
-
-            release_artist_clean = normalize_artist_for_validation(primary_artist)
-
-            for row in track_rows:
-                item_title = normalize_for_track_comparison(row["title"])
-
-                if track_lower not in item_title and item_title not in track_lower:
-                    # Fuzzy title fallback (LML#334): typographic noise that leaves
-                    # token content intact (singular/plural, a dropped interior word,
-                    # dash-vs-paren suffix) misses the substring gate but clears the
-                    # token_set_ratio floor. Mirrors the API path's
-                    # ``_iter_title_matched_items``.
-                    if (
-                        not item_title
-                        or fuzz.token_set_ratio(track_lower, item_title)
-                        < _TRACK_TITLE_FUZZY_MATCH_THRESHOLD
-                    ):
-                        continue
-
-                seq = row["sequence"]
-                artists_for_track = track_artists.get(seq, [])
-                if artists_for_track:
-                    for track_artist in artists_for_track:
-                        track_artist_lower = normalize_artist_for_validation(track_artist)
-                        if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
-                            return True
-                    joined = normalize_artist_for_validation(" ".join(artists_for_track))
-                    if (
-                        joined
-                        and fuzz.token_set_ratio(artist_lower, joined)
-                        >= _ARTIST_FUZZY_MATCH_THRESHOLD
-                    ):
-                        return True
-
-                # Release-level fallback, consulted whenever the per-track
-                # main credits (post-#333 ``extra = 0`` filter) didn't
-                # close the match — either no per-track main credit exists
-                # for this row at all, or one exists but didn't substring/
-                # fuzz-match the requested artist. Rescued by a
-                # release-level credit that does match. The band-member
-                # shape (per-track main credits list only members, release-
-                # level is the band) is one canonical case; see #333
-                # acceptance criteria. Mirrors the API path in
-                # ``discogs/service.py``. Do not remove without replacing
-                # the rescue path.
-                if release_artist_clean and (
-                    artist_lower in release_artist_clean or release_artist_clean in artist_lower
-                ):
-                    return True
-                if (
-                    release_artist_clean
-                    and fuzz.token_set_ratio(artist_lower, release_artist_clean)
-                    >= _ARTIST_FUZZY_MATCH_THRESHOLD
-                ):
-                    return True
-
-            return False
+            # Adapt the plain asyncpg rows into the shape the shared kernel
+            # needs (LML#1035) -- see the module-note in
+            # ``discogs/matching.py``. ``track_artists.get(seq)`` is ``None``
+            # for a row with no ``extra = 0`` credits, matching
+            # ``TrackItem.artists``'s ``None``/empty shape on the API path.
+            entries = (
+                TracklistEntry(title=row["title"], artists=track_artists.get(row["sequence"]))
+                for row in track_rows
+            )
+            return scan_tracklist_for_match(entries, track, artist, release_artist=primary_artist)
 
         except Exception as e:
             _classify_cache_error("validate_track_on_release", e)

--- a/discogs/matching.py
+++ b/discogs/matching.py
@@ -23,6 +23,10 @@ asymmetry that gates the swap on the Postgres analog landing.
 """
 
 import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+from rapidfuzz import fuzz
 
 # `to_match_form` (NFKD + diacritic-strip + lowercase + trim) is the
 # right base for validation comparisons here. Switching to
@@ -93,3 +97,146 @@ def normalize_artist_for_validation(name: str) -> str:
         return ""
     result = name.lower().replace('"', "").replace("'", "")
     return strip_discogs_suffix(result).strip()
+
+
+# ---------------------------------------------------------------------------
+# Tracklist-match kernel (LML#1035)
+# ---------------------------------------------------------------------------
+#
+# `discogs/service.py` (the rate-limited live-Discogs-API path) and
+# `discogs/cache_service.py` (the unthrottled local-PG path) both need to
+# answer the same question -- "does this release's tracklist contain this
+# track, credited to this artist?" -- but hold their tracklist rows in
+# different native shapes (parsed Pydantic `TrackItem` models vs. plain
+# asyncpg `Record` rows grouped by track sequence). Before LML#1035 each
+# service carried its own copy of the match algorithm AND its own copy of
+# the two fuzzy-match thresholds below, so a tuning change landing in one
+# file could silently diverge cache-path vs API-path validation verdicts.
+#
+# `scan_tracklist_for_match` is that one shared, pure/sync kernel. Both
+# services adapt their native tracklist rows into `TracklistEntry` at the
+# call site and delegate here; neither duplicates the match logic or the
+# thresholds anymore.
+
+# Fuzzy fallback for tracklist-match artist comparison. Strict substring
+# matching loses on collaboration trios where neither name is a substring of
+# the other (e.g., request "Orcutt Shelley Miller" vs release artist
+# "Bill Orcutt, Tashi Shelley & Robbie Miller"). rapidfuzz token_set_ratio is
+# order- and stopword-tolerant; the threshold was chosen so that one shared
+# token across two short names ("Bill Orcutt" vs "Orcutt Shelley Miller") just
+# clears the bar (~70.6) while unrelated artists score well below 50. See
+# LML#210. Formerly duplicated verbatim as `_ARTIST_FUZZY_MATCH_THRESHOLD` in
+# both `discogs/service.py` and `discogs/cache_service.py`.
+ARTIST_FUZZY_MATCH_THRESHOLD = 70
+
+# Fuzzy fallback for tracklist-match track-title comparison (LML#334). The
+# bidirectional substring gate loses on typographic noise that leaves token
+# content intact: a singular/plural typo ("tower of dub" vs "Towers Of Dub"),
+# a dropped interior word ("smells teen spirit" vs "Smells Like Teen
+# Spirit"), or a dash-vs-paren suffix ("de la soul - radio edit" vs "de la
+# soul (radio edit)"). token_set_ratio is order- and stopword-tolerant. The
+# threshold is stricter than the artist-side 70 because track titles are
+# short, so a single shared token can score 50+; 85 lets the substitutions
+# above through (each scores >= 96) while rejecting one-shared-token
+# adversarial near-misses ("towers of dub" vs "towers of london" scores
+# ~82). Formerly duplicated verbatim as `_TRACK_TITLE_FUZZY_MATCH_THRESHOLD`
+# in both `discogs/service.py` and `discogs/cache_service.py`.
+TRACK_TITLE_FUZZY_MATCH_THRESHOLD = 85
+
+
+@dataclass(frozen=True, slots=True)
+class TracklistEntry:
+    """One tracklist row, in the shape :func:`scan_tracklist_for_match` needs.
+
+    The API path and the cache path hold tracklist rows in different native
+    shapes (see the module note above). Each caller adapts its own shape
+    into a list of these before calling the kernel, keeping the kernel free
+    of both ``discogs.models`` (Pydantic) and ``asyncpg`` dependencies.
+    """
+
+    title: str
+    artists: Sequence[str] | None = None
+
+
+def scan_tracklist_for_match(
+    tracklist: Iterable[TracklistEntry],
+    track: str,
+    artist: str,
+    *,
+    release_artist: str,
+) -> bool:
+    """Return whether ``track`` by ``artist`` is found on ``tracklist``.
+
+    The shared, pure/sync core of tracklist-match validation (LML#1035):
+
+    1. Title gate per entry: bidirectional substring on the normalized
+       title, then a ``token_set_ratio`` fuzzy fallback (LML#334) so
+       typographic noise that leaves token content intact still matches.
+    2. Per-track artist credits (if any): bidirectional substring per
+       credited name, then a joined-credit ``token_set_ratio`` fuzzy
+       fallback (LML#210) for collaborations credited as separate names.
+    3. Release-level artist (``release_artist``): consulted whenever the
+       per-track credits haven't already matched -- per-track credits often
+       list band members / producers / writers rather than the band itself,
+       so the release-level credit is the last word on "is this track by
+       this artist." Same substring-then-fuzzy shape as step 2.
+
+    A title-matched entry that fails steps 2 and 3 does not short-circuit
+    the scan -- later entries (e.g. a second title-matched track with a
+    different per-track credit) are still tried. Returns ``False`` only
+    after every entry has been checked without a match.
+
+    Must stay pure and synchronous: the cache path calls this against local
+    PG rows with no rate limit, while the API path calls it under the
+    Discogs rate limiter. Neither path's concurrency posture may change, so
+    this function performs no I/O and awaits nothing.
+
+    Args:
+        tracklist: Tracklist rows, already adapted to :class:`TracklistEntry`.
+        track: Raw (not pre-normalized) track title being searched for.
+        artist: Raw (not pre-normalized) artist name being searched for.
+        release_artist: Raw (not pre-normalized) release-level artist credit.
+
+    Returns:
+        ``True`` if ``track`` by ``artist`` is found on the tracklist.
+    """
+    track_lower = normalize_for_track_comparison(track)
+    artist_lower = normalize_artist_for_validation(artist)
+    release_artist_lower = normalize_artist_for_validation(release_artist)
+
+    for entry in tracklist:
+        item_title = normalize_for_track_comparison(entry.title)
+        title_matches = track_lower in item_title or item_title in track_lower
+        if not title_matches and item_title:
+            title_matches = (
+                fuzz.token_set_ratio(track_lower, item_title) >= TRACK_TITLE_FUZZY_MATCH_THRESHOLD
+            )
+        if not title_matches:
+            continue
+
+        if entry.artists:
+            for track_artist in entry.artists:
+                track_artist_lower = normalize_artist_for_validation(track_artist)
+                if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
+                    return True
+            joined = normalize_artist_for_validation(" ".join(entry.artists))
+            if (
+                joined
+                and fuzz.token_set_ratio(artist_lower, joined) >= ARTIST_FUZZY_MATCH_THRESHOLD
+            ):
+                return True
+
+        # Release-level artist. Always consulted when per-track credits
+        # haven't already matched -- see the docstring's step 3.
+        if release_artist_lower and (
+            artist_lower in release_artist_lower or release_artist_lower in artist_lower
+        ):
+            return True
+        if (
+            release_artist_lower
+            and fuzz.token_set_ratio(artist_lower, release_artist_lower)
+            >= ARTIST_FUZZY_MATCH_THRESHOLD
+        ):
+            return True
+
+    return False

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -27,7 +27,12 @@ from config.settings import get_settings
 from discogs.breaker import DiscogsBreakerOpenError
 from discogs.fallthrough import apply_request_ctx_tags, fallthrough, request_context
 from discogs.live_request_counter import increment_discogs_live_requests_total
-from discogs.matching import normalize_artist_for_validation, normalize_for_track_comparison
+from discogs.matching import (
+    TRACK_TITLE_FUZZY_MATCH_THRESHOLD,
+    TracklistEntry,
+    normalize_for_track_comparison,
+    scan_tracklist_for_match,
+)
 from discogs.memory_cache import (
     ARTIST_CACHE,
     LABEL_CACHE,
@@ -140,28 +145,6 @@ One lookup can make several live Discogs requests; the request-level measurement
 should retain the worst observed backlog, not whichever request happened to run
 last. Weak keys mirror ``core.bulk_concurrency``'s queue-wait measurement cache.
 """
-
-# Fuzzy fallback for `validate_track_on_release` artist matching. Strict substring
-# matching loses on collaboration trios where neither name is a substring of the
-# other (e.g., request "Orcutt Shelley Miller" vs release artist
-# "Bill Orcutt, Tashi Shelley & Robbie Miller"). rapidfuzz token_set_ratio is
-# order- and stopword-tolerant; the threshold was chosen so that one shared
-# token across two short names ("Bill Orcutt" vs "Orcutt Shelley Miller") just
-# clears the bar (~70.6) while unrelated artists score well below 50. See LML#210.
-_ARTIST_FUZZY_MATCH_THRESHOLD = 70
-
-# Fuzzy fallback for `validate_track_on_release` track-title matching (LML#334).
-# The bidirectional substring gate loses on typographic noise that leaves token
-# content intact: a singular/plural typo ("tower of dub" vs "Towers Of Dub"), a
-# dropped interior word ("smells teen spirit" vs "Smells Like Teen Spirit"), or a
-# dash-vs-paren suffix ("de la soul - radio edit" vs "de la soul (radio edit)").
-# token_set_ratio is order- and stopword-tolerant. The threshold is stricter than
-# the artist-side 70 because track titles are short, so a single shared token can
-# score 50+; 85 lets the substitutions above through (each scores >= 96) while
-# rejecting one-shared-token adversarial near-misses ("towers of dub" vs "towers
-# of london" scores ~82). Mirrored in `discogs/cache_service.py` so cache hits and
-# misses agree on the verdict.
-_TRACK_TITLE_FUZZY_MATCH_THRESHOLD = 85
 
 
 def _approx_semaphore_queue_depth(semaphore: asyncio.Semaphore) -> int:
@@ -2085,11 +2068,7 @@ class DiscogsService:
             if release is None:
                 return False
 
-            track_lower = normalize_for_track_comparison(track)
-            artist_lower = normalize_artist_for_validation(artist)
-            return _scan_tracklist_for_match(
-                release, release_id, track, track_lower, artist, artist_lower
-            )
+            return _scan_tracklist_for_match(release, release_id, track, artist)
 
         cache = self.cache_service
         if cache is not None:
@@ -2181,7 +2160,7 @@ def _iter_title_matched_items(
             yield item
         elif (
             item_title
-            and fuzz.token_set_ratio(track_lower, item_title) >= _TRACK_TITLE_FUZZY_MATCH_THRESHOLD
+            and fuzz.token_set_ratio(track_lower, item_title) >= TRACK_TITLE_FUZZY_MATCH_THRESHOLD
         ):
             yield item
 
@@ -2190,58 +2169,27 @@ def _scan_tracklist_for_match(
     release: ReleaseMetadataResponse,
     release_id: int,
     track: str,
-    track_lower: str,
     artist: str,
-    artist_lower: str,
 ) -> bool:
     """Tracklist match logic extracted from ``validate_track_on_release``.
 
-    Kept as a module-level helper so ``validate_track_on_release``'s body
-    after the seam refactor reads as orchestration, not algorithm. Inputs
-    are pre-normalized by the caller (single call to
-    ``normalize_for_track_comparison`` / ``normalize_artist_for_validation``)
-    so the inner loop is hot-path arithmetic.
+    Thin wrapper (LML#1035) around the shared, pure/sync
+    :func:`discogs.matching.scan_tracklist_for_match` kernel: adapts
+    ``release.tracklist`` (parsed ``TrackItem`` models) into
+    :class:`~discogs.matching.TracklistEntry` rows and logs the verdict.
+    ``discogs/cache_service.py``'s ``validate_track_on_release`` calls the
+    same kernel over its own asyncpg-row adaptation, so the two paths can no
+    longer diverge on tuning.
     """
-    for item in _iter_title_matched_items(release, track_lower):
-        # Per-track credits first (compilations, or tracks crediting the
-        # writers/performers). A positive hit short-circuits.
-        if item.artists:
-            for track_artist in item.artists:
-                track_artist_lower = normalize_artist_for_validation(track_artist)
-                if artist_lower in track_artist_lower or track_artist_lower in artist_lower:
-                    logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
-                    return True
-            # Fuzzy fallback: when no individual per-track artist substring-matches,
-            # compare against the joined credit string. Catches collaboration trios
-            # where each member is credited separately but the request uses the
-            # compact group name (LML#210).
-            joined = normalize_artist_for_validation(" ".join(item.artists))
-            if (
-                joined
-                and fuzz.token_set_ratio(artist_lower, joined) >= _ARTIST_FUZZY_MATCH_THRESHOLD
-            ):
-                logger.info(f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}")
-                return True
-
-        # Release-level artist. Always consulted when per-track credits
-        # haven't already matched — per-track credits often list band
-        # members / producers / writers rather than the band itself (e.g.,
-        # The Orb's "Towers Of Dub" on Live 93 is credited to Paterson /
-        # Weston / Fehlmann), so the release-level credit is the last
-        # word on "is this track by this artist."
-        release_artist = normalize_artist_for_validation(release.artist)
-        if release_artist and (artist_lower in release_artist or release_artist in artist_lower):
-            logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
-            return True
-        if (
-            release_artist
-            and fuzz.token_set_ratio(artist_lower, release_artist) >= _ARTIST_FUZZY_MATCH_THRESHOLD
-        ):
-            logger.info(f"Validated (fuzzy): '{track}' by '{artist}' on release {release_id}")
-            return True
-
-    logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")
-    return False
+    entries = (
+        TracklistEntry(title=item.title, artists=item.artists) for item in release.tracklist or []
+    )
+    matched = scan_tracklist_for_match(entries, track, artist, release_artist=release.artist)
+    if matched:
+        logger.info(f"Validated: '{track}' by '{artist}' found on release {release_id}")
+    else:
+        logger.info(f"Track '{track}' by '{artist}' NOT found on release {release_id}")
+    return matched
 
 
 def _scan_tracklist_for_credit(release: ReleaseMetadataResponse, track_lower: str) -> str | None:

--- a/scripts/cache_miss_provenance.py
+++ b/scripts/cache_miss_provenance.py
@@ -23,7 +23,8 @@ Input shapes accepted (pick one):
   the API leg (i.e., the cache missed for that release_id):
 
     * ``Validated: 'TRACK' by 'ARTIST' found on release RELEASE_ID``
-    * ``Validated (fuzzy): 'TRACK' by 'ARTIST' on release RELEASE_ID``
+    * ``Validated (fuzzy): 'TRACK' by 'ARTIST' on release RELEASE_ID`` (LML#1035:
+      no longer emitted going forward -- kept for parsing historical logs)
     * ``Track 'TRACK' by 'ARTIST' NOT found on release RELEASE_ID``
 
   ``method`` is set to ``validate_track_on_release`` for all three. The
@@ -80,6 +81,9 @@ class MissEvent:
 _LOG_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"Validated: '.+' by '.+' found on release (\d+)"), "validate_track_on_release"),
     (
+        # LML#1035 folded discogs/service.py's fuzzy/exact match branches into
+        # one shared kernel, so this "(fuzzy)" variant is no longer emitted by
+        # current code -- retained so the script keeps parsing pre-#1035 logs.
         re.compile(r"Validated \(fuzzy\): '.+' by '.+' on release (\d+)"),
         "validate_track_on_release",
     ),

--- a/tests/unit/test_tracklist_scan_characterization_1035.py
+++ b/tests/unit/test_tracklist_scan_characterization_1035.py
@@ -1,0 +1,225 @@
+"""Characterization tests for the tracklist-scan matching algorithm (LML#1035).
+
+The track-validation matching algorithm exists twice: the API path
+(``discogs.service._iter_title_matched_items`` + ``_scan_tracklist_for_match``,
+reached through ``DiscogsService.validate_track_on_release``) and the cache
+path (the inline loop inside ``DiscogsCacheService.validate_track_on_release``,
+whose comments say "Mirrors the API path"). Both copies also duplicate
+``_ARTIST_FUZZY_MATCH_THRESHOLD = 70`` and ``_TRACK_TITLE_FUZZY_MATCH_THRESHOLD
+= 85`` verbatim.
+
+This module pins the CURRENT behavior of BOTH copies against one shared table
+of cases before either copy is touched. Each ``ScanCase`` is exercised against
+both ``DiscogsService.validate_track_on_release`` (mocking ``get_release``) and
+``DiscogsCacheService.validate_track_on_release`` (mocking the asyncpg pool),
+so a divergence between the two copies shows up as a single parametrized
+failure instead of two independently-drifting test files. Manual trace of both
+implementations found them logically equivalent (title match: bidirectional
+substring OR ``token_set_ratio`` fuzzy fallback; per-track artist: substring
+then joined-credit fuzzy fallback; release-level artist: substring then fuzzy
+fallback) -- these tests are the empirical confirmation of that trace, run
+before the extraction in the same PR. No reconciliation was required; see the
+PR body for the full diff writeup.
+
+WXYC-representative fixtures throughout (Stereolab, Chuquimamani-Condori,
+Juana Molina, Duke Ellington & John Coltrane, Sessa, Large Professor) per
+CLAUDE.md's fixture guidance. Never Beatles/Radiohead/Queen.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from discogs.cache_service import DiscogsCacheService
+from discogs.models import ReleaseMetadataResponse, TrackItem
+from discogs.service import DiscogsService
+from tests.unit.test_cache_service import make_fetch_router
+
+
+@dataclass(frozen=True)
+class ScanCase:
+    """One tracklist-match scenario, expressed path-agnostically.
+
+    ``release_track_title`` / ``release_track_artists`` describe the release's
+    single tracklist row; ``release_artist`` is the release-level credit. Both
+    the API-path ``ReleaseMetadataResponse``/``TrackItem`` shape and the
+    cache-path asyncpg row shape are derived from these same fields, so the
+    two paths are compared against identical input.
+    """
+
+    id: str
+    release_artist: str
+    release_track_title: str
+    release_track_artists: list[str] | None
+    query_track: str
+    query_artist: str
+    expected: bool
+    note: str
+
+
+CASES: list[ScanCase] = [
+    ScanCase(
+        id="title_exact_per_track_artist_substring",
+        release_artist="Various",
+        release_track_title="Back, Baby",
+        release_track_artists=["Jessica Pratt"],
+        query_track="Back, Baby",
+        query_artist="Jessica Pratt",
+        expected=True,
+        note="Exact title, direct per-track artist substring match.",
+    ),
+    ScanCase(
+        id="title_fuzzy_only_dropped_word",
+        release_artist="Chuquimamani-Condori",
+        release_track_title="Call Your Name",
+        release_track_artists=None,
+        query_track="call name",
+        query_artist="Chuquimamani-Condori",
+        expected=True,
+        note=(
+            "Query drops the interior word 'Your'; token_set_ratio scores "
+            "100 (>= 85 floor). No per-track credit, so the release-level "
+            "artist substring-matches once the title gate opens on the "
+            "fuzzy fallback."
+        ),
+    ),
+    ScanCase(
+        id="title_miss_unrelated",
+        release_artist="Juana Molina",
+        release_track_title="Call Your Name",
+        release_track_artists=None,
+        query_track="Aluminum Tunes",
+        query_artist="Juana Molina",
+        expected=False,
+        note=(
+            "Query track title is unrelated to the release's only track "
+            "(token_set_ratio ~43, well below the 85 floor; no substring "
+            "relation either). The artist would match if the title did, so "
+            "this isolates the title gate."
+        ),
+    ),
+    ScanCase(
+        id="per_track_credits_miss_release_level_substring_fallback",
+        release_artist="Stereolab",
+        release_track_title="Percolator",
+        release_track_artists=["Laetitia Sadier", "Tim Gane"],
+        query_track="Percolator",
+        query_artist="Stereolab",
+        expected=True,
+        note=(
+            "Per-track credits list the two band members, not the band "
+            "name; neither the individual substring check nor the joined "
+            "fuzzy fallback (score ~18) reaches 'Stereolab', so the "
+            "release-level artist substring fallback must fire."
+        ),
+    ),
+    ScanCase(
+        id="joined_multiartist_fuzzy_duke_ellington_coltrane",
+        release_artist="Various",
+        release_track_title="In A Sentimental Mood",
+        release_track_artists=["Duke Ellington", "John Coltrane"],
+        query_track="In A Sentimental Mood",
+        query_artist="Ellington Coltrane",
+        expected=True,
+        note=(
+            "WXYC flowsheet-style compact credit for a joined performance. "
+            "Neither 'Duke Ellington' nor 'John Coltrane' individually "
+            "substring-matches 'Ellington Coltrane', but the joined credit "
+            "'Duke Ellington John Coltrane' scores 100 on token_set_ratio "
+            "(>= 70 floor) -- LML#210's canonical joined-credit case."
+        ),
+    ),
+    ScanCase(
+        id="fuzzy_reject_unrelated_artist",
+        release_artist="Duke Ellington & John Coltrane",
+        release_track_title="In A Sentimental Mood",
+        release_track_artists=None,
+        query_track="In A Sentimental Mood",
+        query_artist="Thelonious Monk",
+        expected=False,
+        note=(
+            "Title matches; the release-level fuzzy fallback must still "
+            "reject an unrelated artist (token_set_ratio ~42, well below "
+            "the 70 floor)."
+        ),
+    ),
+    ScanCase(
+        id="anv_suffix_per_track_artist_match",
+        release_artist="Various",
+        release_track_title="Pequena Vertigem de Amor",
+        release_track_artists=["Sessa*"],
+        query_track="Pequena Vertigem de Amor",
+        query_artist="Sessa",
+        expected=True,
+        note=(
+            "Discogs ANV disambiguation asterisk on the per-track credit "
+            "('Sessa*'). Neither normalize function strips '*', but "
+            "bidirectional substring still matches ('sessa' in 'sessa*')."
+        ),
+    ),
+    ScanCase(
+        id="anv_suffix_release_level_artist_match",
+        release_artist="Large Professor*",
+        release_track_title="1st Class",
+        release_track_artists=None,
+        query_track="1st Class",
+        query_artist="Large Professor",
+        expected=True,
+        note="Same ANV-asterisk tolerance, exercised on the release-level credit.",
+    ),
+]
+
+
+def _api_release(case: ScanCase) -> ReleaseMetadataResponse:
+    return ReleaseMetadataResponse(
+        release_id=1,
+        title="Test Release",
+        artist=case.release_artist,
+        release_url="https://discogs.com/release/1",
+        tracklist=[
+            TrackItem(
+                position="1",
+                title=case.release_track_title,
+                artists=case.release_track_artists,
+            )
+        ],
+    )
+
+
+def _configure_cache_pool(case: ScanCase, mock_asyncpg_pool) -> None:
+    mock_asyncpg_pool.fetchval = AsyncMock(return_value=True)
+    track_artist_rows = (
+        [{"track_sequence": 1, "artist_name": name} for name in case.release_track_artists]
+        if case.release_track_artists
+        else []
+    )
+    mock_asyncpg_pool.fetch = AsyncMock(
+        side_effect=make_fetch_router(
+            release_track_artist=track_artist_rows,
+            release_track=[{"sequence": 1, "title": case.release_track_title}],
+        )
+    )
+    mock_asyncpg_pool.fetchrow = AsyncMock(return_value={"artist_name": case.release_artist})
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+class TestTracklistScanCharacterization:
+    """Same table, run against both duplicate implementations (LML#1035)."""
+
+    @pytest.mark.asyncio
+    async def test_api_path(self, case: ScanCase):
+        service = DiscogsService(token="test-token")
+        release = _api_release(case)
+        with patch.object(service, "get_release", new_callable=AsyncMock, return_value=release):
+            result = await service.validate_track_on_release(1, case.query_track, case.query_artist)
+        assert result is case.expected, case.note
+
+    @pytest.mark.asyncio
+    async def test_cache_path(self, case: ScanCase, mock_asyncpg_pool):
+        cache_service = DiscogsCacheService(mock_asyncpg_pool)
+        _configure_cache_pool(case, mock_asyncpg_pool)
+        result = await cache_service.validate_track_on_release(
+            1, case.query_track, case.query_artist
+        )
+        assert result is case.expected, case.note


### PR DESCRIPTION
Closes #1035

## Problem

The track-validation matching algorithm existed twice: `discogs/service.py` (`_iter_title_matched_items` + `_scan_tracklist_for_match`, the rate-limited live-Discogs-API path) and an inline loop inside `discogs/cache_service.py`'s `validate_track_on_release` (the unthrottled local-PG path), whose comments literally said "Mirrors the API path." Both files also duplicated `_ARTIST_FUZZY_MATCH_THRESHOLD = 70` and `_TRACK_TITLE_FUZZY_MATCH_THRESHOLD = 85` verbatim. A tuning change landing in only one copy could silently diverge cache-path vs API-path validation verdicts -- the same class of bug behind #956 and #971.

## Approach

Followed the ticket's mandated order:

1. **Characterization tests first** (`tests/unit/test_tracklist_scan_characterization_1035.py`): a parametrized table of 8 scenarios -- title exact match, title fuzzy-only match (dropped word), title miss, per-track-artist substring match, per-track-artist miss falling back to release-level substring, the joined multi-artist fuzzy fallback (Duke Ellington & John Coltrane, LML#210's canonical case), and Discogs ANV asterisk-suffixed credits on both the per-track and release-level side -- run against BOTH `DiscogsService.validate_track_on_release` (mocking `get_release`) and `DiscogsCacheService.validate_track_on_release` (mocking the asyncpg pool). All WXYC-representative fixtures (Stereolab, Chuquimamani-Condori, Juana Molina, Jessica Pratt, Sessa, Large Professor). Confirmed these 16 assertions pass against the pre-refactor duplicated implementations before touching either.
2. **Diffed the two copies by hand** (title-match rule, per-track-credit rule, release-level-credit rule, loop/short-circuit structure) in addition to running the characterization table. Both copies were logically identical -- the cache path just spells the same substring-then-fuzzy-then-fallback logic across dict rows instead of parsed Pydantic models.
3. **Extracted the kernel**: `discogs/matching.py` now owns `scan_tracklist_for_match(tracklist, track, artist, *, release_artist) -> bool` (pure, synchronous, no I/O) plus both threshold constants (renamed from the file-private `_ARTIST_FUZZY_MATCH_THRESHOLD`/`_TRACK_TITLE_FUZZY_MATCH_THRESHOLD` to public `ARTIST_FUZZY_MATCH_THRESHOLD`/`TRACK_TITLE_FUZZY_MATCH_THRESHOLD` since they're now cross-module). A new `TracklistEntry(title, artists)` dataclass is the common input shape; each service adapts its own native tracklist rows (parsed `TrackItem` models on the API side, asyncpg `Record` rows grouped by track sequence on the cache side) into a `TracklistEntry` generator at the call site, keeping the kernel free of both `discogs.models` and `asyncpg` dependencies. Both duplicated threshold constants are deleted from `discogs/service.py` and `discogs/cache_service.py`.

## Verdict-affecting reconciliations

**None** -- the characterization suite showed the two copies produced identical verdicts on every case in the table, and the manual trace of both implementations confirmed they're structurally the same algorithm. No matching behavior changed for either path.

## Scope note (not a verdict change)

`discogs/service.py`'s `_iter_title_matched_items` (used by the unrelated `_scan_tracklist_for_credit` / `find_track_position` credit-recovery and BMI-writer-credit helpers, which the cache path never duplicated) was left in place rather than folded into the new kernel, to keep the extraction's blast radius limited to the actually-duplicated `validate_track_on_release` logic. It now imports the shared `TRACK_TITLE_FUZZY_MATCH_THRESHOLD` from `discogs/matching.py` instead of a locally-duplicated constant, so it can no longer drift from the kernel's threshold even though a few lines of the title-match test remain textually separate.

One minor logging-granularity change: the API path's old inline loop logged `"Validated (fuzzy): ..."` vs `"Validated: ..."` depending on which sub-rule fired; since the kernel returns a plain bool, `_scan_tracklist_for_match`'s wrapper now logs a single `"Validated: ..."` / `"NOT found"` message regardless of which internal rule matched. Not a verdict change (no test asserts on log text) but noted for transparency.

## Test results

- `tests/unit/test_tracklist_scan_characterization_1035.py`: 16/16 passing (8 cases x 2 paths), both pre- and post-extraction.
- `uv run --no-sync pytest -m "not pg and not external_api"`: 4993 passed, 578 deselected, 2 xfailed (2 pre-existing unrelated flakes present on origin/main baseline too -- `test_shed_lookup_emits_no_error_level_logs` and `test_no_module_level_asyncio_lock_in_dependencies` -- both pass individually and fail identically on a clean origin/main run, confirmed by diffing a baseline run against this branch).
- `ruff format --check .` / `ruff check .`: clean.
- `mypy discogs/matching.py discogs/service.py discogs/cache_service.py tests/unit/test_tracklist_scan_characterization_1035.py --ignore-missing-imports`: no issues.
