### PR TITLE
fix(matching): break find_best_match/find_best_typed_match ties deterministically

### DIFF
--- a/clients/streaming/matching.py
+++ b/clients/streaming/matching.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable, Iterable
+from typing import Any
 
 import sentry_sdk
 from rapidfuzz import fuzz
@@ -686,9 +687,16 @@ def find_best_match(
         break (upstream shape change or broken extractor), surfaced so the
         caller can treat the source as errored and retry (LML#376) rather than
         record a definitive no-match. A sparse minority never raises.
+
+    LML#1097: an exact-tie combined score resolves deterministically by
+    ascending ``result_url`` (the ``url_fn`` extraction is required of every
+    caller, so this needs no new parameter) rather than by whichever
+    candidate the caller's API happened to list first -- upstream ordering
+    isn't guaranteed stable across repeated identical queries.
     """
     best: dict | None = None
     best_score = 0.0
+    best_url = ""
     total = 0
     extraction_failures = 0
     last_error: Exception | None = None
@@ -714,8 +722,9 @@ def find_best_match(
         if not is_acceptable_match(artist_score, title_score):
             continue
         combined = (artist_score + title_score) / 2
-        if combined > best_score:
+        if combined > best_score or (combined == best_score and result_url < best_url):
             best_score = combined
+            best_url = result_url
             match: dict = {
                 "url": result_url,
                 "confidence": combined,
@@ -745,6 +754,7 @@ def find_best_typed_match[T](
     query_title: str | Iterable[str],
     artist_fn: Callable[[T], str | None | Iterable[str | None]],
     title_fn: Callable[[T], str | None],
+    key_fn: Callable[[T], Any] | None = None,
 ) -> T | None:
     """Return the highest-scoring result that clears the 80/80 floor, or None.
 
@@ -780,14 +790,19 @@ def find_best_typed_match[T](
     or whitespace-only is dropped from the scoring set; if no usable variant
     survives on either side, the result is rejected.
 
-    None-valued extractors score as 0 against any non-empty query. Ties
-    resolve to the first candidate reaching the score, preserving input
-    order. An extractor that *raises* (vs. returns None) is treated as a
-    malformed candidate: the row is skipped and logged rather than scored
-    (LML#640). The real callers pass attribute extractors (``lambda r:
-    r.artist``), whose failure mode is ``AttributeError``, so
-    ``_EXTRACTION_ERRORS`` includes it — a ``None``/wrong-type candidate is
-    skipped, not fatal.
+    None-valued extractors score as 0 against any non-empty query. When
+    ``key_fn`` is given, an exact tie resolves deterministically by ascending
+    ``key_fn(item)`` (LML#1097) — mirroring ``release_resolution.py``'s
+    ``(-score, release_id)`` sort key, e.g. ``key_fn=lambda r: r.release_id``.
+    Without ``key_fn`` (no natural deterministic key exists for every
+    possible ``T``), ties fall back to the first candidate reaching the
+    score, preserving input order — the pre-#1097 behavior, kept only for
+    callers that can't offer a meaningful secondary key. An extractor that
+    *raises* (vs. returns None) is treated as a malformed candidate: the row
+    is skipped and logged rather than scored (LML#640). The real callers pass
+    attribute extractors (``lambda r: r.artist``), whose failure mode is
+    ``AttributeError``, so ``_EXTRACTION_ERRORS`` includes it — a
+    ``None``/wrong-type candidate is skipped, not fatal.
 
     Unlike ``find_best_match``, this does NOT re-raise on total extraction
     failure. Its callers are the lookup pipeline (``lookup/orchestrator.py``),
@@ -808,6 +823,7 @@ def find_best_typed_match[T](
 
     best: T | None = None
     best_score = 0.0
+    best_key: Any = None
     for item in results:
         # Per-item guard, as in ``find_best_match``: a malformed candidate is
         # skipped, not fatal (LML#640). No total-failure re-raise here — the
@@ -831,8 +847,16 @@ def find_best_typed_match[T](
         if not is_acceptable_match(artist_score, title_score):
             continue
         combined = (artist_score + title_score) / 2
-        if combined > best_score:
+        item_key = key_fn(item) if key_fn is not None else None
+        is_better = combined > best_score or (
+            combined == best_score
+            and key_fn is not None
+            and best is not None
+            and item_key < best_key
+        )
+        if is_better:
             best_score = combined
+            best_key = item_key
             best = item
     return best
 

--- a/lookup/artwork.py
+++ b/lookup/artwork.py
@@ -332,6 +332,9 @@ async def fetch_artwork_for_items(
                 query_title=album_variants,
                 artist_fn=lambda r: r.artist_variants(),
                 title_fn=lambda r: r.album,
+                # LML#1097: deterministic tie-break by release_id, mirroring
+                # release_resolution.py's (-score, release_id) sort key.
+                key_fn=lambda r: r.release_id,
             )
             if result is None:
                 # A found-on-compilation in-library row that carries a validated

--- a/lookup/strategies/library_miss.py
+++ b/lookup/strategies/library_miss.py
@@ -92,6 +92,9 @@ async def _library_miss_discogs_search(
             query_title=album,
             artist_fn=lambda r: r.artist_variants(),
             title_fn=lambda r: r.album,
+            # LML#1097: deterministic tie-break by release_id, mirroring
+            # release_resolution.py's (-score, release_id) sort key.
+            key_fn=lambda r: r.release_id,
         )
 
     try:

--- a/scripts/measure_artwork_match_floor.py
+++ b/scripts/measure_artwork_match_floor.py
@@ -177,6 +177,9 @@ def classify(
         query_title=query.title_variants,
         artist_fn=lambda r: r.artist,
         title_fn=lambda r: r.album,
+        # LML#1097: deterministic tie-break by release_id, matching the
+        # production callers in lookup/artwork.py and lookup/strategies/library_miss.py.
+        key_fn=lambda r: r.release_id,
     )
 
     best_combined = 0.0

--- a/tests/integration/test_library_miss_recall_live.py
+++ b/tests/integration/test_library_miss_recall_live.py
@@ -71,14 +71,22 @@ async def test_anadol_and_marie_klock_resolves_either_pressing(service):
 @pytest.mark.asyncio
 async def test_matmos_self_titled_placeholder_resolves(service):
     """Category 4: the query-side "S/T" swap searches the artist name instead
-    of the literal placeholder (which scores 22.2 and can never pass)."""
+    of the literal placeholder (which scores 22.2 and can never pass).
+
+    63794 and 20466 both score 100/100/100 -- a genuine exact tie Discogs
+    itself doesn't order consistently. LML#1097 makes ``find_best_typed_match``
+    break such ties deterministically by ascending ``release_id`` rather than
+    by whichever the API happened to return first, so 20466 (not 63794) is
+    the now-guaranteed pick -- both remain acceptable per this test's contract
+    (mirrors ``test_anadol_and_marie_klock_resolves_either_pressing`` above).
+    """
     result = await _library_miss_discogs_search(
         _parsed("Matmos", "S/T"),
         discogs_service=service,
     )
-    assert result is not None, "expected release 63794; got no floor-clearing candidate"
+    assert result is not None, "expected release 63794 or 20466; got no floor-clearing candidate"
     _, best = result
-    assert best.release_id == 63794, f"resolved wrong release {best.release_id}"
+    assert best.release_id in {63794, 20466}, f"resolved wrong release {best.release_id}"
     assert (best.album or "").strip().upper() != "S/T", (
         "a candidate literally titled 'S/T' must never clear via the placeholder"
     )

--- a/tests/unit/test_streaming_matching.py
+++ b/tests/unit/test_streaming_matching.py
@@ -639,6 +639,51 @@ class TestFindBestMatch:
         assert best is not None
         assert best["id"] == "abc123"
 
+    def test_ties_break_deterministically_by_url_not_input_order(self):
+        """LML#1097: an exact-combined-score tie must resolve the same way
+        regardless of which candidate the caller's API happened to list
+        first -- by ascending url_fn(item), not first-in-list-wins."""
+        from clients.streaming.matching import find_best_match
+
+        candidate_a = {"artist": "Stereolab", "album": "Aluminum Tunes", "url": "http://z"}
+        candidate_b = {"artist": "Stereolab", "album": "Aluminum Tunes", "url": "http://a"}
+
+        for results in ([candidate_a, candidate_b], [candidate_b, candidate_a]):
+            best = find_best_match(
+                results,
+                "Stereolab",
+                "Aluminum Tunes",
+                artist_fn=lambda r: r["artist"],
+                title_fn=lambda r: r["album"],
+                url_fn=lambda r: r["url"],
+            )
+            assert best is not None
+            assert best["url"] == "http://a"
+
+    def test_ties_from_crossed_axis_scores_break_deterministically(self):
+        """A tie doesn't require identical strings: two candidates with
+        different, non-identical (artist_score, title_score) pairs can
+        average to the same combined score (e.g. (100, 80) vs (80, 100)).
+        Must still resolve deterministically by url, not input order."""
+        from clients.streaming.matching import find_best_match
+
+        scores = {"ArtistHigh": 100, "ArtistLow": 80, "TitleHigh": 100, "TitleLow": 80}
+        candidate_a = {"artist": "ArtistHigh", "album": "TitleLow", "url": "http://z"}
+        candidate_b = {"artist": "ArtistLow", "album": "TitleHigh", "url": "http://a"}
+
+        with patch("clients.streaming.matching.score_match", side_effect=lambda _q, r: scores[r]):
+            for results in ([candidate_a, candidate_b], [candidate_b, candidate_a]):
+                best = find_best_match(
+                    results,
+                    "query artist",
+                    "query title",
+                    artist_fn=lambda r: r["artist"],
+                    title_fn=lambda r: r["album"],
+                    url_fn=lambda r: r["url"],
+                )
+                assert best is not None
+                assert best["url"] == "http://a"
+
     def test_no_id_key_when_id_fn_omitted(self):
         from clients.streaming.matching import find_best_match
 
@@ -1472,9 +1517,10 @@ class TestFindBestTypedMatch:
         )
         assert best is good
 
-    def test_first_result_wins_on_tie(self):
-        """Ties resolve to the first candidate reaching the score — mirrors
-        find_best_match's order-preserving behavior."""
+    def test_first_result_wins_on_tie_when_no_key_fn_given(self):
+        """Without a key_fn, a caller that can't offer a deterministic
+        secondary key falls back to preserving input order on an exact
+        tie -- documented, not guaranteed-deterministic, behavior."""
         from clients.streaming.matching import find_best_typed_match
         from tests.factories import make_discogs_result
 
@@ -1488,6 +1534,50 @@ class TestFindBestTypedMatch:
             title_fn=lambda r: r.album,
         )
         assert best is first
+
+    def test_ties_break_deterministically_by_key_fn(self):
+        """LML#1097: when the caller supplies key_fn, an exact tie resolves
+        the same way regardless of input order -- by ascending key_fn(item),
+        mirroring release_resolution.py's (-score, release_id) sort key."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        low_id = make_discogs_result(release_id=1, album="Aluminum Tunes", artist="Stereolab")
+        high_id = make_discogs_result(release_id=2, album="Aluminum Tunes", artist="Stereolab")
+
+        for candidates in ([low_id, high_id], [high_id, low_id]):
+            best = find_best_typed_match(
+                candidates,
+                query_artist="Stereolab",
+                query_title="Aluminum Tunes",
+                artist_fn=lambda r: r.artist,
+                title_fn=lambda r: r.album,
+                key_fn=lambda r: r.release_id,
+            )
+            assert best is low_id
+
+    def test_ties_from_crossed_axis_scores_break_by_key_fn(self):
+        """A tie doesn't require identical strings -- different, non-identical
+        (artist_score, title_score) pairs can average to the same combined
+        score. Must still resolve deterministically via key_fn, not order."""
+        from clients.streaming.matching import find_best_typed_match
+        from tests.factories import make_discogs_result
+
+        scores = {"ArtistHigh": 100, "ArtistLow": 80, "TitleHigh": 100, "TitleLow": 80}
+        low_id = make_discogs_result(release_id=1, album="TitleLow", artist="ArtistHigh")
+        high_id = make_discogs_result(release_id=2, album="TitleHigh", artist="ArtistLow")
+
+        with patch("clients.streaming.matching.score_match", side_effect=lambda _q, r: scores[r]):
+            for candidates in ([low_id, high_id], [high_id, low_id]):
+                best = find_best_typed_match(
+                    candidates,
+                    query_artist="query artist",
+                    query_title="query title",
+                    artist_fn=lambda r: r.artist,
+                    title_fn=lambda r: r.album,
+                    key_fn=lambda r: r.release_id,
+                )
+                assert best is low_id
 
     def test_query_artist_accepts_variant_list_and_takes_max(self):
         """When the search-query form ('Various') differs from the canonical


### PR DESCRIPTION
Closes #1097

## Summary
- `find_best_match`/`find_best_typed_match` folded candidates with a strict `combined > best_score` comparison, so an exact-score tie resolved to whichever candidate the caller's upstream API happened to list first -- non-deterministic across repeated identical queries. `lookup/release_resolution.py`'s sibling functions already avoid this via a `(-score, release_id)` stable sort key; these two didn't.
- `find_best_match` now breaks ties by ascending `url_fn(item)` -- already a required extractor for every caller, so no signature change needed there.
- `find_best_typed_match` gains an optional `key_fn` parameter for callers with a natural deterministic secondary key. Both real production callers (`lookup/artwork.py`, `lookup/strategies/library_miss.py`) and the calibration script (`scripts/measure_artwork_match_floor.py`) now pass `key_fn=lambda r: r.release_id`, mirroring `release_resolution.py`'s existing tie-break. Without `key_fn`, the function keeps the pre-existing first-wins fallback, since no universal deterministic key exists for an arbitrary generic `T`.

## Test plan
- [x] New failing tests added first: exact ties via identical strings and via crossed `(artist_score, title_score)` pairs (e.g. `(100,80)` vs `(80,100)` averaging to the same combined score) for both functions, each asserting the same winner regardless of input order; confirmed red (`TypeError: unexpected keyword argument 'key_fn'` / order-dependent failures)
- [x] Renamed `test_first_result_wins_on_tie` -> `test_first_result_wins_on_tie_when_no_key_fn_given` to document the intentional fallback rather than imply it's the guaranteed contract
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean on all 4 changed source files
- [x] Full unit suite: 5035 passed