### PR TITLE
fix(ci): stop a dropped build-log stream from failing a healthy Railway deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,32 @@ jobs:
       # the uploaded working directory so /health can report it. See LML#509.
       - name: Record deployed commit SHA for /health
         run: echo "${{ github.sha }}" > COMMIT_SHA
+      # `--detach --json` returns as soon as the upload is accepted, prints
+      # {"deploymentId": ..., "logsUrl": ...} and nothing else on stdout, and never opens a log
+      # stream. Plain `railway up` streams build logs and hard-exits 1 if that stream drops --
+      # and only in "CI mode", which $CI auto-enables on every Actions runner. That turned
+      # transient log-transport hiccups into a red deploy while the deployment went live
+      # (railwayapp/cli v4.58.0 src/commands/up.rs:240, :275-279). The wait step is the real gate.
       - name: Deploy to Railway
-        run: railway up --service library-metadata-lookup
+        id: deploy
+        run: |
+          railway up --detach --json --service library-metadata-lookup > "$RUNNER_TEMP/deploy.json"
+          jq -e . "$RUNNER_TEMP/deploy.json"
+          {
+            echo "deployment_id=$(jq -er .deploymentId "$RUNNER_TEMP/deploy.json")"
+            echo "logs_url=$(jq -er .logsUrl "$RUNNER_TEMP/deploy.json")"
+          } >> "$GITHUB_OUTPUT"
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_STAGING }}
+      # Polls the deployment API for the real terminal status. Stronger than the old gate:
+      # `railway up` returned when the *build* finished, SUCCESS here means Railway's healthcheck
+      # passed and the revision is serving.
+      - name: Wait for deployment to go live
+        run: ./scripts/wait_for_railway_deployment.sh library-metadata-lookup "$DEPLOYMENT_ID" "$LOGS_URL"
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_STAGING }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
+          LOGS_URL: ${{ steps.deploy.outputs.logs_url }}
 
   smoke-test-staging:
     name: Smoke Test (Staging)
@@ -249,10 +271,24 @@ jobs:
       # the uploaded working directory so /health can report it. See LML#509.
       - name: Record deployed commit SHA for /health
         run: echo "${{ github.sha }}" > COMMIT_SHA
+      # See deploy-staging for why this is `--detach --json` plus an explicit wait.
       - name: Deploy to Railway
-        run: railway up --service library-metadata-lookup
+        id: deploy
+        run: |
+          railway up --detach --json --service library-metadata-lookup > "$RUNNER_TEMP/deploy.json"
+          jq -e . "$RUNNER_TEMP/deploy.json"
+          {
+            echo "deployment_id=$(jq -er .deploymentId "$RUNNER_TEMP/deploy.json")"
+            echo "logs_url=$(jq -er .logsUrl "$RUNNER_TEMP/deploy.json")"
+          } >> "$GITHUB_OUTPUT"
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_PRODUCTION }}
+      - name: Wait for deployment to go live
+        run: ./scripts/wait_for_railway_deployment.sh library-metadata-lookup "$DEPLOYMENT_ID" "$LOGS_URL"
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_PRODUCTION }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
+          LOGS_URL: ${{ steps.deploy.outputs.logs_url }}
 
   smoke-test-production:
     name: Smoke Test (Production)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,15 +207,21 @@ jobs:
         run: |
           railway up --detach --json --service library-metadata-lookup > "$RUNNER_TEMP/deploy.json"
           jq -e . "$RUNNER_TEMP/deploy.json"
