### PR TITLE
fix(bandcamp): decode HTML entities in og:title before scoring

### DIFF
--- a/clients/bandcamp.py
+++ b/clients/bandcamp.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 # so it still takes effect there; removing this import would only break the
 # patch-target resolution, not any real behavior. Keep it.
 import asyncio  # noqa: F401
+import html
 import logging
 import re
 
@@ -155,11 +156,18 @@ def parse_og_title(og_title: str) -> tuple[str, str] | None:
     """Split a Bandcamp album page's ``og:title`` content ("Title, by Artist")
     into ``(title, artist)``. Returns ``None`` if the content doesn't match
     that shape.
+
+    The HTML attribute value is entity-escaped (``&#39;``, ``&amp;``, etc.)
+    by Bandcamp's page rendering, so both halves are unescaped before being
+    returned -- otherwise a genuinely correct match with an apostrophe or
+    ampersand in its title/artist scores tens of points below the acceptance
+    floor against the un-escaped library string (LML#1069 album-search
+    backlog).
     """
     match = _OG_TITLE_SPLIT_RE.match(og_title)
     if not match:
         return None
-    return match.group(1), match.group(2)
+    return html.unescape(match.group(1)), html.unescape(match.group(2))
 
 
 def extract_slug(url: str | None) -> str | None:

--- a/tests/unit/test_bandcamp_album_search.py
+++ b/tests/unit/test_bandcamp_album_search.py
@@ -290,6 +290,23 @@ class TestParseOgTitle:
     def test_no_match_returns_none(self):
         assert parse_og_title("Not the expected shape") is None
 
+    def test_decodes_html_entities(self):
+        """Bandcamp HTML-escapes og:title content -- an apostrophe in a real
+        artist/title renders as ``&#39;`` in the page source. Without
+        decoding, score_match compares the literal escaped text and a
+        genuinely correct match can drop 40+ points below the acceptance
+        floor (LML#1069 album-search backlog: The UMC's, id 2674)."""
+        assert parse_og_title("Fruits Of Nature, by The UMC&#39;s") == (
+            "Fruits Of Nature",
+            "The UMC's",
+        )
+
+    def test_decodes_ampersand_entity(self):
+        assert parse_og_title("Bombscare EP, by Low &amp; Spring Heel Jack") == (
+            "Bombscare EP",
+            "Low & Spring Heel Jack",
+        )
+
 
 class TestVerifyAlbumPage:
     @pytest.mark.asyncio
@@ -361,6 +378,34 @@ class TestVerifyAlbumPage:
             "https://someone.bandcamp.com/album/whatever", "Stereolab", "Aluminum Tunes"
         )
         assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_accepts_match_with_html_escaped_apostrophe(self):
+        """Regression for LML#1069's album-search backlog: a real Bandcamp
+        og:title HTML-escapes apostrophes, e.g. ``The UMC&#39;s``. Comparing
+        the un-decoded text against the library's "The UMC's" scores 57.1
+        (apostrophe-only diff), well below the 80 floor, even though the
+        page is the correct match."""
+        html = '<meta property="og:title" content="Fruits Of Nature, by The UMC&#39;s">'
+        client = BandcampClient()
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.request = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text=html,
+                request=httpx.Request(
+                    "GET", "https://wildpitchrecords.bandcamp.com/album/fruits-of-nature"
+                ),
+            )
+        )
+        client._http = mock_http
+
+        ok = await client.verify_album_page(
+            "https://wildpitchrecords.bandcamp.com/album/fruits-of-nature",
+            "The UMC's",
+            "Fruits of Nature",
+        )
+        assert ok is True
 
 
 class TestFindAlbumMatchViaSearch:


### PR DESCRIPTION
## Bug

`parse_og_title` (`clients/bandcamp.py`) splits a Bandcamp album page's `og:title` meta-attribute content ("Title, by Artist") but never HTML-unescapes either half before returning it. Bandcamp's page rendering HTML-escapes apostrophes/ampersands in that attribute (e.g. `The UMC&#39;s`, `Low &amp; Spring Heel Jack`), so `verify_album_page`'s `score_match` compares the literal escaped text against the library's plain string.

### Repro

```python
from clients.streaming.matching import score_match
score_match("The UMC's", "The UMC's")        # -> 100.0
score_match("The UMC's", "The UMC&#39;s")    # -> 57.1  (same string, just HTML-escaped)
```

Discovered while re-running the LML#1069 album-search drain's ~299-row pending backlog against #1084's catalog-number regex fix. #1084's own description attributed that whole backlog to the catalog-number-bracket case, but re-running it against the real production data showed only ~21 rows actually needed that fix — most of the remaining rows failed `verify_album_page` for this separate reason instead (any title/artist containing an apostrophe or ampersand, which is common in the WXYC catalog).

## Fix

`parse_og_title` now runs `html.unescape()` on both the title and artist halves after the regex split, before either is returned to the caller.

## Tests

TDD: added failing tests first, confirmed red, then implemented the fix.

- `tests/unit/test_bandcamp_album_search.py::TestParseOgTitle::test_decodes_html_entities` — `"Fruits Of Nature, by The UMC&#39;s"` -> `("Fruits Of Nature", "The UMC's")`.
- `tests/unit/test_bandcamp_album_search.py::TestParseOgTitle::test_decodes_ampersand_entity` — `"Bombscare EP, by Low &amp; Spring Heel Jack"` -> `("Bombscare EP", "Low & Spring Heel Jack")`.
- `tests/unit/test_bandcamp_album_search.py::TestVerifyAlbumPage::test_accepts_match_with_html_escaped_apostrophe` — end-to-end pin of the real repro case (id 2674 in the album-search backlog): an HTML-escaped og:title now clears the 80 floor and `verify_album_page` returns `True`.

## Verification

- `ruff check .` / `ruff format --check .` — clean
- `mypy clients/bandcamp.py --ignore-missing-imports` — no issues
- `pytest tests/unit/` — 5029 passed

No tracked issue for this fix — like #1084, it's a small, narrowly-scoped correctness fix discovered mid-drain (only caller of `verify_album_page` is the offline `scripts/bandcamp_pipeline.py` album-search phase, not any live `/lookup`/`/streaming-check` path), not worth its own ticket.

## Related

- WXYC/library-metadata-lookup#1084 — the catalog-number bracket fix this backlog re-run was validating; this fix addresses most of the remainder of the same ~299-row pool.
- WXYC/library-metadata-lookup#1069 — the album-first Bandcamp discovery drain this backlog belongs to.