### PR TITLE
build: install wxyc-etl from PyPI instead of compiling it from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,3 @@
-FROM python:3.12-slim AS builder
-
-# Install Rust toolchain and build wxyc-etl wheel
-RUN apt-get update && apt-get install -y --no-install-recommends curl git gcc libc6-dev && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    . "$HOME/.cargo/env" && \
-    pip install --no-cache-dir maturin && \
-    git clone --depth 1 https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl && \
-    cd /tmp/wxyc-etl/wxyc-etl-python && \
-    maturin build --release && \
-    cp /tmp/wxyc-etl/target/wheels/*.whl /tmp/
-
 FROM python:3.12-slim
 
 # Create non-root user
@@ -17,11 +5,13 @@ RUN groupadd -r appuser && useradd -r -g appuser -s /sbin/nologin appuser
 
 WORKDIR /app
 
-# Install wxyc-etl wheel from builder stage
-COPY --from=builder /tmp/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
-
-# Install dependencies
+# Install dependencies. wxyc-etl (like every other dependency) is pinned in
+# pyproject.toml (`wxyc-etl>=0.8.0,<0.9.0`) and ships prebuilt abi3 manylinux
+# wheels on PyPI, so `pip install .` pulls it with no build step. This is the
+# same resolution CI validates against. Do NOT reintroduce a source build of
+# wxyc-etl here: compiling it from git HEAD ignored the version pin (shipping
+# an untested version into the image) and paid a full Rust release compile on
+# every cold build. See WXYC/library-metadata-lookup#1077.
 COPY pyproject.toml ./
 RUN pip install --no-cache-dir .
 


### PR DESCRIPTION
## Summary

The `Dockerfile` builder stage installed a Rust toolchain + maturin, `git clone`d `wxyc-etl`'s default-branch HEAD, and ran `maturin build --release` on every cold build. This PR deletes that stage and lets `pip install .` resolve `wxyc-etl` — and every other dependency — from PyPI as a prebuilt wheel, which is the exact resolution CI already validates.

Two things this fixes:

- **Cold-build speed.** The Rust release compile was the dominant cold-build cost — the deploy job swung from **34s warm** to **2m26s cold** ([run 30717245980](https://github.com/WXYC/library-metadata-lookup/actions/runs/30717245980) vs [run 30415465822](https://github.com/WXYC/library-metadata-lookup/actions/runs/30415465822)). Removing it takes a no-cache build to **15.9s** locally.
- **Version drift (correctness).** `git clone` with no ref built `wxyc-etl` HEAD, ignoring the `pyproject.toml` pin `wxyc-etl>=0.8.0,<0.9.0`. Latest published `wxyc-etl` is already `0.10.0`, so the image had been shipping a version **outside the range CI tests against**. `pip install .` now honours the pin.

## Verification (local Docker)

- No-cache build **15.9s** (was ~2m26s cold).
- `wxyc-etl 0.8.0` — within the pin, matching CI.
- `wxyc_etl.text` / `wxyc_etl.schema` native extension imports cleanly.
- All runtime deps import; app boots to `Application startup complete`.
- Image size 371MB.

The Railway/prod verification is the existing post-deploy smoke test (`/health` green + `commit_sha` present).

Closes #1077