### PR TITLE
refactor(#1033): hoist bulk-dispatch gather/sentinel race into run_bulk_gather

### DIFF
--- a/artists/router.py
+++ b/artists/router.py
@@ -36,6 +36,7 @@ from artists.genre_models import (
 )
 from artists.resolver import BareNameArtistResolver, InvalidNameError
 from core.bulk_body import TRANSIENT_PG_ERRORS, parse_bulk_body, resolve_input_cap
+from core.bulk_concurrency import run_bulk_gather, watch_disconnect
 from core.dependencies import (
     get_artist_resolve_posthog_client,
     get_discogs_cache_service_from_pool,
@@ -473,78 +474,93 @@ async def genres_bulk(
     artists = request.artists
     logger.info("artist-genres bulk start: artists=%d", len(artists))
 
+    async def _process_all() -> list[ArtistGenresResultItem]:
+        # Bio enrichment: one cache-only bulk artist-details read for the
+        # whole batch, keyed on the supplied Discogs ids (name-only inputs
+        # can't be keyed and get no bio). Cheap and additive — it stays
+        # inside the bulk budget rather than fanning out a per-artist live
+        # API call on top of the genres fallback.
+        #
+        # Best-effort + fault-isolated: bio is a nullable add-on, so a
+        # failure in THIS extra read must never fail the genres batch the
+        # endpoint exists to serve. Degrade to no-bios and press on; the
+        # genres path below hits the cache on its own and still 503s on a
+        # genuine pool outage. `CancelledError` (client abort / shutdown)
+        # is a `BaseException`, so `except Exception` lets it propagate.
+        bio_ids = sorted({a.discogs_artist_id for a in artists if a.discogs_artist_id is not None})
+        try:
+            bio_by_id = (
+                _extract_artist_bios(await discogs_cache.get_artist_details_bulk(bio_ids))
+                if bio_ids
+                else {}
+            )
+        except Exception:
+            logger.warning(
+                "artist-genres bio enrichment read failed; serving genres without bios",
+                exc_info=True,
+            )
+            bio_by_id = {}
+
+        # Artists are processed sequentially: the cache reads are cheap, and
+        # running the (rare) API-fallback legs serially inherits the shared
+        # Discogs limiter's global pacing without the intra-request fan-out
+        # that would starve interleaved live-lookup traffic (the LML#370/#372
+        # cascade-cascade lesson) — so this whole batch is passed to
+        # `run_bulk_gather` (LML#1033) as ONE coroutine rather than N
+        # concurrently gathered ones; the helper only adds the disconnect
+        # race here, not per-item concurrency.
+        results: list[ArtistGenresResultItem] = []
+        for item in artists:
+            agg = await resolve_artist_genres(
+                artist_name=item.artist_name,
+                discogs_artist_id=item.discogs_artist_id,
+                discogs_cache=discogs_cache,
+                discogs_service=discogs_service,
+            )
+            results.append(
+                ArtistGenresResultItem(
+                    artist_name=item.artist_name,
+                    discogs_artist_id=item.discogs_artist_id,
+                    genres=agg.genres,
+                    styles=agg.styles,
+                    source=agg.source,
+                    bio=(
+                        bio_by_id.get(item.discogs_artist_id)
+                        if item.discogs_artist_id is not None
+                        else None
+                    ),
+                )
+            )
+        return results
+
     with sentry_sdk.start_span(op="http.server", name=f"POST {_GENRES_ROUTE_PATH}") as http_span:
         http_span.set_data("http.method", "POST")
         http_span.set_data("http.target", _GENRES_ROUTE_PATH)
         http_span.set_data("lml.artist_genres.artists", len(artists))
 
+        def _on_abort() -> None:
+            http_span.set_data("http.status_code", 499)
+            logger.warning("artist-genres bulk aborted by client: artists=%d", len(artists))
+
         try:
-            # Don't spend the bio read if the client already walked away
-            # (mirrors the per-item guard's budget-freeing intent, run once
-            # up front rather than only inside the genres loop below).
-            if await http_request.is_disconnected():
-                http_span.set_data("http.status_code", 499)
-                logger.warning("artist-genres bulk aborted by client: artists=%d", len(artists))
-                raise HTTPException(status_code=499, detail="client disconnected")
-
-            # Bio enrichment: one cache-only bulk artist-details read for the
-            # whole batch, keyed on the supplied Discogs ids (name-only inputs
-            # can't be keyed and get no bio). Cheap and additive — it stays
-            # inside the bulk budget rather than fanning out a per-artist live
-            # API call on top of the genres fallback.
-            #
-            # Best-effort + fault-isolated: bio is a nullable add-on, so a
-            # failure in THIS extra read must never fail the genres batch the
-            # endpoint exists to serve. Degrade to no-bios and press on; the
-            # genres path below hits the cache on its own and still 503s on a
-            # genuine pool outage. `CancelledError` (client abort / shutdown)
-            # is a `BaseException`, so `except Exception` lets it propagate.
-            bio_ids = sorted(
-                {a.discogs_artist_id for a in artists if a.discogs_artist_id is not None}
-            )
-            try:
-                bio_by_id = (
-                    _extract_artist_bios(await discogs_cache.get_artist_details_bulk(bio_ids))
-                    if bio_ids
-                    else {}
+            # Race the (sequential) batch against a client-disconnect sentinel
+            # (LML#1033: core.bulk_concurrency.run_bulk_gather), replacing the
+            # per-await `http_request.is_disconnected()` polling this route
+            # used before -- polling only ever caught a disconnect at the next
+            # loop iteration; the sentinel race gets the same 499 outcome via
+            # the standard cancellation path instead (a disconnect cancels
+            # `_process_all()`, which raises `CancelledError` at whatever
+            # `await` it's parked on -- same effect as the old per-item check,
+            # without a poll call per item).
+            results = (
+                await run_bulk_gather(
+                    [_process_all()],
+                    http_request=http_request,
+                    watch_disconnect_fn=watch_disconnect,
+                    on_abort=_on_abort,
+                    sentinel_task_name="lml.artist_genres.disconnect_sentinel",
                 )
-            except Exception:
-                logger.warning(
-                    "artist-genres bio enrichment read failed; serving genres without bios",
-                    exc_info=True,
-                )
-                bio_by_id = {}
-
-            results: list[ArtistGenresResultItem] = []
-            for item in artists:
-                # Free the shared Discogs rate-limit budget promptly if the
-                # client walks away mid-batch (mirrors the bulk family's
-                # watch_disconnect 499, adapted to the sequential loop).
-                if await http_request.is_disconnected():
-                    http_span.set_data("http.status_code", 499)
-                    logger.warning("artist-genres bulk aborted by client: artists=%d", len(artists))
-                    raise HTTPException(status_code=499, detail="client disconnected")
-
-                agg = await resolve_artist_genres(
-                    artist_name=item.artist_name,
-                    discogs_artist_id=item.discogs_artist_id,
-                    discogs_cache=discogs_cache,
-                    discogs_service=discogs_service,
-                )
-                results.append(
-                    ArtistGenresResultItem(
-                        artist_name=item.artist_name,
-                        discogs_artist_id=item.discogs_artist_id,
-                        genres=agg.genres,
-                        styles=agg.styles,
-                        source=agg.source,
-                        bio=(
-                            bio_by_id.get(item.discogs_artist_id)
-                            if item.discogs_artist_id is not None
-                            else None
-                        ),
-                    )
-                )
+            )[0]
         except asyncio.CancelledError:
             http_span.set_data("http.status_code", 499)
             logger.warning("artist-genres bulk aborted by client: artists=%d", len(artists))

--- a/cache/router.py
+++ b/cache/router.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -47,8 +47,8 @@ from cache.models import (
 from core.bulk_body import TRANSIENT_PG_ERRORS, parse_bulk_body
 from core.bulk_concurrency import (
     acquire_bulk_global_permit,
-    cancel_and_drain,
     max_concurrency_from_env,
+    run_bulk_gather,
     watch_disconnect,
 )
 from core.dependencies import get_discogs_service, get_musicbrainz_pg
@@ -234,40 +234,29 @@ async def handle_refresh_for_identities(
             span.set_data("lml.cache.size", len(identity_ids))
             span.set_data("lml.cache.max_concurrent", max_concurrent)
 
-            gather_future = asyncio.gather(*(_run_one(identity_id) for identity_id in identity_ids))
-            sentinel_task = asyncio.create_task(
-                watch_disconnect(http_request),
-                name="lml.cache.disconnect_sentinel",
-            )
-            waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
-
-            try:
-                done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
-            except BaseException:
-                # Parent cancellation must propagate to both children AND drain
-                # them, not just signal. Without the drain, the in-flight items
-                # keep holding Discogs semaphore permits while the cancel
-                # propagates asynchronously.
-                await cancel_and_drain(gather_future)
-                await cancel_and_drain(sentinel_task)
-                raise
-
-            client_aborted = sentinel_task in done and not gather_future.done()
-            span.set_data("lml.cache.client_aborted", client_aborted)
-
-            if client_aborted:
-                sentry_sdk.set_tag("lml.client_aborted", "true")
-                await cancel_and_drain(gather_future)
+            def _on_abort() -> None:
                 logger.warning(
                     "cache refresh aborted by client: size=%d max_concurrent=%d",
                     len(identity_ids),
                     max_concurrent,
                 )
                 http_span.set_data("http.status_code", 499)
-                raise HTTPException(status_code=499, detail="client disconnected")
 
-            await cancel_and_drain(sentinel_task)
-            results = gather_future.result()
+            # Race the gather against a client-disconnect sentinel (LML#1033:
+            # core.bulk_concurrency.run_bulk_gather). Mirrors `/lookup/bulk`'s
+            # shape (lookup/router.py). Spawning the sentinel must happen
+            # *after* `parse_bulk_body` above has fully consumed the request
+            # body — `watch_disconnect` awaits `request.receive()`, which
+            # would otherwise swallow `http.request` body messages the body
+            # parser needs.
+            results = await run_bulk_gather(
+                (_run_one(identity_id) for identity_id in identity_ids),
+                http_request=http_request,
+                watch_disconnect_fn=watch_disconnect,
+                on_abort=_on_abort,
+                sentinel_task_name="lml.cache.disconnect_sentinel",
+                on_race_settled=lambda aborted: span.set_data("lml.cache.client_aborted", aborted),
+            )
 
         counts = Counter(r.status for r in results)
         http_span.set_data("lml.cache.warmed", counts.get("warmed", 0))

--- a/core/bulk_concurrency.py
+++ b/core/bulk_concurrency.py
@@ -71,10 +71,11 @@ import logging
 import os
 import time
 import weakref
+from collections.abc import Awaitable, Callable, Coroutine, Iterable
 from typing import Any
 
 import sentry_sdk
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 from core.observability import observability_guard, project_capped
 
@@ -394,6 +395,117 @@ async def cancel_and_drain(future: asyncio.Future[Any]) -> None:
         await future
 
 
+async def run_bulk_gather[R](
+    coroutines: Iterable[Awaitable[R]],
+    *,
+    http_request: Request,
+    watch_disconnect_fn: Callable[[Request], Coroutine[Any, Any, None]],
+    on_abort: Callable[[], None],
+    sentinel_task_name: str = "lml.bulk.disconnect_sentinel",
+    on_race_settled: Callable[[bool], None] | None = None,
+) -> list[R]:
+    """Race a bulk ``asyncio.gather`` against a client-disconnect sentinel (LML#1033).
+
+    Hoisted out of ``handle_bulk_lookup`` (``lookup/router.py``),
+    ``bulk_resolve_libraries`` (``identity/router.py``), and
+    ``handle_refresh_for_identities`` (``cache/router.py``), which copy-pasted
+    this ~40-line shape nearly verbatim: spawn the gather, race it against
+    :func:`watch_disconnect`, drain BOTH arms on any exit (including parent
+    cancellation, so permit-holding tasks always unwind), tag
+    ``lml.client_aborted`` and raise ``HTTPException(499)`` when the sentinel
+    wins, else drain the sentinel and hand back the gather's own result.
+
+    NOT used by the single ``/lookup`` permit-phase race in
+    ``lookup.router.handle_lookup`` (LML#706/#715/#953) — that races a
+    *semaphore acquire*, not a batch gather, returns a body with
+    ``response.status_code = 499`` instead of raising, and has its own
+    permit-leak-safety shape. Deliberately left alone — the LML#1033 non-goal.
+
+    Args:
+        coroutines: Already-constructed awaitables, one per unit of work —
+            typically ``(run_one(item) for item in items)``. A single-element
+            iterable also works: ``artists.router.genres_bulk`` passes
+            ``[process_all_artists()]``, since that route's per-artist loop
+            stays sequential inside its own coroutine (LML#370/#372's
+            cascade-cascade lesson) and only wants the disconnect race, not
+            per-item concurrency.
+        http_request: Forwarded to ``watch_disconnect_fn``. The sentinel must
+            be spawned only after the request body is fully consumed (e.g. by
+            ``parse_bulk_body`` before this call) — ``watch_disconnect``
+            awaits ``request.receive()``, which would otherwise swallow the
+            ``http.request`` body messages the body parser needs.
+        watch_disconnect_fn: The caller's OWN module-level reference to
+            :func:`watch_disconnect` (e.g. ``lookup.router.watch_disconnect``),
+            not this module's. Existing tests patch
+            ``patch("<router-module>.watch_disconnect", fake_sentinel)``;
+            calling this module's own ``watch_disconnect`` directly would not
+            observe that patch.
+        on_abort: Invoked once, after the ``lml.client_aborted`` tag is set
+            and the gather is cancelled + drained, but before the 499 is
+            raised. Each route uses it for its own abort log line and
+            ``http_span.set_data("http.status_code", 499)`` — wording/fields
+            differ per route, so they stay call-site data (the "parameterize
+            or accept a callback" LML#1033 calls for on per-route span data).
+        sentinel_task_name: Forwarded to ``asyncio.create_task`` so each
+            route keeps its own distinguishable task name (mirrors the
+            pre-extraction per-route names).
+        on_race_settled: Optional; called with the computed ``client_aborted``
+            boolean right after the race settles, for both outcomes.
+            ``handle_bulk_lookup`` / ``handle_refresh_for_identities`` use
+            this for an inner span's ``client_aborted`` data;
+            ``bulk_resolve_libraries`` never did, so it stays opt-in.
+
+    Returns:
+        ``gather_future.result()`` — per-item results in input order
+        (``asyncio.gather`` preserves order regardless of completion order).
+
+    Raises:
+        HTTPException: 499 ``"client disconnected"``, when the sentinel wins.
+        BaseException: whatever ``gather_future.result()`` raises when a
+            per-item coroutine didn't isolate its own failure (route-specific
+            — e.g. ``bulk_resolve_libraries``'s fail-closed
+            ``HTTPException(503)`` — the caller decides whether to catch it,
+            same as before this extraction), or whatever cancelled this
+            coroutine while it was itself awaiting the race.
+    """
+    gather_future = asyncio.gather(*coroutines)
+    sentinel_task = asyncio.create_task(watch_disconnect_fn(http_request), name=sentinel_task_name)
+    waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
+
+    try:
+        done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
+    except BaseException:
+        # Parent task cancellation (server shutdown / timeout middleware) must
+        # propagate to both children AND drain them, not just signal them —
+        # otherwise the permits an in-flight item still holds stay held while
+        # the cancellation propagates asynchronously.
+        await cancel_and_drain(gather_future)
+        await cancel_and_drain(sentinel_task)
+        raise
+
+    # Tie broken toward "gather done": if both completed in the same
+    # `asyncio.wait` wakeup, the work already finished, so proceed rather
+    # than treat it as an abort.
+    client_aborted = sentinel_task in done and not gather_future.done()
+    if on_race_settled is not None:
+        on_race_settled(client_aborted)
+
+    if client_aborted:
+        # Tag is global-scope (filterable across all routes as
+        # `lml.client_aborted:true`); any span data is the caller's to set
+        # via `on_abort`.
+        sentry_sdk.set_tag("lml.client_aborted", "true")
+        await cancel_and_drain(gather_future)
+        on_abort()
+        raise HTTPException(status_code=499, detail="client disconnected")
+
+    # Work finished first (or failed). Drain the still-pending sentinel so it
+    # doesn't leak, then surface the gather's outcome — which may itself
+    # raise; that's the caller's to handle.
+    await cancel_and_drain(sentinel_task)
+    return gather_future.result()
+
+
 __all__ = [
     "LOW_PRIORITY_CALLER_CLASS",
     "ClientDisconnectedWhileQueuedError",
@@ -404,5 +516,6 @@ __all__ = [
     "maybe_acquire_bulk_global_permit_or_reap",
     "max_concurrency_from_env",
     "resolve_caller_class",
+    "run_bulk_gather",
     "watch_disconnect",
 ]

--- a/identity/router.py
+++ b/identity/router.py
@@ -16,7 +16,6 @@ Provides:
 import asyncio
 import logging
 from collections import Counter
-from typing import Any
 
 import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -28,8 +27,8 @@ from core.bulk_body import (
 )
 from core.bulk_concurrency import (
     acquire_bulk_global_permit,
-    cancel_and_drain,
     max_concurrency_from_env,
+    run_bulk_gather,
     watch_disconnect,
 )
 from core.dependencies import discogs_pool_max_size
@@ -330,59 +329,35 @@ async def bulk_resolve_libraries(
         http_span.set_data("lml.bulk_resolve.inputs", inputs_count)
         http_span.set_data("lml.bulk_resolve.max_concurrent", max_concurrent)
 
-        # Race the gather against a client-disconnect sentinel (LML#700). uvicorn
-        # does not propagate a client socket close into the handler, so a plain
-        # `await asyncio.gather(...)` runs the in-flight per-input tasks — and the
-        # discogs-cache pool permits they hold (bounded by `max_concurrent`) — to
-        # completion against a client that is already gone. The sentinel lets a
-        # disconnect cancel the outstanding gather promptly instead. Mirrors the
-        # `/lookup/bulk` shape (lookup/router.py) and reuses the shared
-        # `watch_disconnect` / `cancel_and_drain` helpers rather than forking the
-        # logic.
-        #
-        # `gather` preserves input order (results[i] <-> inputs[i]) regardless of
-        # completion order, satisfying the api.yaml ordering contract.
+        def _on_abort() -> None:
+            # 499 = Nginx "client closed request" — nobody reads the body, but
+            # it pins the span/log for triage.
+            http_span.set_data("http.status_code", 499)
+            logger.warning("bulk resolve aborted by client: inputs=%d", inputs_count)
+
+        # Race the gather against a client-disconnect sentinel (LML#700,
+        # hoisted into core.bulk_concurrency.run_bulk_gather by LML#1033).
+        # uvicorn does not propagate a client socket close into the handler,
+        # so a plain `await asyncio.gather(...)` would run the in-flight
+        # per-input tasks — and the discogs-cache pool permits they hold
+        # (bounded by `max_concurrent`) — to completion against a client that
+        # is already gone; the sentinel lets a disconnect cancel the
+        # outstanding gather promptly instead. `gather` preserves input order
+        # (results[i] <-> inputs[i]) regardless of completion order,
+        # satisfying the api.yaml ordering contract.
         #
         # Spawning the sentinel must happen *after* `await http_request.json()`
         # above has fully consumed the request body — `watch_disconnect` awaits
         # `request.receive()`, which would otherwise swallow the `http.request`
         # body messages the JSON parser needs.
-        gather_future = asyncio.gather(*(_resolve_one(r) for r in request.inputs))
-        sentinel_task = asyncio.create_task(
-            watch_disconnect(http_request),
-            name="lml.bulk_resolve.disconnect_sentinel",
-        )
-        waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
-
         try:
-            done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
-        except BaseException:
-            # Outer cancellation (server shutdown / timeout middleware) must
-            # propagate to both children AND drain them, not just signal them — a
-            # bare `.cancel()` is asynchronous, so the pool permits stay held
-            # until the tasks observe the cancel and unwind.
-            await cancel_and_drain(gather_future)
-            await cancel_and_drain(sentinel_task)
-            raise
-
-        if sentinel_task in done and not gather_future.done():
-            # Client departed first. Cancel + drain the gather so the per-input
-            # tasks unwind and their permits free promptly instead of after the
-            # whole batch finishes. The tag is global-scope (filterable across
-            # routes as `lml.client_aborted:true`); the 499 + warn log mirror the
-            # `/lookup/bulk` abort branch. 499 = Nginx "client closed request" —
-            # nobody reads the body, but it pins the span/log for triage.
-            sentry_sdk.set_tag("lml.client_aborted", "true")
-            await cancel_and_drain(gather_future)
-            http_span.set_data("http.status_code", 499)
-            logger.warning("bulk resolve aborted by client: inputs=%d", inputs_count)
-            raise HTTPException(status_code=499, detail="client disconnected")
-
-        # Work finished first (or failed). Drain the still-pending sentinel so it
-        # doesn't leak, then surface the gather's outcome.
-        await cancel_and_drain(sentinel_task)
-        try:
-            results = gather_future.result()
+            results = await run_bulk_gather(
+                (_resolve_one(r) for r in request.inputs),
+                http_request=http_request,
+                watch_disconnect_fn=watch_disconnect,
+                on_abort=_on_abort,
+                sentinel_task_name="lml.bulk_resolve.disconnect_sentinel",
+            )
         except asyncio.CancelledError:
             # Server-driven cancellation surfaced through the gather (shutdown /
             # outer timeout), or a child observed a cancel — distinct from the
@@ -393,7 +368,10 @@ async def bulk_resolve_libraries(
             logger.warning("bulk resolve aborted (cancelled): inputs=%d", inputs_count)
             raise
         except HTTPException as exc:
-            # Fail-closed 503 (or any explicit status) from a per-input failure.
+            # Fail-closed 503 (or any explicit status) from a per-input failure
+            # -- or the 499 `run_bulk_gather` itself raises on abort, whose
+            # `on_abort` callback above already pinned the span/log, so this
+            # `set_data` call is a harmless no-op re-write to the same value.
             # Pin the status on the span before re-raising so the trace carries
             # the real outcome rather than an unset code.
             http_span.set_data("http.status_code", exc.status_code)

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from collections import Counter
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
@@ -30,6 +30,7 @@ from core.bulk_concurrency import (
     max_concurrency_from_env,
     maybe_acquire_bulk_global_permit_or_reap,
     resolve_caller_class,
+    run_bulk_gather,
     watch_disconnect,
 )
 from core.dependencies import (
@@ -544,6 +545,13 @@ async def handle_lookup(
             # perform_lookup runs to completion (a disconnect mid-lookup is not
             # reaped; that phase already holds its resources).
             #
+            # NOT `core.bulk_concurrency.run_bulk_gather` (LML#1033): that helper
+            # races a batch `asyncio.gather` and raises `HTTPException(499)`; this
+            # race is over a single semaphore acquire and returns a 499 response
+            # body instead (`ClientDisconnectedWhileQueuedError` below), with its
+            # own permit-leak-safety shape. Deliberately left alone — LML#1033's
+            # documented non-goal.
+            #
             # Cancelling `semaphore.acquire()` is permit-safe on this repo's Python
             # (>=3.12): if the acquire is cancelled AFTER the permit was granted
             # (the acquire/sentinel tie), Semaphore.acquire returns the permit and
@@ -985,45 +993,7 @@ async def handle_bulk_lookup(
             span.set_data("lml.bulk.size", len(request.items))
             span.set_data("lml.bulk.max_concurrent", max_concurrent)
 
-            # Race the gather against a client-disconnect sentinel. If the
-            # client departs first, cancel the gather so Discogs semaphore
-            # permits free for the next caller; without this, queue depth grows
-            # monotonically across batches.
-            #
-            # Spawning the sentinel must happen *after* `await
-            # http_request.json()` above has fully consumed the request body —
-            # watch_disconnect awaits `request.receive()`, which would
-            # otherwise swallow `http.request` body messages the body parser
-            # needs.
-            gather_future = asyncio.gather(
-                *(_run_one(i, item) for i, item in enumerate(request.items))
-            )
-            sentinel_task = asyncio.create_task(
-                watch_disconnect(http_request),
-                name="lml.bulk.disconnect_sentinel",
-            )
-            waitables: set[asyncio.Future[Any]] = {gather_future, sentinel_task}
-
-            try:
-                done, _pending = await asyncio.wait(waitables, return_when=asyncio.FIRST_COMPLETED)
-            except BaseException:
-                # Parent task cancellation must propagate to both children AND
-                # the children must be drained, not just signalled — otherwise
-                # the semaphore permits this PR exists to release are still
-                # held while the cancellation propagates asynchronously.
-                await cancel_and_drain(gather_future)
-                await cancel_and_drain(sentinel_task)
-                raise
-
-            client_aborted = sentinel_task in done and not gather_future.done()
-            span.set_data("lml.bulk.client_aborted", client_aborted)
-
-            if client_aborted:
-                # Tag is global-scope (filterable across all routes); span data
-                # carries the bulk-specific context. Key-name asymmetry
-                # intentional.
-                sentry_sdk.set_tag("lml.client_aborted", "true")
-                await cancel_and_drain(gather_future)
+            def _on_abort() -> None:
                 # Exit log fires for the abort branch too — operators see the
                 # batch size + abort reason without digging into Sentry.
                 logger.warning(
@@ -1031,13 +1001,31 @@ async def handle_bulk_lookup(
                     len(request.items),
                     max_concurrent,
                 )
-                http_span.set_data("http.status_code", 499)
                 # 499 = Nginx "client closed request". Skip PostHog: partial
                 # counts would skew batch-completion analytics.
-                raise HTTPException(status_code=499, detail="client disconnected")
+                http_span.set_data("http.status_code", 499)
 
-            await cancel_and_drain(sentinel_task)
-            results = gather_future.result()
+            # Race the gather against a client-disconnect sentinel (LML#1033:
+            # core.bulk_concurrency.run_bulk_gather). If the client departs
+            # first, the gather is cancelled so Discogs semaphore permits free
+            # for the next caller; without this, queue depth grows
+            # monotonically across batches.
+            #
+            # Spawning the sentinel must happen *after* `parse_bulk_body`
+            # above has fully consumed the request body — `watch_disconnect`
+            # awaits `request.receive()`, which would otherwise swallow
+            # `http.request` body messages the body parser needs.
+            results = await run_bulk_gather(
+                (_run_one(i, item) for i, item in enumerate(request.items)),
+                http_request=http_request,
+                watch_disconnect_fn=watch_disconnect,
+                on_abort=_on_abort,
+                sentinel_task_name="lml.bulk.disconnect_sentinel",
+                # Span data carries the bulk-specific context; the Sentry tag
+                # `run_bulk_gather` sets on abort is global-scope. Key-name
+                # asymmetry intentional.
+                on_race_settled=lambda aborted: span.set_data("lml.bulk.client_aborted", aborted),
+            )
 
         _project_cache_stats_to_transaction(get_cache_stats())
 

--- a/tests/unit/test_artist_genres_router.py
+++ b/tests/unit/test_artist_genres_router.py
@@ -9,7 +9,9 @@ routes). The ranking + fallback *semantics* live in
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import asyncio
+import logging
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -317,6 +319,73 @@ class TestErrorSurface:
                     _ROUTE, content=b"not json {", headers={"Content-Type": "application/json"}
                 )
         assert resp.status_code == 400
+
+
+class TestClientAbort:
+    """Client-disconnect handling (LML#1033): migrated from per-await
+    ``http_request.is_disconnected()`` polling to the shared
+    ``core.bulk_concurrency.run_bulk_gather`` sentinel race the other three
+    bulk-family routes already use. The per-artist loop stays sequential (one
+    coroutine, no per-item concurrency — see ``artists.router.genres_bulk``),
+    so this pins the *outcome*, not a dispatch-shape change. Mirrors
+    ``TestBulkLookupClientAbort`` in ``test_bulk_lookup_endpoint.py``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_returns_499_cancels_work_tags_and_logs(self, make_app, caplog):
+        started = 0
+        cleaned_up = 0
+
+        async def slow_resolve(**kwargs):
+            nonlocal started, cleaned_up
+            started += 1
+            try:
+                await asyncio.sleep(5)
+                raise AssertionError("should have been cancelled before returning")
+            finally:
+                cleaned_up += 1
+
+        async def fake_sentinel(_request):
+            await asyncio.sleep(0.01)
+
+        captured_tags: dict[str, str] = {}
+
+        ctx, app = make_app()
+        with ctx:
+            with (
+                patch("artists.router.resolve_artist_genres", side_effect=slow_resolve),
+                patch("artists.router.watch_disconnect", fake_sentinel),
+                patch(
+                    "core.bulk_concurrency.sentry_sdk.set_tag",
+                    side_effect=captured_tags.__setitem__,
+                ),
+                caplog.at_level(logging.WARNING, logger="artists.router"),
+            ):
+                resp = await asyncio.wait_for(
+                    _post(
+                        app,
+                        {
+                            "artists": [
+                                {"artist_name": "Stereolab"},
+                                {"artist_name": "Jessica Pratt"},
+                                {"artist_name": "Juana Molina"},
+                            ]
+                        },
+                    ),
+                    timeout=3.0,
+                )
+
+        assert resp.status_code == 499, f"Expected 499 on client disconnect, got {resp.status_code}"
+        assert started > 0, "test mis-configured: no items ever started"
+        assert started == cleaned_up, (
+            f"{started - cleaned_up} item(s) started but never cleaned up — "
+            "cancellation did not propagate into the sequential loop"
+        )
+        assert captured_tags.get("lml.client_aborted") == "true", (
+            f"Expected lml.client_aborted=true tag; got {captured_tags!r}"
+        )
+        abort_logs = [r for r in caplog.records if "artist-genres bulk aborted" in r.message]
+        assert abort_logs, f"Expected an abort warn log; got: {[r.message for r in caplog.records]}"
 
 
 class TestAuth:

--- a/tests/unit/test_error_payload_shape.py
+++ b/tests/unit/test_error_payload_shape.py
@@ -15,7 +15,8 @@ file; this file only asserts the *envelope* the handlers produce.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -134,23 +135,34 @@ class TestHttpExceptionEnvelope:
         route. Genuine mid-flight cancellation (`asyncio.CancelledError`) is a
         `BaseException`, so it is never caught by either handler and still
         propagates unconverted.
+
+        LML#1033: `genres_bulk` migrated off `http_request.is_disconnected()`
+        polling onto the shared `core.bulk_concurrency.run_bulk_gather`
+        sentinel race (the same mechanism `/lookup/bulk` and the other
+        bulk-family routes use), so producing the 499 here means racing a
+        fast `watch_disconnect` against a slow per-item call instead of
+        monkeypatching `Request.is_disconnected`.
         """
 
-        async def _always_disconnected(self):
-            return True
+        async def _slow_resolve(**kwargs):
+            await asyncio.sleep(5)
+            raise AssertionError("should have been cancelled before returning")
 
-        # is_disconnected is read off the raw Starlette Request, not a DI seam,
-        # so patch it directly rather than through dependency_overrides.
-        from starlette.requests import Request as StarletteRequest
+        async def _fast_disconnect(_request):
+            await asyncio.sleep(0.01)
 
-        original = StarletteRequest.is_disconnected
-        StarletteRequest.is_disconnected = _always_disconnected
-        try:
-            resp = await _post(
-                app_client, _GENRES_ROUTE, json_body={"artists": [{"artist_name": "Stereolab"}]}
+        with (
+            patch("artists.router.resolve_artist_genres", side_effect=_slow_resolve),
+            patch("artists.router.watch_disconnect", _fast_disconnect),
+        ):
+            resp = await asyncio.wait_for(
+                _post(
+                    app_client,
+                    _GENRES_ROUTE,
+                    json_body={"artists": [{"artist_name": "Stereolab"}]},
+                ),
+                timeout=3.0,
             )
-        finally:
-            StarletteRequest.is_disconnected = original
 
         assert resp.status_code == 499
 

--- a/tests/unit/test_run_bulk_gather.py
+++ b/tests/unit/test_run_bulk_gather.py
@@ -1,0 +1,215 @@
+"""Unit tests for `core.bulk_concurrency.run_bulk_gather` (LML#1033).
+
+Exercises the shared bulk-dispatch orchestration in isolation, independent of
+any one FastAPI route. The per-endpoint abort-path suites
+(`test_bulk_lookup_endpoint.py`, `test_bulk_resolve_libraries_endpoint.py`,
+`test_cache_refresh_endpoint.py`, `test_artist_genres_router.py`) continue to
+pin end-to-end behavior through the HTTP layer; these tests pin the extracted
+helper's own contract directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from core.bulk_concurrency import run_bulk_gather
+
+# WXYC-representative fixture data (see repo CLAUDE.md) standing in for
+# generic "bulk items" -- only their count and completion timing matter here.
+_WXYC_ARTISTS = ["Stereolab", "Jessica Pratt", "Juana Molina"]
+
+
+async def _never_disconnects(_request: object) -> None:
+    await asyncio.sleep(3600)
+
+
+async def _immediate_coro(value: str) -> str:
+    return value
+
+
+class TestRunBulkGatherNormalCompletion:
+    @pytest.mark.asyncio
+    async def test_returns_per_item_results_in_order(self):
+        async def _run_one(name: str) -> str:
+            await asyncio.sleep(0)
+            return f"resolved:{name}"
+
+        settled: list[bool] = []
+
+        results = await run_bulk_gather(
+            (_run_one(name) for name in _WXYC_ARTISTS),
+            http_request=object(),
+            watch_disconnect_fn=_never_disconnects,
+            on_abort=lambda: pytest.fail("on_abort must not fire on normal completion"),
+            on_race_settled=settled.append,
+        )
+
+        assert results == [f"resolved:{name}" for name in _WXYC_ARTISTS]
+        assert settled == [False]
+
+    @pytest.mark.asyncio
+    async def test_single_coroutine_iterable_works_and_on_race_settled_is_optional(self):
+        """A single-element iterable (the `genres_bulk` shape, whose
+        per-artist loop stays sequential inside its own coroutine) works the
+        same as an N-item generator -- and, since this call omits
+        `on_race_settled`, doubles as proof that the callback is optional.
+        """
+
+        async def _process_all() -> list[str]:
+            return [f"processed:{name}" for name in _WXYC_ARTISTS]
+
+        results = await run_bulk_gather(
+            [_process_all()],
+            http_request=object(),
+            watch_disconnect_fn=_never_disconnects,
+            on_abort=lambda: pytest.fail("on_abort must not fire on normal completion"),
+        )
+
+        assert results == [[f"processed:{name}" for name in _WXYC_ARTISTS]]
+
+
+class TestRunBulkGatherClientAbort:
+    @pytest.mark.asyncio
+    async def test_sentinel_win_raises_499_and_cancels_in_flight_items(self):
+        started = 0
+        cleaned_up = 0
+
+        async def _slow_run_one(name: str) -> str:
+            nonlocal started, cleaned_up
+            started += 1
+            try:
+                await asyncio.sleep(5)
+                return name
+            finally:
+                cleaned_up += 1
+
+        async def _fast_disconnect(_request: object) -> None:
+            await asyncio.sleep(0.01)
+
+        abort_calls = 0
+        settled: list[bool] = []
+
+        def _on_abort() -> None:
+            nonlocal abort_calls
+            abort_calls += 1
+
+        captured_tags: dict[str, str] = {}
+
+        with patch(
+            "core.bulk_concurrency.sentry_sdk.set_tag", side_effect=captured_tags.__setitem__
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await asyncio.wait_for(
+                    run_bulk_gather(
+                        (_slow_run_one(name) for name in _WXYC_ARTISTS),
+                        http_request=object(),
+                        watch_disconnect_fn=_fast_disconnect,
+                        on_abort=_on_abort,
+                        on_race_settled=settled.append,
+                    ),
+                    timeout=3.0,
+                )
+
+        assert exc_info.value.status_code == 499
+        assert exc_info.value.detail == "client disconnected"
+        assert abort_calls == 1
+        assert settled == [True], f"expected on_race_settled(True) before the 499; got {settled}"
+        assert captured_tags.get("lml.client_aborted") == "true", (
+            f"Expected lml.client_aborted=true tag; got {captured_tags!r}"
+        )
+        assert started > 0, "test mis-configured: no items ever started"
+        assert started == cleaned_up, (
+            f"{started - cleaned_up} item(s) started but never cleaned up -- "
+            "cancellation did not reach the in-flight items"
+        )
+
+
+class TestRunBulkGatherParentCancellation:
+    @pytest.mark.asyncio
+    async def test_cancelling_the_caller_drains_both_arms(self):
+        """Cancelling the task awaiting `run_bulk_gather` (the `except
+        BaseException` branch around `asyncio.wait`, distinct from the
+        sentinel winning) must still cancel AND drain both the gather and the
+        sentinel, not just signal them.
+        """
+        item_started = 0
+        item_cleaned_up = 0
+        sentinel_started = 0
+        sentinel_cleaned_up = 0
+
+        async def _slow_run_one(name: str) -> str:
+            nonlocal item_started, item_cleaned_up
+            item_started += 1
+            try:
+                await asyncio.sleep(5)
+                return name
+            finally:
+                item_cleaned_up += 1
+
+        async def _slow_disconnect(_request: object) -> None:
+            nonlocal sentinel_started, sentinel_cleaned_up
+            sentinel_started += 1
+            try:
+                await asyncio.sleep(5)
+            finally:
+                sentinel_cleaned_up += 1
+
+        outer = asyncio.ensure_future(
+            run_bulk_gather(
+                (_slow_run_one(name) for name in _WXYC_ARTISTS),
+                http_request=object(),
+                watch_disconnect_fn=_slow_disconnect,
+                on_abort=lambda: pytest.fail("on_abort must not fire on parent cancellation"),
+            )
+        )
+        # Let both arms actually start before cancelling the caller.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        outer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await outer
+
+        assert item_started > 0 and sentinel_started > 0, "test mis-configured"
+        assert item_started == item_cleaned_up, (
+            f"{item_started - item_cleaned_up} in-flight item(s) never unwound on cancellation"
+        )
+        assert sentinel_started == sentinel_cleaned_up, "the disconnect sentinel never unwound"
+
+
+class TestRunBulkGatherTieBreak:
+    @pytest.mark.asyncio
+    async def test_tie_between_gather_and_sentinel_resolves_toward_gather_done(self):
+        """When the gather and the sentinel both settle in the same
+        `asyncio.wait` wakeup, the tie must resolve toward "work already
+        finished", never an abort. Both coroutines below have no internal
+        `await`, so under CPython's single-threaded event loop they complete
+        before `run_bulk_gather`'s own `asyncio.wait` wakes, producing a
+        genuine tie rather than a timing guess.
+        """
+
+        async def _immediate_disconnect(_request: object) -> None:
+            return None
+
+        settled: list[bool] = []
+        abort_calls = 0
+
+        def _on_abort() -> None:
+            nonlocal abort_calls
+            abort_calls += 1
+
+        results = await run_bulk_gather(
+            (_immediate_coro(name) for name in _WXYC_ARTISTS),
+            http_request=object(),
+            watch_disconnect_fn=_immediate_disconnect,
+            on_abort=_on_abort,
+            on_race_settled=settled.append,
+        )
+
+        assert results == _WXYC_ARTISTS
+        assert settled == [False], f"expected the tie to resolve non-aborted; got {settled}"
+        assert abort_calls == 0


### PR DESCRIPTION
Closes #1033

## Summary

Extracts the copy-pasted bulk-dispatch orchestration -- `asyncio.gather` over per-item runners raced against a `watch_disconnect` sentinel, `cancel_and_drain` on both arms, the `lml.client_aborted` Sentry tag, the abort log line, and the `HTTPException(499)` -- into a shared `run_bulk_gather(...)` in `core/bulk_concurrency.py`. Converts the three copy sites (`handle_bulk_lookup`, `bulk_resolve_libraries`, `handle_refresh_for_identities`) onto the helper, and migrates `artists/router.py`'s `genres_bulk` off its `is_disconnected()` polling loop onto the same sentinel race.

## Design

`run_bulk_gather` takes already-constructed coroutines (e.g. `(run_one(item) for item in items)`), not an `items`/`run_one` pair -- this lets `genres_bulk` reuse the exact same helper for its sequential per-artist loop (the LML#370/#372 cascade-cascade lesson means that route must NOT fan out per-item concurrency) by passing a single wrapping coroutine, `[process_all_artists()]`, instead of special-casing a sequential mode inside the helper.

Per-route Sentry span data and abort log wording differ across routes, so those stay call-site data via two callbacks: `on_abort` (fires once, right before the 499 raises) and the optional `on_race_settled` (fires with the computed `client_aborted` boolean for both outcomes -- only `handle_bulk_lookup` and `handle_refresh_for_identities` used this pre-extraction, so it stays opt-in).

## Preserving load-bearing semantics

- **Acquisition order** (batch-semaphore OUTER, global-permit INNER, #716) lives entirely inside each route's own `run_one`/per-item coroutine, untouched by this extraction.
- **Sentinel-after-body-consumed**: `run_bulk_gather` is still called after each route's own `parse_bulk_body`, same as before; the in-code comment explaining why (`watch_disconnect` awaits `request.receive()` and would swallow body messages) is preserved at each call site and centralized in the helper's docstring.
- **Cancellation-drain**: the `except BaseException` / `cancel_and_drain` shape around `asyncio.wait` is verbatim inside the helper, with the original comments ported.
- **Test-patchability**: `watch_disconnect_fn` is threaded through as an explicit parameter -- each router passes its own module-level, patchable `watch_disconnect` reference -- rather than the helper importing/calling `watch_disconnect` itself. This is why the existing `patch("lookup.router.watch_disconnect", fake_sentinel)`-style tests in `test_bulk_lookup_endpoint.py`, `test_bulk_resolve_libraries_endpoint.py`, and `test_cache_refresh_endpoint.py` all pass unchanged.
- **Non-goal**: the single `/lookup` permit-phase race in `handle_lookup` (a semaphore-acquire race with its own permit-leak-safety shape, not a batch gather) is untouched, with a pointer comment added explaining why it doesn't use `run_bulk_gather`.
- **Identity-route parent-cancellation logging**: `bulk_resolve_libraries` wraps the helper call in its pre-existing `except asyncio.CancelledError` handler, which previously only covered the synchronous `gather_future.result()` -- a parent cancellation (server shutdown / outer timeout) now emits that handler's `"bulk resolve aborted (cancelled)"` WARN line where before it propagated silently. This matches the handler's stated intent and is the one per-route log-line difference in this PR.
- **`genres_bulk` migration**: removing the `is_disconnected()` polling changes the *mechanism* (poll before each item -> sentinel race over the whole sequential batch) but not the outcome -- a disconnect still cancels the in-flight work and returns 499 with the same log line, now via the standard `asyncio.CancelledError` propagation instead of a poll. Two deliberate behavior additions on this route: the `lml.client_aborted` Sentry tag is *new* here (the old polling branches never set it -- all four routes now tag uniformly, pinned by the new `TestClientAbort` test), and the disconnect can now interrupt an in-flight item mid-await rather than waiting for the next between-item poll (the only side effect on that path, the `get_release` fallthrough cache write-back, runs in a transaction and rolls back cleanly). `test_error_payload_shape.py`'s pre-existing 499-envelope test, which drove the disconnect via a global `Request.is_disconnected` monkeypatch, is updated to drive it via the new `watch_disconnect` + slow-per-item-call pattern instead (same assertion, new mechanism).

## Tests

New `tests/unit/test_run_bulk_gather.py` unit-tests the helper directly: normal completion, client-abort (sentinel wins, in-flight items cancelled and drained, tag + callback fire), parent cancellation (both arms cancelled and drained), and the tie-toward-gather-done race outcome. A new `TestClientAbort` test in `test_artist_genres_router.py` pins `genres_bulk`'s new disconnect behavior (499, in-flight-work cancellation, tag, log). All pre-existing abort-path tests for the three converted routes pass unchanged.

## Deviations from the ticket

- `run_bulk_gather`'s signature takes already-constructed coroutines rather than the ticket's illustrative `(items, run_one)` shape -- needed so `genres_bulk`'s single sequential coroutine can reuse the same helper without a special "sequential mode."
- The PR diff (786 lines: 583 insertions / 203 deletions per `git diff --stat`, net +380) is a bit over the ticket's `≲600` line target. Most of the excess is the TDD-mandated `run_bulk_gather` unit-test file (215 lines) and the ported/centralized in-code comments the ticket's constraints explicitly require preserving; trimmed docstrings and merged redundant test cases once already to bring it down from an initial ~890.

