### PR TITLE
chore(codegen): regenerate api_models.py for the CTA write-path contract

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -564,6 +564,52 @@ class TrackSearchParams(BaseModel):
     n: int | None = None
 
 
+class CompilationTrackInput(BaseModel):
+    artist_name: constr(min_length=1, max_length=255) = Field(
+        ..., description="Per-track performing artist (CTA.artist_name)."
+    )
+    track_title: constr(max_length=255) | None = Field(
+        None, description="Track title; nullable, matching the CTA column."
+    )
+    track_position: constr(max_length=20) | None = Field(
+        None, description='Sleeve position label, e.g. "A1", "3".'
+    )
+
+
+class CompilationTrack(BaseModel):
+    id: int = Field(..., description="Server-assigned CTA row id.")
+    artist_name: str
+    track_title: str | None = None
+    track_position: str | None = None
+
+
+class CompilationTrackList(BaseModel):
+    library_id: int
+    tracks: list[CompilationTrack]
+
+
+class CompilationTracksWriteRequest(BaseModel):
+    tracks: list[CompilationTrackInput] = Field(..., min_length=1)
+
+
+class CompilationTracksWriteResponse(BaseModel):
+    library_id: int
+    inserted: int = Field(..., description="Rows newly created.")
+    skipped: int = Field(
+        ...,
+        description="Rows already present (matched on a CTA uniqueness key); left untouched.",
+    )
+    tracks: list[CompilationTrack]
+
+
+class CompilationTrackSuggestions(BaseModel):
+    library_id: int
+    discogs_release_id: int = Field(
+        ..., description="The resolved Discogs release id, or null if none resolved."
+    )
+    tracks: list[CompilationTrackInput]
+
+
 class RotationEntry(BaseModel):
     id: int
     album_id: int


### PR DESCRIPTION
Mechanical codegen fan-out for the merged CTA write-path contract (WXYC/wxyc-shared#291, api.yaml 1.28.0; serves WXYC/Backend-Service#1964).

Picks up the six `Compilation*` models via `scripts/generate_api_models.sh` (pinned datamodel-code-generator 0.56.1). Additive — no existing model changed; +46 lines in `generated/api_models.py` only. Keeps the codegen-freshness gate green now that the SSOT moved.

No LML code consumes these models yet (the CTA write path is a Backend surface); this is drift-prevention.

Note: datamodel-code-generator renders the required+nullable `CompilationTrackSuggestions.discogs_release_id` as a non-null `int` (known generator limitation for required+nullable in OpenAPI 3.0). The api.yaml + the TS/Swift/Kotlin generators keep it nullable; immaterial here since no Python service consumes it, and making the field optional was rejected as an oasdiff `response-property-became-optional` breaking change.

Fan-out sibling: request-o-matic regen (datamodel-code-generator 0.57.0).