### PR TITLE
fix(streaming): detect and log dedup-key collisions in deduplicate_library

### DIFF
--- a/scripts/streaming_availability/dedup.py
+++ b/scripts/streaming_availability/dedup.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 
 import aiosqlite
 from wxyc_etl.text import is_compilation_artist
 
 from clients.streaming.matching import normalize_album_title, normalize_artist_name
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -26,26 +29,77 @@ class DeduplicatedAlbum:
     is_single: bool = False
 
 
+def _diverges(existing: DeduplicatedAlbum, *, genre: str | None, label: str | None) -> bool:
+    """True when a colliding row's genre/label/compilation-ness materially
+    conflicts with the group's captured first-row values (LML#1095).
+
+    Requires BOTH sides non-null for genre/label -- one row simply missing a
+    field is a common real shape (incomplete cataloging of a second format),
+    not a divergence signal. Measured against the real WXYC catalog: 31 of
+    905 multi-row normalized-key groups show a genuine genre/label conflict,
+    a mix of miscategorized re-catalogued duplicates and (plausibly) a few
+    genuinely distinct same-named items -- ambiguous enough from title/artist
+    alone that this stays a detection signal for operators to audit, not an
+    auto-split trigger.
+    """
+    if genre and existing.genre and genre != existing.genre:
+        return True
+    if label and existing.label and label != existing.label:
+        return True
+    return False
+
+
 async def deduplicate_library(db_path: str) -> list[DeduplicatedAlbum]:
     """Read all rows from library.db and deduplicate by normalized (artist, title).
 
     Uses alternate_artist_name when available. Groups rows with the same
     normalized artist+title across formats into a single DeduplicatedAlbum.
+
+    LML#1095: a second row colliding on the same normalized key with a
+    materially different genre/label/compilation-ness logs a warning (its
+    own metadata is still discarded -- first-row-wins, unchanged) so a real
+    metadata collision is visible to operators instead of silently dropped.
     """
     groups: dict[tuple[str, str], DeduplicatedAlbum] = {}
 
     async with aiosqlite.connect(db_path) as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
-            "SELECT id, title, artist, genre, format, alternate_artist_name, label FROM library"
+            "SELECT id, title, artist, genre, format, alternate_artist_name, label FROM library "
+            "ORDER BY id"
         ) as cursor:
             async for row in cursor:
                 artist = row["alternate_artist_name"] or row["artist"] or ""
                 title = row["title"] or ""
+                genre = row["genre"]
+                label = row["label"]
+                is_compilation = is_compilation_artist(artist)
 
                 norm_artist = normalize_artist_name(artist)
                 norm_title = normalize_album_title(title)
                 key = (norm_artist, norm_title)
+
+                existing = groups.get(key)
+                if existing is not None and (
+                    _diverges(existing, genre=genre, label=label)
+                    or is_compilation != existing.is_compilation
+                ):
+                    logger.warning(
+                        "dedup collision: library_id=%s (genre=%r, label=%r, "
+                        "is_compilation=%s) collapses onto library_id(s)=%s "
+                        "(genre=%r, label=%r, is_compilation=%s) under "
+                        "normalized key %r -- keeping first-row metadata, "
+                        "this row's genre/label/is_compilation is discarded",
+                        row["id"],
+                        genre,
+                        label,
+                        is_compilation,
+                        existing.library_ids,
+                        existing.genre,
+                        existing.label,
+                        existing.is_compilation,
+                        key,
+                    )
 
                 if key not in groups:
                     groups[key] = DeduplicatedAlbum(
@@ -55,9 +109,9 @@ async def deduplicate_library(db_path: str) -> list[DeduplicatedAlbum]:
                         display_title=title,
                         library_ids=[],
                         formats=[],
-                        genre=row["genre"],
-                        label=row["label"],
-                        is_compilation=is_compilation_artist(artist),
+                        genre=genre,
+                        label=label,
+                        is_compilation=is_compilation,
                     )
 
                 album = groups[key]

--- a/tests/unit/test_streaming_dedup.py
+++ b/tests/unit/test_streaming_dedup.py
@@ -1,7 +1,9 @@
 """Unit tests for scripts/streaming_availability/dedup.py."""
 
+import logging
 import sqlite3
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -150,6 +152,109 @@ class TestDeduplicateLibrary:
         result = await deduplicate_library(db_path)
         assert result[0].genre == "Electronic"
         assert result[0].label == "Warp"
