### PR TITLE
chore(deps): bump wxyc-fastapi to >=1.5.0 for the before_send_transaction passthrough

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,11 @@ dependencies = [
     "asyncpg>=0.29.0",
     "rapidfuzz>=3.0.0",
     "cachetools>=5.0.0",
-    "wxyc-fastapi[posthog]>=1.4.0,<2.0.0",
+    # 1.5.0 adds the keyword-only `before_send_transaction` passthrough on
+    # `init_sentry`, the only hook that can drop individual child spans (by
+    # filtering `event["spans"]`). Required by LML#1175 to shed the asyncpg
+    # connection-reset span. See WXYC/wxyc-fastapi#40.
+    "wxyc-fastapi[posthog]>=1.5.0,<2.0.0",
     "aiolimiter>=1.1.0",
     "python-multipart>=0.0.6",
     "wxyc-etl>=0.10.0,<0.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.6" },
     { name = "uvicorn", specifier = ">=0.24.0" },
     { name = "wxyc-etl", specifier = ">=0.10.0,<0.11.0" },
-    { name = "wxyc-fastapi", extras = ["posthog"], specifier = ">=1.4.0,<2.0.0" },
+    { name = "wxyc-fastapi", extras = ["posthog"], specifier = ">=1.5.0,<2.0.0" },
     { name = "ytmusicapi", marker = "extra == 'drain'", specifier = "==1.12.1" },
 ]
 provides-extras = ["dev", "drain"]
@@ -1542,16 +1542,16 @@ wheels = [
 
 [[package]]
 name = "wxyc-fastapi"
-version = "1.4.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "sentry-sdk", extra = ["fastapi"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/bd/4da7356a8c5108d8eea9a95fc0b7732c3bf072f84ba8cbdc5d752d007ea9/wxyc_fastapi-1.4.0.tar.gz", hash = "sha256:2d0b03f0ce7a1be51e6379e8c56ff25378d16e6d7c19f7c8beb2f52c93adff39", size = 26686, upload-time = "2026-08-09T17:14:31.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/09/29e534081ca26b8b416af1aee30e56efb16409f6878106e07bb653d954b9/wxyc_fastapi-1.5.0.tar.gz", hash = "sha256:14bffc7c36a52eaef89b7908932440243373b4e32526eb18d3ac373507ee7f05", size = 27045, upload-time = "2026-08-10T17:30:13.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/a5/328ac08ca3fa3defa3127e1c668e203c67df87635f8bac68d73713ff28dd/wxyc_fastapi-1.4.0-py3-none-any.whl", hash = "sha256:5b7d52f108706444d0641272167ca8c298bf1d2c7056a3e3c34cc039c607e61f", size = 29419, upload-time = "2026-08-09T17:14:29.91Z" },
+    { url = "https://files.pythonhosted.org/packages/36/cf/6dfd75bbbdf08c4df5bc680ef0ada378e647bfe5b4e96739634742579ce7/wxyc_fastapi-1.5.0-py3-none-any.whl", hash = "sha256:ac37c17febca205e7364440d32cae7fd8385603c2e08e8d0bc2015ab6b9f3341", size = 29819, upload-time = "2026-08-10T17:30:11.832Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Pin bump only — unblocks WXYC/library-metadata-lookup#1175.

## What

`wxyc-fastapi` [1.5.0](https://pypi.org/project/wxyc-fastapi/1.5.0/) (WXYC/wxyc-fastapi#40, merged and tagged 2026-08-10) adds an optional `before_send_transaction` parameter to `init_sentry()`, forwarded to `sentry_sdk.init()`. It is the only hook that can drop **individual child spans** — mutate `event["spans"]` and return the modified event to keep the transaction with fewer spans; returning `None` drops the entire transaction, which is far blunter.

```
"wxyc-fastapi[posthog]>=1.4.0,<2.0.0"   ->   >=1.5.0,<2.0.0
```

## Why now

WXYC/library-metadata-lookup#1175 needs the hook to shed the asyncpg connection-reset span — `SELECT pg_advisory_unlock_all(); CLOSE ALL; UNLISTEN *; RESET ALL;`, emitted on every pool connection release with one fixed, sub-millisecond description. At **1,528,070 spans / 14d it is 19% of the entire WXYC Sentry org's span consumption** and its single largest line item. The org crossed 80% of its monthly reserved span budget on 2026-08-10.

## Behavior change

None. No call site passes the new parameter yet, and the release is additive:

```
$ python -c "import inspect; from wxyc_fastapi.observability.sentry import init_sentry; \
    print(inspect.signature(init_sentry).parameters['before_send_transaction'])"
before_send_transaction: 'Callable[[Event, Hint], Event | None] | None' = None
```

Verified `KEYWORD_ONLY` with a `None` default against the published wheel, so every existing call is unchanged. `traces_sample_rate` also keeps its `1.0` default upstream, so this does not interact with the `SENTRY_TRACES_SAMPLE_RATE` override added in #1174.

## Verification

`uv.lock` regenerated — the diff is confined to the `wxyc-fastapi` entry and its specifier. Local CI matches the pipeline:

| | |
|---|---|
| `ruff check .` | passed |
| `ruff format --check .` | 553 files formatted |
| `mypy . --ignore-missing-imports` | no issues, 553 files |
| `pytest -m 'not pg and not external_api'` | **5936 passed**, 1 skipped, 2 xfailed |

## Related

- WXYC/wxyc-fastapi#40 — the upstream feature
- WXYC/library-metadata-lookup#1175 — the consumer this unblocks
- WXYC/library-metadata-lookup#1174 — `SENTRY_TRACES_SAMPLE_RATE` override (merged)
- WXYC/Backend-Service#2089 — the Backend-Service half of the span-budget work (merged + deployed)
