### PR TITLE
fix(bandcamp): apply normalize_bc_title fallback in verify_album_page

### DIFF
--- a/clients/bandcamp.py
+++ b/clients/bandcamp.py
@@ -494,6 +494,16 @@ class BandcampClient(BaseStreamingClient):
         link (worse than no link at all, per the LML#1069 plan's house rule)
         before a write. Conservative: any fetch or parse failure returns
         ``False`` -- an unverifiable hit is not written.
+
+        Runs the SAME raw-then-normalized acceptance pass as
+        ``find_album_match_via_search``: raw fields first, then
+        ``normalize_bc_title`` on both sides' titles if that misses. Without
+        the second pass, a match ``find_album_match_via_search`` only found
+        via its own normalized pass (e.g. a library title carrying a
+        cataloger annotation the real release title never had -- "Dreamy
+        [full-length]" vs the page's "Dreamy") gets re-scored here against
+        the raw un-normalized title and wrongly rejected -- the LML#1069
+        85-row verify_failed floor.
         """
         resp = await self._request_with_retry("GET", url, timeout=15.0, follow_redirects=True)
         if resp is None or resp.status_code != 200:
@@ -506,4 +516,10 @@ class BandcampClient(BaseStreamingClient):
         if parsed is None:
             return False
         page_title, page_artist = parsed
-        return is_acceptable_match(score_match(artist, page_artist), score_match(title, page_title))
+        artist_score = score_match(artist, page_artist)
+        if is_acceptable_match(artist_score, score_match(title, page_title)):
+            return True
+        return is_acceptable_match(
+            artist_score,
+            score_match(normalize_bc_title(title), normalize_bc_title(page_title)),
+        )

--- a/tests/unit/test_bandcamp_album_search.py
+++ b/tests/unit/test_bandcamp_album_search.py
@@ -380,6 +380,59 @@ class TestVerifyAlbumPage:
         assert ok is False
 
     @pytest.mark.asyncio
+    async def test_accepts_when_only_normalized_titles_match(self):
+        """LML#1069 85-row verify_failed floor: find_album_match_via_search
+        accepts a hit via its second (normalize_bc_title) pass -- e.g. a
+        library title carrying a cataloger annotation the real release
+        title never had ("Dreamy [full-length]" vs the page's "Dreamy") --
+        but verify_album_page re-scored the RAW un-normalized title against
+        the page title and rejected an otherwise-correct match. verify_album_page
+        must fall back to the same normalize_bc_title comparison the search
+        step used to accept the match.
+        """
+        html = '<meta property="og:title" content="Dreamy, by Beat Happening">'
+        client = BandcampClient()
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.request = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text=html,
+                request=httpx.Request("GET", "https://beathappening.bandcamp.com/album/dreamy"),
+            )
+        )
+        client._http = mock_http
+
+        ok = await client.verify_album_page(
+            "https://beathappening.bandcamp.com/album/dreamy",
+            "Beat Happening",
+            "Dreamy [full-length]",
+        )
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_still_rejects_when_normalized_titles_also_mismatch(self):
+        """The normalize_bc_title fallback must not widen the floor itself --
+        a genuinely wrong page still fails both passes."""
+        html = '<meta property="og:title" content="Totally Different Album, by Someone Else">'
+        client = BandcampClient()
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.request = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text=html,
+                request=httpx.Request("GET", "https://someone.bandcamp.com/album/whatever"),
+            )
+        )
+        client._http = mock_http
+
+        ok = await client.verify_album_page(
+            "https://someone.bandcamp.com/album/whatever",
+            "Stereolab",
+            "Aluminum Tunes [full-length]",
+        )
+        assert ok is False
+
+    @pytest.mark.asyncio
     async def test_accepts_match_with_html_escaped_apostrophe(self):
         """Regression for LML#1069's album-search backlog: a real Bandcamp
         og:title HTML-escapes apostrophes, e.g. ``The UMC&#39;s``. Comparing


### PR DESCRIPTION
## Summary
- `find_album_match_via_search` accepts a hit via a raw-then-`normalize_bc_title` two-pass check, but `verify_album_page` only ever re-scored the raw title against the page title -- so a match found through the normalized pass got rejected during verification even though the underlying match was correct.
- Root cause of the LML#1069 85-row `verify_failed` floor left after PR #1084 (bracket-regex) and PR #1099 (HTML-entity decode): library titles carrying a cataloger annotation the real release never had ("Dreamy [full-length]", "Rock for Light [reissue, w/ extra tracks]", "Swap [1997]") score well under 80 raw but 88-100 once normalized. Live-verified against 8 sampled rows from the stuck pool: 8/8 flip from a failing raw score (46-67) to a passing normalized score (88-100).
- Fix: `verify_album_page` now falls back to the same `normalize_bc_title` comparison on both sides' titles when the raw pass misses, mirroring the search step's own acceptance logic.

## Test plan
- [x] New failing test added first (`test_accepts_when_only_normalized_titles_match`, using the real "Dreamy [full-length]" repro case), confirmed red
- [x] Fix applied, test green; added a negative case (`test_still_rejects_when_normalized_titles_also_mismatch`) confirming the fallback doesn't widen the floor for genuine mismatches
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy clients/bandcamp.py tests/unit/test_bandcamp_album_search.py --ignore-missing-imports` clean
- [x] Full unit suite: 5031 passed