### PR TITLE
refactor(#1034): entity/cache_toolkit.py for the lml_cache.* get/set skeleton

### DIFF
--- a/entity/api_keys.py
+++ b/entity/api_keys.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from entity.cache_toolkit import swallowing_execute
 from entity.sources import PgSource
 
 logger = logging.getLogger(__name__)
@@ -119,10 +120,13 @@ async def mark_key_used(pg: PgSource, key_hash: str) -> None:
     The throttling ``WHERE`` clause in ``_TOUCH_LAST_USED_SQL`` means a touch
     within the last hour is a no-op UPDATE (0 rows affected), not an error.
     """
-    try:
-        await pg.execute(_TOUCH_LAST_USED_SQL, key_hash)
-    except Exception:
-        logger.exception("api_keys last_used_at touch failed")
+    await swallowing_execute(
+        pg,
+        _TOUCH_LAST_USED_SQL,
+        key_hash,
+        logger=logger,
+        log_label="api_keys last_used_at touch failed",
+    )
 
 
 async def insert_api_key(

--- a/entity/cache_toolkit.py
+++ b/entity/cache_toolkit.py
@@ -1,0 +1,142 @@
+"""Shared toolkit for the ``lml_cache.*`` free-function store idiom (LML#1034).
+
+Nine store bodies across ``entity/streaming_url_cache.py``,
+``entity/track_streaming_url_cache.py``, ``entity/release_resolution_cache.py``,
+``entity/compilation_track_location.py``, ``entity/library_release_override.py``,
+and ``entity/api_keys.py`` (``mark_key_used`` only) repeated one skeleton:
+normalize keys, run a ``PgSource.fetchone``/``fetchall``/``execute`` call, and
+on any exception log it and degrade to a miss shape rather than propagate --
+every one of these tables is a best-effort cache, and a PG hiccup must never
+break the ``/lookup`` request path.
+
+This module gives that idiom two composable free functions (matching the
+repo's free-function store idiom, not a class hierarchy) instead of a
+hand-rolled ``try/except`` at each call site:
+
+- :func:`swallowing_fetch` -- runs ``pg.fetchone`` (default) or ``pg.fetchall``
+  (``many=True``), and on any exception logs via the CALLER's own ``logger``
+  and returns the caller's ``miss`` sentinel instead of raising.
+- :func:`swallowing_execute` -- the write-side equivalent around
+  ``pg.execute``; never returns a value, since every UPSERT/UPDATE call site
+  treats a write failure as fire-and-forget.
+
+Both take the caller's ``logger`` (never one owned by this toolkit) so the
+emitted ``LogRecord.name`` still attributes to the owning module (e.g.
+``entity.api_keys``) -- load-bearing for that module's existing
+``test_swallows_pg_errors`` unit test, and for incident response, which greps
+logs by module name. Both also take ``log_label`` (a ``%``-style format
+string) and ``log_args`` separately, rather than a single pre-formatted
+string: this keeps the lazy interpolation (no string-formatting cost unless
+the exception path actually fires) AND the exact ``record.msg``/``record.args``
+shape of every pre-refactor call site unchanged. Each module kept its own
+message wording verbatim (different verbs -- "get failed", "probe failed",
+"prefetch failed", "touch failed" -- different argument counts, ``%s`` vs
+``%r``) precisely because those messages are greppable in incident response;
+this toolkit does not attempt to unify them into one template.
+
+:class:`CachedValue` replaces two independently-defined three-valued carriers
+that existed only to let a caller distinguish a fresh cache hit from a fresh
+*known* miss (skip the live probe) from an absent/stale row (run it):
+``streaming_url_cache._CachedRow`` and ``release_resolution_cache.
+ReleaseResolution``. ``entity.release_resolution_cache.ReleaseResolution``
+stays importable as a name- and constructor-shape-preserving alias -- external
+code constructs it with its original ``release_id=`` keyword -- see that
+module's ``ReleaseResolution`` for the compatibility shim.
+
+``DEFAULT_MISS_TTL`` was duplicated verbatim in ``streaming_url_cache.py`` and
+``release_resolution_cache.py``; this is its single home. Both modules
+re-export it under their own name, so existing imports (e.g. ``from
+entity.streaming_url_cache import DEFAULT_MISS_TTL``) keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from entity.sources import PgSource
+
+# How long a known-miss cache row stays authoritative before a caller
+# re-checks the upstream source. Was duplicated verbatim in
+# streaming_url_cache.py and release_resolution_cache.py; both now import it
+# from here (LML#1034). 7 days trades freshness for cache amortization --
+# long enough that a request spike doesn't repeatedly hammer an upstream API
+# for the same misses, short enough that a newly-available item becomes
+# visible within a week.
+DEFAULT_MISS_TTL = timedelta(days=7)
+
+
+@dataclass(frozen=True)
+class CachedValue[T]:
+    """Three-valued outcome of a PG cache-row read: hit / fresh-miss / absent-or-stale.
+
+    Generalizes ``streaming_url_cache._CachedRow`` and
+    ``release_resolution_cache.ReleaseResolution`` -- both existed only to let
+    a caller distinguish a fresh cache hit from a fresh *known* miss (skip the
+    live probe) from an absent-or-stale row (run it), where the SQL ``WHERE``
+    clause already collapses "absent" and "stale" into the same "no row"
+    shape:
+
+    * ``was_present=True`` and ``value`` is not ``None`` -- a fresh hit.
+      Short-circuit with this ``value``.
+    * ``was_present=True`` and ``value is None`` -- a fresh *known miss*: the
+      row exists (a prior probe already came up empty) and is still inside
+      its TTL. Short-circuit -- do not repeat the live probe.
+    * ``was_present=False`` (``value`` always ``None``) -- no fresh row:
+      either genuinely absent, or present but aged past its TTL. Run the live
+      probe.
+    """
+
+    value: T | None
+    was_present: bool
+
+
+async def swallowing_fetch(
+    pg: PgSource,
+    sql: str,
+    *args: Any,
+    miss: Any,
+    logger: logging.Logger,
+    log_label: str,
+    log_args: Sequence[Any] = (),
+    many: bool = False,
+) -> Any:
+    """Run ``pg.fetchone(sql, *args)`` (or ``pg.fetchall`` when ``many=True``).
+
+    On any exception, logs ``logger.exception(log_label, *log_args)`` --
+    lazy ``%``-style interpolation, so a caller's pre-refactor message text
+    and args survive unchanged -- and returns ``miss`` instead of raising.
+    ``logger`` must be the CALLING module's own logger (not one owned by this
+    toolkit) so the emitted record's ``name`` still attributes to that
+    module.
+    """
+    fetch = pg.fetchall if many else pg.fetchone
+    try:
+        return await fetch(sql, *args)
+    except Exception:
+        logger.exception(log_label, *log_args)
+        return miss
+
+
+async def swallowing_execute(
+    pg: PgSource,
+    sql: str,
+    *args: Any,
+    logger: logging.Logger,
+    log_label: str,
+    log_args: Sequence[Any] = (),
+) -> None:
+    """Run ``pg.execute(sql, *args)``, swallowing (and logging) any exception.
+
+    Cache writes across every call site are fire-and-forget: a request that
+    produced a real value still returns it even if the write-back fails.
+    Same ``logger``/``log_label``/``log_args`` contract as
+    :func:`swallowing_fetch`.
+    """
+    try:
+        await pg.execute(sql, *args)
+    except Exception:
+        logger.exception(log_label, *log_args)

--- a/entity/compilation_track_location.py
+++ b/entity/compilation_track_location.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 
 from wxyc_etl.text import to_match_form
 
+from entity.cache_toolkit import swallowing_fetch
 from entity.sources import PgSource
 
 logger = logging.getLogger(__name__)
@@ -121,13 +122,15 @@ async def get_compilation_track_locations(
     normalized_title = to_match_form(track_title)
     if not normalized_artist or not normalized_title:
         return []
-    try:
-        rows = await pg.fetchall(_SELECT_LOCATIONS_SQL, normalized_artist, normalized_title)
-    except Exception:
-        logger.exception(
-            "compilation_track_location probe failed for artist=%r title=%r",
-            normalized_artist,
-            normalized_title,
-        )
-        return []
+    rows = await swallowing_fetch(
+        pg,
+        _SELECT_LOCATIONS_SQL,
+        normalized_artist,
+        normalized_title,
+        miss=[],
+        logger=logger,
+        log_label="compilation_track_location probe failed for artist=%r title=%r",
+        log_args=(normalized_artist, normalized_title),
+        many=True,
+    )
     return [CompilationTrackLocationRow(**row) for row in rows]

--- a/entity/library_release_override.py
+++ b/entity/library_release_override.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import logging
 
+from entity.cache_toolkit import swallowing_fetch
 from entity.sources import PgSource
 
 logger = logging.getLogger(__name__)
@@ -92,9 +93,14 @@ async def get_library_release_overrides(pg: PgSource, library_ids: list[int]) ->
     """
     if not library_ids:
         return {}
-    try:
-        rows = await pg.fetchall(_SELECT_SQL, library_ids)
-    except Exception:
-        logger.exception("library_release_override prefetch failed for %d ids", len(library_ids))
-        return {}
+    rows = await swallowing_fetch(
+        pg,
+        _SELECT_SQL,
+        library_ids,
+        miss=[],
+        logger=logger,
+        log_label="library_release_override prefetch failed for %d ids",
+        log_args=(len(library_ids),),
+        many=True,
+    )
     return {row["library_id"]: row["discogs_release_id"] for row in rows}

--- a/entity/release_resolution_cache.py
+++ b/entity/release_resolution_cache.py
@@ -69,12 +69,12 @@ result to gate its read-through.)
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 from wxyc_etl.text import to_match_form
 from wxyc_fastapi.observability import get_cache_stats_recorder
 
+from entity.cache_toolkit import DEFAULT_MISS_TTL, CachedValue, swallowing_execute, swallowing_fetch
 from entity.sources import PgSource
 
 logger = logging.getLogger(__name__)
@@ -100,11 +100,13 @@ RELEASE_RESOLUTION_CACHE_UNAVAILABLE_STAT_KEY = "release_resolution_cache_unavai
 # get deleted, so let positive entries self-heal on a quarterly cadence.
 DEFAULT_POSITIVE_TTL = timedelta(days=90)
 
-# How long a known-miss row stays authoritative before we re-probe Discogs.
-# Matches the negative cache / streaming cache (7 days): long enough that a
-# request spike doesn't repeatedly hammer the API for the same misses, short
-# enough that a newly-cataloged release becomes resolvable within a week.
-DEFAULT_MISS_TTL = timedelta(days=7)
+# DEFAULT_MISS_TTL (7 days -- matches the negative cache / streaming cache;
+# long enough that a request spike doesn't repeatedly hammer the API for the
+# same misses, short enough that a newly-cataloged release becomes resolvable
+# within a week) is re-exported from entity.cache_toolkit (LML#1034) -- it was
+# defined here verbatim (and duplicated in streaming_url_cache.py) before the
+# duplication survey gave it one home. The import above keeps it importable
+# under this module's name for any existing caller.
 
 # LML#824: how long a *crowd-out* miss stays authoritative. A crowd-out empty
 # (the bounded resolve truncated its candidate set at ``max_validations`` — the
@@ -181,8 +183,7 @@ SET release_id = EXCLUDED.release_id,
 """
 
 
-@dataclass(frozen=True)
-class ReleaseResolution:
+class ReleaseResolution(CachedValue[int]):
     """Outcome of a release-resolution cache read.
 
     Three-valued, because a positive cache must let the caller tell a fresh
@@ -199,10 +200,33 @@ class ReleaseResolution:
       aged past its TTL (``miss_ttl``, or ``crowd_out_miss_ttl`` for a crowd-out
       miss). Run the live probe. The SQL WHERE collapses all these into this
       shape, so the caller can't (and needn't) tell them apart.
+
+    Name- and constructor-shape-preserving alias over ``entity.cache_toolkit
+    .CachedValue`` (LML#1034): external code (``lookup/rowless.py``,
+    ``tests/unit/test_nonlibrary_release_resolution.py``) imports this class
+    by name and constructs it with ``release_id=``/``was_present=`` keywords,
+    so it keeps its own field name rather than folding into the generic
+    ``value`` field callers never see.
     """
 
-    release_id: int | None
-    was_present: bool
+    def __init__(self, release_id: int | None, was_present: bool) -> None:
+        super().__init__(value=release_id, was_present=was_present)
+
+    @property
+    def release_id(self) -> int | None:
+        return self.value
+
+    def __repr__(self) -> str:
+        return (
+            f"ReleaseResolution(release_id={self.release_id!r}, was_present={self.was_present!r})"
+        )
+
+
+# Sentinel distinct from a legitimate ``fetchone`` result of ``None`` (an
+# absent row): lets ``get_cached_release_id`` tell "the PG call raised" from
+# "the PG call succeeded and found no fresh row" after delegating the
+# try/except to ``swallowing_fetch``, so its LML#681 stats stay correct.
+_UNAVAILABLE = object()
 
 
 async def set_up_release_resolution_cache_schema(pg: PgSource) -> None:
@@ -255,23 +279,29 @@ async def get_cached_release_id(
     positive_cutoff = reference_now - positive_ttl
     miss_cutoff = reference_now - miss_ttl
     crowd_out_cutoff = reference_now - crowd_out_miss_ttl
-    try:
-        row = await pg.fetchone(
-            _SELECT_SQL,
-            artist_key,
-            title_key,
-            is_track,
-            positive_cutoff,
-            miss_cutoff,
-            crowd_out_cutoff,
-        )
-    except Exception:
-        logger.exception(
-            "release_resolution_cache get failed for %s / %s / is_track=%s",
-            artist_key,
-            title_key,
-            is_track,
-        )
+    # Policy divergence (LML#1034, kept local, not delegated to the toolkit):
+    # the PG-exception branch and the "row is None" branch both resolve to the
+    # same ReleaseResolution shape, but must record DIFFERENT cache-stats
+    # counters (LML#681) -- a PG outage must not inflate the miss rate. A
+    # sentinel distinct from ``None`` (which fetchone itself can legitimately
+    # return for "no row") lets this thin wrapper still tell the two apart
+    # after delegating the try/except to swallowing_fetch.
+    row = await swallowing_fetch(
+        pg,
+        _SELECT_SQL,
+        artist_key,
+        title_key,
+        is_track,
+        positive_cutoff,
+        miss_cutoff,
+        crowd_out_cutoff,
+        miss=_UNAVAILABLE,
+        logger=logger,
+        log_label="release_resolution_cache get failed for %s / %s / is_track=%s",
+        log_args=(artist_key, title_key, is_track),
+    )
+
+    if row is _UNAVAILABLE:
         # Degradation, not a cache miss (LML#681): count it apart so a PG outage
         # doesn't inflate the miss rate. The caller still falls through to a live
         # probe as if the cache were empty.
@@ -321,12 +351,15 @@ async def set_cached_release_id(
     artist_key = to_match_form(artist)
     title_key = to_match_form(title)
     crowd_out_flag = crowd_out and release_id is None
-    try:
-        await pg.execute(_UPSERT_SQL, artist_key, title_key, is_track, release_id, crowd_out_flag)
-    except Exception:
-        logger.exception(
-            "release_resolution_cache set failed for %s / %s / is_track=%s",
-            artist_key,
-            title_key,
-            is_track,
-        )
+    await swallowing_execute(
+        pg,
+        _UPSERT_SQL,
+        artist_key,
+        title_key,
+        is_track,
+        release_id,
+        crowd_out_flag,
+        logger=logger,
+        log_label="release_resolution_cache set failed for %s / %s / is_track=%s",
+        log_args=(artist_key, title_key, is_track),
+    )

--- a/entity/streaming_url_cache.py
+++ b/entity/streaming_url_cache.py
@@ -61,17 +61,16 @@ from typing import Literal
 from wxyc_etl.text import to_match_form
 
 from clients.streaming.base import BaseStreamingClient
+from entity.cache_toolkit import DEFAULT_MISS_TTL, CachedValue, swallowing_execute, swallowing_fetch
 from entity.sources import PgSource
 
 logger = logging.getLogger(__name__)
 
-# How long a known-miss row stays authoritative before we re-check the
-# upstream service. Hits are kept forever; this TTL only applies when
-# ``url IS NULL``. 7 days trades freshness for cache amortization — long
-# enough that bulk request-spike traffic doesn't repeatedly hammer the API
-# for the same misses, short enough that a newly-released album becomes
-# visible within a week.
-DEFAULT_MISS_TTL = timedelta(days=7)
+# DEFAULT_MISS_TTL is re-exported from entity.cache_toolkit (LML#1034) -- it
+# was defined here verbatim (and duplicated in release_resolution_cache.py)
+# before the duplication survey gave it one home. The import above keeps it
+# importable under this module's name for existing callers
+# (lookup/streaming_url_postprocess.py, tests/unit/test_streaming_url_cache.py).
 
 # The services the cache ships. The named CHECK constraint pins this set at
 # the DB level; a future PR adding a service (Deezer's 'deezer_album') extends
@@ -230,21 +229,6 @@ async def set_up_streaming_url_cache_schema(pg: PgSource) -> None:
             await conn.execute(_DDL_SERVICE_WIDEN_CHECK)
 
 
-@dataclass(frozen=True)
-class _CachedRow:
-    """Internal carrier for a cache SELECT outcome.
-
-    The cache's public surface is ``str | None`` — the resolver only needs
-    the URL. ``_CachedRow`` carries the extra "was a row returned" bit that
-    the resolver uses to distinguish a fresh known miss (skip the API) from a
-    stale or absent entry (call the API). Kept private to this module so its
-    shape can evolve without leaking into call sites.
-    """
-
-    url: str | None
-    was_present: bool
-
-
 async def get_cached_streaming_url(
     pg: PgSource,
     *,
@@ -268,7 +252,7 @@ async def get_cached_streaming_url(
     result = await _fetch_cached_row(
         pg, service=service, artist=artist, album=album, miss_ttl=miss_ttl, now=now
     )
-    return result.url
+    return result.value
 
 
 async def peek_cached_streaming_url(
@@ -299,7 +283,7 @@ async def peek_cached_streaming_url(
     result = await _fetch_cached_row(
         pg, service=service, artist=artist, album=album, miss_ttl=miss_ttl, now=now
     )
-    return result.url, result.was_present
+    return result.value, result.was_present
 
 
 async def _fetch_cached_row(
@@ -310,7 +294,7 @@ async def _fetch_cached_row(
     album: str,
     miss_ttl: timedelta,
     now: datetime | None,
-) -> _CachedRow:
+) -> CachedValue[str]:
     """Read the cache row keyed by ``(service, artist, album)`` honoring the TTL.
 
     Module-private helper powering both ``get_cached_streaming_url`` (URL only)
@@ -321,21 +305,26 @@ async def _fetch_cached_row(
     album_key = to_match_form(album)
     reference_now = now or datetime.now(UTC)
     miss_cutoff = reference_now - miss_ttl
-    try:
-        row = await pg.fetchone(_SELECT_SQL, service, artist_key, album_key, miss_cutoff)
-    except Exception:
-        logger.exception(
-            "streaming_url_cache get failed for %s / %s / %s", service, artist_key, album_key
-        )
-        return _CachedRow(url=None, was_present=False)
+    row = await swallowing_fetch(
+        pg,
+        _SELECT_SQL,
+        service,
+        artist_key,
+        album_key,
+        miss_cutoff,
+        miss=None,
+        logger=logger,
+        log_label="streaming_url_cache get failed for %s / %s / %s",
+        log_args=(service, artist_key, album_key),
+    )
 
     if row is None:
-        # Either no row at all, or a stale known-miss filtered out by the SQL
-        # WHERE. Both render the same way; the resolver treats either as
-        # "call the API."
-        return _CachedRow(url=None, was_present=False)
+        # Either a PG failure, no row at all, or a stale known-miss filtered
+        # out by the SQL WHERE. All render the same way; the resolver treats
+        # any of them as "call the API."
+        return CachedValue(value=None, was_present=False)
 
-    return _CachedRow(url=row["url"], was_present=True)
+    return CachedValue(value=row["url"], was_present=True)
 
 
 ResolveSource = Literal[
@@ -397,8 +386,8 @@ async def resolve_streaming_url_with_cache(
     cached = await _fetch_cached_row(
         pg, service=service, artist=artist, album=album, miss_ttl=miss_ttl, now=now
     )
-    if cached.url is not None:
-        return ResolveOutcome(url=cached.url, source="cache_hit")
+    if cached.value is not None:
+        return ResolveOutcome(url=cached.value, source="cache_hit")
     if cached.was_present:
         # SQL filter already excluded stale misses; a present row with NULL
         # URL is necessarily an in-TTL known miss — skip the API.
@@ -445,9 +434,14 @@ async def set_cached_streaming_url(
     """
     artist_key = to_match_form(artist)
     album_key = to_match_form(album)
-    try:
-        await pg.execute(_UPSERT_SQL, service, artist_key, album_key, url)
-    except Exception:
-        logger.exception(
-            "streaming_url_cache set failed for %s / %s / %s", service, artist_key, album_key
-        )
+    await swallowing_execute(
+        pg,
+        _UPSERT_SQL,
+        service,
+        artist_key,
+        album_key,
+        url,
+        logger=logger,
+        log_label="streaming_url_cache set failed for %s / %s / %s",
+        log_args=(service, artist_key, album_key),
+    )

--- a/entity/track_streaming_url_cache.py
+++ b/entity/track_streaming_url_cache.py
@@ -39,6 +39,7 @@ import logging
 
 from wxyc_etl.text import to_match_form
 
+from entity.cache_toolkit import swallowing_execute, swallowing_fetch
 from entity.sources import PgSource
 
 logger = logging.getLogger(__name__)
@@ -146,17 +147,18 @@ async def get_cached_track_streaming_url(
     artist_key = to_match_form(artist)
     album_key = _album_key(album)
     song_key = to_match_form(song)
-    try:
-        row = await pg.fetchone(_SELECT_SQL, service, artist_key, album_key, song_key)
-    except Exception:
-        logger.exception(
-            "track_streaming_url_cache get failed for %s / %s / %s / %s",
-            service,
-            artist_key,
-            album_key,
-            song_key,
-        )
-        return None
+    row = await swallowing_fetch(
+        pg,
+        _SELECT_SQL,
+        service,
+        artist_key,
+        album_key,
+        song_key,
+        miss=None,
+        logger=logger,
+        log_label="track_streaming_url_cache get failed for %s / %s / %s / %s",
+        log_args=(service, artist_key, album_key, song_key),
+    )
     if row is None:
         return None
     return row["url"]
@@ -182,13 +184,15 @@ async def set_cached_track_streaming_url(
     artist_key = to_match_form(artist)
     album_key = _album_key(album)
     song_key = to_match_form(song)
-    try:
-        await pg.execute(_UPSERT_SQL, service, artist_key, album_key, song_key, url)
-    except Exception:
-        logger.exception(
-            "track_streaming_url_cache set failed for %s / %s / %s / %s",
-            service,
-            artist_key,
-            album_key,
-            song_key,
-        )
+    await swallowing_execute(
+        pg,
+        _UPSERT_SQL,
+        service,
+        artist_key,
+        album_key,
+        song_key,
+        url,
+        logger=logger,
+        log_label="track_streaming_url_cache set failed for %s / %s / %s / %s",
+        log_args=(service, artist_key, album_key, song_key),
+    )

--- a/tests/unit/test_cache_toolkit.py
+++ b/tests/unit/test_cache_toolkit.py
@@ -1,0 +1,208 @@
+"""Unit tests for ``entity.cache_toolkit`` (LML#1034).
+
+``swallowing_fetch`` / ``swallowing_execute`` wrap the "normalize keys ->
+``pg.fetchone``/``pg.fetchall``/``pg.execute`` -> ``except Exception: log +
+return a miss shape``" skeleton shared by the ``lml_cache.*`` store modules'
+nine get/set bodies (``entity/streaming_url_cache.py``,
+``entity/track_streaming_url_cache.py``, ``entity/release_resolution_cache.py``,
+``entity/compilation_track_location.py``, ``entity/library_release_override.py``,
+``entity/api_keys.py``'s ``mark_key_used``). These tests pin the toolkit's own
+contract in isolation -- hit path, miss-shape return on exception, and
+log-label emission via the CALLER's own logger (not one owned by this
+module), which is load-bearing for ``entity.api_keys``'s existing
+``test_swallows_pg_errors`` (it asserts ``record.name == "entity.api_keys"``).
+The existing per-module test suites continue to pin each call site's exact
+SQL bind shape and message text unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from entity.cache_toolkit import (
+    DEFAULT_MISS_TTL,
+    CachedValue,
+    swallowing_execute,
+    swallowing_fetch,
+)
+from entity.sources import PgSource
+
+# A logger name distinct from any real module, so these tests can assert on
+# ``record.name`` without colliding with a production logger.
+_LOGGER = logging.getLogger("entity.cache_toolkit_test_caller")
+
+
+@pytest.mark.asyncio
+class TestSwallowingFetch:
+    async def test_returns_row_on_hit_fetchone(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value={"url": "https://music.apple.com/us/album/x/1"})
+
+        result = await swallowing_fetch(
+            pg,
+            "SELECT url FROM t WHERE artist = $1",
+            "Stereolab",
+            miss=None,
+            logger=_LOGGER,
+            log_label="t get failed for %s",
+        )
+
+        assert result == {"url": "https://music.apple.com/us/album/x/1"}
+        pg.fetchone.assert_awaited_once_with("SELECT url FROM t WHERE artist = $1", "Stereolab")
+
+    async def test_returns_rows_on_hit_fetchall(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchall = AsyncMock(return_value=[{"artist": "Juana Molina"}])
+
+        result = await swallowing_fetch(
+            pg,
+            "SELECT artist FROM t",
+            miss=[],
+            logger=_LOGGER,
+            log_label="t probe failed",
+            many=True,
+        )
+
+        assert result == [{"artist": "Juana Molina"}]
+        pg.fetchall.assert_awaited_once_with("SELECT artist FROM t")
+        pg.fetchone.assert_not_awaited()
+
+    async def test_returns_miss_shape_on_exception(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(side_effect=RuntimeError("pg down"))
+        sentinel_miss = object()
+
+        result = await swallowing_fetch(
+            pg,
+            "SELECT 1",
+            miss=sentinel_miss,
+            logger=_LOGGER,
+            log_label="t get failed",
+        )
+
+        assert result is sentinel_miss
+
+    async def test_logs_via_the_passed_logger_with_label_and_args(self, caplog):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(side_effect=RuntimeError("pg down"))
+
+        with caplog.at_level(logging.ERROR, logger=_LOGGER.name):
+            await swallowing_fetch(
+                pg,
+                "SELECT 1",
+                "Jessica Pratt",
+                "On Your Own Love Again",
+                miss=None,
+                logger=_LOGGER,
+                log_label="streaming_url_cache get failed for %s / %s",
+                log_args=("Jessica Pratt", "On Your Own Love Again"),
+            )
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.name == _LOGGER.name
+        assert record.levelno == logging.ERROR
+        assert record.getMessage() == (
+            "streaming_url_cache get failed for Jessica Pratt / On Your Own Love Again"
+        )
+        assert record.exc_info is not None
+
+    async def test_no_log_emitted_on_success(self, caplog):
+        pg = AsyncMock(spec=PgSource)
+        pg.fetchone = AsyncMock(return_value=None)
+
+        with caplog.at_level(logging.ERROR, logger=_LOGGER.name):
+            result = await swallowing_fetch(
+                pg,
+                "SELECT 1",
+                miss=None,
+                logger=_LOGGER,
+                log_label="t get failed",
+            )
+
+        assert result is None
+        assert caplog.records == []
+
+
+@pytest.mark.asyncio
+class TestSwallowingExecute:
+    async def test_executes_and_returns_none_on_success(self):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(return_value="UPDATE 1")
+
+        result = await swallowing_execute(
+            pg,
+            "UPDATE t SET x = $1 WHERE y = $2",
+            "a",
+            "b",
+            logger=_LOGGER,
+            log_label="t set failed",
+        )
+
+        assert result is None
+        pg.execute.assert_awaited_once_with("UPDATE t SET x = $1 WHERE y = $2", "a", "b")
+
+    async def test_swallows_exception_and_logs_label_with_args(self, caplog):
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(side_effect=RuntimeError("pg down"))
+
+        with caplog.at_level(logging.ERROR, logger=_LOGGER.name):
+            result = await swallowing_execute(
+                pg,
+                "UPDATE t SET x = $1",
+                "Juana Molina",
+                logger=_LOGGER,
+                log_label="t set failed for %s",
+                log_args=("Juana Molina",),
+            )  # must not raise
+
+        assert result is None
+        assert len(caplog.records) == 1
+        assert caplog.records[0].getMessage() == "t set failed for Juana Molina"
+        assert caplog.records[0].name == _LOGGER.name
+
+    async def test_no_args_message_renders_verbatim(self, caplog):
+        # Mirrors api_keys.mark_key_used's message, which has no interpolation.
+        pg = AsyncMock(spec=PgSource)
+        pg.execute = AsyncMock(side_effect=RuntimeError("pg down"))
+
+        with caplog.at_level(logging.ERROR, logger=_LOGGER.name):
+            await swallowing_execute(
+                pg,
+                "UPDATE t SET x = $1",
+                "k",
+                logger=_LOGGER,
+                log_label="api_keys last_used_at touch failed",
+            )
+
+        assert caplog.records[0].getMessage() == "api_keys last_used_at touch failed"
+
+
+def test_default_miss_ttl_is_seven_days():
+    assert DEFAULT_MISS_TTL == timedelta(days=7)
+
+
+class TestCachedValue:
+    def test_hit_shape(self):
+        cached = CachedValue(value="https://music.apple.com/us/album/x/1", was_present=True)
+        assert cached.value == "https://music.apple.com/us/album/x/1"
+        assert cached.was_present is True
+
+    def test_fresh_miss_shape(self):
+        cached: CachedValue[str] = CachedValue(value=None, was_present=True)
+        assert cached.value is None
+        assert cached.was_present is True
+
+    def test_absent_or_stale_shape(self):
+        cached: CachedValue[str] = CachedValue(value=None, was_present=False)
+        assert cached.value is None
+        assert cached.was_present is False
+
+    def test_is_frozen(self):
+        cached = CachedValue(value=1, was_present=True)
+        with pytest.raises(AttributeError):
+            cached.value = 2  # type: ignore[misc]


### PR DESCRIPTION
Closes #1034

## Approach

The `lml_cache.*` free-function store modules in `entity/` repeated one skeleton across five get bodies and four set bodies: normalize keys, run a `pg.fetchone`/`pg.fetchall`/`pg.execute` call, and on any exception log it and degrade to a miss shape rather than propagate. This adds `entity/cache_toolkit.py`, a small free-function toolkit (matching the repo's free-function store idiom, not a class hierarchy) with:

- `swallowing_fetch(pg, sql, *args, miss, logger, log_label, log_args=(), many=False)` -- runs `pg.fetchone` (default) or `pg.fetchall` (`many=True`), swallows any exception, and returns the caller's `miss` sentinel. Takes the caller's own `logger` object (not a toolkit-owned one) and the caller's exact pre-refactor `log_label`/`log_args`, so the emitted `LogRecord.name` still attributes to the owning module and every message's text stays byte-identical -- both are load-bearing for incident-response grepping and for `entity/api_keys.py`'s existing `test_swallows_pg_errors` unit test.
- `swallowing_execute(pg, sql, *args, logger, log_label, log_args=())` -- the write-side equivalent around `pg.execute`.
- `CachedValue[T]`, a generic three-valued (`value`, `was_present`) carrier replacing the two independently-defined carriers that existed only to distinguish a fresh hit from a fresh known-miss from an absent/stale row: `streaming_url_cache._CachedRow` and `release_resolution_cache.ReleaseResolution`.
- A single `DEFAULT_MISS_TTL` definition, replacing the verbatim duplicate in `streaming_url_cache.py` and `release_resolution_cache.py` (both now re-export it under their own name so existing imports keep working).

Nine call sites become thin wrappers around the toolkit plus their local key normalization: `streaming_url_cache._fetch_cached_row`/`set_cached_streaming_url`, `track_streaming_url_cache.get_cached_track_streaming_url`/`set_cached_track_streaming_url`, `release_resolution_cache.get_cached_release_id`/`set_cached_release_id`, `compilation_track_location.get_compilation_track_locations`, `library_release_override.get_library_release_overrides`, and `api_keys.mark_key_used`.

`release_resolution_cache.ReleaseResolution` is kept importable as a name- and constructor-shape-preserving alias -- `lookup/rowless.py` and `tests/unit/test_nonlibrary_release_resolution.py` construct it with the original `release_id=` keyword -- implemented as a thin `CachedValue[int]` subclass with a `release_id` property and matching `__repr__`. Per the ticket's policy carve-out, `get_cached_release_id` keeps its cache-stats recording (`get_cache_stats_recorder().record(...)`) and its three TTL cutoffs local rather than folding them into the toolkit; a module-private sentinel distinguishes the PG-exception branch from the "row is None" branch after delegating the try/except to `swallowing_fetch`, so the LML#681 hit/miss/unavailable counters stay correct. `entity/store.py` (the `entity.*`-schema identity contract), the `api_keys` read functions that raise through by design, and `discogs_rate_bucket.try_acquire` are untouched, per the ticket's constraints. No DDL changes -- that's the companion ticket #1038.

## Test plan

- [x] New `tests/unit/test_cache_toolkit.py`: hit path (fetchone and fetchall), miss-shape return on exception, log-label/log-args emission via the caller's own logger, `swallowing_execute` success/exception paths, `CachedValue` shape + immutability, single `DEFAULT_MISS_TTL` definition
- [x] Full existing unit/integration suite (`pytest -m "not pg and not external_api"`) passes unchanged: 5002 passed (same as the pre-change baseline; one pre-existing failure and one pre-existing error on `origin/main` are unrelated to this change)
- [x] Full `pytest -m pg` suite against local PostgreSQL: 549 passed, 9 skipped
- [x] `ruff format --check .`, `ruff check .`, `mypy` on every touched file: all clean