### PR TITLE
perf(ci): parallelize Default Tests and cut ~74s of serial test waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,20 @@ jobs:
       # Default `pytest` honours pyproject addopts (`-m 'not pg and not external_api'`),
       # so this job runs every unmarked test across tests/unit/, tests/integration/, and
       # tests/e2e/. Infra-tagged tests run in their own jobs (`pg`, `external_api`).
-      - run: pytest -v --cov=. --cov-report=xml
+      #
+      # -n auto (pytest-xdist) fans the ~5k independent unit tests across the
+      # runner's cores; --cov combines per-worker coverage automatically. xdist is
+      # scoped to this job only — the pg / external_api jobs stay serial (they
+      # share a PG schema / the Discogs rate budget). --durations surfaces the
+      # slowest tests so a serial-wait backslide (e.g. an un-mocked sleep) is
+      # visible in the log instead of silently re-inflating the run.
+      - name: Run tests
+        env:
+          # sys.monitoring line tracer (Python 3.12 + coverage >= 7.4): lower
+          # per-line coverage overhead than the default C trace core, verified to
+          # produce identical line counts (line-rate 0.8717 either way).
+          COVERAGE_CORE: sysmon
+        run: pytest -n auto --cov=. --cov-report=xml --durations=15
       - name: Upload coverage reports
         uses: codecov/codecov-action@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,12 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "pytest-httpx>=0.22.0",
     "pytest-cov>=4.0.0",
+    # pytest-xdist parallelizes the Default Tests job across the runner's cores
+    # (`-n auto`). The suite is ~5k independent unit tests; each xdist worker is
+    # its own process, so the per-loop rate-limit/semaphore singletons and moto's
+    # in-process S3 mock stay isolated. Only the Default job uses it — the pg and
+    # external_api jobs stay serial (shared PG schema / Discogs rate budget).
+    "pytest-xdist>=3.5.0",
     # ruff, mypy, and datamodel-code-generator are pinned (not >=) so a new
     # release that changes lint rules, type-check rules, or generated-code
     # formatting cannot silently fail CI on an unrelated PR. Bumps should be

--- a/tests/unit/test_ratelimit_concurrent.py
+++ b/tests/unit/test_ratelimit_concurrent.py
@@ -10,6 +10,7 @@ import asyncio
 import time
 
 import pytest
+from aiolimiter import AsyncLimiter
 
 from discogs.ratelimit import get_rate_limiter, get_semaphore, reset_rate_limiting
 
@@ -83,15 +84,35 @@ class TestConcurrentRateLimiter:
     """Verify the rate limiter prevents burst bypass under parallel load."""
 
     @pytest.mark.asyncio
-    async def test_rate_limiter_no_burst_bypass(self):
-        """Concurrent tasks cannot bypass the rate limiter by acquiring simultaneously.
+    async def test_rate_limiter_uses_configured_rate(self):
+        """get_rate_limiter() wires the configured req/min into a 60s-window bucket.
 
