### PR TITLE
fix(build): local Docker build hygiene and packaging manifest drift

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,13 @@ venv/
 __pycache__/
 *.pyc
 logs/
+
+# Repo-root pipeline scratch output and runtime databases (LML#1132). Plain
+# globs — patterns do not cross `/`, so these do not drop the tracked
+# `tests/fixtures/*.json` (already excluded via `tests/` above) or the
+# tracked `entity/*.sql` reference DDL (nothing at runtime opens those files
+# by path; the executed DDL lives in entity/ddl.py).
+*.db
+*.json
+*.csv
+*.sql

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,13 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
 
+# Once-per-process guard for the ``resolved_library_db_path`` empty-value
+# WARNING. The property is read on the request path (``get_library_db`` and
+# ``get_object_store`` in ``core/dependencies.py`` are FastAPI dependencies), so
+# an unguarded ``logger.warning`` would emit one identical line per request for
+# the entire life of a misconfigured deploy. Reset in tests via monkeypatch.
+_empty_library_db_path_warned = False
+
 # Postgres memory-value grammar (digits + optional unit) for ``work_mem`` (LML#804).
 # ``discogs_search_work_mem`` is interpolated into a ``SET LOCAL`` string (Postgres
 # ``SET`` takes no bind params), so it is validated against this at BOTH ends: the
@@ -70,10 +77,15 @@ class Settings(BaseSettings):
             # deploy would otherwise silently serve library.db from whatever
             # the process's CWD happens to be -- a stale or wrong catalog
             # with no signal in the logs. See WXYC/library-metadata-lookup#1132.
-            logger.warning(
-                "library_db_path was set but empty; falling back to "
-                "library.db in the current working directory"
-            )
+            # Warned once per process: this property is read per request, and a
+            # per-request repeat would bury the signal it exists to raise.
+            global _empty_library_db_path_warned
+            if not _empty_library_db_path_warned:
+                _empty_library_db_path_warned = True
+                logger.warning(
+                    "library_db_path was set but empty; falling back to "
+                    "library.db in the current working directory"
+                )
             return Path("library.db")
         return self.library_db_path
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,5 +1,6 @@
 """Application configuration using Pydantic Settings."""
 
+import logging
 import re
 from functools import lru_cache
 from pathlib import Path
@@ -7,6 +8,8 @@ from typing import Literal
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 # Postgres memory-value grammar (digits + optional unit) for ``work_mem`` (LML#804).
 # ``discogs_search_work_mem`` is interpolated into a ``SET LOCAL`` string (Postgres
@@ -61,6 +64,16 @@ class Settings(BaseSettings):
     def resolved_library_db_path(self) -> Path:
         """Get the library database path, handling empty env var case."""
         if not str(self.library_db_path) or str(self.library_db_path) == ".":
