### PR TITLE
feat(streaming): YouTube Music coverage drain — client, harness, and fill-only write path (#1056)

### DIFF
--- a/clients/streaming/youtube_music.py
+++ b/clients/streaming/youtube_music.py
@@ -1,0 +1,144 @@
+"""YouTube Music album-match client backed by the unofficial ytmusicapi.
+
+Standalone (not a ``BaseStreamingClient`` subclass) because ytmusicapi is a
+*synchronous*, ``requests``-based library — the httpx lifecycle the base class
+manages does not apply. It still honors the
+``find_album_match(artist, title) -> SourceMatch | None`` contract the
+streaming-check orchestrator (LML#392) gathers over, so it can later be dropped
+into the interactive ``/lookup`` per-service gather (LML#1056 follow-up).
+
+Unauthenticated: ``YTMusic()`` with no OAuth/cookie returns album results
+carrying a ``browseId`` (``MPREb_…``) that maps to a direct
+``music.youtube.com/browse/<browseId>`` album page — the targeted-link upgrade
+the coverage epic (LML#830) is after, established by the go/no-go spike
+(LML#833).
+
+Matching routes through the shared production matcher
+(``find_best_source_match`` → 80/80 floor via ``is_acceptable_match``), which
+scores both axes with ``score_match`` (token_sort). That is inherently immune
+to the ``token_set_ratio`` subset inflation that produced the spike's
+"Goya"-class false positive, so no bespoke short-title guard is needed here.
+
+Test seam: pass ``search_fn`` to inject a fake searcher; the default lazily
+constructs ``YTMusic().search`` so unit tests never import ytmusicapi and never
+touch the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from aiolimiter import AsyncLimiter
+
+from clients.streaming.matching import find_best_source_match
+from streaming.models import SourceMatch
+
+logger = logging.getLogger(__name__)
+
+# ytmusicapi's ``search(query, filter, limit)`` — kept as a narrow injectable
+# type so tests can pass any callable of this shape.
+SearchFn = Callable[[str, str, int], list[dict[str, Any]]]
+
+_BROWSE_URL_TEMPLATE = "https://music.youtube.com/browse/{browse_id}"
+_ALBUMS_FILTER = "albums"
+
+
+def build_browse_url(browse_id: str) -> str:
+    """Map a YouTube Music album ``browseId`` to its direct browse URL.
+
+    >>> build_browse_url("MPREb_abc")
+    'https://music.youtube.com/browse/MPREb_abc'
+    """
+    return _BROWSE_URL_TEMPLATE.format(browse_id=browse_id)
+
+
+class YouTubeMusicClient:
+    """Resolve verified YouTube Music album URLs for ``(artist, title)`` pairs.
+
+    Args:
+        search_fn: Optional injected searcher with the ytmusicapi
+            ``search(query, filter, limit)`` signature. Defaults to a lazily
+            constructed unauthenticated ``YTMusic().search``.
+        rate_limit: ``(max_rate, time_period)`` for the internal
+            ``AsyncLimiter``. Defaults to 2 requests/second — polite pacing for
+            an offline drain, well under any observed rate-limit ceiling
+            (the spike saw 0/206 429s at ~1.6 req/s).
+        limit: Number of album candidates to request per search.
+    """
+
+    DEFAULT_LIMIT = 5
+
+    def __init__(
+        self,
+        *,
+        search_fn: SearchFn | None = None,
+        rate_limit: tuple[float, float] = (2, 1),
+        limit: int = DEFAULT_LIMIT,
+    ) -> None:
+        self._search_fn = search_fn
+        self._rate_limiter = AsyncLimiter(*rate_limit)
+        self._limit = limit
+
+    def _get_search_fn(self) -> SearchFn:
+        """Return the searcher, lazily constructing the real ytmusicapi client.
+
+        The import is deferred so that unit tests injecting ``search_fn`` never
+        need ytmusicapi installed, and the service image never pays the import
+        unless the client is actually used.
+        """
+        if self._search_fn is None:
+            from ytmusicapi import YTMusic  # lazy: keep the dep off the test/import path
+
+            yt = YTMusic()
+
+            def search(query: str, filter: str, limit: int) -> list[dict[str, Any]]:  # noqa: A002
+                # ytmusicapi types `filter` as a Literal of allowed strings; our
+                # injectable SearchFn seam widens it to `str`. The only caller
+                # (`search_album`) always passes `_ALBUMS_FILTER` ("albums"), a
+                # valid member, so this narrowing is safe. The ignore is inert in
+                # CI (ytmusicapi is a `drain` extra, absent under `.[dev]`, so the
+                # module is Any) and only bites when the extra is installed.
+                return yt.search(query, filter=filter, limit=limit)  # type: ignore[arg-type]
+
+            self._search_fn = search
+        return self._search_fn
+
+    async def search_album(self, artist: str, title: str) -> list[dict[str, Any]]:
+        """Search YouTube Music for ``(artist, title)`` album candidates.
+
+        Runs the synchronous ytmusicapi call in a worker thread so the coroutine
+        never blocks the event loop. Returns candidate rows filtered to those
+        carrying both a ``browseId`` and a ``title`` — dropping browse-less rows
+        here guarantees a winning candidate can never yield a
+        ``.../browse/None`` URL. Returns ``[]`` on any search error (the drain
+        treats a raise as a skip, not a fatal).
+        """
+        query = f"{artist} {title}".strip()
+        search = self._get_search_fn()
+        await self._rate_limiter.acquire()
+        try:
+            results = await asyncio.to_thread(search, query, _ALBUMS_FILTER, self._limit)
+        except Exception:
+            logger.exception("YouTube Music search failed for %s - %s", artist, title)
+            return []
+        return [r for r in results if r.get("browseId") and r.get("title")]
+
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        """Return the best 80/80-clearing album match as a ``SourceMatch``.
+
+        See ``BaseStreamingClient.find_album_match`` for the contract. The
+        ytmusicapi response shape (``artists[0].name`` / ``title`` /
+        ``browseId``) is encapsulated in the extractor lambdas here.
+        """
+        return find_best_source_match(
+            await self.search_album(artist, title),
+            artist,
+            title,
+            artist_fn=lambda x: x["artists"][0]["name"],
+            title_fn=lambda x: x["title"],
+            url_fn=lambda x: build_browse_url(x["browseId"]),
+            service="youtube_music",
+        )

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -326,3 +326,22 @@ uv run python -m scripts.resolve_apple_urls \
 ```
 
 The emitted `apple_urls.tsv` is applied back via the Backend-Service fill-only write (SELECT-before / count-after; never overwrites a non-null URL).
+
+## YouTube Music Coverage Drain (`scripts/ytm_coverage_drain.py`)
+
+Resolves verified `music.youtube.com/browse/<browseId>` album links for a set of canonical `(artist, title)` candidates (epic [LML#830](https://github.com/WXYC/library-metadata-lookup/issues/830), impl [LML#1056](https://github.com/WXYC/library-metadata-lookup/issues/1056); GO from the [#833](https://github.com/WXYC/library-metadata-lookup/issues/833) spike). Uses `YouTubeMusicClient` (`clients/streaming/youtube_music.py`) — unauthenticated `ytmusicapi` album search, scored through the shared production matcher (`find_best_source_match`, 80/80 floor). Per-candidate exceptions are isolated (a malformed search becomes a miss, never aborts the run).
+
+**Write path — Option A.** Persistence is fill-only into `streaming_availability.db` (`ResultsDB.update_youtube_music_url`, `WHERE youtube_music_url IS NULL`). The rest of the chain already exists: `scripts/export_streaming_links.py` carries `albums.youtube_music_url` into `library.db.streaming_links` and `/lookup` surfaces it — this drain is the producer. Each match maps back to its `albums` row by normalized `(artist, title)` (`get_album_id_by_names`, same normalizer as the dedup pipeline), so there is no drift; unmatched candidates are tallied and skipped, never wrong-written.
+
+`ytmusicapi` is the optional `drain` extra (not a runtime dep; lazy import) — run under `--extra drain`. `--execute` is opt-in; the default is dry-run (writes nothing). Persisting is the operator's action (off-peak, fill-only, one bulk consumer at a time), followed by a `POST /admin/upload-streaming-db` republish.
+
+```bash
+# dry-run: resolve + coverage report (count, hit rate, sample matches/misses)
+uv run --extra drain python -m scripts.ytm_coverage_drain \
+  --sample-csv resolved_names.csv --limit 200 --concurrency 4 \
+  --report-json /tmp/ytm_drain_report.json
+
+# persist (opt-in, fill-only) into the streaming_availability store
+uv run --extra drain python -m scripts.ytm_coverage_drain \
+  --sample-csv resolved_names.csv --execute --results-db streaming_availability.db
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,16 @@ dev = [
     # marker needed — it patches botocore's HTTP layer, so no network or service.
     "moto[s3]>=5.0.0",
 ]
+# ytmusicapi backs the offline YouTube Music coverage drain (LML#1056). It is an
+# *extra*, not a runtime dependency: the client's import is lazy and the service
+# never resolves YouTube Music on the /lookup hot path, so the deploy image stays
+# lean. Pinned exactly (not >=) because it is a reverse-engineered web client
+# whose internal API Google changes periodically — a silent minor bump could
+# break the drain mid-run; bumps should be deliberate, changelog-reviewed PRs.
+# Run the drain with `uv run --extra drain python -m scripts.ytm_coverage_drain`.
+drain = [
+    "ytmusicapi==1.12.1",
+]
 
 [build-system]
 requires = ["setuptools>=65.0", "wheel"]

--- a/scripts/streaming_availability/results_db.py
+++ b/scripts/streaming_availability/results_db.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 import aiosqlite
 
+from clients.streaming.matching import normalize_album_title, normalize_artist_name
 from scripts.streaming_availability.dedup import DeduplicatedAlbum
 
 _SCHEMA = """
@@ -119,8 +120,17 @@ class ResultsDB:
             ("bandcamp_url", "TEXT"),
             ("bandcamp_status", "TEXT NOT NULL DEFAULT 'pending'"),
             ("bandcamp_checked_at", "TEXT"),
+            # YouTube Music coverage drain (#1056). The drain fills youtube_music_url
+            # offline; export_streaming_links.py already carries it into
+            # library.db.streaming_links and /lookup already surfaces it. On prod the
+            # url column predates ResultsDB (earlier pipeline era) so this ALTER is a
+            # no-op there and only the status/checked_at markers are added.
+            ("youtube_music_url", "TEXT"),
+            ("youtube_music_status", "TEXT NOT NULL DEFAULT 'pending'"),
+            ("youtube_music_checked_at", "TEXT"),
         ]
         bandcamp_status_added = "bandcamp_status" not in columns
