### PR TITLE
Drop dead Optional guards left by the strict-nullable narrowing

### DIFF
--- a/artists/router.py
+++ b/artists/router.py
@@ -319,7 +319,7 @@ async def resolve_bulk(
     )
 
     names = [n.root for n in request.names]
-    dry_run = bool(request.dry_run)
+    dry_run = request.dry_run
     logger.info("artist-resolve bulk start: names=%d dry_run=%s", len(names), dry_run)
 
     # Per-request telemetry bracket: `search_artists` records API calls into

--- a/lookup/strategies/va_rescue.py
+++ b/lookup/strategies/va_rescue.py
@@ -132,7 +132,7 @@ async def _tracklist_credits_artist(
     if release is None or not release.tracklist:
         return False
     for track in release.tracklist:
-        for credit in track.artists or []:
+        for credit in track.artists:
             if score_match(query_artist, credit) >= SCORE_MATCH_ACCEPTANCE_FLOOR:
                 return True
         for segment in _segments(track.title or ""):


### PR DESCRIPTION
## Problem

PR #1154 (merged 0bc5a40) narrowed two generated model fields from Optional to non-Optional: `ArtistResolveBulkRequest.dry_run` is now `bool` (default `False`), and `DiscogsTrackItem.artists` is now `list[str]` (default `[]`). Two defensive guards written for the old Optional shape are now provably unreachable dead code that still signals "this may be None" to the next reader.

## Change

`artists/router.py`: `dry_run = bool(request.dry_run)` becomes `dry_run = request.dry_run` — `request` is an `ArtistResolveBulkRequest` (built by `parse_bulk_body`), so `request.dry_run` is already a `bool`. `lookup/strategies/va_rescue.py`: `for credit in track.artists or []:` becomes `for credit in track.artists:` — `track` iterates over `release.tracklist`, where `release` is a `ReleaseMetadataResponse` (returned by `DiscogsService.get_release`); `ReleaseMetadataResponse` subclasses the generated `DiscogsReleaseMetadata`, whose `tracklist: list[DiscogsTrackItem] = Field([], validate_default=True)` is non-Optional and holds `DiscogsTrackItem` instances directly, so `track.artists` is already a `list[str]`.

## Type-level verification

Confirmed directly against current `generated/api_models.py` before making the change:
- `ArtistResolveBulkRequest.dry_run: bool = Field(False, ...)` (non-Optional, no `| None`).
- `DiscogsTrackItem.artists: list[str] = []` (non-Optional, no `| None`).
- `DiscogsReleaseMetadata.tracklist: list[DiscogsTrackItem] = Field([], validate_default=True)` (non-Optional), and `ReleaseMetadataResponse` (the type `va_rescue.py`'s `release` actually is, via `DiscogsService.get_release`) subclasses it without overriding `tracklist`, so no widening back to `Optional` happens anywhere between the generated model and the call site.
- `artists/router.py` calls `parse_bulk_body(http_request, ArtistResolveBulkRequest, ...)` directly — no local override layer re-widens `dry_run`.

Both premises hold, so the change is a provable no-op given the current generated types.

## Testing

No new test is added — the issue itself notes TDD isn't meaningfully applicable here, since there's no new behavior to pin, only dead code to remove. Ran the existing suite instead: `ruff check .` and `ruff format --check .` both pass, `mypy . --ignore-missing-imports` reports no issues across 551 source files, and the full unit suite (`pytest tests/unit/`) passes at 5482/5482, including `tests/unit/test_artist_resolve_router.py` and `tests/unit/test_va_rescue.py`, which exercise both changed call sites directly.

Closes #1161