### PR TITLE
chore(codegen): regenerate api_models.py for the discogsUnavailable contract

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -1969,6 +1969,17 @@ class AlbumMetadataResponse(BaseModel):
     youtubeMusicUrl: str | None = Field(None, description="YouTube Music search URL")
     bandcampUrl: str | None = Field(None, description="Bandcamp search URL")
     soundcloudUrl: str | None = Field(None, description="SoundCloud search URL")
+    discogsUnavailable: bool | None = Field(
+        None,
+        description="True when a music director has marked this release as not on Discogs; downstream render surfaces should suppress Discogs-derived artwork/links/tracklist. Mirrors the `Album` schema's MD-set marker (WXYC/wiki plans/rotation-discogs-unavailable.md).",
+    )
+    discogsUnavailableNote: constr(max_length=500) | None = Field(
+        None, description="Optional free-text reason for `discogsUnavailable`."
+    )
+    lastDiscogsRecheckAt: AwareDatetime | None = Field(
+        None,
+        description="Stamped on every recheck attempt by the\n`library-discogs-unavailable-recheck` cron. Read-only from the\nclient side.\n",
+    )
 
 
 class ArtistMetadataResponse(BaseModel):
@@ -2294,6 +2305,13 @@ class FlowsheetEntryResponse(FlowsheetEntryBase):
     artwork_url: str | None = None
     discogs_url: str | None = None
     release_year: int | None = None
+    discogsUnavailable: bool | None = Field(
+        None,
+        description='Rides the same MD-set "not on Discogs" flag as the Album surfaces (see `Album.discogsUnavailable`), non-nullable to match them. Deliberately camelCase — unlike its snake_case siblings in this block — to match Backend\'s `withDiscogsUnavailableCamelCase` serializer. Contract-first: the V2 flowsheet album embed will carry this field once the BS-emit piece (WXYC/Backend-Service#1908) lands; it is not emitted there yet.',
+    )
+    discogsUnavailableNote: constr(max_length=500) | None = Field(
+        None, description="Optional free-text reason for `discogsUnavailable`."
+    )
     spotify_url: str | None = None
     apple_music_url: str | None = None
     youtube_music_url: str | None = None
@@ -2457,6 +2475,17 @@ class AlbumSearchResult(BaseModel):
     artwork_url: str | None = Field(
         None,
         description="Album cover artwork URL from Discogs. Null if artwork has not been fetched yet or is unavailable.",
+    )
+    discogsUnavailable: bool | None = Field(
+        None,
+        description="MD-set marker indicating this release is intentionally not on\nDiscogs (embargoed promo, audience-segment release, etc.). When\ntrue, the LML runtime-lookup chokepoint does not attempt Discogs\nresolution for this release. See WXYC/wiki plans/rotation-discogs-unavailable.md.\n",
+    )
+    discogsUnavailableNote: constr(max_length=500) | None = Field(
+        None, description="Optional free-text reason for `discogsUnavailable`."
+    )
+    lastDiscogsRecheckAt: AwareDatetime | None = Field(
+        None,
+        description="Stamped on every recheck attempt by the\n`library-discogs-unavailable-recheck` cron. Read-only from the\nclient side.\n",
     )
     matched_via: list[TrackMatchHint] | None = Field(
         None,


### PR DESCRIPTION
## Summary

Catches LML's committed `generated/api_models.py` up to `wxyc-shared` `api.yaml` 3.2.0, which added the `discogsUnavailable` / `discogsUnavailableNote` / `lastDiscogsRecheckAt` fields to `AlbumMetadataResponse`, `FlowsheetEntryResponse`, and `AlbumSearchResult` (the [WXYC/Backend-Service#1908](https://github.com/WXYC/Backend-Service/issues/1908) rotation-discogs-unavailable contract).

The upstream `api.yaml` merge landed without a paired LML regen, so **Codegen Freshness** (`git diff --exit-code` against a fresh `datamodel-code-generator` run) began failing on **every open LML PR**. This restores it to green and unblocks the queue.

## Change

- Regenerated via `scripts/generate_api_models.sh` against the synced local `wxyc-shared` checkout.
- Purely additive: 29 inserted lines, no `entity/*.sql` change.
- Verified idempotent (re-running the generator leaves the tree clean).

## Scope note

Mechanical codegen catch-up only. The generated fields are contract-first: the Backend emit piece (BS#1908) is tracked separately; LML does not yet read or emit these fields.