### PR TITLE
refactor(streaming): one StreamingService enum + one service registry

### DIFF
--- a/entity/streaming_catalog.py
+++ b/entity/streaming_catalog.py
@@ -85,21 +85,17 @@ from entity.ddl import (
     build_widen_service_check_sql,
 )
 from entity.sources import PgSource
+from streaming.service import OFFLINE_CATALOG_SERVICES
 
 # The services a catalog probe can target. The named CHECK pins this set at
 # the DB level; the seed maps the SQLite wide columns (spotify_*, deezer_*,
 # apple_*, bandcamp_*) and the real prod file's drift columns (tidal_url,
 # youtube_music_url, soundcloud_url) onto these values. Adding a service
-# extends this tuple and the widen DO block below picks it up.
-_SERVICES = (
-    "spotify",
-    "deezer",
-    "apple_music",
-    "bandcamp",
-    "tidal",
-    "youtube_music",
-    "soundcloud",
-)
+# extends ``streaming.service.OFFLINE_CATALOG_SERVICES`` and the widen DO
+# block below picks it up. LML#1037: derived from the shared
+# ``StreamingService`` enum (catalog-key granularity) instead of a
+# free-floating literal tuple -- same values, same order.
+_SERVICES = tuple(s.catalog_key for s in OFFLINE_CATALOG_SERVICES)
 
 # Import-time tripwire: service values are spliced into SQL literals and read
 # back out of pg_get_constraintdef's deparse by the widen block's quoted-

--- a/entity/streaming_url_cache.py
+++ b/entity/streaming_url_cache.py
@@ -65,6 +65,7 @@ from entity.cache_toolkit import DEFAULT_MISS_TTL, CachedValue, swallowing_execu
 from entity.ddl import LML_CACHE_SCHEMA_DDL as _DDL_SCHEMA
 from entity.ddl import bootstrap_lml_cache_table, widen_service_check
 from entity.sources import PgSource
+from streaming.service import ALBUM_CACHE_KEYS, ALBUM_CACHED_SERVICES
 
 logger = logging.getLogger(__name__)
 
@@ -76,10 +77,13 @@ logger = logging.getLogger(__name__)
 
 # The services the cache ships. The named CHECK constraint pins this set at
 # the DB level; a future PR adding a service (Deezer's 'deezer_album') extends
-# this tuple and the widen DO block below picks it up. Kept as a module
-# constant so the bootstrap DDL and a parity test can both reference it
-# without re-typing the literal. PR-3 added 'bandcamp'.
-_SERVICES = ("apple_music_album", "spotify_album", "bandcamp")
+# ``streaming.service.ALBUM_CACHED_SERVICES`` and the widen DO block below
+# picks it up. Kept as a module constant so the bootstrap DDL and a parity
+# test can both reference it without re-typing the literal. PR-3 added
+# 'bandcamp'. LML#1037: derived from the shared ``StreamingService`` enum's
+# album-cache-key granularity instead of a free-floating literal tuple --
+# same values, same order.
+_SERVICES = tuple(ALBUM_CACHE_KEYS[s] for s in ALBUM_CACHED_SERVICES)
 
 # Shared IN-list literal so the CREATE-time CHECK and the widen DO block's
 # code-side array are generated from the same source — they can never drift.

--- a/entity/track_streaming_url_cache.py
+++ b/entity/track_streaming_url_cache.py
@@ -44,14 +44,18 @@ from entity.cache_toolkit import swallowing_execute, swallowing_fetch
 from entity.ddl import LML_CACHE_SCHEMA_DDL as _DDL_SCHEMA
 from entity.ddl import bootstrap_lml_cache_table, widen_service_check
 from entity.sources import PgSource
+from streaming.service import TRACK_CACHE_KEYS, StreamingService
 
 logger = logging.getLogger(__name__)
 
 # The single service L1 ships. The named CHECK constraint pins this set at the
-# DB level; a future PR (e.g. a Spotify track deep-link) extends this tuple and
-# the ALTER below picks it up. Kept as a module constant so the bootstrap DDL
-# and the parity test can both reference it without re-typing the literal.
-APPLE_MUSIC_TRACK_SERVICE = "apple_music_track"
+# DB level; a future PR (e.g. a Spotify track deep-link) extends
+# ``streaming.service.TRACK_CACHE_KEYS`` and the ALTER below picks it up.
+# Kept as a module constant so the bootstrap DDL and the parity test can both
+# reference it without re-typing the literal. LML#1037: derived from the
+# shared ``StreamingService`` enum's track-cache-key granularity instead of a
+# free-floating literal -- same value.
+APPLE_MUSIC_TRACK_SERVICE: str = TRACK_CACHE_KEYS[StreamingService.APPLE_MUSIC]
 _SERVICES = (APPLE_MUSIC_TRACK_SERVICE,)
 
 # Shared IN-list literal so the CREATE-time CHECK is generated from the same

--- a/identity/release_validation.py
+++ b/identity/release_validation.py
@@ -190,8 +190,14 @@ def _validate_spotify_album_id(source: str, external_id: str) -> str:
 # ``lookup.streaming_url_postprocess.STREAMING_URL_CACHE_CONFIG``: Discogs
 # release/master are identity-mintable but never URL-cached (they aren't
 # resolved from a live streaming probe), and Bandcamp is identity-mintable
-# but only joins the cache registry in PR-3. The parity test asserts
-# ``STREAMING_URL_CACHE_CONFIG.keys() ⊆ RELEASE_SOURCE_CONFIG.keys()``.
+# but only joins the cache registry in PR-3. This registry stays keyed by the
+# bare mint-source string (LML#1037 did not fold it into the
+# ``streaming.service.StreamingService`` enum — it mixes two Discogs
+# identity-only sources into an otherwise streaming-service-shaped key set,
+# which is exactly the kind of asymmetric membership the enum's three
+# vocabularies don't have). The parity test asserts the image of
+# ``STREAMING_URL_CACHE_CONFIG``'s enum keys under
+# ``streaming.service.ALBUM_CACHE_KEYS`` ⊆ ``RELEASE_SOURCE_CONFIG.keys()``.
 # ``musicbrainz_release`` is intentionally absent — it is read-only today
 # (no write helper / sentinel rule), readable via the store's
 # ``_RELEASE_IDENTITY_COLUMN_TO_SOURCE`` tuple but not mintable here.

--- a/lookup/streaming_url_postprocess.py
+++ b/lookup/streaming_url_postprocess.py
@@ -97,6 +97,7 @@ from lookup.timeouts import APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR, probe_timeout_s_
 from release.apple_music_url_parser import apple_album_id_from_url
 from release.bandcamp_url_parser import bandcamp_album_id_from_url
 from release.spotify_url_parser import spotify_album_id_from_url
+from streaming.service import ALBUM_CACHE_KEYS, ALBUM_CACHED_SERVICES, StreamingService
 
 if TYPE_CHECKING:
     from config.settings import Settings
@@ -185,10 +186,13 @@ class StreamingUrlCacheConfig:
     concerns) so neither registry carries Optional fields for the other's
     members. ``flag_setting`` names the per-service ``Settings`` attribute;
     ``url_to_external_id`` extracts the mintable ID from a resolved URL