+          # Assign on their own lines: `echo "$(jq -er ...)"` would discard jq's exit status
+          # (the substitution's failure is invisible to `set -e` once `echo` succeeds) and write
+          # the literal string "null", which the wait step would then poll for until it timed out.
+          deployment_id="$(jq -er .deploymentId "$RUNNER_TEMP/deploy.json")"
+          logs_url="$(jq -er .logsUrl "$RUNNER_TEMP/deploy.json")"
           {
-            echo "deployment_id=$(jq -er .deploymentId "$RUNNER_TEMP/deploy.json")"
-            echo "logs_url=$(jq -er .logsUrl "$RUNNER_TEMP/deploy.json")"
+            echo "deployment_id=$deployment_id"
+            echo "logs_url=$logs_url"
           } >> "$GITHUB_OUTPUT"
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_STAGING }}
-      # Polls the deployment API for the real terminal status. Stronger than the old gate:
-      # `railway up` returned when the *build* finished, SUCCESS here means Railway's healthcheck
-      # passed and the revision is serving.
+      # Polls the deployment API for the real terminal status. At least as strong as the old
+      # gate and usually stronger: `railway up` raced a build-log stream against a deploy-status
+      # subscription and normally returned once the *build* finished, whereas SUCCESS here means
+      # Railway's healthcheck passed (railway.toml sets healthcheckPath) and the revision serves.
       - name: Wait for deployment to go live
         run: ./scripts/wait_for_railway_deployment.sh library-metadata-lookup "$DEPLOYMENT_ID" "$LOGS_URL"
         env:
@@ -277,9 +283,14 @@ jobs:
         run: |
           railway up --detach --json --service library-metadata-lookup > "$RUNNER_TEMP/deploy.json"
           jq -e . "$RUNNER_TEMP/deploy.json"
+          # Assign on their own lines: `echo "$(jq -er ...)"` would discard jq's exit status
+          # (the substitution's failure is invisible to `set -e` once `echo` succeeds) and write
+          # the literal string "null", which the wait step would then poll for until it timed out.
+          deployment_id="$(jq -er .deploymentId "$RUNNER_TEMP/deploy.json")"
+          logs_url="$(jq -er .logsUrl "$RUNNER_TEMP/deploy.json")"
           {
-            echo "deployment_id=$(jq -er .deploymentId "$RUNNER_TEMP/deploy.json")"
-            echo "logs_url=$(jq -er .logsUrl "$RUNNER_TEMP/deploy.json")"
+            echo "deployment_id=$deployment_id"
+            echo "logs_url=$logs_url"
           } >> "$GITHUB_OUTPUT"
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_PRODUCTION }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,10 +38,25 @@ The `--detach` is load-bearing. Plain `railway up` attaches to the build-log str
 
 Consequences of splitting deploy from wait:
 
