### PR TITLE
chore(codegen): regenerate api_models against wxyc-shared 363718c

### DIFF
--- a/generated/api_models.py
+++ b/generated/api_models.py
@@ -2598,6 +2598,25 @@ class AppConfig(BaseModel):
     posthogHost: str = Field(..., description="PostHog ingestion host")
     requestOMaticUrl: str = Field(..., description="Request-o-matic service URL for song requests")
     apiBaseUrl: str = Field(..., description="Backend API base URL")
+    donateUrl: str | None = Field(
+        None,
+        description="Canonical hosted donation page URL behind the \"Support the station\" entry point. Backend-Service serves `''` — never `null`, never an omitted key — whenever its `DONATE_URL` variable is unset (WXYC/Backend-Service#2111), so a client MUST treat an empty string exactly as it treats an absent field and fall through to its own fallback destination. That empty-string wire value is also why this carries no `format: uri`: `''` is a legitimate value here and would fail uri validation. An enabled entry point with an empty or otherwise unusable URL is a reachable server state, because `DONATE_URL` and `DONATE_ENABLED` are independent variables on one deploy — `donateEnabled` governs visibility alone and never implies this field is usable. A client that cannot resolve a usable destination from this field or from its own fallback MUST NOT render the entry point.\n",
+    )
+    donateEnabled: bool | None = Field(
+        None,
+        description='Whether clients should render the donate entry point. `false` hides it. The field carries no schema-level `default` on purpose, for the same reason as `BulkResolveLibrariesRequest.include_tracks`: `openapi-typescript` emits a default-bearing property as non-optional even when it is absent from `required`, which would arm the very decode-failure cascade both donate fields are kept optional to avoid. Absent therefore means "the producer predates this field", and each client applies its own bootstrap default — absence is NOT a kill switch and MUST NOT be read as one, so a client whose own default is "show" owns the validity of its fallback destination for that window. `false` is likewise a deploy-time switch rather than an instant one: `GET /config` is served `Cache-Control: public, max-age=3600` and clients may cache the decoded config for the life of a process, so an entry point can keep rendering for an hour or more after the variable flips. Anything needing a faster kill than that belongs at the destination, not here.\n',
+    )
+
+
+class AppSecrets(BaseModel):
+    discogsApiKey: str = Field(
+        ...,
+        description="Discogs API consumer key, for clients that call Discogs directly.",
+    )
+    discogsApiSecret: str = Field(
+        ...,
+        description="Discogs API consumer secret, for clients that call Discogs directly.",
+    )
 
 
 class TrackListItem(BaseModel):


### PR DESCRIPTION
## Why

Codegen Freshness downloads `api.yaml` from wxyc-shared `main` at run time and diffs it against the committed snapshot, so an upstream spec merge turns the job red on **every** open LML PR until someone regenerates. It is currently red on #1185 and #1013, neither of which touches a generated file or a contract.

## What changed

Two upstream additions have landed since the last regen (`f514aa1`, wxyc-shared `83ac750`):

- `AppConfig.donateUrl` and `AppConfig.donateEnabled` — both optional (WXYC/Backend-Service#2111, the donation entry point).
- A new `AppSecrets` model for `GET /config/secrets` (`discogsApiKey` / `discogsApiSecret`).

**Purely additive.** No existing field changes shape, is removed, or is retyped; LML consumes none of the three. The whole diff is 19 added lines in `generated/api_models.py` and nothing else in the tree — the job's other two generators (`regenerate_streaming_catalog_sql`, `regenerate_lml_cache_sql`) produce no drift.

Pinned with `--ref 363718ce02256c4e3f9ff05130af1ac3b9d8f495` so the regen is reproducible rather than "whatever `main` happened to say at the time". CI stays deliberately unpinned — that is what makes it a drift signal at all (WXYC/wxyc-shared#319).

Local: 5,959 passed / 1 skipped / 670 deselected, `ruff check` + `ruff format --check` clean, `mypy . --ignore-missing-imports` clean.

## A note on #1117

#1117 was filed against a *different* instance of this same recurring failure: wxyc-shared `cae6030` (api.yaml 1.29.0, the BS#1965 CTA export). That content has since landed here on its own — `CatalogCompilationTrackRow` is present in the committed snapshot on `main` today, absorbed by the later `1.33.0` / `1.35.0` / `83ac750` regens — so the issue's literal desired end state was already met without the ticket being closed, and today's red comes from newer upstream commits it never mentions.

I am closing it with this PR anyway, because it is the repo's standing home for "Codegen Freshness is red, regenerate" and leaving it open while the job is green would misreport the state. If you would rather keep it open as the tracker for the recurring *condition* — the snapshot will drift again the next time wxyc-shared merges a spec change — say so and I will reopen it and drop the `Closes`.

Closes #1117