-    (``None`` → surface URL, skip mint). The registry *key* doubles as the
+    (``None`` → surface URL, skip mint). The registry *key* (a
+    ``StreamingService`` member, LML#1037) doubles as the client-dispatch
+    lookup (``service.catalog_key`` into the ``clients`` dict / the returned
+    ``statuses`` dict) and, via ``streaming.service.ALBUM_CACHE_KEYS``, the
     mint source (a key into ``RELEASE_SOURCE_CONFIG``) — the post-process
-    threads it into ``_mint_identity`` directly, so there is no separate
-    ``mint_source`` field to keep in sync.
+    derives both from the key rather than carrying a ``client_attr`` field
+    that would just restate ``service.catalog_key``.
 
     ``probe_timeout_s`` is the static per-service wall-clock ceiling.
     ``timeout_env_var`` (optional) names an integer-ms env var that overrides
@@ -202,40 +206,42 @@ class StreamingUrlCacheConfig:
     probe_timeout_s: float
     url_to_external_id: Callable[[str], str | None]
     url_field: str
-    client_attr: str
     flag_setting: str
     timeout_env_var: str | None = None
 
 
-# Cache + post-process registry. Deliberately a SUBSET of
+# Cache + post-process registry (LML#1037: keyed by ``StreamingService``
+# instead of a free-floating album-cache-key string — the same
+# ``ALBUM_CACHED_SERVICES`` ordering ``entity/streaming_url_cache.py``'s
+# ``_SERVICES`` derives from, so this dict's iteration order and that table's
+# CHECK-constraint literal order stay in lockstep). Deliberately a SUBSET of
 # ``identity.release_validation.RELEASE_SOURCE_CONFIG`` (5 entries): Discogs
 # release/master are identity-only (never resolved from a live streaming
 # probe). Apple + Spotify (PR-1) and Bandcamp (PR-3) are all
-# minted-from-live-probe AND URL-cached. The parity test asserts these keys ⊆
-# RELEASE_SOURCE_CONFIG keys; the completeness guard in the test suite pins the
-# exact key set. A future PR adds Deezer ('deezer_album') here and ALTERs the
-# table's named CHECK constraint to match.
-STREAMING_URL_CACHE_CONFIG: dict[str, StreamingUrlCacheConfig] = {
-    "apple_music_album": StreamingUrlCacheConfig(
+# minted-from-live-probe AND URL-cached. The parity test asserts these keys'
+# ``ALBUM_CACHE_KEYS`` images ⊆ RELEASE_SOURCE_CONFIG keys; the completeness
+# guard in the test suite pins the exact key set. A future PR adds Deezer here
+# (extending ``streaming.service.ALBUM_CACHE_KEYS``) and ALTERs the table's
+# named CHECK constraint to match.
+STREAMING_URL_CACHE_CONFIG: dict[StreamingService, StreamingUrlCacheConfig] = {
+    StreamingService.APPLE_MUSIC: StreamingUrlCacheConfig(
         miss_ttl=DEFAULT_MISS_TTL,
         probe_timeout_s=_DEFAULT_PROBE_TIMEOUT_S,
         url_to_external_id=apple_album_id_from_url,
         url_field="apple_music_url",
-        client_attr="apple_music",
         flag_setting="lml_persist_streaming_url_apple_music",
         # Back-compat: the pre-LML#573 Apple post-process honored this env var
         # (via apple_music_lookup_timeout_s); keep it tuning this leg too.
         timeout_env_var=APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR,
     ),
-    "spotify_album": StreamingUrlCacheConfig(
+    StreamingService.SPOTIFY: StreamingUrlCacheConfig(
         miss_ttl=DEFAULT_MISS_TTL,
         probe_timeout_s=_DEFAULT_PROBE_TIMEOUT_S,
         url_to_external_id=spotify_album_id_from_url,
         url_field="spotify_url",
-        client_attr="spotify",
         flag_setting="lml_persist_streaming_url_spotify",
     ),
-    "bandcamp": StreamingUrlCacheConfig(
+    StreamingService.BANDCAMP: StreamingUrlCacheConfig(
         miss_ttl=DEFAULT_MISS_TTL,
         # Looser ceiling than Apple/Spotify — see _BANDCAMP_PROBE_TIMEOUT_S.
         probe_timeout_s=_BANDCAMP_PROBE_TIMEOUT_S,
@@ -243,10 +249,13 @@ STREAMING_URL_CACHE_CONFIG: dict[str, StreamingUrlCacheConfig] = {
         # extractor returns the parser-canonical URL the validator expects.
         url_to_external_id=bandcamp_album_id_from_url,
         url_field="bandcamp_url",
-        client_attr="bandcamp",
         flag_setting="lml_persist_streaming_url_bandcamp",
     ),
 }
+assert tuple(STREAMING_URL_CACHE_CONFIG) == ALBUM_CACHED_SERVICES, (
+    "STREAMING_URL_CACHE_CONFIG's declaration order drifted from "
+    "streaming.service.ALBUM_CACHED_SERVICES"
+)
 
 
 async def apply_streaming_url_postprocess(
@@ -277,7 +286,7 @@ async def apply_streaming_url_postprocess(
         update: The item's ``update`` dict. Each active service's
             ``cfg.url_field`` key must be present (``None`` or ``str``); on a
             cache hit it is overwritten with the URL.
-        clients: Maps ``cfg.client_attr`` → client (or ``None`` when the
+        clients: Maps ``service.catalog_key`` → client (or ``None`` when the
             service's credentials are unconfigured — that service is skipped,
             not an error). Each client is a process-global singleton, so the
             background warm may use it after the request returns.
@@ -294,7 +303,7 @@ async def apply_streaming_url_postprocess(
 
     Returns:
         LML#1053: the per-service resolution verdict for every service this
-        call actually consulted, keyed by ``cfg.client_attr`` (``apple_music``
+        call actually consulted, keyed by ``service.catalog_key`` (``apple_music``
         / ``spotify`` / ``bandcamp`` — the same keys the wire contract's
         ``StreamingResolution`` object uses). A cache hit maps to ``verified``;
         a known recent miss (a fresh "not found" already on record) maps to
@@ -315,12 +324,17 @@ async def apply_streaming_url_postprocess(
     # Capture the (narrowed, non-None) client in the tuple via the walrus so
     # the loop below doesn't re-index the dict (and so the type-checker sees a
     # non-Optional client when threading it into the background warm).
+    # ``storage_key`` (LML#1037: ``ALBUM_CACHE_KEYS[service]``, e.g.
+    # "apple_music_album") is the exact string every downstream PG bind /
+    # Sentry key / mint-source call used before this refactor — only the
+    # registry's OUTER key changed type (str -> StreamingService); every
+    # runtime string value threaded through below is unchanged.
     active = [
-        (service_key, cfg, client)
-        for service_key, cfg in STREAMING_URL_CACHE_CONFIG.items()
+        (service, ALBUM_CACHE_KEYS[service], cfg, client)
+        for service, cfg in STREAMING_URL_CACHE_CONFIG.items()
         if getattr(settings, cfg.flag_setting, False)
         and update.get(cfg.url_field) is None
-        and (client := clients.get(cfg.client_attr)) is not None
+        and (client := clients.get(service.catalog_key)) is not None
     ]
     if not active:
         return {}
@@ -334,62 +348,62 @@ async def apply_streaming_url_postprocess(
         *(
             peek_cached_streaming_url(
                 pg,
-                service=service_key,
+                service=storage_key,
                 artist=request_artist,
                 album=request_album,
                 miss_ttl=cfg.miss_ttl,
             )
-            for service_key, cfg, _client in active
+            for _service, storage_key, cfg, _client in active
         ),
         return_exceptions=True,
     )
 
     suppress_warm = should_suppress_streaming_warm()
     statuses: dict[str, StreamingResolutionStatus] = {}
-    for (service_key, cfg, client), peek in zip(active, peeks, strict=True):
+    for (service, storage_key, cfg, client), peek in zip(active, peeks, strict=True):
         if isinstance(peek, BaseException):
             logger.warning(
                 "streaming-URL cache peek failed for %s / %s / %s: %r",
-                service_key,
+                storage_key,
                 request_artist,
                 request_album,
                 peek,
             )
             # LML#1053: an attempted-but-errored consult is inconclusive, not
             # never-consulted — same bucket as a timeout.
-            statuses[cfg.client_attr] = StreamingResolutionStatus.unresolved
+            statuses[service.catalog_key] = StreamingResolutionStatus.unresolved
             continue
         cached_url, has_fresh_decision = peek
         if cached_url is not None:
             # Synchronous hit: fill the URL now. No mint — the URL was minted on
             # the resolution that first wrote this cache row.
             update[cfg.url_field] = cached_url
-            _project_sentry(service_key, "cache_hit")
-            statuses[cfg.client_attr] = StreamingResolutionStatus.verified
+            _project_sentry(storage_key, "cache_hit")
+            statuses[service.catalog_key] = StreamingResolutionStatus.verified
         elif has_fresh_decision:
             # Known recent miss: the cache already records "checked, not found"
             # within the TTL. No probe is warranted, so don't schedule a no-op
             # warm (it would just re-derive the same recent-miss verdict). A
             # real, sourced negative — not a couldn't-check.
-            _project_sentry(service_key, "cache_miss_recent")
-            statuses[cfg.client_attr] = StreamingResolutionStatus.absent
+            _project_sentry(storage_key, "cache_miss_recent")
+            statuses[service.catalog_key] = StreamingResolutionStatus.absent
         elif suppress_warm:
             # Bulk path: cache read-fill only. The offline warmer owns bulk fill;
             # spawning a warm here would decouple the drain's probes from the
             # request and starve the live /lookup path's own warms. No warm
             # means no confirmed verdict this request — transient, not terminal.
-            _project_sentry(service_key, "cache_miss_unwarmed")
-            statuses[cfg.client_attr] = StreamingResolutionStatus.unresolved
+            _project_sentry(storage_key, "cache_miss_unwarmed")
+            statuses[service.catalog_key] = StreamingResolutionStatus.unresolved
         else:
             # Genuine miss (absent/stale): defer the live probe + UPSERT + mint
             # to a bounded, deduplicated background task. The response returns
             # without this service's URL; the warm fills the cache for next
             # time — so this request's verdict is transient, not terminal.
             _enqueue_streaming_warm(
-                service_key, cfg, client, pg, entity_store, request_artist, request_album
+                storage_key, cfg, client, pg, entity_store, request_artist, request_album
             )
-            _project_sentry(service_key, "cache_miss_enqueued")
-            statuses[cfg.client_attr] = StreamingResolutionStatus.unresolved
+            _project_sentry(storage_key, "cache_miss_enqueued")
+            statuses[service.catalog_key] = StreamingResolutionStatus.unresolved
 
     return statuses
 

--- a/lookup/streaming_url_postprocess.py
+++ b/lookup/streaming_url_postprocess.py
@@ -252,10 +252,15 @@ STREAMING_URL_CACHE_CONFIG: dict[StreamingService, StreamingUrlCacheConfig] = {
         flag_setting="lml_persist_streaming_url_bandcamp",
     ),
 }
-assert tuple(STREAMING_URL_CACHE_CONFIG) == ALBUM_CACHED_SERVICES, (
-    "STREAMING_URL_CACHE_CONFIG's declaration order drifted from "
-    "streaming.service.ALBUM_CACHED_SERVICES"
-)
+# Explicit raise (not bare `assert`) so this drift guard survives `python -O` /
+# `PYTHONOPTIMIZE=1`, which compiles `assert` statements out and would silently
+# disable it in optimized production runs -- mirroring the same-class import-time
+# guard convention in streaming/orchestrator.py.
+if tuple(STREAMING_URL_CACHE_CONFIG) != ALBUM_CACHED_SERVICES:
+    raise RuntimeError(
+        "STREAMING_URL_CACHE_CONFIG's declaration order drifted from "
+        "streaming.service.ALBUM_CACHED_SERVICES"
+    )
 
 
 async def apply_streaming_url_postprocess(

--- a/streaming/orchestrator.py
+++ b/streaming/orchestrator.py
@@ -10,6 +10,7 @@ from clients.streaming.apple_music import AppleMusicClient
 from clients.streaming.deezer import DeezerClient
 from clients.streaming.spotify import SpotifyClient
 from streaming.models import StreamingCheckResponse, StreamingCheckSources
+from streaming.service import CATALOG_CHECK_SERVICES
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +19,12 @@ logger = logging.getLogger(__name__)
 # API-locked, so the gather loop relies on this mapping being 1:1).
 # Explicit raise (not `assert`) so the guard survives `python -O` /
 # `PYTHONOPTIMIZE=1`, which compiles bare `assert` statements out and would
-# silently disable the check in optimized production runs.
-_EXPECTED_SERVICE_FIELDS = {"spotify", "deezer", "apple_music", "bandcamp"}
+# silently disable the check in optimized production runs. LML#1037: derived
+# from the shared `StreamingService` enum's catalog-key granularity (via
+# `CATALOG_CHECK_SERVICES`, the canonical ordering this module's kwargs and
+# `StreamingCheckSources`'s fields both follow) instead of a free-floating
+# literal set -- same values.
+_EXPECTED_SERVICE_FIELDS = {s.catalog_key for s in CATALOG_CHECK_SERVICES}
 if set(StreamingCheckSources.model_fields) != _EXPECTED_SERVICE_FIELDS:
     raise RuntimeError(
         "StreamingCheckSources fields drifted from check_streaming_availability "
@@ -69,12 +74,20 @@ async def check_streaming_availability(
     # The kwarg names (spotify / deezer / apple_music / bandcamp) double as
     # `StreamingCheckSources` field names — the response shape is API-locked,
     # so the gather loop maps name-to-client uniformly without branching.
-    clients = {
-        "spotify": spotify,
-        "deezer": deezer,
-        "apple_music": apple_music,
-        "bandcamp": bandcamp,
-    }
+    # LML#1037: the dict's KEYS are derived from `CATALOG_CHECK_SERVICES` (the
+    # same canonical ordering `_EXPECTED_SERVICE_FIELDS` above uses) instead of
+    # a free-floating literal dict — the VALUES still bind directly to this
+    # function's named kwargs (unchanged signature, so `streaming/router.py`'s
+    # call site and every existing test needs no update). `strict=True` makes
+    # a future kwarg/registry-order drift fail loudly at call time rather than
+    # silently mis-pairing a client with the wrong service key.
+    clients = dict(
+        zip(
+            (s.catalog_key for s in CATALOG_CHECK_SERVICES),
+            (spotify, deezer, apple_music, bandcamp),
+            strict=True,
+        )
+    )
     tasks: dict[str, asyncio.Task] = {
         name: asyncio.create_task(client.find_album_match(artist, title))
         for name, client in clients.items()

--- a/streaming/service.py
+++ b/streaming/service.py
@@ -1,0 +1,176 @@
+"""Canonical streaming-service identity (LML#1037).
+
+Before this module, the same streaming platforms were named by three
+independently hand-maintained, disjoint vocabularies, each with its own
+tuple/registry (and two docstrings existing solely to police the confusion
+between them, "do not conflate them"):
+
+* **Catalog-key granularity** (bare service name) --
+  ``streaming/models.py``'s ``StreamingCheckSources`` field names,
+  ``streaming/orchestrator.py``'s client-dispatch table + kwargs, and
+  ``entity/streaming_catalog.py``'s offline-catalog service axis (7 services,
+  including Tidal / YouTube Music / SoundCloud, which have no cache tier
+  below).
+* **Album-cache-key granularity** (``entity/streaming_url_cache.py``'s
+  ``_SERVICES`` / ``lookup/streaming_url_postprocess.STREAMING_URL_CACHE_CONFIG``)
+  -- the storage key in ``lml_cache.album_streaming_url_cache``. Apple and
+  Spotify carry an ``_album`` suffix (they also have a distinct track-cache
+  granularity below); Bandcamp does not (it has no track granularity, so its
+  storage key is its bare catalog key).
+* **Track-cache-key granularity** (``entity/track_streaming_url_cache.py``) --
+  the storage key in ``lml_cache.track_streaming_url_cache``. Today only Apple
+  Music ships a track-scoped cache tier (LML#893, lever L1).
+
+``StreamingService`` is the single enum every one of those three vocabularies
+now derives from: one member per platform, with the bare catalog key as the
+enum VALUE and the other two granularities exposed as properties.
+
+**Hard constraint (LML#1037): "map, never rename".** The ``album_cache_key`` /
+``track_cache_key`` values below are copied VERBATIM from the pre-refactor
+literal tuples they replace. They are load-bearing in named CHECK constraints
+on populated ``lml_cache.*`` tables (``entity/ddl.py``'s widen-only DO block
+merges a code-side service set into whatever is already deployed; a renamed
+key here would look like a *narrowing* to that block, which is deliberately
+never allowed to happen automatically). Changing a value here to anything
+other than what the corresponding pre-refactor tuple already shipped requires
+its own migration-scoped ticket, never a rename disguised as a refactor. See
+``tests/unit/test_streaming_service.py`` for the pinning tests and each owning
+module's own test file (``test_streaming_url_cache_schema.py``,
+``test_track_streaming_url_cache_schema.py``, ``test_streaming_catalog_schema.py``,
+and their ``@pytest.mark.pg`` integration-layer twins) for the CHECK-list
+parity proof against both the code-side ``_SERVICES`` constant and the LIVE
+deployed constraint.
+
+Because ``StreamingService`` is a ``StrEnum``, a member compares equal to and
+serializes as its bare catalog-key string (``StreamingService.SPOTIFY ==
+"spotify"``, ``f"{StreamingService.SPOTIFY}" == "spotify"``) -- every
+pre-refactor call site that compared against or interpolated a bare literal
+keeps working unchanged when handed a member instead.
+
+This module is deliberately dependency-free (stdlib only) so every other
+streaming-adjacent package -- ``streaming/``, ``entity/``, ``lookup/`` -- can
+depend on it without risking an import cycle.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class StreamingService(StrEnum):
+    """One member per streaming platform LML integrates with.
+
+    The enum VALUE is the bare "catalog key" (see the module docstring for
+    the three-granularity rundown). ``album_cache_key`` / ``track_cache_key``
+    are ``None`` for a service with no tier at that granularity.
+    """
+
+    SPOTIFY = "spotify"
+    DEEZER = "deezer"
+    APPLE_MUSIC = "apple_music"
+    BANDCAMP = "bandcamp"
+    TIDAL = "tidal"
+    YOUTUBE_MUSIC = "youtube_music"
+    SOUNDCLOUD = "soundcloud"
+
+    @property
+    def catalog_key(self) -> str:
+        """Bare service name -- identical to ``self.value``.
+
+        Used by ``StreamingCheckSources`` / ``StreamingResolution`` field
+        names, ``streaming/orchestrator.py``'s client-dispatch table, and
+        ``entity/streaming_catalog.py``'s offline-catalog service axis.
+        """
+        return self.value
+
+    @property
+    def album_cache_key(self) -> str | None:
+        """Storage key in ``lml_cache.album_streaming_url_cache``.
+
+        Also the mint-source key into
+        ``identity.release_validation.RELEASE_SOURCE_CONFIG`` for the three
+        services that are both URL-cached and identity-mintable.
+        ``None`` for a service with no persistent album-URL cache tier
+        (today: Deezer, Tidal, YouTube Music, SoundCloud).
+        """
+        return ALBUM_CACHE_KEYS.get(self)
+
+    @property
+    def track_cache_key(self) -> str | None:
+        """Storage key in ``lml_cache.track_streaming_url_cache``.
+
+        ``None`` for a service with no track-scoped cache tier (today, only
+        Apple Music has one -- LML#893, lever L1).
+        """
+        return TRACK_CACHE_KEYS.get(self)
+
+
+# Album-cache storage keys -- verbatim from the pre-refactor
+# ``entity/streaming_url_cache.py`` ``_SERVICES`` tuple
+# (``("apple_music_album", "spotify_album", "bandcamp")``). Only the three
+# services with a persistent ``lml_cache.album_streaming_url_cache`` tier
+# appear here; every other ``StreamingService`` member is absent (so
+# ``.get()`` -- the property's lookup -- correctly returns ``None`` for them).
+ALBUM_CACHE_KEYS: dict[StreamingService, str] = {
+    StreamingService.APPLE_MUSIC: "apple_music_album",
+    StreamingService.SPOTIFY: "spotify_album",
+    StreamingService.BANDCAMP: "bandcamp",
+}
+
+# Track-cache storage keys -- verbatim from the pre-refactor
+# ``entity/track_streaming_url_cache.py`` ``APPLE_MUSIC_TRACK_SERVICE`` /
+# ``_SERVICES``. A future track-cache addition (e.g. a Spotify track
+# deep-link) extends this dict.
+TRACK_CACHE_KEYS: dict[StreamingService, str] = {
+    StreamingService.APPLE_MUSIC: "apple_music_track",
+}
+
+# Reverse views: storage key -> service. Built from the forward dicts so they
+# can never drift out of lockstep with them.
+SERVICE_BY_ALBUM_CACHE_KEY: dict[str, StreamingService] = {
+    key: service for service, key in ALBUM_CACHE_KEYS.items()
+}
+SERVICE_BY_TRACK_CACHE_KEY: dict[str, StreamingService] = {
+    key: service for service, key in TRACK_CACHE_KEYS.items()
+}
+
+# Canonical per-call-site ORDERING tuples. Each preserves the exact
+# declaration order of the pre-refactor tuple/dict it replaces -- not just its
+# set of members -- so every derived DDL literal / dict-iteration order stays
+# byte-identical across this refactor (no gratuitous CREATE-time or gather-
+# order churn). A new call site should reference one of these (or add a new
+# one here) rather than re-declaring its own ad hoc service list -- that
+# free-floating-tuple duplication is exactly what LML#1037 exists to retire.
+
+# streaming/models.py's StreamingCheckSources field order / the orchestrator's
+# check_streaming_availability kwarg order.
+CATALOG_CHECK_SERVICES: tuple[StreamingService, ...] = (
+    StreamingService.SPOTIFY,
+    StreamingService.DEEZER,
+    StreamingService.APPLE_MUSIC,
+    StreamingService.BANDCAMP,
+)
+
+# entity/streaming_url_cache.py's _SERVICES / lookup/streaming_url_postprocess.py's
+# STREAMING_URL_CACHE_CONFIG declaration order.
+ALBUM_CACHED_SERVICES: tuple[StreamingService, ...] = (
+    StreamingService.APPLE_MUSIC,
+    StreamingService.SPOTIFY,
+    StreamingService.BANDCAMP,
+)
+
+# entity/track_streaming_url_cache.py's _SERVICES.
+TRACK_CACHED_SERVICES: tuple[StreamingService, ...] = (StreamingService.APPLE_MUSIC,)
+
+# entity/streaming_catalog.py's _SERVICES (the 7-service offline-catalog axis,
+# including the drift services -- tidal / youtube_music / soundcloud -- that
+# exist only as columns in the real prod streaming_availability.db).
+OFFLINE_CATALOG_SERVICES: tuple[StreamingService, ...] = (
+    StreamingService.SPOTIFY,
+    StreamingService.DEEZER,
+    StreamingService.APPLE_MUSIC,
+    StreamingService.BANDCAMP,
+    StreamingService.TIDAL,
+    StreamingService.YOUTUBE_MUSIC,
+    StreamingService.SOUNDCLOUD,
+)

--- a/tests/integration/test_streaming_catalog.py
+++ b/tests/integration/test_streaming_catalog.py
@@ -20,6 +20,7 @@ Run with: pytest -m pg -v tests/integration/test_streaming_catalog.py
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import asyncpg
@@ -31,6 +32,7 @@ from entity.streaming_catalog import (
     _TABLES,
     set_up_streaming_catalog_schema,
 )
+from streaming.service import StreamingService
 from tests.integration.conftest import opted_in, skip_if_named_tables_populated
 
 # ``_TABLES`` is parents-before-children (creation order), so its reverse is
@@ -506,6 +508,38 @@ class TestSchemaBootstrap:
                 list(_TABLES),
             )
         assert sorted(r["event_object_table"] for r in rows) == sorted(_TABLES)
+
+
+@pytest.mark.pg
+class TestStreamingServiceCheckParity:
+    """LML#1037 hard constraint: the LIVE deployed CHECK constraint's value
+    set must equal the ``StreamingService`` enum's full catalog-key set (all
+    7 offline-catalog services), byte-for-byte. See
+    ``tests/unit/test_streaming_catalog_schema.py::TestStreamingServiceParity``
+    for the code-side (unit-level) twin."""
+
+    @pytest.mark.asyncio
+    async def test_deployed_check_matches_enum_catalog_keys(self, pg_pool, pg_source):
+        await set_up_streaming_catalog_schema(pg_source)
+        async with pg_pool.acquire() as conn:
+            constraint_def = await conn.fetchval(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint "
+                "WHERE conname = 'streaming_album_service_valid' "
+                "AND conrelid = 'lml_cache.streaming_album_service'::regclass"
+            )
+        assert constraint_def is not None
+        deployed = set(re.findall(r"'([^']+)'", constraint_def))
+        expected = {s.catalog_key for s in StreamingService}
+        assert deployed == expected
+        assert deployed == {
+            "spotify",
+            "deezer",
+            "apple_music",
+            "bandcamp",
+            "tidal",
+            "youtube_music",
+            "soundcloud",
+        }
 
 
 @pytest.mark.pg

--- a/tests/integration/test_streaming_url_persistent_lookup.py
+++ b/tests/integration/test_streaming_url_persistent_lookup.py
@@ -21,6 +21,7 @@ Run with: pytest -m pg -v tests/integration/test_streaming_url_persistent_lookup
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
@@ -36,6 +37,7 @@ from entity.streaming_url_cache import (
     set_up_streaming_url_cache_schema,
 )
 from streaming.models import SourceMatch
+from streaming.service import StreamingService
 from tests.integration.conftest import skip_if_named_tables_populated
 
 _SERVICE_CASES = [
@@ -204,6 +206,32 @@ class TestSchemaBootstrap:
             )
         assert oid_after == oid_before
         assert preserved == 1
+
+
+@pytest.mark.pg
+class TestStreamingServiceCheckParity:
+    """LML#1037 hard constraint: the LIVE deployed CHECK constraint's value
+    set must equal the ``StreamingService`` enum's album-cache-key storage
+    keys, byte-for-byte -- not just the code-side ``_SERVICES`` tuple the
+    unit-level twin (``tests/unit/test_streaming_url_cache_schema.py::
+    TestStreamingServiceParity``) pins. This is the proof that the refactor
+    introduced zero data migration: what PostgreSQL actually enforces after a
+    fresh boot is exactly what the enum says it should."""
+
+    @pytest.mark.asyncio
+    async def test_deployed_check_matches_enum_album_cache_keys(self, pg_pool, pg_source):
+        await set_up_streaming_url_cache_schema(pg_source)
+        async with pg_pool.acquire() as conn:
+            constraint_def = await conn.fetchval(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint "
+                "WHERE conname = 'album_streaming_url_cache_service_valid' "
+                "AND conrelid = 'lml_cache.album_streaming_url_cache'::regclass"
+            )
+        assert constraint_def is not None
+        deployed = set(re.findall(r"'([^']+)'", constraint_def))
+        expected = {s.album_cache_key for s in StreamingService if s.album_cache_key is not None}
+        assert deployed == expected
+        assert deployed == {"apple_music_album", "spotify_album", "bandcamp"}
 
 
 @pytest.mark.pg

--- a/tests/integration/test_track_streaming_url_cache_pg.py
+++ b/tests/integration/test_track_streaming_url_cache_pg.py
@@ -17,6 +17,8 @@ Run with: pytest -m pg -v tests/integration/test_track_streaming_url_cache_pg.py
 
 from __future__ import annotations
 
+import re
+
 import asyncpg
 import pytest
 import pytest_asyncio
@@ -27,6 +29,7 @@ from entity.track_streaming_url_cache import (
     set_cached_track_streaming_url,
     set_up_track_streaming_url_cache_schema,
 )
+from streaming.service import StreamingService
 from tests.integration.conftest import skip_if_named_tables_populated
 
 _ARTIST = "Juana Molina"
@@ -89,6 +92,29 @@ class TestSchemaBootstrap:
                     "VALUES ($1, 'x', 'y', 'z', NULL)",
                     APPLE_MUSIC_TRACK_SERVICE,
                 )
+
+
+@pytest.mark.pg
+class TestStreamingServiceCheckParity:
+    """LML#1037 hard constraint: the LIVE deployed CHECK constraint's value
+    set must equal the ``StreamingService`` enum's track-cache-key storage
+    keys, byte-for-byte. See ``tests/unit/test_track_streaming_url_cache_schema.py::
+    TestStreamingServiceParity`` for the code-side (unit-level) twin."""
+
+    @pytest.mark.asyncio
+    async def test_deployed_check_matches_enum_track_cache_keys(self, pg_pool, pg_source):
+        await set_up_track_streaming_url_cache_schema(pg_source)
+        async with pg_pool.acquire() as conn:
+            constraint_def = await conn.fetchval(
+                "SELECT pg_get_constraintdef(oid) FROM pg_constraint "
+                "WHERE conname = 'track_streaming_url_cache_service_valid' "
+                "AND conrelid = 'lml_cache.track_streaming_url_cache'::regclass"
+            )
+        assert constraint_def is not None
+        deployed = set(re.findall(r"'([^']+)'", constraint_def))
+        expected = {s.track_cache_key for s in StreamingService if s.track_cache_key is not None}
+        assert deployed == expected
+        assert deployed == {"apple_music_track"}
 
 
 @pytest.mark.pg

--- a/tests/unit/test_lookup_streaming_url_postprocess.py
+++ b/tests/unit/test_lookup_streaming_url_postprocess.py
@@ -62,7 +62,14 @@ from lookup.streaming_url_postprocess import (
     apply_streaming_url_postprocess,
     set_suppress_streaming_warm,
 )
+from streaming.service import ALBUM_CACHE_KEYS, SERVICE_BY_ALBUM_CACHE_KEY, StreamingService
 from tests.conftest import drain_streaming_warm_tasks, reset_streaming_warm_state
+
+# Maps this file's storage-key test data (``_CASES``, string-keyed) onto the
+# StreamingService enum member that owns each key (LML#1037:
+# STREAMING_URL_CACHE_CONFIG is keyed by the enum, not the bare storage
+# string).
+_SERVICE_BY_STORAGE_KEY = SERVICE_BY_ALBUM_CACHE_KEY
 
 # Per-service test data. The cache module is service-agnostic; what differs per
 # service is the URL field, client attr, per-service flag, and a
@@ -956,32 +963,43 @@ class TestWarmConcurrencyBound:
 
 class TestRegistryInvariants:
     """The cache registry is a subset of the identity registry; guards keep it
-    from drifting."""
+    from drifting.
+
+    LML#1037: ``STREAMING_URL_CACHE_CONFIG`` is now keyed by the
+    ``StreamingService`` enum, not the bare album-cache-key string this file's
+    own ``_CASES`` test data (and ``RELEASE_SOURCE_CONFIG``, out of this
+    ticket's scope) still use — every comparison below maps one side through
+    ``ALBUM_CACHE_KEYS`` / ``SERVICE_BY_ALBUM_CACHE_KEY`` rather than
+    comparing the registry's keys directly against a string.
+    """
 
     def test_parametrize_keys_match_cache_config(self):
-        assert set(_CASES) == set(STREAMING_URL_CACHE_CONFIG.keys())
+        assert set(_CASES) == {ALBUM_CACHE_KEYS[s] for s in STREAMING_URL_CACHE_CONFIG}
 
     def test_cache_config_is_subset_of_release_source_config(self):
-        assert set(STREAMING_URL_CACHE_CONFIG.keys()) <= set(RELEASE_SOURCE_CONFIG.keys())
+        assert {ALBUM_CACHE_KEYS[s] for s in STREAMING_URL_CACHE_CONFIG} <= set(
+            RELEASE_SOURCE_CONFIG.keys()
+        )
 
     def test_cache_config_matches_table_check_constraint_allowlist(self):
         from entity.streaming_url_cache import _SERVICES
 
-        assert set(STREAMING_URL_CACHE_CONFIG.keys()) == set(_SERVICES)
+        assert {ALBUM_CACHE_KEYS[s] for s in STREAMING_URL_CACHE_CONFIG} == set(_SERVICES)
 
     def test_cache_config_ships_apple_spotify_and_bandcamp(self):
         assert set(STREAMING_URL_CACHE_CONFIG.keys()) == {
-            "apple_music_album",
-            "spotify_album",
-            "bandcamp",
+            StreamingService.APPLE_MUSIC,
+            StreamingService.SPOTIFY,
+            StreamingService.BANDCAMP,
         }
 
     @pytest.mark.parametrize("service", list(_CASES))
     def test_cache_config_fields_match_expectations(self, service):
         case = _CASES[service]
-        cfg = STREAMING_URL_CACHE_CONFIG[service]
+        enum_service = _SERVICE_BY_STORAGE_KEY[service]
+        cfg = STREAMING_URL_CACHE_CONFIG[enum_service]
         assert cfg.url_field == case["url_field"]
-        assert cfg.client_attr == case["client_attr"]
+        assert enum_service.catalog_key == case["client_attr"]
         assert cfg.flag_setting == case["flag_setting"]
         assert cfg.probe_timeout_s == case["probe_timeout_s"]
         assert service in RELEASE_SOURCE_CONFIG
@@ -1005,28 +1023,32 @@ class TestPerServiceTimeoutResolution:
         from lookup.timeouts import APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR
 
         assert (
-            STREAMING_URL_CACHE_CONFIG["apple_music_album"].timeout_env_var
+            STREAMING_URL_CACHE_CONFIG[StreamingService.APPLE_MUSIC].timeout_env_var
             == APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR
         )
 
     def test_spotify_entry_has_no_env_var(self):
-        assert STREAMING_URL_CACHE_CONFIG["spotify_album"].timeout_env_var is None
+        assert STREAMING_URL_CACHE_CONFIG[StreamingService.SPOTIFY].timeout_env_var is None
 
     def test_bandcamp_entry_has_no_env_var(self):
-        assert STREAMING_URL_CACHE_CONFIG["bandcamp"].timeout_env_var is None
+        assert STREAMING_URL_CACHE_CONFIG[StreamingService.BANDCAMP].timeout_env_var is None
 
     def test_bandcamp_effective_timeout_is_static_nine_seconds(self, monkeypatch):
         from lookup.timeouts import APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR
 
         monkeypatch.setenv(APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR, "1500")
-        assert mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG["bandcamp"]) == 9.0
+        assert (
+            mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG[StreamingService.BANDCAMP])
+            == 9.0
+        )
 
     def test_apple_effective_timeout_honors_env_override(self, monkeypatch):
         from lookup.timeouts import APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR
 
         monkeypatch.setenv(APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR, "1500")
         assert (
-            mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG["apple_music_album"]) == 1.5
+            mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG[StreamingService.APPLE_MUSIC])
+            == 1.5
         )
 
     def test_apple_effective_timeout_defaults_without_env(self, monkeypatch):
@@ -1034,11 +1056,15 @@ class TestPerServiceTimeoutResolution:
 
         monkeypatch.delenv(APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR, raising=False)
         assert (
-            mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG["apple_music_album"]) == 4.0
+            mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG[StreamingService.APPLE_MUSIC])
+            == 4.0
         )
 
     def test_spotify_effective_timeout_ignores_apple_env(self, monkeypatch):
         from lookup.timeouts import APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR
 
         monkeypatch.setenv(APPLE_MUSIC_LOOKUP_TIMEOUT_ENV_VAR, "1500")
-        assert mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG["spotify_album"]) == 4.0
+        assert (
+            mod._effective_probe_timeout_s(STREAMING_URL_CACHE_CONFIG[StreamingService.SPOTIFY])
+            == 4.0
+        )

--- a/tests/unit/test_streaming_catalog_schema.py
+++ b/tests/unit/test_streaming_catalog_schema.py
@@ -119,6 +119,31 @@ class _FakePgSource:
         yield _FakeConnection(self)
 
 
+class TestStreamingServiceParity:
+    """LML#1037 hard constraint: the enum-derived storage keys must equal
+    ``_SERVICES`` -- the CHECK-list parity proof for the code-side allowlist.
+    The LIVE deployed-constraint counterpart is
+    ``tests/integration/test_streaming_catalog.py::
+    TestStreamingServiceCheckParity``.
+    """
+
+    def test_services_equals_enum_catalog_keys(self):
+        from streaming.service import StreamingService
+
+        assert set(_SERVICES) == {s.catalog_key for s in StreamingService}
+
+    def test_services_is_exactly_the_seven_offline_catalog_services(self):
+        assert set(_SERVICES) == {
+            "spotify",
+            "deezer",
+            "apple_music",
+            "bandcamp",
+            "tidal",
+            "youtube_music",
+            "soundcloud",
+        }
+
+
 class TestCanonicalDDLReference:
     """``entity/streaming_catalog.sql`` is the inline DDL reference."""
 

--- a/tests/unit/test_streaming_service.py
+++ b/tests/unit/test_streaming_service.py
@@ -1,0 +1,191 @@
+"""Unit tests for the canonical streaming-service enum (LML#1037).
+
+``streaming.service.StreamingService`` is the single source of truth this
+refactor introduces for the three previously-disjoint service-name
+vocabularies (see the module docstring in ``streaming/service.py``). These
+tests pin:
+
+* the enum's bare VALUE (the "catalog key") never drifts from the pre-refactor
+  literal strings that ``StreamingCheckSources`` / the orchestrator / the
+  offline catalog already used;
+* the ``album_cache_key`` / ``track_cache_key`` per-member mapping never
+  drifts from the pre-refactor literal storage-key strings that are
+  load-bearing in DB CHECK constraints on populated ``lml_cache.*`` tables
+  (the hard "map, never rename" constraint);
+* the canonical ordering tuples each call site derives its own local table
+  from stay in the pre-refactor declaration order (so every derived DDL /
+  registry stays byte-identical, not just set-equal).
+
+Downstream per-module CHECK-list parity (the enum's storage keys against each
+table's actual ``_SERVICES`` constant, and — at the integration layer —
+against the LIVE deployed CHECK constraint) is covered in each owning
+module's own test file, not duplicated here:
+
+* ``tests/unit/test_streaming_url_cache_schema.py``
+* ``tests/unit/test_track_streaming_url_cache_schema.py``
+* ``tests/unit/test_streaming_catalog_schema.py``
+* ``tests/integration/test_streaming_url_persistent_lookup.py``
+* ``tests/integration/test_track_streaming_url_cache_pg.py``
+* ``tests/integration/test_streaming_catalog.py``
+"""
+
+from __future__ import annotations
+
+from streaming.service import (
+    ALBUM_CACHE_KEYS,
+    ALBUM_CACHED_SERVICES,
+    CATALOG_CHECK_SERVICES,
+    OFFLINE_CATALOG_SERVICES,
+    SERVICE_BY_ALBUM_CACHE_KEY,
+    SERVICE_BY_TRACK_CACHE_KEY,
+    TRACK_CACHE_KEYS,
+    TRACK_CACHED_SERVICES,
+    StreamingService,
+)
+
+
+class TestCatalogKey:
+    """The enum VALUE doubles as the bare "catalog key" -- unchanged from
+    every pre-refactor bare-string call site (StreamingCheckSources fields,
+    the orchestrator's client-dispatch keys, the offline catalog's service
+    axis)."""
+
+    def test_values_match_the_preexisting_bare_strings(self):
+        assert StreamingService.SPOTIFY.value == "spotify"
+        assert StreamingService.DEEZER.value == "deezer"
+        assert StreamingService.APPLE_MUSIC.value == "apple_music"
+        assert StreamingService.BANDCAMP.value == "bandcamp"
+        assert StreamingService.TIDAL.value == "tidal"
+        assert StreamingService.YOUTUBE_MUSIC.value == "youtube_music"
+        assert StreamingService.SOUNDCLOUD.value == "soundcloud"
+
+    def test_catalog_key_equals_the_enum_value(self):
+        for service in StreamingService:
+            assert service.catalog_key == service.value
+
+    def test_members_compare_equal_to_their_bare_string(self):
+        # StrEnum equality/serialization parity -- callers that still compare
+        # against a bare literal (e.g. ``service == "spotify"``) or interpolate
+        # a member into an f-string keep working unchanged.
+        assert StreamingService.SPOTIFY == "spotify"
+        assert str(StreamingService.APPLE_MUSIC) == "apple_music"
+        assert f"{StreamingService.BANDCAMP}" == "bandcamp"
+
+
+class TestAlbumCacheKey:
+    """Storage key in ``lml_cache.album_streaming_url_cache`` -- load-bearing
+    in that table's named CHECK constraint. Must map to the pre-refactor
+    literal, never rename it."""
+
+    def test_apple_music_maps_to_apple_music_album(self):
+        assert StreamingService.APPLE_MUSIC.album_cache_key == "apple_music_album"
+
+    def test_spotify_maps_to_spotify_album(self):
+        assert StreamingService.SPOTIFY.album_cache_key == "spotify_album"
+
+    def test_bandcamp_maps_to_bare_bandcamp(self):
+        # Bandcamp has no album/track granularity split -- its storage key IS
+        # its catalog key, unlike Apple/Spotify's "_album"-suffixed pair.
+        assert StreamingService.BANDCAMP.album_cache_key == "bandcamp"
+
+    def test_services_with_no_album_cache_tier_map_to_none(self):
+        for service in (
+            StreamingService.DEEZER,
+            StreamingService.TIDAL,
+            StreamingService.YOUTUBE_MUSIC,
+            StreamingService.SOUNDCLOUD,
+        ):
+            assert service.album_cache_key is None
+
+    def test_album_cache_keys_dict_matches_the_property(self):
+        for service in StreamingService:
+            assert ALBUM_CACHE_KEYS.get(service) == service.album_cache_key
+
+    def test_album_cache_keys_dict_has_exactly_three_entries(self):
+        assert set(ALBUM_CACHE_KEYS) == {
+            StreamingService.APPLE_MUSIC,
+            StreamingService.SPOTIFY,
+            StreamingService.BANDCAMP,
+        }
+
+    def test_reverse_lookup_round_trips(self):
+        for service, key in ALBUM_CACHE_KEYS.items():
+            assert SERVICE_BY_ALBUM_CACHE_KEY[key] is service
+
+
+class TestTrackCacheKey:
+    """Storage key in ``lml_cache.track_streaming_url_cache`` -- load-bearing
+    in that table's named CHECK constraint."""
+
+    def test_apple_music_maps_to_apple_music_track(self):
+        assert StreamingService.APPLE_MUSIC.track_cache_key == "apple_music_track"
+
+    def test_every_other_service_maps_to_none(self):
+        for service in StreamingService:
+            if service is StreamingService.APPLE_MUSIC:
+                continue
+            assert service.track_cache_key is None
+
+    def test_track_cache_keys_dict_matches_the_property(self):
+        for service in StreamingService:
+            assert TRACK_CACHE_KEYS.get(service) == service.track_cache_key
+
+    def test_track_cache_keys_dict_has_exactly_one_entry(self):
+        assert TRACK_CACHE_KEYS == {StreamingService.APPLE_MUSIC: "apple_music_track"}
+
+    def test_reverse_lookup_round_trips(self):
+        for service, key in TRACK_CACHE_KEYS.items():
+            assert SERVICE_BY_TRACK_CACHE_KEY[key] is service
+
+
+class TestCanonicalOrderingTuples:
+    """Each call site's pre-refactor declaration order is preserved exactly --
+    not just set-equality -- so every derived DDL/registry stays byte-identical
+    across the refactor (no gratuitous CREATE-time literal reordering)."""
+
+    def test_catalog_check_services_matches_streaming_check_sources_order(self):
+        assert CATALOG_CHECK_SERVICES == (
+            StreamingService.SPOTIFY,
+            StreamingService.DEEZER,
+            StreamingService.APPLE_MUSIC,
+            StreamingService.BANDCAMP,
+        )
+
+    def test_album_cached_services_matches_streaming_url_cache_config_order(self):
+        assert ALBUM_CACHED_SERVICES == (
+            StreamingService.APPLE_MUSIC,
+            StreamingService.SPOTIFY,
+            StreamingService.BANDCAMP,
+        )
+
+    def test_track_cached_services_is_apple_music_only(self):
+        assert TRACK_CACHED_SERVICES == (StreamingService.APPLE_MUSIC,)
+
+    def test_offline_catalog_services_matches_streaming_catalog_order(self):
+        assert OFFLINE_CATALOG_SERVICES == (
+            StreamingService.SPOTIFY,
+            StreamingService.DEEZER,
+            StreamingService.APPLE_MUSIC,
+            StreamingService.BANDCAMP,
+            StreamingService.TIDAL,
+            StreamingService.YOUTUBE_MUSIC,
+            StreamingService.SOUNDCLOUD,
+        )
+
+    def test_ordering_tuples_carry_no_duplicates(self):
+        for services in (
+            CATALOG_CHECK_SERVICES,
+            ALBUM_CACHED_SERVICES,
+            TRACK_CACHED_SERVICES,
+            OFFLINE_CATALOG_SERVICES,
+        ):
+            assert len(services) == len(set(services))
+
+    def test_offline_catalog_services_is_a_superset_of_catalog_check_services(self):
+        assert set(CATALOG_CHECK_SERVICES) <= set(OFFLINE_CATALOG_SERVICES)
+
+    def test_album_cached_services_matches_the_album_cache_keys_dict(self):
+        assert set(ALBUM_CACHED_SERVICES) == set(ALBUM_CACHE_KEYS)
+
+    def test_track_cached_services_matches_the_track_cache_keys_dict(self):
+        assert set(TRACK_CACHED_SERVICES) == set(TRACK_CACHE_KEYS)

--- a/tests/unit/test_streaming_url_cache_schema.py
+++ b/tests/unit/test_streaming_url_cache_schema.py
@@ -131,6 +131,29 @@ class TestCanonicalDDLReference:
         assert "PRIMARY KEY (service, artist_normalized, album_normalized)" in ddl
 
 
+class TestStreamingServiceParity:
+    """LML#1037 hard constraint: the enum-derived storage keys must equal
+    ``_SERVICES`` -- the CHECK-list parity proof for the code-side allowlist.
+    The LIVE deployed-constraint counterpart (against a real PostgreSQL
+    connection) is
+    ``tests/integration/test_streaming_url_persistent_lookup.py::
+    TestStreamingServiceCheckParity``.
+    """
+
+    def test_services_equals_enum_album_cache_keys(self):
+        from entity.streaming_url_cache import _SERVICES
+        from streaming.service import StreamingService
+
+        assert set(_SERVICES) == {
+            s.album_cache_key for s in StreamingService if s.album_cache_key is not None
+        }
+
+    def test_services_is_exactly_apple_spotify_bandcamp(self):
+        from entity.streaming_url_cache import _SERVICES
+
+        assert set(_SERVICES) == {"apple_music_album", "spotify_album", "bandcamp"}
+
+
 @pytest.mark.asyncio
 class TestSetUpStreamingUrlCacheSchema:
     """``set_up_streaming_url_cache_schema`` runs exactly the idempotent DDL."""

--- a/tests/unit/test_track_streaming_url_cache_schema.py
+++ b/tests/unit/test_track_streaming_url_cache_schema.py
@@ -56,6 +56,25 @@ class TestCanonicalDDLReference:
         assert "PRIMARY KEY (service, artist_normalized, album_normalized, song_normalized)" in ddl
 
 
+class TestStreamingServiceParity:
+    """LML#1037 hard constraint: the enum-derived storage keys must equal
+    ``_SERVICES`` -- the CHECK-list parity proof for the code-side allowlist.
+    The LIVE deployed-constraint counterpart is
+    ``tests/integration/test_track_streaming_url_cache_pg.py::
+    TestStreamingServiceCheckParity``.
+    """
+
+    def test_services_equals_enum_track_cache_keys(self):
+        from streaming.service import StreamingService
+
+        assert set(_SERVICES) == {
+            s.track_cache_key for s in StreamingService if s.track_cache_key is not None
+        }
+
+    def test_services_is_exactly_apple_music_track(self):
+        assert set(_SERVICES) == {"apple_music_track"}
+
+
 @pytest.mark.asyncio
 class TestSetUpTrackStreamingUrlCacheSchema:
     """LML#1038 PR-2: runs through ``entity.ddl.bootstrap_lml_cache_table`` --


### PR DESCRIPTION
Closes #1037. Sub-issue of epic #595 (streaming-cache polymorphism); lands ahead of any #595 PR-E.

## Problem

The same streaming platforms were named by three independently hand-maintained, disjoint vocabularies (see #1037's table), each feeding its own `_SERVICES`/`_SERVICE_IN_LIST` SQL fragment and its own CHECK-widen DDL generation:

1. **Catalog-key granularity** — `streaming/models.py`'s `StreamingCheckSources` fields, `streaming/orchestrator.py`'s client-dispatch table + `_EXPECTED_SERVICE_FIELDS`, `entity/streaming_catalog.py`'s 7-service offline-catalog axis.
2. **Album-cache-key granularity** — `entity/streaming_url_cache.py`'s `_SERVICES`, `lookup/streaming_url_postprocess.py`'s `STREAMING_URL_CACHE_CONFIG`.
3. **Track-cache-key granularity** — `entity/track_streaming_url_cache.py`'s `APPLE_MUSIC_TRACK_SERVICE`/`_SERVICES`.

## Enum design

New `streaming/service.py`: one `StreamingService` StrEnum member per platform (`SPOTIFY, DEEZER, APPLE_MUSIC, BANDCAMP, TIDAL, YOUTUBE_MUSIC, SOUNDCLOUD`). The enum VALUE is the bare catalog key (`StreamingService.APPLE_MUSIC == "apple_music"`, since `StrEnum` members compare-equal-to and serialize-as their string value — every pre-refactor bare-string comparison/interpolation keeps working unchanged). Three properties expose the other granularities:

- `.catalog_key` — same as `.value`.
- `.album_cache_key` — storage key in `lml_cache.album_streaming_url_cache` (`None` for services with no album-cache tier). `APPLE_MUSIC -> "apple_music_album"`, `SPOTIFY -> "spotify_album"`, `BANDCAMP -> "bandcamp"`.
- `.track_cache_key` — storage key in `lml_cache.track_streaming_url_cache` (`None` for everything except `APPLE_MUSIC -> "apple_music_track"` today).

Backed by two small forward dicts (`ALBUM_CACHE_KEYS`, `TRACK_CACHE_KEYS`) plus their reverse views (`SERVICE_BY_ALBUM_CACHE_KEY`, `SERVICE_BY_TRACK_CACHE_KEY`), and four canonical **ordering** tuples (`CATALOG_CHECK_SERVICES`, `ALBUM_CACHED_SERVICES`, `TRACK_CACHED_SERVICES`, `OFFLINE_CATALOG_SERVICES`) that preserve each pre-refactor call site's exact declaration order — not just its member set — so every derived DDL literal / dict-iteration order stays byte-identical.

## How each vocabulary now derives from it

- `streaming/orchestrator.py`: `_EXPECTED_SERVICE_FIELDS = {s.catalog_key for s in CATALOG_CHECK_SERVICES}`; the `clients` dict inside `check_streaming_availability` is built via `zip(CATALOG_CHECK_SERVICES, (spotify, deezer, apple_music, bandcamp), strict=True)` instead of a literal dict — the function's public kwargs/signature are untouched.
- `entity/streaming_catalog.py`: `_SERVICES = tuple(s.catalog_key for s in OFFLINE_CATALOG_SERVICES)`.
- `entity/streaming_url_cache.py`: `_SERVICES = tuple(ALBUM_CACHE_KEYS[s] for s in ALBUM_CACHED_SERVICES)`.
- `entity/track_streaming_url_cache.py`: `APPLE_MUSIC_TRACK_SERVICE = TRACK_CACHE_KEYS[StreamingService.APPLE_MUSIC]`.
- `lookup/streaming_url_postprocess.py`: `STREAMING_URL_CACHE_CONFIG` is now `dict[StreamingService, StreamingUrlCacheConfig]` (was `dict[str, ...]`) — this is the "orchestrator client table + STREAMING_URL_CACHE_CONFIG fold into one registry keyed by the enum" the ticket calls for: the registry's own key now doubles as both the client-dispatch lookup (`clients.get(service.catalog_key)`) and, via `ALBUM_CACHE_KEYS[service]`, the storage/mint-source string — so the now-redundant `client_attr` field (it always equaled `service.catalog_key`) is deleted from `StreamingUrlCacheConfig`. Every runtime string threaded into a PG bind, a Sentry key, or `_mint_identity`'s `source` is derived once at the top of the per-service loop and passed through **unchanged** from there down — only the registries' key *type* changed, no value changed.

`identity/release_validation.py`'s `RELEASE_SOURCE_CONFIG` (and its satellite call sites, `cache/dispatch.py`'s `_NOT_IMPLEMENTED_SOURCES`, `entity/store.py`'s `_RELEASE_IDENTITY_COLUMN_TO_SOURCE`) are **consciously out of scope**: they mix two Discogs-identity-only sources (`discogs_release`, `discogs_master`) and (in `cache/dispatch.py`) MusicBrainz into an otherwise streaming-service-shaped key set — exactly the asymmetric membership the enum's three vocabularies never have, per that registry's own pre-existing docstring rationale for staying separate from `STREAMING_URL_CACHE_CONFIG`. #1037's problem table doesn't name it either. Left a doc comment pointing at the new enum for future readers.

`lookup/enrichment/item.py`'s `clients={"apple_music": ..., "spotify": ..., "bandcamp": ...}` call site is untouched — it's a call site passing named client objects through under literal keys that must match `service.catalog_key`, not a vocabulary/registry definition.

## Zero DB migration / CHECK-constraint parity proof

Every per-table `_SERVICES` constant carries the **exact same values in the exact same order** as before the refactor (verified: both `.sql` DDL sidecar generators — `scripts/regenerate_streaming_catalog_sql.py` and `scripts/regenerate_lml_cache_sql.py` — produce a byte-identical `git diff` after this change). New live-PG parity tests assert the LIVE deployed CHECK constraint's value set equals the enum's storage-key set for all three tables:

- `tests/integration/test_streaming_url_persistent_lookup.py::TestStreamingServiceCheckParity::test_deployed_check_matches_enum_album_cache_keys`
- `tests/integration/test_track_streaming_url_cache_pg.py::TestStreamingServiceCheckParity::test_deployed_check_matches_enum_track_cache_keys`
- `tests/integration/test_streaming_catalog.py::TestStreamingServiceCheckParity::test_deployed_check_matches_enum_catalog_keys`

Unit-level (mocked, fast) twins pin the same invariant against the code-side `_SERVICES` constant directly:

- `tests/unit/test_streaming_url_cache_schema.py::TestStreamingServiceParity`
- `tests/unit/test_track_streaming_url_cache_schema.py::TestStreamingServiceParity`
- `tests/unit/test_streaming_catalog_schema.py::TestStreamingServiceParity`
- `tests/unit/test_streaming_service.py` — the enum module's own pinning tests (23 tests: catalog/album/track key mapping, reverse lookups, and all four ordering tuples).

All `-m pg` tests ran against local PostgreSQL (`postgresql://discogs:discogs@localhost:5433/discogs`) and pass (552 passed, 9 skipped).

## Telemetry byte-identical (grep-diff proof)

Every Sentry `set_data` call, every `_project_sentry` outcome key, and every `start_span` kwarg is untouched — confirmed by grepping the diff itself for zero touched lines:

```
$ git diff origin/main -- lookup/streaming_url_postprocess.py | grep -E "^[+-]" | grep -iE "set_data|persistent_lookup|start_span|posthog"
(no output)
```

`_project_sentry`'s function body (the `f"streaming_url.persistent_lookup.{outcome}.{service_key}"` templates) is unchanged; only the *value* substituted for `{service_key}` is computed differently (`ALBUM_CACHE_KEYS[service]` instead of a dict key that was already that string) — same runtime string either way, verified by the full existing `tests/unit/test_lookup_streaming_url_postprocess.py` suite (80 tests, all green) which asserts the exact status/telemetry shapes.

## No free-floating service-string tuples remain (grep proof)

```
$ grep -rn '"spotify", "deezer", "apple_music", "bandcamp"' --include="*.py" . | grep -v streaming/service.py
(no production hits; one legitimate test-fixture literal in tests/unit/test_recheck_streaming_after_mojibake.py asserting against StreamingCheckSources's wire shape)

$ grep -rln '"tidal".*"youtube_music".*"soundcloud"' --include="*.py" . | grep -v streaming/service.py
tests/unit/test_streaming_catalog_schema.py   # pre-existing test assertion pinning literal expected values, not a production registry
```

## Hard constraints checklist

- [x] Map, never rename — every `album_cache_key`/`track_cache_key` value is copied verbatim from the pre-refactor tuple it replaces (see `streaming/service.py`'s module docstring + inline comments).
- [x] No wire change — `streaming/models.py` untouched; `StreamingCheckSources`/`StreamingResolution` field names unchanged.
- [x] Separate tables stay separate — `lml_cache.album_streaming_url_cache` and `lml_cache.track_streaming_url_cache` remain two distinct tables; this PR touches naming/registries only.
- [x] Telemetry byte-identical — see grep-diff proof above.

## Local CI parity

- `ruff format --check .` — clean
- `ruff check .` — clean
- `pytest -m "not pg and not external_api"` — 5178 passed, 1 skipped, 2 xfailed (same 2 pre-existing flakes as origin/main: `test_shed_lookup_emits_no_error_level_logs`, `test_no_module_level_asyncio_lock_in_dependencies` — both pass in isolation)
- `pytest -m pg` — 552 passed, 9 skipped (local homebrew postgresql@16, port 5433)
- `mypy . --ignore-missing-imports` — clean, 522 source files
- Codegen freshness (`scripts/regenerate_streaming_catalog_sql.py` + `scripts/regenerate_lml_cache_sql.py`) — zero drift, `generated/` untouched (no `api.yaml`-governed model touched)

## Sequencing note

Rebased onto current `origin/main` (`ff4dd34`), which already includes #1062's YouTube Music drain (`clients/streaming/youtube_music.py` + offline `scripts/` + tests) — confirmed file-disjoint from every file this PR touches. `entity/streaming_catalog.py`'s 7-service list already models `youtube_music`; this PR's `StreamingService.YOUTUBE_MUSIC` / `OFFLINE_CATALOG_SERVICES` line up with it unchanged.