-- **The gate got stronger, not weaker.** `railway up` returned when the *build* finished; `SUCCESS` from the deployment API means Railway's healthcheck passed and the revision is actually serving. `Smoke Test (Staging)` no longer races the rollout.
-- **Build logs no longer stream into the Actions log.** The deploy step prints the deployment's `logsUrl`; open that for build output. The wait script repeats it on failure and on timeout.
-- **A superseded deploy does not fail the run.** If a newer push supersedes this deployment (`SKIPPED`/`REMOVED`), the script exits 0 — that newer run gates its own deploy, and failing here would just be a different false red.
-- Tunables, all with defaults that suit CI: `RAILWAY_DEPLOY_TIMEOUT_SECONDS` (900), `RAILWAY_DEPLOY_POLL_INTERVAL_SECONDS` (10), `RAILWAY_DEPLOY_MAX_POLL_ERRORS` (10, consecutive polling errors tolerated before giving up — a single Railway API blip must not fail a good deploy).
+- **The gate is at least as strong as before, and usually stronger.** The old `railway up` raced a build-log stream against a deploy-status subscription and normally returned once the *build* finished; `SUCCESS` from the deployment API means Railway's healthcheck passed and the revision is actually serving. (That last clause depends on `railway.toml` setting `healthcheckPath` — it currently does. Remove that and `SUCCESS` weakens to "container started".) `Smoke Test (Staging)` no longer races the rollout.
+- **Build logs no longer stream into the Actions log.** The deploy step prints the deployment's `logsUrl`, and on `FAILED`/`CRASHED` the wait script dumps the last `RAILWAY_DEPLOY_BUILD_LOG_LINES` of build log inline so a broken build is still diagnosable from the run alone.
+
+How the wait script maps deployment status to an outcome:
+
+| Status | Outcome |
+|---|---|
+| `SUCCESS`, `SLEEPING` | pass — the revision deployed |
+| `FAILED`, `CRASHED` | fail, with the tail of the build log |
+| `NEEDS_APPROVAL` | fail fast — terminal until a human acts, so waiting out the budget only delays the signal |
+| `SKIPPED`, `REMOVED`, `REMOVING` | pass **only if** a newer deployment exists to supersede this one; otherwise fail (see below) |
+| `BUILDING`, `DEPLOYING`, `INITIALIZING`, `QUEUED`, `WAITING` | keep polling |
+| anything else | keep polling, with a warning naming the value |
+
+That last row matters: the CLI `Debug`-formats the status enum, so a status Railway adds after our pinned CLI version arrives as `Other("NEW_STATUS")`. It is logged rather than silently treated as a hang.
+
+**Supersession is verified, not assumed.** A newer push supersedes an in-flight deployment, and failing that run would be exactly the false red this script removes — so `SKIPPED`/`REMOVED`/`REMOVING` passes. But the script first checks the payload for a deployment with a later `createdAt`. If there is none, the deployment was rolled back or removed by hand rather than replaced, and the script fails instead of reporting success for a revision that never went live.
+
+Tunables, all with defaults that suit CI: `RAILWAY_DEPLOY_TIMEOUT_SECONDS` (900), `RAILWAY_DEPLOY_POLL_INTERVAL_SECONDS` (10), `RAILWAY_DEPLOY_MAX_POLL_ERRORS` (10), `RAILWAY_DEPLOY_BUILD_LOG_LINES` (100). The error tolerance is the point of the exercise: a single Railway API blip — including a zero-exit response that fails to parse — must not fail a good deploy, so it counts toward the tolerance instead of aborting.
 
 ## CI pin maintenance
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,6 +30,19 @@
 
 See [`testing.md`](testing.md#pytest-markers-architecture-a) for what each test job runs.
 
+### How the deploy jobs gate
+
+`deploy-staging` / `deploy-production` run `railway up --detach --json`, capture the returned `deploymentId`, and then block on [`scripts/wait_for_railway_deployment.sh`](../scripts/wait_for_railway_deployment.sh) until the Railway deployment API reports a terminal status.
+
+The `--detach` is load-bearing. Plain `railway up` attaches to the build-log stream and calls `std::process::exit(1)` when that stream drops — but only in the CLI's "CI mode", which `$CI` auto-enables on every GitHub Actions runner (railwayapp/cli v4.58.0, `src/commands/up.rs:240` and `:275-279`). A transient `Failed to stream build logs: Failed to retrieve build log` therefore turned a perfectly healthy deploy into a red **Deploy to Staging**, and took down the smoke test that would have shown the deploy was fine.
+
+Consequences of splitting deploy from wait:
+
+- **The gate got stronger, not weaker.** `railway up` returned when the *build* finished; `SUCCESS` from the deployment API means Railway's healthcheck passed and the revision is actually serving. `Smoke Test (Staging)` no longer races the rollout.
+- **Build logs no longer stream into the Actions log.** The deploy step prints the deployment's `logsUrl`; open that for build output. The wait script repeats it on failure and on timeout.
+- **A superseded deploy does not fail the run.** If a newer push supersedes this deployment (`SKIPPED`/`REMOVED`), the script exits 0 — that newer run gates its own deploy, and failing here would just be a different false red.
+- Tunables, all with defaults that suit CI: `RAILWAY_DEPLOY_TIMEOUT_SECONDS` (900), `RAILWAY_DEPLOY_POLL_INTERVAL_SECONDS` (10), `RAILWAY_DEPLOY_MAX_POLL_ERRORS` (10, consecutive polling errors tolerated before giving up — a single Railway API blip must not fail a good deploy).
+
 ## CI pin maintenance
 
 Four classes of pin in `.github/workflows/*.yml` exist for supply-chain reasons (mirrors WXYC/request-o-matic#124's free-tier hardening; see WXYC/wiki#67 for the org-wide rollout). They will bit-rot and need occasional bumps:

--- a/scripts/wait_for_railway_deployment.sh
+++ b/scripts/wait_for_railway_deployment.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# wait_for_railway_deployment.sh — block until a Railway deployment reaches a terminal state.
+#
+# Why this exists: `railway up` streams build logs, and the CLI hard-exits 1 when that stream
+# drops -- but only in "CI mode", which is auto-enabled by the $CI variable that every GitHub
+# Actions runner sets. A transient log-transport hiccup ("Failed to stream build logs: Failed to
+# retrieve build log") therefore failed the deploy job while the deployment itself went live and
+# healthy. See railwayapp/cli v4.58.0, src/commands/up.rs:240 (ci_mode) and :275-279 (exit 1).
+#
+# CI now deploys with `railway up --detach --json`, which returns as soon as the upload is
+# accepted, never opens a log stream, and prints {"deploymentId": ..., "logsUrl": ...} on stdout
+# (up.rs:230-238). This script does the waiting instead, polling the deployment API for the real
+# terminal status -- which is a stronger gate than the old one: `railway up` returned when the
+# *build* finished, whereas SUCCESS here means Railway's healthcheck passed and the revision is
+# actually serving.
+#
+# Usage:
+#   wait_for_railway_deployment.sh <service> <deployment-id> [logs-url]
+#
+# Exit codes:
+#   0  deployment reached SUCCESS, or was superseded by a newer deployment
+#   1  deployment reached FAILED/CRASHED, timed out, or polling kept erroring
+#   2  bad usage
+#
+# Environment:
+#   RAILWAY_TOKEN                         required -- project-scoped deploy token
+#   RAILWAY_DEPLOY_TIMEOUT_SECONDS        total budget in seconds (default 900)
+#   RAILWAY_DEPLOY_POLL_INTERVAL_SECONDS  gap between polls in seconds (default 10)
+#   RAILWAY_DEPLOY_MAX_POLL_ERRORS        consecutive API errors tolerated (default 10)
+
+set -euo pipefail
+
+SERVICE="${1:-}"
+DEPLOYMENT_ID="${2:-}"
+LOGS_URL="${3:-}"
+
+if [[ -z "$SERVICE" || -z "$DEPLOYMENT_ID" ]]; then
+  echo "usage: $(basename "$0") <service> <deployment-id> [logs-url]" >&2
+  exit 2
+fi
+
+TIMEOUT_SECONDS="${RAILWAY_DEPLOY_TIMEOUT_SECONDS:-900}"
+POLL_INTERVAL_SECONDS="${RAILWAY_DEPLOY_POLL_INTERVAL_SECONDS:-10}"
+MAX_POLL_ERRORS="${RAILWAY_DEPLOY_MAX_POLL_ERRORS:-10}"
+
+# Timestamps here are UTC on purpose: these lines interleave with GitHub Actions' own UTC log
+# timestamps, and the deployment `createdAt` values from the Railway API are UTC too.
+log() {
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+stderr_file="$(mktemp)"
+cleanup() { rm -f "$stderr_file"; }
+trap cleanup EXIT
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+consecutive_errors=0
+last_status=""
+
+log "Waiting for Railway deployment ${DEPLOYMENT_ID} (service: ${SERVICE})"
+log "Timeout ${TIMEOUT_SECONDS}s, polling every ${POLL_INTERVAL_SECONDS}s"
+if [[ -n "$LOGS_URL" ]]; then
+  log "Build logs: ${LOGS_URL}"
+fi
+
+while :; do
+  status=""
+  if payload="$(railway deployment list --service "$SERVICE" --limit 50 --json 2>"$stderr_file")"; then
+    consecutive_errors=0
+    # `.[0].status // "UNKNOWN"` also covers the brief window right after upload where the
+    # deployment has not yet appeared in the list.
+    status="$(printf '%s' "$payload" | jq -r --arg id "$DEPLOYMENT_ID" \
+      'map(select(.id == $id)) | .[0].status // "UNKNOWN"')"
+  else
+    consecutive_errors=$(( consecutive_errors + 1 ))
+    log "WARN: 'railway deployment list' failed (${consecutive_errors}/${MAX_POLL_ERRORS}): $(tr '\n' ' ' <"$stderr_file")"
+    if (( consecutive_errors >= MAX_POLL_ERRORS )); then
+      log "ERROR: giving up after ${consecutive_errors} consecutive polling failures"
+      exit 1
+    fi
+  fi
+
+  if [[ -n "$status" && "$status" != "$last_status" ]]; then
+    log "status: ${status}"
+    last_status="$status"
+  fi
+
+  case "$status" in
+    SUCCESS)
+      log "Deployment ${DEPLOYMENT_ID} is live."
+      exit 0
+      ;;
+    FAILED | CRASHED)
+      log "ERROR: deployment ${DEPLOYMENT_ID} reported ${status}"
+      if [[ -n "$LOGS_URL" ]]; then
+        log "Inspect the build at ${LOGS_URL}"
+      fi
+      exit 1
+      ;;
+    SKIPPED | REMOVED)
+      # A newer deployment superseded this one -- normally a second push to the same branch while
+      # this run was still deploying. That newer run gates its own deploy, so failing here would
+      # just be the false red this script exists to remove.
+      log "Deployment ${DEPLOYMENT_ID} was ${status} (superseded by a newer deployment); not failing."
+      exit 0
+      ;;
+  esac
+
+  if (( $(date +%s) >= deadline )); then
+    log "ERROR: timed out after ${TIMEOUT_SECONDS}s (last status: ${last_status:-none})"
+    if [[ -n "$LOGS_URL" ]]; then
+      log "Inspect the build at ${LOGS_URL}"
+    fi
+    exit 1
+  fi
+
+  sleep "$POLL_INTERVAL_SECONDS"
+done