+            # LIBRARY_DB_PATH was set but empty (or unset -- pydantic's Path
+            # coercion turns "" into "."). Production always sets a real
+            # value, so this branch is latent today, but a misconfigured
+            # deploy would otherwise silently serve library.db from whatever
+            # the process's CWD happens to be -- a stale or wrong catalog
+            # with no signal in the logs. See WXYC/library-metadata-lookup#1132.
+            logger.warning(
+                "library_db_path was set but empty; falling back to "
+                "library.db in the current working directory"
+            )
             return Path("library.db")
         return self.library_db_path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,16 @@ requires = ["setuptools>=65.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["core*", "config*", "library*", "discogs*", "lookup*", "routers*", "services*", "generated*", "scripts*", "entity*", "clients*", "storage*"]
+# Kept in lockstep with the actual top-level package layout by
+# tests/unit/test_packaging_manifest.py (LML#1132) -- a new top-level
+# __init__.py-carrying directory that isn't added here fails that test.
+# py-modules = ["main"] is deliberately NOT added: Dockerfile's dependency
+# layer (`COPY pyproject.toml ./` then `pip install .`) installs from a
+# context containing only pyproject.toml, so an explicit py-modules entry
+# would hard-fail on the missing main.py. Making the package genuinely
+# installable needs a Dockerfile reorder that forfeits that layer's cache --
+# out of scope here.
+include = ["core*", "config*", "library*", "discogs*", "lookup*", "routers*", "services*", "generated*", "scripts*", "entity*", "clients*", "storage*", "artists*", "identity*", "release*", "streaming*", "cache*"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/unit/test_packaging_manifest.py
+++ b/tests/unit/test_packaging_manifest.py
@@ -1,0 +1,56 @@
+"""Repo-root cleanup Phase 3 (LML#1132): the packaging manifest must list
+every top-level package.
+
+``pyproject.toml``'s ``[tool.setuptools.packages.find]`` ``include`` list had
+drifted from the actual package layout: it named 12 top-level packages while
+the repo had grown to 17 non-test top-level directories carrying an
+``__init__.py``. Five (``artists``, ``identity``, ``release``, ``streaming``,
+``cache``) were missing despite being runtime-imported, so a ``pip install .``
+(the path ``Dockerfile`` takes) silently shipped an incomplete package with no
+CI signal. This meta-test locks the two lists together -- following the
+repo's existing meta-test habit (``tests/unit/test_env_hermeticity.py``,
+``tests/integration/test_pg_fixture_guard_adoption.py``) -- so a future new
+top-level package can't drift out of ``include`` again unnoticed.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _top_level_packages() -> set[str]:
+    """Every top-level directory (excluding ``tests/``) containing an
+    ``__init__.py``."""
+    return {
+        entry.name
+        for entry in REPO_ROOT.iterdir()
+        if entry.is_dir() and entry.name != "tests" and (entry / "__init__.py").is_file()
+    }
+
+
+def _include_patterns() -> list[str]:
+    manifest = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    include: list[str] = manifest["tool"]["setuptools"]["packages"]["find"]["include"]
+    return include
+
+
+def test_every_top_level_package_is_in_packages_find_include():
+    """Every top-level ``__init__.py``-carrying directory must appear in
+    ``packages.find.include`` (as a bare name or a ``name*`` glob), or ``pip
+    install .`` silently drops it from the installed package.
+    """
+    include = _include_patterns()
+    included_names = {pattern.rstrip("*") for pattern in include}
+    actual_packages = _top_level_packages()
+
+    missing = actual_packages - included_names
+    assert not missing, (
+        f"Top-level package(s) {sorted(missing)} have an __init__.py but are "
+        "not listed in pyproject.toml's [tool.setuptools.packages.find] "
+        "include list. Add them (as `<name>*`, matching the existing entries) "
+        "or `pip install .` will silently ship an incomplete package. See "
+        "WXYC/library-metadata-lookup#1132."
+    )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -5,7 +5,19 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from config import settings as settings_module
 from config.settings import Settings, get_settings
+
+
+@pytest.fixture
+def reset_empty_path_warning(monkeypatch):
+    """Clear the once-per-process guard on the empty-path fallback WARNING.
+
+    The guard is module state, so without this the test that asserts the
+    warning fires would depend on which test in the session reached the
+    fallback branch first.
+    """
+    monkeypatch.setattr(settings_module, "_empty_library_db_path_warned", False)
 
 
 class TestResolvedLibraryDbPath:
@@ -21,7 +33,7 @@ class TestResolvedLibraryDbPath:
         s = Settings(library_db_path=Path("/data/my_library.db"))
         assert s.resolved_library_db_path == Path("/data/my_library.db")
 
-    def test_empty_value_fallback_logs_warning(self, caplog):
+    def test_empty_value_fallback_logs_warning(self, caplog, reset_empty_path_warning):
         """LML#1132: the set-but-empty-env-var fallback (`.` after pydantic's
         Path coercion) must warn loudly rather than silently serve a
         different catalog than the one an operator thinks they configured."""
@@ -32,6 +44,24 @@ class TestResolvedLibraryDbPath:
         warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
         assert any("library_db_path" in m.lower() or "library.db" in m for m in warnings), (
             f"expected a WARNING naming the fallback path, got: {warnings}"
+        )
+
+    def test_empty_value_fallback_warns_once_per_process(self, caplog, reset_empty_path_warning):
+        """The fallback branch is reached from ``get_library_db``, which is a
+        per-request FastAPI dependency (``core/dependencies.py``), plus the
+        boot-fetch (``main.py``) and ``get_object_store``. An unguarded
+        ``logger.warning`` there emits one identical line **per request** for
+        the whole life of a misconfigured deploy -- burying the signal it
+        exists to raise. Measured against the built image before this guard:
+        6 lines for 5 ``GET /health`` calls. Warn once per process instead."""
+        s = Settings(library_db_path=Path("."))
+        with caplog.at_level("WARNING", logger="config.settings"):
+            for _ in range(5):
+                assert s.resolved_library_db_path == Path("library.db")
+        warnings = [r for r in caplog.records if r.name == "config.settings"]
+        assert len(warnings) == 1, (
+            f"expected exactly one WARNING across 5 property reads, got {len(warnings)}: "
+            f"{[r.getMessage() for r in warnings]}"
         )
 
     def test_valid_custom_path_does_not_warn(self, caplog):

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -21,6 +21,27 @@ class TestResolvedLibraryDbPath:
         s = Settings(library_db_path=Path("/data/my_library.db"))
         assert s.resolved_library_db_path == Path("/data/my_library.db")
 
+    def test_empty_value_fallback_logs_warning(self, caplog):
+        """LML#1132: the set-but-empty-env-var fallback (`.` after pydantic's
+        Path coercion) must warn loudly rather than silently serve a
+        different catalog than the one an operator thinks they configured."""
+        s = Settings(library_db_path=Path("."))
+        with caplog.at_level("WARNING", logger="config.settings"):
+            result = s.resolved_library_db_path
+        assert result == Path("library.db")
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any("library_db_path" in m.lower() or "library.db" in m for m in warnings), (
+            f"expected a WARNING naming the fallback path, got: {warnings}"
+        )
+
+    def test_valid_custom_path_does_not_warn(self, caplog):
+        """The warning is scoped to the fallback branch only -- a real,
+        non-empty path must never trigger it."""
+        s = Settings(library_db_path=Path("/data/my_library.db"))
+        with caplog.at_level("WARNING", logger="config.settings"):
+            _ = s.resolved_library_db_path
+        assert not caplog.records
+
 
 class TestStreamingUrlPersistFlags:
     """LML#573 AND-gate: a service persists only when the master AND its