-        The rate limiter is configured for N requests per minute. If we fire
-        more tasks than the rate limit in quick succession, they should be
-        throttled and not all complete instantly.
+        Pins the production shape (``discogs_rate_limit`` tokens per 60s) that the
+        throttle-behavior test below deliberately compresses for speed.
         """
+        from config.settings import get_settings
+
         reset_rate_limiting()
         limiter = get_rate_limiter()
+        settings = get_settings()
+
+        assert limiter.max_rate == settings.discogs_rate_limit
+        assert limiter.time_period == 60
+
+    @pytest.mark.asyncio
+    async def test_rate_limiter_no_burst_bypass(self):
+        """Concurrent tasks exceeding the burst are throttled, not all admitted at once.
+
+        Exercises the same ``AsyncLimiter`` token bucket the service uses, but on a
+        compressed window (5 tokens / 100ms rather than the production 50 / 60s).
+        A real 60s window refills one overflow token every ~1.2s, so proving the
+        throttle with 10 overflow tasks costs ~12s of pure wall-clock wait for a
+        ``span > 0`` assertion. The compressed window verifies the identical
+        behavior in milliseconds; the production window value is pinned in
+        ``test_rate_limiter_uses_configured_rate`` above.
+        """
+        max_rate = 5
+        limiter = AsyncLimiter(max_rate, 0.1)
 
         timestamps: list[float] = []
         lock = asyncio.Lock()
@@ -101,19 +122,17 @@ class TestConcurrentRateLimiter:
                 async with lock:
                     timestamps.append(time.monotonic())
 
-        # Fire more tasks than the rate limit allows
-        # Default rate limit is 50/min, so fire 60 tasks
-        tasks = [asyncio.create_task(worker()) for _ in range(60)]
+        # Fire more tasks than the burst: the first `max_rate` drain the initial
+        # bucket instantly, the rest must wait for refill.
+        tasks = [asyncio.create_task(worker()) for _ in range(max_rate * 2)]
         await asyncio.gather(*tasks)
 
-        assert len(timestamps) == 60
+        assert len(timestamps) == max_rate * 2
 
-        # All timestamps should exist (all tasks completed)
-        # The rate limiter uses a token bucket, so the first batch goes through
-        # immediately and subsequent ones are delayed.
-        # Check that at least one task was delayed (span > 0)
+        # The overflow tasks are delayed relative to the first batch, so the
+        # admission span is strictly positive (no burst bypass).
         time_span = timestamps[-1] - timestamps[0]
-        assert time_span > 0, "Rate limiter should have throttled some requests"
+        assert time_span > 0, "Rate limiter should have throttled the overflow tasks"
 
     @pytest.mark.asyncio
     async def test_rate_limiter_concurrent_with_semaphore(self):

--- a/tests/unit/test_spotify_client.py
+++ b/tests/unit/test_spotify_client.py
@@ -180,7 +180,12 @@ class TestErrorHandling:
             )
         )
         client._http = mock_http
-        results = await client.search_album("Stereolab", "Aluminum Tunes")
+        # A constant 500 exhausts the exponential-backoff retry loop (both the
+        # quoted and unquoted passes). Patch asyncio.sleep so the test asserts the
+        # empty-result contract without waiting out the real ~62s of backoff --
+        # mirrors TestRetryOn429.test_retries_on_429 above.
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            results = await client.search_album("Stereolab", "Aluminum Tunes")
         assert results == []
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -513,6 +513,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
@@ -667,6 +676,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -689,6 +699,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.22.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
@@ -1145,6 +1156,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/5574834da9499066fa1a5ea9c336f94dba2eae02298d36dab192fcf95c86/pytest_httpx-0.36.0.tar.gz", hash = "sha256:9edb66a5fd4388ce3c343189bc67e7e1cb50b07c2e3fc83b97d511975e8a831b", size = 56793, upload-time = "2025-12-02T16:34:57.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/d2/1eb1ea9c84f0d2033eb0b49675afdc71aa4ea801b74615f00f3c33b725e3/pytest_httpx-0.36.0-py3-none-any.whl", hash = "sha256:bd4c120bb80e142df856e825ec9f17981effb84d159f9fa29ed97e2357c3a9c8", size = 20229, upload-time = "2025-12-02T16:34:56.45Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1064.

## Why

Profiling the **Default Tests** job ([run 30716829168](https://github.com/WXYC/library-metadata-lookup/actions/runs/30716829168/job/91413709087)) showed a ~3m34s job dominated by a 164s single-core `pytest` step. Two tests alone burned ~74s waiting out real timers.

## Changes

- **Spotify server-error test (~62s → <5ms):** `test_returns_empty_on_server_error` didn't patch `asyncio.sleep`, so a constant `500` exhausted the real exponential backoff (`1+2+4+8+16`s) across both the quoted and unquoted search passes. Patch `asyncio.sleep`, mirroring the sibling 429 retry test. Contract assertion (`results == []`) unchanged.
- **Rate-limiter burst test (~12s → 0.10s):** `test_rate_limiter_no_burst_bypass` waited ~12s for a real 50/min token bucket to refill 10 overflow tokens just to assert `span > 0`. Compress to 5 tokens / 100ms — same no-burst-bypass behavior, proven in ms. New `test_rate_limiter_uses_configured_rate` pins the production 50-per-60s wiring the slow version implicitly covered.
- **Parallelize (`-n auto`):** add `pytest-xdist` and run the Default job across the runner's cores. Scoped to this job only; `pg` / `external_api` stay serial (shared PG schema / Discogs rate budget).
- **Faster coverage:** `COVERAGE_CORE=sysmon` (sys.monitoring line tracer), verified identical line counts; `--durations=15` so a future serial-wait regression shows up in the log.

## Verification

- Full default suite green under `pytest -n auto` + sysmon coverage: **5095 passed, 1 skipped, 2 xfailed**, 0 failures.
- Coverage line-rate unchanged at **0.8717** (identical between sysmon and the default coverage core).
- The two offending tests now run in <5ms and 0.10s.
- `ruff check` / `ruff format --check` / `mypy` / `actionlint` all clean. Marker routing unchanged.
