### PR TITLE
refactor(matching): consolidate the byte-identical dedup regex, document the rest

### DIFF
--- a/clients/bandcamp.py
+++ b/clients/bandcamp.py
@@ -61,6 +61,15 @@ _HTTPS_PREFIX = "https://"
 # query-only -- scoring still sees the raw title (clients/bandcamp.py's
 # ``find_album_match_via_search``), so over-stripping here costs recall, not
 # precision.
+#
+# LML#1096 audit: deliberately kept independent of (and more aggressive
+# than) ``clients/streaming/matching.py``'s canonical, scoring-side
+# ``strip_format_suffix``/``_CATALOG_NUMBER_BRACKET_RE`` -- that regex
+# conservatively preserves multi-word brackets ("[Disc One]") and
+# pure-numeric brackets ("[2019]") since they can be real title content on
+# the SCORING axis; a search QUERY has no such precision cost from
+# over-stripping. See ``test_strips_content_the_canonical_regex_preserves``
+# in ``tests/unit/test_bandcamp_album_search.py`` for the pinned divergence.
 _QUERY_BRACKET_TAG_RE = re.compile(r"\s*\[[^\]]*\]\s*$")
 _QUERY_STUDIO_SUFFIX_RE = re.compile(r"\s*\(studio\)\s*$", re.IGNORECASE)
 _QUERY_VINYL_SIZE_RE = re.compile(r"\s+\d{1,2}[\"”]\s*$")

--- a/scripts/match_compilations.py
+++ b/scripts/match_compilations.py
@@ -17,6 +17,8 @@ import aiosqlite
 import asyncpg
 from rapidfuzz import fuzz
 
+from clients.streaming.matching import _FORMAT_SUFFIX_RE
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
@@ -27,14 +29,19 @@ log = logging.getLogger(__name__)
 DISCOGS_URL = "postgresql://jake@localhost/discogs"
 SQLITE_PATH = "streaming_availability.db"
 
-# Strip annotations: [techno comp], (14 cds), etc.
+# Strip annotations: [techno comp], (14 cds), etc. Deliberately unconditional
+# (LML#1096 audit), unlike clients/streaming/matching.py's conservative
+# canonical bracket/parenthetical regexes: a compilation title's bracket/paren
+# content is cataloger noise ("[techno comp]", "(14 cds)") a real compilation
+# title never legitimately carries, unlike an album title where similar
+# content (e.g. "[Live]"/"[Disc One]") can be meaningful -- so this domain
+# intentionally strips more aggressively. See
+# tests/unit/test_match_compilations_normalize.py for the pinned behavior.
 _BRACKET_RE = re.compile(r"\s*\[[^\]]*\]\s*$")
 _PAREN_ANNOTATION_RE = re.compile(r"\s*\([^)]*\)\s*$")
-# Strip trailing format suffixes
-_FORMAT_SUFFIX_RE = re.compile(
-    r"""\s+(?:\d{1,2}[""]|LP|EP|CD|x\s*\d+)$""",
-    re.IGNORECASE,
-)
+# _FORMAT_SUFFIX_RE above is imported from the canonical implementation
+# (LML#1096) -- this one pattern was a byte-for-byte duplicate with no
+# domain-specific divergence, unlike the bracket/paren patterns above.
 # Strip leading label/annotation prefixes like "tribute: " or "FA 05-90 - "
 _LABEL_PREFIX_RE = re.compile(r"^[A-Z]{2,}\s*[-:]?\s*(?:\d{2,}-\d{2,}\s*[-:]\s*)?", re.IGNORECASE)
 

--- a/scripts/track_streaming/title_parser.py
+++ b/scripts/track_streaming/title_parser.py
@@ -16,6 +16,18 @@ import re
 from clients.streaming.matching import strip_format_suffix
 
 # Bracket tags: [single], [ep], [split 7-inch], [missing], [45 rpm EP], etc.
+#
+# LML#1096 audit: intentionally unconditional and applied BEFORE
+# strip_format_suffix below (which itself has conservative, letter+digit- or
+# format-word-gated bracket handling) -- by the time strip_format_suffix
+# runs, this has already removed any bracket content, so its own bracket
+# regexes never get a chance to fire here. That's fine: a TRACK title never
+# legitimately carries bracket content the way an ALBUM title occasionally
+# does (a real "[Disc One]"/"[Live]" marker), so this domain's noise is
+# always safe to strip unconditionally. See
+# test_disc_marker_bracket_stripped_unlike_canonical_strip_format_suffix and
+# test_missing_bracket in tests/unit/test_title_parser.py for the pinned
+# divergence from the canonical (album-scoring) behavior.
 _BRACKET_RE = re.compile(r"\s*\[[^\]]*\]\s*$")
 
 # b/w (backed with): A-side b/w B-side

