### PR TITLE
Seed compilation_track_location matches from library_release_override

### DIFF
--- a/scripts/build_compilation_track_location.py
+++ b/scripts/build_compilation_track_location.py
@@ -4,11 +4,14 @@ Answers "which library shelf locations contain track *T* credited to artist
 *A*?" by walking every compilation-shelf row in ``library.db`` (any artist
 ``wxyc_etl.text.is_compilation_artist`` recognizes -- "Various Artists - *"
 and "Soundtracks - *" shelf buckets alike), matching it to a Discogs release
-via the same normalized-title cascade ``scripts/match_compilations.py`` uses
-against ``va_release``, and persisting every ``release_track_artist`` credit
-for that release -- not just the primary artist -- tiered into a coarse
-``credit_role``. Precision ranking is LML#1022's job; this only guarantees
-every candidate row exists for it to rank.
+-- preferring a hand-verified ``lml_cache.library_release_override`` pin
+(LML#850/#858) and falling back to the same normalized-title cascade
+``scripts/match_compilations.py`` uses against ``va_release`` for comps the
+override table doesn't cover (LML#1082) -- and persisting every
+``release_track_artist`` credit for that release -- not just the primary
+artist -- tiered into a coarse ``credit_role``. Precision ranking is
+LML#1022's job; this only guarantees every candidate row exists for it to
+rank.
 
 Runs standalone, outside the FastAPI service (a discogs-etl-cloned checkout
 per the ship-dag triage resolution on LML#1019), so schema bootstrap is
@@ -130,36 +133,68 @@ async def get_processed_library_ids(conn: asyncpg.Connection) -> set[int]:
     return {row["library_id"] for row in rows}
 
 
+_OVERRIDE_SQL = """\
+SELECT library_id, discogs_release_id
+FROM lml_cache.library_release_override
+WHERE library_id = ANY($1)
+  AND discogs_release_id IN (SELECT id FROM va_release)
+  AND EXISTS (
+      SELECT 1 FROM release_track rt WHERE rt.release_id = discogs_release_id
+  )\
+"""
+
+
 async def match_comp_release(
     conn: asyncpg.Connection, comps: list[CompCandidate]
 ) -> dict[int, int]:
-    """Match each comp to a Discogs release id, reusing ``match_compilations.py``.
+    """Match each comp to a Discogs release id: authoritative override first, title cascade as fallback.
 
-    Runs the same exact -> prefix-strip -> trigram cascade the standalone VA
-    matcher uses against ``va_release``, so this build doesn't reinvent
-    comp-title matching. Returns ``library_id -> discogs_release_id`` for
-    every comp that matched; an unmatched comp is simply absent from the
+    Seeds the result from ``lml_cache.library_release_override`` (LML#850 /
+    LML#858) -- the same hand-verified ``library_id -> discogs_release_id``
+    pin the runtime ``/lookup`` path consults via
+    ``lookup/artwork.py::get_library_release_overrides``. An override only
+    seeds a match when its target is itself indexable: present in
+    ``va_release`` *and* carrying at least one ``release_track`` row (the
+    ``_OVERRIDE_SQL`` guard) -- the same "no cached tracklist" skip class the
+    caller already logs for a cascade hit with an empty tracklist. Comps
+    left unclaimed by a (guarded) override fall through to the same exact ->
+    prefix-strip -> trigram cascade ``match_compilations.py`` runs against
+    ``va_release``, so this build still doesn't reinvent comp-title matching
+    for the comps the override table doesn't cover. The override always wins
+    on conflict -- an override-claimed comp is removed from the candidate
+    pool before the cascade runs, so it can never be reassigned by a
+    title match. Returns ``library_id -> discogs_release_id`` for every comp
+    matched either way; a comp matched by neither is simply absent from the
     result (retried on the next run).
     """
     if not comps:
         return {}
-    albums = [
-        CompAlbum(
-            id=comp.library_id,
-            title=comp.title,
-            display_artist=comp.artist,
-            normalized_title=normalize_comp_title(comp.title),
-        )
-        for comp in comps
-    ]
-    await conn.execute("SET pg_trgm.similarity_threshold = 0.3")
-    exact_matches, remaining, title_map = await exact_match(conn, albums)
-    prefix_matches, remaining = await prefix_strip_match(title_map, remaining)
-    fuzzy_matches, _unmatched = await trigram_match(conn, remaining)
-    return {
-        match.comp_id: match.discogs_release_id
-        for match in (*exact_matches, *prefix_matches, *fuzzy_matches)
+
+    library_ids = [comp.library_id for comp in comps]
+    override_rows = await conn.fetch(_OVERRIDE_SQL, library_ids)
+    matches: dict[int, int] = {
+        row["library_id"]: row["discogs_release_id"] for row in override_rows
     }
+
+    remaining_comps = [comp for comp in comps if comp.library_id not in matches]
+    if remaining_comps:
+        albums = [
+            CompAlbum(
+                id=comp.library_id,
+                title=comp.title,
+                display_artist=comp.artist,
+                normalized_title=normalize_comp_title(comp.title),
+            )
+            for comp in remaining_comps
+        ]
+        await conn.execute("SET pg_trgm.similarity_threshold = 0.3")
+        exact_matches, cascade_remaining, title_map = await exact_match(conn, albums)
+        prefix_matches, cascade_remaining = await prefix_strip_match(title_map, cascade_remaining)
+        fuzzy_matches, _unmatched = await trigram_match(conn, cascade_remaining)
+        for match in (*exact_matches, *prefix_matches, *fuzzy_matches):
+            matches[match.comp_id] = match.discogs_release_id
+
+    return matches
 
 
 _CREDITS_SQL = """\

--- a/scripts/build_compilation_track_location.py
+++ b/scripts/build_compilation_track_location.py
@@ -134,12 +134,12 @@ async def get_processed_library_ids(conn: asyncpg.Connection) -> set[int]:
 
 
 _OVERRIDE_SQL = """\
-SELECT library_id, discogs_release_id
-FROM lml_cache.library_release_override
-WHERE library_id = ANY($1)
-  AND discogs_release_id IN (SELECT id FROM va_release)
+SELECT lro.library_id, lro.discogs_release_id
+FROM lml_cache.library_release_override lro
+WHERE lro.library_id = ANY($1)
+  AND lro.discogs_release_id IN (SELECT id FROM va_release)
   AND EXISTS (
-      SELECT 1 FROM release_track rt WHERE rt.release_id = discogs_release_id
+      SELECT 1 FROM release_track rt WHERE rt.release_id = lro.discogs_release_id
   )\
 """
 

--- a/tests/integration/test_build_compilation_track_location_pg.py
+++ b/tests/integration/test_build_compilation_track_location_pg.py
@@ -349,6 +349,11 @@ class TestMatchCompReleaseOverrideSeeding:
     LIB_ID = 60654
     LIB_TITLE = "Lost In Translation"
     LIB_ARTIST = "Soundtracks - L"
+    # A second "Soundtracks - L" shelf row with a *valid* override to the same
+    # LiT release. Seeded alongside the guard-skip negatives so their result is
+    # a positive `{SIBLING_ID: 13468045}`, not a bare `{}` that would also hold
+    # if override consultation were removed entirely (LML#1083 review).
+    SIBLING_ID = 60655
 
     async def test_shelf_row_has_no_title_cascade_match_on_its_own(self, pg_pool):
         """Baseline: without an override, this shelf row is genuinely unmatchable."""
@@ -373,24 +378,40 @@ class TestMatchCompReleaseOverrideSeeding:
         assert result == {self.LIB_ID: 13468045}
 
     async def test_override_to_a_non_va_release_is_skipped(self, pg_pool):
-        """An override pointed at a release absent from va_release can't seed the index."""
+        """An override pointed at a release absent from va_release can't seed the index.
+
+        A sibling comp with a *valid* override seeds in the same batch, so the
+        omission of LIB_ID proves the guard filtered its (non-va) override --
+        not that override consultation is inert (which would yield a bare {}).
+        """
         async with pg_pool.acquire() as conn:
+            await _seed_lost_in_translation(conn)
             await conn.execute("INSERT INTO release (id, title) VALUES (777, 'Not A VA Release')")
             await conn.execute(
                 "INSERT INTO release_track (release_id, sequence, position, title) VALUES "
                 "(777, 1, 'A1', 'Some Track')"
             )
             await _insert_override(conn, self.LIB_ID, 777)
-            comp = CompCandidate(
-                library_id=self.LIB_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST
-            )
-            result = await match_comp_release(conn, [comp])
+            await _insert_override(conn, self.SIBLING_ID, 13468045)
+            comps = [
+                CompCandidate(library_id=self.LIB_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST),
+                CompCandidate(
+                    library_id=self.SIBLING_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST
+                ),
+            ]
+            result = await match_comp_release(conn, comps)
 
-        assert result == {}
+        assert result == {self.SIBLING_ID: 13468045}
 
     async def test_override_to_a_release_with_no_cached_tracklist_is_skipped(self, pg_pool):
-        """An override pointed at a va_release with zero release_track rows can't seed the index."""
+        """An override pointed at a va_release with zero release_track rows can't seed the index.
+
+        A sibling comp with a *valid* override seeds in the same batch, so the
+        omission of LIB_ID proves the guard filtered its (tracklist-less)
+        override -- not that override consultation is inert.
+        """
         async with pg_pool.acquire() as conn:
+            await _seed_lost_in_translation(conn)
             await conn.execute(
                 "INSERT INTO release (id, title) VALUES (888, 'No Tracklist Cached')"
             )
@@ -399,12 +420,16 @@ class TestMatchCompReleaseOverrideSeeding:
                 "(888, 'No Tracklist Cached', 'no tracklist cached')"
             )
             await _insert_override(conn, self.LIB_ID, 888)
-            comp = CompCandidate(
-                library_id=self.LIB_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST
-            )
-            result = await match_comp_release(conn, [comp])
+            await _insert_override(conn, self.SIBLING_ID, 13468045)
+            comps = [
+                CompCandidate(library_id=self.LIB_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST),
+                CompCandidate(
+                    library_id=self.SIBLING_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST
+                ),
+            ]
+            result = await match_comp_release(conn, comps)
 
-        assert result == {}
+        assert result == {self.SIBLING_ID: 13468045}
 
     async def test_override_wins_over_a_conflicting_title_cascade_match(self, pg_pool):
         """library_id 28 exact-title-matches release 555, but its override points elsewhere."""

--- a/tests/integration/test_build_compilation_track_location_pg.py
+++ b/tests/integration/test_build_compilation_track_location_pg.py
@@ -22,7 +22,11 @@ import aiosqlite
 import pytest
 import pytest_asyncio
 
-from scripts.build_compilation_track_location import build_compilation_track_location
+from scripts.build_compilation_track_location import (
+    CompCandidate,
+    build_compilation_track_location,
+    match_comp_release,
+)
 from tests.integration.conftest import skip_if_named_tables_populated
 
 
@@ -32,13 +36,22 @@ async def fresh_schema(pg_pool):
 
     Mirrors ``test_cache_lean_json_agg_parity.py``'s ``fresh_schema`` fixture
     for the shared (non-LML-owned) ``release*`` tables. The LML-owned
-    ``lml_cache.compilation_track_location`` gets the stricter populated-table
+    ``lml_cache.compilation_track_location`` and ``lml_cache.library_release_override``
+    (LML#1082's override-seeding source) both get the stricter populated-table
     veto (as in ``test_library_release_override.py``) since a mispointed
-    ``DATABASE_URL_TEST`` there would risk real collected recall-index rows.
+    ``DATABASE_URL_TEST`` there would risk real collected recall-index rows or
+    hand-verified override pins.
     """
     async with pg_pool.acquire() as conn:
-        await skip_if_named_tables_populated(conn, (("lml_cache", "compilation_track_location"),))
+        await skip_if_named_tables_populated(
+            conn,
+            (
+                ("lml_cache", "compilation_track_location"),
+                ("lml_cache", "library_release_override"),
+            ),
+        )
         await conn.execute("DROP TABLE IF EXISTS lml_cache.compilation_track_location")
+        await conn.execute("DROP TABLE IF EXISTS lml_cache.library_release_override")
         for table in ("release_track_artist", "release_track", "va_release", "release"):
             await conn.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
         await conn.execute("""
@@ -73,13 +86,17 @@ async def fresh_schema(pg_pool):
             )
         """)
     from entity.compilation_track_location import set_up_compilation_track_location_schema
+    from entity.library_release_override import set_up_library_release_override_schema
     from entity.sources import PgSource
 
-    await set_up_compilation_track_location_schema(PgSource(pool=pg_pool))
+    pg_source = PgSource(pool=pg_pool)
+    await set_up_compilation_track_location_schema(pg_source)
+    await set_up_library_release_override_schema(pg_source)
     yield
     async with pg_pool.acquire() as conn:
         for table in (
             "lml_cache.compilation_track_location",
+            "lml_cache.library_release_override",
             "release_track_artist",
             "release_track",
             "va_release",
@@ -107,6 +124,44 @@ async def _seed_the_sound_of_dub(conn):
             (555, 2, "Scientist", 0, None),
             (555, 2, "Kiki Hitomi", 1, "Featuring"),
         ],
+    )
+
+
+async def _seed_lost_in_translation(conn):
+    """Lost In Translation OST -> Discogs release 13468045 (LML#1082's motivating repro).
+
+    Deliberately NOT title-cascade-matchable from a "Soundtracks - L" shelf row
+    titled "Lost In Translation" -- neither the exact-match nor the
+    prefix-strip phase can bridge "Lost In Translation" to the full Discogs
+    title, so a comp filed against this release is only reachable via
+    ``library_release_override``.
+    """
+    await conn.execute(
+        "INSERT INTO release (id, title) VALUES "
+        "(13468045, 'Lost In Translation (Music From The Motion Picture)')"
+    )
+    await conn.execute(
+        "INSERT INTO va_release (id, title, norm_title) VALUES "
+        "(13468045, 'Lost In Translation (Music From The Motion Picture)', "
+        "'lost in translation music from the motion picture')"
+    )
+    await conn.execute(
+        "INSERT INTO release_track (release_id, sequence, position, title) VALUES "
+        "(13468045, 1, 'A7', 'Tommib')"
+    )
+    await conn.execute(
+        "INSERT INTO release_track_artist "
+        "(release_id, track_sequence, artist_name, extra, role) VALUES "
+        "(13468045, 1, 'Squarepusher', 0, NULL)"
+    )
+
+
+async def _insert_override(conn, library_id: int, discogs_release_id: int) -> None:
+    await conn.execute(
+        "INSERT INTO lml_cache.library_release_override (library_id, discogs_release_id) "
+        "VALUES ($1, $2)",
+        library_id,
+        discogs_release_id,
     )
 
 
@@ -276,3 +331,135 @@ class TestBuildAgainstRealPostgres:
             )
 
         assert stats == {"candidates": 1, "matched": 0, "rows_inserted": 0}
+
+
+@pytest.mark.pg
+@pytest.mark.asyncio
+class TestMatchCompReleaseOverrideSeeding:
+    """Real-Postgres proof of the ``_OVERRIDE_SQL`` guard (LML#1082).
+
+    ``tests/unit/test_build_compilation_track_location.py::TestMatchCompRelease``
+    covers the seeding/precedence/fallback decision against a mocked ``conn``;
+    this class proves the guard predicate itself -- override target must be in
+    ``va_release`` AND carry at least one ``release_track`` row -- against real
+    tables, using the ticket's own repro (library 60654, "Soundtracks - L"
+    shelf, Lost In Translation OST) as the override-only fixture.
+    """
+
+    LIB_ID = 60654
+    LIB_TITLE = "Lost In Translation"
+    LIB_ARTIST = "Soundtracks - L"
+
+    async def test_shelf_row_has_no_title_cascade_match_on_its_own(self, pg_pool):
+        """Baseline: without an override, this shelf row is genuinely unmatchable."""
+        async with pg_pool.acquire() as conn:
+            await _seed_lost_in_translation(conn)
+            comp = CompCandidate(
+                library_id=self.LIB_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST
+            )
+            result = await match_comp_release(conn, [comp])
+
+        assert result == {}
+
+    async def test_override_only_comp_is_indexed_via_the_override(self, pg_pool):
+        async with pg_pool.acquire() as conn:
+            await _seed_lost_in_translation(conn)
+            await _insert_override(conn, self.LIB_ID, 13468045)
+            comp = CompCandidate(
+                library_id=self.LIB_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST
+            )
+            result = await match_comp_release(conn, [comp])
+
+        assert result == {self.LIB_ID: 13468045}
+
+    async def test_override_to_a_non_va_release_is_skipped(self, pg_pool):
+        """An override pointed at a release absent from va_release can't seed the index."""
+        async with pg_pool.acquire() as conn:
+            await conn.execute("INSERT INTO release (id, title) VALUES (777, 'Not A VA Release')")
+            await conn.execute(
+                "INSERT INTO release_track (release_id, sequence, position, title) VALUES "
+                "(777, 1, 'A1', 'Some Track')"
+            )
+            await _insert_override(conn, self.LIB_ID, 777)
+            comp = CompCandidate(
+                library_id=self.LIB_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST
+            )
+            result = await match_comp_release(conn, [comp])
+
+        assert result == {}
+
+    async def test_override_to_a_release_with_no_cached_tracklist_is_skipped(self, pg_pool):
+        """An override pointed at a va_release with zero release_track rows can't seed the index."""
+        async with pg_pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO release (id, title) VALUES (888, 'No Tracklist Cached')"
+            )
+            await conn.execute(
+                "INSERT INTO va_release (id, title, norm_title) VALUES "
+                "(888, 'No Tracklist Cached', 'no tracklist cached')"
+            )
+            await _insert_override(conn, self.LIB_ID, 888)
+            comp = CompCandidate(
+                library_id=self.LIB_ID, title=self.LIB_TITLE, artist=self.LIB_ARTIST
+            )
+            result = await match_comp_release(conn, [comp])
+
+        assert result == {}
+
+    async def test_override_wins_over_a_conflicting_title_cascade_match(self, pg_pool):
+        """library_id 28 exact-title-matches release 555, but its override points elsewhere."""
+        async with pg_pool.acquire() as conn:
+            await _seed_the_sound_of_dub(conn)
+            await _seed_lost_in_translation(conn)
+            await _insert_override(conn, 28, 13468045)
+            comp = CompCandidate(
+                library_id=28, title="The Sound of Dub", artist="Various Artists - Reggae"
+            )
+            result = await match_comp_release(conn, [comp])
+
+        assert result == {28: 13468045}
+
+    async def test_comp_with_no_override_still_falls_through_to_the_title_cascade(self, pg_pool):
+        async with pg_pool.acquire() as conn:
+            await _seed_the_sound_of_dub(conn)
+            comp = CompCandidate(
+                library_id=28, title="The Sound of Dub", artist="Various Artists - Reggae"
+            )
+            result = await match_comp_release(conn, [comp])
+
+        assert result == {28: 555}
+
+    async def test_full_build_indexes_an_override_only_comp_end_to_end(self, pg_pool, tmp_path):
+        """The ticket's own repro, end to end: 60654 gets a compilation_track_location
+
+        row for Squarepusher/Tommib purely off the override -- no title match involved.
+        """
+        async with pg_pool.acquire() as conn:
+            await _seed_lost_in_translation(conn)
+            await _insert_override(conn, self.LIB_ID, 13468045)
+
+        library_db = await _write_library_db(
+            tmp_path, [(self.LIB_ID, self.LIB_TITLE, self.LIB_ARTIST)]
+        )
+
+        async with pg_pool.acquire() as conn:
+            stats = await build_compilation_track_location(
+                library_db_path=library_db,
+                discogs_conn=conn,
+                discogs_service=None,
+                full=True,
+            )
+
+        assert stats == {"candidates": 1, "matched": 1, "rows_inserted": 1}
+        async with pg_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT track_position, track_artist, track_title, discogs_release_id "
+                "FROM lml_cache.compilation_track_location WHERE library_id = $1",
+                self.LIB_ID,
+            )
+        assert dict(row) == {
+            "track_position": "A7",
+            "track_artist": "squarepusher",
+            "track_title": "tommib",
+            "discogs_release_id": 13468045,
+        }

--- a/tests/unit/test_build_compilation_track_location.py
+++ b/tests/unit/test_build_compilation_track_location.py
@@ -18,8 +18,10 @@ from scripts.build_compilation_track_location import (
     build_rows,
     get_processed_library_ids,
     load_library_compilations,
+    match_comp_release,
     tier_credit_role,
 )
+from scripts.match_compilations import DiscogsMatch
 
 
 class TestTierCreditRole:
@@ -122,6 +124,238 @@ class TestGetProcessedLibraryIds:
         )
         result = await get_processed_library_ids(conn)
         assert result == {2, 3}