### PR DESCRIPTION
Closes #1132

## Summary

- `.dockerignore` now excludes `*.db`, `*.json`, `*.csv`, and `*.sql` in addition to its existing entries, so a local `docker build` no longer bakes in whatever pipeline scratch output happens to be sitting at the repo root. Production is unaffected -- `railway up` already honors `.gitignore`, so these files never reached the deploy tarball; this is a local-build-hygiene fix only. `COMMIT_SHA` (no extension, and separately excluded from `.gitignore`/`.dockerignore` by name per LML#509) is untouched.
- `pyproject.toml`'s `[tool.setuptools.packages.find]` `include` list gains the five packages it was silently missing: `artists`, `identity`, `release`, `streaming`, `cache`. All five are runtime-imported. `py-modules = ["main"]` is deliberately **not** added -- `Dockerfile` installs from a context containing only `pyproject.toml` at that layer, so it would hard-fail the build on the missing `main.py`.
- A new packaging meta-test (`tests/unit/test_packaging_manifest.py`) locks the `include` list to the real top-level package layout going forward, so a future new package can't drift out silently again.
- `config/settings.py`'s `resolved_library_db_path` now logs a WARNING when it takes its empty-value fallback (`LIBRARY_DB_PATH` set but empty), instead of silently serving a possibly-stale catalog. Landed as the last, smallest-possible commit since `config/settings.py` is concurrently touched by the in-flight Bandcamp branch stack.

## Measured build-context size (real numbers, not asserted)

Measured with the legacy (non-BuildKit) Docker builder, which tars the full context every run with no incremental-transfer caching to skew the comparison. Run against a working tree carrying the actual ~104 MB of accumulated root scratch data (the two runtime databases plus the live pipeline-script JSON/CSV/SQL output), using `docker build` (no cache) and reading the `Sending build context to Docker daemon` line:

| | Context size |
|---|---|
| Before (current `.dockerignore`) | **108.7 MB** |
| After (this PR's `.dockerignore`) | **4.358 MB** |

The repo-root cleanup plan's Phase 2 (routing script artifacts into a gitignored `artifacts/` directory) has **not** landed yet -- it's blocked on the in-flight Bandcamp branch stack that also touches `config/settings.py`. `.dockerignore` does **not** yet exclude `artifacts/`; that entry is Phase 2's step, not this one's, and is intentionally not added here. Once Phase 2 lands, its ~31 MB of relocated artifacts arrive as an *additional* reduction on top of the numbers above (they're already excluded here today only because these particular files are gitignored by name/glob, not because of an `artifacts/` entry).

## `/health` verification (LML#509 guard)

Built the image locally with the new `.dockerignore` and a fake `COMMIT_SHA` (mirroring what CI writes: `echo "${{ github.sha }}" > COMMIT_SHA`), ran the container, and hit `/health`:

```json
{
  "status": "unhealthy",
  "version": "0.1.0",
  "commit_sha": "deadbeefcafefeed1234567890abcdef12345678",
  "discogs_breaker_state": null,
  "discogs_live_requests_total": 0,
  "services": { "database": "error", "discogs_api": "unavailable", "discogs_cache": "unavailable" }
}
```

`commit_sha` is populated correctly -- the new globs do not touch the extensionless `COMMIT_SHA` file, and it still clears both `.gitignore` and `.dockerignore`. `status: unhealthy` / `database: error` is expected and correct: `library.db` is deliberately no longer baked into the image (that's the fix), and no bucket was configured for this local test, so the boot-fetch has nothing to fetch -- this matches the documented `/health` semantics for a missing `library.db` and is exactly what production's bucket-backed boot-fetch exists to avoid.

## Packaging meta-test: red-then-green evidence

Committed the test first (`test(packaging): add a meta-test locking packages.find.include to the real package layout`) and ran it against the unfixed `pyproject.toml`:

```
FAILED tests/unit/test_packaging_manifest.py::test_every_top_level_package_is_in_packages_find_include
AssertionError: Top-level package(s) ['artists', 'cache', 'identity', 'release', 'streaming'] have an __init__.py but are not listed in pyproject.toml's [tool.setuptools.packages.find] include list.
```

The following commit fixed `pyproject.toml`; the same test then passed:

```
tests/unit/test_packaging_manifest.py::test_every_top_level_package_is_in_packages_find_include PASSED
```

## `.dockerignore` glob safety -- verified, not assumed

Before adding the globs, enumerated every tracked file with each extension (`git ls-files '*.json' '*.sql' '*.db' '*.csv'`):

- Tracked `*.json`: only `tests/fixtures/bandcamp/autocomplete_a_golden_repro.json` and `tests/fixtures/charset-torture.json` -- both already excluded via the existing `tests/` entry.
- Tracked `*.sql`: nine `entity/*.sql` reference-DDL files. Grepped the whole tree for `read_text`/`open(...*.sql...)`/`Path(...*.sql...)` outside `scripts/`/`tests/` and found none -- the only two `.sql` mentions in runtime code are comments pointing at the executed DDL in `entity/ddl.py`.
- Tracked `*.db` / `*.csv`: none.

Plain globs don't cross `/`, matching the existing `*.md` entry's behavior of not dropping `docs/`.

## Local checks

- `uv run --no-sync ruff check .` -- all checks passed
- `uv run --no-sync ruff format --check .` -- all files already formatted
- `uv run --no-sync mypy config/settings.py tests/unit/test_settings.py tests/unit/test_packaging_manifest.py --ignore-missing-imports` -- no issues
- `uv run --no-sync pytest` -- 5531 passed, 1 skipped, 2 xfailed (pre-existing, unrelated), 0 failed
- `bash scripts/check_plan_links.sh` -- exit 0

## Deviations from the plan

None in substance. Per the assigned correction to the plan's stated acceptance criterion: Phase 2 has not landed, so this PR measures and reports real before/after context sizes rather than asserting the plan's composed "~71 MB on top of ~31 MB" figure, and confirms `.dockerignore` does not yet have an `artifacts/` entry (that stays Phase 2's to add).


## Review follow-up: the fallback WARNING fired per request, not once

Independent verification found the step-4 log line was reachable from the request path, not just from boot. `resolved_library_db_path` is read by `get_library_db` and `get_object_store` in `core/dependencies.py`, both of which are FastAPI dependencies. Measured against the built image with `LIBRARY_DB_PATH` set to the empty string: **6 identical WARNING lines for 5 `GET /health` calls**, sustained for the life of a misconfigured deploy — the opposite of "scoped to one log line", and enough volume to bury the signal it exists to raise.

Fixed with a module-level once-per-process guard (`fix(settings): warn once per process on the empty-value library_db_path fallback`). The line still lands at boot, since the lifespan boot-fetch reads the property before serving, and then stops. Re-measured on a rebuilt image: **1 line across 8 `GET /health` calls**, `commit_sha` still populated. The new test asserts exactly one record across five property reads, with a fixture resetting the guard so the assertion doesn't depend on test ordering.

## Build-context size from a clean checkout

The 108.7 MB → 4.358 MB figures above are a developer working tree carrying the accumulated root scratch output; they are reproducible only against that tree's contents. For completeness, measured from a **clean detached checkout of this branch** (legacy builder, same method):

| | Context size |
|---|---|
| Clean checkout, before `.dockerignore` | **4.359 MB** |
| Clean checkout, after `.dockerignore` | **4.359 MB** |

Identical, and correctly so: a clean checkout has no root-level `*.db` / `*.json` / `*.csv` / `*.sql` to drop (the only tracked matches are `entity/*.sql` and `tests/fixtures/*.json`, and both survive — the first because plain globs don't cross `/`, the second because `tests/` was already excluded). The entire ~104 MB benefit accrues to trees that have actually run the pipeline scripts, which is the exposure this phase targets.

Independently re-measured in the main working tree at review time: **119.4 MB → 15.08 MB**, a delta of 104.3 MB matching byte-for-byte the 104,333,679 bytes of root-level files the four globs match. The absolute numbers sit ~11 MB above the ones reported earlier because `.audit/` (11 MB, untracked tool output) has since been regenerated there; the delta is unchanged.

## Image-content diff (what actually disappeared)

Built the image both ways and diffed the exported file lists rather than reasoning from the ignore rules: **2358 `/app` entries before, 2358 after, zero difference** from a clean checkout. Specifically confirmed present in the post-change image: all nine `entity/*.sql` files and `/app/COMMIT_SHA`. Nothing a runtime path reads by name, via `importlib.resources`, or from `entrypoint.sh` / the lifespan boot-fetch left the image.

One residual, out of scope here and worth its own follow-up: `.mypy_cache/` and `.ruff_cache/` are not in `.dockerignore`, so on a developer machine that has run mypy they still enter the context (~47 MB observed). Both are gitignored, so they never reach a `railway up` deploy — the same local-only shape this phase is closing, just not in this phase's four-glob scope.
