### PR TITLE
fix(search): mark a search-leg Discogs breaker shed as degraded on the wire

### DIFF
--- a/core/search.py
+++ b/core/search.py
@@ -385,6 +385,26 @@ class SearchState:
     time" (``results`` may be empty, ``timed_out: True``).
     """
 
+    upstream_shed: bool = False
+    """True when a saturation-breaker shed (any ``BreakerOpenError``) was
+    caught inside the strategy loop and degraded to a cache-only outcome
+    (LML#755 R2-2, LML#1126). Breaker-agnostic since LML#1118 widened the
+    catch to the shared base — today only Discogs strategies fan out from
+    there, but a future breaker-guarded strategy sets this for free.
+
+    Distinct from ``timed_out``: a shed means "couldn't ask upstream" (the
+    breaker is open), not "ran out of time to ask". Projected onto
+    ``LookupState.upstream_shed`` and surfaced as
+    ``LookupResponse.degraded=True`` / ``degraded_reason=upstream_unavailable``
+    so a shed response is distinguishable on the wire from a genuine no-match
+    — before LML#1126, a search-leg shed produced the byte-identical
+    ``results: [], timeout: false, degraded: false`` shape a real miss does.
+    Set even when a later strategy still recovers results (the shed strategy's
+    own contribution is missing/unconfirmed regardless), matching the tail
+    shed arms (``_build_degraded_response``), which mark ``degraded=True``
+    while keeping whatever the library + cached legs already produced.
+    """
+
 
 # Type aliases for strategy functions
 ConditionFunc = Callable[[ParsedRequest, SearchState, str], bool]
@@ -965,11 +985,21 @@ async def _run_strategy_pipeline(
                 # covered for free, with no new catch to add. We ``continue`` (not
                 # ``break``) so a later strategy — which may hit only the cache —
                 # still runs.
+                #
+                # LML#1126: record the shed on ``state.upstream_shed`` so the
+                # response can be marked degraded instead of laundering into a
+                # byte-identical genuine no-match. This is a marker only — no
+                # per-shed WARNING/ERROR (LML#805/#798 already fixed that noise
+                # posture; the existing INFO line below is unchanged). The marker
+                # is breaker-agnostic for the same reason the catch is: any
+                # breaker-guarded strategy's shed is an "upstream unavailable,"
+                # not a no-match.
                 logger.info(
                     "%s shed strategy %s; degrading to cache-only",
                     type(exc).__name__,
                     strategy.name,
                 )
+                state.upstream_shed = True
                 outcome = Outcome.empty()
 
             # The one write site: every per-strategy ``SearchState`` mutation

--- a/lookup/orchestrator.py
+++ b/lookup/orchestrator.py
@@ -330,6 +330,15 @@ class LookupState:
     abandoned. Written by the search pipeline (step 3); read by the response
     build (``LookupResponse.timeout``) and the degraded-response build."""
 
+    upstream_shed: bool = False
+    """True when the search pipeline (step 3) caught a Discogs saturation-
+    breaker shed in its one catch boundary and degraded to a cache-only
+    outcome (LML#755 R2-2). Copied from ``SearchState.upstream_shed``; read by
+    the normal response build, which emits ``degraded=True`` (mirroring the
+    tail legs' ``_build_degraded_response``) instead of the pre-LML#1126
+    hardcoded ``degraded=False`` — even when ``library_results`` ended up
+    non-empty, since the shed strategy's own contribution is still missing."""
+
     @property
     def result_count(self) -> int:
         """Row count for the response; ``items_with_artwork`` takes precedence when non-empty."""
@@ -613,6 +622,7 @@ async def _step_search_pipeline(
         state.artist_fallback_results = search_state.artist_fallback_results
         state.matched_via_by_id = search_state.matched_via_by_id
         state.timed_out = search_state.timed_out
+        state.upstream_shed = search_state.upstream_shed
         # LML#808: preserve the full, pre-truncation candidate set so track
         # validation (3b) can widen past the ``limit_results`` cut instead of
         # only ever seeing the top ``MAX_SEARCH_RESULTS`` rows by rowid.
@@ -1327,6 +1337,9 @@ async def perform_lookup(
     )
     _project_post_fold_trace_attrs(result_items, search_type)
 
+    # LML#1126: a search-leg breaker shed must not read as a genuine no-match
+    # -- see ``LookupState.upstream_shed``'s docstring.
+    degraded = state.upstream_shed
     return LookupResponse(
         results=result_items,
         search_type=search_type,
@@ -1336,7 +1349,8 @@ async def perform_lookup(
         corrected_artist=state.corrected_artist,
         external_source=external_source,
         timeout=state.timed_out,
-        degraded=False,
+        degraded=degraded,
+        degraded_reason=DegradedReason.upstream_unavailable if degraded else None,
     )
 
 

--- a/tests/unit/test_module_budgets.py
+++ b/tests/unit/test_module_budgets.py
@@ -99,7 +99,22 @@ MODULE_BUDGETS: dict[str, int] = {
     # documented extraction blocker (the reconciliation needs
     # build_context_message, orchestrator-only) is the debt to pay down
     # before the next one.
-    "lookup/orchestrator.py": 1650,
+    #
+    # Recalibrated 2026-08-05 (LML#1126): the 1650 ceiling above was set to the
+    # file's exact measured size, leaving zero headroom, and this ticket's
+    # change landed on top of it via a rebase — CI was green on both PRs
+    # independently and only the merge order produced the overflow. The growth
+    # is irreducible and not a new concern: one `LookupState.upstream_shed`
+    # field (that dataclass lives here) plus its two call sites — the copy in
+    # `_step_search_pipeline` and the `degraded`/`degraded_reason` pair in
+    # `perform_lookup`'s response build. There is no module to extract; the
+    # shed-detection logic itself lives in `core/search.py`. Same shape as
+    # LML#944's `router.py` recalibration ("an import plus the two irreducible
+    # call sites") and the same tight-on-purpose formula: smallest multiple of
+    # 50 at or above the new measured 1664, not a re-derived 1.3x. This is the
+    # FOURTH consecutive recalibration — the extraction debt named directly
+    # above is now overdue and tracked at LML#1142.
+    "lookup/orchestrator.py": 1700,
     "lookup/release_resolution.py": 550,
     # Recalibrated 2026-07-27 (LML#944): unrelated changes since the 2026-07-06
     # calibration had already carried this file to exactly its old 950-line

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from core.exceptions import BreakerOpenError
+from core.search import SearchState
 from discogs.breaker import DiscogsBreakerOpenError
 from discogs.models import DiscogsSearchResponse
 from entity.compilation_track_location import CompilationTrackLocationRow
@@ -304,6 +305,96 @@ class TestPerformLookupBasic:
 
         assert isinstance(response, LookupResponse)
         assert len(response.results) == 0
+        # LML#1126 regression pin: a genuine no-match (no breaker shed anywhere
+        # in the pipeline) must stay byte-identical to the pre-#1126 contract —
+        # this is the exact shape a search-leg shed used to falsify.
+        assert response.degraded is False
+        assert response.degraded_reason is None
+        assert response.timeout is False
+
+    @pytest.mark.asyncio
+    async def test_search_leg_shed_marks_response_degraded(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        """LML#1126: a Discogs saturation-breaker shed caught inside the search
+        pipeline (core/search.py's one catch boundary, R2-2) degrades to an
+        empty/cache-only ``SearchState`` with ``upstream_shed=True`` set. That
+        flag must ride onto ``LookupState`` and surface on the wire as
+        ``degraded: true, degraded_reason: upstream_unavailable`` — before this
+        fix the response was byte-identical to a genuine no-match.
+
+        ``execute_search_pipeline`` is patched directly (rather than driving a
+        real strategy through ``DiscogsBreakerOpenError``, which is already
+        pinned at the runner level in ``tests/unit/test_search.py``) to isolate
+        the orchestrator-side copy-through + response-build wiring this ticket
+        adds. No album on the request so the library-miss probe (3a) — gated on
+        empty ``library_results`` plus a present ``album`` — does not fire and
+        need its own Discogs mock.
+        """
+        request = LookupRequest(
+            artist="Jessica Pratt",
+            song="Back, Baby",
+            raw_message="Jessica Pratt - Back, Baby",
+        )
+
+        shed_state = SearchState(results=[], upstream_shed=True)
+
+        with patch(
+            "lookup.orchestrator.execute_search_pipeline",
+            AsyncMock(return_value=shed_state),
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        assert isinstance(response, LookupResponse)
+        assert response.results == []
+        assert response.degraded is True
+        assert response.degraded_reason == DegradedReason.upstream_unavailable
+        # Control flow unchanged: no 500, timeout stays independent of the shed.
+        assert response.timeout is False
+
+    @pytest.mark.asyncio
+    async def test_search_leg_shed_with_results_still_marks_degraded(
+        self, mock_library_db, mock_discogs_service, telemetry, stereolab_item
+    ):
+        """Decision (LML#1126): a shed that still produced library results is
+        ALSO marked degraded=True. ``degraded`` means "trustworthy but
+        incomplete" — a lookup that found library rows but could not reach
+        Discogs to confirm/enrich them is exactly that, matching the tail-shed
+        arms (``_build_degraded_response``), which keep whatever the library +
+        cached legs produced while still returning ``degraded=True``."""
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[
+                make_discogs_result(
+                    release_id=555,
+                    album="Emperor Tomato Ketchup",
+                    artist="Stereolab",
+                )
+            ]
+        )
+
+        request = LookupRequest(
+            artist="Stereolab",
+            album="Emperor Tomato Ketchup",
+            raw_message="Stereolab - Emperor Tomato Ketchup",
+        )
+
+        shed_state = SearchState(results=[stereolab_item], upstream_shed=True)
+
+        with patch(
+            "lookup.orchestrator.execute_search_pipeline",
+            AsyncMock(return_value=shed_state),
+        ):
+            response = await perform_lookup(
+                request, mock_library_db, mock_discogs_service, telemetry
+            )
+
+        assert isinstance(response, LookupResponse)
+        assert len(response.results) == 1
+        assert response.results[0].library_item.artist == "Stereolab"
+        assert response.degraded is True
+        assert response.degraded_reason == DegradedReason.upstream_unavailable
 
     @pytest.mark.asyncio
     async def test_no_discogs_service_still_works(self, mock_library_db, telemetry, queen_item):

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1319,6 +1319,10 @@ class TestBreakerShedInRunner:
 
         assert state.results == []
         assert SearchStrategyType.TRACK_ON_COMPILATION in state.strategies_tried
+        # LML#1126: the shed must be recorded on SearchState so the orchestrator
+        # can mark the wire response degraded instead of a byte-identical
+        # genuine no-match.
+        assert state.upstream_shed is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -1370,9 +1374,39 @@ class TestBreakerShedInRunner:
 
         state = await execute_search_pipeline(parsed, "x", strategies, song_not_found=True)
 
-        # The later strategy still ran and surfaced its match despite the shed.
+        # The later strategy still ran and surfaced its match despite the shed —
+        # ``continue`` semantics are preserved.
         assert [i.id for i in state.results] == [7]
         assert SearchStrategyType.SONG_AS_ARTIST in state.strategies_tried
+        # LML#1126: a shed that still produced results (via a later cache-only
+        # strategy) is still marked — the response is trustworthy but
+        # incomplete, not a clean hit.
+        assert state.upstream_shed is True
+
+    @pytest.mark.asyncio
+    async def test_no_shed_leaves_upstream_shed_false(self, monkeypatch):
+        """Regression pin (LML#1126): a genuine miss with no breaker involvement
+        must NOT set ``upstream_shed`` — this is what keeps a real no-match
+        distinguishable from a shed on the wire."""
+        monkeypatch.setenv("LML_SEARCH_HARD_TIMEOUT_MS", "60000")
+        monkeypatch.setenv("LML_SEARCH_BUDGET_MS", "60000")
+
+        async def miss_attempt(parsed, state, raw_message):  # noqa: ARG001
+            return Outcome.empty()
+
+        strategies = [
+            _StubStrategy(
+                name=SearchStrategyType.TRACK_ON_COMPILATION,
+                condition=lambda *_a: True,
+                attempt_func=miss_attempt,
+            )
+        ]
+        parsed = ParsedRequest(artist="Juana Molina", song="La Verdad", raw_message="x")
+
+        state = await execute_search_pipeline(parsed, "x", strategies, song_not_found=True)
+
+        assert state.results == []
+        assert state.upstream_shed is False
 
 
 class TestHardCapSoftBudgetIndependence:


### PR DESCRIPTION
Closes #1126

## Problem

`core/search.py:953-966`'s `except DiscogsBreakerOpenError` arm — the one catch boundary on the search path — degraded a Discogs saturation-breaker shed to an empty `Outcome`, leaving no signal behind. The lookup then fell through to the normal response builder (`lookup/orchestrator.py`), which hardcoded `degraded=False`. Net wire result: `results: [], timeout: false, degraded: false` — byte-identical to a genuine no-match, exactly the shape `api.yaml` documents as the definition of a real miss.

Tail-leg sheds (`lookup/orchestrator.py`'s two `except DiscogsBreakerOpenError` legs around the enrichment tail and identity resolution) were already correct — they return `_build_degraded_response(degraded_reason=DegradedReason.upstream_unavailable)`. This was the one asymmetric path; both are unchanged and still pinned by their existing tests (`test_breaker_shed_in_tail_degrades_to_cache_only_not_500`, `test_tail_shed_on_caller_deadline_degrades_deadline_exceeded`).

## Fix

Mirrors the exact plumbing `SearchState.timed_out` already uses end to end:

1. `SearchState.upstream_shed: bool = False` (`core/search.py`).
2. Set it in the `except DiscogsBreakerOpenError` arm, alongside the existing `logger.info` — no new log line, no per-shed WARNING/ERROR (LML#805/#798 posture preserved). `continue` semantics are unchanged: a later cache-only strategy still runs.
3. Copied onto `LookupState.upstream_shed` at the same site `state.timed_out = search_state.timed_out` already lives.
4. The normal response builder now emits `degraded=state.upstream_shed`, `degraded_reason=DegradedReason.upstream_unavailable if degraded else None`, instead of the hardcoded `degraded=False`.

No `api.yaml` change: `degraded`, `degraded_reason`, and `upstream_unavailable` already exist in the published contract and in `generated/api_models.py`.

## Results-still-present decision

**A shed that still produced results is also marked `degraded: true`.** Went with the ticket's recommendation: `degraded` means "trustworthy but incomplete," and a lookup that found library/cached rows but couldn't reach Discogs to confirm or enrich them is exactly that — regardless of whether a *later* strategy in the cascade happened to recover a hit after the shed. This also matches the tail arms, which return `_build_degraded_response` while keeping whatever the library + cached legs already produced, rather than distinguishing "shed with nothing" from "shed with something." Covered by `test_search_leg_shed_with_results_still_marks_degraded`.

## Volume step change / telemetry implication

Consumers will now see **more** `degraded: true` responses — every search-leg breaker shed that previously laundered into a silent no-match. This is the intent (it's what lets Backend-Service's `flowsheet-metadata-backfill` leave a shed row retryable instead of terminalizing it as `enriched_no_match`, per WXYC/Backend-Service#1995). Flagging per the ticket, not changing either myself:

- **wxyc-canary#82**'s shed alarm currently under-counts by however large the search-leg share of total sheds is; its threshold may need recalibrating against the new baseline once this ships.
- **LML#931**'s `degraded-mode-result` telemetry dimension is listed in `lookup/caller_reason.py` as still gated on #930/#943 (not yet implemented), so it isn't live to under-count today — but whoever wires it up should be aware the search-leg source now exists.

One asymmetry worth noting: the tail-shed builder (`_build_degraded_response`) also sets a Sentry `lml.degraded_reason` tag for canary/telemetry slicing. This PR's normal-response-builder path does not set that tag — the ticket's suggested approach mirrors `timed_out`'s plumbing exactly (wire fields only), and `timed_out` doesn't carry a parallel Sentry tag either. If #931's `degraded-mode-result` dimension is built out later, it should pick up this path's Sentry tagging as a follow-up.

## PR #1120 interaction

WXYC/library-metadata-lookup#1120 (branch `lml-1118-breaker-open-error-base`) is open and refactors every `except DiscogsBreakerOpenError` leg — including the one this PR touches in `core/search.py` — onto a shared `BreakerOpenError` base class. This PR adds a statement *inside* that `except` body; it doesn't touch what's caught. Expect a trivial rebase conflict on that one `except` line whichever of the two merges second — the change is compatible either way, and this PR does not do #1120's refactor.

## Testing (TDD)

- `tests/unit/test_search.py::TestBreakerShedInRunner` — extended with `upstream_shed` assertions on the existing shed test, the existing shed-then-recovery test, and a new `test_no_shed_leaves_upstream_shed_false` regression pin for a genuine miss.
- `tests/unit/test_orchestrator.py::TestPerformLookupBasic`:
  - `test_no_results_returns_empty` extended to pin `degraded is False`, `degraded_reason is None`, `timeout is False` on a genuine no-match — the exact contract sentence the bug falsified.
  - `test_search_leg_shed_marks_response_degraded` (new) — a search-leg shed (`SearchState.upstream_shed=True`, empty results) surfaces `degraded: true, degraded_reason: upstream_unavailable`.
  - `test_search_leg_shed_with_results_still_marks_degraded` (new) — same, with library results present, covering the decision above.
  - Existing tail-shed tests (`test_breaker_shed_in_tail_degrades_to_cache_only_not_500`, `test_tail_shed_on_caller_deadline_degrades_deadline_exceeded`) pass unmodified — regression pin that tail behavior is untouched.

All test fixtures use WXYC-representative artists (Stereolab, Jessica Pratt, Juana Molina).

Local gate: `ruff format --check .`, `ruff check .`, `mypy . --ignore-missing-imports`, `pytest tests/unit/` (5174 passed) all green.

## Rebase onto #1120 (2026-08-05)

#1120 merged first, so this branch was rebased onto it. Two conflicts, both resolved in its favor:

- `core/search.py` — took #1120's widened `except BreakerOpenError as exc:` and its comment; this PR's `state.upstream_shed = True` marker sits inside that body unchanged. The `SearchState.upstream_shed` docstring was widened to match: the marker is now breaker-agnostic for the same reason the catch is, so a future breaker-guarded strategy sets it for free.
- `tests/unit/test_orchestrator.py` — import-block collision only; all three imports kept.

**Module-budget recalibration.** The rebase pushed `lookup/orchestrator.py` to 1664 lines, over its 1650 ceiling. Both PRs were green independently — only the merge order produced the overflow, because the 1650 entry had been set to the file's *exact* measured size with zero headroom. Raised to 1700 using the table's own "smallest multiple of 50 at or above measured" convention.

This is the **fourth** consecutive recalibration of this file, and the third to defer the same extraction. `tests/unit/test_module_budgets.py`'s policy is explicit that raising a ceiling is a last resort, so the deferred work now has its own ticket rather than another footnote: **WXYC/library-metadata-lookup#1142**. Nothing in this PR was extractable — the growth is one `LookupState` field (that dataclass lives in `orchestrator.py`) plus its two irreducible call sites, the same shape LML#944 recalibrated `router.py` for.

Post-rebase local gate re-run: `ruff check`, `ruff format --check`, `mypy . --ignore-missing-imports` (535 files, no issues), `pytest tests/unit` — **5204 passed**.