--- a/scripts/wait_for_railway_deployment.sh
+++ b/scripts/wait_for_railway_deployment.sh
@@ -11,16 +11,22 @@
 # CI now deploys with `railway up --detach --json`, which returns as soon as the upload is
 # accepted, never opens a log stream, and prints {"deploymentId": ..., "logsUrl": ...} on stdout
 # (up.rs:230-238). This script does the waiting instead, polling the deployment API for the real
-# terminal status -- which is a stronger gate than the old one: `railway up` returned when the
-# *build* finished, whereas SUCCESS here means Railway's healthcheck passed and the revision is
-# actually serving.
+# terminal status -- which is at least as strong a gate as the old one, and usually stronger:
+# `railway up` raced a build-log stream against a deploy-status subscription and normally
+# returned when the *build* finished, whereas SUCCESS here means Railway's healthcheck passed
+# (the services set `healthcheckPath` in railway.toml) and the revision is actually serving.
+#
+# Every failure mode here is designed to fail *closed* and to say why. A transient error must
+# never fail a healthy deploy -- that is the bug this script exists to remove -- but a deployment
+# that genuinely did not land must never report success either.
 #
 # Usage:
 #   wait_for_railway_deployment.sh <service> <deployment-id> [logs-url]
 #
 # Exit codes:
-#   0  deployment reached SUCCESS, or was superseded by a newer deployment
-#   1  deployment reached FAILED/CRASHED, timed out, or polling kept erroring
+#   0  deployment reached SUCCESS/SLEEPING, or was verifiably superseded by a newer deployment
+#   1  deployment reached FAILED/CRASHED/NEEDS_APPROVAL, was removed without a successor,
+#      timed out, or polling kept erroring
 #   2  bad usage
 #
 # Environment:
@@ -28,6 +34,7 @@
 #   RAILWAY_DEPLOY_TIMEOUT_SECONDS        total budget in seconds (default 900)
 #   RAILWAY_DEPLOY_POLL_INTERVAL_SECONDS  gap between polls in seconds (default 10)
 #   RAILWAY_DEPLOY_MAX_POLL_ERRORS        consecutive API errors tolerated (default 10)
+#   RAILWAY_DEPLOY_BUILD_LOG_LINES        build-log lines to dump on failure (default 100)
 
 set -euo pipefail
 
@@ -43,6 +50,7 @@ fi
 TIMEOUT_SECONDS="${RAILWAY_DEPLOY_TIMEOUT_SECONDS:-900}"
 POLL_INTERVAL_SECONDS="${RAILWAY_DEPLOY_POLL_INTERVAL_SECONDS:-10}"
 MAX_POLL_ERRORS="${RAILWAY_DEPLOY_MAX_POLL_ERRORS:-10}"