+
+
+@pytest.mark.asyncio
+class TestMatchCompRelease:
+    """``match_comp_release`` seeds from ``library_release_override`` before the title cascade (LML#1082).
+
+    ``conn`` is a full mock here, so the guard predicate itself (release must
+    be in ``va_release`` AND carry a ``release_track`` row) is not re-derived
+    in Python -- it's delegated to the SQL in ``_OVERRIDE_SQL`` and proved
+    against real tables in ``tests/integration/test_build_compilation_track_location_pg.py``.
+    What's covered here is the seeding/precedence/fallback *decision*: a
+    library_id the guarded query returns is trusted outright; one it omits
+    (whether because it carries no override, or because the guard filtered
+    it -- both look identical from this function's perspective) falls
+    through to the title cascade.
+    """
+
+    LOST_IN_TRANSLATION = CompCandidate(
+        library_id=60654,
+        title="Lost In Translation (Music From The Motion Picture)",
+        artist="Soundtracks - L",
+    )
+    SOUND_OF_DUB = CompCandidate(
+        library_id=28, title="The Sound of Dub", artist="Various Artists - Reggae"
+    )
+
+    @staticmethod
+    def _conn_with_override_rows(rows):
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=rows)
+        return conn
+
+    @staticmethod
+    def _fail_if_called(name):
+        async def _fail(*args, **kwargs):
+            raise AssertionError(f"{name} must not run when every comp is override-matched")
+
+        return _fail
+
+    async def test_override_only_comp_is_indexed_without_running_the_cascade(self, monkeypatch):
+        conn = self._conn_with_override_rows(
+            [{"library_id": 60654, "discogs_release_id": 13468045}]
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.exact_match",
+            self._fail_if_called("exact_match"),
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.prefix_strip_match",
+            self._fail_if_called("prefix_strip_match"),
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.trigram_match",
+            self._fail_if_called("trigram_match"),
+        )
+
+        result = await match_comp_release(conn, [self.LOST_IN_TRANSLATION])
+
+        assert result == {60654: 13468045}
+        conn.fetch.assert_awaited_once()
+        sql, library_ids = conn.fetch.await_args.args
+        assert "library_release_override" in sql
+        assert "va_release" in sql
+        assert "release_track" in sql
+        assert library_ids == [60654]
+
+    async def test_override_wins_over_a_conflicting_title_cascade_match(self, monkeypatch):
+        """The override-claimed comp never reaches the cascade, so it can't be reassigned."""
+        conn = self._conn_with_override_rows(
+            [{"library_id": 60654, "discogs_release_id": 13468045}]
+        )
+        seen_album_ids: list[int] = []
+
+        async def fake_exact_match(conn_arg, albums):
+            seen_album_ids.extend(a.id for a in albums)
+            # If the override-claimed comp leaked through here, it would
+            # resolve to this deliberately-wrong release id.
+            matched = [
+                DiscogsMatch(
+                    comp_id=a.id,
+                    comp_title=a.title,
+                    discogs_release_id=999999,
+                    discogs_title="wrong release",
+                    confidence=100.0,
+                    track_count=0,
+                )
+                for a in albums
+                if a.id == 60654
+            ]
+            title_map: dict[str, list[tuple[int, str]]] = {}
+            remaining = [a for a in albums if a.id != 60654]
+            return matched, remaining, title_map
+
+        async def fake_prefix_strip_match(title_map, albums):
+            return [], albums
+
+        async def fake_trigram_match(conn_arg, albums):
+            return [], albums
+
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.exact_match", fake_exact_match
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.prefix_strip_match",
+            fake_prefix_strip_match,
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.trigram_match", fake_trigram_match
+        )
+
+        result = await match_comp_release(conn, [self.LOST_IN_TRANSLATION, self.SOUND_OF_DUB])
+
+        assert result[60654] == 13468045  # override wins, not the cascade's 999999
+        assert 60654 not in seen_album_ids  # override-claimed comp never entered the cascade
+
+    async def test_guard_filtered_comp_falls_back_to_title_cascade(self, monkeypatch):
+        """A comp whose override the SQL guard excluded (bad va_release/no tracklist)
+
+        looks, from this function's perspective, identical to "no override at
+        all" -- the guarded query simply omits its row -- so it must still get
+        a chance at the title cascade.
+        """
+        conn = self._conn_with_override_rows([])  # guard filtered it out (or no override exists)
+
+        async def fake_exact_match(conn_arg, albums):
+            matched = [
+                DiscogsMatch(
+                    comp_id=a.id,
+                    comp_title=a.title,
+                    discogs_release_id=555,
+                    discogs_title=a.title,
+                    confidence=100.0,
+                    track_count=0,
+                )
+                for a in albums
+            ]
+            return matched, [], {}
+
+        async def fake_prefix_strip_match(title_map, albums):
+            return [], albums
+
+        async def fake_trigram_match(conn_arg, albums):
+            return [], albums
+
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.exact_match", fake_exact_match
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.prefix_strip_match",
+            fake_prefix_strip_match,
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.trigram_match", fake_trigram_match
+        )
+
+        result = await match_comp_release(conn, [self.SOUND_OF_DUB])
+
+        assert result == {28: 555}
+
+    async def test_no_override_at_all_preserves_the_existing_cascade_composition(self, monkeypatch):
+        """Regression: zero overrides in play must reproduce the pre-#1082 cascade merge exactly."""
+        conn = self._conn_with_override_rows([])
+
+        async def fake_exact_match(conn_arg, albums):
+            matched = [
+                DiscogsMatch(
+                    comp_id=1,
+                    comp_title="Exact Hit",
+                    discogs_release_id=100,
+                    discogs_title="Exact Hit",
+                    confidence=100.0,
+                    track_count=0,
+                )
+            ]
+            remaining = [a for a in albums if a.id != 1]
+            return matched, remaining, {"exact hit": [(100, "Exact Hit")]}
+
+        async def fake_prefix_strip_match(title_map, albums):
+            matched = [
+                DiscogsMatch(
+                    comp_id=2,
+                    comp_title="Prefix Hit",
+                    discogs_release_id=200,
+                    discogs_title="Prefix Hit",
+                    confidence=95.0,
+                    track_count=0,
+                )
+            ]
+            remaining = [a for a in albums if a.id != 2]
+            return matched, remaining
+
+        async def fake_trigram_match(conn_arg, albums):
+            matched = [
+                DiscogsMatch(
+                    comp_id=3,
+                    comp_title="Fuzzy Hit",
+                    discogs_release_id=300,
+                    discogs_title="Fuzzy-ish Hit",
+                    confidence=85.0,
+                    track_count=0,
+                )
+            ]
+            remaining = [a for a in albums if a.id != 3]
+            return matched, remaining
+
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.exact_match", fake_exact_match
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.prefix_strip_match",
+            fake_prefix_strip_match,
+        )
+        monkeypatch.setattr(
+            "scripts.build_compilation_track_location.trigram_match", fake_trigram_match
+        )
+
+        comps = [
+            CompCandidate(library_id=1, title="Exact Hit", artist="Various Artists"),
+            CompCandidate(library_id=2, title="Label - Prefix Hit", artist="Various Artists"),
+            CompCandidate(library_id=3, title="Fuzzy Hitt", artist="Various Artists"),
+            CompCandidate(library_id=4, title="No Match", artist="Various Artists"),
+        ]
+
+        result = await match_comp_release(conn, comps)
+
+        assert result == {1: 100, 2: 200, 3: 300}
+
+    async def test_no_comps_short_circuits_without_querying_the_override_table(self):
+        conn = AsyncMock()
+        result = await match_comp_release(conn, [])
+        assert result == {}
+        conn.fetch.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #1082. `match_comp_release` (`scripts/build_compilation_track_location.py`) built the V/A recall index purely from `match_compilations.py`'s normalized-title cascade against `va_release`, ignoring `lml_cache.library_release_override` entirely -- so a comp whose shelf string doesn't title-match Discogs stayed excluded from the index even when an authoritative override for it already existed, and the runtime `/lookup` path (`lookup/artwork.py::get_library_release_overrides`) honors that same override. Measured on prod 2026-08-02, 2,935 override-backed comps were missing from the index for exactly this reason, including the #1027 step-6 repro (library 60654, Lost In Translation OST, squarepusher/tommib).

