### PR TITLE
fix(discogs): guard the container siblings of the #1154 present-but-null fix

### DIFF
--- a/discogs/service.py
+++ b/discogs/service.py
@@ -1456,10 +1456,27 @@ class DiscogsService:
                 data = response.json()
 
                 # Extract all artists
-                raw_artists = data.get("artists", [])
+                # Discogs may send an explicit null for a container key too,
+                # not just a scalar; .get(key, default) only defaults on an
+                # absent key, so a present-but-null container would raise
+                # `for a in None` here (LML#1156, same class as `join` below).
+                # Rule applied throughout this parse: guard a site iff the
+                # guard restores a documented schema default (a container
+                # defaults to `[]`, `join` defaults to `""`); never invent a
+                # value for a required field with no default (`name` below,
+                # `title`, `position`) -- `_api_fetch`'s return is persisted
+                # via `cache.write_release`, so inventing "" there would
+                # write bad data into the PG cache instead of leaving a
+                # malformed payload as a retryable miss. Same principle as
+                # the `master_id` normalization below (never persist an
+                # invented `0`).
+                raw_artists = data.get("artists") or []
                 artist_credits = [
                     ArtistCredit(
                         artist_id=a.get("id"),
+                        # `name` has no schema default (required `str`) --
+                        # deliberately left unguarded; see the container-vs-
+                        # leaf note above `raw_artists` (LML#1156).
                         name=a.get("name", ""),
                         # Discogs may send an explicit null; .get() only
                         # defaults on an absent key, and the model rejects
@@ -1472,10 +1489,11 @@ class DiscogsService:
                 artist_id = artist_credits[0].artist_id if artist_credits else None
 
                 # Extract extra artists (credits)
-                raw_extras = data.get("extraartists", [])
+                raw_extras = data.get("extraartists") or []
                 extra_artist_credits = [
                     ArtistCredit(
                         artist_id=a.get("id"),
+                        # No default for `name` -- see the rule above.
                         name=a.get("name", ""),
                         role=a.get("role"),
                     )
@@ -1483,10 +1501,11 @@ class DiscogsService:
                 ]
 
                 # Extract all labels
-                raw_labels = data.get("labels", [])
+                raw_labels = data.get("labels") or []
                 label_credits = [
                     LabelCredit(
                         label_id=lbl.get("id"),
+                        # No default for `name` -- see the rule above.
                         name=lbl.get("name", ""),
                         catno=lbl.get("catno"),
                     )
@@ -1501,12 +1520,16 @@ class DiscogsService:
                 # Extract tracklist with per-track artists (for compilations)
                 tracklist = [
                     TrackItem(
+                        # `position`/`title` have no defaults -- see the rule
+                        # above; left unguarded, same as before this PR.
                         position=t.get("position", ""),
                         title=t.get("title", ""),
                         duration=t.get("duration"),
-                        artists=[a.get("name", "") for a in t.get("artists", [])],
+                        # Container guard: a track with a release-level-only
+                        # credit can carry `"artists": null` (LML#1156).
+                        artists=[a.get("name", "") for a in t.get("artists") or []],
                     )
-                    for t in data.get("tracklist", [])
+                    for t in data.get("tracklist") or []
                 ]
 
                 # Extract artwork
@@ -1523,7 +1546,7 @@ class DiscogsService:
                         # survives; None is rejected post-wxyc-shared#302.
                         embed=True if v.get("embed") is None else v["embed"],
                     )
-                    for v in data.get("videos", [])
+                    for v in data.get("videos") or []
                     if v.get("uri")
                 ]
 
@@ -1709,13 +1732,19 @@ class DiscogsService:
 
                 return ArtistDetails(
                     artist_id=artist_id,
+                    # No default for `name` -- see the guard-vs-leaf rule in
+                    # `get_release` above `raw_artists` (LML#1156); left
+                    # unguarded, same as before this PR.
                     name=data.get("name", ""),
                     profile=data.get("profile") or None,
                     image_url=image_url,
                     name_variations=data.get("namevariations") or [],
                     aliases=[
                         ArtistRef(id=a["id"], name=a["name"])
-                        for a in data.get("aliases", [])
+                        # Container guard, same class as namevariations/urls
+                        # above: a present-but-null "aliases" would raise
+                        # `for a in None` here (LML#1156).
+                        for a in data.get("aliases") or []
                         if "id" in a and "name" in a
                     ],
                     members=[
@@ -1726,7 +1755,8 @@ class DiscogsService:
                             # survives; None is rejected post-wxyc-shared#302.
                             active=True if m.get("active") is None else m["active"],
                         )
-                        for m in data.get("members", [])
+                        # Same container guard as "aliases" above (LML#1156).
+                        for m in data.get("members") or []
                         if "id" in m and "name" in m
                     ],
                     urls=data.get("urls") or [],

--- a/tests/unit/test_discogs_service.py
+++ b/tests/unit/test_discogs_service.py
@@ -2952,6 +2952,149 @@ class TestGetReleaseNullFieldNormalization:
         assert result.videos[0].embed is False
 
 
+class TestGetReleaseNullContainerNormalization:
+    """WXYC/library-metadata-lookup#1156: the container siblings PR #1154
+    (0bc5a40) left unguarded. ``dict.get(key, default)`` only applies
+    ``default`` on an *absent* key -- a present-but-null container (Discogs
+    sends ``"tracklist": null`` the same way it sends a null scalar) passes
+    straight into a ``for x in None`` comprehension, raising ``TypeError``
+    inside ``get_release``'s broad ``except Exception: return None`` and
+    degrading a correct Discogs answer into a cache miss on the ``/lookup``
+    hot path. Same hazard class as ``TestGetReleaseNullFieldNormalization``
+    above, two lines away.
+
+    The container guard is only correct because a container has a documented
+    schema default (``[]``) to restore. The required-``str`` leaves in the
+    same comprehensions (``name``, ``title``) have no such default, and
+    ``_api_fetch``'s return value is persisted (``cache.write_release``) --
+    so those sites are deliberately left unguarded and asserted to degrade to
+    ``None`` below, not normalized to an invented ``""``."""
+
+    BASE_RESPONSE = {
+        "title": "Aluminum Tunes",
+        "artists": [{"id": 388, "name": "Stereolab"}],
+        "extraartists": [{"id": 500, "name": "John McEntire", "role": "Mixed By"}],
+        "labels": [{"id": 1, "name": "Drag City"}],
+        "tracklist": [{"position": "A1", "title": "Pause", "artists": []}],
+        "images": [],
+        "videos": [{"uri": "https://www.youtube.com/watch?v=x", "title": "Pause"}],
+    }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "json_key,result_attr",
+        [
+            ("artists", "artists"),
+            ("extraartists", "extra_artists"),
+            ("labels", "labels"),
+            ("tracklist", "tracklist"),
+            ("videos", "videos"),
+        ],
+    )
+    async def test_null_container_normalizes_to_empty_list(self, service, json_key, result_attr):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {**self.BASE_RESPONSE, json_key: None}
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_release(12345)
+
+        assert result is not None
+        assert getattr(result, result_attr) == []
+
+    @pytest.mark.asyncio
+    async def test_null_per_track_artists_normalizes_to_empty_list(self, service):
+        """The tracklist comprehension's per-track ``t.get("artists", [])`` is
+        the same hazard nested one level deeper -- a track that carries
+        ``"artists": null`` (release-level-only credit) must not raise."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            **self.BASE_RESPONSE,
+            "tracklist": [{"position": "A1", "title": "Pause", "artists": None}],
+        }
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_release(12345)
+
+        assert result is not None
+        assert result.tracklist[0].artists == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "json_key",
+        ["artists", "extraartists", "labels"],
+    )
+    async def test_null_credit_name_degrades_to_none(self, service, caplog, json_key):
+        """``ArtistCredit.name``/``LabelCredit.name`` are required ``str``
+        with no schema default to restore -- unlike the container sites
+        above, there is nothing documented to fall back to, and
+        ``_api_fetch``'s return value is persisted via
+        ``cache.write_release``. Inventing ``""`` here would write bad data
+        into the PG cache instead of leaving a malformed payload as a
+        retryable miss, so a present-but-null ``name`` is deliberately left
+        unguarded and must degrade to ``None`` (LML#1156 review)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            **self.BASE_RESPONSE,
+            json_key: [{"id": 1, "name": None}],
+        }
+
+        with (
+            patch.object(
+                service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+            ),
+            caplog.at_level("ERROR", logger="discogs.service"),
+        ):
+            result = await service.get_release(12345)
+
+        assert result is None
+        assert any(
+            "Failed to fetch release" in r.getMessage() and "name" in r.getMessage()
+            for r in caplog.records
+        ), (
+            "expected a validation-error breadcrumb naming the unguarded "
+            f"field, got: {[r.getMessage() for r in caplog.records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_null_track_title_degrades_to_none(self, service, caplog):
+        """``TrackItem.title`` has no schema default -- same rule as
+        ``test_null_credit_name_degrades_to_none`` above."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            **self.BASE_RESPONSE,
+            "tracklist": [{"position": "A1", "title": None, "artists": []}],
+        }
+
+        with (
+            patch.object(
+                service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+            ),
+            caplog.at_level("ERROR", logger="discogs.service"),
+        ):
+            result = await service.get_release(12345)
+
+        assert result is None
+        assert any(
+            "Failed to fetch release" in r.getMessage() and "title" in r.getMessage()
+            for r in caplog.records
+        ), (
+            "expected a validation-error breadcrumb naming the unguarded "
+            f"field, got: {[r.getMessage() for r in caplog.records]}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # get_artist_details
 # ---------------------------------------------------------------------------
@@ -3411,6 +3554,76 @@ class TestGetArtistDetails:
                 await service.get_artist_details(77)
 
         get_settings.cache_clear()
+
+
+class TestGetArtistDetailsNullContainerNormalization:
+    """WXYC/library-metadata-lookup#1156: the ``aliases``/``members`` container
+    siblings of ``namevariations``/``urls`` (guarded in 42189e8). Same hazard
+    as ``TestGetReleaseNullContainerNormalization`` above: a present-but-null
+    container raises ``for x in None`` inside ``get_artist_details``'s broad
+    ``except Exception: return None``, degrading a correct artist read into
+    a cache miss.
+
+    ``ArtistDetails.name`` has no schema default to restore and
+    ``_api_fetch``'s return value is persisted (``cache.write_artist_details``),
+    so it is deliberately left unguarded below (see the release-parse tests'
+    class docstring for the full rule)."""
+
+    BASE_RESPONSE = {
+        "id": 388,
+        "name": "Stereolab",
+        "aliases": [{"id": 500, "name": "Groop"}],
+        "members": [{"id": 200, "name": "Laetitia Sadier"}],
+        "images": [],
+    }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "json_key,result_attr",
+        [("aliases", "aliases"), ("members", "members")],
+    )
+    async def test_null_container_normalizes_to_empty_list(self, service, json_key, result_attr):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {**self.BASE_RESPONSE, json_key: None}
+
+        with patch.object(
+            service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+        ):
+            result = await service.get_artist_details(388)
+
+        assert result is not None
+        assert getattr(result, result_attr) == []
+
+    @pytest.mark.asyncio
+    async def test_null_artist_name_degrades_to_none(self, service, caplog):
+        """``ArtistDetails.name`` is required ``str`` with no schema default
+        -- the same unguarded-leaf shape as the release parse's
+        ``ArtistCredit.name``. A present-but-null value must degrade to a
+        retryable cache miss, not persist an invented ``""`` into
+        ``cache.write_artist_details`` (LML#1156 review)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {**self.BASE_RESPONSE, "name": None}
+
+        with (
+            patch.object(
+                service, "_request_with_retry", new_callable=AsyncMock, return_value=mock_resp
+            ),
+            caplog.at_level("ERROR", logger="discogs.service"),
+        ):
+            result = await service.get_artist_details(388)
+
+        assert result is None
+        assert any(
+            "Failed to fetch artist details" in r.getMessage() and "name" in r.getMessage()
+            for r in caplog.records
+        ), (
+            "expected a validation-error breadcrumb naming the unguarded "
+            f"field, got: {[r.getMessage() for r in caplog.records]}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

PR #1154 (merged `0bc5a40`) guarded scalar/leaf keys in `discogs/service.py`'s Discogs API parse against a present-but-null JSON value, since `dict.get(key, default)` only applies `default` on an *absent* key. It left the sibling container keys unguarded in the same comprehensions: `artists`, `extraartists`, `labels`, `tracklist` (plus the nested per-track `artists` list), and `videos` in `get_release`'s release parse, and `aliases`/`members` in `get_artist_details`'s artist parse. A present-but-null container raises `for x in None` inside the surrounding broad `except Exception: return None`, degrading a correct Discogs answer into a cache miss on the `/lookup` hot path -- the same hazard class `0bc5a40` closed for `namevariations`/`urls`, two lines away.

Closes #1156.

## The rule

Guard a site if and only if the guard restores a documented schema default. Never invent a value for a required field that has no default. `_api_fetch`'s return value is persisted (`cache.write_release` / `cache.write_artist_details`), so an `or ""` on a required-no-default field doesn't just dodge a `ValidationError` -- it writes the invented value into the PG cache, converting a transient upstream glitch into permanently poisoned data on every subsequent read. This is the same principle already applied fifteen lines above the container guards, in the `master_id` comment: normalize `master_id = 0` to `None` "so ... a cold-API write-back never persists `master_id = 0` into the PG cache."

Under that rule:

- **Has a default -> guard.** `DiscogsTrackItem.artists: list[str] = []`, `DiscogsArtistCredit.join: str = Field("", ...)`, `Member.active: bool = True`, `namevariations`, `urls`, `genres`, `styles`, and the eight container sites this PR guards.
- **No default -> leave unguarded.** `DiscogsArtistCredit.name`, `DiscogsLabelCredit.name`, `DiscogsTrackItem.position`/`title`, `DiscogsReleaseMetadata.title`/`artist`, `Alias.id`/`name`, `Member.id`/`name`. A release with no title or an artist with no name is a malformed payload; degrading to a retryable cache miss is correct and is the pre-existing, unchanged behavior.

`position` (the release parse's `TrackItem.position`), the release-level `title`, and the `aliases`/`members` `id`/`name` membership checks are deliberately left unguarded under this rule -- they are not misses.

## Fix

Applies the established `or []` guard idiom from `255bcd7`/`0bc5a40` to the eight container sites enumerated in #1156: `artists`, `extraartists`, `labels`, `tracklist`, the nested per-track `artists`, `videos` in `get_release`; `aliases`, `members` in `get_artist_details`. The `"id" in a and "name" in a` membership checks on `aliases`/`members` are untouched.

## Tests

Two test classes in `tests/unit/test_discogs_service.py`, mirroring the pattern established in `255bcd7`/`42189e8`: build a mock Discogs response with the key present and explicitly `null`, assert the parse still succeeds with the schema default instead of degrading to `None`.

- `TestGetReleaseNullContainerNormalization` -- `get_release`'s five top-level containers (parametrized) and the nested per-track `artists` list normalize to `[]`. The required-no-default leaves (`name` on artists/extra-artists/labels, parametrized, and track `title`) are asserted to degrade to `None` with a validation-error breadcrumb naming the field, pinning that the null is deliberately left unguarded rather than silently missed.
- `TestGetArtistDetailsNullContainerNormalization` -- `aliases`/`members` (parametrized) normalize to `[]`; the artist-name leaf is asserted to degrade to `None` the same way.

All new/changed cases were run red first, then green.

## CI note

`Codegen Freshness` is expected red on this PR -- it's the pre-existing #1117 drift (committed `generated/api_models.py` trailing several wxyc-shared `api.yaml` PRs merged upstream today), unrelated to this change and not part of the deploy gate's `needs:` list.