+BUILD_LOG_LINES="${RAILWAY_DEPLOY_BUILD_LOG_LINES:-100}"
 
 # Timestamps here are UTC on purpose: these lines interleave with GitHub Actions' own UTC log
 # timestamps, and the deployment `createdAt` values from the Railway API are UTC too.
@@ -50,9 +58,26 @@ log() {
   printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
 }
 
+show_logs_url() {
+  if [[ -n "$LOGS_URL" ]]; then
+    log "Inspect the build at ${LOGS_URL}"
+  fi
+}
+
+# On a genuinely broken build the Actions log would otherwise contain no build output at all,
+# just a dashboard link. Upstream's own automation guidance (up.rs:28) pairs `deployment list`
+# polling with exactly this call. Best-effort: never let a log-fetch failure mask the real error.
+dump_build_logs() {
+  log "--- last ${BUILD_LOG_LINES} lines of build log ---"
+  if ! railway logs --build --lines "$BUILD_LOG_LINES" "$DEPLOYMENT_ID" 2>&1; then
+    log "WARN: could not fetch build logs; see ${LOGS_URL:-the Railway dashboard}"
+  fi
+  log "--- end of build log ---"
+}
+
 stderr_file="$(mktemp)"
 cleanup() { rm -f "$stderr_file"; }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
 deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
 consecutive_errors=0
@@ -60,25 +85,49 @@ last_status=""
 
 log "Waiting for Railway deployment ${DEPLOYMENT_ID} (service: ${SERVICE})"
 log "Timeout ${TIMEOUT_SECONDS}s, polling every ${POLL_INTERVAL_SECONDS}s"
-if [[ -n "$LOGS_URL" ]]; then
-  log "Build logs: ${LOGS_URL}"
-fi
+show_logs_url
 
 while :; do
   status=""
+  payload=""
+  poll_error=""
+  # An explicit flag, not `[[ -n "$poll_error" ]]`: a non-zero `railway` exit with nothing on
+  # stderr would otherwise leave the message empty, go uncounted, and loop silently to timeout.
+  poll_failed=0
+
   if payload="$(railway deployment list --service "$SERVICE" --limit 50 --json 2>"$stderr_file")"; then
-    consecutive_errors=0
-    # `.[0].status // "UNKNOWN"` also covers the brief window right after upload where the
-    # deployment has not yet appeared in the list.
-    status="$(printf '%s' "$payload" | jq -r --arg id "$DEPLOYMENT_ID" \
-      'map(select(.id == $id)) | .[0].status // "UNKNOWN"')"
+    # jq must not be allowed to kill the script: a zero-exit-but-unparseable response (a CLI
+    # warning on stdout, a truncated body, a proxy error page) is exactly the transient blip
+    # this script is supposed to absorb, so it counts against MAX_POLL_ERRORS like any other.
+    # `.[0].status // "UNKNOWN"` also covers the window right after upload where the deployment
+    # has not yet appeared in the list.
+    if ! status="$(printf '%s' "$payload" | jq -r --arg id "$DEPLOYMENT_ID" \
+      'map(select(.id == $id)) | .[0].status // "UNKNOWN"' 2>"$stderr_file")"; then
+      poll_failed=1
+      poll_error="unparseable 'deployment list' output: $(tr '\n' ' ' <"$stderr_file")"
+    elif [[ -z "$status" ]]; then
+      poll_failed=1
+      poll_error="empty 'deployment list' output"
+    fi
   else
+    poll_failed=1
+    poll_error="$(tr '\n' ' ' <"$stderr_file")"
+    if [[ -z "${poll_error// /}" ]]; then
+      poll_error="'railway deployment list' exited non-zero with no stderr"
+    fi
+  fi
+
+  if (( poll_failed )); then
+    status=""
     consecutive_errors=$(( consecutive_errors + 1 ))