`match_comp_release` now queries `lml_cache.library_release_override` for the batch's `library_id`s first, guarded so only rows whose `discogs_release_id` is both present in `va_release` and has at least one cached `release_track` row can seed a match. Comps not claimed by a guarded override are removed from the candidate pool before the title cascade runs, so the cascade only ever sees comps the override table doesn't cover, and an override always wins any conflict with a title match by construction. A comp matched by neither source stays simply absent, retried on the next run, per the existing semantics.

Cross-references #1027 (location-union enablement tracker, blocked on this landing), #850/#858 (the override table this build now consults), and #937 (12 known-invalid override pins, which fail the guard harmlessly).

## Test plan

- [x] `tests/unit/test_build_compilation_track_location.py::TestMatchCompRelease` -- mocked-`conn` coverage of the seeding/precedence/fallback decision: override-only comp indexed without running the cascade, override wins over a conflicting title-cascade match, a guard-filtered/absent override falls through to the cascade, and the pre-#1082 cascade composition is unchanged when no overrides are in play.
- [x] `tests/integration/test_build_compilation_track_location_pg.py::TestMatchCompReleaseOverrideSeeding` (`pytest -m pg`) -- real-Postgres proof of the guard predicate itself: override to a non-`va_release` release is skipped, override to a `va_release` with no cached tracklist is skipped, override wins over a real exact-title-match, and a comp with no override still falls through to the cascade. Includes an end-to-end run through `build_compilation_track_location` reproducing the ticket's own repro (library 60654 -> Squarepusher/Tommib) and asserting the resulting row.
- [x] `ruff check .` / `ruff format --check .` clean.
- [x] `mypy . --ignore-missing-imports` clean.
- [x] Full default suite (`pytest -n auto`) green modulo three pre-existing xdist-parallelism flakes unrelated to this change (reproduced identically against unmodified `origin/main`).

No `api.yaml` change, so `scripts/generate_api_models.sh` wasn't run. No schema change -- read-only against `library_release_override`.