+        youtube_music_status_added = "youtube_music_status" not in columns
         for col_name, col_type in migrations:
             if col_name not in columns:
                 await self._db.execute(f"ALTER TABLE albums ADD COLUMN {col_name} {col_type}")
@@ -129,6 +139,10 @@ class ResultsDB:
         await self._db.execute(
             "CREATE INDEX IF NOT EXISTS idx_albums_bandcamp_status ON albums(bandcamp_status)"
         )
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_albums_youtube_music_status "
+            "ON albums(youtube_music_status)"
+        )
         if bandcamp_status_added:
             # The ALTER stamps 'pending' on every existing row; rows that already
             # carry a resolved URL are really 'found'. Backfill so the marker is
@@ -136,6 +150,14 @@ class ResultsDB:
             await self._db.execute(
                 "UPDATE albums SET bandcamp_status = 'found' "
                 "WHERE bandcamp_url IS NOT NULL AND bandcamp_status = 'pending'"
+            )
+        if youtube_music_status_added:
+            # Same #661 backfill for the youtube_music marker: a prod row carrying a
+            # url from the earlier pipeline era is 'found', not 'pending', so a
+            # fill-only drain skips it and reporting stays trustworthy.
+            await self._db.execute(
+                "UPDATE albums SET youtube_music_status = 'found' "
+                "WHERE youtube_music_url IS NOT NULL AND youtube_music_status = 'pending'"
             )
 
     async def close(self) -> None:
@@ -296,6 +318,7 @@ class ResultsDB:
             "discogs": {},
             "deezer": {},
             "bandcamp": {},
+            "youtube_music": {},
             "total": 0,
         }
 
@@ -303,7 +326,7 @@ class ResultsDB:
         row = await cursor.fetchone()
         stats["total"] = row[0] if row else 0
 
-        for service in ("spotify", "apple", "discogs", "deezer", "bandcamp"):
+        for service in ("spotify", "apple", "discogs", "deezer", "bandcamp", "youtube_music"):
             col = f"{service}_status"
             cursor = await self._db.execute(
                 f"SELECT {col}, COUNT(*) FROM albums GROUP BY {col}"  # noqa: S608
@@ -363,6 +386,48 @@ class ResultsDB:
                 (now, album_id),
             )
             await self._db.commit()