-    log "WARN: 'railway deployment list' failed (${consecutive_errors}/${MAX_POLL_ERRORS}): $(tr '\n' ' ' <"$stderr_file")"
+    log "WARN: poll failed (${consecutive_errors}/${MAX_POLL_ERRORS}): ${poll_error}"
     if (( consecutive_errors >= MAX_POLL_ERRORS )); then
       log "ERROR: giving up after ${consecutive_errors} consecutive polling failures"
+      show_logs_url
       exit 1
     fi
+  else
+    consecutive_errors=0
   fi
 
   if [[ -n "$status" && "$status" != "$last_status" ]]; then
@@ -87,31 +136,60 @@ while :; do
   fi
 
   case "$status" in
-    SUCCESS)
-      log "Deployment ${DEPLOYMENT_ID} is live."
+    "")
+      : # poll error, already logged and counted
+      ;;
+    SUCCESS | SLEEPING)
+      log "Deployment ${DEPLOYMENT_ID} is live (${status})."
       exit 0
       ;;
     FAILED | CRASHED)
       log "ERROR: deployment ${DEPLOYMENT_ID} reported ${status}"
-      if [[ -n "$LOGS_URL" ]]; then
-        log "Inspect the build at ${LOGS_URL}"
-      fi
+      dump_build_logs
+      show_logs_url
       exit 1
       ;;
-    SKIPPED | REMOVED)
-      # A newer deployment superseded this one -- normally a second push to the same branch while
-      # this run was still deploying. That newer run gates its own deploy, so failing here would
-      # just be the false red this script exists to remove.
-      log "Deployment ${DEPLOYMENT_ID} was ${status} (superseded by a newer deployment); not failing."
-      exit 0
+    NEEDS_APPROVAL)
+      # Terminal until a human acts, so waiting out the full budget only delays the signal.
+      log "ERROR: deployment ${DEPLOYMENT_ID} is awaiting manual approval in the Railway dashboard."
+      show_logs_url
+      exit 1
+      ;;
+    SKIPPED | REMOVED | REMOVING)
+      # Normally a newer push superseded this deployment: that run gates its own deploy, so
+      # failing here would just be the false red this script exists to remove. But "superseded"
+      # is a claim worth checking -- an operator rolling back mid-run produces the same status
+      # with no successor, and exiting 0 there would report success for a revision that never
+      # went live. createdAt is ISO-8601 UTC, so lexicographic comparison is chronological.
+      newer=""
+      if ! newer="$(printf '%s' "$payload" | jq -r --arg id "$DEPLOYMENT_ID" \
+        '(map(select(.id == $id)) | .[0].createdAt) as $ours
+         | map(select(.createdAt > $ours)) | length' 2>/dev/null)"; then
+        newer=""
+      fi
+      if [[ "$newer" =~ ^[0-9]+$ ]] && (( newer > 0 )); then
+        log "Deployment ${DEPLOYMENT_ID} was ${status}, superseded by ${newer} newer deployment(s); not failing."
+        exit 0
+      fi
+      log "ERROR: deployment ${DEPLOYMENT_ID} was ${status} with no newer deployment to supersede it."
+      log "That usually means it was rolled back or removed by hand, not replaced by a newer push."
+      show_logs_url
+      exit 1
+      ;;
+    BUILDING | DEPLOYING | INITIALIZING | QUEUED | WAITING | UNKNOWN)
+      : # not terminal, keep polling
+      ;;
+    *)
+      # The CLI Debug-formats the status enum (deployment.rs:167), so a value Railway adds after
+      # this CLI pin arrives as Other("NEW_STATUS"). Keep waiting, but say so rather than letting
+      # it look like a silent hang.
+      log "WARN: unrecognized deployment status '${status}'; continuing to wait."
       ;;
   esac
 
   if (( $(date +%s) >= deadline )); then
     log "ERROR: timed out after ${TIMEOUT_SECONDS}s (last status: ${last_status:-none})"
-    if [[ -n "$LOGS_URL" ]]; then
-      log "Inspect the build at ${LOGS_URL}"
-    fi
+    show_logs_url
     exit 1
   fi
 


### PR DESCRIPTION
## Problem

