### PR TITLE
fix(lookup): let the library-miss 80/80 floor clear a Discogs disambiguation suffix

### DIFF
--- a/lookup/strategies/library_miss.py
+++ b/lookup/strategies/library_miss.py
@@ -14,6 +14,7 @@ Strategy-adjacent, so it lives in this package (LML#727).
 import logging
 
 from clients.streaming.matching import find_best_typed_match
+from discogs.matching import strip_discogs_suffix
 from discogs.models import DiscogsSearchRequest, DiscogsSearchResponse, DiscogsSearchResult
 from discogs.service import DiscogsService
 from library.models import LibraryItem
@@ -22,6 +23,40 @@ from lookup.strategies.va_rescue import find_va_comp_match
 from services.parser import ParsedRequest
 
 logger = logging.getLogger(__name__)
+
+
+def _artist_variants_with_stripped_suffix(result: DiscogsSearchResult) -> list[str | None]:
+    """Candidate-side artist scoring variants, widened with each raw variant's
+    Discogs-disambiguation-suffix-stripped form (LML#1206).
+
+    Discogs assigns a trailing ``(N)`` suffix to a cached credit whenever
+    multiple Discogs artists share a name (``"Mavi (12)"``). The 80/80
+    floor's fuzzy comparison (``score_match`` -> ``fuzz.token_sort_ratio``)
+    treats that suffix as ordinary title content: ``score_match("MAVI",
+    "Mavi (12)")`` measures 61.5, under the 80.0 acceptance floor, even
+    though retrieval already had the right release in hand (every arm --
+    PG-cache and live API alike -- surfaces the same raw suffixed credit and
+    floor-fails identically). A bare-name query for such a credit returned no
+    results on every arm.
+
+    Adding the numeric-only (``broad=False``) stripped form as an *extra*
+    variant lets a bare-name query clear via its own exact match, without
+    disturbing the raw variant (a caller who already types the suffixed form
+    keeps matching that too) and without widening to non-numeric qualifier
+    suffixes like ``"(UK)"`` -- those score exactly as before, deliberately
+    narrower than ``clients.streaming.matching.strip_discogs_disambig``
+    (``broad=True``, used elsewhere for canonical-artist resolution).
+
+    The title axis is untouched, so this can never mint a match on the
+    artist axis alone: when the cache holds multiple suffixed variants of
+    one bare name, every variant's artist axis can clear via its own
+    stripped form, but only the one whose album also matches the query
+    clears ``is_acceptable_match`` -- the existing album confirmation stays
+    the conservative gate, not this variant list.
+    """
+    raw_variants = result.artist_variants()
+    stripped_variants = [strip_discogs_suffix(v) for v in raw_variants if v]
+    return [*raw_variants, *stripped_variants]
 
 
 async def _library_miss_discogs_search(
@@ -90,7 +125,9 @@ async def _library_miss_discogs_search(
             response.results,
             query_artist=artist,
             query_title=album,
-            artist_fn=lambda r: r.artist_variants(),
+            # LML#1206: widened with the suffix-stripped form of each
+            # candidate variant -- see the function's own docstring.
+            artist_fn=_artist_variants_with_stripped_suffix,
             title_fn=lambda r: r.album,
             # LML#1097: deterministic tie-break by release_id, mirroring
             # release_resolution.py's (-score, release_id) sort key.

--- a/tests/integration/test_library_miss_recall_live.py
+++ b/tests/integration/test_library_miss_recall_live.py
@@ -123,15 +123,38 @@ async def test_tasquier_comp_resolves_via_tracklist_credit(service):
 
 @pytest.mark.asyncio
 async def test_mavi_disambiguation_suffix_resolves(service):
-    """LML#1206: the bare name ``"MAVI"`` must resolve *The Pilot* (release
-    37193856), cached under Discogs' disambiguation-suffixed credit
-    ``"Mavi (12)"`` — the live-API companion to the mocked reproduction in
+    """LML#1206: the bare name ``"MAVI"`` must resolve *The Pilot*, credited
+    under Discogs' disambiguation-suffixed form ``"Mavi (12)"`` — the live-API
+    companion to the mocked reproduction in
     ``tests/unit/test_library_miss_discogs.py::TestDisambiguationSuffixRecall``.
+
+    Both *The Pilot* pressings are correct and share master 4206252: 35940307
+    is the 2025-11-25 digital release, 37193856 the 2026-02-27 vinyl LP. Their
+    tracklists are identical and both carry the ticket's two victim tracks
+    (``31 Days`` and ``G-Annis Freestyle``), so either satisfies the enrichment
+    the ticket is about. The API arm this module exercises (no PG cache
+    attached) surfaces both at a 100/100 tie, which LML#1097 breaks
+    deterministically by ascending ``release_id`` — making 35940307 the
+    guaranteed pick here, while the ticket's prod measurement named 37193856
+    because the PG cache arm holds that pressing. Pinning the set rather than
+    one id mirrors ``test_anadol_and_marie_klock_resolves_either_pressing`` and
+    ``test_matmos_self_titled_placeholder_resolves`` above.
+
+    The credit assertion is what carries this test's protocol value: the
+    resolved candidate must be the *suffixed* credit, which is precisely what
+    could not clear the 80/80 floor before this fix
+    (``score_match("MAVI", "Mavi (12)")`` = 61.5).
     """
     result = await _library_miss_discogs_search(
         _parsed("MAVI", "The Pilot"),
         discogs_service=service,
     )
-    assert result is not None, "expected release 37193856; got no floor-clearing candidate"
+    assert result is not None, "expected a The Pilot pressing; got no floor-clearing candidate"
     _, best = result
-    assert best.release_id == 37193856, f"resolved wrong release {best.release_id}"
+    assert best.release_id in {35940307, 37193856}, f"resolved wrong release {best.release_id}"
+    assert best.artist == "Mavi (12)", (
+        f"expected the disambiguation-suffixed credit this fix targets; got {best.artist!r}"
+    )
+    assert (best.album or "").strip().lower() == "the pilot", (
+        f"resolved the wrong album {best.album!r}"
+    )

--- a/tests/integration/test_library_miss_recall_live.py
+++ b/tests/integration/test_library_miss_recall_live.py
@@ -119,3 +119,19 @@ async def test_tasquier_comp_resolves_via_tracklist_credit(service):
     assert result is not None, "expected release 27518829; got no candidate past floor or rescue"
     _, best = result
     assert best.release_id == 27518829, f"resolved wrong release {best.release_id}"
+
+
+@pytest.mark.asyncio
+async def test_mavi_disambiguation_suffix_resolves(service):
+    """LML#1206: the bare name ``"MAVI"`` must resolve *The Pilot* (release
+    37193856), cached under Discogs' disambiguation-suffixed credit
+    ``"Mavi (12)"`` — the live-API companion to the mocked reproduction in
+    ``tests/unit/test_library_miss_discogs.py::TestDisambiguationSuffixRecall``.
+    """
+    result = await _library_miss_discogs_search(
+        _parsed("MAVI", "The Pilot"),
+        discogs_service=service,
+    )
+    assert result is not None, "expected release 37193856; got no floor-clearing candidate"
+    _, best = result
+    assert best.release_id == 37193856, f"resolved wrong release {best.release_id}"

--- a/tests/unit/test_library_miss_discogs.py
+++ b/tests/unit/test_library_miss_discogs.py
@@ -1420,3 +1420,166 @@ class TestLibraryMissNoPoison:
         )
         assert result is None
         assert mock_discogs_service.search.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# LML#1206 — Discogs disambiguation suffix defeats the 80/80 floor
+# ---------------------------------------------------------------------------
+
+
+class TestDisambiguationSuffixRecall:
+    """A Discogs disambiguation suffix on the cached artist credit
+    (``"Mavi (12)"``, the ``(N)`` Discogs appends whenever multiple artists
+    share a name) defeated the 80/80 floor for a bare-name query. Measured
+    against prod: ``MAVI`` / ``Mavi`` / *The Pilot* / ``31 Days`` returned
+    zero results, while ``Mavi (12)`` / *The Pilot* / ``31 Days`` returned one
+    (release 37193856).
+
+    Root cause traced to ``_floor_best``'s call into
+    ``find_best_typed_match``: the artist axis scores
+    ``score_match(query_artist, r.artist_variants())`` — plain
+    ``fuzz.token_sort_ratio`` over the RAW candidate credit, with no
+    disambiguation-suffix strip on either side. ``score_match("MAVI", "Mavi
+    (12)")`` measures 61.5, well under the shared 80.0
+    ``SCORE_MATCH_ACCEPTANCE_FLOOR`` (``clients/streaming/matching.py``), so
+    ``is_acceptable_match`` rejects the candidate outright — retrieval
+    already had the right release in hand (the PG cache's own
+    trigram-similarity ordering clears its floor comfortably at this pair),
+    but this scoring gate discarded it before it ever reached the response.
+    ``score_match("Mavi (12)", "Mavi (12)")`` measures 100, which is why the
+    exact suffixed query worked.
+    """
+
+    RELEASE_ID = 37193856
+    ALBUM = "The Pilot"
+    SUFFIXED_ARTIST = "Mavi (12)"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("query_artist", ["MAVI", "Mavi", "mavi"])
+    async def test_bare_name_resolves_suffixed_credit(self, mock_discogs_service, query_artist):
+        """Every case form of the bare name must retrieve the suffix-credited
+        release — case was never the variable in the ticket's prod measurement,
+        the suffix was."""
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[
+                make_discogs_result(
+                    release_id=self.RELEASE_ID,
+                    artist=self.SUFFIXED_ARTIST,
+                    album=self.ALBUM,
+                )
+            ]
+        )
+        result = await _library_miss_discogs_search(
+            _parsed(query_artist, self.ALBUM), discogs_service=mock_discogs_service
+        )
+        assert result is not None, (
+            f"query_artist={query_artist!r} did not resolve the "
+            f"{self.SUFFIXED_ARTIST!r}-credited release despite the exact album match"
+        )
+        _, discogs_result = result
+        assert discogs_result.release_id == self.RELEASE_ID
+
+    @pytest.mark.asyncio
+    async def test_no_suffix_control_unaffected(self, mock_discogs_service):
+        """AC — a bare name whose cached credit has NO suffix must not regress."""
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[
+                make_discogs_result(release_id=self.RELEASE_ID, artist="Mavi", album=self.ALBUM)
+            ]
+        )
+        result = await _library_miss_discogs_search(
+            _parsed("Mavi", self.ALBUM), discogs_service=mock_discogs_service
+        )
+        assert result is not None
+        _, discogs_result = result
+        assert discogs_result.release_id == self.RELEASE_ID
+        assert discogs_result.artist == "Mavi"
+
+    @pytest.mark.asyncio
+    async def test_conservative_multi_variant_resolution(self, mock_discogs_service):
+        """AC — when the cache holds multiple suffixed variants of one bare
+        name, the album axis is what disambiguates: only the variant whose
+        album ALSO matches the query is accepted. The artist axis alone must
+        never mint a match — a hypothetical ``"Mavi (3)"`` on an unrelated
+        album must not win just because its stripped form also reads
+        "Mavi"."""
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[
+                make_discogs_result(
+                    release_id=self.RELEASE_ID,
+                    artist=self.SUFFIXED_ARTIST,
+                    album=self.ALBUM,
+                ),
+                make_discogs_result(
+                    release_id=99999999,
+                    artist="Mavi (3)",
+                    album="A Completely Different Album",
+                ),
+            ]
+        )
+        result = await _library_miss_discogs_search(
+            _parsed("Mavi", self.ALBUM), discogs_service=mock_discogs_service
+        )
+        assert result is not None
+        _, discogs_result = result
+        assert discogs_result.release_id == self.RELEASE_ID, (
+            "the hypothetical Mavi (3) / unrelated-album candidate must not win — "
+            f"got {discogs_result.release_id}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_qualifier_suffix_not_widened(self, mock_discogs_service):
+        """AC — ``broad=False`` (numeric-only) semantics: a non-numeric
+        qualifier suffix like ``"(UK)"`` must NOT be treated as a
+        disambiguation suffix and promoted for a bare-name query."""
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[make_discogs_result(release_id=88888888, artist="Mavi (UK)", album=self.ALBUM)]
+        )
+        result = await _library_miss_discogs_search(
+            _parsed("Mavi", self.ALBUM), discogs_service=mock_discogs_service
+        )
+        assert result is None, (
+            "a non-numeric qualifier suffix must not be promoted by the LML#1206 fix"
+        )
+
+
+class TestPerformLookupDisambiguationSuffixRecall:
+    """End-to-end replay of the LML#1206 prod measurement through the real
+    ``perform_lookup`` spine, with a faked cache layer standing in for
+    prod discogs-cache — the caller-facing shape of the bug: a library miss
+    plus a live Discogs candidate credited under a disambiguation suffix
+    (``release_id=37193856``, ``"Mavi (12)"``, *The Pilot*) must resolve for
+    the bare-name caller, not just for the internal helper."""
+
+    @pytest.mark.asyncio
+    async def test_bare_name_query_gets_a_match(
+        self, mock_library_db, mock_discogs_service, telemetry
+    ):
+        mock_library_db.search.return_value = []
+        mock_library_db.find_similar_artist.return_value = None
+        mock_discogs_service.search.return_value = DiscogsSearchResponse(
+            results=[
+                make_discogs_result(
+                    release_id=37193856,
+                    artist="Mavi (12)",
+                    album="The Pilot",
+                )
+            ]
+        )
+        mock_discogs_service.get_release = AsyncMock(return_value=None)
+
+        request = LookupRequest(
+            artist="MAVI",
+            album="The Pilot",
+            song="31 Days",
+            raw_message="MAVI - 31 Days - The Pilot",
+        )
+        response = await perform_lookup(request, mock_library_db, mock_discogs_service, telemetry)
+
+        assert len(response.results) == 1, (
+            "MAVI / The Pilot / 31 Days must resolve release 37193856 through the "
+            f"library-miss path; got {response.results}"
+        )
+        item = response.results[0]
+        assert item.artwork is not None
+        assert item.artwork.release_id == 37193856


### PR DESCRIPTION
Closes #1206

## Problem

`/api/v1/lookup` returns **0 results** for `MAVI` / *The Pilot* / `31 Days`, but **1 result** for `Mavi (12)` / *The Pilot* / `31 Days`. `Mavi (12)` is how Discogs credits the artist — the `(N)` disambiguation suffix Discogs assigns whenever several artists share a name. Case is not the variable; both `MAVI` and `Mavi` miss. The suffix is.

Two real WXYC playcuts were lost to this, both from the rotation album *The Pilot*: Backend-Service `flowsheet` #5308909 (`MAVI — 31 Days`) and #5308853 (`MAVI — G-ANNIS FREESTYLE`). Both wrote `metadata_status = 'enriched_no_match'`, which is terminal in Backend-Service (WXYC/Backend-Service#2176), so they stay unenriched permanently. Because the trigger is "Discogs disambiguated this artist name", the blast radius is every common or colliding artist name in the WXYC library, not a one-off.

## History: the retrieval framing was measured and refuted

**Read this before the diff.** The issue's own `## Suggested approach` section is superseded — it proposed closing an assumed *retrieval* asymmetry (fold the artist key at retrieval time, or fire a second `ILIKE '<name> (%'` query when the bare-name attempt returns nothing). Both options address a gap that does not exist. Measured against the prod discogs-cache (recorded in full in [the correction comment on #1206](https://github.com/WXYC/library-metadata-lookup/issues/1206#issuecomment-5318365906)):

The **unmodified** `_SEARCH_BY_TRACK_ARTIST_SQL` CTE (`discogs/cache_service.py`) already returns the right row for the bare name:

| query artist | limit | rows | release 37193856 present | window full? |
|---|---|---|---|---|
| `Mavi` | 20 | 1 | yes | no |
| `Mavi` | 200 | 1 | yes | no |
| `MAVI` | 20 | 1 | yes | no |
| `Mavi (12)` | 20 | 1 | yes | no |

The window never fills at either limit, so candidate crowding is not the mechanism. `search_releases`' artist+album query (the `ARTIST_PLUS_ALBUM` path) likewise returns the release for the bare name:

| query artist | rows | release 37193856 | score |
|---|---|---|---|
| `MAVI` | 1 | yes | **0.812** |
| `Mavi` | 1 | yes | **0.812** |
| `Mavi (12)` | 1 | yes | **1.000** |

The `pg_trgm` threshold is 0.3 and `similarity('mavi','mavi (12)') = 0.625`, so the bare name clears the trigram floor easily. **Retrieval is ruled out at every SQL layer.** Nothing in the cache-query layer needed changing, and a retrieval-side fold or fallback query would have been dead code.

## Root cause

The discard happens one layer downstream, in scoring. `_floor_best()` in `lookup/strategies/library_miss.py` scores the query artist against the **raw, unstripped** Discogs credit via `score_match` (`clients/streaming/matching.py`, plain `fuzz.token_sort_ratio` over normalized forms), and `is_acceptable_match` requires **both** axes ≥ `SCORE_MATCH_ACCEPTANCE_FLOOR = 80.0`. Verified by running the repo's own code:

```
SCORE_MATCH_ACCEPTANCE_FLOOR = 80.0
score_match('MAVI',      'Mavi (12)') =  61.538  -> REJECT
score_match('Mavi',      'Mavi (12)') =  61.538  -> REJECT
score_match('mavi',      'Mavi (12)') =  61.538  -> REJECT
score_match('Mavi (12)', 'Mavi (12)') = 100.000  -> PASS
```

61.5 fails the floor; 100 passes. That is the entire bug, and it explains the exact prod signature: the candidate was present at score 0.812 and the response was still empty. It also explains why every arm behaves identically — the PG cache arm and the live API arm both surface the same raw suffixed credit and floor-fail on it the same way.

## What changed

`_artist_variants_with_stripped_suffix()` widens the **candidate-side** artist variant list passed to `find_best_typed_match`'s `artist_fn` with each raw variant's disambiguation-suffix-stripped form, via `discogs.matching.strip_discogs_suffix` (`broad=False`, numeric-only). The stripped form is added as an *extra* variant, never a replacement, so a caller who already types the suffixed form keeps matching the raw variant at 100 exactly as before. The artist axis takes the max across variants, so the bare name now clears via its own exact match.

`broad=False` is deliberate and preserved: non-numeric qualifier suffixes are never widened. Confirmed directly — `score_match('MAVI', 'Mavi (UK)')` stays **61.538**, i.e. `(UK)` continues to be treated as ordinary title content, deliberately narrower than `clients.streaming.matching.strip_discogs_disambig` (`broad=True`, used elsewhere for canonical-artist resolution).

**The title axis is untouched.** This can never mint a match on the artist axis alone. When the cache holds multiple suffixed variants of one bare name, every variant's artist axis can clear via its own stripped form, but only the one whose album also matches the query clears `is_acceptable_match` — the existing album confirmation stays the conservative gate, which is what the ticket's conservative-resolution acceptance criterion asks for. `tests/unit/test_library_miss_discogs.py::TestDisambiguationSuffixRecall::test_conservative_multi_variant_resolution` pins exactly that with the ticket's hypothetical `Mavi (3)` on an unrelated album.

Tests added: a parameterized bare-name reproduction over `MAVI` / `Mavi` / `mavi`, a no-suffix control (a bare name whose cached credit has no suffix must not regress), the multi-variant conservative-resolution case, a `(UK)` qualifier-suffix negative, an end-to-end replay through the real `perform_lookup` spine, and a live-API companion in `tests/integration/test_library_miss_recall_live.py` (`external_api`-marked).

## Verification

```
uv run ruff check .            -> All checks passed!
uv run ruff format --check .   -> 587 files already formatted
uv run pytest -n auto -q       -> 6422 passed, 1 skipped, 2 xfailed
git diff --stat origin/main    -> 3 files changed, 217 insertions(+), 1 deletion(-)
```

Local `-m pg` noise (14 failures across `artist_candidate_sets`, `artist_resolve_bulk`, `entity_resolution`) is a local Homebrew PG@16 missing `wxyc_unaccent.rules`. Confirmed pre-existing by stashing this branch and re-running against unmodified `origin/main` — **not** caused by this change. The `external_api`-marked live replay self-skips without `DISCOGS_TOKEN`.

## Open question for the reviewer (scope, not a defect)

`score_match` / `find_best_typed_match` in `clients/streaming/matching.py` are shared infrastructure, reused by callers well outside this path — Bandcamp, Apple Music, YouTube Music, artwork matching, and Wikipedia URL picking. Each of those plausibly hits the same raw-credit gap, since none of them strips a Discogs disambiguation suffix before scoring either.

This PR deliberately does **not** sweep them. The fix is applied at the one call site where the bug was measured, keeping the blast radius to the library-miss path and leaving the shared scorer's behavior unchanged for every other caller. The alternative — pushing the strip down into `score_match` itself — would fix all callers at once but silently changes scoring for paths that were never measured, and would need its own evidence.

Worth a reviewer's opinion on whether that restraint is right, or whether a follow-up ticket should sweep the other callers deliberately. Flagging it rather than deciding it unilaterally.
