### PR TITLE
refactor(#1036): consolidate router preamble, service guards, and 503-detail template

### DIFF
--- a/artists/router.py
+++ b/artists/router.py
@@ -42,6 +42,7 @@ from core.dependencies import (
     get_discogs_cache_service_from_pool,
     get_discogs_service,
 )
+from core.service_unavailable import service_unavailable_detail
 from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 from discogs.service import BREAKER_OPEN_STAT_KEY, DiscogsService
 from entity.store import EntityStore
@@ -102,8 +103,8 @@ _GENRES_ROUTE_PATH = "/api/v1/artists/genres/bulk"
 # inside Railway's ~5-minute request-timeout ceiling. Callers page.
 _GENRES_INPUT_CAP = 25
 
-_DISCOGS_CACHE_UNAVAILABLE_DETAIL = (
-    "Discogs cache is not available. Ensure DATABASE_URL_DISCOGS is configured."
+_DISCOGS_CACHE_UNAVAILABLE_DETAIL = service_unavailable_detail(
+    "Discogs cache", "Ensure DATABASE_URL_DISCOGS is configured."
 )
 # Mid-flight variants: the dependency gates above prove the wiring existed at
 # request start, so a failure DURING the request is most often a transient
@@ -327,6 +328,11 @@ async def resolve_bulk(
     # requests — the LML#544 shape rule), and RequestTelemetry carries the
     # aggregate event. Explicit `http.server` span mirrors the siblings —
     # query with `op:http.server span.description:*artists/resolve/bulk*`.
+    # Deliberately narrower than lookup/router.py's full
+    # `_LML_CACHE_STATS_EXTRA_KEYS` (LML#1036 seeding-decision survey, see
+    # that constant's docstring): this route never touches the release-
+    # resolution cache or the event-loop-lag gauge, so seeding those keys
+    # here would add permanently-zero noise instead of a stable series.
     init_cache_stats(extra_keys=(BREAKER_OPEN_STAT_KEY,))
     telemetry = RequestTelemetry(
         api_call_keys=["discogs"],

--- a/cache/router.py
+++ b/cache/router.py
@@ -52,10 +52,11 @@ from core.bulk_concurrency import (
     watch_disconnect,
 )
 from core.dependencies import get_discogs_service, get_musicbrainz_pg
+from core.service_unavailable import service_unavailable_detail
 from discogs.ratelimit import set_discogs_low_priority
 from discogs.service import DiscogsService
 from entity.store import EntityStore
-from identity.dependencies import get_entity_store, require_entity_store
+from identity.dependencies import get_entity_store, require_entity_store, require_service
 from streaming.dependencies import (
     get_apple_music_client,
     get_bandcamp_client,
@@ -94,16 +95,15 @@ _REFRESH_DEFAULT_CONCURRENCY = 10
 
 _REFRESH_ROUTE = "/api/v1/cache/refresh-for-identities"
 
-_DISCOGS_SERVICE_UNAVAILABLE_DETAIL = (
-    "Discogs service is not available. Ensure DISCOGS_TOKEN (or "
-    "DISCOGS_API_KEY / DISCOGS_API_SECRET) is configured."
+_DISCOGS_SERVICE_UNAVAILABLE_DETAIL = service_unavailable_detail(
+    "Discogs service",
+    "Ensure DISCOGS_TOKEN (or DISCOGS_API_KEY / DISCOGS_API_SECRET) is configured.",
 )
 
-
-def _require_discogs_service(service: DiscogsService | None) -> DiscogsService:
-    if service is None:
-        raise HTTPException(status_code=503, detail=_DISCOGS_SERVICE_UNAVAILABLE_DETAIL) from None
-    return service
+# LML#1036: was a hand-written `_require_discogs_service` guard, a verbatim
+# copy of discogs/router.py's own (now also retired). Both are instances of
+# the shared `require_service` factory (identity/dependencies.py).
+_require_discogs_service = require_service(get_discogs_service, _DISCOGS_SERVICE_UNAVAILABLE_DETAIL)
 
 
 @router.post(
@@ -133,7 +133,7 @@ def _require_discogs_service(service: DiscogsService | None) -> DiscogsService:
 async def handle_refresh_for_identities(
     http_request: Request,
     entity_store: EntityStore | None = Depends(get_entity_store),
-    discogs_service: DiscogsService | None = Depends(get_discogs_service),
+    discogs: DiscogsService = Depends(_require_discogs_service),
     mb_pg: PgSourceProtocol | None = Depends(get_musicbrainz_pg),
     spotify_client: SpotifyClient | None = Depends(get_spotify_client),
     apple_music_client: AppleMusicClient | None = Depends(get_apple_music_client),
@@ -154,7 +154,6 @@ async def handle_refresh_for_identities(
     )
 
     store = require_entity_store(entity_store)
-    discogs = _require_discogs_service(discogs_service)
 
     # LML#927: this route is part of the bulk family (shares the LML#716
     # global permit with `/lookup/bulk` and identity bulk-resolve), so it is

--- a/core/service_unavailable.py
+++ b/core/service_unavailable.py
@@ -1,0 +1,38 @@
+"""Shared template for "service unavailable" 503 detail strings (LML#1036).
+
+Five-plus per-service 503 detail constants had drifted into independent
+wording across ``identity/dependencies.py``, ``cache/router.py``,
+``discogs/router.py``, and ``artists/router.py`` -- e.g. "Entity store is not
+available. Ensure DATABASE_URL_DISCOGS is configured and the entity schema
+has been applied." vs "Discogs cache is not available. Ensure
+DATABASE_URL_DISCOGS is configured." Four of those five share one shape --
+"<Service> is not available. <Remedy>" -- differing only in which service and
+which remedy sentence. This module gives that shape a single build site so a
+future service's 503 stays on the same tone instead of inventing new
+phrasing.
+
+Consolidates CONSTRUCTION, not CONTENT: every existing detail string built
+here is byte-identical to what shipped before this refactor -- see each call
+site's own comment for the literal it reproduces. One holdout,
+``discogs/router.py``'s legacy ``_require_service`` detail ("Discogs service
+is not configured. Set DISCOGS_TOKEN environment variable."), uses a
+different verb ("not configured" vs "not available") and doesn't fit this
+shape; it stays a hand-written literal there rather than being forced through
+this template at the cost of changing its wire bytes.
+
+Layering: this module has no imports of its own (a pure string builder), so
+it is safe for any layer -- ``core/``, ``identity/``, or a router module -- to
+import.
+"""
+
+from __future__ import annotations
+
+
+def service_unavailable_detail(service: str, remedy: str) -> str:
+    """Build a "<service> is not available. <remedy>" 503 detail string.
+
+    ``service`` should read naturally mid-sentence (e.g. ``"Discogs cache"``,
+    ``"Entity store"``); ``remedy`` is a complete sentence, including its
+    trailing period (e.g. ``"Set DATABASE_URL_DISCOGS."``).
+    """
+    return f"{service} is not available. {remedy}"

--- a/discogs/router.py
+++ b/discogs/router.py
@@ -7,6 +7,7 @@ import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from core.dependencies import get_discogs_cache_service, get_discogs_service
+from core.service_unavailable import service_unavailable_detail
 from discogs.breaker import DiscogsBreakerOpenError
 from discogs.cache_service import CacheUnavailableError, DiscogsCacheService
 from discogs.markup_parser import DiscogsServiceResolver, parse_async
@@ -20,6 +21,7 @@ from discogs.models import (
     TracksAutocompleteResponse,
 )
 from discogs.service import DiscogsService
+from identity.dependencies import require_service
 
 logger = logging.getLogger(__name__)
 
@@ -36,15 +38,20 @@ _REFRESH_DESCRIPTION = (
     "`DELETE /admin/discogs/tombstone/{type}/{id}` for that recovery surface."
 )
 
+# LML#1036: does NOT fit `service_unavailable_detail`'s "is not available"
+# shape -- this one is phrased "is not configured". Kept as a hand-written
+# literal rather than changed to match every other service's detail bytes.
+_DISCOGS_SERVICE_UNAVAILABLE_DETAIL = (
+    "Discogs service is not configured. Set DISCOGS_TOKEN environment variable."
+)
+_DISCOGS_CACHE_UNAVAILABLE_DETAIL = service_unavailable_detail(
+    "Discogs cache", "Set DATABASE_URL_DISCOGS."
+)
 
-def _require_service(service: DiscogsService | None) -> DiscogsService:
-    """Raise 503 if service is not available."""
-    if service is None:
-        raise HTTPException(
-            status_code=503,
-            detail="Discogs service is not configured. Set DISCOGS_TOKEN environment variable.",
-        )
-    return service
+# LML#1036: was a hand-written `_require_service` guard, a verbatim copy of
+# cache/router.py's own (now also retired). Both are instances of the shared
+# `require_service` factory (identity/dependencies.py).
+_require_discogs_service = require_service(get_discogs_service, _DISCOGS_SERVICE_UNAVAILABLE_DETAIL)
 
 
 def _refresh_l1(cached_func: Callable, *args, **kwargs) -> None:
@@ -82,10 +89,9 @@ async def get_track_releases(
     track: str = Query(..., description="Track/song title to search for"),
     artist: str | None = Query(None, description="Optional artist name for filtering"),
     limit: int = Query(20, ge=1, le=100, description="Maximum number of results"),
-    service: DiscogsService | None = Depends(get_discogs_service),
+    svc: DiscogsService = Depends(_require_discogs_service),
 ) -> TrackReleasesResponse:
     """Find all releases containing a specific track."""
-    svc = _require_service(service)
     return await svc.search_releases_by_track(track, artist, limit)
 
 
@@ -102,10 +108,9 @@ async def get_track_releases(
 async def get_release(
     release_id: int,
     refresh: bool = Query(False, description=_REFRESH_DESCRIPTION),
-    service: DiscogsService | None = Depends(get_discogs_service),
+    svc: DiscogsService = Depends(_require_discogs_service),
 ) -> ReleaseMetadataResponse:
     """Get full metadata for a release by ID."""
-    svc = _require_service(service)
     if refresh:
         _refresh_l1(DiscogsService.get_release, release_id)
     try:
@@ -141,10 +146,9 @@ async def get_release(
 async def get_artist(
     artist_id: int,
     refresh: bool = Query(False, description=_REFRESH_DESCRIPTION),
-    service: DiscogsService | None = Depends(get_discogs_service),
+    svc: DiscogsService = Depends(_require_discogs_service),
 ) -> ArtistDetails:
     """Get full details for an artist by Discogs ID."""
-    svc = _require_service(service)
     if refresh:
         _refresh_l1(DiscogsService.get_artist_details, artist_id)
     try:
@@ -196,11 +200,9 @@ async def resolve_entity(
     entity_type: EntityType,
     entity_id: int,
     refresh: bool = Query(False, description=_REFRESH_DESCRIPTION),
-    service: DiscogsService | None = Depends(get_discogs_service),
+    svc: DiscogsService = Depends(_require_discogs_service),
 ) -> EntityResolveResponse:
     """Resolve a Discogs entity (artist, release, or master) to its name."""
-    svc = _require_service(service)
-
     # Dispatch to the cached method matching this entity type. Adding a new
     # `EntityType` value MUST come with a matching entry here; the parametrized
     # test in test_discogs_router.py walks every enum value so a missing leg
@@ -263,7 +265,7 @@ async def autocomplete_tracks(
     if cache is None:
         raise HTTPException(
             status_code=503,
-            detail="Discogs cache is not available. Set DATABASE_URL_DISCOGS.",
+            detail=_DISCOGS_CACHE_UNAVAILABLE_DETAIL,
         )
 
     try:

--- a/identity/dependencies.py
+++ b/identity/dependencies.py
@@ -2,12 +2,14 @@
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 
 from fastapi import Depends, HTTPException
 
 from config.settings import Settings, get_settings
 from core.bulk_body import TRANSIENT_PG_ERRORS
 from core.dependencies import get_discogs_pool
+from core.service_unavailable import service_unavailable_detail
 from entity.sources import PgSource
 from entity.store import EntityStore
 
@@ -15,9 +17,9 @@ logger = logging.getLogger(__name__)
 
 # Shared across every router that depends on `get_entity_store` (cache/router.py,
 # identity/router.py, ...) — previously duplicated verbatim in each router module.
-_ENTITY_STORE_UNAVAILABLE_DETAIL = (
-    "Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
-    "and the entity schema has been applied."
+_ENTITY_STORE_UNAVAILABLE_DETAIL = service_unavailable_detail(
+    "Entity store",
+    "Ensure DATABASE_URL_DISCOGS is configured and the entity schema has been applied.",
 )
 
 _entity_store: EntityStore | None = None
@@ -116,6 +118,38 @@ def require_entity_store(store: EntityStore | None) -> EntityStore:
     if store is None:
         raise HTTPException(status_code=503, detail=_ENTITY_STORE_UNAVAILABLE_DETAIL) from None
     return store
+
+
+def require_service[T](
+    getter: Callable[..., Awaitable[T | None]], detail: str
+) -> Callable[..., Awaitable[T]]:
+    """Build a FastAPI dependency that 503s when ``getter`` resolves to ``None`` (LML#1036).
+
+    Generic sibling of :func:`require_entity_store`: that helper is a
+    hand-written "None -> 503" guard for exactly one type (``EntityStore``),
+    called manually inside a handler body against an already-resolved
+    ``Depends(get_entity_store)`` value. This factory produces the same guard
+    for any optional-service getter dependency, parametrized by the getter
+    and the 503 detail, and wires it in ONE step instead of two: use it
+    directly as ``Depends(require_service(get_discogs_service, detail))`` in
+    a route signature. FastAPI resolves ``getter`` itself (a normal
+    dependency, complete with its own nested ``Depends()`` chain and
+    per-request caching) via the returned callable's own ``Depends(getter)``
+    default, so ``app.dependency_overrides[getter]`` still reaches through
+    the wrapper exactly as it would a bare ``Depends(getter)`` parameter.
+
+    ``discogs/router.py``'s ``_require_service`` and ``cache/router.py``'s
+    ``_require_discogs_service`` were two hand-written copies of exactly this
+    "if service is None: raise HTTPException(503, ...)" shape; both are now
+    instances of this factory (``require_service(get_discogs_service, ...)``).
+    """
+
+    async def _require(service: T | None = Depends(getter)) -> T:
+        if service is None:
+            raise HTTPException(status_code=503, detail=detail) from None
+        return service
+
+    return _require
 
 
 async def close_entity_store() -> None:

--- a/lookup/router.py
+++ b/lookup/router.py
@@ -269,7 +269,27 @@ and Sentry payload shapes stay stable. Used at BOTH ``handle_lookup`` and
 ``init_cache_stats`` and LML#544 round 2 for the shape-stability rationale.
 Adding a new key here is the single point of update; LML#681's row-less flag
 observability (flag tags, ``nonlibrary_release_surfaced``, the #632
-hit/miss/unavailable counters) was the most recent addition."""
+hit/miss/unavailable counters) was the most recent addition.
+
+LML#1036 seeding-decision survey: this is one of four ``init_cache_stats(...)``
+call sites in the repo, and the other three deliberately seed a narrower (or
+empty) set rather than this one -- surveyed and confirmed intentional, not
+drift:
+
+* ``artists/router.py``'s ``resolve_bulk`` seeds only ``(BREAKER_OPEN_STAT_KEY,)``
+  because that route's payload never touches the release-resolution cache,
+  the event-loop-lag gauge, or any of this tuple's other lookup-pipeline-
+  specific counters -- seeding them would add permanently-zero noise to a
+  shape those subsystems never apply to. The Discogs saturation-breaker
+  counter IS relevant there (escalation can shed on that route too), so it
+  alone is seeded.
+* ``streaming/router.py``'s ``handle_streaming_check`` calls bare
+  ``init_cache_stats()`` (no extras) because that path is application-cache-
+  free end to end (LML#639/#641) -- there is no LML-specific key for it to
+  stabilize.
+
+Each site's own call comment carries its local rationale; this note just
+records that the three-way split was reviewed together and left as-is."""
 
 
 def _record_lml_flag_tags() -> None:
@@ -321,6 +341,58 @@ def _record_event_loop_lag() -> None:
         if lag_ms is None:
             return
         get_cache_stats_recorder().record(EVENT_LOOP_LAG_STAT_KEY, lag_ms)
+
+
+def init_lookup_observability(
+    family: str,
+    caller_reason: str | None,
+    *,
+    skip_cache: bool = False,
+    extra_keys: tuple[str, ...] = _LML_CACHE_STATS_EXTRA_KEYS,
+) -> None:
+    """Shared telemetry preamble for `/lookup` and `/lookup/bulk` (LML#1036).
+
+    Runs the same six-call sequence both handlers ran inline at request
+    entry, in the order `handle_lookup` established:
+
+    1. ``init_cache_stats(extra_keys=extra_keys)`` — seed the cache_stats
+       context so PostHog/Sentry payload shapes stay stable (LML#544 round 2).
+    2. ``_record_lml_flag_tags()`` — LML#681 row-less-family flag state, once
+       per context.
+    3. ``_record_event_loop_lag()`` — LML#907 event-loop-lag gauge sample,
+       once per context.
+    4. ``record_endpoint_family_tag(family)`` — LML#944 traffic-class tag.
+    5. ``record_caller_reason_tag(caller_reason)`` — LML#931 caller-reason tag.
+    6. ``set_skip_cache(True)`` when ``skip_cache`` is truthy.
+
+    Both handlers called this same six-call block verbatim before this
+    extraction; the "once per cache_stats context" contract steps 2 and 3
+    depend on (LML#681 — `_record_lml_flag_tags` is an additive-only
+    recorder, so calling it more than once per context would double-count)
+    is preserved because this helper itself is still called exactly once per
+    handler invocation, same as the inline block was.
+
+    `extra_keys` defaults to the shared `_LML_CACHE_STATS_EXTRA_KEYS` set
+    both existing call sites already passed identically; a future sibling
+    endpoint with a different seeding decision passes its own tuple (see the
+    LML#1036 seeding-decision survey in `_LML_CACHE_STATS_EXTRA_KEYS`'s
+    docstring above).
+
+    `record_low_priority_tag` is deliberately NOT part of this preamble: at
+    `handle_lookup` it must run AFTER `resolve_caller_class` resolves
+    `low_priority` — a value this function has no access to — and at
+    `handle_bulk_lookup` it is called unconditionally with `True`. Both call
+    sites invoke it separately, next to their own call to this helper; see
+    `lookup.endpoint_family.record_low_priority_tag`'s call-site-timing
+    docstring for why moving it here would be wrong.
+    """
+    init_cache_stats(extra_keys=extra_keys)
+    _record_lml_flag_tags()
+    _record_event_loop_lag()
+    record_endpoint_family_tag(family)
+    record_caller_reason_tag(caller_reason)
+    if skip_cache:
+        set_skip_cache(True)
 
 
 # Canonical full path for the bulk endpoint. Referenced by the explicit
@@ -473,19 +545,15 @@ async def handle_lookup(
     ),
 ):
     """Process a lookup request."""
-    # Pre-declare LML-specific cache-stats keys so PostHog/Sentry payload shapes
-    # are stable even on requests with zero in-flight joins or zero L1 write
-    # failures (LML#544 round 2). Without extra_keys, the keys would only
-    # appear in payloads from the first request that records them.
-    init_cache_stats(extra_keys=_LML_CACHE_STATS_EXTRA_KEYS)
-    # LML#681: tag the per-request payload with the row-less-family flag state
-    # (0/1) once per context so the flip is sliceable in PostHog/Sentry.
-    _record_lml_flag_tags()
-    _record_event_loop_lag()
-    record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP)
-    record_caller_reason_tag(x_caller_reason)
-    if skip_cache:
-        set_skip_cache(True)
+    # LML#1036: shared telemetry preamble (cache_stats seed, LML#681 flag
+    # tags, LML#907 event-loop-lag stamp, endpoint-family + caller-reason
+    # Sentry tags, skip_cache honor) -- see `init_lookup_observability`.
+    init_lookup_observability(
+        ENDPOINT_FAMILY_LOOKUP,
+        x_caller_reason,
+        skip_cache=skip_cache,
+        extra_keys=_LML_CACHE_STATS_EXTRA_KEYS,
+    )
 
     try:
         # LML#928/#953: class 5 (batch/cron/backfill) additionally routes this
@@ -842,17 +910,11 @@ async def handle_bulk_lookup(
     # transaction only commit on response completion.
     logger.info("bulk lookup start: size=%d", len(request.items))
 
-    # Honor the same `skip_cache` query flag the per-item route accepts. Backed
-    # by a ContextVar, so setting once at the batch top propagates into each
-    # `_run_one` task via the inherited task context.
-    if skip_cache:
-        set_skip_cache(True)
-
     # Bulk does streaming-URL cache read-fill ONLY — never spawns the background
     # warm (LML#706). A 35k-album drain returns fast per item, so an enqueued
     # warm tail would decouple from the request and starve the live /lookup
-    # path's own warms. Same ContextVar-propagation mechanism as `skip_cache`,
-    # and the same posture as the unconditional `bandcamp=None` pin below —
+    # path's own warms. Same ContextVar-propagation mechanism as `skip_cache`
+    # below, and the same posture as the unconditional `bandcamp=None` pin —
     # `allow_release_resolution_fallback` is caller-controlled since LML#920.
     set_suppress_streaming_warm(True)
 
@@ -863,22 +925,26 @@ async def handle_bulk_lookup(
     set_discogs_low_priority(True)
 
     # One cache_stats context for the whole batch: the in-process caches are
-    # shared, so aggregate counters reflect the batch's behavior — the property
-    # that motivates this endpoint.
-    # Pre-declare LML-specific cache-stats keys so PostHog/Sentry payload shapes
-    # are stable even on requests with zero in-flight joins or zero L1 write
-    # failures (LML#544 round 2). Without extra_keys, the keys would only
-    # appear in payloads from the first request that records them.
-    init_cache_stats(extra_keys=_LML_CACHE_STATS_EXTRA_KEYS)
-    # LML#681: record the flag tag once for the whole batch (shared context),
-    # so the bulk value stays 0/1 instead of summing across items.
-    _record_lml_flag_tags()
-    _record_event_loop_lag()
-    record_endpoint_family_tag(ENDPOINT_FAMILY_LOOKUP_BULK)
+    # shared, so aggregate counters reflect the batch's behavior — the
+    # property that motivates this endpoint. LML#1036: shared telemetry
+    # preamble (see `init_lookup_observability`) -- also honors the same
+    # `skip_cache` query flag the per-item route accepts (backed by a
+    # ContextVar, so setting once at the batch top propagates into each
+    # `_run_one` task via the inherited task context) and records the flag
+    # tag once for the whole batch (shared context), so the bulk value stays
+    # 0/1 instead of summing across items.
+    init_lookup_observability(
+        ENDPOINT_FAMILY_LOOKUP_BULK,
+        x_caller_reason,
+        skip_cache=skip_cache,
+        extra_keys=_LML_CACHE_STATS_EXTRA_KEYS,
+    )
     # LML#930 PR2: every item on this route is always low priority (mirrors
-    # the unconditional set_discogs_low_priority(True) above).
+    # the unconditional set_discogs_low_priority(True) above). Not part of
+    # the shared preamble -- unlike `handle_lookup` (where `low_priority` is
+    # resolved later from `resolve_caller_class`), here it's unconditionally
+    # True, so this call just sits next to the preamble instead of inside it.
     record_low_priority_tag(True)
-    record_caller_reason_tag(x_caller_reason)
 
     max_concurrent = max_concurrency_from_env(_BULK_LOOKUP_DEFAULT_CONCURRENCY)
     semaphore = asyncio.Semaphore(max_concurrent)

--- a/streaming/router.py
+++ b/streaming/router.py
@@ -224,6 +224,9 @@ async def handle_streaming_check(
     # Per-request telemetry (LML#639). The cache-stats bracket and api_calls map
     # are seeded with a stable, all-zero shape: the streaming-check path is
     # application-cache-free and the clients record no API calls yet (LML#641).
+    # No `extra_keys` (LML#1036 seeding-decision survey, see
+    # `lookup.router._LML_CACHE_STATS_EXTRA_KEYS`'s docstring): there is no
+    # LML-specific key this cache-free path needs to stabilize.
     init_cache_stats()
     telemetry = RequestTelemetry(
         api_call_keys=list(_STREAMING_SERVICES),

--- a/tests/unit/test_discogs_router.py
+++ b/tests/unit/test_discogs_router.py
@@ -15,24 +15,30 @@ from discogs.models import (
     ReleaseMetadataResponse,
     TrackReleasesResponse,
 )
-from discogs.router import _require_service
+from discogs.router import _DISCOGS_SERVICE_UNAVAILABLE_DETAIL, _require_discogs_service
 from discogs.service import DiscogsService
 from tests.unit.conftest import override_deps
 
 # ---------------------------------------------------------------------------
-# _require_service
+# _require_discogs_service (LML#1036: an instance of the shared
+# identity.dependencies.require_service factory -- see
+# tests/unit/test_identity_dependencies.py::TestRequireService for the
+# factory's own unit tests).
 # ---------------------------------------------------------------------------
 
 
-class TestRequireService:
-    def test_returns_service(self):
+class TestRequireDiscogsService:
+    @pytest.mark.asyncio
+    async def test_returns_service(self):
         svc = AsyncMock(spec=DiscogsService)
-        assert _require_service(svc) is svc
+        assert await _require_discogs_service(service=svc) is svc
 
-    def test_none_raises_503(self):
+    @pytest.mark.asyncio
+    async def test_none_raises_503_with_the_configured_detail(self):
         with pytest.raises(HTTPException) as exc_info:
-            _require_service(None)
+            await _require_discogs_service(service=None)
         assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == _DISCOGS_SERVICE_UNAVAILABLE_DETAIL
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_identity_dependencies.py
+++ b/tests/unit/test_identity_dependencies.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, patch
 
 import asyncpg
 import pytest
+from fastapi import Depends, FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
 
 import core.dependencies as core_deps
 import identity.dependencies as deps
@@ -289,3 +291,71 @@ async def test_returns_none_when_probe_raises_interface_error(
     assert result is None
     assert deps._entity_probe_failed is True
     assert any("probe failed; disabling identity routes" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# require_service (LML#1036) — generic sibling of require_entity_store
+# ---------------------------------------------------------------------------
+
+
+async def _fake_getter() -> str | None:
+    """Stand-in FastAPI getter dependency for `require_service` unit tests."""
+    return None
+
+
+class TestRequireService:
+    @pytest.mark.asyncio
+    async def test_passes_a_resolved_service_through(self):
+        """A non-None value reaches the caller unchanged — the getter is
+        never consulted directly, since the value is supplied to the guard's
+        own `service` parameter, exactly as FastAPI's Depends() resolution
+        would supply it."""
+        guard = deps.require_service(_fake_getter, "irrelevant detail")
+        sentinel = object()
+        assert await guard(service=sentinel) is sentinel
+
+    @pytest.mark.asyncio
+    async def test_raises_503_with_the_exact_detail_when_the_getter_yields_none(self):
+        detail = "Widget service is not available. Set WIDGET_TOKEN."
+        guard = deps.require_service(_fake_getter, detail)
+        with pytest.raises(HTTPException) as exc_info:
+            await guard(service=None)
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == detail
+
+    @pytest.mark.asyncio
+    async def test_wired_as_a_route_dependency_resolves_the_getter_via_depends(self):
+        """The guard's default parameter is `Depends(getter)`, not a direct
+        call to `getter()` — so when mounted on a route, FastAPI's own
+        dependency-injection resolves it (and `app.dependency_overrides`
+        reaches it), matching how `discogs/router.py` and `cache/router.py`
+        wire it in (``Depends(require_service(get_discogs_service, ...))``)."""
+
+        async def _unavailable_getter() -> str | None:
+            return None
+
+        async def _available_getter() -> str | None:
+            return "widget-service"
+
+        detail = "Widget service is not available."
+        unavailable_guard = deps.require_service(_unavailable_getter, detail)
+        available_guard = deps.require_service(_available_getter, detail)
+
+        app = FastAPI()
+
+        @app.get("/unavailable")
+        async def unavailable_probe(service: str = Depends(unavailable_guard)) -> dict:
+            return {"service": service}
+
+        @app.get("/available")
+        async def available_probe(service: str = Depends(available_guard)) -> dict:
+            return {"service": service}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            unavailable_resp = await client.get("/unavailable")
+            available_resp = await client.get("/available")
+
+        assert unavailable_resp.status_code == 503
+        assert unavailable_resp.json()["detail"] == detail
+        assert available_resp.status_code == 200
+        assert available_resp.json() == {"service": "widget-service"}

--- a/tests/unit/test_lookup_router.py
+++ b/tests/unit/test_lookup_router.py
@@ -1058,6 +1058,117 @@ class TestHandleLookup:
         assert library_item["library_url"] == "https://dj.wxyc.org/dashboard/album/legacy/10"
 
 
+class TestInitLookupObservability:
+    """LML#1036: `init_lookup_observability` replaces the identical six-call
+    preamble block `handle_lookup` and `handle_bulk_lookup` used to repeat
+    inline (`init_cache_stats` -> `_record_lml_flag_tags` ->
+    `_record_event_loop_lag` -> `record_endpoint_family_tag` ->
+    `record_caller_reason_tag` -> conditional `set_skip_cache`). These tests
+    exercise the helper directly and assert against the recorded cache-stats
+    / tag state it produces, not implementation internals -- the same
+    externally-observable contract the two endpoints' own end-to-end tests
+    (test_rowless_flag_observability.py, this file's
+    `test_extra_keys_seeded_and_projected_onto_transaction`) already pin.
+    """
+
+    def test_seeds_the_passed_extra_keys_at_zero(self):
+        """Step 1: `init_cache_stats(extra_keys=...)` seeds every passed key
+        at 0 -- the LML#544 round 2 shape-stability contract this helper must
+        not regress."""
+        from wxyc_fastapi.observability import get_cache_stats
+
+        from lookup.router import ENDPOINT_FAMILY_LOOKUP, init_lookup_observability
+
+        init_lookup_observability(
+            ENDPOINT_FAMILY_LOOKUP,
+            None,
+            extra_keys=("lml1036_probe_key_a", "lml1036_probe_key_b"),
+        )
+
+        stats = get_cache_stats()
+        assert stats["lml1036_probe_key_a"] == 0
+        assert stats["lml1036_probe_key_b"] == 0
+
+    @pytest.mark.parametrize("nonlibrary, expected", [(True, 1), (False, 0)])
+    def test_records_the_lml681_flag_tag_once(self, monkeypatch, nonlibrary, expected):
+        """Step 2: `_record_lml_flag_tags` (LML#681) -- the flag state lands
+        as a clean 0/1 cache_stats key. Calling the helper once must record
+        it exactly once, preserving the #681 "once per cache_stats context,
+        additive-only recorder" contract -- a regression here would sum
+        across repeated calls instead of reflecting the flag cleanly."""
+        from wxyc_fastapi.observability import get_cache_stats
+
+        from config.settings import get_settings
+        from lookup.router import (
+            _LML_CACHE_STATS_EXTRA_KEYS,
+            ENDPOINT_FAMILY_LOOKUP,
+            LML_RESOLVE_NONLIBRARY_RELEASE_STAT_KEY,
+            init_lookup_observability,
+        )
+
+        monkeypatch.setenv("LML_RESOLVE_NONLIBRARY_RELEASE", "true" if nonlibrary else "false")
+        get_settings.cache_clear()
+        try:
+            init_lookup_observability(
+                ENDPOINT_FAMILY_LOOKUP, None, extra_keys=_LML_CACHE_STATS_EXTRA_KEYS
+            )
+            stats = get_cache_stats()
+            assert stats[LML_RESOLVE_NONLIBRARY_RELEASE_STAT_KEY] == expected
+        finally:
+            get_settings.cache_clear()
+
+    def test_records_endpoint_family_and_caller_reason_sentry_tags(self):
+        """Steps 4-5: both string-valued Sentry tags fire exactly once, with
+        the family/reason the caller passed in -- matching
+        `record_endpoint_family_tag` / `record_caller_reason_tag`'s own
+        per-call contract. Both helpers reach `sentry_sdk.set_tag` through the
+        SAME shared module object regardless of which package imports it, so
+        this patches the one canonical target rather than two import paths
+        (patching both would silently patch-then-repatch the same attribute)."""
+        from lookup.router import ENDPOINT_FAMILY_LOOKUP_BULK, init_lookup_observability
+
+        with patch("sentry_sdk.set_tag") as mock_set_tag:
+            init_lookup_observability(
+                ENDPOINT_FAMILY_LOOKUP_BULK, "proxy-library-search", extra_keys=()
+            )
+
+        mock_set_tag.assert_any_call("lml.endpoint_family", ENDPOINT_FAMILY_LOOKUP_BULK)
+        mock_set_tag.assert_any_call("lml.caller_reason", "proxy-library-search")
+        assert mock_set_tag.call_count == 2
+
+    def test_absent_caller_reason_sets_no_sentry_tag(self):
+        """`caller_reason=None` is `record_caller_reason_tag`'s documented
+        no-op contract -- no tag call at all, not an empty-string tag. The
+        endpoint-family tag still fires, so this asserts on the specific
+        `lml.caller_reason` call rather than total call count."""
+        from lookup.router import ENDPOINT_FAMILY_LOOKUP, init_lookup_observability
+
+        with patch("sentry_sdk.set_tag") as mock_set_tag:
+            init_lookup_observability(ENDPOINT_FAMILY_LOOKUP, None, extra_keys=())
+
+        called_keys = [c.args[0] for c in mock_set_tag.call_args_list]
+        assert "lml.caller_reason" not in called_keys
+
+    def test_skip_cache_true_sets_the_context_var(self):
+        """Step 6: a truthy `skip_cache` honors the query flag by flipping the
+        ContextVar the memory-cache layer reads."""
+        from discogs.memory_cache import should_skip_cache
+        from lookup.router import ENDPOINT_FAMILY_LOOKUP, init_lookup_observability
+
+        init_lookup_observability(ENDPOINT_FAMILY_LOOKUP, None, skip_cache=True, extra_keys=())
+        assert should_skip_cache() is True
+
+    def test_skip_cache_defaults_to_false_and_is_a_no_op(self):
+        """`skip_cache` defaults to False; the ContextVar is left alone (the
+        session-wide `reset_caches` autouse fixture already primes it False,
+        so this pins the helper's own default doesn't flip it)."""
+        from discogs.memory_cache import should_skip_cache
+        from lookup.router import ENDPOINT_FAMILY_LOOKUP, init_lookup_observability
+
+        init_lookup_observability(ENDPOINT_FAMILY_LOOKUP, None, extra_keys=())
+        assert should_skip_cache() is False
+
+
 class TestCallerClassLowPriorityLane:
     """LML#928/#953: ``X-Caller-Class`` routes a single ``/lookup`` request
     onto the low-priority lane (the LML#716/#924 process-global bulk permit)

--- a/tests/unit/test_service_unavailable.py
+++ b/tests/unit/test_service_unavailable.py
@@ -1,0 +1,74 @@
+"""Unit tests for core/service_unavailable.py and the LML#1036 503-detail
+consolidation.
+
+The consolidation's whole point is CONSTRUCTION, not CONTENT: every existing
+503 detail string must keep its exact wire bytes even though it is now built
+from `service_unavailable_detail(...)` instead of hand-typed inline. Each
+class below pins one call site's exact byte value against the literal that
+shipped before this refactor.
+"""
+
+from __future__ import annotations
+
+from core.service_unavailable import service_unavailable_detail
+
+
+class TestServiceUnavailableDetail:
+    def test_builds_the_is_not_available_shape(self):
+        assert (
+            service_unavailable_detail("Discogs cache", "Set DATABASE_URL_DISCOGS.")
+            == "Discogs cache is not available. Set DATABASE_URL_DISCOGS."
+        )
+
+    def test_service_and_remedy_are_both_required_positionally_or_by_keyword(self):
+        assert (
+            service_unavailable_detail(service="Widget service", remedy="Set WIDGET_TOKEN.")
+            == "Widget service is not available. Set WIDGET_TOKEN."
+        )
+
+
+class TestDetailBytesUnchanged:
+    """Pins the exact byte value each consolidated constant produces, matching
+    what shipped on `main` before LML#1036 -- a regression test for
+    "consolidate construction, not content."""
+
+    def test_entity_store_unavailable_detail(self):
+        from identity.dependencies import _ENTITY_STORE_UNAVAILABLE_DETAIL
+
+        assert _ENTITY_STORE_UNAVAILABLE_DETAIL == (
+            "Entity store is not available. Ensure DATABASE_URL_DISCOGS is configured "
+            "and the entity schema has been applied."
+        )
+
+    def test_cache_router_discogs_service_unavailable_detail(self):
+        from cache.router import _DISCOGS_SERVICE_UNAVAILABLE_DETAIL
+
+        assert _DISCOGS_SERVICE_UNAVAILABLE_DETAIL == (
+            "Discogs service is not available. Ensure DISCOGS_TOKEN (or "
+            "DISCOGS_API_KEY / DISCOGS_API_SECRET) is configured."
+        )
+
+    def test_discogs_router_cache_unavailable_detail(self):
+        from discogs.router import _DISCOGS_CACHE_UNAVAILABLE_DETAIL
+
+        assert _DISCOGS_CACHE_UNAVAILABLE_DETAIL == (
+            "Discogs cache is not available. Set DATABASE_URL_DISCOGS."
+        )
+
+    def test_artists_router_discogs_cache_unavailable_detail(self):
+        from artists.router import _DISCOGS_CACHE_UNAVAILABLE_DETAIL
+
+        assert _DISCOGS_CACHE_UNAVAILABLE_DETAIL == (
+            "Discogs cache is not available. Ensure DATABASE_URL_DISCOGS is configured."
+        )
+
+    def test_discogs_router_service_unavailable_detail_is_the_deliberate_holdout(self):
+        """This one is phrased "is not configured", not "is not available" --
+        it does not fit `service_unavailable_detail`'s shape and is kept as a
+        hand-written literal per LML#1036 rather than have its bytes changed
+        to match the template."""
+        from discogs.router import _DISCOGS_SERVICE_UNAVAILABLE_DETAIL
+
+        assert _DISCOGS_SERVICE_UNAVAILABLE_DETAIL == (
+            "Discogs service is not configured. Set DISCOGS_TOKEN environment variable."
+        )


### PR DESCRIPTION
Closes #1036

## Approach

Four independent duplication patterns had accumulated across the router layer, each drifted since it was added on its own ticket:

1. **Telemetry preamble**: `handle_lookup` and `handle_bulk_lookup` repeated the identical six-call block (`init_cache_stats` -> `_record_lml_flag_tags` -> `_record_event_loop_lag` -> `record_endpoint_family_tag` -> `record_caller_reason_tag` -> conditional `set_skip_cache`). Extracted to `init_lookup_observability(family, caller_reason, *, skip_cache=False, extra_keys=...)`, used by both handlers.
2. **Service guards**: `discogs/router.py`'s `_require_service` and `cache/router.py`'s `_require_discogs_service` were two hand-written copies of the same "raise 503 if None" shape. Both are now instances of a new `require_service(getter, detail)` factory in `identity/dependencies.py`, next to `require_entity_store`.
3. **Cache-stats seeding**: left as-is (four call sites, three distinct shapes) with the decision now recorded rather than left implicit.
4. **503 detail strings**: five-plus per-service detail constants are now built from one shared template where their existing bytes permit it; one holdout is documented and left alone.

## Where the preamble helper lives, and why

`init_lookup_observability` lives directly in `lookup/router.py`, not a separate module. It needs three router-private symbols -- `_LML_CACHE_STATS_EXTRA_KEYS`, `_record_lml_flag_tags`, `_record_event_loop_lag` -- that are tightly coupled to the stat-key constant table already defined in that file. Splitting it into a sibling module (the way `lookup/endpoint_family.py` and `lookup/caller_reason.py` were split out) would either force those constants and helper functions out of `router.py` too, or require every call site to pass them in as parameters for the benefit of exactly two call sites. In-module keeps the diff small and the constants next to the one place that reads them; `lookup/router.py` stays well within its 1250-line module budget (`tests/unit/test_module_budgets.py`) after the change.

`record_low_priority_tag` is deliberately NOT part of the shared preamble: at `handle_lookup` it must run after `resolve_caller_class` resolves `low_priority` (a value the preamble has no access to at its call site), and at `handle_bulk_lookup` it's called unconditionally with `True`. Both handlers call it separately, next to their own call into the helper.

`require_service(getter, detail)` is a genuine dependency *factory*, not a rename of the old guard functions' call-a-value-directly shape. It wraps the getter in its own `Depends(getter)` default, so `Depends(require_service(get_discogs_service, detail))` collapses the old two-step `Depends(get_discogs_service)` + manual `if service is None: raise ...` into one route parameter, and `app.dependency_overrides[get_discogs_service]` still reaches through the wrapper exactly as it would a bare `Depends(get_discogs_service)` (verified in `tests/unit/test_identity_dependencies.py::TestRequireService` and by the unchanged discogs/cache 503 integration tests).

## Seeding decision (cache-stats, part 3)

Not unified -- the variance across the four `init_cache_stats(...)` call sites was surveyed and confirmed deliberate, and the decision is now recorded in `lookup/router.py`'s `_LML_CACHE_STATS_EXTRA_KEYS` docstring plus a cross-referencing comment at each of the other two call sites:

- `lookup/router.py` (`handle_lookup` + `handle_bulk_lookup`): full `_LML_CACHE_STATS_EXTRA_KEYS` set, for the LML#544 round-2 shape-stability contract both endpoints share.
- `artists/router.py`'s `resolve_bulk`: only `(BREAKER_OPEN_STAT_KEY,)`, since that route never touches the release-resolution cache, the event-loop-lag gauge, or the other lookup-pipeline-specific counters in the full set -- seeding them would add permanently-zero noise rather than a stable series.
- `streaming/router.py`'s `handle_streaming_check`: bare `init_cache_stats()`, no extras, since that path is application-cache-free end to end (LML#639/#641).

No payload-shape changes in this PR -- every route keeps the same seeded keys it had before.

## 503 detail template (part 4)

`core/service_unavailable.py` adds `service_unavailable_detail(service, remedy)`, building the `"<service> is not available. <remedy>"` shape four of the five existing detail strings already used (`identity/dependencies.py`'s entity-store detail, `cache/router.py`'s and `artists/router.py`'s and `discogs/router.py`'s Discogs-cache details). Every templated string is byte-identical to what shipped before -- pinned by `tests/unit/test_service_unavailable.py::TestDetailBytesUnchanged`. `discogs/router.py`'s `_require_service`-guard detail ("Discogs service is **not configured**. Set DISCOGS_TOKEN environment variable.") uses a different verb and doesn't fit the template's phrasing; it's left as a hand-written literal with a comment explaining why, per the ticket's "leave that one in place and note it" instruction.

## Import-level rebase note

This branch was rebased onto `main` after PR #1057 (LML#1033, `run_bulk_gather` extraction) merged as 468a5b2. The rebase was clean with zero conflicts -- this PR's scope (telemetry preamble at the top of both lookup handlers, the two service guards, cache-stats seeding comments, and the 503-detail template) never touches the gather/sentinel disconnect blocks or the `genres_bulk` body that #1057 rewrote.

## Tests

- New: `tests/unit/test_identity_dependencies.py::TestRequireService` -- the factory passes a resolved service through, 503s with the exact detail when the getter yields None, and resolves the getter via FastAPI's own `Depends()` (so `app.dependency_overrides` reaches it).
- New: `tests/unit/test_lookup_router.py::TestInitLookupObservability` -- the helper seeds the passed extra keys at zero, records the LML#681 flag tag exactly once, records both Sentry tags (and skips the caller-reason tag when absent), and honors/no-ops `skip_cache` per its default.
- New: `tests/unit/test_service_unavailable.py` -- the template's shape, plus a byte-exact regression pin for every existing 503 detail string this PR touches.
- Updated: `tests/unit/test_discogs_router.py`'s `TestRequireService` -> `TestRequireDiscogsService`, now exercising the `require_service`-produced instance instead of the retired hand-written function.
- Existing payload-shape tests (`test_rowless_flag_observability.py`, `test_lookup_router.py`'s cache-stats projection tests, `test_discogs_router.py`'s and `test_cache_refresh_endpoint.py`'s 503 tests) pass unchanged.

Full suite: `pytest -m "not pg and not external_api"` -- 5041 passed, 1 skipped, 2 xfailed. Two failures reproduce (`test_shed_lookup_emits_no_error_level_logs`, `test_no_module_level_asyncio_lock_in_dependencies`) but both pass in isolation and are the documented pre-existing order-dependent flakes triggered by this PR's new test files shifting collection order, not a regression from these changes.

`ruff format --check`, `ruff check`, and `mypy` on every touched file all pass locally.