+
+    @pytest.mark.asyncio
+    async def test_diverging_genre_logs_warning_but_still_merges(self, tmp_path, caplog):
+        """LML#1095: two distinct library_ids that collapse to the same
+        normalized (artist, title) key with materially different genre are a
+        silent collision today -- the second row's genre is dropped with no
+        signal. Detect and log it (so operators can audit real frequency)
+        without changing the merge itself: measured against the real WXYC
+        catalog, this pattern is at least as often a data-quality artifact
+        (the same physical item re-catalogued with an inconsistent genre tag)
+        as it is two genuinely distinct items, so auto-splitting on this
+        signal alone isn't warranted."""
+        db_path = _create_test_db(
+            tmp_path,
+            [
+                (1, "Orion", "Orion", "O", 1, 1, "Electronic", "cd", None, None),
+                (2, "Orion", "Orion", "O", 1, 2, "Rock", "vinyl - LP", None, None),
+            ],
+        )
+        with caplog.at_level(logging.WARNING):
+            result = await deduplicate_library(db_path)
+        assert len(result) == 1
+        assert sorted(result[0].library_ids) == [1, 2]
+        assert result[0].genre == "Electronic"  # first-row-wins, unchanged
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "1" in warnings[0].getMessage() and "2" in warnings[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_diverging_label_logs_warning(self, tmp_path, caplog):
+        db_path = _create_test_db(
+            tmp_path,
+            [
+                (1, "Black Book", "Greg Osby", "G", 1, 1, "Jazz", "cd", None, "Blue Note"),
+                (2, "Black Book", "Greg Osby", "G", 1, 2, "Jazz", "vinyl - LP", None, "JMT"),
+            ],
+        )
+        with caplog.at_level(logging.WARNING):
+            await deduplicate_library(db_path)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_one_sided_null_genre_does_not_warn(self, tmp_path, caplog):
+        """Incomplete metadata on one row (a common real shape -- one catalog
+        entry never got a genre) is not treated as a divergence signal."""
+        db_path = _create_test_db(
+            tmp_path,
+            [
+                (1, "Aluminum Tunes", "Stereolab", "S", 1, 1, None, "cd", None, "Duophonic"),
+                (
+                    2,
+                    "Aluminum Tunes",
+                    "Stereolab",
+                    "S",
+                    1,
+                    2,
+                    "Rock",
+                    "vinyl - LP",
+                    None,
+                    "Duophonic",
+                ),
+            ],
+        )
+        with caplog.at_level(logging.WARNING):
+            await deduplicate_library(db_path)
+        assert not any(r.levelno == logging.WARNING for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_matching_genre_label_does_not_warn(self, tmp_path, caplog):
+        """Sanity check: the existing identical-metadata multi-format case
+        (test_genre_and_label_from_first_row) must not spuriously warn."""
+        db_path = _create_test_db(
+            tmp_path,
+            [
+                (1, "Confield", "Autechre", "A", 1, 1, "Electronic", "cd", None, "Warp"),
+                (2, "Confield", "Autechre", "A", 1, 2, "Electronic", "vinyl - LP", None, "Warp"),
+            ],
+        )
+        with caplog.at_level(logging.WARNING):
+            await deduplicate_library(db_path)
+        assert not any(r.levelno == logging.WARNING for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_diverging_is_compilation_logs_warning(self, tmp_path, caplog):
+        """is_compilation is derived per-row from is_compilation_artist(artist)
+        -- a collision where that verdict flips is exactly as much a signal
+        as a genre/label conflict."""
+        db_path = _create_test_db(
+            tmp_path,
+            [
+                (1, "Rarities", "Overlap Artist", "O", 1, 1, "Rock", "cd", None, None),
+                (2, "Rarities", "Overlap Artist", "O", 1, 2, "Rock", "vinyl - LP", None, None),
+            ],
+        )
+        with patch(
+            "scripts.streaming_availability.dedup.is_compilation_artist",
+            side_effect=[False, True],
+        ):
+            with caplog.at_level(logging.WARNING):
+                await deduplicate_library(db_path)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
 
     @pytest.mark.asyncio
     async def test_empty_database(self, tmp_path):


### PR DESCRIPTION
Closes #1095

## Summary
- `deduplicate_library` groups library rows by normalized `(artist, title)` with no `ORDER BY` on the source read, and silently keeps only the first-encountered row's `genre`/`label`/`is_compilation` when a second row collides on the same key. No signal fires today when that collision's metadata materially conflicts.
- Added `ORDER BY id` for read determinism (cheap, zero behavior risk).
- Added divergence detection: a collision logs a `logger.warning` (with both rows' ids and the conflicting field) when genre, label, or `is_compilation` materially differs. Requires both sides non-null for genre/label so a row that's simply missing a field (common -- a second format's catalog entry that never got a genre) doesn't false-positive.

## Why detection, not a structural split
The ticket's own suggested approach frames this as staged: detect and measure real frequency first, decide on a structural fix (splitting colliding groups into separate DB rows) only if warranted. I measured against the real production `library.db` (64,676 rows) before picking a scope: 905 groups have more than one row, and 31 show a genuine genre/label conflict. Spot-checking the examples (e.g. two "Orion"/"Orion" rows tagged Electronic vs Rock, two "Greg Osby"/"Black Book" rows tagged Hiphop vs Jazz), this looks at least as often like the same physical item re-catalogued twice with an inconsistent genre tag as it does two genuinely distinct same-named items -- ambiguous enough from title/artist alone that auto-splitting isn't clearly the right call. A wrong split would double-search and potentially mint two different Bandcamp/Spotify URLs for what's really one release.

A structural fix (splitting colliding groups into separate `albums` rows) also isn't free: `results_db.py`'s `UNIQUE(normalized_artist, normalized_title)` constraint and `get_album_id_by_names`'s docstring both treat "at most one row per normalized name pair" as a load-bearing invariant relied on elsewhere (e.g. the #1056 drain's discogs-cache join). Loosening it needs its own scoped change with a real audit of every caller, not something to bundle into a detection PR.

`catalog_dao.py` (LML#842's in-flight PG rewrite) needs no change: it isn't wired to a live caller yet, and once it is, it will consume `deduplicate_library`'s own output -- inheriting this detection automatically since the function's return shape is unchanged.

## Test plan
- [x] New tests added first (genre divergence, label divergence, is_compilation divergence via a patched extractor, one-sided-null-doesn't-warn, matching-metadata-doesn't-warn); confirmed the 3 positive-case tests failed before the fix
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy scripts/streaming_availability/dedup.py --ignore-missing-imports` clean
- [x] Full unit suite: 5040 passed