### PR TITLE
Productionize the YTM drain: resumable DB-aware pending-scan candidate source

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -350,19 +350,27 @@ The emitted `apple_urls.tsv` is applied back via the Backend-Service fill-only w
 
 ## YouTube Music Coverage Drain (`scripts/ytm_coverage_drain.py`)
 
-Resolves verified `music.youtube.com/browse/<browseId>` album links for a set of canonical `(artist, title)` candidates (epic [LML#830](https://github.com/WXYC/library-metadata-lookup/issues/830), impl [LML#1056](https://github.com/WXYC/library-metadata-lookup/issues/1056); GO from the [#833](https://github.com/WXYC/library-metadata-lookup/issues/833) spike). Uses `YouTubeMusicClient` (`clients/streaming/youtube_music.py`) — unauthenticated `ytmusicapi` album search, scored through the shared production matcher (`find_best_source_match`, 80/80 floor). Per-candidate exceptions are isolated (a malformed search becomes a miss, never aborts the run).
+Resolves verified `music.youtube.com/browse/<browseId>` album links for a set of canonical `(artist, title)` candidates (epic [LML#830](https://github.com/WXYC/library-metadata-lookup/issues/830), impl [LML#1056](https://github.com/WXYC/library-metadata-lookup/issues/1056), productionized [LML#1070](https://github.com/WXYC/library-metadata-lookup/issues/1070); GO from the [#833](https://github.com/WXYC/library-metadata-lookup/issues/833) spike). Uses `YouTubeMusicClient` (`clients/streaming/youtube_music.py`) — unauthenticated `ytmusicapi` album search, scored through the shared production matcher (`find_best_source_match`, 80/80 floor). Per-candidate exceptions are isolated (a malformed search becomes a miss, never aborts the run).
 
-**Write path — Option A.** Persistence is fill-only into `streaming_availability.db` (`ResultsDB.update_youtube_music_url`, `WHERE youtube_music_url IS NULL`). The rest of the chain already exists: `scripts/export_streaming_links.py` carries `albums.youtube_music_url` into `library.db.streaming_links` and `/lookup` surfaces it — this drain is the producer. Each match maps back to its `albums` row by normalized `(artist, title)` (`get_album_id_by_names`, same normalizer as the dedup pipeline), so there is no drift; unmatched candidates are tallied and skipped, never wrong-written.
+**Candidate source (DECIDED, #1070).** Exactly one of `--from-db` / `--sample-csv` is required. `--from-db` is the production source: a pending-scan over `streaming_availability.db.albums` (`ResultsDB.get_pending("youtube_music", limit)`), which already excludes both resolved (`found`) and previously-attempted (`not_found`) rows — the drain is **resumable for free**. Because `albums` already holds the canonical `(artist, title)`, the row's own `id` is carried as the write target, eliminating the names-join entirely on this path. `--sample-csv` remains the credential-free dry-run/sample harness; wiring `entity.release_identity` → discogs-cache as a candidate source was considered and rejected (same-or-narrower universe, needs prod credentials + a human go-ahead mid-run).
+
+**Write path — Option A.** Persistence is fill-only into `streaming_availability.db`: `ResultsDB.update_youtube_music_url` (`WHERE youtube_music_url IS NULL`) for matches, and `ResultsDB.mark_youtube_music_not_found` (same guard) for misses — so a re-run never re-searches an already-attempted candidate and never downgrades a resolved row. The rest of the chain already exists: `scripts/export_streaming_links.py` carries `albums.youtube_music_url` into `library.db.streaming_links` and `/lookup` surfaces it — this drain is the producer. On `--from-db`, each outcome writes by the candidate's own `album_id` (no names-join); on `--sample-csv`, a match maps to its `albums` row by normalized `(artist, title)` (`get_album_id_by_names`) and an unmatched candidate is tallied and skipped, never wrong-written — a `--sample-csv` miss has no `album_id` and so is skipped (not markable).
 
 `ytmusicapi` is the optional `drain` extra (not a runtime dep; lazy import) — run under `--extra drain`. `--execute` is opt-in; the default is dry-run (writes nothing). Persisting is the operator's action (off-peak, fill-only, one bulk consumer at a time), followed by a `POST /admin/upload-streaming-db` republish.
 
 ```bash
-# dry-run: resolve + coverage report (count, hit rate, sample matches/misses)
+# production dry-run: pending-scan + coverage report, write nothing
+uv run --extra drain python -m scripts.ytm_coverage_drain \
+  --from-db --limit 200 --results-db streaming_availability.db
+
+# production persist (opt-in, fill-only, resumable pagination): --limit is the
+# get_pending page size; each --execute run marks found + not_found and shrinks
+# the next run's pending set, so repeated invocations walk the whole backlog
+uv run --extra drain python -m scripts.ytm_coverage_drain \
+  --from-db --limit 200 --execute --results-db streaming_availability.db
+
+# sample dry-run (credential-free, local CSV)
 uv run --extra drain python -m scripts.ytm_coverage_drain \
   --sample-csv resolved_names.csv --limit 200 --concurrency 4 \
   --report-json /tmp/ytm_drain_report.json
-
-# persist (opt-in, fill-only) into the streaming_availability store
-uv run --extra drain python -m scripts.ytm_coverage_drain \
-  --sample-csv resolved_names.csv --execute --results-db streaming_availability.db
 ```

--- a/scripts/streaming_availability/results_db.py
+++ b/scripts/streaming_availability/results_db.py
@@ -387,22 +387,28 @@ class ResultsDB:
             )
             await self._db.commit()
 
-    async def mark_youtube_music_not_found(self, album_id: int) -> None:
+    async def mark_youtube_music_not_found(self, album_id: int) -> bool:
         """Durably record a YTM drain attempt that found no match -- fill-only guarded.
 
         Mirrors mark_bandcamp_not_found (#661) but adds `AND youtube_music_url IS NULL`
         so a transient miss can never downgrade a row already resolved to 'found'
         (Data Safety; the #669 fill-only invariant). Leaves youtube_music_url NULL.
+
+        Returns ``True`` if the row was marked ``not_found``, ``False`` if it was
+        a no-op (already resolved) -- lets callers (the #1070 drain's
+        ``execute_write``) distinguish a genuine miss from a moot one instead of
+        overcounting a not_found tally when the guard silently blocks the write.
         """
         assert self._db is not None
         async with self._write_lock:
             now = datetime.now(UTC).isoformat()
-            await self._db.execute(
+            cursor = await self._db.execute(
                 "UPDATE albums SET youtube_music_status = 'not_found', "
                 "youtube_music_checked_at = ? WHERE id = ? AND youtube_music_url IS NULL",
                 (now, album_id),
             )
             await self._db.commit()
+            return cursor.rowcount > 0
 
     async def update_youtube_music_url(self, album_id: int, url: str) -> bool:
         """Fill in a verified YouTube Music album URL -- **fill-only**.

--- a/scripts/streaming_availability/results_db.py
+++ b/scripts/streaming_availability/results_db.py
@@ -387,6 +387,23 @@ class ResultsDB:
             )
             await self._db.commit()
 
+    async def mark_youtube_music_not_found(self, album_id: int) -> None:
+        """Durably record a YTM drain attempt that found no match -- fill-only guarded.
+
+        Mirrors mark_bandcamp_not_found (#661) but adds `AND youtube_music_url IS NULL`
+        so a transient miss can never downgrade a row already resolved to 'found'
+        (Data Safety; the #669 fill-only invariant). Leaves youtube_music_url NULL.
+        """
+        assert self._db is not None
+        async with self._write_lock:
+            now = datetime.now(UTC).isoformat()
+            await self._db.execute(
+                "UPDATE albums SET youtube_music_status = 'not_found', "
+                "youtube_music_checked_at = ? WHERE id = ? AND youtube_music_url IS NULL",
+                (now, album_id),
+            )
+            await self._db.commit()
+
     async def update_youtube_music_url(self, album_id: int, url: str) -> bool:
         """Fill in a verified YouTube Music album URL -- **fill-only**.
 

--- a/scripts/ytm_coverage_drain.py
+++ b/scripts/ytm_coverage_drain.py
@@ -152,8 +152,14 @@ async def load_candidates_from_db(db: ResultsDB, limit: int) -> list[Candidate]:
     is resumable for free -- a re-run only ever sees the untried backlog. Each
     row's own ``id`` is carried as ``Candidate.album_id`` so the write path can
     target it directly, with no ``(artist, title)`` names-join. ``db`` must
-    already be connected; rows with a blank display artist or title are
-    skipped, mirroring :func:`load_candidates_from_rows`.
+    already be connected.
+
+    A row with a blank display artist or title can never be meaningfully
+    searched, so unlike :func:`load_candidates_from_rows` (whose CSV/one-shot
+    callers can just drop it), it is marked ``not_found`` here rather than
+    silently skipped: ``get_pending`` has no ``ORDER BY``/``OFFSET``, so a row
+    left ``pending`` would reappear in this exact page on every future call and
+    could stall pagination for real candidates behind it.
     """
     rows = await db.get_pending("youtube_music", limit=limit)
     out: list[Candidate] = []
@@ -161,6 +167,12 @@ async def load_candidates_from_db(db: ResultsDB, limit: int) -> list[Candidate]:
         artist = str(row["display_artist"] or "").strip()
         title = str(row["display_title"] or "").strip()
         if not artist or not title:
+            log.warning(
+                "albums row %s has a blank display artist/title; marking "
+                "not_found instead of leaving it pending forever",
+                row["id"],
+            )
+            await db.mark_youtube_music_not_found(row["id"])
             continue
         out.append(Candidate(artist=artist, title=title, album_id=row["id"]))
     return out
@@ -223,6 +235,7 @@ async def execute_write(
     outcomes: Sequence[DrainOutcome],
     *,
     db_path: str = DEFAULT_RESULTS_DB_PATH,
+    db: ResultsDB | None = None,
 ) -> dict[str, int]:
     """Fill-only-persist every drain outcome -- matches and misses -- (#1070).
 
@@ -240,23 +253,36 @@ async def execute_write(
 
     For a **miss**: if the candidate carries an ``album_id``, durably mark
     ``not_found`` (fill-only guarded) so a re-run's pending-scan skips it --
-    the resumability this drain exists for (#1070). A CSV-path miss has no
-    ``album_id`` and no row to mark, so it's skipped silently (expected).
+    the resumability this drain exists for (#1070). If the row was actually
+    resolved out-of-band since the pending-scan read, the guard no-ops and the
+    miss is tallied ``already_present`` instead, so a moot miss never inflates
+    ``not_found``. A CSV-path miss has no ``album_id`` and no row to mark, so
+    it's skipped silently (expected).
+
+    ``db``: an already-connected :class:`ResultsDB` to reuse instead of opening
+    a new one against ``db_path``. The ``--from-db`` CLI path passes the same
+    connection its pending-scan already opened, avoiding a second
+    connect/migrate round-trip against the same SQLite file. When omitted (the
+    default, and every pre-#1070 caller), a connection is opened here and
+    closed on return, as before -- a caller-supplied ``db`` is never closed by
+    this function, since it doesn't own it.
 
     Returns a tally ``{written, already_present, unmatched, not_found}``.
     Default is dry-run: this runs only under the explicit ``--execute``
     opt-in, off-peak, one bulk consumer at a time.
     """
     tally = {"written": 0, "already_present": 0, "unmatched": 0, "not_found": 0}
-    db = ResultsDB(db_path)
-    await db.connect()
+    owns_connection = db is None
+    if db is None:
+        db = ResultsDB(db_path)
+        await db.connect()
     try:
         for outcome in outcomes:
             candidate = outcome.candidate
             if outcome.match is None:
                 if candidate.album_id is not None:
-                    await db.mark_youtube_music_not_found(candidate.album_id)
-                    tally["not_found"] += 1
+                    marked = await db.mark_youtube_music_not_found(candidate.album_id)
+                    tally["not_found" if marked else "already_present"] += 1
                 continue
             album_id = candidate.album_id
             if album_id is None:
@@ -272,57 +298,63 @@ async def execute_write(
             wrote = await db.update_youtube_music_url(album_id, outcome.match.url)
             tally["written" if wrote else "already_present"] += 1
     finally:
-        await db.close()
+        if owns_connection:
+            await db.close()
     return tally
 
 
 async def _run(args: argparse.Namespace) -> dict[str, Any]:
-    if args.from_db:
-        db = ResultsDB(args.results_db)
-        await db.connect()
-        try:
+    # In --from-db mode, this connection stays open across the load and (if
+    # --execute) the write, so execute_write reuses it instead of paying a
+    # second connect/migrate round-trip against the same SQLite file (#1070).
+    db: ResultsDB | None = None
+    try:
+        if args.from_db:
+            db = ResultsDB(args.results_db)
+            await db.connect()
             candidates = await load_candidates_from_db(db, args.limit)
-        finally:
-            await db.close()
-    else:
-        candidates = load_candidates_from_csv(args.sample_csv)
-        if args.limit:
-            candidates = candidates[: args.limit]
-    log.info(
-        "resolving %d candidates against YouTube Music (concurrency=%d, rate=%.1f/s)",
-        len(candidates),
-        args.concurrency,
-        args.rate,
-    )
-    client = YouTubeMusicClient(rate_limit=(args.rate, 1), limit=args.search_limit)
-    outcomes = await resolve_candidates(client, candidates, concurrency=args.concurrency)
-    report = summarize(outcomes, sample_size=args.sample_size)
-    log.info(
-        "resolved %d/%d (%.1f%%)",
-        report["resolved"],
-        report["candidates"],
-        100 * report["hit_rate"],
-    )
-    if args.execute:
-        # Opt-in, fill-only persistence of every outcome -- found and missed
-        # alike (#1070 resumability). Default path is dry-run and writes nothing.
-        tally = await execute_write(outcomes, db_path=args.results_db)
-        report["write"] = tally
+        else:
+            candidates = load_candidates_from_csv(args.sample_csv)
+            if args.limit:
+                candidates = candidates[: args.limit]
         log.info(
-            "persisted YTM outcomes: %d written, %d already present, %d unmatched, "
-            "%d not_found (db=%s)",
-            tally["written"],
-            tally["already_present"],
-            tally["unmatched"],
-            tally["not_found"],
-            args.results_db,
+            "resolving %d candidates against YouTube Music (concurrency=%d, rate=%.1f/s)",
+            len(candidates),
+            args.concurrency,
+            args.rate,
         )
-    print(json.dumps(report, indent=2, ensure_ascii=False))
-    if args.report_json:
-        with open(args.report_json, "w", encoding="utf-8") as f:
-            json.dump(report, f, indent=2, ensure_ascii=False)
-        log.info("wrote report to %s", args.report_json)
-    return report
+        client = YouTubeMusicClient(rate_limit=(args.rate, 1), limit=args.search_limit)
+        outcomes = await resolve_candidates(client, candidates, concurrency=args.concurrency)
+        report = summarize(outcomes, sample_size=args.sample_size)
+        log.info(
+            "resolved %d/%d (%.1f%%)",
+            report["resolved"],
+            report["candidates"],
+            100 * report["hit_rate"],
+        )
+        if args.execute:
+            # Opt-in, fill-only persistence of every outcome -- found and missed
+            # alike (#1070 resumability). Default path is dry-run and writes nothing.
+            tally = await execute_write(outcomes, db_path=args.results_db, db=db)
+            report["write"] = tally
+            log.info(
+                "persisted YTM outcomes: %d written, %d already present, %d unmatched, "
+                "%d not_found (db=%s)",
+                tally["written"],
+                tally["already_present"],
+                tally["unmatched"],
+                tally["not_found"],
+                args.results_db,
+            )
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        if args.report_json:
+            with open(args.report_json, "w", encoding="utf-8") as f:
+                json.dump(report, f, indent=2, ensure_ascii=False)
+            log.info("wrote report to %s", args.report_json)
+        return report
+    finally:
+        if db is not None:
+            await db.close()
 
 
 def main(argv: Sequence[str] | None = None) -> dict[str, Any]:

--- a/scripts/ytm_coverage_drain.py
+++ b/scripts/ytm_coverage_drain.py
@@ -1,49 +1,63 @@
 #!/usr/bin/env python3
-"""YouTube Music coverage drain (LML#1056).
+"""YouTube Music coverage drain (LML#1056, productionized in #1070).
 
 Resolves verified ``music.youtube.com/browse/<browseId>`` album links for a set
 of canonical ``(artist, title)`` candidates via :class:`YouTubeMusicClient`
 (80/80 floor, shared production matcher), emits a coverage report, and -- under
-the explicit ``--execute`` opt-in -- fill-only-persists the matches.
+the explicit ``--execute`` opt-in -- fill-only-persists every outcome (matches
+*and* misses).
 
 Write path (Option A of the #1056 / #1052 fork)
 -----------------------------------------------
 Persistence goes to ``streaming_availability.db`` -- LML's authoritative,
 top-priority offline link store -- via :meth:`ResultsDB.update_youtube_music_url`
-(fill-only). The rest of the chain already exists: ``export_streaming_links.py``
-copies ``albums.youtube_music_url`` into ``library.db.streaming_links`` and
-``/lookup`` surfaces it, so this drain is the last missing piece, the producer.
-The sibling ``lml_cache.album_streaming_url_cache`` (Option B) is reserved for
-#1052's runtime/rowless population, which cannot reach this library-keyed store.
+(fill-only) and :meth:`ResultsDB.mark_youtube_music_not_found` (also fill-only
+guarded: it can never downgrade a row already resolved to ``found``). The rest
+of the chain already exists: ``export_streaming_links.py`` copies
+``albums.youtube_music_url`` into ``library.db.streaming_links`` and ``/lookup``
+surfaces it, so this drain is the last missing piece, the producer. The sibling
+``lml_cache.album_streaming_url_cache`` (Option B) is reserved for #1052's
+runtime/rowless population, which cannot reach this library-keyed store.
 
-Candidate source
-----------------
-The real drain drives off ``entity.release_identity``. That table carries only
-per-source external IDs (``discogs_release_id``, ``discogs_master_id``, …) — it
-has **no** ``artist``/``title`` columns — so the canonical ``(artist, title)`` is
-obtained by resolving ``discogs_release_id`` against the discogs-cache release
-table, exactly as the #525 cache warmer's ``_refresh_discogs_release`` does. That
-join runs in the discogs-cache PostgreSQL and needs prod credentials plus a human
-go-ahead, so it is out of scope for this harness. The operator supplies
-already-resolved rows and this module stays schema-agnostic via
-:func:`load_candidates_from_rows`; :func:`load_candidates_from_csv` is the
-credential-free path for a local sample. :func:`execute_write` then maps each
-match back to its ``albums`` row by normalized ``(artist, title)`` -- the same
-key the dedup pipeline wrote -- so there is no normalization drift.
+Candidate source (DECIDED, #1070)
+----------------------------------
+The production candidate source is a **pending-scan over
+``streaming_availability.db.albums``**, via ``--from-db`` ->
+:func:`load_candidates_from_db` -> ``ResultsDB.get_pending("youtube_music",
+limit)``. Because ``albums`` already holds the canonical ``(artist, title)``
+that keys every row, the row's own ``id`` is the write target and its
+``display_artist`` / ``display_title`` are the search terms -- no cross-store
+names-join needed. The ``youtube_music_status = 'pending'`` filter excludes
+both resolved (``found``) and previously-attempted (``not_found``) rows, so
+the drain is **resumable for free**: each ``--execute`` run marks its page
+(found + not_found), shrinking the next run's pending set. Wiring
+``entity.release_identity`` -> discogs-cache as the candidate source was
+considered and rejected (same-or-narrower universe, needs prod credentials
+and a human go-ahead mid-run); file a follow-up only if the ``albums``
+universe ever proves insufficient. ``--sample-csv`` -> :func:`load_candidates_from_csv`
+remains the credential-free dry-run/sample harness; its misses have no
+``album_id`` and are skipped (not markable) by :func:`execute_write`.
 
 Usage
 -----
 ``ytmusicapi`` lives in the ``drain`` extra (not ``dev``), and ``_run`` always
 builds a real client, so the drain must run under ``--extra drain`` or the lazy
-``from ytmusicapi import YTMusic`` raises ``ModuleNotFoundError``.
+``from ytmusicapi import YTMusic`` raises ``ModuleNotFoundError``. Exactly one
+of ``--from-db`` / ``--sample-csv`` is required.
 
-    # dry-run (default): resolve + report, write nothing
+    # production dry-run: pending-scan + report, write nothing
+    uv run --extra drain python -m scripts.ytm_coverage_drain --from-db \
+        --limit 200 --results-db streaming_availability.db
+
+    # production persist (opt-in, fill-only, resumable pagination): --limit is
+    # the get_pending page size; each --execute run shrinks the pending set,
+    # so repeated invocations walk the whole backlog
+    uv run --extra drain python -m scripts.ytm_coverage_drain --from-db \
+        --limit 200 --execute --results-db streaming_availability.db
+
+    # sample dry-run (credential-free, local CSV)
     uv run --extra drain python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
         --limit 200 --concurrency 4 --report-json /tmp/ytm_drain_report.json
-
-    # persist (opt-in, fill-only): add --execute + the target DB
-    uv run --extra drain python -m scripts.ytm_coverage_drain --sample-csv resolved_names.csv \
-        --execute --results-db streaming_availability.db
 
 Persisting is the user's action -- off-peak, fill-only, one bulk LML consumer at
 a time -- and republishing to prod is a separate ``POST /admin/upload-streaming-db``
@@ -82,6 +96,7 @@ class Candidate:
     title: str
     discogs_release_id: int | None = None
     identity_id: int | None = None
+    album_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -127,6 +142,28 @@ def load_candidates_from_csv(path: str) -> list[Candidate]:
     """Load candidates from a CSV with an ``artist,title`` header (dry-run path)."""
     with open(path, newline="", encoding="utf-8") as f:
         return load_candidates_from_rows(csv.DictReader(f), artist_key="artist", title_key="title")
+
+
+async def load_candidates_from_db(db: ResultsDB, limit: int) -> list[Candidate]:
+    """Load the production candidate source: the ``albums`` pending-scan (#1070).
+
+    ``get_pending("youtube_music", limit)`` already excludes both resolved
+    (``found``) and previously-attempted (``not_found``) rows, so this loader
+    is resumable for free -- a re-run only ever sees the untried backlog. Each
+    row's own ``id`` is carried as ``Candidate.album_id`` so the write path can
+    target it directly, with no ``(artist, title)`` names-join. ``db`` must
+    already be connected; rows with a blank display artist or title are
+    skipped, mirroring :func:`load_candidates_from_rows`.
+    """
+    rows = await db.get_pending("youtube_music", limit=limit)
+    out: list[Candidate] = []
+    for row in rows:
+        artist = str(row["display_artist"] or "").strip()
+        title = str(row["display_title"] or "").strip()
+        if not artist or not title:
+            continue
+        out.append(Candidate(artist=artist, title=title, album_id=row["id"]))
+    return out
 
 
 async def resolve_candidates(
@@ -183,42 +220,53 @@ def summarize(
 
 
 async def execute_write(
-    matched_outcomes: Sequence[DrainOutcome],
+    outcomes: Sequence[DrainOutcome],
     *,
     db_path: str = DEFAULT_RESULTS_DB_PATH,
 ) -> dict[str, int]:
-    """Fill-only-persist verified YTM links into the streaming_availability store.
+    """Fill-only-persist every drain outcome -- matches and misses -- (#1070).
 
     Option A of the #1056 write-path fork: ``streaming_availability.db`` is the
-    authoritative, top-priority offline link store. Each match maps to its
-    ``albums`` row by normalized ``(artist, title)`` -- the exact key the dedup
-    pipeline wrote -- and ``youtube_music_url`` is filled only when NULL, so a
-    resolved (higher-priority) link is never clobbered (Data Safety; #669). The
-    rest of the chain already exists: ``export_streaming_links.py`` carries the
-    column into ``library.db.streaming_links`` and ``/lookup`` surfaces it, so
-    this is the last missing piece -- the producer.
+    authoritative, top-priority offline link store. The rest of the chain
+    already exists: ``export_streaming_links.py`` carries ``youtube_music_url``
+    into ``library.db.streaming_links`` and ``/lookup`` surfaces it, so this is
+    the producer.
 
-    Returns a tally ``{written, already_present, unmatched}``. A candidate whose
-    normalized ``(artist, title)`` has no ``albums`` row is counted ``unmatched``
-    and skipped (never a wrong write). Default is dry-run: this runs only under
-    the explicit ``--execute`` opt-in, off-peak, one bulk consumer at a time.
+    For a **match**: prefer ``outcome.candidate.album_id`` (the from-db pending-
+    scan path -- write straight to the row, no names-join) and fall back to a
+    normalized ``(artist, title)`` lookup only when it's unset (the CSV path).
+    ``youtube_music_url`` is filled only when NULL, so a resolved (higher-
+    priority) link is never clobbered (Data Safety; #669).
+
+    For a **miss**: if the candidate carries an ``album_id``, durably mark
+    ``not_found`` (fill-only guarded) so a re-run's pending-scan skips it --
+    the resumability this drain exists for (#1070). A CSV-path miss has no
+    ``album_id`` and no row to mark, so it's skipped silently (expected).
+
+    Returns a tally ``{written, already_present, unmatched, not_found}``.
+    Default is dry-run: this runs only under the explicit ``--execute``
+    opt-in, off-peak, one bulk consumer at a time.
     """
-    tally = {"written": 0, "already_present": 0, "unmatched": 0}
+    tally = {"written": 0, "already_present": 0, "unmatched": 0, "not_found": 0}
     db = ResultsDB(db_path)
     await db.connect()
     try:
-        for outcome in matched_outcomes:
-            if outcome.match is None:  # defensive: caller passes matches only
+        for outcome in outcomes:
+            candidate = outcome.candidate
+            if outcome.match is None:
+                if candidate.album_id is not None:
+                    await db.mark_youtube_music_not_found(candidate.album_id)
+                    tally["not_found"] += 1
                 continue
-            album_id = await db.get_album_id_by_names(
-                outcome.candidate.artist, outcome.candidate.title
-            )
+            album_id = candidate.album_id
+            if album_id is None:
+                album_id = await db.get_album_id_by_names(candidate.artist, candidate.title)
             if album_id is None:
                 tally["unmatched"] += 1
                 log.warning(
                     "no albums row for %r - %r; skipping YTM url write",
-                    outcome.candidate.artist,
-                    outcome.candidate.title,
+                    candidate.artist,
+                    candidate.title,
                 )
                 continue
             wrote = await db.update_youtube_music_url(album_id, outcome.match.url)
@@ -229,9 +277,17 @@ async def execute_write(
 
 
 async def _run(args: argparse.Namespace) -> dict[str, Any]:
-    candidates = load_candidates_from_csv(args.sample_csv)
-    if args.limit:
-        candidates = candidates[: args.limit]
+    if args.from_db:
+        db = ResultsDB(args.results_db)
+        await db.connect()
+        try:
+            candidates = await load_candidates_from_db(db, args.limit)
+        finally:
+            await db.close()
+    else:
+        candidates = load_candidates_from_csv(args.sample_csv)
+        if args.limit:
+            candidates = candidates[: args.limit]
     log.info(
         "resolving %d candidates against YouTube Music (concurrency=%d, rate=%.1f/s)",
         len(candidates),
@@ -248,17 +304,17 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
         100 * report["hit_rate"],
     )
     if args.execute:
-        # Opt-in, fill-only persistence into the streaming_availability store
-        # (Option A). Default path is dry-run and writes nothing.
-        tally = await execute_write(
-            [o for o in outcomes if o.match is not None], db_path=args.results_db
-        )
+        # Opt-in, fill-only persistence of every outcome -- found and missed
+        # alike (#1070 resumability). Default path is dry-run and writes nothing.
+        tally = await execute_write(outcomes, db_path=args.results_db)
         report["write"] = tally
         log.info(
-            "persisted YTM links: %d written, %d already present, %d unmatched (db=%s)",
+            "persisted YTM outcomes: %d written, %d already present, %d unmatched, "
+            "%d not_found (db=%s)",
             tally["written"],
             tally["already_present"],
             tally["unmatched"],
+            tally["not_found"],
             args.results_db,
         )
     print(json.dumps(report, indent=2, ensure_ascii=False))
@@ -271,14 +327,28 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
 
 def main(argv: Sequence[str] | None = None) -> dict[str, Any]:
     parser = argparse.ArgumentParser(
-        description="YouTube Music coverage drain — dry-run harness (LML#1056)."
+        description="YouTube Music coverage drain (LML#1056, productionized in #1070)."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--sample-csv",
+        help="Credential-free dry-run/sample harness: a CSV with an 'artist,title' "
+        "header holding resolved canonical names.",
+    )
+    source.add_argument(
+        "--from-db",
+        action="store_true",
+        help="Production candidate source: a pending-scan over --results-db's albums "
+        "table (get_pending('youtube_music', --limit)). Resumable for free -- a "
+        "--execute run marks found + not_found, shrinking the next run's pending set.",
     )
     parser.add_argument(
-        "--sample-csv",
-        required=True,
-        help="CSV with an 'artist,title' header holding resolved canonical names.",
+        "--limit",
+        type=int,
+        default=0,
+        help="--sample-csv: cap candidates (0 = all). --from-db: required get_pending "
+        "page size, must be > 0.",
     )
-    parser.add_argument("--limit", type=int, default=0, help="Cap candidates (0 = all).")
     parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
     parser.add_argument(
         "--rate", type=float, default=DEFAULT_RATE, help="Max YouTube Music searches per second."
@@ -291,14 +361,18 @@ def main(argv: Sequence[str] | None = None) -> dict[str, Any]:
     parser.add_argument(
         "--results-db",
         default=DEFAULT_RESULTS_DB_PATH,
-        help="streaming_availability.db path to fill-only-persist into under --execute.",
+        help="streaming_availability.db path. --from-db reads its pending-scan from "
+        "here; --execute fill-only-persists into it.",
     )
     parser.add_argument(
         "--execute",
         action="store_true",
-        help="Opt-in: fill-only-persist matches into --results-db (default: dry-run, writes nothing).",
+        help="Opt-in: fill-only-persist outcomes into --results-db "
+        "(default: dry-run, writes nothing).",
     )
     args = parser.parse_args(argv)
+    if args.from_db and args.limit <= 0:
+        parser.error("--from-db requires --limit > 0 (the get_pending page size)")
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
     return asyncio.run(_run(args))
 

--- a/tests/unit/test_results_db.py
+++ b/tests/unit/test_results_db.py
@@ -792,6 +792,24 @@ class TestYouTubeMusicNotFoundMarker:
         assert rows[0]["youtube_music_url"] == url
 
     @pytest.mark.asyncio
+    async def test_mark_youtube_music_not_found_returns_true_when_marked(self, db):
+        await db.insert_albums([_make_album()])
+        album_id = (await db.get_pending("spotify", limit=10))[0]["id"]
+        marked = await db.mark_youtube_music_not_found(album_id)
+        assert marked is True
+
+    @pytest.mark.asyncio
+    async def test_mark_youtube_music_not_found_returns_false_when_already_resolved(self, db):
+        # The fill-only guard no-ops when the row was resolved out-of-band
+        # between a pending-scan read and this write -- callers (execute_write)
+        # need this signal to avoid overcounting a moot miss as a real one.
+        await db.insert_albums([_make_album()])
+        album_id = (await db.get_pending("spotify", limit=10))[0]["id"]
+        await db.update_youtube_music_url(album_id, "https://music.youtube.com/browse/MPREb_x")
+        marked = await db.mark_youtube_music_not_found(album_id)
+        assert marked is False
+
+    @pytest.mark.asyncio
     async def test_get_pending_youtube_music_excludes_found_and_attempted(self, db):
         await db.insert_albums(
             [

--- a/tests/unit/test_results_db.py
+++ b/tests/unit/test_results_db.py
@@ -762,6 +762,66 @@ class TestYouTubeMusicFillOnlyWrite:
         assert stats["youtube_music"]["found"] == 1
 
 
+class TestYouTubeMusicNotFoundMarker:
+    """Resumable miss marker for the #1070 from-db drain (mirrors #661 bandcamp).
+
+    Unlike mark_bandcamp_not_found, this one is fill-only guarded (AND
+    youtube_music_url IS NULL) so a transient miss can never downgrade a row
+    already resolved to 'found' (Data Safety; the #669 fill-only invariant).
+    """
+
+    @pytest.mark.asyncio
+    async def test_mark_youtube_music_not_found_sets_status_and_timestamp(self, db):
+        await db.insert_albums([_make_album()])
+        album_id = (await db.get_pending("spotify", limit=10))[0]["id"]
+        await db.mark_youtube_music_not_found(album_id)
+        rows = await db.get_pending("spotify", limit=10)
+        assert rows[0]["youtube_music_status"] == "not_found"
+        assert rows[0]["youtube_music_checked_at"] is not None
+        assert rows[0]["youtube_music_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_mark_youtube_music_not_found_never_downgrades_found(self, db):
+        await db.insert_albums([_make_album()])
+        album_id = (await db.get_pending("spotify", limit=10))[0]["id"]
+        url = "https://music.youtube.com/browse/MPREb_stereolab"
+        await db.update_youtube_music_url(album_id, url)
+        await db.mark_youtube_music_not_found(album_id)
+        rows = await db.get_pending("spotify", limit=10)
+        assert rows[0]["youtube_music_status"] == "found"
+        assert rows[0]["youtube_music_url"] == url
+
+    @pytest.mark.asyncio
+    async def test_get_pending_youtube_music_excludes_found_and_attempted(self, db):
+        await db.insert_albums(
+            [
+                _make_album(),
+                _make_album(
+                    normalized_artist="autechre",
+                    normalized_title="confield",
+                    display_artist="Autechre",
+                    display_title="Confield",
+                    library_ids=[3],
+                ),
+                _make_album(
+                    normalized_artist="juana molina",
+                    normalized_title="doga",
+                    display_artist="Juana Molina",
+                    display_title="DOGA",
+                    library_ids=[4],
+                ),
+            ]
+        )
+        rows = await db.get_pending("spotify", limit=10)
+        by_artist = {r["display_artist"]: r["id"] for r in rows}
+        await db.update_youtube_music_url(
+            by_artist["Stereolab"], "https://music.youtube.com/browse/MPREb_stereolab"
+        )
+        await db.mark_youtube_music_not_found(by_artist["Autechre"])
+        pending = await db.get_pending("youtube_music", limit=10)
+        assert [r["display_artist"] for r in pending] == ["Juana Molina"]
+
+
 class TestGetAlbumIdByNames:
     """execute_write maps a resolved candidate to its albums row by normalized
     (artist, title) -- the exact key the dedup pipeline wrote (dedup.py) -- so

--- a/tests/unit/test_ytm_coverage_drain.py
+++ b/tests/unit/test_ytm_coverage_drain.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import csv
 
+import aiosqlite
 import pytest
 
 from clients.streaming.matching import normalize_album_title, normalize_artist_name
@@ -19,6 +20,7 @@ from scripts.ytm_coverage_drain import (
     DrainOutcome,
     execute_write,
     load_candidates_from_csv,
+    load_candidates_from_db,
     load_candidates_from_rows,
     resolve_candidates,
     summarize,
@@ -153,6 +155,60 @@ class TestLoaders:
         assert [c.artist for c in cands] == ["Sessa"]
 
 
+class TestLoadCandidatesFromDb:
+    """The #1070 from-db candidate source: a pending-scan over albums, resumable
+    for free because get_pending("youtube_music") excludes found + not_found rows.
+    """
+
+    async def _seed(self, db_path: str) -> dict[str, int]:
+        db = ResultsDB(db_path)
+        await db.connect()
+        try:
+            await db.insert_albums(
+                [
+                    DeduplicatedAlbum(
+                        normalized_artist=normalize_artist_name(artist),
+                        normalized_title=normalize_album_title(title),
+                        display_artist=artist,
+                        display_title=title,
+                        library_ids=[1],
+                        formats=["cd"],
+                    )
+                    for artist, title in [
+                        ("Stereolab", "Aluminum Tunes"),
+                        ("Autechre", "Confield"),
+                        ("Juana Molina", "DOGA"),
+                    ]
+                ]
+            )
+            rows = await db.get_pending("spotify", limit=10)
+            by_artist = {r["display_artist"]: r["id"] for r in rows}
+            await db.update_youtube_music_url(
+                by_artist["Stereolab"], "https://music.youtube.com/browse/MPREb_stereolab"
+            )
+            await db.mark_youtube_music_not_found(by_artist["Autechre"])
+            return by_artist
+        finally:
+            await db.close()
+
+    @pytest.mark.asyncio
+    async def test_load_candidates_from_db_yields_only_pending_with_album_id(self, tmp_path):
+        db_path = str(tmp_path / "sa.db")
+        by_artist = await self._seed(db_path)
+
+        db = ResultsDB(db_path)
+        await db.connect()
+        try:
+            candidates = await load_candidates_from_db(db, limit=10)
+        finally:
+            await db.close()
+
+        assert len(candidates) == 1
+        assert candidates[0].artist == "Juana Molina"
+        assert candidates[0].title == "DOGA"
+        assert candidates[0].album_id == by_artist["Juana Molina"]
+
+
 class TestExecuteWritePersists:
     """execute_write fill-only-persists verified YTM links into the
     streaming_availability results DB -- Option A of the #1056 write-path fork.
@@ -188,6 +244,15 @@ class TestExecuteWritePersists:
         finally:
             await db.close()
 
+    async def _read_row(self, db_path: str) -> aiosqlite.Row:
+        db = ResultsDB(db_path)
+        await db.connect()
+        try:
+            rows = await db.get_all_results()
+            return rows[0]
+        finally:
+            await db.close()
+
     @pytest.mark.asyncio
     async def test_fills_matched_url_into_albums_row(self, tmp_path):
         db_path = str(tmp_path / "sa.db")
@@ -195,7 +260,7 @@ class TestExecuteWritePersists:
         url = "https://music.youtube.com/browse/MPREb_stereolab"
         outcome = DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), _match(url=url))
         tally = await execute_write([outcome], db_path=db_path)
-        assert tally == {"written": 1, "already_present": 0, "unmatched": 0}
+        assert tally == {"written": 1, "already_present": 0, "unmatched": 0, "not_found": 0}
         assert await self._read_url(db_path) == url
 
     @pytest.mark.asyncio
@@ -212,7 +277,7 @@ class TestExecuteWritePersists:
             [DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), _match(url=second))],
             db_path=db_path,
         )
-        assert tally == {"written": 0, "already_present": 1, "unmatched": 0}
+        assert tally == {"written": 0, "already_present": 1, "unmatched": 0, "not_found": 0}
         assert await self._read_url(db_path) == first  # original preserved
 
     @pytest.mark.asyncio
@@ -224,5 +289,102 @@ class TestExecuteWritePersists:
             _match(url="https://music.youtube.com/browse/MPREb_ghost"),
         )
         tally = await execute_write([outcome], db_path=db_path)
-        assert tally == {"written": 0, "already_present": 0, "unmatched": 1}
+        assert tally == {"written": 0, "already_present": 0, "unmatched": 1, "not_found": 0}
         assert await self._read_url(db_path) is None
+
+    @pytest.mark.asyncio
+    async def test_execute_write_marks_miss_as_not_found_when_album_id_present(self, tmp_path):
+        db_path = str(tmp_path / "sa.db")
+        await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
+        row = await self._read_row(db_path)
+        outcome = DrainOutcome(
+            Candidate("Stereolab", "Aluminum Tunes", album_id=row["id"]), match=None
+        )
+        tally = await execute_write([outcome], db_path=db_path)
+        assert tally == {"written": 0, "already_present": 0, "unmatched": 0, "not_found": 1}
+        row = await self._read_row(db_path)
+        assert row["youtube_music_status"] == "not_found"
+        assert row["youtube_music_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_execute_write_miss_without_album_id_is_skipped(self, tmp_path):
+        db_path = str(tmp_path / "sa.db")
+        await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
+        outcome = DrainOutcome(Candidate("Stereolab", "Aluminum Tunes"), match=None)
+        tally = await execute_write([outcome], db_path=db_path)
+        assert tally == {"written": 0, "already_present": 0, "unmatched": 0, "not_found": 0}
+        row = await self._read_row(db_path)
+        assert row["youtube_music_status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_execute_write_writes_found_by_album_id_without_names_join(self, tmp_path):
+        db_path = str(tmp_path / "sa.db")
+        await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
+        row = await self._read_row(db_path)
+        url = "https://music.youtube.com/browse/MPREb_stereolab"
+        # Names deliberately wouldn't resolve via get_album_id_by_names -- the
+        # album_id write path must not need the names-join at all.
+        outcome = DrainOutcome(
+            Candidate("Nonmatching Artist", "Nonmatching Title", album_id=row["id"]),
+            _match(url=url),
+        )
+        tally = await execute_write([outcome], db_path=db_path)
+        assert tally == {"written": 1, "already_present": 0, "unmatched": 0, "not_found": 0}
+        assert await self._read_url(db_path) == url
+
+
+class TestRerunResumability:
+    """AC #3: a re-run over an overlapping candidate set re-searches ~0 already-
+    attempted albums. This is the entire point of the #1070 from-db drain --
+    the rate-limited YTM endpoint must never be re-hit for a prior miss.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rerun_over_overlapping_set_researches_zero_attempted(self, tmp_path):
+        db_path = str(tmp_path / "sa.db")
+        seed_db = ResultsDB(db_path)
+        await seed_db.connect()
+        try:
+            await seed_db.insert_albums(
+                [
+                    DeduplicatedAlbum(
+                        normalized_artist=normalize_artist_name(artist),
+                        normalized_title=normalize_album_title(title),
+                        display_artist=artist,
+                        display_title=title,
+                        library_ids=[1],
+                        formats=["cd"],
+                    )
+                    for artist, title in [
+                        ("Stereolab", "Aluminum Tunes"),
+                        ("Juana Molina", "DOGA"),
+                        ("So Kalmery", "Obscure LP"),
+                    ]
+                ]
+            )
+        finally:
+            await seed_db.close()
+
+        client = _FakeClient({("Stereolab", "Aluminum Tunes"): _match()})
+
+        # First run: --from-db, --execute. Marks one found, two not_found.
+        run1_db = ResultsDB(db_path)
+        await run1_db.connect()
+        try:
+            candidates = await load_candidates_from_db(run1_db, limit=10)
+        finally:
+            await run1_db.close()
+        assert len(candidates) == 3
+        outcomes = await resolve_candidates(client, candidates, concurrency=2)
+        assert len(client.calls) == 3
+        tally = await execute_write(outcomes, db_path=db_path)
+        assert tally == {"written": 1, "already_present": 0, "unmatched": 0, "not_found": 2}
+
+        # Re-run over the same (overlapping) set: 0 new candidates, 0 new searches.
+        rerun_db = ResultsDB(db_path)
+        await rerun_db.connect()
+        try:
+            rerun_candidates = await load_candidates_from_db(rerun_db, limit=10)
+        finally:
+            await rerun_db.close()
+        assert rerun_candidates == []

--- a/tests/unit/test_ytm_coverage_drain.py
+++ b/tests/unit/test_ytm_coverage_drain.py
@@ -208,6 +208,46 @@ class TestLoadCandidatesFromDb:
         assert candidates[0].title == "DOGA"
         assert candidates[0].album_id == by_artist["Juana Molina"]
 
+    @pytest.mark.asyncio
+    async def test_blank_display_name_rows_are_marked_not_found_not_left_stalling(self, tmp_path):
+        # get_pending has no ORDER BY/OFFSET, so an unsearchable blank-name row
+        # left 'pending' would reappear in every future pending-scan page and
+        # could stall pagination for real candidates behind it. It must be
+        # marked not_found (like any other attempted-but-unusable candidate)
+        # instead of silently dropped.
+        db_path = str(tmp_path / "sa.db")
+        db = ResultsDB(db_path)
+        await db.connect()
+        try:
+            await db.insert_albums(
+                [
+                    DeduplicatedAlbum(
+                        normalized_artist="blank artist",
+                        normalized_title="blank title",
+                        display_artist="",
+                        display_title="Something",
+                        library_ids=[1],
+                        formats=["cd"],
+                    ),
+                    DeduplicatedAlbum(
+                        normalized_artist=normalize_artist_name("Sessa"),
+                        normalized_title=normalize_album_title("Grandeza"),
+                        display_artist="Sessa",
+                        display_title="Grandeza",
+                        library_ids=[2],
+                        formats=["cd"],
+                    ),
+                ]
+            )
+            candidates = await load_candidates_from_db(db, limit=10)
+            assert [c.artist for c in candidates] == ["Sessa"]
+
+            rows = await db.get_all_results()
+            blank_row = next(r for r in rows if r["display_artist"] == "")
+            assert blank_row["youtube_music_status"] == "not_found"
+        finally:
+            await db.close()
+
 
 class TestExecuteWritePersists:
     """execute_write fill-only-persists verified YTM links into the
@@ -307,6 +347,33 @@ class TestExecuteWritePersists:
         assert row["youtube_music_url"] is None
 
     @pytest.mark.asyncio
+    async def test_execute_write_miss_when_already_resolved_counts_already_present(self, tmp_path):
+        # The row got resolved out-of-band between the pending-scan read and
+        # this write landing (e.g. a second run over an overlapping window).
+        # mark_youtube_music_not_found's fill-only guard no-ops -- the tally
+        # must reflect that as already_present, not double-count it as a
+        # genuine not_found.
+        db_path = str(tmp_path / "sa.db")
+        await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
+        row = await self._read_row(db_path)
+        url = "https://music.youtube.com/browse/MPREb_x"
+        seed_db = ResultsDB(db_path)
+        await seed_db.connect()
+        try:
+            await seed_db.update_youtube_music_url(row["id"], url)
+        finally:
+            await seed_db.close()
+
+        outcome = DrainOutcome(
+            Candidate("Stereolab", "Aluminum Tunes", album_id=row["id"]), match=None
+        )
+        tally = await execute_write([outcome], db_path=db_path)
+        assert tally == {"written": 0, "already_present": 1, "unmatched": 0, "not_found": 0}
+        row = await self._read_row(db_path)
+        assert row["youtube_music_status"] == "found"
+        assert row["youtube_music_url"] == url
+
+    @pytest.mark.asyncio
     async def test_execute_write_miss_without_album_id_is_skipped(self, tmp_path):
         db_path = str(tmp_path / "sa.db")
         await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
@@ -331,6 +398,30 @@ class TestExecuteWritePersists:
         tally = await execute_write([outcome], db_path=db_path)
         assert tally == {"written": 1, "already_present": 0, "unmatched": 0, "not_found": 0}
         assert await self._read_url(db_path) == url
+
+    @pytest.mark.asyncio
+    async def test_reuses_a_provided_connection_instead_of_opening_a_second_one(self, tmp_path):
+        # --from-db --execute would otherwise open a second ResultsDB against
+        # the same file just to write, paying a redundant connect/migrate
+        # round-trip. Passing an already-connected db must be honored, and
+        # execute_write must not close a connection it doesn't own.
+        db_path = str(tmp_path / "sa.db")
+        await self._seed_album(db_path, "Stereolab", "Aluminum Tunes")
+        row = await self._read_row(db_path)
+        db = ResultsDB(db_path)
+        await db.connect()
+        try:
+            url = "https://music.youtube.com/browse/MPREb_reused"
+            outcome = DrainOutcome(
+                Candidate("Stereolab", "Aluminum Tunes", album_id=row["id"]), _match(url=url)
+            )
+            tally = await execute_write([outcome], db_path=db_path, db=db)
+            assert tally == {"written": 1, "already_present": 0, "unmatched": 0, "not_found": 0}
+            # Still open and usable -- execute_write did not close it.
+            rows = await db.get_all_results()
+            assert rows[0]["youtube_music_url"] == url
+        finally:
+            await db.close()
 
 
 class TestRerunResumability:


### PR DESCRIPTION
## Summary

- Adds a fill-only-guarded `ResultsDB.mark_youtube_music_not_found(album_id)` (`AND youtube_music_url IS NULL`) so a transient miss can never downgrade a row already resolved to `found`, mirroring `mark_bandcamp_not_found` (#661) with the extra guard this ticket calls out.
- Adds the production candidate source: `--from-db` drives `load_candidates_from_db` over `ResultsDB.get_pending("youtube_music", limit)`, which already excludes both `found` and `not_found` rows — the drain is resumable for free. Candidates carry the row's own `album_id`, so writes land by id with no `(artist, title)` names-join.
- Generalizes `execute_write` to persist every outcome (found *and* miss), not just matches: a match writes by `album_id` (falling back to the names-join only on the CSV path), a miss with an `album_id` is durably marked `not_found`, and a CSV-path miss (no `album_id`) is skipped silently. Tally dict gains a `not_found` key.
- `--from-db` and `--sample-csv` are now a required, mutually-exclusive argparse group; `--from-db --limit` is a required positive `get_pending` page size, turning repeated `--execute` runs into natural pagination over the whole backlog.

## Test plan

- [x] TDD: every new/changed path (`mark_youtube_music_not_found`, `load_candidates_from_db`, generalized `execute_write`, argparse wiring) has a failing-test-first commit history in the branch.
- [x] `test_rerun_over_overlapping_set_researches_zero_attempted` (AC #3) proves a re-run over an overlapping candidate set issues 0 new YTM searches.
- [x] `uv run --no-sync ruff check .`, `ruff format --check .`, `mypy . --ignore-missing-imports`, and the full unmarked test suite (`pytest -n auto`, 5190 passed) all green locally.
- [x] End-to-end smoke test of `_run` with `--from-db --execute` against a real sqlite file (fake YTM client) confirms the wiring: pending-scan → resolve → fill-only persist of both found and not_found.

Closes #1070