### PR TITLE
refactor(#1040): decompose Discogs _request_with_retry into an admission stack; share the 429 loop with Bandcamp

### DIFF
--- a/clients/bandcamp.py
+++ b/clients/bandcamp.py
@@ -8,7 +8,16 @@ and album-level matching (page scraping).
 
 from __future__ import annotations
 
-import asyncio
+# LML#1040: ``_request_with_retry``'s 429 loop now delegates to the shared
+# ``discogs.admission.retry_429``, whose ``asyncio.sleep(delay)`` call is no
+# longer textually in this module -- but ``tests/unit/
+# test_bandcamp_retry_characterization.py`` patches
+# ``clients.bandcamp.asyncio.sleep`` (module-ATTRIBUTE patching against
+# whatever ``asyncio`` name this module exposes). That patch mutates the
+# SAME shared ``asyncio`` module object ``discogs.admission`` also imports,
+# so it still takes effect there; removing this import would only break the
+# patch-target resolution, not any real behavior. Keep it.
+import asyncio  # noqa: F401
 import logging
 import re
 
@@ -16,6 +25,7 @@ import httpx
 
 from clients.streaming.base import BaseStreamingClient
 from clients.streaming.matching import find_best_source_match, score_match
+from discogs.admission import retry_429
 from streaming.models import SourceMatch
 
 log = logging.getLogger(__name__)
@@ -52,6 +62,34 @@ MAX_RETRIES = 3
 RETRY_BASE_DELAY = 5.0  # seconds
 
 
+def _compute_bandcamp_retry_delay(attempt: int, retry_after: str | None) -> float:
+    """Bandcamp's pre-LML#1040 429 delay policy, unchanged: a valid numeric
+    ``Retry-After`` wins verbatim (no cap); otherwise exponential backoff with
+    NO jitter -- unlike Discogs's ``discogs.service._compute_retry_delay``,
+    which both jitters and caps at 60s. Kept byte-identical to the pre-#1040
+    inline computation; see ``tests/unit/test_bandcamp_retry_characterization.py``.
+    """
+    if retry_after:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    return RETRY_BASE_DELAY * (2**attempt)
+
+
+class _BandcampRequestFailedError(Exception):
+    """Internal sentinel: ``client.request()`` raised inside one attempt.
+
+    Distinguishes a request-layer failure -- converted to ``None``, matching
+    the pre-LML#1040 bare ``except Exception: return None`` that wrapped ONLY
+    the ``client.request()`` call -- from an exception raised by
+    ``self._rate_limiter.acquire()`` or the ``async with self._semaphore:``
+    block, which the pre-#1040 code did NOT catch (and still doesn't: this
+    sentinel is only raised from inside the inner ``try``, so anything else
+    propagates unconverted, same as before).
+    """
+
+
 class BandcampClient(BaseStreamingClient):
     """Bandcamp HTTP client for autocomplete search and page scraping.
 
@@ -65,35 +103,39 @@ class BandcampClient(BaseStreamingClient):
     async def _request_with_retry(self, method: str, url: str, **kwargs) -> httpx.Response | None:
         """Make an HTTP request with retry on 429.
 
-        Returns the response, or None on failure after retries.
+        Returns the response, or None on failure after retries. LML#1040:
+        the retry loop itself is ``discogs.admission.retry_429``, shared with
+        ``DiscogsService._request_with_retry``; this method supplies
+        Bandcamp's own permit acquisition, delay policy, and log wording
+        (byte-identical to the pre-#1040 inline loop -- see
+        ``tests/unit/test_bandcamp_retry_characterization.py``).
         """
         client = await self._get_client()
-        for attempt in range(MAX_RETRIES + 1):
+
+        async def _attempt(attempt: int) -> httpx.Response:
             async with self._semaphore:
                 await self._rate_limiter.acquire()
                 try:
-                    resp = await client.request(method, url, **kwargs)
-                except Exception:
-                    return None
+                    return await client.request(method, url, **kwargs)
+                except Exception as e:
+                    raise _BandcampRequestFailedError() from e
 
-            if resp.status_code == 429:
-                if attempt < MAX_RETRIES:
-                    retry_after = resp.headers.get("Retry-After")
-                    if retry_after:
-                        try:
-                            delay = float(retry_after)
-                        except ValueError:
-                            delay = RETRY_BASE_DELAY * (2**attempt)
-                    else:
-                        delay = RETRY_BASE_DELAY * (2**attempt)
-                    log.warning(f"429 rate limited, retrying in {delay}s (attempt {attempt + 1})")
-                    await asyncio.sleep(delay)
-                    continue
-                log.warning(f"429 rate limited after {MAX_RETRIES} retries, giving up: {url}")
-                return None
+        try:
+            response = await retry_429(
+                _attempt,
+                max_retries=MAX_RETRIES,
+                compute_delay=_compute_bandcamp_retry_delay,
+                on_retry=lambda attempt, delay, retry_after: log.warning(
+                    f"429 rate limited, retrying in {delay}s (attempt {attempt + 1})"
+                ),
+                on_exhausted=lambda: log.warning(
+                    f"429 rate limited after {MAX_RETRIES} retries, giving up: {url}"
+                ),
+            )
+        except _BandcampRequestFailedError:
+            return None
 
-            return resp
-        return None
+        return None if response.status_code == 429 else response
 
     async def find_album_match(self, artist: str, title: str) -> SourceMatch | None:
         """Search Bandcamp for ``(artist, title)`` and return the best match.

--- a/discogs/admission.py
+++ b/discogs/admission.py
@@ -1,0 +1,258 @@
+"""Composable Discogs live-request admission stack (LML#1040).
+
+Extracted from ``DiscogsService._request_with_retry`` -- previously a ~285-line
+method interleaving six concerns line-by-line -- into independently testable
+pieces:
+
+- :func:`admit_or_shed` -- the LML#755 saturation-breaker entry gate plus the
+  LML#787 abort bookkeeping (an admitted request that exits without an
+  explicit terminal outcome reports an abort).
+- :func:`retry_429` -- the generic 429 retry loop (jittered backoff or
+  ``Retry-After``, plus an optional absolute budget deadline), shared with
+  ``clients/bandcamp.py``.
+
+The LML#927 bulk sub-semaphore + LML#358/#569 shared-semaphore acquisition
+(``acquire_discogs_permits``) stays defined in ``discogs/service.py`` rather
+than here, even though it is just as reusable in shape -- ``tests/unit/
+test_discogs_service.py::TestRequestWithRetrySpans`` patches the WHOLE
+``discogs.service.sentry_sdk`` name (``patch("discogs.service.sentry_sdk")``,
+no trailing attribute), which rebinds that one name in ``discogs.service``'s
+own namespace to a mock. That is different from an attribute-level patch
+like ``patch("discogs.service.sentry_sdk.start_span")`` (which mutates the
+shared ``sentry_sdk`` module object itself, so it is visible from any module
+that also did ``import sentry_sdk``): a whole-name patch only affects code
+whose ``sentry_sdk.*`` calls are textually resolved from ``discogs.service``'s
+globals. ``admit_or_shed`` and ``retry_429`` below never call ``sentry_sdk``,
+so they carry no such constraint and can live here.
+
+The per-attempt in-flight breaker re-check (``should_shed_inflight``) and the
+rate-gate acquire also stay inline in ``DiscogsService._request_with_retry``
+-- the former is three lines tightly coupled to that one call site's epoch,
+and the latter has no "permit to release" shape (a token-bucket spend, not a
+hold), so extracting either would add indirection without a reuse payoff.
+
+Every getter this module's callers resolve (``get_discogs_breaker`` etc.) is
+resolved by the CALLER (``discogs/service.py``), never by this module -- the
+functions here take already-resolved objects and callbacks. This is a
+correctness requirement, not a style choice: the breaker/ratelimit test
+suites patch those getters by their ``discogs.service.<name>`` dotted path,
+which is module-ATTRIBUTE patching -- it only intercepts a bare-name lookup
+performed by a function whose CODE lives in that module. Moving a getter call
+into this module would silently stop honoring those patches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+import httpx
+
+from discogs.breaker import DiscogsBreakerOpenError, DiscogsCircuitBreaker
+from discogs.live_request_counter import increment_discogs_live_requests_total
+
+logger = logging.getLogger(__name__)
+
+
+# ===========================================================================
+# LML#755 admit/shed + LML#787 abort bookkeeping
+# ===========================================================================
+
+
+class BreakerAdmission:
+    """Tracks one admitted request's breaker ``epoch`` and whether its
+    terminal outcome (``record_success`` / ``record_failure`` /
+    ``record_server_error``) has already been recorded.
+
+    ``admit_or_shed`` reads ``recorded`` in its ``finally`` to decide whether
+    to report an abort -- the LML#787 fallback for any exit (a mid-flight
+    shed raise, cancellation, an unexpected exception) that never reached one
+    of those three terminal calls.
+    """
+
+    __slots__ = ("epoch", "recorded")
+
+    def __init__(self, epoch: int) -> None:
+        self.epoch = epoch
+        self.recorded = False
+
+    def mark_recorded(self) -> None:
+        self.recorded = True
+
+
+@contextlib.asynccontextmanager
+async def admit_or_shed(
+    breaker: DiscogsCircuitBreaker,
+    method: str,
+    path: str,
+    *,
+    on_shed: Callable[[str, str], None],
+) -> AsyncIterator[BreakerAdmission]:
+    """LML#755 saturation shed. When the breaker is OPEN, fast-fail *before*
+    ``rate_limiter.acquire()`` -- no queuing on the 50/min limiter, no
+    network call, no 429 backoff sleep. The shed raises
+    ``DiscogsBreakerOpenError`` (NOT a ``None`` return): a shed is
+    "couldn't ask, try later", which callers must treat as *unknown* --
+    never a confirmed-empty verdict that would poison a durable negative
+    cache (LML#755 review, FIX 1). Cache hits never reach here -- they
+    short-circuit in ``fallthrough`` before the live probe -- so only the
+    live-probe tail is shed. The epoch this yields guards the half-open
+    trial: the caller's terminal ``record_*`` only drives a half-open
+    transition when its epoch still matches (FIX 6).
+
+    LML#940: count every live-Discogs request *attempt* right here, before
+    the admit/shed decision -- a shed attempt is demand too, and this is the
+    sole ``allow_request()`` call site. See ``discogs/live_request_counter.py``
+    for why counting here (not per ``/lookup``) is required for the
+    wxyc-canary idle-tail fix.
+
+    LML#787: an ADMITTED request must always resolve its breaker bookkeeping.
+    The yielded :class:`BreakerAdmission` tracks whether the caller recorded
+    a terminal outcome; any exit that reaches this generator's ``finally``
+    without one -- a request-layer error the caller re-raises, cancellation
+    during the request / limiter acquire / retry sleep, or an unexpected
+    raise -- reports ``record_aborted``. If the victim was the HALF_OPEN
+    trial, that re-OPENs the breaker (fresh cool-down -> fresh trial) instead
+    of latching it shedding forever (the 2026-07-13 incident); in every other
+    state/epoch it is a no-op. A mid-flight shed raise from inside the retry
+    loop also lands here: its entry epoch is stale by construction (``_open``
+    bumped it), so the abort is a guaranteed no-op.
+
+    Args:
+        breaker: The resolved per-loop breaker (``get_discogs_breaker()`` --
+            resolved by the caller, not here; see the module docstring).
+        method: HTTP method, forwarded to ``on_shed`` and the shed error.
+        path: API path, forwarded to ``on_shed`` and the shed error.
+        on_shed: Invoked with ``(method, path)`` when the breaker sheds --
+            ``DiscogsService._record_breaker_shed`` records the LML#755
+            counter, which needs ``get_cache_stats_recorder()`` resolved from
+            ``discogs.service``'s own namespace (see module docstring).
+
+    Yields:
+        A :class:`BreakerAdmission` the caller must call ``mark_recorded()``
+        on after any terminal ``record_*`` call.
+
+    Raises:
+        DiscogsBreakerOpenError: when the breaker sheds the request.
+    """
+    increment_discogs_live_requests_total()
+    epoch = breaker.allow_request()
+    if epoch is None:
+        on_shed(method, path)
+        raise DiscogsBreakerOpenError(f"Discogs saturation breaker open: {method} {path}")
+
+    admission = BreakerAdmission(epoch)
+    try:
+        yield admission
+    finally:
+        if not admission.recorded:
+            breaker.record_aborted(epoch=admission.epoch)
+
+
+# ===========================================================================
+# LML#1040: the shared 429 retry loop
+# ===========================================================================
+
+
+async def retry_429(
+    make_attempt: Callable[[int], Awaitable[httpx.Response]],
+    *,
+    max_retries: int,
+    compute_delay: Callable[[int, str | None], float],
+    budget_deadline: float | None = None,
+    on_retry: Callable[[int, float, str | None], None] | None = None,
+    on_budget_exceeded: Callable[[float, float], None] | None = None,
+    on_exhausted: Callable[[], None] | None = None,
+) -> httpx.Response:
+    """Shared 429 retry loop: jittered-backoff-or-``Retry-After`` delay, with
+    an optional absolute ``budget_deadline`` that gives up early instead of
+    sleeping past it (LML#758). Used by both ``DiscogsService._request_with_retry``
+    and ``clients.bandcamp.BandcampClient._request_with_retry``.
+
+    ``make_attempt(attempt)`` performs ONE attempt (0-indexed) and returns a
+    response, or raises. An exception is NOT retried -- it propagates
+    directly out of this loop, matching both current call sites: a
+    request-layer failure aborts the whole call rather than eating a retry
+    slot. Callers catch their own exception type(s) around the call to this
+    function (Discogs: ``httpx.RequestError`` only; Bandcamp: broader,
+    matching its pre-existing bare ``except Exception``) -- this loop stays
+    agnostic to that choice.
+
+    A response with ``status_code != 429`` is returned immediately. A 429
+    triggers a retry when attempts remain: the delay is computed via
+    ``compute_delay(attempt, retry_after_header)``, then -- LML#758 -- if
+    ``budget_deadline`` is set (an absolute ``time.monotonic()`` value) and
+    the delay would sleep past it, this gives up immediately instead,
+    calling ``on_budget_exceeded`` and returning the (still-429) response
+    without sleeping. Otherwise ``on_retry`` fires and it sleeps.
+
+    This function never converts a persistent 429 into ``None`` -- when
+    retries are exhausted, or the budget can't absorb the next delay, it
+    returns the LAST response it saw (which is still whatever came back,
+    e.g. a 429). Deciding what a terminal 429 MEANS -- record a breaker
+    failure and degrade to ``None`` (Discogs), or just degrade to ``None``
+    (Bandcamp) -- is the caller's job, done after this returns, so the
+    caller can still read the final response's headers (e.g. Discogs's
+    ``X-Discogs-Ratelimit-Remaining``) for its own terminal accounting.
+
+    Args:
+        make_attempt: Performs attempt number ``attempt`` (0-indexed).
+        max_retries: Maximum RETRY count -- total attempts made is
+            ``max_retries + 1``.
+        compute_delay: ``(attempt, retry_after_header_value) -> seconds``.
+        budget_deadline: An absolute ``time.monotonic()`` deadline. When the
+            next computed delay would sleep past it, gives up before
+            sleeping instead of retrying. ``None`` (the default) disables
+            this check entirely -- the pre-LML#758 attempt-count-only bound.
+        on_retry: Called right before sleeping, with
+            ``(attempt, delay, retry_after_header_value)`` -- purely
+            observational (each caller's own log wording/level).
+        on_budget_exceeded: Called instead of sleeping when the deadline
+            can't absorb the next delay, with ``(remaining_budget, delay)``.
+        on_exhausted: Called when the final attempt (``attempt == max_retries``)
+            is still a 429.
+
+    Returns:
+        The last response ``make_attempt`` produced.
+    """
+    for attempt in range(max_retries + 1):
+        response = await make_attempt(attempt)
+
+        if response.status_code != 429:
+            return response
+
+        if attempt < max_retries:
+            retry_after = response.headers.get("Retry-After")
+            delay = compute_delay(attempt, retry_after)
+
+            # LML#758: don't sleep past the caller's remaining budget. A
+            # deadline is only active when supplied by the caller (Discogs
+            # arms it from ``core.search._run_strategy_pipeline``'s
+            # caller-budget contextvar; Bandcamp never sets one).
+            if budget_deadline is not None:
+                remaining_budget = budget_deadline - time.monotonic()
+                if delay > remaining_budget:
+                    if on_budget_exceeded is not None:
+                        on_budget_exceeded(remaining_budget, delay)
+                    return response
+
+            if on_retry is not None:
+                on_retry(attempt, delay, retry_after)
+            # Sleep WITHOUT holding any permit -- the caller's ``make_attempt``
+            # has already released everything it acquired by the time this
+            # returns (``acquire_discogs_permits`` / Bandcamp's ``async with
+            # self._semaphore``), and re-acquires on the next attempt.
+            await asyncio.sleep(delay)
+            continue
+
+        if on_exhausted is not None:
+            on_exhausted()
+        return response
+
+    # Unreachable: ``range(max_retries + 1)`` always yields at least one
+    # attempt for the ``max_retries >= 0`` every caller passes, and every
+    # loop body path above returns. Kept only to satisfy the type checker.
+    raise AssertionError("retry_429: unreachable -- the loop always returns")

--- a/discogs/service.py
+++ b/discogs/service.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import random
 import time
 import weakref
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from contextvars import ContextVar, Token
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
@@ -24,9 +25,9 @@ from wxyc_fastapi.observability import (
 )
 
 from config.settings import get_settings
+from discogs.admission import admit_or_shed, retry_429
 from discogs.breaker import DiscogsBreakerOpenError
 from discogs.fallthrough import apply_request_ctx_tags, fallthrough, request_context
-from discogs.live_request_counter import increment_discogs_live_requests_total
 from discogs.matching import (
     TRACK_TITLE_FUZZY_MATCH_THRESHOLD,
     TracklistEntry,
@@ -250,6 +251,114 @@ def _project_bulk_semaphore_wait(wait_ms: float) -> None:
             transaction.set_data(_BULK_SEMAPHORE_WAIT_MEASUREMENT, wait_ms)
     except Exception as e:
         logger.warning("Failed to project Discogs bulk semaphore wait: %s", e)
+
+
+@contextlib.asynccontextmanager
+async def acquire_discogs_permits(
+    bulk_semaphore: asyncio.Semaphore | None,
+    semaphore: asyncio.Semaphore,
+    *,
+    low_priority: bool,
+) -> AsyncIterator[None]:
+    """Hold the LML#927 bulk reservation (outer, when ``bulk_semaphore`` is
+    given) and the shared LML#358/#569 concurrency permit (inner) for the
+    duration of the block.
+
+    LML#1040: extracted out of ``_request_with_retry``'s retry loop into its
+    own composable, independently-testable piece -- kept in THIS module
+    (rather than ``discogs/admission.py``, where ``admit_or_shed`` and
+    ``retry_429`` moved) because ``tests/unit/test_discogs_service.py::
+    TestRequestWithRetrySpans`` patches the whole ``discogs.service.sentry_sdk``
+    name; see that test file and the note atop ``discogs/admission.py`` for why.
+
+    The semaphore wraps a single attempt, not the whole retry loop (LML#569).
+    A 429's inter-attempt ``asyncio.sleep(Retry-After)`` must run *outside*
+    the held permit, so a caller riding out a 30-60s rate-limit window
+    doesn't park one of the 5 permits for that whole window and amplify
+    ``lml.discogs.semaphore`` acquire-wait for unrelated callers (the last
+    unhandled tail of #537, cause #3) -- callers must ``async with`` this
+    context manager PER ATTEMPT, not once for the whole retry loop. The egress
+    cap is still the per-attempt rate-gate acquire the caller performs inside
+    this block -- releasing the semaphore during the sleep does not bypass it.
+
+    This ``try/finally`` guarantees exactly one release per acquire:
+    cancellation mid-block or a raise inside it leaves no leaked permit and
+    never double-releases. As a result the ``lml.discogs.semaphore`` /
+    ``lml.discogs.rate_limiter`` spans fire once per attempt rather than once
+    per request -- a span-count schema change documented in the #569 PR (no
+    dashboard/alert aggregates on that count).
+
+    LML#927: a low-priority call holds the bulk reservation semaphore OUTER
+    to the shared semaphore, acquired first so bulk can never occupy more
+    than ``LML_DISCOGS_BULK_MAX_CONCURRENT`` of the shared permits --
+    reserving the rest for interactive callers. Both acquires (and
+    everything the caller does inside this block) live inside the same
+    try/finally as the request itself -- so a cancellation between the two
+    acquires (bulk granted, then cancelled while waiting on the shared one)
+    cannot strand the bulk permit. Released INNER -> OUTER (shared semaphore
+    first, then bulk) in the ``finally``, the same ordered, deadlock-free
+    discipline LML#953 established: nothing already holding the shared
+    semaphore ever waits on this one, so no acquire cycle can form.
+
+    Explicit acquire/release (not ``async with semaphore:``) so the wait is
+    wrapped in a Sentry span. The 5-permit semaphore is the dominant source
+    of pre-request dark time on backfill cascades -- sampling the queue depth
+    right before the await gives the trace explorer a relative-load signal
+    per call. See WXYC/library-metadata-lookup#358.
+
+    Args:
+        bulk_semaphore: The LML#927 bulk-lane reservation semaphore, or
+            ``None`` for an interactive (non-low-priority) caller -- in
+            which case only ``semaphore`` is touched.
+        semaphore: The shared LML#358/#569 concurrency semaphore.
+        low_priority: Tags the ``lml.discogs.semaphore`` span/transaction
+            with ``lml.discogs.priority`` (``"bulk"`` or ``"interactive"``)
+            so wait-time p95/p99 can be sliced by traffic class.
+    """
+    bulk_permit_held = False
+    main_permit_held = False
+    try:
+        if bulk_semaphore is not None:
+            with sentry_sdk.start_span(
+                op="lock.acquire", name="lml.discogs.bulk_semaphore"
+            ) as bulk_span:
+                bulk_queue_depth = _approx_semaphore_queue_depth(bulk_semaphore)
+                bulk_span.set_data("lml.bulk_semaphore.queue_depth", bulk_queue_depth)
+                _project_bulk_semaphore_queue_depth(bulk_queue_depth)
+                apply_request_ctx_tags(bulk_span)
+                bulk_capped_on_arrival = bulk_semaphore.locked()
+                bulk_wait_start = time.perf_counter()
+                await bulk_semaphore.acquire()
+                bulk_permit_held = True
+                if bulk_capped_on_arrival:
+                    _project_bulk_semaphore_wait((time.perf_counter() - bulk_wait_start) * 1000.0)
+
+        with sentry_sdk.start_span(op="lock.acquire", name="lml.discogs.semaphore") as span:
+            queue_depth = _approx_semaphore_queue_depth(semaphore)
+            span.set_data("lml.semaphore.queue_depth", queue_depth)
+            _project_semaphore_queue_depth(queue_depth)
+            apply_request_ctx_tags(span)
+            # LML#927: tag this span with the traffic class so
+            # ``lml.discogs.semaphore`` p95/p99 wait can be sliced by class --
+            # the direct signal for verifying interactive is no longer
+            # head-of-line-blocked behind bulk.
+            sentry_sdk.set_tag("lml.discogs.priority", "bulk" if low_priority else "interactive")
+            await semaphore.acquire()
+            main_permit_held = True
+
+        yield
+    finally:
+        # Released before the retry sleep, on success, and on any
+        # error/cancellation in this attempt -- one release per acquire.
+        # Inner (shared semaphore) released before outer (bulk reservation).
+        if main_permit_held:
+            semaphore.release()
+        if bulk_permit_held:
+            # ``bulk_permit_held`` is only ever set True inside the
+            # ``bulk_semaphore is not None`` branch above, so the semaphore
+            # itself is never None here.
+            assert bulk_semaphore is not None
+            bulk_semaphore.release()
 
 
 def _parse_ratelimit_remaining(raw: str | None) -> int | None:
@@ -555,67 +664,28 @@ class DiscogsService:
         low_priority = is_discogs_low_priority()
         bulk_semaphore = get_bulk_discogs_semaphore() if low_priority else None
 
-        # LML#755 saturation shed. When the breaker is OPEN, fast-fail *before*
-        # ``rate_limiter.acquire()`` — no queuing on the 50/min limiter, no
-        # network call, no 429 backoff sleep. The shed raises
-        # ``DiscogsBreakerOpenError`` (NOT a ``None`` return): a shed is
-        # "couldn't ask, try later", which callers must treat as *unknown* —
-        # never a confirmed-empty verdict that would poison a durable negative
-        # cache (LML#755 review, FIX 1). Cache hits never reach here — they
-        # short-circuit in ``fallthrough`` before the live probe — so only the
-        # live-probe tail is shed. ``epoch`` guards the half-open trial: the
-        # terminal ``record_*`` below only drives a half-open transition when its
-        # epoch still matches (FIX 6).
-        #
-        # LML#940: count every live-Discogs request *attempt* right here,
-        # before the admit/shed decision -- a shed attempt is demand too, and
-        # this is the sole ``allow_request()`` call site. See
-        # ``discogs/live_request_counter.py`` for why counting here (not per
-        # ``/lookup``) is required for the wxyc-canary idle-tail fix.
-        increment_discogs_live_requests_total()
-        epoch = breaker.allow_request()
-        if epoch is None:
-            self._record_breaker_shed(method, path)
-            raise DiscogsBreakerOpenError(f"Discogs saturation breaker open: {method} {path}")
-
         # LML#537: tag both wait spans with the seam's method + cache_state
         # via ``apply_request_ctx_tags`` (a no-op when no context is active —
         # the case for the small handful of legacy direct-call tests).
         # Production callers enter via ``fallthrough()`` (dominant) or via
         # the ``request_context()`` helper (the four API-only methods that
         # bypass the seam and the four ``cache is None`` fallback branches).
+        #
+        # LML#1040: the admission stack below composes three independently
+        # tested pieces (``discogs/admission.py`` -- read their docstrings for
+        # the full rationale this used to carry inline): ``admit_or_shed``
+        # (LML#755 breaker admit/shed + LML#787 abort bookkeeping),
+        # ``acquire_discogs_permits`` (LML#927 bulk reservation, outer, +
+        # LML#358/#569 shared semaphore, inner -- per attempt, released before
+        # the retry sleep), and ``retry_429`` (the 429 backoff loop, with the
+        # LML#758 caller-budget-deadline early-giveup). Verified acquire order
+        # (unchanged from pre-#1040): breaker admit -> per attempt: bulk
+        # sub-semaphore -> shared semaphore -> rate gate -> request.
+        async with admit_or_shed(
+            breaker, method, path, on_shed=self._record_breaker_shed
+        ) as admission:
 
-        # The semaphore wraps a single attempt, not the whole retry loop
-        # (LML#569). A 429's inter-attempt ``asyncio.sleep(Retry-After)`` runs
-        # *outside* the held permit, so a caller riding out a 30-60s rate-limit
-        # window no longer parks one of the 5 permits for that whole window and
-        # amplifies ``lml.discogs.semaphore`` acquire-wait for unrelated callers
-        # (the last unhandled tail of #537, cause #3). The egress cap is still
-        # the per-attempt ``rate_limiter.acquire()`` below — releasing the
-        # semaphore during the sleep does not bypass the AsyncLimiter.
-        #
-        # The per-attempt try/finally guarantees exactly one release per
-        # acquire: cancellation mid-sleep (sleep is outside the block) or a
-        # raise inside the request leaves no leaked permit and never
-        # double-releases. As a result the ``lml.discogs.semaphore`` /
-        # ``lml.discogs.rate_limiter`` spans now fire once per attempt rather
-        # than once per request — a span-count schema change documented in the
-        # #569 PR (no current dashboard/alert aggregates on that count).
-        #
-        # LML#787: an ADMITTED request must always resolve its breaker
-        # bookkeeping. The terminal ``record_*`` sites below set ``recorded``;
-        # any exit that reaches the outer ``finally`` without one — the
-        # ``httpx.RequestError`` → ``return None`` path, cancellation during
-        # the request / limiter acquire / retry sleep, or an unexpected raise —
-        # reports ``record_aborted``. If the victim was the HALF_OPEN trial,
-        # that re-OPENs the breaker (fresh cool-down → fresh trial) instead of
-        # latching it shedding forever (the 2026-07-13 incident); in every
-        # other state/epoch it is a no-op. The mid-flight shed raise inside the
-        # loop also lands here: its entry epoch is stale by construction
-        # (``_open`` bumped it), so the abort is a guaranteed no-op.
-        recorded = False
-        try:
-            for attempt in range(max_retries + 1):
+            async def _attempt(attempt: int) -> httpx.Response:
                 # LML#755 in-flight shed (FIX 3 / R2-1): re-check the breaker at
                 # the top of each attempt via the READ-ONLY
                 # ``should_shed_inflight`` — NOT the state-mutating
@@ -628,72 +698,15 @@ class DiscogsService:
                 # genuine trial (matching epoch) finish and sheds everyone else.
                 # The first attempt (attempt 0) was just admitted above, so only
                 # re-check on retries.
-                if attempt > 0 and breaker.should_shed_inflight(epoch):
+                if attempt > 0 and breaker.should_shed_inflight(admission.epoch):
                     self._record_breaker_shed(method, path)
                     raise DiscogsBreakerOpenError(
                         f"Discogs saturation breaker opened mid-flight: {method} {path}"
                     )
 
-                # LML#927: a low-priority call holds the bulk reservation
-                # semaphore OUTER to the shared semaphore below, acquired
-                # first so bulk can never occupy more than
-                # ``LML_DISCOGS_BULK_MAX_CONCURRENT`` of the shared permits --
-                # reserving the rest for interactive callers. Both acquires
-                # (and everything downstream) now live inside the same
-                # try/finally as the request itself -- not just the bare
-                # `await ...acquire()` calls the pre-#927 code used outside any
-                # try -- so a cancellation between the two acquires (bulk
-                # granted, then cancelled while waiting on the shared one)
-                # cannot strand the bulk permit. Released INNER -> OUTER
-                # (shared semaphore first, then bulk) in the `finally`, the
-                # same ordered, deadlock-free discipline LML#953 established:
-                # nothing already holding the shared semaphore ever waits on
-                # this one, so no acquire cycle can form.
-                bulk_permit_held = False
-                main_permit_held = False
-                try:
-                    if bulk_semaphore is not None:
-                        with sentry_sdk.start_span(
-                            op="lock.acquire", name="lml.discogs.bulk_semaphore"
-                        ) as bulk_span:
-                            bulk_queue_depth = _approx_semaphore_queue_depth(bulk_semaphore)
-                            bulk_span.set_data("lml.bulk_semaphore.queue_depth", bulk_queue_depth)
-                            _project_bulk_semaphore_queue_depth(bulk_queue_depth)
-                            apply_request_ctx_tags(bulk_span)
-                            bulk_capped_on_arrival = bulk_semaphore.locked()
-                            bulk_wait_start = time.perf_counter()
-                            await bulk_semaphore.acquire()
-                            bulk_permit_held = True
-                            if bulk_capped_on_arrival:
-                                _project_bulk_semaphore_wait(
-                                    (time.perf_counter() - bulk_wait_start) * 1000.0
-                                )
-
-                    # Explicit acquire/release (not `async with semaphore:`) so
-                    # the wait is wrapped in a Sentry span. The 5-permit
-                    # semaphore is the dominant source of pre-request dark time
-                    # on backfill cascades — sampling the queue depth right
-                    # before the await gives the trace explorer a
-                    # relative-load signal per call. See
-                    # WXYC/library-metadata-lookup#358.
-                    with sentry_sdk.start_span(
-                        op="lock.acquire", name="lml.discogs.semaphore"
-                    ) as span:
-                        queue_depth = _approx_semaphore_queue_depth(semaphore)
-                        span.set_data("lml.semaphore.queue_depth", queue_depth)
-                        _project_semaphore_queue_depth(queue_depth)
-                        apply_request_ctx_tags(span)
-                        # LML#927: tag this span with the traffic class so
-                        # ``lml.discogs.semaphore`` p95/p99 wait can be sliced
-                        # by class -- the direct signal for verifying
-                        # interactive is no longer head-of-line-blocked behind
-                        # bulk.
-                        sentry_sdk.set_tag(
-                            "lml.discogs.priority", "bulk" if low_priority else "interactive"
-                        )
-                        await semaphore.acquire()
-                        main_permit_held = True
-
+                async with acquire_discogs_permits(
+                    bulk_semaphore, semaphore, low_priority=low_priority
+                ):
                     with sentry_sdk.start_span(
                         op="lock.acquire", name="lml.discogs.rate_limiter"
                     ) as span:
@@ -708,107 +721,86 @@ class DiscogsService:
                     remaining = response.headers.get("X-Discogs-Ratelimit-Remaining")
                     if remaining:
                         logger.debug(f"Discogs rate limit remaining: {remaining}")
-                except httpx.RequestError as e:
-                    logger.error(
-                        "Discogs request failed: %s %s -> %s: %r",
-                        method,
-                        path,
-                        type(e).__name__,
-                        e,
-                        exc_info=True,
-                    )
-                    # No terminal ``record_*`` here on purpose: a network-layer
-                    # failure is not a rate-limit signal, so it neither feeds
-                    # the failure run nor closes a trial. The outer ``finally``
-                    # reports ``record_aborted`` (LML#787) so a dying trial
-                    # re-OPENs instead of latching.
-                    return None
-                finally:
-                    # Released before the retry sleep below, on success, and on
-                    # any error/cancellation in this attempt — one release per
-                    # acquire. Inner (shared semaphore) released before outer
-                    # (bulk reservation).
-                    if main_permit_held:
-                        semaphore.release()
-                    if bulk_permit_held:
-                        # `bulk_permit_held` is only ever set True inside the
-                        # `bulk_semaphore is not None` branch above, so the
-                        # semaphore itself is never None here.
-                        assert bulk_semaphore is not None
-                        bulk_semaphore.release()
 
-                # LML#755: feed the breaker **once per request, on the terminal
-                # outcome** (FIX 2/5), not per attempt — the counting unit is
-                # failed *requests*, not failed attempts. A non-429 terminal
-                # response ends the loop, so we record here and return; a 429
-                # that still has retries left loops WITHOUT recording (the
-                # failure is only terminal once retries are exhausted).
-                remaining_value = _parse_ratelimit_remaining(remaining)
-                if response.status_code != 429:
-                    recorded = True
-                    if response.status_code >= 500:
-                        # 5xx is neutral: don't reset the failure run, don't
-                        # close a half-open trial (FIX 5). Only opens on an
-                        # exhausted floor.
-                        breaker.record_server_error(remaining=remaining_value, epoch=epoch)
-                    else:
-                        breaker.record_success(remaining=remaining_value, epoch=epoch)
-                    return response
+                return response
 
-                if attempt < max_retries:
-                    retry_after = response.headers.get("Retry-After")
-                    delay = _compute_retry_delay(attempt, retry_after)
-
+            try:
+                response = await retry_429(
+                    _attempt,
+                    max_retries=max_retries,
+                    compute_delay=_compute_retry_delay,
                     # LML#758: don't sleep past the caller's remaining budget.
                     # A deadline is only active when this call is running
                     # inside a search pipeline (``core.search._run_strategy_
                     # pipeline`` sets it); direct/API-only callers see ``None``
                     # and keep the pre-#758 attempt-count-only bound.
-                    deadline = _retry_budget_deadline_var.get()
-                    if deadline is not None:
-                        remaining_budget = deadline - time.monotonic()
-                        if delay > remaining_budget:
-                            logger.warning(
-                                "Discogs rate limit hit, remaining caller budget "
-                                "(%.2fs) can't absorb the next retry delay "
-                                "(%.2fs); giving up early instead of sleeping "
-                                "past the deadline",
-                                remaining_budget,
-                                delay,
-                            )
-                            # Same terminal accounting as retries-exhausted
-                            # below: this attempt's response is a genuine 429,
-                            # so the breaker still learns from it. The `None`
-                            # return is the existing "unknown, not confirmed-
-                            # empty" degrade contract every caller of
-                            # `_request_with_retry` already honors (LML#755).
-                            recorded = True
-                            breaker.record_failure(remaining=remaining_value, epoch=epoch)
-                            return None
-
-                    logger.warning(
+                    budget_deadline=_retry_budget_deadline_var.get(),
+                    on_retry=lambda attempt, delay, retry_after: logger.warning(
                         f"Discogs rate limit hit, retrying in {delay:.2f}s "
                         f"(attempt {attempt + 1}/{max_retries + 1}, "
                         f"Retry-After={retry_after})"
-                    )
-                    # Sleep WITHOUT holding the permit; re-acquire on the next
-                    # pass.
-                    await asyncio.sleep(delay)
-                    continue
-
-                # Retries exhausted: this request definitively 429'd. Record
-                # exactly one failure (per-request unit) carrying the last-seen
-                # remaining so an at/below-floor bucket opens proactively even
-                # before the reactive threshold (FIX 2).
-                logger.error("Discogs rate limit hit, max retries exhausted")
-                recorded = True
-                breaker.record_failure(remaining=remaining_value, epoch=epoch)
+                    ),
+                    on_budget_exceeded=lambda remaining_budget, delay: logger.warning(
+                        "Discogs rate limit hit, remaining caller budget "
+                        "(%.2fs) can't absorb the next retry delay "
+                        "(%.2fs); giving up early instead of sleeping "
+                        "past the deadline",
+                        remaining_budget,
+                        delay,
+                    ),
+                    on_exhausted=lambda: logger.error(
+                        "Discogs rate limit hit, max retries exhausted"
+                    ),
+                )
+            except httpx.RequestError as e:
+                logger.error(
+                    "Discogs request failed: %s %s -> %s: %r",
+                    method,
+                    path,
+                    type(e).__name__,
+                    e,
+                    exc_info=True,
+                )
+                # No terminal ``record_*`` here on purpose: a network-layer
+                # failure is not a rate-limit signal, so it neither feeds
+                # the failure run nor closes a trial. ``admit_or_shed``'s
+                # ``finally`` reports ``record_aborted`` (LML#787) so a dying
+                # trial re-OPENs instead of latching.
                 return None
 
+            # LML#755: feed the breaker **once per request, on the terminal
+            # outcome** (FIX 2/5), not per attempt — the counting unit is
+            # failed *requests*, not failed attempts. ``retry_429`` already
+            # collapsed "429s exhausted" and "429, budget can't absorb the
+            # next delay" into the same terminal shape (the last-seen 429
+            # response, returned rather than converted to ``None`` -- see its
+            # docstring), so both cases converge on the ``record_failure``
+            # call below: the 429 is still a genuine rate-limit signal either
+            # way (LML#758).
+            remaining_value = _parse_ratelimit_remaining(
+                response.headers.get("X-Discogs-Ratelimit-Remaining")
+            )
+            if response.status_code != 429:
+                admission.mark_recorded()
+                if response.status_code >= 500:
+                    # 5xx is neutral: don't reset the failure run, don't
+                    # close a half-open trial (FIX 5). Only opens on an
+                    # exhausted floor.
+                    breaker.record_server_error(remaining=remaining_value, epoch=admission.epoch)
+                else:
+                    breaker.record_success(remaining=remaining_value, epoch=admission.epoch)
+                return response
+
+            # Retries exhausted (or the caller budget couldn't absorb the next
+            # retry delay): this request definitively 429'd. Record exactly
+            # one failure (per-request unit) carrying the last-seen remaining
+            # so an at/below-floor bucket opens proactively even before the
+            # reactive threshold (FIX 2). The ``None`` return is the existing
+            # "unknown, not confirmed-empty" degrade contract every caller of
+            # ``_request_with_retry`` already honors (LML#755).
+            admission.mark_recorded()
+            breaker.record_failure(remaining=remaining_value, epoch=admission.epoch)
             return None
-        finally:
-            if not recorded:
-                breaker.record_aborted(epoch=epoch)
 
     def _parse_title(self, title: str) -> tuple[str, str]:
         """Parse Discogs title format 'Artist - Album' into components."""

--- a/tests/unit/test_bandcamp_retry_characterization.py
+++ b/tests/unit/test_bandcamp_retry_characterization.py
@@ -1,0 +1,187 @@
+"""Characterization tests for ``BandcampClient._request_with_retry``'s 429
+retry policy (LML#1040), pinned BEFORE converting it to the shared
+``discogs.admission.retry_429`` loop.
+
+These pin the exact numeric/attempt-count behavior that must survive the
+conversion byte-for-byte:
+
+- the delay progression on sustained 429s -- ``RETRY_BASE_DELAY * 2**attempt``,
+  with NO jitter and NO cap (unlike Discogs's ``_compute_retry_delay``, which
+  has both);
+- ``Retry-After`` header handling -- a valid numeric value wins outright
+  (bypassing the backoff formula entirely, even ignoring ``attempt``), an
+  invalid/non-numeric value falls back to the backoff formula;
+- the total attempt count on sustained 429s (``MAX_RETRIES + 1``);
+- a non-429 request exception aborts immediately, with no retry and no sleep.
+
+Pure unit: a pre-injected mock ``httpx.AsyncClient`` and a stubbed rate
+limiter (``AsyncLimiter(1, 1)`` would otherwise pace real time between the
+multiple attempts these tests drive) -- nothing leaves the process, nothing
+sleeps in wall-clock time.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from clients.bandcamp import MAX_RETRIES, RETRY_BASE_DELAY, BandcampClient
+
+_URL = "https://bandcamp.com/api/fuzzysearch/2/app_autocomplete"
+
+
+class _InstantLimiter:
+    """A rate limiter stand-in with a no-op ``acquire`` -- mirrors the
+    ``fake_limiter`` fixture pattern used throughout the Discogs retry test
+    suites (``tests/unit/test_discogs_ratelimit.py`` et al.), so these tests
+    exercise real attempt/delay counting without paying ``AsyncLimiter(1, 1)``'s
+    real per-attempt pacing."""
+
+    async def acquire(self) -> None:
+        return None
+
+
+def _response(status_code: int, headers: dict[str, str] | None = None) -> httpx.Response:
+    return httpx.Response(status_code, headers=headers or {}, request=httpx.Request("GET", _URL))
+
+
+@pytest.fixture
+def client() -> BandcampClient:
+    c = BandcampClient()
+    c._http = AsyncMock(spec=httpx.AsyncClient)
+    c._rate_limiter = _InstantLimiter()  # type: ignore[assignment]
+    return c
+
+
+class TestDelayProgression:
+    @pytest.mark.asyncio
+    async def test_exponential_backoff_no_jitter_no_cap(self, client):
+        """Sustained 429s (no ``Retry-After``) sleep ``RETRY_BASE_DELAY *
+        2**attempt`` for each retried attempt, unmodified by jitter or a cap."""
+        responses = [_response(429) for _ in range(MAX_RETRIES)] + [_response(200)]
+        client._http.request = AsyncMock(side_effect=responses)
+
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with patch("clients.bandcamp.asyncio.sleep", side_effect=_fake_sleep):
+            result = await client._request_with_retry("GET", _URL)
+
+        assert result is not None
+        assert result.status_code == 200
+        assert sleep_calls == [RETRY_BASE_DELAY * (2**a) for a in range(MAX_RETRIES)]
+        assert client._http.request.await_count == MAX_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_exhausts_after_max_retries_returns_none(self, client):
+        """A 429 on every attempt exhausts at exactly ``MAX_RETRIES + 1``
+        total attempts and gives up, returning ``None``."""
+        client._http.request = AsyncMock(return_value=_response(429))
+
+        with patch("clients.bandcamp.asyncio.sleep", new=AsyncMock()):
+            result = await client._request_with_retry("GET", _URL)
+
+        assert result is None
+        assert client._http.request.await_count == MAX_RETRIES + 1
+
+
+class TestRetryAfterHeader:
+    @pytest.mark.asyncio
+    async def test_valid_numeric_retry_after_wins_over_backoff(self, client):
+        """A numeric ``Retry-After`` is honored verbatim -- it wins over the
+        exponential-backoff formula entirely, not just as a floor/ceiling."""
+        client._http.request = AsyncMock(
+            side_effect=[_response(429, {"Retry-After": "2.5"}), _response(200)]
+        )
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with patch("clients.bandcamp.asyncio.sleep", side_effect=_fake_sleep):
+            result = await client._request_with_retry("GET", _URL)
+
+        assert result is not None
+        assert result.status_code == 200
+        assert sleep_calls == [2.5]
+
+    @pytest.mark.asyncio
+    async def test_invalid_retry_after_falls_back_to_backoff(self, client):
+        """A non-numeric ``Retry-After`` is ignored -- falls back to
+        ``RETRY_BASE_DELAY * 2**attempt`` for that attempt."""
+        client._http.request = AsyncMock(
+            side_effect=[_response(429, {"Retry-After": "not-a-number"}), _response(200)]
+        )
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with patch("clients.bandcamp.asyncio.sleep", side_effect=_fake_sleep):
+            result = await client._request_with_retry("GET", _URL)
+
+        assert result is not None
+        assert sleep_calls == [RETRY_BASE_DELAY * (2**0)]
+
+    @pytest.mark.asyncio
+    async def test_missing_retry_after_uses_backoff(self, client):
+        """No ``Retry-After`` header at all -- same fallback as an invalid one."""
+        client._http.request = AsyncMock(side_effect=[_response(429), _response(200)])
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with patch("clients.bandcamp.asyncio.sleep", side_effect=_fake_sleep):
+            result = await client._request_with_retry("GET", _URL)
+
+        assert result is not None
+        assert sleep_calls == [RETRY_BASE_DELAY * (2**0)]
+
+
+class TestRequestExceptionAbortsImmediately:
+    @pytest.mark.asyncio
+    async def test_request_exception_returns_none_without_retry(self, client):
+        """A request-layer exception on ANY attempt aborts the whole call
+        immediately -- it is not retried, unlike a 429."""
+        client._http.request = AsyncMock(side_effect=httpx.ConnectError("boom"))
+
+        with patch("clients.bandcamp.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = await client._request_with_retry("GET", _URL)
+
+        assert result is None
+        assert client._http.request.await_count == 1
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_exception_after_a_429_retry_still_aborts_without_further_retry(self, client):
+        """A 429 retried once, then a request exception on the SECOND attempt,
+        aborts there -- it does not retry past the exception."""
+        client._http.request = AsyncMock(side_effect=[_response(429), httpx.ConnectError("boom")])
+
+        with patch("clients.bandcamp.asyncio.sleep", new=AsyncMock()):
+            result = await client._request_with_retry("GET", _URL)
+
+        assert result is None
+        assert client._http.request.await_count == 2
+
+
+class TestSemaphoreReleasedBeforeSleep:
+    @pytest.mark.asyncio
+    async def test_permit_released_before_retry_sleep(self, client):
+        """The semaphore permit must be free during the inter-attempt sleep,
+        not held for its duration -- mirrors the Discogs LML#569 contract."""
+        client._http.request = AsyncMock(side_effect=[_response(429), _response(200)])
+
+        async def _fake_sleep(_delay: float) -> None:
+            assert not client._semaphore.locked(), "permit still held entering the retry sleep"
+
+        with patch("clients.bandcamp.asyncio.sleep", side_effect=_fake_sleep):
+            result = await client._request_with_retry("GET", _URL)
+
+        assert result is not None
+        assert not client._semaphore.locked()


### PR DESCRIPTION
Closes #1040

## Problem

`discogs/service.py::_request_with_retry` had grown into a ~285-line method interleaving six concerns line-by-line: breaker admit/shed, live-request telemetry, the LML#927 bulk sub-semaphore, the shared LML#358/#569 semaphore, the LML#841 rate gate, and the 429 retry loop with its LML#758 budget-deadline arithmetic and terminal breaker accounting. Every incident fix to any one of those edited the same method. `clients/bandcamp.py` separately hand-rolled its own parallel 429 loop with its own (differently-shaped) delay policy.

## Approach

`discogs/admission.py` (new) holds two pieces with no reuse-blocking dependency:
- `admit_or_shed` — the LML#755 entry gate plus the LML#787 abort bookkeeping, via a `BreakerAdmission` the caller marks `recorded` on after any terminal `record_*` call.
- `retry_429` — the generic backoff-or-`Retry-After` loop with an optional absolute budget deadline, shared between Discogs and Bandcamp.

`acquire_discogs_permits` — the LML#927 bulk sub-semaphore (outer) plus the shared semaphore (inner), with their Sentry queue-depth/wait projections — stays defined in `discogs/service.py` rather than moving alongside the pieces above. Reason: `tests/unit/test_discogs_service.py::TestRequestWithRetrySpans` patches the *whole* `discogs.service.sentry_sdk` name (`patch("discogs.service.sentry_sdk")`, no trailing attribute), which rebinds that name only in `discogs.service`'s own namespace — unlike an attribute-level patch (`patch("discogs.service.sentry_sdk.start_span")`, which mutates the shared module object and is visible from any module), a whole-name patch only affects `sentry_sdk.*` calls textually resolved from that module's globals. Moving the span-emitting code to `admission.py` silently broke that test class; I verified this by running the test suite after the move and diagnosing the failure before reverting the placement. This is documented in both `discogs/admission.py`'s and `discogs/service.py::acquire_discogs_permits`'s docstrings.

`_request_with_retry`'s body is now the composition: resolve `semaphore`/`rate_gate`/`breaker`/`bulk_semaphore` (unchanged — these getter calls stay bare-name in `discogs/service.py` because the breaker/ratelimit/bulk-reservation test suites patch them via `discogs.service.<name>`, which only intercepts a lookup performed by code textually in that module) → `admit_or_shed(...)` → per-attempt closure (`should_shed_inflight` re-check, inline — 3 lines, not reusable) → `acquire_discogs_permits(...)` → rate-gate span + acquire (inline — no "permit to release" shape) → `client.request(...)` → `retry_429(...)` → post-loop terminal breaker accounting (`record_success`/`record_server_error`/`record_failure`, unified for both "retries exhausted" and "budget can't absorb the next delay" since `retry_429` never converts a persistent 429 to `None` itself — it returns the last response and lets the caller decide, so the caller can still read `X-Discogs-Ratelimit-Remaining`).

`clients/bandcamp.py`'s hand-rolled loop now calls the same `retry_429`, supplying its own permit acquisition (`self._semaphore` + `self._rate_limiter.acquire()`), its own pre-existing delay policy (`RETRY_BASE_DELAY * 2**attempt`, no jitter, no cap — left unchanged per the ticket), and its own log wording via `retry_429`'s `on_retry`/`on_exhausted` hooks. A request-layer exception is threaded through a small sentinel (`_BandcampRequestFailedError`), raised only from inside the `client.request()` try, so it aborts the call without retrying — matching the pre-refactor bare `except Exception` that was scoped to only that call (not `self._rate_limiter.acquire()` or the semaphore).

## Verified acquire order (unchanged)

breaker admit → per attempt: bulk sub-semaphore (outer, low-priority only) → shared semaphore (inner) → rate gate → request. Released inner → outer before the retry sleep. This was verified from the pre-refactor code (not assumed from the ticket's listing, which the ticket itself flagged as a guess) and pinned by the existing `test_discogs_service_bulk_priority.py::TestAcquireOrdering` suite, which passes unchanged.

## Telemetry-key diff

Grepped every literal Sentry/PostHog/cache-stats key string, plus every `start_span(op=..., name=...)` kwarg pair, in `discogs/service.py` + `clients/bandcamp.py` before this change vs. `discogs/service.py` + `discogs/admission.py` + `clients/bandcamp.py` after. Both sets are **identical**:

```
"discogs_breaker_open_shed"
"discogs_bulk_reserved_capped"
"lml.bulk_semaphore.queue_depth"
"lml.discogs.bulk_semaphore_capped"
"lml.discogs.bulk_semaphore_queue_depth"
"lml.discogs.bulk_semaphore_queued"
"lml.discogs.bulk_semaphore_wait_ms"
"lml.discogs.bulk_semaphore"
"lml.discogs.priority"
"lml.discogs.rate_limiter"
"lml.discogs.semaphore_queue_depth"
"lml.discogs.semaphore_queued"
"lml.discogs.semaphore"
"lml.semaphore.queue_depth"
```

`op="lock.acquire"` / `name="lml.discogs.*"` span kwargs: identical before/after.

## Bandcamp compatibility

Byte-compatible. `tests/unit/test_bandcamp_retry_characterization.py` (new) pins, against the pre-refactor implementation first (all 8 passed), then re-run unchanged against the post-refactor implementation (all 8 still pass):
- exponential-backoff progression with no jitter/cap (`RETRY_BASE_DELAY * 2**attempt` for each retried attempt)
- exhaustion at exactly `MAX_RETRIES + 1` total attempts
- a valid numeric `Retry-After` wins verbatim over the backoff formula
- an invalid/missing `Retry-After` falls back to the backoff formula
- a request-layer exception aborts immediately without retrying, whether on the first attempt or after a prior 429 retry
- the semaphore permit is released before the inter-attempt sleep (mirrors the Discogs LML#569 contract)

No divergence needed approval — perfect compatibility was achievable.

## Test results

- `uv run --no-sync ruff format --check .` — clean
- `uv run --no-sync ruff check .` — clean
- `uv run --no-sync mypy discogs/service.py discogs/admission.py clients/bandcamp.py tests/unit/test_bandcamp_retry_characterization.py --ignore-missing-imports` — clean
- `uv run --no-sync pytest -m "not pg and not external_api"` — 5100 passed, 1 skipped, 2 xfailed, 1 failed, 1 error. The failure (`test_shed_lookup_emits_no_error_level_logs`) and error (`test_no_module_level_asyncio_lock_in_dependencies`) are the two pre-existing order-dependent flakes called out in the ticket's own instructions — both pass cleanly in isolation, and both are logically orthogonal to this diff (a caplog-based integration test sensitive to cross-test global-state pollution, and a static source-text substring scan on `core/dependencies.py`, a file this PR never touches).
- Every existing breaker/ratelimit/bulk-reservation/live-counter/telemetry test suite (`test_discogs_breaker_request.py`, `test_discogs_breaker.py`, `test_discogs_bulk_semaphore.py`, `test_discogs_live_request_counter.py`, `test_discogs_ratelimit.py`, `test_ratelimit_concurrent.py`, `test_ratelimit.py`, `test_discogs_service_bulk_priority.py`, `test_discogs_retry_budget_deadline.py`, `test_discogs_request_telemetry.py`, `test_discogs_rate_gate.py`, `test_discogs_service.py::TestRequestWithRetrySpans`) — unchanged, all pass.

## Non-goals

No feature changes, no bundling. The per-attempt in-flight breaker re-check (`should_shed_inflight`) and the rate-gate acquire stay inline in `_request_with_retry` — three lines tightly coupled to that call site's epoch, and a token-bucket spend with no "permit to release" shape, respectively — extracting either would add indirection without a reuse payoff.