--- a/tests/unit/test_bandcamp_album_search.py
+++ b/tests/unit/test_bandcamp_album_search.py
@@ -103,6 +103,33 @@ class TestCleanTitleForQuery:
     def test_empty_string(self):
         assert clean_title_for_query("") == ""
 
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # A multi-word bracket like "[Disc One]" carries real content on
+            # an album title -- clients/streaming/matching.py's canonical
+            # strip_format_suffix deliberately preserves it (LML#1084).
+            # clean_title_for_query strips it anyway: it feeds a SEARCH
+            # QUERY, not the scoring axis (score_match still sees the raw
+            # title in find_album_match_via_search), so over-stripping here
+            # only costs recall, never precision.
+            ("Confield [Disc One]", "Confield"),
+            # A pure-numeric bracket ("[2019]") is ambiguous between a
+            # reissue year and real title content, so the canonical regex
+            # leaves it alone; the query-only strip doesn't need to hedge.
+            ("Confield [2019]", "Confield"),
+        ],
+    )
+    def test_strips_content_the_canonical_regex_preserves(self, raw, expected):
+        """LML#1096 audit: pins the intentional query-side/scoring-side
+        divergence from clients/streaming/matching.py's conservative
+        strip_format_suffix -- see the module comment on
+        _QUERY_BRACKET_TAG_RE for the recall-vs-precision rationale."""
+        from clients.streaming.matching import strip_format_suffix
+
+        assert clean_title_for_query(raw) == expected
+        assert strip_format_suffix(raw) == raw  # canonical regex leaves it untouched
+
 
 class TestNormalizeBcTitle:
     """Parameterized against the LML#1069 measurement's near-miss corpus.

--- a/tests/unit/test_match_compilations_normalize.py
+++ b/tests/unit/test_match_compilations_normalize.py
@@ -1,0 +1,29 @@
+"""Unit tests for scripts/match_compilations.py's normalize_comp_title.
+
+LML#1096: characterizes current behavior before consolidating the duplicated
+``_FORMAT_SUFFIX_RE`` with clients/streaming/matching.py's canonical copy.
+``_BRACKET_RE``/``_PAREN_ANNOTATION_RE`` stay local and unconditional (see the
+module-level comment on them) -- compilation-title annotations like
+"[techno comp]"/"(14 cds)" are cataloger noise a real compilation title never
+legitimately carries, unlike an album title where similar bracket content
+(e.g. "[Live]"/"[Disc One]") can be meaningful, so this domain intentionally
+strips more aggressively than the conservative canonical regex.
+"""
+
+import pytest
+
+from scripts.match_compilations import normalize_comp_title
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        ("CMJ New Music Monthly [techno comp]", "CMJ New Music Monthly"),
+        ("Even More Metal Massacre (14 cds)", "Even More Metal Massacre"),
+        ('Nuggets 12"', "Nuggets"),
+        ("Left of the Dial x 4", "Left of the Dial"),
+        ("Just a normal title", "Just a normal title"),
+    ],
+)
+def test_normalize_comp_title(title, expected):
+    assert normalize_comp_title(title) == expected

--- a/tests/unit/test_title_parser.py
+++ b/tests/unit/test_title_parser.py
@@ -132,6 +132,17 @@ class TestBracketAndFormatStripping:
         result = parse_single_title("Kidding on the Square // If You Hurt Me [missing]")
         assert result == ["Kidding on the Square", "If You Hurt Me"]
 
+    def test_disc_marker_bracket_stripped_unlike_canonical_strip_format_suffix(self):
+        """LML#1096: pins the intentional divergence from clients/streaming/
+        matching.py's conservative strip_format_suffix, which deliberately
+        PRESERVES a multi-word bracket like "[Disc One]" (real content on an
+        album title). A track title never legitimately carries that kind of
+        marker, so this module's own unconditional _BRACKET_RE -- which runs
+        BEFORE strip_format_suffix and so is solely responsible for bracket
+        handling here -- strips it anyway."""
+        result = parse_single_title("Confield [Disc One]")
+        assert result == ["Confield"]
+
 
 class TestNoDelimiter:
     """Titles with no delimiter produce a single track."""


### PR DESCRIPTION
Closes #1096

## Summary
Audited the 4-file bracket/format-suffix title-stripping duplication PR #1084's review flagged:

| File | Verdict |
|---|---|
| `clients/streaming/matching.py` | Canonical -- conservative (catalog-number brackets require both a letter and a digit; multi-word/pure-numeric brackets preserved) |
| `scripts/match_compilations.py` | `_FORMAT_SUFFIX_RE` was a byte-for-byte duplicate with no domain divergence -- **consolidated** (now imports the canonical pattern) |
| `clients/bandcamp.py` | `_QUERY_BRACKET_TAG_RE` is intentionally more aggressive -- **documented + pinned**, not consolidated |
| `scripts/track_streaming/title_parser.py` | Its own `_BRACKET_RE` pre-strip runs ahead of the imported `strip_format_suffix` -- **documented + pinned**, not removed |

## Why 3 of 4 stay independent
I verified each divergence concretely before deciding, rather than assuming the duplication was purely accidental:

- `clean_title_for_query("Confield [Disc One]")` -> `"Confield"`, but the canonical `strip_format_suffix("Confield [Disc One]")` -> unchanged (multi-word brackets can be real album-title content, per PR #1084's own reasoning). Bandcamp's query-side strip has no precision cost from over-stripping since `score_match` still sees the raw title in `find_album_match_via_search` -- only the canonical, scoring-side regex needs to be conservative.
- `scripts/track_streaming/title_parser.py`'s `parse_single_title("Confield [Disc One]")` -> `["Confield"]` for the same reason: a track title never legitimately carries that kind of marker, unlike an album title.
- `scripts/match_compilations.py`'s remaining `_BRACKET_RE`/`_PAREN_ANNOTATION_RE` strip compilation-title cataloger noise ("[techno comp]", "(14 cds)") that, like the track-title case, never carries real content.

Forcing full consolidation on these three would have regressed Bandcamp search recall or started under-stripping real annotation noise in track/compilation titles -- so each site got a strengthened code comment plus a new test pinning the current (correct, intentional) divergence instead.

## Test plan
- [x] `tests/unit/test_match_compilations_normalize.py` added first (no prior coverage existed for `normalize_comp_title`) to pin behavior before the `_FORMAT_SUFFIX_RE` swap
- [x] New pinning tests: `test_disc_marker_bracket_stripped_unlike_canonical_strip_format_suffix` (title_parser.py), `test_strips_content_the_canonical_regex_preserves` (bandcamp.py)
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean on all 3 changed source files
- [x] Full unit suite: 5048 passed