+
+    async def update_youtube_music_url(self, album_id: int, url: str) -> bool:
+        """Fill in a verified YouTube Music album URL -- **fill-only**.
+
+        The write only lands when ``youtube_music_url IS NULL``, so an already
+        resolved (top-priority) link is never clobbered by a later, lower-value
+        pass (Data Safety). On a fill it also stamps the ``found`` status marker
+        and ``checked_at`` so the row is excluded from future pending scans and
+        attempted-vs-resolved reporting stays trustworthy (the #669/#661 lesson).
+
+        Returns ``True`` if a row was filled, ``False`` if it was a no-op
+        (already had a url, or no such album) -- lets the #1056 drain tally
+        written-vs-already-present without a follow-up read.
+        """
+        assert self._db is not None
+        async with self._write_lock:
+            now = datetime.now(UTC).isoformat()
+            cursor = await self._db.execute(
+                "UPDATE albums SET youtube_music_url = ?, youtube_music_status = 'found', "
+                "youtube_music_checked_at = ? WHERE id = ? AND youtube_music_url IS NULL",
+                (url, now, album_id),
+            )
+            await self._db.commit()
+            return cursor.rowcount > 0
+
+    async def get_album_id_by_names(self, artist: str, title: str) -> int | None:
+        """Resolve an album's id from raw ``(artist, title)``.
+
+        Normalizes with the same ``normalize_artist_name`` /
+        ``normalize_album_title`` the dedup pipeline keyed rows with (dedup.py),
+        so a producer resolving names from any source (e.g. the #1056 drain's
+        discogs-cache join) maps to the stored row with zero normalization
+        drift. Returns ``None`` when no row matches. The ``UNIQUE(normalized_
+        artist, normalized_title)`` constraint guarantees at most one match.
+        """
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT id FROM albums WHERE normalized_artist = ? AND normalized_title = ?",
+            (normalize_artist_name(artist), normalize_album_title(title)),
+        )
+        row = await cursor.fetchone()
+        return int(row[0]) if row else None
 
     async def get_artists_without_bandcamp_slug(
         self,

--- a/scripts/ytm_coverage_drain.py
+++ b/scripts/ytm_coverage_drain.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python3
-"""YouTube Music coverage drain — dry-run harness (LML#1056).
+"""YouTube Music coverage drain (LML#1056).
 
 Resolves verified ``music.youtube.com/browse/<browseId>`` album links for a set
 of canonical ``(artist, title)`` candidates via :class:`YouTubeMusicClient`
-(80/80 floor, shared production matcher) and emits a coverage report. It is the
-first acceptance criterion of #1056 ("dry-run report: candidate count, projected
-hit rate, sample matches") and is deliberately **read-only**: the persistence
-step is gated behind :func:`execute_write`, which raises until the write-path
-design fork (#1056 / #1052) is settled.
+(80/80 floor, shared production matcher), emits a coverage report, and -- under
+the explicit ``--execute`` opt-in -- fill-only-persists the matches.
+
+Write path (Option A of the #1056 / #1052 fork)
+-----------------------------------------------
+Persistence goes to ``streaming_availability.db`` -- LML's authoritative,
+top-priority offline link store -- via :meth:`ResultsDB.update_youtube_music_url`
+(fill-only). The rest of the chain already exists: ``export_streaming_links.py``
+copies ``albums.youtube_music_url`` into ``library.db.streaming_links`` and
+``/lookup`` surfaces it, so this drain is the last missing piece, the producer.
+The sibling ``lml_cache.album_streaming_url_cache`` (Option B) is reserved for
+#1052's runtime/rowless population, which cannot reach this library-keyed store.
 
 Candidate source
 ----------------
@@ -17,19 +24,26 @@ has **no** ``artist``/``title`` columns — so the canonical ``(artist, title)``
 obtained by resolving ``discogs_release_id`` against the discogs-cache release
 table, exactly as the #525 cache warmer's ``_refresh_discogs_release`` does. That
 join runs in the discogs-cache PostgreSQL and needs prod credentials plus a human
-go-ahead, so it is out of scope for this dry-run harness. The operator supplies
+go-ahead, so it is out of scope for this harness. The operator supplies
 already-resolved rows and this module stays schema-agnostic via
 :func:`load_candidates_from_rows`; :func:`load_candidates_from_csv` is the
-credential-free path for a local sample.
+credential-free path for a local sample. :func:`execute_write` then maps each
+match back to its ``albums`` row by normalized ``(artist, title)`` -- the same
+key the dedup pipeline wrote -- so there is no normalization drift.
 
-Usage (dry-run only)
---------------------
+Usage
+-----
+    # dry-run (default): resolve + report, write nothing
     uv run python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
         --limit 200 --concurrency 4 --report-json /tmp/ytm_drain_report.json
 
-``--execute`` exists but is a tripwire: it raises :class:`WritePathNotResolvedError`
-so no prod write can happen before the fork is resolved. Persisting is the user's
-action, off-peak, fill-only, one bulk LML consumer at a time.
+    # persist (opt-in, fill-only): add --execute + the target DB
+    uv run python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
+        --execute --results-db streaming_availability.db
+
+Persisting is the user's action -- off-peak, fill-only, one bulk LML consumer at
+a time -- and republishing to prod is a separate ``POST /admin/upload-streaming-db``
+step.
 """
 
 from __future__ import annotations
@@ -44,6 +58,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from clients.streaming.youtube_music import YouTubeMusicClient
+from scripts.streaming_availability.results_db import ResultsDB
 from streaming.models import SourceMatch
 
 log = logging.getLogger("ytm_coverage_drain")
@@ -52,12 +67,7 @@ DEFAULT_CONCURRENCY = 4
 DEFAULT_SAMPLE_SIZE = 15
 DEFAULT_RATE = 2.0
 DEFAULT_SEARCH_LIMIT = 5
-
-
-class WritePathNotResolvedError(RuntimeError):
-    """Raised when ``--execute`` / :func:`execute_write` is used before the
-    #1056 / #1052 write-path design fork (warmer leg vs. direct cache upsert)
-    is resolved. The dry-run path never persists, so this is a hard tripwire."""
+DEFAULT_RESULTS_DB_PATH = "streaming_availability.db"
 
 
 @dataclass(frozen=True)
@@ -159,21 +169,50 @@ def summarize(
     }
 
 
-def execute_write(matched_outcomes: Sequence[DrainOutcome]) -> None:
-    """Persist verified links (fill-only) — GATED, not yet implemented.
+async def execute_write(
+    matched_outcomes: Sequence[DrainOutcome],
+    *,
+    db_path: str = DEFAULT_RESULTS_DB_PATH,
+) -> dict[str, int]:
+    """Fill-only-persist verified YTM links into the streaming_availability store.
 
-    The write path is intentionally unbuilt: #1056 and #1052 share an open
-    design fork over *how* to persist (wire a ``youtube_music`` leg into the
-    ``refresh-for-identities`` dispatcher, the approach rejected for the sibling
-    legs in #548/#549 — versus a direct fill-only upsert into
-    ``lml_cache.album_streaming_url_cache``). Until that is resolved with the
-    user, invoking the write path raises rather than guessing.
+    Option A of the #1056 write-path fork: ``streaming_availability.db`` is the
+    authoritative, top-priority offline link store. Each match maps to its
+    ``albums`` row by normalized ``(artist, title)`` -- the exact key the dedup
+    pipeline wrote -- and ``youtube_music_url`` is filled only when NULL, so a
+    resolved (higher-priority) link is never clobbered (Data Safety; #669). The
+    rest of the chain already exists: ``export_streaming_links.py`` carries the
+    column into ``library.db.streaming_links`` and ``/lookup`` surfaces it, so
+    this is the last missing piece -- the producer.
+
+    Returns a tally ``{written, already_present, unmatched}``. A candidate whose
+    normalized ``(artist, title)`` has no ``albums`` row is counted ``unmatched``
+    and skipped (never a wrong write). Default is dry-run: this runs only under
+    the explicit ``--execute`` opt-in, off-peak, one bulk consumer at a time.
     """
-    raise WritePathNotResolvedError(
-        "YTM drain write path is gated on the #1056/#1052 design fork "
-        "(refresh-for-identities leg vs. direct streaming_url_cache upsert). "
-        f"Refusing to persist {len(matched_outcomes)} matches. Dry-run writes nothing."
-    )
+    tally = {"written": 0, "already_present": 0, "unmatched": 0}
+    db = ResultsDB(db_path)
+    await db.connect()
+    try:
+        for outcome in matched_outcomes:
+            if outcome.match is None:  # defensive: caller passes matches only
+                continue
+            album_id = await db.get_album_id_by_names(
+                outcome.candidate.artist, outcome.candidate.title
+            )
+            if album_id is None:
+                tally["unmatched"] += 1
+                log.warning(
+                    "no albums row for %r - %r; skipping YTM url write",
+                    outcome.candidate.artist,
+                    outcome.candidate.title,
+                )
+                continue
+            wrote = await db.update_youtube_music_url(album_id, outcome.match.url)
+            tally["written" if wrote else "already_present"] += 1
+    finally:
+        await db.close()
+    return tally
 
 
 async def _run(args: argparse.Namespace) -> dict[str, Any]:
@@ -196,8 +235,19 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
         100 * report["hit_rate"],
     )
     if args.execute:
-        # Tripwire: raises until the write-path fork is resolved.
-        execute_write([o for o in outcomes if o.match is not None])
+        # Opt-in, fill-only persistence into the streaming_availability store
+        # (Option A). Default path is dry-run and writes nothing.
+        tally = await execute_write(
+            [o for o in outcomes if o.match is not None], db_path=args.results_db
+        )
+        report["write"] = tally
+        log.info(
+            "persisted YTM links: %d written, %d already present, %d unmatched (db=%s)",
+            tally["written"],
+            tally["already_present"],
+            tally["unmatched"],
+            args.results_db,
+        )
     print(json.dumps(report, indent=2, ensure_ascii=False))
     if args.report_json:
         with open(args.report_json, "w", encoding="utf-8") as f:
@@ -226,9 +276,14 @@ def main(argv: Sequence[str] | None = None) -> dict[str, Any]:
     parser.add_argument("--sample-size", type=int, default=DEFAULT_SAMPLE_SIZE)
     parser.add_argument("--report-json", default=None, help="Optional path to write the report.")
     parser.add_argument(
+        "--results-db",
+        default=DEFAULT_RESULTS_DB_PATH,
+        help="streaming_availability.db path to fill-only-persist into under --execute.",
+    )
+    parser.add_argument(
         "--execute",
         action="store_true",
-        help="(GATED) persist matches — raises until the #1056/#1052 write-path fork is resolved.",
+        help="Opt-in: fill-only-persist matches into --results-db (default: dry-run, writes nothing).",
     )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")

--- a/scripts/ytm_coverage_drain.py
+++ b/scripts/ytm_coverage_drain.py
@@ -33,12 +33,16 @@ key the dedup pipeline wrote -- so there is no normalization drift.
 
 Usage
 -----
+``ytmusicapi`` lives in the ``drain`` extra (not ``dev``), and ``_run`` always
+builds a real client, so the drain must run under ``--extra drain`` or the lazy
+``from ytmusicapi import YTMusic`` raises ``ModuleNotFoundError``.
+
     # dry-run (default): resolve + report, write nothing
-    uv run python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
+    uv run --extra drain python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
         --limit 200 --concurrency 4 --report-json /tmp/ytm_drain_report.json
 
     # persist (opt-in, fill-only): add --execute + the target DB
-    uv run python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
+    uv run --extra drain python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
         --execute --results-db streaming_availability.db
 
 Persisting is the user's action -- off-peak, fill-only, one bulk LML consumer at
@@ -136,7 +140,16 @@ async def resolve_candidates(
 
     async def _one(c: Candidate) -> DrainOutcome:
         async with sem:
-            match = await client.find_album_match(c.artist, c.title)
+            try:
+                match = await client.find_album_match(c.artist, c.title)
+            except Exception:
+                # One malformed search must not abort the whole run. The shared
+                # matcher re-raises when every result row fails extraction
+                # (clients/streaming/matching.py, LML#640/#376) -- e.g. a YTM
+                # result set whose rows all lack `artists`. Treat as a miss,
+                # mirroring the /streaming-check orchestrator's per-task isolation.
+                log.exception("resolve failed for %r - %r; recording a miss", c.artist, c.title)
+                return DrainOutcome(candidate=c, match=None)
         return DrainOutcome(candidate=c, match=match)
 
     return list(await asyncio.gather(*(_one(c) for c in candidates)))

--- a/scripts/ytm_coverage_drain.py
+++ b/scripts/ytm_coverage_drain.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""YouTube Music coverage drain — dry-run harness (LML#1056).
+
+Resolves verified ``music.youtube.com/browse/<browseId>`` album links for a set
+of canonical ``(artist, title)`` candidates via :class:`YouTubeMusicClient`
+(80/80 floor, shared production matcher) and emits a coverage report. It is the
+first acceptance criterion of #1056 ("dry-run report: candidate count, projected
+hit rate, sample matches") and is deliberately **read-only**: the persistence
+step is gated behind :func:`execute_write`, which raises until the write-path
+design fork (#1056 / #1052) is settled.
+
+Candidate source
+----------------
+The real drain drives off ``entity.release_identity``. That table carries only
+per-source external IDs (``discogs_release_id``, ``discogs_master_id``, …) — it
+has **no** ``artist``/``title`` columns — so the canonical ``(artist, title)`` is
+obtained by resolving ``discogs_release_id`` against the discogs-cache release
+table, exactly as the #525 cache warmer's ``_refresh_discogs_release`` does. That
+join runs in the discogs-cache PostgreSQL and needs prod credentials plus a human
+go-ahead, so it is out of scope for this dry-run harness. The operator supplies
+already-resolved rows and this module stays schema-agnostic via
+:func:`load_candidates_from_rows`; :func:`load_candidates_from_csv` is the
+credential-free path for a local sample.
+
+Usage (dry-run only)
+--------------------
+    uv run python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
+        --limit 200 --concurrency 4 --report-json /tmp/ytm_drain_report.json
+
+``--execute`` exists but is a tripwire: it raises :class:`WritePathNotResolvedError`
+so no prod write can happen before the fork is resolved. Persisting is the user's
+action, off-peak, fill-only, one bulk LML consumer at a time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import logging
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from clients.streaming.youtube_music import YouTubeMusicClient
+from streaming.models import SourceMatch
+
+log = logging.getLogger("ytm_coverage_drain")
+
+DEFAULT_CONCURRENCY = 4
+DEFAULT_SAMPLE_SIZE = 15
+DEFAULT_RATE = 2.0
+DEFAULT_SEARCH_LIMIT = 5
+
+
+class WritePathNotResolvedError(RuntimeError):
+    """Raised when ``--execute`` / :func:`execute_write` is used before the
+    #1056 / #1052 write-path design fork (warmer leg vs. direct cache upsert)
+    is resolved. The dry-run path never persists, so this is a hard tripwire."""
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A canonical album to look up on YouTube Music."""
+
+    artist: str
+    title: str
+    discogs_release_id: int | None = None
+    identity_id: int | None = None
+
+
+@dataclass(frozen=True)
+class DrainOutcome:
+    """A candidate paired with its resolved match (``None`` = no 80/80 clear)."""
+
+    candidate: Candidate
+    match: SourceMatch | None
+
+
+def load_candidates_from_rows(
+    rows: Iterable[dict[str, Any]],
+    *,
+    artist_key: str,
+    title_key: str,
+    id_key: str | None = None,
+    identity_key: str | None = None,
+) -> list[Candidate]:
+    """Adapt already-resolved rows into :class:`Candidate` objects.
+
+    Schema-agnostic on purpose: the operator's discogs-cache join can project
+    the canonical artist/title under any column names. Rows with a blank or
+    null artist or title are skipped (they cannot be searched meaningfully).
+    """
+    out: list[Candidate] = []
+    for r in rows:
+        artist = str(r.get(artist_key) or "").strip()
+        title = str(r.get(title_key) or "").strip()
+        if not artist or not title:
+            continue
+        out.append(
+            Candidate(
+                artist=artist,
+                title=title,
+                discogs_release_id=r.get(id_key) if id_key else None,
+                identity_id=r.get(identity_key) if identity_key else None,
+            )
+        )
+    return out
+
+
+def load_candidates_from_csv(path: str) -> list[Candidate]:
+    """Load candidates from a CSV with an ``artist,title`` header (dry-run path)."""
+    with open(path, newline="", encoding="utf-8") as f:
+        return load_candidates_from_rows(csv.DictReader(f), artist_key="artist", title_key="title")
+
+
+async def resolve_candidates(
+    client: YouTubeMusicClient,
+    candidates: Sequence[Candidate],
+    *,
+    concurrency: int = DEFAULT_CONCURRENCY,
+) -> list[DrainOutcome]:
+    """Resolve every candidate concurrently (bounded), preserving input order."""
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _one(c: Candidate) -> DrainOutcome:
+        async with sem:
+            match = await client.find_album_match(c.artist, c.title)
+        return DrainOutcome(candidate=c, match=match)
+
+    return list(await asyncio.gather(*(_one(c) for c in candidates)))
+
+
+def summarize(
+    outcomes: Sequence[DrainOutcome], *, sample_size: int = DEFAULT_SAMPLE_SIZE
+) -> dict[str, Any]:
+    """Aggregate outcomes into a JSON-serializable coverage report."""
+    resolved = [o for o in outcomes if o.match is not None]
+    misses = [o for o in outcomes if o.match is None]
+    n = len(outcomes)
+    return {
+        "candidates": n,
+        "resolved": len(resolved),
+        "misses": len(misses),
+        "hit_rate": (len(resolved) / n) if n else 0.0,
+        "sample_matches": [
+            {
+                "artist": o.candidate.artist,
+                "title": o.candidate.title,
+                "url": o.match.url,  # type: ignore[union-attr]  # resolved => match is not None
+                "confidence": o.match.confidence,  # type: ignore[union-attr]
+            }
+            for o in resolved[:sample_size]
+        ],
+        "sample_misses": [
+            {"artist": o.candidate.artist, "title": o.candidate.title} for o in misses[:sample_size]
+        ],
+    }
+
+
+def execute_write(matched_outcomes: Sequence[DrainOutcome]) -> None:
+    """Persist verified links (fill-only) — GATED, not yet implemented.
+
+    The write path is intentionally unbuilt: #1056 and #1052 share an open
+    design fork over *how* to persist (wire a ``youtube_music`` leg into the
+    ``refresh-for-identities`` dispatcher, the approach rejected for the sibling
+    legs in #548/#549 — versus a direct fill-only upsert into
+    ``lml_cache.album_streaming_url_cache``). Until that is resolved with the
+    user, invoking the write path raises rather than guessing.
+    """
+    raise WritePathNotResolvedError(
+        "YTM drain write path is gated on the #1056/#1052 design fork "
+        "(refresh-for-identities leg vs. direct streaming_url_cache upsert). "
+        f"Refusing to persist {len(matched_outcomes)} matches. Dry-run writes nothing."
+    )
+
+
+async def _run(args: argparse.Namespace) -> dict[str, Any]:
+    candidates = load_candidates_from_csv(args.sample_csv)
+    if args.limit:
+        candidates = candidates[: args.limit]
+    log.info(
+        "resolving %d candidates against YouTube Music (concurrency=%d, rate=%.1f/s)",
+        len(candidates),
+        args.concurrency,
+        args.rate,
+    )
+    client = YouTubeMusicClient(rate_limit=(args.rate, 1), limit=args.search_limit)
+    outcomes = await resolve_candidates(client, candidates, concurrency=args.concurrency)
+    report = summarize(outcomes, sample_size=args.sample_size)
+    log.info(
+        "resolved %d/%d (%.1f%%)",
+        report["resolved"],
+        report["candidates"],
+        100 * report["hit_rate"],
+    )
+    if args.execute:
+        # Tripwire: raises until the write-path fork is resolved.
+        execute_write([o for o in outcomes if o.match is not None])
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    if args.report_json:
+        with open(args.report_json, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+        log.info("wrote report to %s", args.report_json)
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> dict[str, Any]:
+    parser = argparse.ArgumentParser(
+        description="YouTube Music coverage drain — dry-run harness (LML#1056)."
+    )
+    parser.add_argument(
+        "--sample-csv",
+        required=True,
+        help="CSV with an 'artist,title' header holding resolved canonical names.",
+    )
+    parser.add_argument("--limit", type=int, default=0, help="Cap candidates (0 = all).")
+    parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
+    parser.add_argument(
+        "--rate", type=float, default=DEFAULT_RATE, help="Max YouTube Music searches per second."
+    )
+    parser.add_argument(
+        "--search-limit", type=int, default=DEFAULT_SEARCH_LIMIT, help="Candidates per YTM search."
+    )
+    parser.add_argument("--sample-size", type=int, default=DEFAULT_SAMPLE_SIZE)
+    parser.add_argument("--report-json", default=None, help="Optional path to write the report.")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="(GATED) persist matches — raises until the #1056/#1052 write-path fork is resolved.",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_results_db.py
+++ b/tests/unit/test_results_db.py
@@ -764,3 +764,33 @@ class TestYouTubeMusicMigrationOnExistingDb:
             assert rows[0]["youtube_music_url"] == "https://music.youtube.com/browse/MPREb_pre"
         finally:
             await db.close()
+
+    @pytest.mark.asyncio
+    async def test_backfill_runs_once_and_preserves_manual_reset(self, tmp_path):
+        # The pending->found backfill must run only when youtube_music_status is
+        # first added, so a later connect never re-stamps a row an operator
+        # deliberately reset to 'pending' (URL kept) to force a re-attempt.
+        # Removing the youtube_music_status_added guard would clobber that reset
+        # -- this is the regression fence (mirrors the bandcamp analog).
+        path = str(tmp_path / "reset.db")
+
+        db = ResultsDB(path)
+        await db.connect()
+        try:
+            await db.insert_albums([_make_album()])
+            album_id = (await db.get_pending("spotify", limit=10))[0]["id"]
+            await db.update_youtube_music_url(album_id, "https://music.youtube.com/browse/MPREb_x")
+            await db._db.execute(
+                "UPDATE albums SET youtube_music_status = 'pending' WHERE id = ?", (album_id,)
+            )
+            await db._db.commit()
+        finally:
+            await db.close()
+
+        db2 = ResultsDB(path)
+        await db2.connect()
+        try:
+            rows = await db2.get_all_results()
+            assert rows[0]["youtube_music_status"] == "pending"
+        finally:
+            await db2.close()

--- a/tests/unit/test_results_db.py
+++ b/tests/unit/test_results_db.py
@@ -6,6 +6,7 @@ import aiosqlite
 import pytest
 import pytest_asyncio
 
+from clients.streaming.matching import normalize_album_title, normalize_artist_name
 from scripts.streaming_availability.dedup import DeduplicatedAlbum
 from scripts.streaming_availability.results_db import ResultsDB
 
@@ -597,3 +598,169 @@ class TestBandcampStatusMigrationOnExistingDb:
             assert rows[0]["bandcamp_status"] == "pending"
         finally:
             await db2.close()
+
+
+class TestYouTubeMusicFillOnlyWrite:
+    """Fill-only youtube_music_url writer for the #1056 YTM coverage drain.
+
+    The drain resolves verified music.youtube.com/browse/<id> links offline and
+    writes them into the authoritative streaming_availability store (Option A of
+    the #1056 / #1052 write-path fork). Writes are fill-only: a resolved URL is
+    the top-priority link and must never be clobbered by a later, lower-value
+    pass (Data Safety; the #669 status-marker lesson).
+    """
+
+    @pytest.mark.asyncio
+    async def test_columns_exist_and_default(self, db):
+        await db.insert_albums([_make_album()])
+        rows = await db.get_pending("spotify", limit=10)
+        assert rows[0]["youtube_music_url"] is None
+        assert rows[0]["youtube_music_status"] == "pending"
+        assert rows[0]["youtube_music_checked_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_write_sets_url_status_and_timestamp(self, db):
+        await db.insert_albums([_make_album()])
+        album_id = (await db.get_pending("spotify", limit=10))[0]["id"]
+        url = "https://music.youtube.com/browse/MPREb_stereolab"
+        wrote = await db.update_youtube_music_url(album_id, url)
+        assert wrote is True
+        rows = await db.get_pending("spotify", limit=10)
+        assert rows[0]["youtube_music_url"] == url
+        assert rows[0]["youtube_music_status"] == "found"
+        assert rows[0]["youtube_music_checked_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_fill_only_does_not_overwrite_existing_url(self, db):
+        await db.insert_albums([_make_album()])
+        album_id = (await db.get_pending("spotify", limit=10))[0]["id"]
+        first = "https://music.youtube.com/browse/MPREb_first"
+        await db.update_youtube_music_url(album_id, first)
+        wrote = await db.update_youtube_music_url(
+            album_id, "https://music.youtube.com/browse/MPREb_second"
+        )
+        assert wrote is False  # already filled -> no-op
+        rows = await db.get_pending("spotify", limit=10)
+        assert rows[0]["youtube_music_url"] == first  # original preserved
+
+    @pytest.mark.asyncio
+    async def test_write_to_missing_album_is_noop(self, db):
+        wrote = await db.update_youtube_music_url(9999, "https://music.youtube.com/browse/MPREb_x")
+        assert wrote is False
+
+    @pytest.mark.asyncio
+    async def test_get_stats_includes_youtube_music(self, db):
+        await db.insert_albums([_make_album()])
+        album_id = (await db.get_pending("spotify", limit=10))[0]["id"]
+        await db.update_youtube_music_url(album_id, "https://music.youtube.com/browse/MPREb_x")
+        stats = await db.get_stats()
+        assert stats["youtube_music"]["found"] == 1
+
+
+class TestGetAlbumIdByNames:
+    """execute_write maps a resolved candidate to its albums row by normalized
+    (artist, title) -- the exact key the dedup pipeline wrote (dedup.py) -- so
+    there is no normalization drift between producer and store."""
+
+    @pytest.mark.asyncio
+    async def test_finds_row_via_normalized_key(self, db):
+        album = _make_album(
+            normalized_artist=normalize_artist_name("Stereolab"),
+            normalized_title=normalize_album_title("Aluminum Tunes"),
+            display_artist="Stereolab",
+            display_title="Aluminum Tunes",
+        )
+        await db.insert_albums([album])
+        # Raw display-cased names normalize to the stored key.
+        album_id = await db.get_album_id_by_names("Stereolab", "Aluminum Tunes")
+        assert album_id is not None
+        rows = await db.get_pending("spotify", limit=10)
+        assert album_id == rows[0]["id"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_absent(self, db):
+        assert await db.get_album_id_by_names("Nonexistent Artist", "No Such Album") is None
+
+
+class TestYouTubeMusicMigrationOnExistingDb:
+    """Exercise the ALTER path against a DB created before the youtube_music_*
+    columns -- a CREATE-only definition would pass on a fresh DB but silently
+    miss the columns on a pre-existing file (the same regression fence as
+    TestBandcampStatusMigrationOnExistingDb)."""
+
+    OLD_SCHEMA = """
+        CREATE TABLE albums (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            normalized_artist TEXT NOT NULL,
+            normalized_title TEXT NOT NULL,
+            display_artist TEXT NOT NULL,
+            display_title TEXT NOT NULL,
+            library_ids TEXT NOT NULL,
+            formats TEXT NOT NULL,
+            is_compilation INTEGER NOT NULL DEFAULT 0,
+            spotify_status TEXT NOT NULL DEFAULT 'pending',
+            apple_status TEXT NOT NULL DEFAULT 'pending',
+            youtube_music_url TEXT,
+            UNIQUE(normalized_artist, normalized_title)
+        )
+    """
+
+    async def _make_old_db(self, path: str, *, url: str | None) -> None:
+        conn = await aiosqlite.connect(path)
+        try:
+            await conn.executescript(self.OLD_SCHEMA)
+            await conn.execute(
+                "INSERT INTO albums "
+                "(normalized_artist, normalized_title, display_artist, display_title, "
+                " library_ids, formats, youtube_music_url) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "stereolab",
+                    "aluminum tunes",
+                    "Stereolab",
+                    "Aluminum Tunes",
+                    "[1]",
+                    '["cd"]',
+                    url,
+                ),
+            )
+            await conn.commit()
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_migration_adds_status_and_checked_at(self, tmp_path):
+        path = str(tmp_path / "old.db")
+        await self._make_old_db(path, url=None)
+
+        db = ResultsDB(path)
+        await db.connect()
+        try:
+            rows = await db.get_all_results()
+            assert rows[0]["youtube_music_status"] == "pending"
+            assert rows[0]["youtube_music_checked_at"] is None
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_migration_backfills_found_for_resolved_url(self, tmp_path):
+        # A row that already carries a url (from the earlier pipeline era) must be
+        # marked 'found', not left 'pending', so attempted-vs-resolved reporting is
+        # trustworthy and a fill-only pass skips it (#661 pattern).
+        path = str(tmp_path / "old.db")
+        await self._make_old_db(path, url="https://music.youtube.com/browse/MPREb_pre")
+
+        db = ResultsDB(path)
+        await db.connect()
+        try:
+            rows = await db.get_all_results()
+            assert rows[0]["youtube_music_status"] == "found"
+            # Fill-only must not clobber the pre-existing url.
+            wrote = await db.update_youtube_music_url(
+                rows[0]["id"], "https://music.youtube.com/browse/MPREb_new"
+            )
+            assert wrote is False
+            rows = await db.get_all_results()
+            assert rows[0]["youtube_music_url"] == "https://music.youtube.com/browse/MPREb_pre"
+        finally:
+            await db.close()

--- a/tests/unit/test_youtube_music_client.py
+++ b/tests/unit/test_youtube_music_client.py
@@ -1,0 +1,110 @@
+"""Unit tests for clients/streaming/youtube_music.py (LML#1056).
+
+The client is backed by the unofficial, synchronous ``ytmusicapi``, which is
+never imported here: every test injects a fake ``search_fn``, so these run
+without the ytmusicapi dependency and touch no network. This mirrors the
+``client._http = mock`` seam the httpx-based clients use, adapted for a
+sync library.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clients.streaming.youtube_music import YouTubeMusicClient, build_browse_url
+from streaming.models import SourceMatch
+
+
+def _album(
+    title: str = "Aluminum Tunes",
+    artist: str = "Stereolab",
+    browse_id: str | None = "MPREb_stereolab",
+    year: str = "1998",
+) -> dict:
+    """A ytmusicapi ``search(filter='albums')`` result row, per the #833 spike."""
+    return {
+        "title": title,
+        "artists": [{"name": artist, "id": "UCxxx"}],
+        "browseId": browse_id,
+        "year": year,
+        "resultType": "album",
+    }
+
+
+def _fake_search(results: list[dict]):
+    """Fake for ``YTMusic().search(query, filter, limit)`` — ignores the query,
+    returns a fixed candidate list truncated to ``limit``."""
+
+    def search(query: str, filter: str, limit: int) -> list[dict]:  # noqa: A002 (ytm arg name)
+        return list(results)[:limit]
+
+    return search
+
+
+class TestBuildBrowseUrl:
+    def test_builds_direct_music_youtube_browse_url(self):
+        assert build_browse_url("MPREb_abc") == "https://music.youtube.com/browse/MPREb_abc"
+
+
+class TestFindAlbumMatch:
+    @pytest.mark.asyncio
+    async def test_returns_source_match_for_clearing_candidate(self):
+        client = YouTubeMusicClient(search_fn=_fake_search([_album()]))
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert isinstance(match, SourceMatch)
+        assert match.url == "https://music.youtube.com/browse/MPREb_stereolab"
+        assert match.confidence >= 80.0
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_results(self):
+        client = YouTubeMusicClient(search_fn=_fake_search([]))
+        assert await client.find_album_match("Juana Molina", "DOGA") is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_wrong_album_below_floor(self):
+        # Correct artist, unrelated album -> the title axis fails the 80 floor.
+        client = YouTubeMusicClient(
+            search_fn=_fake_search(
+                [_album(title="Some Completely Unrelated Record", artist="Stereolab")]
+            )
+        )
+        assert await client.find_album_match("Stereolab", "Aluminum Tunes") is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_subset_inflation_false_positive(self):
+        # Goya-class artifact (spike LML#833): a short query title/artist buried
+        # inside an unrelated candidate must not clear. The production matcher
+        # scores both axes with score_match (token_sort), not token_set, so the
+        # subset inflation that produced the raw-pass FP is rejected here.
+        client = YouTubeMusicClient(
+            search_fn=_fake_search([_album(artist="Chantal Goya", title="Club Grenadine Sessions")])
+        )
+        assert await client.find_album_match("Grenadine", "Goya") is None
+
+    @pytest.mark.asyncio
+    async def test_skips_candidate_without_browse_id(self):
+        # A candidate missing browseId must never win and yield ".../browse/None".
+        client = YouTubeMusicClient(
+            search_fn=_fake_search([_album(browse_id=None), _album(browse_id="MPREb_good")])
+        )
+        match = await client.find_album_match("Stereolab", "Aluminum Tunes")
+        assert match is not None
+        assert match.url.endswith("MPREb_good")
+
+
+class TestSearchAlbum:
+    @pytest.mark.asyncio
+    async def test_drops_rows_without_browse_id(self):
+        client = YouTubeMusicClient(
+            search_fn=_fake_search([_album(browse_id=None), _album(browse_id="MPREb_ok")])
+        )
+        rows = await client.search_album("Stereolab", "Aluminum Tunes")
+        assert [r["browseId"] for r in rows] == ["MPREb_ok"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_search_raises(self):
+        def boom(query: str, filter: str, limit: int) -> list[dict]:  # noqa: A002
+            raise RuntimeError("ytmusicapi transport error")
+
+        client = YouTubeMusicClient(search_fn=boom)
+        assert await client.search_album("Stereolab", "Aluminum Tunes") == []

--- a/tests/unit/test_ytm_coverage_drain.py
+++ b/tests/unit/test_ytm_coverage_drain.py
@@ -11,10 +11,12 @@ import csv
 
 import pytest
 
+from clients.streaming.matching import normalize_album_title, normalize_artist_name
+from scripts.streaming_availability.dedup import DeduplicatedAlbum
+from scripts.streaming_availability.results_db import ResultsDB
 from scripts.ytm_coverage_drain import (
     Candidate,
     DrainOutcome,
-    WritePathNotResolvedError,
     execute_write,
     load_candidates_from_csv,
     load_candidates_from_rows,
@@ -119,9 +121,76 @@ class TestLoaders:
         assert [c.artist for c in cands] == ["Sessa"]
 
 
-class TestWritePathGated:
-    def test_execute_write_raises_until_fork_resolved(self):
-        # Fill-only persistence is deliberately unimplemented until the
-        # warmer-leg-vs-direct-write fork (#1056 / #1052) is settled.
-        with pytest.raises(WritePathNotResolvedError):
-            execute_write([DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), _match())])
+class TestExecuteWritePersists:
+    """execute_write fill-only-persists verified YTM links into the
+    streaming_availability results DB -- Option A of the #1056 write-path fork.
+    Each match maps to its albums row by normalized (artist, title) and fills
+    youtube_music_url only when NULL, so a resolved link is never clobbered.
+    """
+
+    async def _seed_album(self, db_path: str, artist: str, title: str) -> None:
+        db = ResultsDB(db_path)
+        await db.connect()
+        try:
+            await db.insert_albums(
+                [
+                    DeduplicatedAlbum(
+                        normalized_artist=normalize_artist_name(artist),
+                        normalized_title=normalize_album_title(title),
+                        display_artist=artist,
+                        display_title=title,
+                        library_ids=[1],
+                        formats=["cd"],
+                    )
+                ]
+            )
+        finally:
+            await db.close()
+
+    async def _read_url(self, db_path: str) -> str | None:
+        db = ResultsDB(db_path)
+        await db.connect()
+        try:
+            rows = await db.get_all_results()
+            return rows[0]["youtube_music_url"]
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_fills_matched_url_into_albums_row(self, tmp_path):
+        db_path = str(tmp_path / "sa.db")
+        await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
+        url = "https://music.youtube.com/browse/MPREb_stereolab"
+        outcome = DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), _match(url=url))
+        tally = await execute_write([outcome], db_path=db_path)
+        assert tally == {"written": 1, "already_present": 0, "unmatched": 0}
+        assert await self._read_url(db_path) == url
+
+    @pytest.mark.asyncio
+    async def test_is_fill_only_on_second_run(self, tmp_path):
+        db_path = str(tmp_path / "sa.db")
+        await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
+        first = "https://music.youtube.com/browse/MPREb_first"
+        await execute_write(
+            [DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), _match(url=first))],
+            db_path=db_path,
+        )
+        second = "https://music.youtube.com/browse/MPREb_second"
+        tally = await execute_write(
+            [DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), _match(url=second))],
+            db_path=db_path,
+        )
+        assert tally == {"written": 0, "already_present": 1, "unmatched": 0}
+        assert await self._read_url(db_path) == first  # original preserved
+
+    @pytest.mark.asyncio
+    async def test_unmatched_candidate_is_tallied_not_written(self, tmp_path):
+        db_path = str(tmp_path / "sa.db")
+        await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
+        outcome = DrainOutcome(
+            Candidate("No Such Artist", "No Such Album"),
+            _match(url="https://music.youtube.com/browse/MPREb_ghost"),
+        )
+        tally = await execute_write([outcome], db_path=db_path)
+        assert tally == {"written": 0, "already_present": 0, "unmatched": 1}
+        assert await self._read_url(db_path) is None

--- a/tests/unit/test_ytm_coverage_drain.py
+++ b/tests/unit/test_ytm_coverage_drain.py
@@ -44,6 +44,25 @@ class _FakeClient:
         return self._matches.get((artist, title))
 
 
+class _RaisingClient:
+    """Raises for one (artist, title), matches everything else.
+
+    Mimics the shared matcher's contract of re-raising when every result row
+    fails extraction (``clients/streaming/matching.py``, LML#640/#376) -- e.g. a
+    YTM result set whose rows all lack an ``artists`` key.
+    """
+
+    def __init__(self, raise_on: tuple[str, str]):
+        self._raise_on = raise_on
+        self.calls: list[tuple[str, str]] = []
+
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        self.calls.append((artist, title))
+        if (artist, title) == self._raise_on:
+            raise KeyError("artists")
+        return _match()
+
+
 class TestSummarize:
     def test_counts_and_hit_rate(self):
         outcomes = [
@@ -89,6 +108,19 @@ class TestResolveCandidates:
         cands = [Candidate(f"A{i}", f"T{i}") for i in range(6)]
         outcomes = await resolve_candidates(client, cands, concurrency=3)
         assert [o.candidate.artist for o in outcomes] == [f"A{i}" for i in range(6)]
+
+    @pytest.mark.asyncio
+    async def test_isolates_per_candidate_exceptions(self):
+        # A single malformed search (the matcher re-raises when every row fails
+        # extraction) must become a miss, not abort the whole run and discard
+        # every already-resolved match. Mirrors the /streaming-check orchestrator.
+        client = _RaisingClient(raise_on=("Boom", "Bad"))
+        cands = [Candidate("Boom", "Bad"), Candidate("Stereolab", "Aluminum Tunes")]
+        outcomes = await resolve_candidates(client, cands, concurrency=2)
+        by_artist = {o.candidate.artist: o for o in outcomes}
+        assert by_artist["Boom"].match is None  # raise -> miss
+        assert by_artist["Stereolab"].match is not None  # run continued
+        assert len(client.calls) == 2
 
 
 class TestLoaders:

--- a/tests/unit/test_ytm_coverage_drain.py
+++ b/tests/unit/test_ytm_coverage_drain.py
@@ -1,0 +1,127 @@
+"""Unit tests for scripts/ytm_coverage_drain.py (LML#1056).
+
+Covers the pure/testable seams of the dry-run harness: candidate loading,
+concurrent resolution over an injected client, report summarization, and the
+gated write path. No network, no ytmusicapi, no database.
+"""
+
+from __future__ import annotations
+
+import csv
+
+import pytest
+
+from scripts.ytm_coverage_drain import (
+    Candidate,
+    DrainOutcome,
+    WritePathNotResolvedError,
+    execute_write,
+    load_candidates_from_csv,
+    load_candidates_from_rows,
+    resolve_candidates,
+    summarize,
+)
+from streaming.models import SourceMatch
+
+
+def _match(
+    url: str = "https://music.youtube.com/browse/MPREb_x", conf: float = 95.0
+) -> SourceMatch:
+    return SourceMatch(url=url, confidence=conf)
+
+
+class _FakeClient:
+    """Duck-typed YouTubeMusicClient: returns a preset match per (artist, title)."""
+
+    def __init__(self, matches: dict[tuple[str, str], SourceMatch]):
+        self._matches = matches
+        self.calls: list[tuple[str, str]] = []
+
+    async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
+        self.calls.append((artist, title))
+        return self._matches.get((artist, title))
+
+
+class TestSummarize:
+    def test_counts_and_hit_rate(self):
+        outcomes = [
+            DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), _match()),
+            DrainOutcome(Candidate("Juana Molina", "DOGA"), _match(url=".../browse/MPREb_y")),
+            DrainOutcome(Candidate("So Kalmery", "Obscure LP"), None),
+        ]
+        rep = summarize(outcomes)
+        assert rep["candidates"] == 3
+        assert rep["resolved"] == 2
+        assert rep["misses"] == 1
+        assert rep["hit_rate"] == pytest.approx(2 / 3)
+        assert len(rep["sample_matches"]) == 2
+        assert len(rep["sample_misses"]) == 1
+        assert rep["sample_matches"][0]["url"].startswith("https://music.youtube.com/browse/")
+
+    def test_sample_size_caps_lists(self):
+        outcomes = [DrainOutcome(Candidate(f"A{i}", f"T{i}"), _match()) for i in range(20)]
+        rep = summarize(outcomes, sample_size=5)
+        assert rep["resolved"] == 20
+        assert len(rep["sample_matches"]) == 5
+
+    def test_empty_is_zero_rate_not_div_by_zero(self):
+        rep = summarize([])
+        assert rep["candidates"] == 0
+        assert rep["hit_rate"] == 0.0
+
+
+class TestResolveCandidates:
+    @pytest.mark.asyncio
+    async def test_maps_each_candidate_to_its_match(self):
+        client = _FakeClient({("Stereolab", "Aluminum Tunes"): _match()})
+        cands = [Candidate("Stereolab", "Aluminum Tunes"), Candidate("X", "Y")]
+        outcomes = await resolve_candidates(client, cands, concurrency=2)
+        by_artist = {o.candidate.artist: o for o in outcomes}
+        assert by_artist["Stereolab"].match is not None
+        assert by_artist["X"].match is None
+        assert len(client.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_preserves_input_order(self):
+        client = _FakeClient({})
+        cands = [Candidate(f"A{i}", f"T{i}") for i in range(6)]
+        outcomes = await resolve_candidates(client, cands, concurrency=3)
+        assert [o.candidate.artist for o in outcomes] == [f"A{i}" for i in range(6)]
+
+
+class TestLoaders:
+    def test_load_from_csv_reads_artist_title_header(self, tmp_path):
+        p = tmp_path / "sample.csv"
+        with p.open("w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["artist", "title"])
+            w.writerow(["Stereolab", "Aluminum Tunes"])
+            w.writerow(["Juana Molina", "DOGA"])
+        cands = load_candidates_from_csv(str(p))
+        assert [c.artist for c in cands] == ["Stereolab", "Juana Molina"]
+        assert cands[0].title == "Aluminum Tunes"
+
+    def test_load_from_rows_adapts_arbitrary_keys(self):
+        rows = [{"canon_artist": "Sessa", "canon_title": "Grandeza", "discogs_release_id": 42}]
+        cands = load_candidates_from_rows(
+            rows, artist_key="canon_artist", title_key="canon_title", id_key="discogs_release_id"
+        )
+        assert cands[0].artist == "Sessa"
+        assert cands[0].discogs_release_id == 42
+
+    def test_load_from_rows_skips_blank_or_null_artist_title(self):
+        rows = [
+            {"a": "X", "t": None},
+            {"a": "  ", "t": "Y"},
+            {"a": "Sessa", "t": "Grandeza"},
+        ]
+        cands = load_candidates_from_rows(rows, artist_key="a", title_key="t")
+        assert [c.artist for c in cands] == ["Sessa"]
+
+
+class TestWritePathGated:
+    def test_execute_write_raises_until_fork_resolved(self):
+        # Fill-only persistence is deliberately unimplemented until the
+        # warmer-leg-vs-direct-write fork (#1056 / #1052) is settled.
+        with pytest.raises(WritePathNotResolvedError):
+            execute_write([DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), _match())])

--- a/uv.lock
+++ b/uv.lock
@@ -669,6 +669,9 @@ dev = [
     { name = "pytest-httpx" },
     { name = "ruff" },
 ]
+drain = [
+    { name = "ytmusicapi" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -696,8 +699,9 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.24.0" },
     { name = "wxyc-etl", specifier = ">=0.8.0,<0.9.0" },
     { name = "wxyc-fastapi", extras = ["posthog"], specifier = ">=1.1.0,<2.0.0" },
+    { name = "ytmusicapi", marker = "extra == 'drain'", specifier = "==1.12.1" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "drain"]
 
 [[package]]
 name = "librt"
@@ -1538,4 +1542,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
+]
+
+[[package]]
+name = "ytmusicapi"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/16/f9737ae3a565abaf2e3d106507272f85e43abff6886fb514a22db3a8adaf/ytmusicapi-1.12.1.tar.gz", hash = "sha256:4e33f424db311ece1b9e5f29a51ade46b0697f6e2f284f8a40bcbd7219772755", size = 529510, upload-time = "2026-06-05T16:36:18.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/6d/f7156e7ab9953d09e14ef538de4e92c484169fac19d207b19b9d9eb9c845/ytmusicapi-1.12.1-py3-none-any.whl", hash = "sha256:2a53f6df504b97b93a4d41c804b699b46190207cb9d864fcf4edeb338b1f15d9", size = 108567, upload-time = "2026-06-05T16:36:16.523Z" },
 ]


### PR DESCRIPTION
## What

Implements the YouTube Music coverage drain end to end (epic #830, spike GO from #833): the resolution client, a dry-run coverage harness, and the fill-only write path into LML's authoritative offline link store.

- `clients/streaming/youtube_music.py` — `YouTubeMusicClient`, honoring `find_album_match(artist, title) -> SourceMatch | None`. Unauthenticated `ytmusicapi` search → verified `music.youtube.com/browse/<browseId>` album URL. Standalone (not a `BaseStreamingClient` subclass) because `ytmusicapi` is synchronous/`requests`-based; the sync search runs in `asyncio.to_thread`.
- `scripts/ytm_coverage_drain.py` — loads candidates, resolves concurrently (bounded), emits a coverage report (count, hit rate, sample matches + misses). `--execute` (opt-in) fill-only-persists matches; the default path is dry-run and writes nothing.
- `scripts/streaming_availability/results_db.py` — fill-only `update_youtube_music_url` + a guarded `youtube_music_url`/`_status`/`_checked_at` migration + `get_album_id_by_names`.
- `pyproject.toml` / `uv.lock` — `ytmusicapi==1.12.1` as an optional `drain` **extra** (off the runtime/deploy path; lazy import; pinned exactly because it's a reverse-engineered web client).
- Tests: 29 unit tests, no network / no `ytmusicapi` / no DB-in-prod (injected `search_fn` seam; in-memory / tmp SQLite for the store).

## Write path — Option A (resolves the #1056 / #1052 fork)

Persistence goes to `streaming_availability.db`, LML's authoritative, top-priority offline link store. The rest of the `youtube_music_url` chain **already exists in prod** — this PR adds the only missing piece, the producer:

| Hop | Location | Status |
|---|---|---|
| Source column | `streaming_availability.db.albums.youtube_music_url` | **this PR** (guarded migration + fill-only writer) |
| Export → library.db | `scripts/export_streaming_links.py` (invoked by discogs-etl `sync-library.sh`) | already carries it |
| library.db column | `streaming_links.youtube_music_url` | already created |
| Read | `library/db.py::get_streaming_links` | already reads `row[5]` |
| Surface on `/lookup` | `lookup/enrichment/item.py` | already surfaces it |

Why not the alternatives:
- **Option C** (a `refresh-for-identities` `youtube_music` leg, as the earlier gate framing assumed) is *structurally impossible*: `entity.release_identity` has no `youtube_music` column, so there is no external ID to dispatch on. Its sibling legs (#548/#549) were both closed.
- **Option B** (`lml_cache.album_streaming_url_cache`) stays reserved for **#1052**'s runtime/rowless population, which is gated on a truthy `item.id` and cannot reach this library-keyed store.

## Design notes

- **Fill-only writes** (`WHERE youtube_music_url IS NULL`): a resolved, top-priority link is never clobbered by a later, lower-value pass (Data Safety; the #669 marker lesson). The writer returns whether it wrote, so the drain tallies `{written, already_present, unmatched}` without a re-read.
- **Zero normalization drift**: `execute_write` maps a resolved candidate back to its `albums` row via `get_album_id_by_names`, which normalizes with the *same* `normalize_artist_name`/`normalize_album_title` the dedup pipeline keyed rows with. A candidate with no matching row is tallied `unmatched` and skipped — never a wrong write.
- **Migration mirrors the bandcamp #661 precedent** exactly: columns ALTER-added in `_migrate()` (idempotent on a pre-existing DB), a status index, and a one-time `pending → found` backfill guarded by a `*_status_added` flag. On prod the `url` column predates ResultsDB (earlier pipeline era), so the ALTER is a no-op there and the backfill stamps `found` on any row already carrying a url.
- **Matching reuses the production matcher** (`find_best_source_match` → 80/80 floor via `is_acceptable_match`, `score_match`/token_sort), inherently immune to the `token_set_ratio` subset inflation behind the spike's "Goya"-class false positive — regression-tested, no bespoke short-title guard.

## Operating the drain

Dry-run by default; persistence is opt-in and remains the operator's action (off-peak, fill-only, one bulk consumer at a time), followed by a separate `POST /admin/upload-streaming-db` republish. The real candidate set resolves off `entity.release_identity` → discogs-cache (prod creds + human go-ahead), out of scope for the harness itself, which stays schema-agnostic via `load_candidates_from_rows`.

## Verification

- 29 unit tests + full unit suite green (4760 passed); `ruff check`, `ruff format --check`, `mypy .` clean.
- End-to-end smoke against live YouTube Music: *Juana Molina — DOGA* → real browse URL @ conf 100; *Stereolab — Aluminum Tunes* a legitimate long-tail miss.

Closes #1056

## Related

- Epic: WXYC/library-metadata-lookup#830
- Spike (GO): WXYC/library-metadata-lookup#833
- Reserves Option B for: WXYC/library-metadata-lookup#1052
- Closed sibling-leg precedent (Option C eliminated): WXYC/library-metadata-lookup#548, WXYC/library-metadata-lookup#549