**Deploy to Staging** has been red on `main` for five consecutive pushes (2026-08-04, 08:11 → 10:23 PDT). Every other job in those runs passed. The deploys themselves were fine: Railway reports the CI-created deployments as `SUCCESS`, and staging `/health` serves `commit_sha: 87ab1476…` — the head SHA of the run that went red.

The failure is entirely in log transport:

```
Indexing... / Uploading...
Build Logs: https://railway.com/project/…?id=a6542e75-…
CI mode enabled
[+63s] Failed to stream build logs: Failed to retrieve build log
##[error]Process completed with exit code 1.
```

Root cause, from railwayapp/cli v4.58.0 (the version we pin), `src/commands/up.rs`:

```rust
let ci_mode = Configs::env_is_ci() || args.ci || args.json;   // :240
…
if let Err(e) = stream_build_logs(…).await {
    eprintln!("Failed to stream build logs: {e}");
    if ci_mode { std::process::exit(1); }                     // :275-279
}
```

`Configs::env_is_ci()` is true on every GitHub Actions runner, so a transient websocket drop while *reading logs* hard-fails the deploy job. Note `--ci` was already in effect implicitly — that's the `CI mode enabled` line — so it is not the fix.

The red also had teeth: `Smoke Test (Staging)` is gated on `deploy-staging`, so it was `skipped` on all five runs. Nothing verified the deploy.

## Fix

Deploy with `railway up --detach --json`, then wait on the deployment API explicitly.

`--detach` returns as soon as the upload is accepted and returns *before* any log streaming (`up.rs:230-238`); with `--json` stdout is exactly one object, `{"deploymentId": …, "logsUrl": …}` — the `Indexing`/`Uploading`/`Build Logs` lines are all gated behind `!args.json`. The new `scripts/wait_for_railway_deployment.sh` polls `railway deployment list --json` for that deployment ID until it reaches a terminal status.

**This is a stronger gate than what it replaces.** `railway up` returned when the *build* finished; `SUCCESS` from the deployment API means Railway's healthcheck passed and the revision is serving — so `Smoke Test (Staging)` no longer races the rollout.

Behaviour of the wait script:

| Status | Result |
|---|---|
| `SUCCESS` | exit 0 — revision is live |
| `FAILED`, `CRASHED` | exit 1, pointing at `logsUrl` |
| `SKIPPED`, `REMOVED` | exit 0 — a newer push superseded this deployment; that run gates its own deploy, and failing here would just be a different false red |
| anything else | keep polling until `RAILWAY_DEPLOY_TIMEOUT_SECONDS` (900) |

Consecutive `railway deployment list` errors are tolerated up to `RAILWAY_DEPLOY_MAX_POLL_ERRORS` (10) — a single Railway API blip must not fail a good deploy, which is the whole point of this PR.

Applied to `deploy-production` as well: same latent defect, same fix.

## Trade-off

Build logs no longer stream into the Actions log. The deploy step prints the deployment's `logsUrl`, and the wait script repeats it on failure and on timeout. This is the cost of not having a log-stream hiccup able to fail a deploy; there is no CLI flag that streams logs without also making the stream load-bearing.

## Verification

Ran locally against the live Railway API (CLI `deployment list --json` schema confirmed on the pinned 4.58.0):

- known-`SUCCESS` deployment → exit 0
- known-`REMOVED` deployment → exit 0, "superseded" message
- unknown deployment ID → polls `UNKNOWN`, times out, exit 1
- unresolvable service → 2 consecutive poll errors → exit 1
- missing args → exit 2

`actionlint` and `shellcheck` clean; `ci.yml` parses; the `check-ci-marker-sync` gate passes; and the deploy step's `jq` extraction was exercised against the exact JSON shape the CLI emits.

Note that `deploy-staging` only runs on pushes to `main`, so **CI on this PR cannot exercise the changed jobs** — the first real run is on merge.

## Not in scope

The smoke test asserts `commit_sha` is *present*, not that it equals `github.sha`, so it can still pass against a stale revision. Worth tightening separately; this PR deliberately leaves the smoke-test jobs untouched.
